### PR TITLE
Catch error from `SubmitTicketsForGroupSelection`

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -65,7 +65,7 @@ func Initialize(
 				entry.Seed,
 			)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "tickets submission failed: [%v]", err)
+				fmt.Fprintf(os.Stderr, "tickets submission failed: [%v]\n", err)
 			}
 		}()
 


### PR DESCRIPTION
Refs: #546

Error returned from `SubmitTicketsForGroupSelection` on beacon
initialization has been ignored. 
We need to catch the error and log it.