### PR TITLE
Introduced ephemeral.KeyPair struct

### DIFF
--- a/pkg/net/ephemeral/full_ecdh_test.go
+++ b/pkg/net/ephemeral/full_ecdh_test.go
@@ -8,13 +8,13 @@ func TestFullEcdh(t *testing.T) {
 	//
 
 	// player 1
-	privKey1, pubKey1, err := GenerateKeypair()
+	keyPair1, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// player 2
-	privKey2, pubKey2, err := GenerateKeypair()
+	keyPair2, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,10 +24,10 @@ func TestFullEcdh(t *testing.T) {
 	//
 
 	// player 1:
-	symmetricKey1 := privKey1.Ecdh(pubKey2)
+	symmetricKey1 := keyPair1.PrivateKey.Ecdh(keyPair2.PublicKey)
 
 	// player 2:
-	symmetricKey2 := privKey2.Ecdh(pubKey1)
+	symmetricKey2 := keyPair2.PrivateKey.Ecdh(keyPair1.PublicKey)
 
 	//
 	// players use symmetric key for encryption/decryption

--- a/pkg/net/ephemeral/private_key.go
+++ b/pkg/net/ephemeral/private_key.go
@@ -12,22 +12,31 @@ type PrivateKey btcec.PrivateKey
 // PublicKey is an ephemeral public elliptic curve key.
 type PublicKey btcec.PublicKey
 
+// KeyPair is a pair of ephemeral elliptic curve private and public key.
+type KeyPair struct {
+	PrivateKey *PrivateKey
+	PublicKey  *PublicKey
+}
+
 func curve() *btcec.KoblitzCurve {
 	return btcec.S256()
 }
 
-// GenerateKeypair generates a pair of public and private ephemeral keys
-// that can be used as an input for ECDH.
-func GenerateKeypair() (*PrivateKey, *PublicKey, error) {
+// GenerateKeyPair generates a pair of public and private elliptic curve
+// ephemeral key that can be used as an input for ECDH.
+func GenerateKeyPair() (*KeyPair, error) {
 	ecdsaKey, err := btcec.NewPrivateKey(curve())
 	if err != nil {
-		return nil, nil, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"could not generate new ephemeral keypair [%v]",
 			err,
 		)
 	}
 
-	return (*PrivateKey)(ecdsaKey), (*PublicKey)(&ecdsaKey.PublicKey), nil
+	return &KeyPair{
+		(*PrivateKey)(ecdsaKey),
+		(*PublicKey)(&ecdsaKey.PublicKey),
+	}, nil
 }
 
 // UnmarshalPrivateKey turns a slice of bytes into a `PrivateKey`.

--- a/pkg/net/ephemeral/private_key_test.go
+++ b/pkg/net/ephemeral/private_key_test.go
@@ -6,10 +6,12 @@ import (
 )
 
 func TestMarshalUnmarshalPublicKey(t *testing.T) {
-	_, pubKey, err := GenerateKeypair()
+	keyPair, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	pubKey := keyPair.PublicKey
 
 	marshalled := pubKey.Marshal()
 
@@ -24,10 +26,12 @@ func TestMarshalUnmarshalPublicKey(t *testing.T) {
 }
 
 func TestMarshalUnmarshalPrivateKey(t *testing.T) {
-	privKey, _, err := GenerateKeypair()
+	keyPair, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	privKey := keyPair.PrivateKey
 
 	marshalled := privKey.Marshal()
 


### PR DESCRIPTION
Refs:#310
Refs:#312

The reason for introducing the `KeyPair` struct is to make the key management easier for DKG group members. Each DKG group member needs to hold a `KeyPair` of ephemeral keys that were used for creating a `SymmetricKey` with each other group member. In case of an accusation, accuser reveals the private ephemeral key that was used to create a `SymmetricKey` with the accused party.