### PR TITLE
[WIP] Beacon bacon

### DIFF
--- a/pkg/beacon/relay/relay.go
+++ b/pkg/beacon/relay/relay.go
@@ -61,12 +61,10 @@ func (state *NodeState) GenerateRelayEntryIfEligible(req event.Request) {
 
 func (state *NodeState) memberAndGroupForRequest(
 	req event.Request,
-) (*thresholdgroup.Member, *net.BroadcastChannel) {
+) (*thresholdgroup.Member, net.BroadcastChannel) {
 	// Use request to choose group.
 	// See if we're in the group.
-	// If we are, look up our member entry and our broadcast channel entry.
-	// Return these.
-	// Otherwise return nil, nil.
+	// If we are, look up and return our member entry and our broadcast channel entry.
 	return nil, nil
 }
 


### PR DESCRIPTION
Never a main, often a side dish. Much like our beacon. And by that, I mean bacon.

Given a relay request, we parse this information to identify if the node
is a member of the next group to generate a threshold signature (in
response to the request). We modify `IsNextGroup` and introduce
`GenerateRelayEntryIfEligible` and `AddGroup`.

