### PR TITLE
TECDSA ZKP: Fixed generation of qTilde

### DIFF
--- a/pkg/tecdsa/zkp/zkp_parameters.go
+++ b/pkg/tecdsa/zkp/zkp_parameters.go
@@ -83,12 +83,16 @@ func GeneratePublicParameters(
 	}
 
 	qTilde := big.NewInt(0)
-	for qTilde, _, err = paillier.GenerateSafePrime(
-		safePrimeBitLength,
-		safePrimeGenConcurrencyLevel,
-		safePrimeGenTimeout,
-		rand.Reader,
-	); err == nil && pTilde.Cmp(qTilde) == 0; {
+	for {
+		qTilde, _, err = paillier.GenerateSafePrime(
+			safePrimeBitLength,
+			safePrimeGenConcurrencyLevel,
+			safePrimeGenTimeout,
+			rand.Reader,
+		)
+		if err != nil || pTilde.Cmp(qTilde) != 0 {
+			break
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Fixed loop generating `qTilde` value. When `GenerateSafePrime` function
executed for `qTilde` returned the same value as `pTilde` the loop executed
infinitely without generating a new value for `qTilde`.
We had to modify loop implementation.