### PR TITLE
Fix problem with contract local variables

### DIFF
--- a/contracts/solidity/contracts/KeepGroup.sol
+++ b/contracts/solidity/contracts/KeepGroup.sol
@@ -18,6 +18,10 @@ contract KeepGroup is Ownable, EternalStorage {
     // Current implementation version.
     string public version;
 
+    // Temporary Code for Milestone 1 follows
+    bytes32[] listOfGroupMemberIDs; 
+    // End Temporary Code for Milestone 1 
+
     event Upgraded(string version, address implementation);
 
     // Mirror events from the implementation contract

--- a/contracts/solidity/contracts/KeepGroupImplV1.sol
+++ b/contracts/solidity/contracts/KeepGroupImplV1.sol
@@ -7,6 +7,20 @@ import "./KeepRandomBeaconImplV1.sol";
 
 contract KeepGroupImplV1 is Ownable, EternalStorage {
 
+    // Current implementation contract address.
+    address public implementation;
+
+    // Current implementation version.
+    string public version;
+
+    // Temporary Code for Milestone 1 follows
+    bytes32[] listOfGroupMemberIDs; 
+    // End Temporary Code for Milestone 1
+
+    // Temporary Code for Milestone 1 follows
+    event OnStakerAdded(uint32 index, bytes32 groupMemberID);
+    // End Temporary Code for Milestone 1
+
     event GroupExistsEvent(bytes32 groupPubKey, bool exists);
     event GroupStartedEvent(bytes32 groupPubKey);
     event GroupCompleteEvent(bytes32 groupPubKey);
@@ -201,10 +215,8 @@ contract KeepGroupImplV1 is Ownable, EternalStorage {
         return false;
     }
 
-    // Temporary Code for Milestone 1 follows
 
-    event OnStakerAdded(uint32 index, bytes32 groupMemberID);
-    bytes32[] listOfGroupMemberIDs; 
+    // Temporary Code for Milestone 1 follows
 
     /**
      * @dev Testing for M1 - create a staker.

--- a/contracts/solidity/contracts/KeepRandomBeacon.sol
+++ b/contracts/solidity/contracts/KeepRandomBeacon.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./EternalStorage.sol";
+import "./StakingProxy.sol";
 
 /**
  * @title Keep Random Beacon
@@ -17,6 +18,8 @@ contract KeepRandomBeacon is Ownable, EternalStorage {
 
     // Current implementation version.
     string public version;
+
+    StakingProxy public stakingProxy; // Staking proxy contract that is used to check stake balances against.
 
     event Upgraded(string version, address implementation);
 

--- a/contracts/solidity/contracts/KeepRandomBeaconImplV1.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconImplV1.sol
@@ -14,6 +14,12 @@ import "./EternalStorage.sol";
  */
 contract KeepRandomBeaconImplV1 is Ownable, EternalStorage {
 
+    // Current implementation contract address.
+    address public implementation;
+
+    // Current implementation version.
+    string public version;
+
     StakingProxy public stakingProxy; // Staking proxy contract that is used to check stake balances against.
 
     // These are the public events that are used by clients


### PR DESCRIPTION
Fix proxied contracts local variables overwriting the proxy
contract class local variables.

It turns out that the variables in the proxy use the same memory as the variables in the proxied(to)
contract.  So if you have a variable in the proxy and a variable in the "to" contract and they are different then one can overwrite (or access) the other.

Proxy and Local Variables
=====================================

Let's say you have 2 contracts:

```

contract ProxyFor {

    // Current implementation contract address.
    address public implementation;

    // Current implementation version.
    string public version;

    constructor(string _version, address _implementation) public {
        require(_implementation != address(0), "Implementation address can't be zero.");
        version = _version;
        implementation = _implementation;
    }

    /**
     * @dev Delegate call to the current implementation contract.
     */
    function() public payable {
        address _impl = implementation;
        /* solium-disable-next-line */
        assembly {
            let ptr := mload(0x40)
            calldatacopy(ptr, 0, calldatasize)
            let result := delegatecall(gas, _impl, ptr, calldatasize, 0, 0)
            let size := returndatasize
            returndatacopy(ptr, 0, size)

            switch result
            case 0 { revert(ptr, size) }
            default { return(ptr, size) }
        }
    }

	function setImplementation ( address _implementation ) public {
        implementation = _implementation;
	}
}

```

and the implementation contract:

```

contract TheImplV1 {

	uint256 public myCounter;
	string private myData;

	constructor() {
		myCounter = 1000;
	}

	function setCounterTo1000 ( ) public {
        myCounter = 1000;
	}

	function doSomething() public returns(uint) {
		return 1;
	}

}

```

Now we set it up so that `ProxyFor` has the implementation address of `TheImplV1` contract when
the constructor is called.

We can call ProxyFor.setCounterTo1000().  This will change ProxyFor.implementation to 1000 (dedmial).
There is no contract at that address.  Now the next call ProxyFor.doSomething() will fail with a
weird error.

This change is to address this problem.