### PR TITLE
Update Pedersen commitment with Euler's criterion

### DIFF
--- a/docs/cryptography/trapdoor-commitments.adoc
+++ b/docs/cryptography/trapdoor-commitments.adoc
@@ -52,7 +52,7 @@ will always recover the committed value.
 The Pedersen commitment requires to have two large primes `p` and `q` such
 that `q` divides `p - 1`, a `G~q~` which is a unique subgroup of `Z~p~` of order
 `q` and where `g` is a generator of `G~q~`. We can test whether `g` is a generator
-by checking if it meets the Euler's criterion: g^q mod p == 1.
+by checking if it meets the Euler's criterion: `g^q mod p == 1`.
 
 Then we choose a random `h` which is an element of `G~q~` and that `log~g~(h)` is
 unknown.
@@ -61,7 +61,8 @@ unknown.
 q <- is a prime
 p = 2q + 1 <- is a prime
 
-do g = randomZ[2, q - 1]
+do
+    g = randomZ[2, q - 1]
 until g^q mod p == 1 <- g meets the Euler's criterion
 
 h = (g ^ randomZ[0, q - 1]) % q


### PR DESCRIPTION
The `g` generator needs to meet the Euler's criterion.