### PR TITLE
Ensure map is keyed for the correct type

### DIFF
--- a/pkg/beacon/relay/gjkr/member.go
+++ b/pkg/beacon/relay/gjkr/member.go
@@ -33,7 +33,7 @@ type EphemeralKeyGeneratingMember struct {
 	*memberCore
 	// Ephemeral key pairs used to create symmetric keys,
 	// generated individually for each other group member.
-	ephemeralKeys map[int]*ephemeral.KeyPair
+	ephemeralKeys map[MemberID]*ephemeral.KeyPair
 }
 
 // SymmetricKeyGeneratingMember represents one member in a distributed key


### PR DESCRIPTION
MemberID is now uint32, not int.