### PR TITLE
Make publishing async

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -53,6 +53,16 @@ func Initialize(
 	relayChain.OnRelayEntryRequested(func(request *event.Request) {
 		fmt.Printf("New entry requested [%+v]\n", request)
 
+		// THIS WILL ALLOW ALL GROUPS TO REGISTER LOCALLY.
+		// HACKY BUT TEMPORARY (NOT NEEDED WITH RELAY REQUESTS)
+		if err := blockCounter.WaitForBlocks(2); err != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"failed to wait 2 blocks before determining eligibility: [%v]",
+				err,
+			)
+		}
+
 		go node.GenerateRelayEntryIfEligible(
 			request.RequestID,
 			request.PreviousValue,

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -108,7 +108,16 @@ func (n *Node) JoinGroupIfEligible(
 					return
 				}
 
-				n.registerPendingGroup(entryRequestID.String(), signer, broadcastChannel)
+				// TODO: we will refactor it into one method in another PR
+				n.registerPendingGroup(
+					entryRequestID.String(),
+					signer,
+					broadcastChannel,
+				)
+				n.RegisterGroup(
+					entryRequestID.String(),
+					signer.GroupPublicKeyBytes(),
+				)
 			}()
 		}
 	}


### PR DESCRIPTION
This commit ensures we're not blocked on publishing to "complete"
`ExecuteDKG`. After we complete GJKR and get a valid signer, we spin off
publishing as an async operation, and return the `signer` to register a
pending group. This way, as long as at least one client's publishing 
succeeds, we'll see the new group public key and correctly register the group.

Most importantly, this fixes a subtle three-way race between registering
pending groups, submitting the new group public key, and seeing the
group public key followed by registering a new group. Previously, we
would see the new group public key, attempt to register the group, and
never see our existing pending group as it was racing against key
submission. Now we will eagerly register our pending group much before
we publish.

Closes #582 