### PR TITLE
Drop nonce from broadcast channel name

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -85,7 +85,6 @@ func Initialize(
 				registration.GroupPublicKey,
 			)
 		})
-
 	}
 
 	<-ctx.Done()

--- a/pkg/beacon/relay/group_selection.go
+++ b/pkg/beacon/relay/group_selection.go
@@ -103,7 +103,6 @@ func (n *Node) SubmitTicketsForGroupSelection(
 			go n.JoinGroupIfEligible(
 				relayChain,
 				&groupselection.Result{selectedTickets},
-				beaconValue,
 				entryRequestID,
 				entrySeed,
 			)

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -59,7 +59,6 @@ type membership struct {
 func (n *Node) JoinGroupIfEligible(
 	relayChain relaychain.Interface,
 	groupSelectionResult *groupselection.Result,
-	entryValue []byte,
 	entryRequestID *big.Int,
 	entrySeed *big.Int,
 ) {


### PR DESCRIPTION
We no longer mix previous beacon output with broadcast channel name since all the tickets values have been already mixed with previous beacon output.