### PR TITLE
Interkeep Emojineering Troll Face: Add RFC template

### DIFF
--- a/docs/rfc/rfc.adoc
+++ b/docs/rfc/rfc.adoc
@@ -48,6 +48,7 @@ proposal, this is important.
 
 If any open questions are left that you haven't yet investigated, what are they?
 
+[bibliography]
 == Related Links
 
 - Flowdock Links


### PR DESCRIPTION
Just riffing off of the [Internet Engineering Task Force](https://en.wikipedia.org/wiki/IETF)
like a weirdo...

This adds the RFC template to the RFC directory under `docs/rfc/rfc.adoc`.
Notably, we still need a directory structure that indicates the status of an
RFC; more to come on that front.