### PR TITLE
[WIP] DKG Phase 13

### DIFF
--- a/pkg/beacon/relay/chain/chain.go
+++ b/pkg/beacon/relay/chain/chain.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/beacon/relay/config"
 	"github.com/keep-network/keep-core/pkg/beacon/relay/event"
+	"github.com/keep-network/keep-core/pkg/beacon/relay/result"
 	"github.com/keep-network/keep-core/pkg/gen/async"
 )
 
@@ -43,4 +44,8 @@ type Interface interface {
 	// RequestRelayEntry makes an on-chain request to start generation of a
 	// random signature.  An event is generated.
 	RequestRelayEntry(blockReward, seed *big.Int) *async.RelayRequestPromise
+	// IsResultPublished checks if the result is already published to the blockchain.
+	IsResultPublished(result *result.Result) bool
+
+	SubmitResult(publisherID int, result *result.Result) *async.ResultPublishPromise
 }

--- a/pkg/beacon/relay/event/event.go
+++ b/pkg/beacon/relay/event/event.go
@@ -42,3 +42,8 @@ type StakerRegistration struct {
 	Index         int
 	GroupMemberID string
 }
+
+type PublishedResult struct {
+	PublisherID int
+	Hash        []byte
+}

--- a/pkg/beacon/relay/gjkr/dkg.go
+++ b/pkg/beacon/relay/gjkr/dkg.go
@@ -4,12 +4,22 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"math/big"
+
+	"github.com/keep-network/keep-core/pkg/chain"
 )
 
 // DKG contains the configuration data needed for the DKG protocol execution.
 type DKG struct {
 	// P, Q are big primes, such that `p = 2q + 1`
 	P, Q *big.Int
+
+	chain chain.Handle
+
+	// Blockchain block heigh when the protocol execution started.
+	// TODO: Move it to chain.BlockCounter ?
+	initialBlockHeight int // t_init
+	expectedDuration   int // t_dkg
+	blockStep          int // t_step
 }
 
 // RandomQ generates a random `big.Int` in range (0, q).

--- a/pkg/beacon/relay/gjkr/group.go
+++ b/pkg/beacon/relay/gjkr/group.go
@@ -21,3 +21,13 @@ func (g *Group) MemberIDs() []int {
 func (g *Group) RegisterMemberID(id int) {
 	g.memberIDs = append(g.memberIDs, id)
 }
+
+func (g *Group) DisqualifiedMembers() []int {
+	// TODO: Implement
+	return []int{}
+}
+
+func (g *Group) InactiveMembers() []int {
+	// TODO: Implement
+	return []int{}
+}

--- a/pkg/beacon/relay/gjkr/member.go
+++ b/pkg/beacon/relay/gjkr/member.go
@@ -3,6 +3,8 @@ package gjkr
 import (
 	"math/big"
 
+	"github.com/keep-network/keep-core/pkg/beacon/relay/result"
+
 	"github.com/keep-network/keep-core/pkg/beacon/relay/pedersen"
 )
 
@@ -72,4 +74,10 @@ type SharingMember struct {
 	// Public values of each polynomial `a` coefficient defined in secretCoefficients
 	// field. It is denoted as `A_ik` in protocol specification.
 	publicCoefficients []*big.Int
+}
+
+type PublishingMember struct {
+	*SharingMember
+
+	result *result.Result
 }

--- a/pkg/beacon/relay/gjkr/protocol_commitments_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_commitments_test.go
@@ -240,7 +240,7 @@ func predefinedDKG() (*DKG, error) {
 	if !result {
 		return nil, fmt.Errorf("failed to initialize q")
 	}
-	return &DKG{p, q}, nil
+	return &DKG{P: p, Q: q}, nil
 }
 
 func filterPeerSharesMessage(

--- a/pkg/beacon/relay/gjkr/publish.go
+++ b/pkg/beacon/relay/gjkr/publish.go
@@ -1,0 +1,93 @@
+package gjkr
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/keep-network/keep-core/pkg/beacon/relay/event"
+	"github.com/keep-network/keep-core/pkg/beacon/relay/result"
+)
+
+func (pm *PublishingMember) PrepareResult() error {
+	// if nPlayers(IA + DQ) > T/2:
+	//   correctResult = Result.failure(disqualified = DQ)
+	// else:
+	//   correctResult = Result.success(pubkey = Y, inactive = IA, disqualified = DQ)
+
+	// resultHash = hash(correctResult)
+
+	pm.result = &result.Result{
+		Type:           result.MixedSuccess, // TODO: Implement all types
+		GroupPublicKey: big.NewInt(123),     // TODO: Use group public key after Phase 12 is merged
+		Disqualified:   pm.group.DisqualifiedMembers(),
+		Inactive:       pm.group.InactiveMembers(),
+	}
+
+	return nil
+}
+
+func (pm *PublishingMember) PublishResult(result *result.Result, t_dkg int) (*event.PublishedResult, error) {
+	chainRelay := pm.protocolConfig.chain.ThresholdRelay()
+	// while not resultPublished:
+	for !chainRelay.IsResultPublished(result) {
+		publisherID, err := pm.determinePublisherID() // j
+		if err != nil {
+			return nil, err
+		}
+		//   if j >= i:
+		if publisherID >= pm.ID {
+			errors := make(chan error)
+			eventPublish := make(chan *event.PublishedResult)
+			// broadcast(correctResult)
+			chainRelay.SubmitResult(
+				pm.ID,
+				result,
+			).OnComplete(func(publish *event.PublishedResult, err error) {
+				eventPublish <- publish
+				errors <- err
+			})
+			return <-eventPublish, <-errors
+		}
+	}
+	return nil, nil
+}
+
+func (pm *PublishingMember) determinePublisherID() (int, error) {
+	t_dkg := pm.protocolConfig.expectedDuration
+	t_step := pm.protocolConfig.blockStep
+
+	blockCounter, err := pm.protocolConfig.chain.BlockCounter()
+	if err != nil {
+		return 0, err
+	}
+	//   T_now = getCurrentBlockHeight()
+	t_now, err := blockCounter.CurrentBlock()
+	if err != nil {
+		return 0, err
+	}
+
+	// # using T_init from phase 1
+	t_init := pm.protocolConfig.initialBlockHeight
+	//   T_elapsed = T_now - T_init
+	t_elapsed := t_now - t_init
+
+	// # determine highest index j eligible to submit
+	// if T_elapsed <= T_dkg:
+	var playerIndex int
+	if t_elapsed <= t_dkg {
+		// j = 1
+		playerIndex = 0
+		//   else:
+	} else {
+		//     T_over = T_elapsed - T_dkg
+		t_over := t_elapsed - t_dkg
+		//     j = 1 + ceiling(T_over / T_step)
+		playerIndex = int(math.Ceil(float64(t_over / t_step)))
+	}
+	if playerIndex > pm.group.groupSize {
+		panic(fmt.Errorf("player index %d out of group size", playerIndex))
+	}
+	j := pm.group.MemberIDs()[playerIndex]
+	return j, nil
+}

--- a/pkg/beacon/relay/gjkr/publish_test.go
+++ b/pkg/beacon/relay/gjkr/publish_test.go
@@ -1,0 +1,162 @@
+package gjkr
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/beacon/relay/event"
+	"github.com/keep-network/keep-core/pkg/beacon/relay/result"
+	"github.com/keep-network/keep-core/pkg/chain/local"
+)
+
+func TestPublishResult(t *testing.T) {
+	members, err := initializePublishingMembersGroup(1, 3)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	member := members[0]
+
+	chainRelay := member.protocolConfig.chain.ThresholdRelay()
+
+	result1 := &result.Result{GroupPublicKey: big.NewInt(1)}
+	expectedEvent := &event.PublishedResult{
+		PublisherID: member.ID,
+		Hash:        []byte(fmt.Sprintf("%v", result1)),
+	}
+	if chainRelay.IsResultPublished(result1) {
+		t.Fatalf("Result is already published on chain")
+	}
+
+	eventPublish, err := member.PublishResult(result1, 5)
+	if err != nil {
+		t.Fatalf("\nexpected: %s\nactual:   %s\n", "", err)
+	}
+	if !reflect.DeepEqual(expectedEvent, eventPublish) {
+		t.Fatalf("\nexpected: %v\nactual:   %v\n", expectedEvent, eventPublish)
+	}
+
+	if !chainRelay.IsResultPublished(result1) {
+		t.Fatalf("Result should be published on chain")
+	}
+
+	result2 := &result.Result{GroupPublicKey: big.NewInt(2)}
+	if chainRelay.IsResultPublished(result2) {
+		t.Fatalf("Result is already published on chain")
+	}
+	eventPublish2, err := member.PublishResult(result2, 5)
+	expectedEvent2 := &event.PublishedResult{
+		PublisherID: member.ID,
+		Hash:        []byte(fmt.Sprintf("%v", result2)),
+	}
+	if err != nil {
+		t.Fatalf("\nexpected: %s\nactual:   %s\n", "", err)
+	}
+	if !reflect.DeepEqual(expectedEvent2, eventPublish2) {
+		t.Fatalf("\nexpected: %v\nactual:   %v\n", expectedEvent2, eventPublish2)
+	}
+
+	if !chainRelay.IsResultPublished(result2) {
+		t.Fatalf("Result should be published on chain")
+	}
+}
+
+func TestPublishResult2(t *testing.T) {
+	members, err := initializePublishingMembersGroup(1, 3)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	member := members[0]
+
+	result1 := &result.Result{GroupPublicKey: big.NewInt(20001)}
+	expectedEvent1 := &event.PublishedResult{
+		PublisherID: members[0].ID,
+		Hash:        []byte(fmt.Sprintf("%v", result1)),
+	}
+	eventPublish1, err := member.PublishResult(result1, 5)
+	if err != nil {
+		t.Fatalf("\nexpected: %s\nactual:   %s\n", "", err)
+	}
+	if !reflect.DeepEqual(expectedEvent1, eventPublish1) {
+		t.Fatalf("\nexpected: %v\nactual:   %v\n", expectedEvent1, eventPublish1)
+	}
+
+	member = members[1]
+	eventPublish21, err := member.PublishResult(result1, 5)
+	// expectedError := fmt.Errorf("sad")
+	// if !reflect.DeepEqual(expectedError, err) {
+	// 	t.Fatalf("\nexpected: %s\nactual:   %s\n", "", err)
+	// }
+	if eventPublish21 != nil {
+		t.Fatalf("\nexpected: %v\nactual:   %v\n", nil, eventPublish21)
+	}
+
+	result2 := &result.Result{GroupPublicKey: big.NewInt(20002)}
+	expectedEvent2 := &event.PublishedResult{
+		PublisherID: members[1].ID,
+		Hash:        []byte(fmt.Sprintf("%v", result2)),
+	}
+	eventPublish2, err := member.PublishResult(result2, 5)
+	if err != nil {
+		t.Fatalf("\nexpected: %s\nactual:   %s\n", "", err)
+	}
+	if !reflect.DeepEqual(expectedEvent2, eventPublish2) {
+		t.Fatalf("\nexpected: %v\nactual:   %v\n", expectedEvent2, eventPublish2)
+	}
+
+}
+
+func initializePublishingMembersGroup(threshold, groupSize int) ([]*PublishingMember, error) {
+	chain := local.Connect(10, 4)
+	blockCounter, err := chain.BlockCounter()
+	if err != nil {
+		return nil, err
+	}
+	err = blockCounter.WaitForBlocks(1)
+	if err != nil {
+		return nil, err
+	}
+
+	initialBlockHeight, err := blockCounter.CurrentBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	dkg := &DKG{
+		chain:              chain,
+		expectedDuration:   4,
+		blockStep:          1,
+		initialBlockHeight: initialBlockHeight,
+	}
+
+	group := &Group{
+		groupSize:          groupSize,
+		dishonestThreshold: threshold,
+	}
+
+	var members []*PublishingMember
+
+	for i := 1; i <= groupSize; i++ {
+		id := i
+		members = append(members,
+			&PublishingMember{
+				SharingMember: &SharingMember{
+					QualifiedMember: &QualifiedMember{
+						SharesJustifyingMember: &SharesJustifyingMember{
+							CommittingMember: &CommittingMember{
+								memberCore: &memberCore{
+									ID:             id,
+									group:          group,
+									protocolConfig: dkg,
+								},
+							},
+						},
+					},
+				},
+			})
+		group.RegisterMemberID(id)
+	}
+	return members, nil
+}

--- a/pkg/beacon/relay/result/result.go
+++ b/pkg/beacon/relay/result/result.go
@@ -1,0 +1,28 @@
+package result
+
+import (
+	"fmt"
+	"math/big"
+)
+
+type ResultType int
+
+const (
+	NoFaultFailure ResultType = iota
+	FailureDQ
+	PerfectSuccess
+	SuccessIA
+	SuccessDQ
+	MixedSuccess
+)
+
+type Result struct {
+	Type           ResultType
+	GroupPublicKey *big.Int `json:"pubkey"`
+	Disqualified   []int    `json:"disqualified"`
+	Inactive       []int    `json:"inactive"`
+}
+
+func (r *Result) Hash() []byte {
+	return []byte(fmt.Sprintf("%v", r))
+}

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -14,6 +14,8 @@ type BlockCounter interface {
 	// BlockWaiter returns a channel that will emit the current block height
 	// after the given number of blocks has elapsed and then immediately close.
 	BlockWaiter(numBlocks int) (<-chan int, error)
+	// CurrentBlock returns the current block heigh.
+	CurrentBlock() (int, error)
 }
 
 // Handle represents a handle to a blockchain that provides access to the core

--- a/pkg/chain/ethereum/blockcounter.go
+++ b/pkg/chain/ethereum/blockcounter.go
@@ -68,6 +68,11 @@ func (ebc *ethereumBlockCounter) BlockWaiter(
 	return newWaiter, nil
 }
 
+// CurrentBlock returns the current block number.
+func (ebc *ethereumBlockCounter) CurrentBlock() (int, error) {
+	return ebc.latestBlockHeight, nil
+}
+
 // receiveBlocks gets each new block back from Geth and extracts the
 // block height (topBlockNumber) form it.  For each block height that is being
 // waited on a message will be sent.

--- a/pkg/chain/local/blockcounter.go
+++ b/pkg/chain/local/blockcounter.go
@@ -48,6 +48,11 @@ func (counter *localBlockCounter) BlockWaiter(numBlocks int) (<-chan int, error)
 	return newWaiter, nil
 }
 
+// CurrentBlock returns the current block number.
+func (counter *localBlockCounter) CurrentBlock() (int, error) {
+	return counter.blockHeight, nil
+}
+
 // count is an internal function that counts up time to simulate the generation
 // of blocks.
 func (counter *localBlockCounter) count() {

--- a/pkg/gen/async.go
+++ b/pkg/gen/async.go
@@ -62,6 +62,11 @@ func main() {
 			Prefix:     "RelayRequest",
 			outputFile: "relay_entry_requested_promise.go",
 		},
+		{
+			Type:       "*event.PublishedResult",
+			Prefix:     "ResultPublish",
+			outputFile: "event_result_publish_promise.go",
+		},
 	}
 
 	if err := generatePromisesCode(configs); err != nil {


### PR DESCRIPTION

### [Phase 13: Result publication](http://docs.keep.network/cryptography/beacon_dkg.html#_phase_13_result_publication)

Let _IA = IA_1 + IA_2 + ... + IA_10_

Let _DQ = DQ_1 + DQ_2 + ... + DQ_10_

Player _P_1_ is the participant designated to submit the result on-chain.
However, if _P_1_ does not submit a transaction within _T_dkg_ blocks of starting the key generation protocol, _P_2_ becomes eligible to submit the public key.
After _T_dkg + T_step_ blocks, _P_3_ becomes eligible, after _T_dkg + 2 * T_step_ blocks _P_4_, and so on.

When _P_j_ submits the result, players _P_k | k < j_ will face a small penalty for being late,  while _P_j_ will receive the submission reward.

``` python
if nPlayers(IA + DQ) > T/2:
  correctResult = Result.failure(disqualified = DQ)
else:
  correctResult = Result.success(pubkey = Y, inactive = IA, disqualified = DQ)

resultHash = hash(correctResult)

alreadySubmitted = False
resultPublished = False
finished = False

while not resultPublished:
  T_now = getCurrentBlockHeight()

  # using T_init from phase 1
  T_elapsed = T_now - T_init

  # determine highest index j eligible to submit
  if T_elapsed <= T_dkg:
    j = 1
  else:
    T_over = T_elapsed - T_dkg
    j = 1 + ceiling(T_over / T_step)

  if j >= i:
    broadcast(correctResult)
    resultPublished = True
    alreadySubmitted = True
  else:
    resultPublished = checkChainForResult()
```