### PR TITLE
Fix ganache-cli version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/node:8
     steps:
         - checkout
-        - run: sudo npm install -g ganache-cli
+        - run: sudo npm install -g ganache-cli@6.1.0
         - run:
             name: Running testrpc
             command: ganache-cli


### PR DESCRIPTION
We were not locking ganache-cli version and the newest one - 6.2.0- released today is not working with our solidity tests. It's also [not working for everyone else](https://github.com/trufflesuite/ganache-cli/issues/530) 😉 