### PR TITLE
Fixed event request ID comparison for Ethereum events

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -223,7 +223,7 @@ func (ec *ethereumChain) SubmitRelayEntry(
 		for {
 			select {
 			case event := <-generatedEntry:
-				if event.RequestID == newEntry.RequestID {
+				if event.RequestID.Cmp(newEntry.RequestID) == 0 {
 					subscription.Unsubscribe()
 					close(generatedEntry)
 
@@ -456,7 +456,7 @@ func (ec *ethereumChain) SubmitDKGResult(
 		for {
 			select {
 			case event, isOpen := <-publishedResult:
-				if isOpen && event.RequestID == requestID {
+				if isOpen && event.RequestID.Cmp(requestID) == 0 {
 					subscription.Unsubscribe()
 					close(publishedResult)
 


### PR DESCRIPTION
Refs: #546 

We can't use `==` to compare two `big.Int`s. Instead, we should use `Cmp` method. As a result of wrong comparison, expected code was never called:
- submit relay entry promise was never fulfilled
- submig DKG result promise was never fulfilled

Example:
```
package main

import (
	"fmt"
	"math/big"
)

func main() {
	one1 := big.NewInt(1)
	one2 := big.NewInt(1)
	
	fmt.Printf("%v\n", one1 == one2)
	fmt.Printf("%v\n", one1.Cmp(one2) == 0)
}
```

Gives:
```
false
true
```