### PR TITLE
Connection-level handshake protocol - leftovers

### DIFF
--- a/pkg/net/security/handshake/connection_handshake.go
+++ b/pkg/net/security/handshake/connection_handshake.go
@@ -63,7 +63,7 @@ type act1Message struct {
 
 // act2Message is sent in the second handshake act by the responder to the
 // initiator. It contains randomly generated `nonce2`, which is an 8-byte
-// unsigned integer and `challenge`, which is the result of SHA256 on the
+// unsigned integer, and `challenge`, which is the result of SHA256 on the
 // concatenated bytes of `nonce1` and `nonce2`.
 //
 // act2Message should be signed with responder's static private key.


### PR DESCRIPTION
Refs: #298

This PR addresses all the comments left to #329 after it has been merged.
- Refer to `crypto/rand` as `crand`
- Grammar fixes to the documentation
- Call input message parameters just `message` instead of `act#Msg`
- Use `fmt.Errorf` instead of `errors.New`
- When possible, keep returned structs as one-liners