### PR TITLE
Update ethereum setup docs

### DIFF
--- a/docs/development/local-keep-network.adoc
+++ b/docs/development/local-keep-network.adoc
@@ -108,11 +108,12 @@ to unlock this account since tokens will only be added to it as a mining block
 reward:
 
 ```
-$ geth --port 3000 --networkid 1101 --identity "somerandomidentity" --ws --wsaddr "127.0.0.1" \
---wsport "8546" --wsorigins "" --rpc --rpcport "8545" --rpcaddr "127.0.0.1" \
---rpccorsdomain "" --rpcapi "db,ssh,miner,admin,eth,net,web3,personal" \
---datadir=$GETH_DATA_DIR --syncmode "fast" --miner.etherbase=$ETHEREUM_ACCOUNT --mine \
---miner.threads=1
+$ geth --port 3000 --networkid 1101 --identity "somerandomidentity" \
+    --ws --wsaddr "127.0.0.1" --wsport "8546" --wsorigins "" \
+    --rpc --rpcport "8545" --rpcaddr "127.0.0.1" --rpccorsdomain "" \
+    --rpcapi "db,ssh,miner,admin,eth,net,web3,personal" \
+    --datadir=$GETH_DATA_DIR --syncmode "fast" \
+    --miner.etherbase=$ETHEREUM_ACCOUNT --mine --miner.threads=1
 
 INFO [10-13|13:35:01] Maximum peer count                       ETH=25 LES=0 total=25
 INFO [10-13|13:35:01] Starting peer-to-peer node               instance=Geth/somerandomidentity/v1.8.11-stable/darwin-amd64/go1.10.3


### PR DESCRIPTION
Update docs to reflect changes to geth api


After `geth 1.8.14`, geth changes a few cli commands to reflect changes to the api. 
Rather than `--fast`, geth introduces a `--syncmode <speed>` command with variable 
levels of speed. Rather than `etherbase` and `threads`, geth namespaces these 
commands under `miner` ie `miner.threads` and `miner.etherbase` (introducing a few 
other configurations as well).

Also use environment variables to make things easier for the reader, and clarify a few points.