### PR TITLE
Dropped Promise.NewPromise function

### DIFF
--- a/pkg/callback/promise.go
+++ b/pkg/callback/promise.go
@@ -17,14 +17,6 @@ type Promise struct {
 	isComplete bool
 }
 
-// NewPromise creates a new, uncompleted Promise instance with
-// no success, complete or failure callback configured.
-func NewPromise() *Promise {
-	return &Promise{
-		isComplete: false,
-	}
-}
-
 // OnSuccess registers a function to be called when the Promise
 // has been fulfilled. In case of a failed Promise, function is not
 // called at all. OnSuccess is a non-blocking operation. Only one on success

--- a/pkg/callback/promise_test.go
+++ b/pkg/callback/promise_test.go
@@ -16,7 +16,7 @@ func TestPromiseOnSuccessFulfill(t *testing.T) {
 
 	expectedResult := "batman"
 
-	promise := NewPromise()
+	promise := Promise{}
 
 	promise.OnSuccess(func(in interface{}) {
 		done <- in
@@ -53,7 +53,7 @@ func TestPromiseOnCompleteFulfill(t *testing.T) {
 
 	expectedResult := "robin"
 
-	promise := NewPromise()
+	promise := Promise{}
 
 	promise.OnComplete(func(in interface{}, err error) {
 		if err != nil {
@@ -90,7 +90,7 @@ func TestPromiseOnFailureFail(t *testing.T) {
 
 	expectedResult := fmt.Errorf("it's not working")
 
-	promise := NewPromise()
+	promise := Promise{}
 
 	promise.OnFailure(func(err error) {
 		done <- err
@@ -127,7 +127,7 @@ func TestPromiseOnCompleteFail(t *testing.T) {
 
 	expectedFailure := fmt.Errorf("catwoman")
 
-	promise := NewPromise()
+	promise := Promise{}
 
 	promise.OnComplete(func(in interface{}, err error) {
 		if in != nil {
@@ -157,7 +157,7 @@ func TestPromiseOnCompleteFail(t *testing.T) {
 }
 
 func TestPromiseFulfill(t *testing.T) {
-	promise := NewPromise()
+	promise := Promise{}
 
 	if promise.isComplete {
 		t.Error("Promise is completed")
@@ -174,7 +174,7 @@ func TestPromiseFulfill(t *testing.T) {
 }
 
 func TestPromiseFail(t *testing.T) {
-	promise := NewPromise()
+	promise := Promise{}
 
 	if promise.isComplete {
 		t.Error("Promise is completed")
@@ -202,7 +202,7 @@ func TestPromiseAlreadyCompleted(t *testing.T) {
 	}{
 		"Fulfill with result `promise already completed`": {
 			function: func() error {
-				promise := NewPromise().OnSuccess(func(in interface{}) { done <- true })
+				promise := (&Promise{}).OnSuccess(func(in interface{}) { done <- true })
 				promise.Fulfill(nil)
 				return promise.Fulfill(nil)
 			},
@@ -210,7 +210,7 @@ func TestPromiseAlreadyCompleted(t *testing.T) {
 		},
 		"Fail with result `promise already completed`": {
 			function: func() error {
-				promise := NewPromise().OnFailure(func(error) { done <- true })
+				promise := (&Promise{}).OnFailure(func(error) { done <- true })
 				promise.Fail(nil)
 				return promise.Fail(nil)
 			},


### PR DESCRIPTION
The preferred way is to directly allocate a new Promise with just `Promise{}`. Now it's just a preferred approach but after we switch to code generation for promises it will be a must.

We want to drop the `NewPromise` function before it widespread in our codebase.