### PR TITLE
Fix bug in Connect

### DIFF
--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -72,7 +72,7 @@ func Connect(ctx context.Context, config *Config) (net.Provider, error) {
 	}
 
 	// FIXME: return an error if we don't provide bootstrap peers
-	if len(config.Peers) > 0 {
+	if len(config.Peers) == 0 {
 		return provider, nil
 	}
 


### PR DESCRIPTION
This bug would ensure that we never bootstrap if we were given bootstrap
peers. Instead of returning when we have bootstrap peers, we now check
to see if the list of expected peers is empty and then returning.