### PR TITLE
Replace node's StakeID with Staker.ID() func

### DIFF
--- a/pkg/beacon/relay/group_selection.go
+++ b/pkg/beacon/relay/group_selection.go
@@ -68,7 +68,7 @@ func (n *Node) SubmitTicketsForGroupSelection(
 	errCh := make(chan error, len(tickets))
 	quitTicketSubmission := make(chan struct{}, 0)
 	quitTicketChallenge := make(chan struct{}, 0)
-	groupCandidate := &groupCandidate{address: n.StakeID, tickets: tickets}
+	groupCandidate := &groupCandidate{address: n.Staker.ID(), tickets: tickets}
 
 	// Phase 2a: submit all tickets that fall under the natural threshold
 	go groupCandidate.submitTickets(
@@ -102,7 +102,7 @@ func (n *Node) SubmitTicketsForGroupSelection(
 			// determine if we're eligible for the next group.
 			go n.JoinGroupIfEligible(
 				relayChain,
-				&groupselection.Result{selectedTickets},
+				&groupselection.Result{SelectedTickets: selectedTickets},
 				entryRequestID,
 				entrySeed,
 			)

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -21,8 +21,6 @@ import (
 type Node struct {
 	mutex sync.Mutex
 
-	// StakeID is the ID this node is using to prove its stake in the system.
-	StakeID string
 	// Staker is an on-chain identity that this node is using to prove its
 	// stake in the system.
 	Staker chain.Staker
@@ -84,7 +82,7 @@ func (n *Node) JoinGroupIfEligible(
 		// off an instance of DKG. We may have multiple
 		// tickets in the selected tickets (which would
 		// result in multiple instances of DKG).
-		if ticket.IsFromStaker(n.StakeID) {
+		if ticket.IsFromStaker(n.Staker.ID()) {
 			go dkg2.ExecuteDKG(
 				entryRequestID,
 				entrySeed,


### PR DESCRIPTION
Node struct contains `Staker` field which holds `ID()` function. This function can
be used instead of `StakeID` field for a node to get stake identification in the system.