### PR TITLE
RFC 5: Stake delegation specification

### DIFF
--- a/docs/rfc/rfc-5-stake-delegation-specification.adoc
+++ b/docs/rfc/rfc-5-stake-delegation-specification.adoc
@@ -172,7 +172,7 @@ current time,
 [#undelegating]
 ==== Undelegating a stake
 
-1. The _owner_ or _operator_ chooses to undelegate the stake, and creates a
+1. The _owner_ or _operator_ chooses to undelegate the stake, and creates an
 _undelegation order_.
 
 2. Either the _owner_ or _operator_ signs the _undelegation order_ and publishes


### PR DESCRIPTION
This specification of the stake delegation is based on the requirements defined in the RFC 3.

Its aim is to guide how contracts should be implemented to be consistent with the requirements.