### PR TITLE
Added cleanup to async promise generator

### DIFF
--- a/pkg/gen/async.go
+++ b/pkg/gen/async.go
@@ -1,4 +1,4 @@
-//go:generate go run async.go
+//go:generate sh -c "rm -f ./async/*_promise.go; go run async.go"
 // Code generation execution command requires the package to be set to `main`.
 package main
 


### PR DESCRIPTION
Generated promises code caused issues on local development machines,
especially when switching between branches.

Simple cleanup has been added to the go:generate command:
`//go:generate sh -c "rm -f ./async/*_promise.go; go run async.go"`
It removes all files matching `*_promise.go` in `async` directory which
is output dir for promises generation.
Command contains `-f` flag so it won't output any message if the
directory is already empty and matching files were not found.