### PR TITLE
Relay Unchained: Factor out subparts of relay/chain.Interface

### DIFF
--- a/pkg/beacon/relay/chain/chain.go
+++ b/pkg/beacon/relay/chain/chain.go
@@ -8,26 +8,59 @@ import (
 	"github.com/keep-network/keep-core/pkg/gen/async"
 )
 
-// Interface represents the interface that the relay expects to interact
-// with the anchoring blockchain on.
-type Interface interface {
-	// GetConfig returns the expected configuration of the threshold relay.
-	GetConfig() (config.Chain, error)
-	// SubmitGroupPublicKey submits a 96-byte BLS public key to the blockchain,
-	// associated with a request with id requestID. On-chain errors are reported
-	// through the promise.
-	SubmitGroupPublicKey(requestID *big.Int, key [96]byte) *async.GroupRegistrationPromise
+// RelayEntryInterface defines the subset of the relay chain interface that
+// pertains specifically to submission and retrieval of relay requests and
+// entries.
+type RelayEntryInterface interface {
+	// RequestRelayEntry makes an on-chain request to start generation of a
+	// random signature.  An event is generated.
+	RequestRelayEntry(blockReward, seed *big.Int) *async.RelayRequestPromise
 	// SubmitRelayEntry submits an entry in the threshold relay and returns a
 	// promise to track the submission result. The promise is fulfilled with
 	// the entry as seen on-chain, or failed if there is an error submitting
 	// the entry.
 	SubmitRelayEntry(entry *event.Entry) *async.RelayEntryPromise
+
 	// OnRelayEntryGenerated is a callback that is invoked when an on-chain
 	// notification of a new, valid relay entry is seen.
 	OnRelayEntryGenerated(func(entry *event.Entry))
 	// OnRelayEntryRequested is a callback that is invoked when an on-chain
 	// notification of a new, valid relay request is seen.
 	OnRelayEntryRequested(func(request *event.Request))
+}
+
+// GroupInterface defines the subset of the relay chain interface that pertains
+// specifically to relay group management.
+type GroupInterface interface {
+	// SubmitGroupPublicKey submits a 96-byte BLS public key to the blockchain,
+	// associated with a request with id requestID. On-chain errors are reported
+	// through the promise.
+	SubmitGroupPublicKey(requestID *big.Int, key [96]byte) *async.GroupRegistrationPromise
+	// OnGroupRegistered is a callback that is invoked when an on-chain
+	// notification of a new, valid group being registered is seen.
+	OnGroupRegistered(func(key *event.GroupRegistration))
+}
+
+// DistributedKeyGenerationInterface defines the subset of the relay chain
+// interface that pertains specifically to group formation's distributed key
+// generation process.
+type DistributedKeyGenerationInterface interface {
+	// IsDKGResultPublished checks if the specific DKG result has already been
+	// published to a chain for given request ID.
+	IsDKGResultPublished(requestID *big.Int, dkgResult *DKGResult) bool
+	// SubmitDKGResult sends DKG result to a chain.
+	SubmitDKGResult(requestID *big.Int, dkgResult *DKGResult) *async.DKGResultPublicationPromise
+	// OnDKGResultPublished is a callback that is invoked when an on-chain
+	// notification of a new, valid published result is seen.
+	OnDKGResultPublished(func(dkgResultPublication *event.DKGResultPublication))
+}
+
+// Interface represents the interface that the relay expects to interact with
+// the anchoring blockchain on.
+type Interface interface {
+	// GetConfig returns the expected configuration of the threshold relay.
+	GetConfig() (config.Chain, error)
+
 	// OnStakerAdded is a callback that is invoked when an on-chain
 	// notification of a new, valid staker is seen.
 	OnStakerAdded(func(staker *event.StakerRegistration))
@@ -37,18 +70,8 @@ type Interface interface {
 	// GetStakerList is a temporary function for Milestone 1 that
 	// gets back the list of stakers.
 	GetStakerList() ([]string, error)
-	// OnGroupRegistered is a callback that is invoked when an on-chain
-	// notification of a new, valid group being registered is seen.
-	OnGroupRegistered(func(key *event.GroupRegistration))
-	// RequestRelayEntry makes an on-chain request to start generation of a
-	// random signature.  An event is generated.
-	RequestRelayEntry(blockReward, seed *big.Int) *async.RelayRequestPromise
-	// IsDKGResultPublished checks if the specific DKG result has already been
-	// published to a chain for given request ID.
-	IsDKGResultPublished(requestID *big.Int, dkgResult *DKGResult) bool
-	// SubmitDKGResult sends DKG result to a chain.
-	SubmitDKGResult(requestID *big.Int, dkgResult *DKGResult) *async.DKGResultPublicationPromise
-	// OnDKGResultPublished is a callback that is invoked when an on-chain
-	// notification of a new, valid published result is seen.
-	OnDKGResultPublished(func(dkgResultPublication *event.DKGResultPublication))
+
+	GroupInterface
+	RelayEntryInterface
+	DistributedKeyGenerationInterface
 }

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -53,7 +53,7 @@ type membership struct {
 // whether the node is or is not eligible for the new group, and group joining
 // and key submission is performed in a background goroutine.
 func (n *Node) JoinGroupIfEligible(
-	relayChain relaychain.Interface,
+	groupChain relaychain.GroupInterface,
 	requestID *big.Int,
 	entryValue *big.Int,
 ) {
@@ -96,7 +96,7 @@ func (n *Node) JoinGroupIfEligible(
 
 			n.registerPendingGroup(requestID.String(), member, groupChannel)
 
-			relayChain.SubmitGroupPublicKey(
+			groupChain.SubmitGroupPublicKey(
 				requestID,
 				member.GroupPublicKeyBytes(),
 			).OnComplete(func(registration *event.GroupRegistration, err error) {

--- a/pkg/beacon/relay/relay.go
+++ b/pkg/beacon/relay/relay.go
@@ -44,7 +44,7 @@ func NewNode(
 // signature creation and submission is performed in a background goroutine.
 func (n *Node) GenerateRelayEntryIfEligible(
 	request *event.Request,
-	relayChain relaychain.Interface,
+	relayChain relaychain.RelayEntryInterface,
 ) {
 	combinedEntryToSign := combineEntryToSign(
 		request.PreviousValue.Bytes(),


### PR DESCRIPTION
The relay chain interface at a high level was becoming quite bloated. Now
that it's broken down, functions that are specifically geared towards a subset
of the functionality can depend solely on that functionality. The top-level
`chain.Interface` still includes all three broken-out sub-interfaces, so
that the implementation requirements remain unchanged.

-------

Since this leaves `chain.Interface` unchanged to external observers, we
should be able to merge quickly and iterate on the resulting split in some
of the PRs that are adding to this interface.