### PR TITLE
TECDSA: Function to return Signer's Public Key

### DIFF
--- a/pkg/tecdsa/signer.go
+++ b/pkg/tecdsa/signer.go
@@ -332,7 +332,8 @@ func (ls *LocalSigner) WithDsaKey(dsaKey *ThresholdDsaKey) *Signer {
 	}
 }
 
-// PublicKey returns a public key from `ThresholdDsaKey` of the signer
+// PublicKey returns a public key from `ThresholdDsaKey` of the signer.
+// The public key is expected to be identical for all signers in a signing group.
 func (s *Signer) PublicKey() *curve.Point {
 	return s.dsaKey.PublicKey
 }


### PR DESCRIPTION
Added a function to get Signer's Public Key which is a part of `ThresholdDsaKey` in private `dsaKey` field.