### PR TITLE
DKG: Replace `peer` with `other member` in DKG impl

### DIFF
--- a/pkg/beacon/relay/gjkr/gen/pb/message.proto
+++ b/pkg/beacon/relay/gjkr/gen/pb/message.proto
@@ -4,21 +4,21 @@ option go_package = "pb";
 package gjkr;
 
 message EphemeralPublicKey {
-    bytes senderID = 1;
-    bytes receiverID = 2;
-    bytes ephemeralPublicKey = 3;
+  bytes senderID = 1;
+  bytes receiverID = 2;
+  bytes ephemeralPublicKey = 3;
 }
 
 message MemberCommitments {
-    bytes senderID = 1;
-    repeated bytes commitments = 2;
+  bytes senderID = 1;
+  repeated bytes commitments = 2;
 }
 
-message PeerShares {
-    bytes senderID = 1;
-    bytes receiverID = 2;
-    bytes encryptedShareS = 3;
-    bytes encryptedShareT = 4;
+message OtherMemberShares {
+  bytes senderID = 1;
+  bytes receiverID = 2;
+  bytes encryptedShareS = 3;
+  bytes encryptedShareT = 4;
 }
 
 message SecretSharesAccusations {
@@ -27,8 +27,8 @@ message SecretSharesAccusations {
 }
 
 message MemberPublicKeySharePoints {
-    bytes senderID = 1;
-    repeated bytes publicKeySharePoints = 2;
+  bytes senderID = 1;
+  repeated bytes publicKeySharePoints = 2;
 }
 
 message PointsAccusations {

--- a/pkg/beacon/relay/gjkr/marshaling.go
+++ b/pkg/beacon/relay/gjkr/marshaling.go
@@ -86,34 +86,34 @@ func (mcm *MemberCommitmentsMessage) Unmarshal(bytes []byte) error {
 	return nil
 }
 
-// Type returns a string describing a PeerSharesMessage type for marshaling
+// Type returns a string describing a OtherMemberSharesMessage type for marshaling
 // purposes
-func (psm *PeerSharesMessage) Type() string {
-	return "gjkr/peer_shares"
+func (omsm *OtherMemberSharesMessage) Type() string {
+	return "gjkr/other_member_shares"
 }
 
-// Marshal converts this PeerSharesMessage to a byte array suitable for
+// Marshal converts this OtherMemberSharesMessage to a byte array suitable for
 // network communication.
-func (psm *PeerSharesMessage) Marshal() ([]byte, error) {
-	return (&pb.PeerShares{
-		SenderID:        memberIDToBytes(psm.senderID),
-		ReceiverID:      memberIDToBytes(psm.receiverID),
-		EncryptedShareS: psm.encryptedShareS,
-		EncryptedShareT: psm.encryptedShareT,
+func (omsm *OtherMemberSharesMessage) Marshal() ([]byte, error) {
+	return (&pb.OtherMemberShares{
+		SenderID:        memberIDToBytes(omsm.senderID),
+		ReceiverID:      memberIDToBytes(omsm.receiverID),
+		EncryptedShareS: omsm.encryptedShareS,
+		EncryptedShareT: omsm.encryptedShareT,
 	}).Marshal()
 }
 
-// Unmarshal converts a byte array produced by Marshal to a PeerSharesMessage.
-func (psm *PeerSharesMessage) Unmarshal(bytes []byte) error {
-	pbMsg := pb.PeerShares{}
+// Unmarshal converts a byte array produced by Marshal to a OtherMemberSharesMessage.
+func (omsm *OtherMemberSharesMessage) Unmarshal(bytes []byte) error {
+	pbMsg := pb.OtherMemberShares{}
 	if err := pbMsg.Unmarshal(bytes); err != nil {
 		return err
 	}
 
-	psm.senderID = bytesToMemberID(pbMsg.SenderID)
-	psm.receiverID = bytesToMemberID(pbMsg.ReceiverID)
-	psm.encryptedShareS = pbMsg.EncryptedShareS
-	psm.encryptedShareT = pbMsg.EncryptedShareT
+	omsm.senderID = bytesToMemberID(pbMsg.SenderID)
+	omsm.receiverID = bytesToMemberID(pbMsg.ReceiverID)
+	omsm.encryptedShareS = pbMsg.EncryptedShareS
+	omsm.encryptedShareT = pbMsg.EncryptedShareT
 
 	return nil
 }

--- a/pkg/beacon/relay/gjkr/marshaling_test.go
+++ b/pkg/beacon/relay/gjkr/marshaling_test.go
@@ -53,14 +53,14 @@ func TestMemberCommitmentsMessageRoundtrip(t *testing.T) {
 	}
 }
 
-func TestPeerSharesMessageRoundtrip(t *testing.T) {
-	msg := &PeerSharesMessage{
+func TestOtherMemberSharesMessageRoundtrip(t *testing.T) {
+	msg := &OtherMemberSharesMessage{
 		senderID:        MemberID(997),
 		receiverID:      MemberID(112),
 		encryptedShareS: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
 		encryptedShareT: []byte{0x0F, 0x0E, 0x0D, 0x0C, 0x0B},
 	}
-	unmarshaled := &PeerSharesMessage{}
+	unmarshaled := &OtherMemberSharesMessage{}
 
 	err := pbutils.RoundTrip(msg, unmarshaled)
 	if err != nil {

--- a/pkg/beacon/relay/gjkr/member.go
+++ b/pkg/beacon/relay/gjkr/member.go
@@ -83,15 +83,15 @@ type CommittingMember struct {
 type CommitmentsVerifyingMember struct {
 	*CommittingMember
 
-	// Shares calculated for the current member by peer group members which passed
+	// Shares calculated for the current member by other group members which passed
 	// the validation.
 	//
 	// receivedValidSharesS are defined as `s_ji` and receivedValidSharesT are
 	// defined as `t_ji` across the protocol specification.
 	receivedValidSharesS, receivedValidSharesT map[MemberID]*big.Int
-	// Commitments to coefficients received from peer group members which passed
+	// Commitments to coefficients received from other group members which passed
 	// the validation.
-	receivedValidPeerCommitments map[MemberID][]*big.Int
+	receivedValidOtherMemberCommitments map[MemberID][]*big.Int
 }
 
 // SharesJustifyingMember represents one member in a threshold key sharing group,
@@ -119,7 +119,7 @@ type QualifiedMember struct {
 
 // SharingMember represents one member in a threshold key sharing group, after it
 // has been qualified to the master private key sharing group. A member shares
-// public values of it's polynomial coefficients with peer members.
+// public values of it's polynomial coefficients with other members.
 //
 // Executes Phase 7 and Phase 8 of the protocol.
 type SharingMember struct {
@@ -129,9 +129,9 @@ type SharingMember struct {
 	// field. It is denoted as `A_ik` in protocol specification. The zeroth
 	// public key share point `A_i0` is a member's public key share.
 	publicKeySharePoints []*big.Int
-	// Public key share points received from peer group members which passed the
+	// Public key share points received from other group members which passed the
 	// validation. Defined as `A_jk` across the protocol documentation.
-	receivedValidPeerPublicKeySharePoints map[MemberID][]*big.Int
+	receivedValidOtherMemberPublicKeySharePoints map[MemberID][]*big.Int
 }
 
 // individualPublicKey returns current member's individual public key.
@@ -140,19 +140,19 @@ func (rm *ReconstructingMember) individualPublicKey() *big.Int {
 	return rm.publicKeySharePoints[0]
 }
 
-// receivedValidPeerIndividualPublicKeys returns individual public keys received
-// from peer members which passed the validation. Individual public key is zeroth
+// receivedValidOtherMemberIndividualPublicKeys returns individual public keys received
+// from other members which passed the validation. Individual public key is zeroth
 // public key share point `A_j0`.
-func (sm *SharingMember) receivedValidPeerIndividualPublicKeys() []*big.Int {
-	var receivedValidPeerIndividualPublicKeys []*big.Int
+func (sm *SharingMember) receivedValidOtherMemberIndividualPublicKeys() []*big.Int {
+	var receivedValidOtherMemberIndividualPublicKeys []*big.Int
 
-	for _, peerPublicKeySharePoints := range sm.receivedValidPeerPublicKeySharePoints {
-		receivedValidPeerIndividualPublicKeys = append(
-			receivedValidPeerIndividualPublicKeys,
-			peerPublicKeySharePoints[0],
+	for _, otherMemberPublicKeySharePoints := range sm.receivedValidOtherMemberPublicKeySharePoints {
+		receivedValidOtherMemberIndividualPublicKeys = append(
+			receivedValidOtherMemberIndividualPublicKeys,
+			otherMemberPublicKeySharePoints[0],
 		)
 	}
-	return receivedValidPeerIndividualPublicKeys
+	return receivedValidOtherMemberIndividualPublicKeys
 }
 
 // PointsJustifyingMember represents one member in a threshold key sharing group,

--- a/pkg/beacon/relay/gjkr/message_buffer.go
+++ b/pkg/beacon/relay/gjkr/message_buffer.go
@@ -33,13 +33,13 @@ type messageBuffer interface {
 		receiver int,
 	) *EphemeralPublicKeyMessage
 
-	// peerSharesMessage returns the `PeerShareMessage` broadcast in the third
-	// protocol round by the given sender for the given receiver. It is required
-	// to pass an `ephemeral.SymmetricKey` used to encrypt the communication
-	// between the sender and receiver.
-	peerSharesMessage(
+	// otherMemberSharesMessage returns the `OtherMemberSharesMessage` broadcast
+	// in the third protocol round by the given sender for the given receiver.
+	// It is required to pass an `ephemeral.SymmetricKey` used to encrypt the
+	// communication between the sender and receiver.
+	otherMemberSharesMessage(
 		sender int,
 		receiver int,
 		key ephemeral.SymmetricKey,
-	) *PeerSharesMessage
+	) *OtherMemberSharesMessage
 }

--- a/pkg/beacon/relay/gjkr/message_test.go
+++ b/pkg/beacon/relay/gjkr/message_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/keep-network/keep-core/pkg/net/ephemeral"
 )
 
-func TestCreateNewPeerSharesMessage(t *testing.T) {
+func TestCreateNewOtherMemberSharesMessage(t *testing.T) {
 	shareS := big.NewInt(1381319)
 	shareT := big.NewInt(1010212)
 
-	peerSharesMessage, key, err := newTestPeerSharesMessage(shareS, shareT)
+	otherMemberSharesMessage, key, err := newTestOtherMemberSharesMessage(shareS, shareT)
 
-	decryptedS, err := peerSharesMessage.decryptShareS(key)
+	decryptedS, err := otherMemberSharesMessage.decryptShareS(key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	decryptedT, err := peerSharesMessage.decryptShareT(key)
+	decryptedT, err := otherMemberSharesMessage.decryptShareT(key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,20 +42,20 @@ func TestCreateNewPeerSharesMessage(t *testing.T) {
 
 func TestCanDecrypt(t *testing.T) {
 	var tests = map[string]struct {
-		modifyMessage  func(msg *PeerSharesMessage)
+		modifyMessage  func(msg *OtherMemberSharesMessage)
 		expectedResult bool
 	}{
 		"decryption possible": {
 			expectedResult: true,
 		},
 		"decryption not possible - invalid S": {
-			modifyMessage: func(msg *PeerSharesMessage) {
+			modifyMessage: func(msg *OtherMemberSharesMessage) {
 				msg.encryptedShareS = []byte{0x01, 0x02, 0x03}
 			},
 			expectedResult: false,
 		},
 		"decryption not possible - invalid T": {
-			modifyMessage: func(msg *PeerSharesMessage) {
+			modifyMessage: func(msg *OtherMemberSharesMessage) {
 				msg.encryptedShareT = []byte{0x04, 0x05, 0x06}
 			},
 			expectedResult: false,
@@ -67,7 +67,7 @@ func TestCanDecrypt(t *testing.T) {
 			shareS := big.NewInt(90787123)
 			shareT := big.NewInt(62829113)
 
-			message, key, err := newTestPeerSharesMessage(shareS, shareT)
+			message, key, err := newTestOtherMemberSharesMessage(shareS, shareT)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -89,9 +89,8 @@ func TestCanDecrypt(t *testing.T) {
 	}
 }
 
-func newTestPeerSharesMessage(shareS, shareT *big.Int) (
-	*PeerSharesMessage,
-	ephemeral.SymmetricKey,
+func newTestOtherMemberSharesMessage(shareS, shareT *big.Int) (
+	*OtherMemberSharesMessage, ephemeral.SymmetricKey,
 	error,
 ) {
 	keyPair1, err := ephemeral.GenerateKeyPair()
@@ -106,10 +105,10 @@ func newTestPeerSharesMessage(shareS, shareT *big.Int) (
 
 	key := keyPair1.PrivateKey.Ecdh(keyPair2.PublicKey)
 
-	peerSharesMessage, err := newPeerSharesMessage(1, 2, shareS, shareT, key)
+	otherMemberSharesMessage, err := newOtherMemberSharesMessage(1, 2, shareS, shareT, key)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return peerSharesMessage, key, nil
+	return otherMemberSharesMessage, key, nil
 }

--- a/pkg/beacon/relay/gjkr/protocol_accusations_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_accusations_test.go
@@ -90,8 +90,8 @@ func TestResolveSecretSharesAccusations(t *testing.T) {
 			}
 
 			if test.modifyCommitments != nil {
-				member.receivedValidPeerCommitments[test.accusedID] =
-					test.modifyCommitments(member.receivedValidPeerCommitments[test.accusedID])
+				member.receivedValidOtherMemberCommitments[test.accusedID] =
+					test.modifyCommitments(member.receivedValidOtherMemberCommitments[test.accusedID])
 			}
 
 			result, err := member.ResolveSecretSharesAccusations(
@@ -178,8 +178,8 @@ func TestResolvePublicKeySharePointsAccusations(t *testing.T) {
 				revealedShareS = test.modifyShareS(revealedShareS)
 			}
 			if test.modifyPublicKeySharePoints != nil {
-				member.receivedValidPeerPublicKeySharePoints[test.accusedID] =
-					test.modifyPublicKeySharePoints(member.receivedValidPeerPublicKeySharePoints[test.accusedID])
+				member.receivedValidOtherMemberPublicKeySharePoints[test.accusedID] =
+					test.modifyPublicKeySharePoints(member.receivedValidOtherMemberPublicKeySharePoints[test.accusedID])
 			}
 			result, err := member.ResolvePublicKeySharePointsAccusations(
 				test.accuserID,
@@ -220,8 +220,8 @@ func findCoefficientsJustifyingMemberByID(
 // InitializeSharesJustifyingMemberGroup generates a group of members and simulates
 // shares calculation and commitments sharing betwen members (Phases 3 and 4).
 // It generates coefficients for each group member, calculates commitments and
-// shares for each peer member individually. At the end it stores values for each
-// member just like they would be received from peers.
+// shares for each other member individually. At the end it stores values for each
+// member just like they would be received from others.
 func initializeSharesJustifyingMemberGroup(threshold, groupSize int, dkg *DKG) ([]*SharesJustifyingMember, error) {
 	commitmentsVerifyingMembers, err := initializeCommitmentsVerifiyingMembersGroup(threshold, groupSize, dkg)
 	if err != nil {
@@ -268,13 +268,13 @@ func initializeSharesJustifyingMemberGroup(threshold, groupSize int, dkg *DKG) (
 		groupCommitments[m.ID] = commitments
 	}
 	// Simulate phase where members are calculating shares individually for each
-	// peer member and store received shares and commitments from peers.
+	// other member and store received shares and commitments from others.
 	for _, m := range sharesJustifyingMembers {
 		for _, p := range sharesJustifyingMembers {
 			if m.ID != p.ID {
 				p.receivedValidSharesS[m.ID] = m.evaluateMemberShare(p.ID, groupCoefficientsA[m.ID])
 				p.receivedValidSharesT[m.ID] = m.evaluateMemberShare(p.ID, groupCoefficientsB[m.ID])
-				p.receivedValidPeerCommitments[m.ID] = groupCommitments[m.ID]
+				p.receivedValidOtherMemberCommitments[m.ID] = groupCommitments[m.ID]
 			}
 		}
 	}
@@ -286,7 +286,7 @@ func initializeSharesJustifyingMemberGroup(threshold, groupSize int, dkg *DKG) (
 // simulates public coefficients calculation and sharing between members
 // (Phase 7 and 8). It expects secret coefficients to be already stored in
 // secretCoefficients field for each group member. At the end it stores
-// values for each member just like they would be received from peers.
+// values for each member just like they would be received from others.
 func initializePointsJustifyingMemberGroup(
 	threshold, groupSize int,
 	dkg *DKG,
@@ -310,11 +310,11 @@ func initializePointsJustifyingMemberGroup(
 		m.CalculatePublicKeySharePoints()
 	}
 	// Simulate phase where members store received public key share points from
-	// peers (Phase 8).
+	// others (Phase 8).
 	for _, m := range pointsJustifyingMembers {
 		for _, p := range pointsJustifyingMembers {
 			if m.ID != p.ID {
-				m.receivedValidPeerPublicKeySharePoints[p.ID] = p.publicKeySharePoints
+				m.receivedValidOtherMemberPublicKeySharePoints[p.ID] = p.publicKeySharePoints
 			}
 		}
 	}

--- a/pkg/beacon/relay/gjkr/protocol_reconstructions_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_reconstructions_test.go
@@ -115,10 +115,10 @@ func TestCombineGroupPublicKey(t *testing.T) {
 	// public key.
 	member.publicKeySharePoints = []*big.Int{big.NewInt(10), big.NewInt(11), big.NewInt(12)}
 
-	// Public coefficients received from peer members. Each peer member's zeroth
+	// Public coefficients received from other members. Each other member's zeroth
 	// coefficient is their individual public key.
-	member.receivedValidPeerPublicKeySharePoints[2] = []*big.Int{big.NewInt(20), big.NewInt(21), big.NewInt(22)}
-	member.receivedValidPeerPublicKeySharePoints[3] = []*big.Int{big.NewInt(30), big.NewInt(31), big.NewInt(32)}
+	member.receivedValidOtherMemberPublicKeySharePoints[2] = []*big.Int{big.NewInt(20), big.NewInt(21), big.NewInt(22)}
+	member.receivedValidOtherMemberPublicKeySharePoints[3] = []*big.Int{big.NewInt(30), big.NewInt(31), big.NewInt(32)}
 
 	// Reconstructed individual public keys for disqualified members.
 	member.reconstructedIndividualPublicKeys[4] = big.NewInt(91)
@@ -159,7 +159,7 @@ func initializeReconstructingMembersGroup(threshold, groupSize int, dkg *DKG) ([
 }
 
 // disqualifyMembers disqualifies specific members for a test run. It collects
-// shares calculated by disqualified members for their peers and reveals them.
+// shares calculated by disqualified members for other members and reveals them.
 func disqualifyMembers(
 	members []*ReconstructingMember,
 	disqualifiedMembersIDs []MemberID,
@@ -173,8 +173,8 @@ func disqualifyMembers(
 			if !contains(disqualifiedMembersIDs, m.ID) {
 				// collect all shares which this member received from disqualified
 				// member and store them in sharesReceivedFromDisqualifiedMember
-				for peerID, receivedShare := range m.receivedValidSharesS {
-					if peerID == disqualifiedMemberID {
+				for otherMemberID, receivedShare := range m.receivedValidSharesS {
+					if otherMemberID == disqualifiedMemberID {
 						sharesReceivedFromDisqualifiedMember[m.ID] = receivedShare
 						break
 					}
@@ -183,7 +183,7 @@ func disqualifyMembers(
 		}
 		allDisqualifiedShares[i] = &DisqualifiedShares{
 			disqualifiedMemberID: disqualifiedMemberID,
-			peerSharesS:          sharesReceivedFromDisqualifiedMember,
+			otherMemberSharesS:   sharesReceivedFromDisqualifiedMember,
 		}
 	}
 

--- a/pkg/beacon/relay/gjkr/protocol_sharing_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_sharing_test.go
@@ -19,8 +19,8 @@ func TestCombineReceivedShares(t *testing.T) {
 
 	receivedShareS := make(map[MemberID]*big.Int)
 	receivedShareT := make(map[MemberID]*big.Int)
-	// Simulate shares received from peer members.
-	// Peer members IDs are in [100, 101, 102, 103, 104, 105] to differ them from
+	// Simulate shares received from other members.
+	// Other members IDs are in [100, 101, 102, 103, 104, 105] to differ them from
 	// slice indices.
 	for i := 0; i <= 5; i++ {
 		receivedShareS[MemberID(100+i)] = big.NewInt(int64(10 + i))
@@ -230,7 +230,7 @@ func initializeSharingMembersGroup(threshold, groupSize int, dkg *DKG) ([]*Shari
 					CommitmentsVerifyingMember: cvm,
 				},
 			},
-			receivedValidPeerPublicKeySharePoints: make(map[MemberID][]*big.Int, groupSize-1),
+			receivedValidOtherMemberPublicKeySharePoints: make(map[MemberID][]*big.Int, groupSize-1),
 		})
 	}
 

--- a/pkg/beacon/relay/gjkr/protocol_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_test.go
@@ -14,7 +14,7 @@ func TestRoundTrip(t *testing.T) {
 		t.Fatalf("group initialization failed [%s]", err)
 	}
 
-	var sharesMessages []*PeerSharesMessage
+	var sharesMessages []*OtherMemberSharesMessage
 	var commitmentsMessages []*MemberCommitmentsMessage
 	for _, member := range committingMembers {
 		sharesMessage, commitmentsMessage, err := member.CalculateMembersSharesAndCommitments()
@@ -30,16 +30,16 @@ func TestRoundTrip(t *testing.T) {
 	for _, cm := range committingMembers {
 		commitmentsVerifyingMembers = append(commitmentsVerifyingMembers,
 			&CommitmentsVerifyingMember{CommittingMember: cm,
-				receivedValidSharesS:         make(map[MemberID]*big.Int),
-				receivedValidSharesT:         make(map[MemberID]*big.Int),
-				receivedValidPeerCommitments: make(map[MemberID][]*big.Int),
+				receivedValidSharesS:                make(map[MemberID]*big.Int),
+				receivedValidSharesT:                make(map[MemberID]*big.Int),
+				receivedValidOtherMemberCommitments: make(map[MemberID][]*big.Int),
 			},
 		)
 	}
 
 	for _, member := range commitmentsVerifyingMembers {
 		accusedSecretSharesMessage, err := member.VerifyReceivedSharesAndCommitmentsMessages(
-			filterPeerSharesMessage(sharesMessages, member.ID),
+			filterOtherMemberSharesMessage(sharesMessages, member.ID),
 			filterMemberCommitmentsMessages(commitmentsMessages, member.ID),
 		)
 		if err != nil {
@@ -71,8 +71,8 @@ func TestRoundTrip(t *testing.T) {
 	// TODO: Handle transition from CommittingMember to SharingMember in Next() function
 	for _, qm := range qualifiedMembers {
 		sharingMembers = append(sharingMembers, &SharingMember{
-			QualifiedMember:                       qm,
-			receivedValidPeerPublicKeySharePoints: make(map[MemberID][]*big.Int, groupSize-1),
+			QualifiedMember: qm,
+			receivedValidOtherMemberPublicKeySharePoints: make(map[MemberID][]*big.Int, groupSize-1),
 		})
 	}
 


### PR DESCRIPTION
When referring to other members in the group in the DKG protocol implementation we will use `other member` instead of `peer` which has networking connotation.