### PR TITLE
T-ECDSA: Fix tests ethereum verification for R, S length less than 32 bytes

### DIFF
--- a/pkg/tecdsa/signer_smoke_test.go
+++ b/pkg/tecdsa/signer_smoke_test.go
@@ -231,7 +231,7 @@ func TestFullInitAndSignPath(t *testing.T) {
 		signature,
 	)
 	if err != nil {
-		t.Logf("H: %x\n", messageHash)
+		t.Logf("H: %v\n", new(big.Int).SetBytes(messageHash))
 		t.Logf("R: %v\n", signature.R)
 		t.Logf("S: %v\n", signature.S)
 		t.Logf("X: %v\n", round5Signers[0].dsaKey.PublicKey.X)
@@ -246,7 +246,7 @@ func TestFullInitAndSignPath(t *testing.T) {
 		signature,
 	)
 	if err != nil {
-		fmt.Printf("H: %x\n", messageHash)
+		fmt.Printf("H: %v\n", new(big.Int).SetBytes(messageHash))
 		fmt.Printf("R: %v\n", signature.R)
 		fmt.Printf("S: %v\n", signature.S)
 		fmt.Printf("X: %v\n", round5Signers[0].dsaKey.PublicKey.X)


### PR DESCRIPTION
Some test runs for signing process were falling ethereum verification.

We discovered that in ~0,5% runs one of the generated signature's  R, S values was less than 32 bytes long. Ethereum requires that concatenated R,S values should be exactly 64 bytes long.
We've added padding function which prefixes bytes slice with zeros up to total length of 32 bytes.