### PR TITLE
RFC 2: Network Security Implementation

### DIFF
--- a/docs/rfc/rfc-2-network-security-implementation.adoc
+++ b/docs/rfc/rfc-2-network-security-implementation.adoc
@@ -221,6 +221,12 @@ signature against sender's key. If the signature is not valid, peer rejects the
 message and drops the connection with the peer that relayed that message since 
 that peer is the one that tampered the message.
 
+Peer which tampered the message is blacklisted by the peer who received the 
+relayed, tampered message. Peer is blacklisted for a certain period of time, 
+tracked as an on-chain parameter. This time period is never shorter than the time 
+needed to re-transmit the message. During the time peer is blacklisted, all 
+connection attempts from that peer to the peer who blacklisted it are rejected.
+
 ==== Group formation
 
 In the Keep network, peers may form groups selected to execute various protocols.


### PR DESCRIPTION
This document attempts to explain how we are going to implement network security in Keep network so that all the requirements from #275 (RFC 1) are fulfilled. 