### PR TITLE
Local network RegisterIdentifier don't return an error

### DIFF
--- a/pkg/net/local/local.go
+++ b/pkg/net/local/local.go
@@ -242,19 +242,12 @@ func (lc *localChannel) RegisterIdentifier(
 	lc.identifiersMutex.Lock()
 	defer lc.identifiersMutex.Unlock()
 
-	if _, exists := lc.transportToProtoIdentifiers[transportIdentifier]; exists {
-		return fmt.Errorf(
-			"already have a protocol identifier associated with [%v]",
-			transportIdentifier)
+	if _, exists := lc.transportToProtoIdentifiers[transportIdentifier]; !exists {
+		lc.transportToProtoIdentifiers[transportIdentifier] = protocolIdentifier
 	}
-	if _, exists := lc.protoToTransportIdentifiers[protocolIdentifier]; exists {
-		return fmt.Errorf(
-			"already have a transport identifier associated with [%v]",
-			protocolIdentifier)
+	if _, exists := lc.protoToTransportIdentifiers[protocolIdentifier]; !exists {
+		lc.protoToTransportIdentifiers[protocolIdentifier] = transportIdentifier
 	}
-
-	lc.transportToProtoIdentifiers[transportIdentifier] = protocolIdentifier
-	lc.protoToTransportIdentifiers[protocolIdentifier] = transportIdentifier
 
 	return nil
 }


### PR DESCRIPTION
Local network `RegisterIdentifier` function won't return an error if identifier already exists. 
This is related to a case when staker published multiple tickets https://github.com/keep-network/keep-core/pull/516/commits/239388c8e77a1f7199ab6b2deff3f703e379529c it might cause failures in DKG execution:
`[member:6, state: *dkg2.joinState] Failed to receive a message [already have a protocol identifier associated with [jiOgjhYeVwBTCMLfrDGXqwpzwVGqMZcL]]`.