### PR TITLE
Bump up request ID for the next generated relay entry

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"os"
 
 	"github.com/keep-network/keep-core/pkg/beacon/relay"
@@ -69,8 +70,10 @@ func Initialize(
 			}
 		}()
 
+		nextRequestID := new(big.Int).Add(entry.RequestID, big.NewInt(1))
+
 		go node.GenerateRelayEntryIfEligible(
-			entry.RequestID,
+			nextRequestID,
 			entry.PreviousEntry,
 			entry.Seed,
 			relayChain,


### PR DESCRIPTION
Refs: #546

We use request ID to say if DKG result for the given request ID has been already published. We need to use different request ID to avoid a situation when all members give up because the result is already on-chain and this is the result of the previous execution.