### PR TITLE
Smoke test updates to work with DKG2

### DIFF
--- a/cmd/smoketest.go
+++ b/cmd/smoketest.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	defaultGroupSize int = 10
-	defaultThreshold int = 4
+	defaultGroupSize    int = 10
+	defaultThreshold    int = 4
+	defaultMinimumStake int = 2000000
 )
 
 // SmokeTestCommand contains the definition of the smoke-test command-line
@@ -25,10 +26,12 @@ const (
 var SmokeTestCommand cli.Command
 
 const (
-	groupSizeFlag  = "group-size"
-	groupSizeShort = "g"
-	thresholdFlag  = "threshold"
-	thresholdShort = "t"
+	groupSizeFlag     = "group-size"
+	groupSizeShort    = "g"
+	thresholdFlag     = "threshold"
+	thresholdShort    = "t"
+	minimumStakeFlag  = "minimum-stake"
+	minimumStakeShort = "s"
 )
 
 const smokeTestDescription = `The smoke-test command creates a local threshold group of the
@@ -54,6 +57,10 @@ func init() {
 				Name:  thresholdFlag + "," + thresholdShort,
 				Value: defaultThreshold,
 			},
+			&cli.IntFlag{
+				Name:  minimumStakeFlag + "," + minimumStakeShort,
+				Value: defaultMinimumStake,
+			},
 		},
 	}
 }
@@ -63,8 +70,14 @@ func init() {
 func SmokeTest(c *cli.Context) error {
 	groupSize := c.Int(groupSizeFlag)
 	threshold := c.Int(thresholdFlag)
+	minimumStake := c.Int(minimumStakeFlag)
 
-	chainHandle := local.Connect(groupSize, threshold)
+	chainHandle := local.Connect(
+		groupSize,
+		threshold,
+		big.NewInt(int64(minimumStake)),
+	)
+
 	context, contextCancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	for i := 0; i < groupSize; i++ {


### PR DESCRIPTION
This PR introduces changes to the smoke test to work with 2 version (GJKR) version of DKG.
It requires other PRs to be merged before running this smoke test:
- depends on https://github.com/keep-network/keep-core/pull/523
- depends on https://github.com/keep-network/keep-core/pull/522

The smoke test to be fully functional requires Phase 14 to be implemented and validations added to the test to cover Phase 14.