### PR TITLE
Add timeout to go tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: Run Go tests
           command: |
-            docker run -w /go/src/github.com/keep-network/keep-core go_build_env go test -timeout=60s ./.../
+            docker run -w /go/src/github.com/keep-network/keep-core go_build_env go test -race -count=2 -timeout=60s ./.../
       - run:
           name: Save Docker image layer cache
           command: |


### PR DESCRIPTION
I remembered I knew this trick, and I recall it being something that we were trying to do before.

Our tests should never exceed a reasonable amount of time. If they do, that's a test failure and should be handled by the team. As our test count is low, we'll start low, and adjust as the number and the complexity of our tests increases.