### PR TITLE
Handle closed channel in consumer

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -211,7 +211,13 @@ func (ec *ethereumChain) SubmitRelayEntry(
 	go func() {
 		for {
 			select {
-			case event := <-generatedEntry:
+			case event, success := <-generatedEntry:
+				// Channel is closed when SubmitRelayEntry failed.
+				// When this happens, event is nil.
+				if !success {
+					return
+				}
+
 				if event.RequestID.Cmp(newEntry.RequestID) == 0 {
 					subscription.Unsubscribe()
 					close(generatedEntry)
@@ -365,7 +371,13 @@ func (ec *ethereumChain) RequestRelayEntry(
 	go func() {
 		for {
 			select {
-			case event := <-requestedEntry:
+			case event, success := <-requestedEntry:
+				// Channel is closed when RequestRelayEntry failed.
+				// When this happens, event is nil.
+				if !success {
+					return
+				}
+
 				subscription.Unsubscribe()
 				close(requestedEntry)
 
@@ -450,8 +462,14 @@ func (ec *ethereumChain) SubmitDKGResult(
 	go func() {
 		for {
 			select {
-			case event, isOpen := <-publishedResult:
-				if isOpen && event.RequestID.Cmp(requestID) == 0 {
+			case event, success := <-publishedResult:
+				// Channel is closed when SubmitDKGResult failed.
+				// When this happens, event is nil.
+				if !success {
+					return
+				}
+
+				if event.RequestID.Cmp(requestID) == 0 {
 					subscription.Unsubscribe()
 					close(publishedResult)
 


### PR DESCRIPTION
Refs:#546

When a failure occurs during submitting relay entry, requesting relay entry or submitting DKG result, event channel is closed.

In this situation, receiver gets a `nil` event. We need to handle this situation gracefully by closing receiver and ignoring nil event.

This situation is well described by the following test:
```

func TestChannel(t *testing.T) {
	generatedEntry := make(chan *event.Entry)

	go func() {
		for {
			select {
			case event := <-generatedEntry:
				fmt.Printf("Received event [%v]\n", event)
				return
			}
		}
	}()

	close(generatedEntry)
}
```
which outputs:
```
Received event [<nil>]
```