### PR TITLE
Add an app layer nonce to wire messages

### DIFF
--- a/pkg/net/gen/pb/message.proto
+++ b/pkg/net/gen/pb/message.proto
@@ -8,14 +8,14 @@ package net;
 // with the contents).
 message NetworkEnvelope {
   // The marshalled network message.
-  bytes network_message = 1;
+  bytes message = 1;
 
   // Signature over the network message.
   bytes signature = 2;
 }
 
-// Message contains a marshalled payload. It also contains the Identities of
-// the sender and receiver. Optionally, a Message may contain an encrypted
+// NetworkMessage contains a marshalled payload. It also contains the Identities
+// of the sender and receiver. Optionally, a Message may contain an encrypted
 // payload for messages which need to be secret; in this case, the encrypted
 // field will be set.
 message NetworkMessage {

--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -207,8 +207,8 @@ func (c *channel) sealEnvelope(
 	}
 
 	return &pb.NetworkEnvelope{
-		NetworkMessage: messageBytes,
-		Signature:      signature,
+		Message:   messageBytes,
+		Signature: signature,
 	}, nil
 }
 
@@ -296,14 +296,14 @@ func (c *channel) processPubsubMessage(pubsubMessage *pubsub.Message) error {
 
 	if err := c.verify(
 		pubsubMessage.GetFrom(),
-		envelope.GetNetworkMessage(),
+		envelope.GetMessage(),
 		envelope.GetSignature(),
 	); err != nil {
 		return err
 	}
 
 	var protoMessage pb.NetworkMessage
-	if err := proto.Unmarshal(envelope.NetworkMessage, &protoMessage); err != nil {
+	if err := proto.Unmarshal(envelope.Message, &protoMessage); err != nil {
 		return err
 	}
 

--- a/pkg/net/libp2p/signature_test.go
+++ b/pkg/net/libp2p/signature_test.go
@@ -131,7 +131,7 @@ func TestRejectMessageWithUnexpectedSignature(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adversarySignature, err := adversaryKey.Sign(envelope.NetworkMessage)
+	adversarySignature, err := adversaryKey.Sign(envelope.Message)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/307

Specifically addresses:

> Include current peer's nonce in the message sent