### PR TITLE
Fix higlight.js version to the most recent minor version - build error fix

### DIFF
--- a/contracts/solidity/docs/doxity/package.json
+++ b/contracts/solidity/docs/doxity/package.json
@@ -5,7 +5,7 @@
   "author": "Chris Hitchcott <hitchcott@gmail.com>",
   "dependencies": {
     "@hitchcott/semantic-ui-react": "^0.61.1",
-    "highlight.js": "^9.7.0",
+    "highlight.js": "~9.7.0",
     "highlightjs-solidity": "^1.0.5",
     "react-document-title": "^2.0.1",
     "react-markdown": "^2.4.2",


### PR DESCRIPTION
`~9.7.0` matches all `9.7.X` versions but not `9.8.X`. There is a recent issue in the referenced `higlight.js` library causing our build to fail: https://github.com/highlightjs/highlight.js/issues/1984

Sticking to `9.7.X` should solve this problem.