### PR TITLE
Allow submitting relay entry for testing the app

### DIFF
--- a/cmd/smoketest.go
+++ b/cmd/smoketest.go
@@ -75,7 +75,7 @@ func SmokeTest(c *cli.Context) error {
 
 	chainHandle.ThresholdRelay().SubmitRelayEntry(&event.Entry{
 		RequestID:     big.NewInt(int64(135)),
-		Value:         [32]byte{},
+		Value:         big.NewInt(int64(154)),
 		GroupID:       big.NewInt(int64(168)),
 		PreviousEntry: &big.Int{},
 	})

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -3,7 +3,6 @@ package beacon
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"os"
 	"sync"
 	"time"
@@ -98,8 +97,7 @@ func Initialize(
 		})
 
 		relayChain.OnRelayEntryGenerated(func(entry *event.Entry) {
-			entryBigInt := (&big.Int{}).SetBytes(entry.Value[:])
-			node.JoinGroupIfEligible(relayChain, entry.RequestID, entryBigInt)
+			node.JoinGroupIfEligible(relayChain, entry.RequestID, entry.Value)
 		})
 
 		relayChain.OnGroupRegistered(func(registration *event.GroupRegistration) {

--- a/pkg/beacon/relay/event/event.go
+++ b/pkg/beacon/relay/event/event.go
@@ -11,7 +11,7 @@ import (
 // Entry represents one entry in the threshold relay.
 type Entry struct {
 	RequestID     *big.Int
-	Value         [32]byte
+	Value         *big.Int
 	GroupID       *big.Int
 	PreviousEntry *big.Int
 	Timestamp     time.Time
@@ -24,7 +24,7 @@ type Request struct {
 	BlockReward *big.Int
 	Seed        *big.Int
 
-	PreviousValue [32]byte
+	PreviousValue *big.Int
 }
 
 // GroupRegistration represents a registered group in the threshold relay with a

--- a/pkg/beacon/relay/genesis.go
+++ b/pkg/beacon/relay/genesis.go
@@ -1,0 +1,17 @@
+package relay
+
+import "math/big"
+
+// https://www.wolframalpha.com/input/?i=pi+to+78+digits
+const piAsString = "31415926535897932384626433832795028841971693993751058209749445923078164062862"
+
+// Genesis is the seed value for the network. The n digits of pi that fit into a
+// *big.Int represent a "nothing up our sleeve" value that all consumers of this
+// network can verify.
+func GenesisEntryValue() *big.Int {
+	value, success := big.NewInt(0).SetString(piAsString, 10)
+	if !success {
+		panic("failed to parse Pi as string")
+	}
+	return value
+}

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -107,12 +107,10 @@ func (ec *ethereumChain) SubmitRelayEntry(
 			previousEntry *big.Int,
 			blockNumber *big.Int,
 		) {
-			var value [32]byte
-			copy(value[:], requestResponse.Bytes()[:32])
 
 			err := relayEntryPromise.Fulfill(&event.Entry{
 				RequestID:     requestID,
-				Value:         value,
+				Value:         requestResponse,
 				GroupID:       requestGroupID,
 				PreviousEntry: previousEntry,
 				Timestamp:     time.Now().UTC(),
@@ -151,12 +149,11 @@ func (ec *ethereumChain) SubmitRelayEntry(
 		return relayEntryPromise
 	}
 
-	groupSignature := big.NewInt(int64(0)).SetBytes(newEntry.Value[:])
 	_, err = ec.keepRandomBeaconContract.SubmitRelayEntry(
 		newEntry.RequestID,
 		newEntry.GroupID,
 		newEntry.PreviousEntry,
-		groupSignature,
+		newEntry.Value,
 	)
 	if err != nil {
 		promiseErr := relayEntryPromise.Fail(
@@ -186,12 +183,9 @@ func (ec *ethereumChain) OnRelayEntryGenerated(handle func(entry *event.Entry)) 
 			previousEntry *big.Int,
 			blockNumber *big.Int,
 		) {
-			var value [32]byte
-			copy(value[:], requestResponse.Bytes())
-
 			handle(&event.Entry{
 				RequestID:     requestID,
-				Value:         value,
+				Value:         requestResponse,
 				GroupID:       requestGroupID,
 				PreviousEntry: previousEntry,
 				Timestamp:     time.Now().UTC(),

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -21,7 +21,7 @@ type localChain struct {
 	groupRegistrations      map[string][96]byte
 
 	groupRelayEntriesMutex sync.Mutex
-	groupRelayEntries      map[string][32]byte
+	groupRelayEntries      map[string]*big.Int
 
 	handlerMutex               sync.Mutex
 	relayEntryHandlers         []func(entry *event.Entry)
@@ -30,7 +30,7 @@ type localChain struct {
 	stakerRegistrationHandlers []func(staker *event.StakerRegistration)
 
 	requestID   int64
-	latestValue [32]byte
+	latestValue *big.Int
 
 	simulatedHeight int64
 	blockCounter    chain.BlockCounter
@@ -187,7 +187,7 @@ func Connect(groupSize int, threshold int) chain.Handle {
 			Threshold: threshold,
 		},
 		groupRegistrationsMutex: sync.Mutex{},
-		groupRelayEntries:       make(map[string][32]byte),
+		groupRelayEntries:       make(map[string]*big.Int),
 		groupRegistrations:      make(map[string][96]byte),
 		blockCounter:            bc,
 	}


### PR DESCRIPTION
Peers in our network listen for an initial relay entry, the seed to the 
network, to kick off the initial group selection. This initial group selection 
determines which peers are selected to run DKG to create the very first 
group. Those that succeed in group creation then may respond to relay requests.

All of this hinges on a valid seed relay entry. This cli command enables
a tester to submit a random value to instigate group selection.

Work in progress while I identify issues with my local environment. 

Closes https://github.com/keep-network/keep-core/issues/348