### PR TITLE
Updated IsDKGResultPublished method allowing it to return error

### DIFF
--- a/pkg/beacon/relay/chain/chain.go
+++ b/pkg/beacon/relay/chain/chain.go
@@ -66,7 +66,7 @@ type DistributedKeyGenerationInterface interface {
 	OnDKGResultPublished(func(dkgResultPublication *event.DKGResultPublication)) event.Subscription
 	// IsDKGResultPublished checks if any DKG result has already been published
 	// to a chain for the given request ID.
-	IsDKGResultPublished(requestID *big.Int) bool
+	IsDKGResultPublished(requestID *big.Int) (bool, error)
 }
 
 // Interface represents the interface that the relay expects to interact with

--- a/pkg/beacon/relay/dkg2/publish_result.go
+++ b/pkg/beacon/relay/dkg2/publish_result.go
@@ -78,7 +78,16 @@ func (pm *Publisher) publishResult(result *relayChain.DKGResult) (int, error) {
 
 	// Check if any result has already been published to the chain with current
 	// request ID.
-	if chainRelay.IsDKGResultPublished(pm.RequestID) {
+	alreadyPublished, err := chainRelay.IsDKGResultPublished(pm.RequestID)
+	if err != nil {
+		return -1, fmt.Errorf(
+			"could not check if the result is already published [%v]",
+			err,
+		)
+	}
+
+	// Someone who was ahead of us in the queue published the result. Giving up.
+	if alreadyPublished {
 		return -1, nil
 	}
 

--- a/pkg/beacon/relay/dkg2/publish_result_test.go
+++ b/pkg/beacon/relay/dkg2/publish_result_test.go
@@ -57,7 +57,12 @@ func TestPublishDKGResult(t *testing.T) {
 
 			chainRelay := publisher.chainHandle.ThresholdRelay()
 
-			if chainRelay.IsDKGResultPublished(publisher.RequestID) {
+			isPublished, err := chainRelay.IsDKGResultPublished(publisher.RequestID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if isPublished {
 				t.Fatalf("result is already published on chain")
 			}
 			// TEST
@@ -72,7 +77,11 @@ func TestPublishDKGResult(t *testing.T) {
 					currentBlock,
 				)
 			}
-			if !chainRelay.IsDKGResultPublished(publisher.RequestID) {
+			isPublished, err = chainRelay.IsDKGResultPublished(publisher.RequestID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !isPublished {
 				t.Fatalf("result is not published on chain")
 			}
 		})

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -321,9 +321,8 @@ func (ec *ethereumChain) RequestRelayEntry(
 }
 
 // IsDKGResultPublished checks if the result is already published to a chain.
-func (ec *ethereumChain) IsDKGResultPublished(requestID *big.Int) bool {
-	// TODO Implement
-	return false
+func (ec *ethereumChain) IsDKGResultPublished(requestID *big.Int) (bool, error) {
+	return false, nil
 }
 
 // SubmitDKGResult sends DKG result to a chain.

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -244,8 +244,8 @@ func (c *localChain) RequestRelayEntry(
 
 // IsDKGResultPublished simulates check if the result was already submitted to a
 // chain.
-func (c *localChain) IsDKGResultPublished(requestID *big.Int) bool {
-	return c.submittedResults[requestID] != nil
+func (c *localChain) IsDKGResultPublished(requestID *big.Int) (bool, error) {
+	return c.submittedResults[requestID] != nil, nil
 }
 
 // SubmitDKGResult submits the result to a chain.

--- a/pkg/chain/local/local_test.go
+++ b/pkg/chain/local/local_test.go
@@ -150,7 +150,10 @@ func TestLocalIsDKGResultPublished(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			actualResult := chainHandle.IsDKGResultPublished(test.requestID)
+			actualResult, err := chainHandle.IsDKGResultPublished(test.requestID)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if actualResult != test.expectedResult {
 				t.Fatalf("\nexpected: %v\nactual:   %v\n", test.expectedResult, actualResult)


### PR DESCRIPTION
Refs: #322

Every interaction with chain can err due to the infrastructure problem. Hence, `IsDKGResultPublished` should be able to return `error` next to the `bool` result.