### PR TITLE
Added large file check to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,7 @@ repos:
     - id: go-imports
     - id: go-vet
     - id: go-lint
+ - repo: https://github.com/keep-network/pre-commit-hooks.git
+   rev: 63e729f
+   hooks:
+    - id: check-added-large-files


### PR DESCRIPTION
Does what it says!

We'll all have to run `pre-commit install --install-hooks` once this is merged to get things set up properly.