### PR TITLE
Pass signer from ExecuteDKG to pending group

### DIFF
--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -98,7 +98,7 @@ func (n *Node) JoinGroupIfEligible(
 
 			fmt.Printf("Executing dkg with index = %v...\n", index)
 			go func() {
-				dkg2.ExecuteDKG(
+				signer, err := dkg2.ExecuteDKG(
 					entryRequestID,
 					entrySeed,
 					playerIndex,
@@ -108,9 +108,12 @@ func (n *Node) JoinGroupIfEligible(
 					relayChain,
 					broadcastChannel,
 				)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to execute dkg: [%v].", err)
+					return
+				}
 
-				// TODO: pass in the member
-				n.registerPendingGroup(entryRequestID.String(), nil, broadcastChannel)
+				n.registerPendingGroup(entryRequestID.String(), signer, broadcastChannel)
 			}()
 		}
 	}


### PR DESCRIPTION
Refs: #546

Signer returned by `ExecuteDKG` function is passed to `registerPendingGroup` function.