### PR TITLE
Go Ethereum Yourself: Pin go-ethereum dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,11 +10,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/agl/ed25519"
-  packages = [
-    ".",
-    "edwards25519",
-    "extra25519"
-  ]
+  packages = [".","edwards25519","extra25519"]
   revision = "5312a61534124124185d41f09206b9fef1d88403"
 
 [[projects]]
@@ -49,44 +45,14 @@
 [[projects]]
   branch = "master"
   name = "github.com/docker/spdystream"
-  packages = [
-    ".",
-    "spdy"
-  ]
+  packages = [".","spdy"]
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
   name = "github.com/ethereum/go-ethereum"
-  packages = [
-    ".",
-    "accounts",
-    "accounts/abi",
-    "accounts/abi/bind",
-    "accounts/keystore",
-    "cmd/abigen",
-    "common",
-    "common/compiler",
-    "common/hexutil",
-    "common/math",
-    "common/mclock",
-    "core/types",
-    "crypto",
-    "crypto/bn256/cloudflare",
-    "crypto/secp256k1",
-    "crypto/sha3",
-    "ethclient",
-    "ethdb",
-    "event",
-    "log",
-    "metrics",
-    "p2p/netutil",
-    "params",
-    "rlp",
-    "rpc",
-    "trie"
-  ]
-  revision = "316fc7ecfc10d06603f1358c1f4c1020ec36dd2a"
-  version = "v1.8.14"
+  packages = [".","accounts","accounts/abi","accounts/abi/bind","accounts/keystore","cmd/abigen","common","common/compiler","common/hexutil","common/math","common/mclock","core/types","crypto","crypto/bn256/cloudflare","crypto/secp256k1","crypto/sha3","ethclient","ethdb","event","log","metrics","p2p/netutil","params","rlp","rpc","trie"]
+  revision = "89451f7c382ad2185987ee369f16416f89c28a7d"
+  source = "https://github.com/keep-network/go-ethereum.git"
 
 [[projects]]
   name = "github.com/fd/go-nat"
@@ -102,36 +68,7 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = [
-    "gogoproto",
-    "io",
-    "plugin/compare",
-    "plugin/defaultcheck",
-    "plugin/description",
-    "plugin/embedcheck",
-    "plugin/enumstringer",
-    "plugin/equal",
-    "plugin/face",
-    "plugin/gostring",
-    "plugin/marshalto",
-    "plugin/oneofcheck",
-    "plugin/populate",
-    "plugin/size",
-    "plugin/stringer",
-    "plugin/testgen",
-    "plugin/union",
-    "plugin/unmarshal",
-    "proto",
-    "protoc-gen-gogo/descriptor",
-    "protoc-gen-gogo/generator",
-    "protoc-gen-gogo/generator/internal/remap",
-    "protoc-gen-gogo/grpc",
-    "protoc-gen-gogo/plugin",
-    "protoc-gen-gogoslick",
-    "sortkeys",
-    "vanity",
-    "vanity/command"
-  ]
+  packages = ["gogoproto","io","plugin/compare","plugin/defaultcheck","plugin/description","plugin/embedcheck","plugin/enumstringer","plugin/equal","plugin/face","plugin/gostring","plugin/marshalto","plugin/oneofcheck","plugin/populate","plugin/size","plugin/stringer","plugin/testgen","plugin/union","plugin/unmarshal","proto","protoc-gen-gogo/descriptor","protoc-gen-gogo/generator","protoc-gen-gogo/generator/internal/remap","protoc-gen-gogo/grpc","protoc-gen-gogo/plugin","protoc-gen-gogoslick","sortkeys","vanity","vanity/command"]
   revision = "baf2ea5cdb7ce2d399176f925052690c3dad1f56"
   source = "https://github.com/keep-network/protobuf.git"
 
@@ -168,24 +105,13 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
+  packages = [".","simplelru"]
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
   name = "github.com/huin/goupnp"
-  packages = [
-    ".",
-    "dcps/internetgateway1",
-    "dcps/internetgateway2",
-    "httpu",
-    "scpd",
-    "soap",
-    "ssdp"
-  ]
+  packages = [".","dcps/internetgateway1","dcps/internetgateway2","httpu","scpd","soap","ssdp"]
   revision = "1395d1447324cbea88d249fbfcfd70ea878fdfca"
 
 [[projects]]
@@ -196,12 +122,7 @@
 
 [[projects]]
   name = "github.com/ipfs/go-datastore"
-  packages = [
-    ".",
-    "autobatch",
-    "query",
-    "sync"
-  ]
+  packages = [".","autobatch","query","sync"]
   revision = "f2426c09e56ae390fc416f21b224c7d7ad13418c"
 
 [[projects]]
@@ -213,12 +134,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/ipfs/go-log"
-  packages = [
-    ".",
-    "tracer",
-    "tracer/wire",
-    "writer"
-  ]
+  packages = [".","tracer","tracer/wire","writer"]
   revision = "b9df188d0fae32d69c1a519fa81741668a12f55a"
 
 [[projects]]
@@ -254,12 +170,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/jbenet/goprocess"
-  packages = [
-    ".",
-    "context",
-    "periodic",
-    "ratelimit"
-  ]
+  packages = [".","context","periodic","ratelimit"]
   revision = "b497e2f366b8624394fb2e89c10ab607bebdde0b"
 
 [[projects]]
@@ -276,10 +187,7 @@
 
 [[projects]]
   name = "github.com/libp2p/go-floodsub"
-  packages = [
-    ".",
-    "pb"
-  ]
+  packages = [".","pb"]
   revision = "10eaec55ad0fe58b2fb77cbaf01a3760eb8c211b"
   source = "https://github.com/keep-network/go-floodsub.git"
 
@@ -292,21 +200,13 @@
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p"
-  packages = [
-    "p2p/host/basic",
-    "p2p/host/routed",
-    "p2p/protocol/identify",
-    "p2p/protocol/identify/pb"
-  ]
+  packages = ["p2p/host/basic","p2p/host/routed","p2p/protocol/identify","p2p/protocol/identify/pb"]
   revision = "268a4c92d9475dbed4eee55511c4d954cef93eac"
 
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p-circuit"
-  packages = [
-    ".",
-    "pb"
-  ]
+  packages = [".","pb"]
   revision = "3413b1cb6ea15a413f4983cfce9cb4e5196827e4"
 
 [[projects]]
@@ -317,10 +217,7 @@
 
 [[projects]]
   name = "github.com/libp2p/go-libp2p-crypto"
-  packages = [
-    ".",
-    "pb"
-  ]
+  packages = [".","pb"]
   revision = "18915b5467c77ad8c07a35328c2cab468667a4e8"
 
 [[projects]]
@@ -349,21 +246,13 @@
 
 [[projects]]
   name = "github.com/libp2p/go-libp2p-kad-dht"
-  packages = [
-    ".",
-    "opts",
-    "pb",
-    "providers"
-  ]
+  packages = [".","opts","pb","providers"]
   revision = "240a27a66982945ba87967a08a6e04b74b228c45"
 
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p-kbucket"
-  packages = [
-    ".",
-    "keyspace"
-  ]
+  packages = [".","keyspace"]
   revision = "a88e1b7030c460c8bb9f09cab9bb3f4bc727edb2"
 
 [[projects]]
@@ -375,11 +264,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p-metrics"
-  packages = [
-    ".",
-    "conn",
-    "stream"
-  ]
+  packages = [".","conn","stream"]
   revision = "2b4a2757a26649c9a603519647cc9d4478ade5c6"
 
 [[projects]]
@@ -396,20 +281,12 @@
 
 [[projects]]
   name = "github.com/libp2p/go-libp2p-peer"
-  packages = [
-    ".",
-    "peerset",
-    "test"
-  ]
+  packages = [".","peerset","test"]
   revision = "e8858116ad7f0a54dfc2bb6af554f2024221d19c"
 
 [[projects]]
   name = "github.com/libp2p/go-libp2p-peerstore"
-  packages = [
-    ".",
-    "addr",
-    "queue"
-  ]
+  packages = [".","addr","queue"]
   revision = "7ac092e7f77f5bda1cb6e4ef95efbe911e97db41"
 
 [[projects]]
@@ -421,29 +298,19 @@
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p-record"
-  packages = [
-    ".",
-    "pb"
-  ]
+  packages = [".","pb"]
   revision = "e1ffee3ceea9ca1e583965bea51bd7b35b543518"
 
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p-routing"
-  packages = [
-    ".",
-    "notifications",
-    "options"
-  ]
+  packages = [".","notifications","options"]
   revision = "d2bd3b71dacda2bcb7bd666816abe4e0685bda01"
 
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-libp2p-secio"
-  packages = [
-    ".",
-    "pb"
-  ]
+  packages = [".","pb"]
   revision = "146b7055645501f741c5644d4a3d207614f08899"
 
 [[projects]]
@@ -467,10 +334,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-msgio"
-  packages = [
-    ".",
-    "mpool"
-  ]
+  packages = [".","mpool"]
   revision = "d82125c9907e1365775356505f14277d47dfd4d6"
 
 [[projects]]
@@ -482,11 +346,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/libp2p/go-reuseport"
-  packages = [
-    ".",
-    "poll",
-    "singlepoll"
-  ]
+  packages = [".","poll","singlepoll"]
   revision = "15a1cd37f0502f3b2eccb6d71a7958edda314633"
 
 [[projects]]
@@ -585,11 +445,7 @@
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [
-    ".",
-    "ext",
-    "log"
-  ]
+  packages = [".","ext","log"]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
@@ -625,20 +481,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/syndtr/goleveldb"
-  packages = [
-    "leveldb",
-    "leveldb/cache",
-    "leveldb/comparer",
-    "leveldb/errors",
-    "leveldb/filter",
-    "leveldb/iterator",
-    "leveldb/journal",
-    "leveldb/memdb",
-    "leveldb/opt",
-    "leveldb/storage",
-    "leveldb/table",
-    "leveldb/util"
-  ]
+  packages = ["leveldb","leveldb/cache","leveldb/comparer","leveldb/errors","leveldb/filter","leveldb/iterator","leveldb/journal","leveldb/memdb","leveldb/opt","leveldb/storage","leveldb/table","leveldb/util"]
   revision = "5d6fca44a948d2be89a9702de7717f0168403d3d"
 
 [[projects]]
@@ -716,70 +559,31 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "blake2s",
-    "blowfish",
-    "pbkdf2",
-    "scrypt",
-    "sha3",
-    "ssh/terminal"
-  ]
+  packages = ["blake2s","blowfish","pbkdf2","scrypt","sha3","ssh/terminal"]
   revision = "df8d4716b3472e4a531c33cedbe537dae921a1a9"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "html",
-    "html/atom",
-    "html/charset",
-    "websocket"
-  ]
+  packages = ["context","html","html/atom","html/charset","websocket"]
   revision = "1e491301e022f8f977054da4c2d852decd59571f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "cpu",
-    "unix",
-    "windows"
-  ]
+  packages = ["cpu","unix","windows"]
   revision = "c11f84a56e43e20a78cee75a7c034031ecf57d1f"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "encoding",
-    "encoding/charmap",
-    "encoding/htmlindex",
-    "encoding/internal",
-    "encoding/internal/identifier",
-    "encoding/japanese",
-    "encoding/korean",
-    "encoding/simplifiedchinese",
-    "encoding/traditionalchinese",
-    "encoding/unicode",
-    "internal/gen",
-    "internal/tag",
-    "internal/utf8internal",
-    "language",
-    "runes",
-    "transform",
-    "unicode/cldr"
-  ]
+  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/utf8internal","language","runes","transform","unicode/cldr"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
-  packages = [
-    "go/ast/astutil",
-    "imports",
-    "internal/fastwalk"
-  ]
+  packages = ["go/ast/astutil","imports","internal/fastwalk"]
   revision = "a5b4c53f6e8bdcafa95a94671bf2d1203365858b"
 
 [[projects]]
@@ -797,6 +601,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e6bc4e312276c68cf61cc85688d34dad74da1cc9fac4100ab19cf200617386f9"
+  inputs-digest = "af9bc30cea058eb14c3a5758657634457492b42035364380786d480a11e09c0d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,6 +33,11 @@ required = ["github.com/gogo/protobuf/protoc-gen-gogoslick", "github.com/ethereu
   source = "https://github.com/keep-network/go-dfinity-crypto.git"
 
 [[constraint]]
+  name = "github.com/ethereum/go-ethereum"
+  revision = "89451f7c382ad2185987ee369f16416f89c28a7d"
+  source = "https://github.com/keep-network/go-ethereum.git"
+
+[[constraint]]
   name = "github.com/BurntSushi/toml"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   source = "https://github.com/keep-network/toml.git"


### PR DESCRIPTION
@rargulati noted in #272 that we don't have `go-ethereum` pinned as a
dependency. keep-network had a clone already, so after updating the clone in
question to the latest from upstream, this PR pins the go-ethereum dependency
to the latest verified release commit, for release 1.8.15.