### PR TITLE
Increased on-chain timeouts for group selection process

### DIFF
--- a/contracts/solidity/migrations/2_deploy_contracts.js
+++ b/contracts/solidity/migrations/2_deploy_contracts.js
@@ -16,9 +16,9 @@ const minStake = 1;
 
 const groupThreshold = 3;
 const groupSize = 5;
-const timeoutInitial = 1;
-const timeoutSubmission = 1;
-const timeoutChallenge = 1;
+const timeoutInitial = 10;
+const timeoutSubmission = 10;
+const timeoutChallenge = 10;
 
 module.exports = (deployer) => {
   deployer.then(async () => {


### PR DESCRIPTION
Refs:#546

We have a check in submit ticket contract code that makes sure timeout has not passed yet. 1 block timeout is definitely not enough so we set all of them to 10 for now. This will be probably adjusted in the future.