### PR TITLE
Move group registration to submitGroupPublicKey

### DIFF
--- a/contracts/solidity/contracts/KeepGroupImplV1.sol
+++ b/contracts/solidity/contracts/KeepGroupImplV1.sol
@@ -250,21 +250,22 @@ contract KeepGroupImplV1 is Ownable {
         _dkgResultPublished[requestId] = true;
   
         emit DkgResultPublishedEvent(requestId, groupPubKey);
-
-        // TODO: Remove this section once dispute logic is implemented,
-        // implement conflict resolution logic described in Phase 14,
-        // make sure only valid members are stored.
-        _groups.push(groupPubKey);
-        address[] memory members = orderedParticipants();
-        for (uint i = 0; i < _groupSize; i++) {
-            _groupMembers[groupPubKey].push(members[i]);
-        }
-        emit OnGroupRegistered(groupPubKey);
     }
 
     // Legacy code moved from Random Beacon contract
     // TODO: refactor according to the Phase 14
     function submitGroupPublicKey(bytes groupPublicKey, uint256 requestID) public {
+
+        // TODO: Remove this section once dispute logic is implemented,
+        // implement conflict resolution logic described in Phase 14,
+        // make sure only valid members are stored.
+        _groups.push(groupPublicKey);
+        address[] memory members = orderedParticipants();
+        for (uint i = 0; i < _groupSize; i++) {
+            _groupMembers[groupPublicKey].push(members[i]);
+        }
+        emit OnGroupRegistered(groupPublicKey);
+
         uint256 activationBlockHeight = block.number;
         emit SubmitGroupPublicKeyEvent(groupPublicKey, requestID, activationBlockHeight);
     }


### PR DESCRIPTION
Moving group registration to `submitGroupPublicKey()` the final method to save `groupPubKey` that passed conflict resolution phase.