### PR TITLE
ASCII Me A Question: Add asciidoctor PDF/HTML building to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,16 @@ jobs:
           command: |
             cd docs
             asciidoctor *.adoc */*.adoc
+            for a in $(ls *.html */*.html); do mkdir -p /tmp/docs/$(dirname $a); cp $a /tmp/docs/$(dirname $a)/; done
+            asciidoctor-pdf *.adoc */*.adoc
             for a in $(ls *.pdf */*.pdf); do mkdir -p /tmp/docs/$(dirname $a); cp $a /tmp/docs/$(dirname $a)/; done
       - persist_to_workspace:
           root: /tmp/docs
           paths:
             - ./*.pdf
             - ./*/*.pdf
+            - ./*.html
+            - ./*/*.html
   upload_docs:
     docker:
       - image: google/cloud-sdk:slim


### PR DESCRIPTION
Quick PR to run asciidoctor PDF/HTML generation to Circle CI. After this, any PR that contains a file `docs/**.adoc` should build to `http://docs.keep.network/<branch>/**.[pdf|html]`. TBD once Circle actually gets its paws on this PR heh.