### PR TITLE
Move logic from newApp into main

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,14 +35,6 @@ func main() {
 		log.Fatal("Failed to initialize BLS.", err)
 	}
 
-	err := newApp(version, revision).Run(os.Args)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func newApp(version, revision string) *cli.App {
-
 	app := cli.NewApp()
 	app.Name = path.Base(os.Args[0])
 	app.Usage = "CLI for The Keep Network"
@@ -89,7 +81,10 @@ ENVIRONMENT VARIABLES:
 
 `, cli.AppHelpTemplate)
 
-	return app
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func printInfo(c *cli.Context) {


### PR DESCRIPTION
I rewrote that and main does look much better with `err := app.Run(os.Args)` rather than `err := newApp(version, revision).Run(os.Args)`