### PR TITLE
Unsubscribe from events after promise fulfilled

### DIFF
--- a/pkg/chain/ethereum/keep_group.go
+++ b/pkg/chain/ethereum/keep_group.go
@@ -253,6 +253,7 @@ func (kg *keepGroup) WatchGroupCompleteEvent(
 	eventChan := make(chan *gen.KeepGroupImplV1GroupCompleteEvent)
 	eventSubscription, err := kg.contract.WatchGroupCompleteEvent(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for GroupCompleteEvent events [%v]",
 			err,
@@ -287,6 +288,7 @@ func (kg *keepGroup) WatchGroupErrorCode(
 	eventChan := make(chan *gen.KeepGroupImplV1GroupErrorCode)
 	eventSubscription, err := kg.contract.WatchGroupErrorCode(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"failed go create watch for GroupErrorCode events: [%v]",
 			err,
@@ -322,6 +324,7 @@ func (kg *keepGroup) WatchGroupExistsEvent(
 	eventChan := make(chan *gen.KeepGroupImplV1GroupExistsEvent)
 	eventSubscription, err := kg.contract.WatchGroupExistsEvent(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for GropExistsEvent events [%v]",
 			err,
@@ -357,6 +360,7 @@ func (kg *keepGroup) WatchGroupStartedEvent(
 	eventChan := make(chan *gen.KeepGroupImplV1GroupStartedEvent)
 	eventSubscription, err := kg.contract.WatchGroupStartedEvent(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for GorupStartedEvent events [%v]",
 			err,
@@ -392,6 +396,7 @@ func (kg *keepGroup) WatchOnStakerAdded(
 	eventChan := make(chan *gen.KeepGroupImplV1OnStakerAdded)
 	eventSubscription, err := kg.contract.WatchOnStakerAdded(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf("error creating watch for OnStakerAdded events [%v]", err)
 	}
 	go func() {

--- a/pkg/chain/ethereum/keep_random_beacon.go
+++ b/pkg/chain/ethereum/keep_random_beacon.go
@@ -171,6 +171,7 @@ func (krb *KeepRandomBeacon) WatchRelayEntryRequested(
 	eventChan := make(chan *gen.KeepRandomBeaconImplV1RelayEntryRequested)
 	eventSubscription, err := krb.contract.WatchRelayEntryRequested(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for RelayEntryRequested events: [%v]",
 			err,
@@ -218,6 +219,7 @@ func (krb *KeepRandomBeacon) WatchRelayEntryGenerated(
 	eventChan := make(chan *gen.KeepRandomBeaconImplV1RelayEntryGenerated)
 	eventSubscription, err := krb.contract.WatchRelayEntryGenerated(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for RelayEntryGenerated event: [%v]",
 			err,
@@ -262,6 +264,7 @@ func (krb *KeepRandomBeacon) WatchRelayResetEvent(
 	eventChan := make(chan *gen.KeepRandomBeaconImplV1RelayResetEvent)
 	eventSubscription, err := krb.contract.WatchRelayResetEvent(nil, eventChan)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for RelayResetEvent event: [%v]",
 			err,
@@ -308,6 +311,7 @@ func (krb *KeepRandomBeacon) WatchSubmitGroupPublicKeyEvent(
 		eventChan,
 	)
 	if err != nil {
+		close(eventChan)
 		return fmt.Errorf(
 			"error creating watch for SubmitGroupPublicKeyEvent event: [%v]",
 			err,


### PR DESCRIPTION
Unsubscribe from events after promise has been
fulfilled.  This is to prevent duplicate events.

Issue #231.
