### PR TITLE
Commitment generation and validation on bn256 elliptic curve

### DIFF
--- a/pkg/tecdsa/commitment/trapdoor_commitment_test.go
+++ b/pkg/tecdsa/commitment/trapdoor_commitment_test.go
@@ -21,7 +21,7 @@ func TestGenerateAndValidateCommitment(t *testing.T) {
 		"negative validation - incorrect `secret`": {
 			modifySecret: func(secret *Secret) {
 				msg := []byte("top secret message2")
-				secret.secret = &msg
+				secret.message = &msg
 			},
 			modifyCommitment: nil,
 			expectedResult:   false,
@@ -59,7 +59,7 @@ func TestGenerateAndValidateCommitment(t *testing.T) {
 			msg := []byte("top secret message")
 
 			// Generate Commitment
-			commitment, err := GenerateCommitment(&msg)
+			commitment, secret, err := GenerateCommitment(&msg)
 			if err != nil {
 				t.Fatalf("generation error [%v]", err)
 			}
@@ -69,13 +69,13 @@ func TestGenerateAndValidateCommitment(t *testing.T) {
 				test.modifyCommitment(commitment)
 			}
 
-			newSecret := commitment.secret
+			newSecret := secret
 			if test.modifySecret != nil {
-				test.modifySecret(&newSecret)
+				test.modifySecret(newSecret)
 			}
 
 			// Validate Commitment
-			result := commitment.ValidateCommitment(&newSecret)
+			result := commitment.ValidateCommitment(newSecret)
 
 			// Check result
 			if result != test.expectedResult {
@@ -89,19 +89,19 @@ func TestCommitmentRandomness(t *testing.T) {
 	msg := []byte("top secret message")
 
 	// Generate Commitment 1
-	commitment1, err := GenerateCommitment(&msg)
+	commitment1, secret1, err := GenerateCommitment(&msg)
 	if err != nil {
 		t.Fatalf("generation error [%v]", err)
 	}
 
 	// Generate Commitment 2
-	commitment2, err := GenerateCommitment(&msg)
+	commitment2, secret2, err := GenerateCommitment(&msg)
 	if err != nil {
 		t.Fatalf("generation error [%v]", err)
 	}
 
 	// Check decommitments are unique
-	if commitment1.secret.r.Cmp(commitment2.secret.r) == 0 {
+	if secret1.r.Cmp(secret2.r) == 0 {
 		t.Fatal("both decommitment keys `r` are equal")
 	}
 


### PR DESCRIPTION
Refs keep-network/keep-core#115

Implementation of Elliptic Curve VSS commitments generation and validation.

Utilizes cloud flare's [BN256 elliptic curve implementation](https://github.com/ethereum/go-ethereum/tree/master/crypto/bn256/cloudflare/bn256.go) from _go-ethereum_ project and it's pairing implementation.

###  Generating commitment
INPUT: `secret`

```golang
pubKey = randomZ[0, q - 1]
r = randomZ[0, q - 1]

digest = sha256(secret) mod q

// + and * are operations on the selected curve
he = h + g * pubKey
commitment = g * digest + he * r

return (r, pubKey, h, commitment)
```

###  Commitment verification
INPUT: `secret, r, commitment, pubKey, h`

```golang
digest = sha256(secret) mod q

// + and * are operations on the selected curve
a = g * r 
b = h + g * pubKey 
c = commitment - g * digest

return pairing(a, b) == pairing(g, c)
```
