### PR TITLE
Introduce basic network Identity package

### DIFF
--- a/pkg/net/interface.go
+++ b/pkg/net/interface.go
@@ -24,7 +24,6 @@ type GroupIdentity struct {
 // TransportIdentifier represents the identity of a participant at the transport
 // layer (e.g., libp2p).
 type TransportIdentifier interface {
-	ID() string
 	// Returns a string name of the network provider. Expected to be purely
 	// informational.
 	ProviderName() string

--- a/pkg/net/libp2p_test.go
+++ b/pkg/net/libp2p_test.go
@@ -1,19 +1,17 @@
-package p2p
+package net
 
 import (
 	"testing"
 
-	"github.com/keep-network/keep-core/pkg/net"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 func TestAddIdentityToStore(t *testing.T) {
-	identity, err := LoadOrGenerateIdentity(0, "")
+	pi, err := loadOrGenerateIdentity(0, "")
 	if err != nil {
 		t.Fatalf("Failed to generate valid PeerIdentity with err: %s", err)
 	}
-	pi := identity.(*peerIdentity)
-	ps, err := AddIdentityToStore(pi)
+	ps, err := addIdentityToStore(pi)
 	if err != nil {
 		t.Fatalf("Failed to add Identity to store with err: %s", err)
 	}
@@ -30,12 +28,11 @@ func TestAddIdentityToStore(t *testing.T) {
 }
 
 func TestPublicKeyFunctions(t *testing.T) {
-	identity, err := LoadOrGenerateIdentity(0, "")
+	pi, err := loadOrGenerateIdentity(0, "")
 	if err != nil {
 		t.Fatalf("Failed to generate valid PeerIdentity with err: %s", err)
 	}
-	pi := identity.(*peerIdentity)
-	ps, err := AddIdentityToStore(pi)
+	ps, err := addIdentityToStore(pi)
 	if err != nil {
 		t.Fatalf("Failed to add Identity to store with err: %s", err)
 	}
@@ -49,7 +46,8 @@ func TestPublicKeyFunctions(t *testing.T) {
 		t.Fatalf("Failed to sign msg with err: %s", err)
 	}
 
-	pubKey, err := pi.PubKeyFromID(pi.ID())
+	ti := pi.ID().(TransportIdentifier)
+	pubKey, err := pi.PubKeyFromID(ti)
 	if err != nil {
 		t.Fatalf("Failed to generate public key from id with err %s", err)
 	}
@@ -72,6 +70,6 @@ func TestPublicKeyFunctions(t *testing.T) {
 	}
 }
 
-func toPeerID(pi net.ID) peer.ID {
-	return peer.ID(pi)
+func toPeerID(ti TransportIdentifier) peer.ID {
+	return peer.ID(ti.(networkID))
 }


### PR DESCRIPTION
> "My Name Is" is a song by American rapper Eminem from his major-label debut album The Slim Shady LP (1999). The song samples Labi Siffre's 1975 track "I Got The...". The song was ranked at #26 on "VH1's 100 Greatest Songs of the '90s".[2] "My Name Is" was also ranked #6 on Q Magazine's "1001 Best Songs Ever". [3] The song was placed at number 39 by Rolling Stone on their list of "100 Greatest Hip-Hop songs of all time" in April 2016.[4] The recording garnered Eminem his first Grammy Award for Best Rap Solo Performance at the 42nd Grammy Awards in 2000.

More at [https://en.wikipedia.org/wiki/My_Name_Is](https://en.wikipedia.org/wiki/My_Name_Is)

The goal behind `net.Identity` is to expose a minimal subset of network
level identifiers for external consumption (ie, in registering the
association between a network and protocol identifiers).

We identifiy peers within the libp2p network by their peer.ID and
ed25519 public keys. These public keys are generated from the
corresponding private keys.

This PR attempts to focus the work started in #69 

TODO:
 - [x] Tests
 - [x] Address any review