### PR TITLE
Moving copy instruction generates files correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,13 +72,14 @@ RUN go install github.com/ethereum/go-ethereum/cmd/abigen
 COPY ./contracts/solidity $APP_DIR/contracts/solidity
 RUN cd $APP_DIR/contracts/solidity && npm install
 
-COPY ./ $APP_DIR/
 COPY ./pkg/net/gen $APP_DIR/pkg/net/gen
 COPY ./pkg/chain/gen $APP_DIR/pkg/chain/gen
 COPY ./pkg/beacon/relay/dkg/gen $APP_DIR/pkg/beacon/relay/dkg/gen
 COPY ./pkg/beacon/relay/thresholdsignature/gen $APP_DIR/pkg/beacon/relay/thresholdsignature/gen
-COPY ./pkg/gen $APP_DIR/pkg/gen
 RUN go generate ./.../gen
+
+COPY ./ $APP_DIR/
+RUN go generate ./pkg/gen
 
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o $APP_NAME ./ && \
 	mv $APP_NAME $BIN_PATH


### PR DESCRIPTION
Doing a generate before we pull in our code will cause a failure when
attempting to generate a file that depends on code that hasn't been
copied over yet. We correctly generate code as the dependencies will be
available to code that requires it.