### PR TITLE
Initialize threshold message type in Execute

### DIFF
--- a/pkg/beacon/relay/relay.go
+++ b/pkg/beacon/relay/relay.go
@@ -59,9 +59,6 @@ func (n *Node) GenerateRelayEntryIfEligible(
 	}
 
 	for _, signer := range memberships {
-
-		thresholdsignature.Init(signer.channel)
-
 		go func(signer *membership) {
 			signature, err := thresholdsignature.Execute(
 				combinedEntryToSign,

--- a/pkg/beacon/relay/thresholdsignature/thresholdsignature.go
+++ b/pkg/beacon/relay/thresholdsignature/thresholdsignature.go
@@ -44,6 +44,9 @@ func Execute(
 		},
 	}
 
+	// Initialize channel to perform threshold signing process.
+	Init(channel)
+
 	channel.Recv(handler)
 	defer channel.UnregisterRecv(handler.Type)
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/582

Following the convention for registering a message type inside of the
function/goroutine where it's being used (ala dkg), we do the same for
thresholdgroup. It could be the case that the init and the Execute (in a
goroutine) diverged. Rather: keep it all inside of the same goroutine.

