### PR TITLE
DKG protocol specification updates (2)

### DIFF
--- a/docs/cryptography/beacon_dkg.adoc
+++ b/docs/cryptography/beacon_dkg.adoc
@@ -475,7 +475,7 @@ for m in (G_6 - G_11): # <1>
     for k in is_m, s_mk in ss_m:
       a_mk = product(
         for l in is_m, l /= k:
-          k / (k - l)
+          l / (l - k)
       )
       s_mk * a_mk
   )


### PR DESCRIPTION
* Phase 11 pseudocoude was fixed to calculate `l / (l - k)` instead of `k
/ (k - l)`.
This was corrected based on [conversation](https://www.flowdock.com/app/cardforcoin/keep/threads/XbRLZ1ALU_Y6lyew8SMgNgSI-uU).
* Added `mod q` operation to `z_mk` calculation in Phase 11, according to [discussion](https://www.flowdock.com/app/cardforcoin/tech/threads/o_Y6lsdOokqrFaDhPxpomQn_5Ma).