### PR TITLE
Vetter Vetting: Bump to a fixed version of the go vet hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
  - repo: https://github.com/keep-network/pre-commit-golang.git
-   rev: ab57c5d
+   rev: 124552e
    hooks:
     - id: go-imports
     - id: go-vet


### PR DESCRIPTION
go vet run on individual files can run into issues where it doesn't find
other files in the same package. Running go tool vet on the individual
files instead fixes this issue.

Bumps to our fork's commit with this fix.