### PR TITLE
Update golang version to 1.11.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine3.7 AS runtime
+FROM golang:1.11.4-alpine3.7 AS runtime
 
 ENV APP_NAME=keep-client \
 	BIN_PATH=/usr/local/bin \


### PR DESCRIPTION
This will allow the team to be on the same version of go, and more
importantly, gofmt. The latest version of go made some changes to the
formatter that creates churn in files that are updated by team members
on go pre 1.11 and those on 1.11.