### PR TITLE
eth-testnet: Mount persistent volumes

### DIFF
--- a/infrastructure/kube/keep-dev/eth-miner-nodes.yaml
+++ b/infrastructure/kube/keep-dev/eth-miner-nodes.yaml
@@ -55,6 +55,9 @@ spec:
         - containerPort: 8545
         - containerPort: 8546
         - containerPort: 30303
+        volumeMounts:
+        - name: eth-miner-node
+          mountPath: /mnt/eth-data
         env:
         - name: INSTANCE_NAME
           valueFrom:

--- a/infrastructure/kube/keep-dev/eth-tx-nodes.yaml
+++ b/infrastructure/kube/keep-dev/eth-tx-nodes.yaml
@@ -54,6 +54,9 @@ spec:
         - containerPort: 8545
         - containerPort: 8546
         - containerPort: 30303
+        volumeMounts:
+        - name: eth-tx-node
+          mountPath: /mnt/eth-data
         env:
         - name: INSTANCE_NAME
           valueFrom:


### PR DESCRIPTION
We need a way to recover eth-testnet data if a pod gets shot.  We
decided to address this by mounting a persistent volume and setting
the eth data dir to the mount point.  With all of that said we (I)
never mounted the volume claim...and only noticed after the chain
reset again.  :untada:

--------------

Commit message should cover the salient bits.  I messed up and never mounted the persistent volume claims, so our eth data was not persisted during the last pod cycle on Feb 2nd.

I've double checked that the volume is indeed mounted now.

tx-node
```
bash-4.4# df -h | grep /mnt
/dev/sdb                  4.9G    200.2M      4.4G   4% /mnt/eth-data
```

miner
```
bash-4.4# df -h | grep /mnt
/dev/sdc                  4.9G      2.0G      2.6G  44% /mnt/eth-data