### PR TITLE
Link Group contract to Random Beacon on migration

### DIFF
--- a/contracts/solidity/migrations/2_deploy_contracts.js
+++ b/contracts/solidity/migrations/2_deploy_contracts.js
@@ -37,6 +37,8 @@ module.exports = (deployer) => {
     await deployer.deploy(KeepGroup, KeepGroupImplV1.address);
     await KeepRandomBeaconImplV1.at(KeepRandomBeacon.address).initialize(minPayment, withdrawalDelay);
     await KeepGroupImplV1.at(KeepGroup.address).initialize(
-      StakingProxy.address, KeepRandomBeacon.address, minStake, groupThreshold, groupSize, timeoutInitial, timeoutSubmission, timeoutChallenge);
+      StakingProxy.address, KeepRandomBeacon.address, minStake, groupThreshold, groupSize, timeoutInitial, timeoutSubmission, timeoutChallenge
+    );
+    await KeepRandomBeaconImplV1.at(KeepRandomBeacon.address).setGroupContract(KeepGroup.address);
   });
 };


### PR DESCRIPTION
Due to testing in Ganache, and not end-to-end testing in Geth, we left out a critical piece of code. We must load the contracts, then later call the initialization functions.