### PR TITLE
Group selection doc update

### DIFF
--- a/docs/cryptography/beacon_group_selection.adoc
+++ b/docs/cryptography/beacon_group_selection.adoc
@@ -85,7 +85,7 @@ and _N_ properly denotes the number of virtual stakers in _P_.
 |The value of the highest-valued ticket in _P_
 
 |_Space~tickets~_
-|Is a space consiting of all possible tickets. It is strongly related
+|Is a space consisting of all possible tickets. It is strongly related
 with a pseudo random function that is used for ticket generation.
 Currently the _Space~tickets~_ is equal to _2^256^- 1_, which is due
 to selection of SHA3-256 as our pseudo random function.
@@ -121,7 +121,7 @@ above values.
 
 Currently the _Stake~j~_ and _Weight~j~_ can be public and _Q~j~_ can be the 
 ECDSA pubkey of _S~j~_. Future work towards indistinguishable staking would make
-_Stake~j~_ and _Weight~j~_ values private and enable theirs verification via
+_Stake~j~_ and _Weight~j~_ values private and enable their verification via
 zero-knowledge proofs.
 
 == Protocol


### PR DESCRIPTION
From my comments from #245 

1. As it is explicitly mention that our approach will evolve towards indistinguishable staking we also need to mark that the `Weight_j` needs to be private and proved by ZKP. The `Weight_j` is a function of `Stake_j` and for some cases it might be possible to distinguish actual stackers by theirs `Weight_j` values.

2. For future proofing the case when we change our pseudo random function from SHA3-256 to something different we should update our natural threshold description from `Threshold_nat = N * (2^256 - 1) / (Tokens_total / MINIMUM_STAKE)` to `Threshold_nat = N * Ticket_space / (Tokens_total / MINIMUM_STAKE)` and mention that our `Ticket_space` is currently equal to `2^256 - 1` which is the space of all possible outputs of SHA3-256 which is our pseudo random function.

3. In the process of submission and verification of tickets `W_k` we are comparing them tho the `Threshold_nat`. With our current definition of `Threshold_nat` we will have a type mismatch cause `W_k` is a 256bits int and `Threshold_nat` will be a (double) float. I would correct the natural threshold definition with a floor function `Threshold_nat = floor(N * Ticket_space / (Tokens_total / MINIMUM_STAKE))`. And same applies to other definitions of thresholds.