### PR TITLE
Π_1,i - Zero-Knowledge Proof

### DIFF
--- a/pkg/tecdsa/zkp/dsa_paillier_secret_key_factor_range_proof.go
+++ b/pkg/tecdsa/zkp/dsa_paillier_secret_key_factor_range_proof.go
@@ -57,7 +57,7 @@ type DsaPaillierSecretKeyFactorRangeProof struct {
 }
 
 // CommitDsaPaillierSecretKeyFactorRange generates
-// `DsaPaillierSecretKeyFactorRangeProof ` for the specified DSA secret
+// `DsaPaillierSecretKeyFactorRangeProof` for the specified DSA secret
 // key and multiplication factor. It's required to use the same randomness
 // `r` to generate this proof as the one used for Paillier encryption of
 // `secretDsaKeyShare` into `encryptedSecretDsaKeyShare`.
@@ -72,22 +72,22 @@ func CommitDsaPaillierSecretKeyFactorRange(
 ) (*DsaPaillierSecretKeyFactorRangeProof, error) {
 	alpha, err := rand.Int(random, params.QCube())
 	if err != nil {
-		return nil, fmt.Errorf("could not construct ZKP1i [%v]", err)
+		return nil, fmt.Errorf("could not construct the proof [%v]", err)
 	}
 
 	beta, err := randomFromMultiplicativeGroup(random, params.N)
 	if err != nil {
-		return nil, fmt.Errorf("could not construct ZKP1i [%v]", err)
+		return nil, fmt.Errorf("could not construct the proof [%v]", err)
 	}
 
 	rho, err := rand.Int(random, params.QNTilde())
 	if err != nil {
-		return nil, fmt.Errorf("could not construct ZKP1i [%v]", err)
+		return nil, fmt.Errorf("could not construct the proof [%v]", err)
 	}
 
 	gamma, err := rand.Int(random, params.QCubeNTilde())
 	if err != nil {
-		return nil, fmt.Errorf("could not construct ZKP1i [%v]", err)
+		return nil, fmt.Errorf("could not construct the proof [%v]", err)
 	}
 
 	// u_1 = ((h1)^η)*((h2)^ρ) mod N ̃
@@ -157,8 +157,7 @@ func CommitDsaPaillierSecretKeyFactorRange(
 }
 
 // Verify checks the `DsaPaillierSecretKeyFactorRangeProof` against the provided
-// DSA secret key and the multiplication factor
-// shares.
+// DSA secret key and the multiplication factor.
 // If they match values used to generate the proof, function returns `true`.
 // Otherwise, `false` is returned.
 func (zkp *DsaPaillierSecretKeyFactorRangeProof) Verify(
@@ -210,7 +209,7 @@ func (zkp *DsaPaillierSecretKeyFactorRangeProof) allParametersInRange(params *Pu
 // phase.
 //
 // We want to verify whether z = (Γ^s1)*(s2^N)*(c3^(−e))
-// is equal to z = Γ^α * β^N mod N^2
+// is equal to z = Γ^α * β^N
 // we evaluated in the commitment phase.
 //
 // Since:

--- a/pkg/tecdsa/zkp/dsa_paillier_secret_key_factor_range_proof_test.go
+++ b/pkg/tecdsa/zkp/dsa_paillier_secret_key_factor_range_proof_test.go
@@ -147,10 +147,7 @@ func TestDsaPaillierSecretKeyFactorRangeProofRoundTrip(t *testing.T) {
 	// GIVEN
 	message := big.NewInt(430)
 
-	p, _ := new(big.Int).SetString("23", 10)
-	q, _ := new(big.Int).SetString("47", 10)
-
-	privateKey := paillier.CreatePrivateKey(p, q)
+	privateKey := paillier.CreatePrivateKey(big.NewInt(23), big.NewInt(47))
 
 	params, err := GeneratePublicParameters(privateKey.N, secp256k1.S256())
 	if err != nil {
@@ -172,6 +169,9 @@ func TestDsaPaillierSecretKeyFactorRangeProofRoundTrip(t *testing.T) {
 		t.Fatalf("could not generate eta [%v]", err)
 	}
 
+	// An encrypted plaintext raised to the power of another plaintext will
+	// decrypt to the product of the two plaintexts:
+	// (E(c2))^η = E(c2 * η)
 	encryptedSecretDsaKeyMultiple := &paillier.Cypher{C: new(big.Int).Exp(encryptedSecretDsaKey.C, factor, params.NSquare())}
 
 	encryptedFactor, err := privateKey.EncryptWithR(factor, r)
@@ -181,7 +181,8 @@ func TestDsaPaillierSecretKeyFactorRangeProofRoundTrip(t *testing.T) {
 	}
 
 	// WHEN
-	zkp, err := CommitDsaPaillierSecretKeyFactorRange(encryptedSecretDsaKeyMultiple, encryptedSecretDsaKey, encryptedFactor, factor, r, params, rand.Reader)
+	zkp, err := CommitDsaPaillierSecretKeyFactorRange(encryptedSecretDsaKeyMultiple,
+		encryptedSecretDsaKey, encryptedFactor, factor, r, params, rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Refs #115

This is an implementation of Genaros ZKP Π_1,i used in the second round of Signature Generation.

![image](https://user-images.githubusercontent.com/10741774/42638129-2c780b3e-85ed-11e8-905c-af5e74e4511d.png)
![image](https://user-images.githubusercontent.com/10741774/42638165-3d866a1a-85ed-11e8-81ab-ce815f4bdd4d.png)

It still needs to be verified and named more appropriately.
We need to change name of the `PI1` struct,  `CommitZkpPi1` function, `c1` parameter and files `zkp_1.go`,  `zkp_1_test.go`