### PR TITLE
Switch from EDDSA to ECDSA keys.

### DIFF
--- a/pkg/net/libp2p/identity.go
+++ b/pkg/net/libp2p/identity.go
@@ -112,7 +112,7 @@ func generateIdentity(randseed int) (*identity, error) {
 		r = rand.Reader
 	}
 
-	privKey, pubKey, err := libp2pcrypto.GenerateKeyPairWithReader(libp2pcrypto.Ed25519, 2048, r)
+	privKey, pubKey, err := libp2pcrypto.GenerateSecp256k1Key(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Swap out ed25519 (EDDSA) keys for secp256k1 (ECDSA) keys.

Given that ECDSA keys are faster to verify on chain, we want to drive
consistency by opting to have all of our keys be ECDSA (to avoid
ambiguity). We may revisit this decision, but this gives us a solid
starting point (though network identities may never make it on-chain).