### PR TITLE
Turbo TeX: Boost TeX doc build performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
             - /caches/client.tar
   generate_docs_tex:
     docker:
-      - image: thomasweise/texlive
+      - image: keepnetwork/texlive:3
     steps:
       - checkout
       - run:

--- a/docs/scripts/generate-pngs.sh
+++ b/docs/scripts/generate-pngs.sh
@@ -23,5 +23,5 @@ pdflatex -halt-on-error $target_basename.tex $target_basename.pdf
 
 mkdir -p $img_dir
 echo "Generating $img_dir/$target_basename.png from $target_basename.pdf..."
-gs -dNOPAUSE -sDEVICE=pngalpha -dFirstPage=1 -dLastPage=1 -sOutputFile=$img_dir/$target_basename.png -r300 -q $target_basename.pdf -c quit
+pdftoppm $target_basename.pdf $img_dir/$target_basename -png -f 1 -singlefile -rx 300 -ry 300
 echo "Finished with exit status $?."


### PR DESCRIPTION
In particular, a swap to a custom-built minimal texlive docker image
means a much shorter pull time as the new image is much smaller.
Additionally, we change to `pdftoppm` for generating PNGs from PDFs as
there were issues with Ghostscript in Alpine Linux.

Build time for `generate_docs_tex` is down from ~80-100s to ~20s.