### PR TITLE
Local network setup doc - small updates

### DIFF
--- a/docs/development/local-keep-network.adoc
+++ b/docs/development/local-keep-network.adoc
@@ -82,11 +82,11 @@ of the account from above prepended with `0x`:
 }
 ```
 
-Save the path to your data directory and preferred ethereum account in
+Save the path to your data directory and `geth` client's account in
 environment variables:
 ```
 $ export GETH_DATA_DIR=/Users/piotr/ethereum/data/
-$ export ETHEREUM_ACCOUNT=0xca6aa3681a4f6ff5f759fec196d80fb0539b3626
+$ export GETH_ETHEREUM_ACCOUNT=0xdd9fc033955d6fbb4908967bb2fe2a74ec965e92
 ```
 
 ```
@@ -113,7 +113,7 @@ $ geth --port 3000 --networkid 1101 --identity "somerandomidentity" \
     --rpc --rpcport "8545" --rpcaddr "127.0.0.1" --rpccorsdomain "" \
     --rpcapi "db,ssh,miner,admin,eth,net,web3,personal" \
     --datadir=$GETH_DATA_DIR --syncmode "fast" \
-    --miner.etherbase=$ETHEREUM_ACCOUNT --mine --miner.threads=1
+    --miner.etherbase=$GETH_ETHEREUM_ACCOUNT --mine --miner.threads=1
 
 INFO [10-13|13:35:01] Maximum peer count                       ETH=25 LES=0 total=25
 INFO [10-13|13:35:01] Starting peer-to-peer node               instance=Geth/somerandomidentity/v1.8.11-stable/darwin-amd64/go1.10.3


### PR DESCRIPTION
I did not review #350 - my fault. There are two changes I'd like to propose:

#### Use a separate account for Ethereum client and Keep client

Note that we create two addresses with `geth` and one of them - after #350 - is unused. We can use the same account for `geth` and keep but if so, we should create only one address with `geth` at the beginning. Anyway, after we update the signing process, we'll probably need to have each node with its own account so the strategy where `geth` has its own and Keep client has its own makes sense.

#### Set `wsorigins` to `"*"` when starting `geth`.

With `wsorigins` set to `""` Keep client can't attach:
```
2018/10/23 12:28:56 error connecting to Ethereum node: [error Connecting to Geth Server: ws://127.0.0.1:8546 [bad status]]
```

and on `geth` node:
```
WARN [10-23|12:28:56.356] origin 'http://piotrs-macbook-pro.local' not allowed on WS-RPC interface
```

settings `wsorigins` to `"*"` solves the problem.

```
$ geth version
Geth
Version: 1.8.14-stable
Architecture: amd64
Protocol Versions: [63 62]
Network Id: 1
Go Version: go1.10.3
Operating System: darwin
GOPATH=
GOROOT=/usr/local/Cellar/go/1.10.3/libexec
```