### PR TITLE
Transform Ethereum address to bytes using common.Address

### DIFF
--- a/pkg/chain/ethereum/stake_monitor.go
+++ b/pkg/chain/ethereum/stake_monitor.go
@@ -65,7 +65,7 @@ type ethereumStaker struct {
 }
 
 func (es *ethereumStaker) ID() []byte {
-	return []byte(es.address)
+	return common.HexToAddress(es.address).Bytes()
 }
 
 func (es *ethereumStaker) Stake() (*big.Int, error) {


### PR DESCRIPTION
Refs: #546

We can't just transform string to bytes and then to int because geth client from time to time rejects a transaction. This is not happening if we use `common.Address` from go-ethereum to transform string
address representation to bytes.