### PR TITLE
[WIP] Update DKG yellowpaper for BLS

### DIFF
--- a/docs/yellowpaper/beacon/dkg-util.py
+++ b/docs/yellowpaper/beacon/dkg-util.py
@@ -11,10 +11,9 @@ def ecSum(points):
 
 
 def evaluateAt(z, coeffs):
-    Q = BLS_CURVE_ORDER
     return sum([
         coeffs[k] * z^k for k in [0..T]
-    ]) % Q
+    ]) % SECRET_SHARING_FIELD_ORDER
 
 
 def ephemeralPubkey(senderIndex, recipientIndex):

--- a/docs/yellowpaper/beacon/dkg.py
+++ b/docs/yellowpaper/beacon/dkg.py
@@ -97,15 +97,13 @@ for complaint in messages[4]:
 # PHASE 6
 #
 
-# q = curveOrder
-
 self.x = sum([
     self.shares[j].share_S for j in goodParticipants[6]
-]) % BLS_CURVE_ORDER
+]) % BLS_G1_ORDER
 
 self.x_prime = sum([
     self.shares[j].share_T for j in goodParticipants[6]
-]) % BLS_CURVE_ORDER
+]) % BLS_G1_ORDER
 
 #
 # PHASE 7


### PR DESCRIPTION
New pseudocode updating the group operations for BLS curve G1, and hopefully improving the readability and coherence of the pseudocode (which is now even closer to compiling as python).

Summary of changes:
- private keys and shares are scalars for G1
- commitments etc. for the VSS scheme are performed on G1 instead of the prime field
- more thorough handling of misbehaviour and other failures
- utility functions added to improve structure
- pseudocode math should now correspond 1-1 to GJKR paper, to eliminate source of typos
- variables given more descriptive names wrt their roles, with local aliases where necessary to show correspondence with the math formulae

TODO:
- incorporate the changes to the main document, and update the non-code sections
- early and late phases are less precisely defined than the middle