### PR TITLE
Rename Tokens_total and add its definition

### DIFF
--- a/docs/random-beacon/group-selection.adoc
+++ b/docs/random-beacon/group-selection.adoc
@@ -91,8 +91,8 @@ Currently the _Space~tickets~_ is equal to _2^256^- 1_, which is due
 to selection of SHA3-256 as our pseudo random function.
 
 |_Supply~tokens~_
-|Is the total number of supplied tokens. The number of issued tokens is set to
-10^9 and will not change during the system lifetime.
+|Is the total number of tokens which are going to be supplied during the project
+lifetime and is set to 10^9.
 
 |Natural threshold
 |_Threshold~nat~ = floor(N * Space~tickets~ / (Supply~tokens~ / MINIMUM_STAKE))_


### PR DESCRIPTION
Renamed `Tokens_total` into `Supply_tokens` in the group selection documentation. 
`Supply_tokens` better reflects the meaning of the value under it.

[Flowdock discussion](https://www.flowdock.com/app/cardforcoin/tech/messages/232427)