### PR TITLE
[WIP] Road to public testnet

### DIFF
--- a/docs/release/pub-testnet-minimum-todo.adoc
+++ b/docs/release/pub-testnet-minimum-todo.adoc
@@ -19,7 +19,7 @@ A stab at minimum effort to get the Keep public testnet off the ground.
   ** Launch N keep seed bootstrap peers (regular peers?)
   ** Metrics dashboard
   ** Business hours on-call rotation
-  ** CI deploy on merge to master
+  ** Deploy on merge to master
 
 - Documentation *[Owner: ""]*
   ** Where


### PR DESCRIPTION
We've had a few discussions with various parts of the whole to get at the effort needed for a public testnet launch.  At this point what we need is to collect those disparate channels into a roadmap with minimum effort for go-live.  This is a stab at that effort.

This is not exhaustive, and a chunking of big items into buckets.  This is all subject to change, the document should be used to facilitate a path to understanding minimum effort, give that effort owners, and a timeline.