### PR TITLE
Banana Dance: Try to fix issue introduced in PR merge

### DIFF
--- a/pkg/beacon/relay/chain/chain.go
+++ b/pkg/beacon/relay/chain/chain.go
@@ -93,6 +93,9 @@ type DistributedKeyGenerationInterface interface {
 	// to a chain for the given request ID.
 	// TODO: Change to: IsDKGResultSubmitted
 	IsDKGResultPublished(requestID *big.Int) (bool, error)
+	// CalculateDKGResultHash calculates 256-bit hash of DKG result in standard
+	// specific for the chain. Operation is performed off-chain.
+	CalculateDKGResultHash(dkgResult *DKGResult) (DKGResultHash, error)
 	// GetDKGResultsVotes returns a map containing number of votes for each DKG
 	// result hash registered under specific request ID.
 	GetDKGResultsVotes(requestID *big.Int) DKGResultsVotes

--- a/pkg/beacon/relay/chain/result.go
+++ b/pkg/beacon/relay/chain/result.go
@@ -38,20 +38,20 @@ type DKGResultHash [32]byte
 type DKGResultsVotes map[DKGResultHash]int
 
 // Equals checks if two DKG results are equal.
-func (r1 *DKGResult) Equals(r2 *DKGResult) bool {
-	if r1 == nil || r2 == nil {
-		return r1 == r2
+func (r *DKGResult) Equals(r2 *DKGResult) bool {
+	if r == nil || r2 == nil {
+		return r == r2
 	}
-	if r1.Success != r2.Success {
+	if r.Success != r2.Success {
 		return false
 	}
-	if !bytes.Equal(r1.GroupPublicKey, r2.GroupPublicKey) {
+	if !bytes.Equal(r.GroupPublicKey, r2.GroupPublicKey) {
 		return false
 	}
-	if !bytes.Equal(r1.Disqualified, r2.Disqualified) {
+	if !bytes.Equal(r.Disqualified, r2.Disqualified) {
 		return false
 	}
-	if !bytes.Equal(r1.Inactive, r2.Inactive) {
+	if !bytes.Equal(r.Inactive, r2.Inactive) {
 		return false
 	}
 	return true

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/keep-network/keep-core/pkg/beacon/relay/chain"
 	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
 	relayconfig "github.com/keep-network/keep-core/pkg/beacon/relay/config"
@@ -517,6 +519,53 @@ func (ec *ethereumChain) SubmitDKGResult(
 	}
 
 	return resultPublicationPromise
+}
+
+// CalculateDKGResultHash calculates Keccak-256 hash of the DKG result. Operation
+// is performed off-chain.
+//
+// It first encodes the result using solidity ABI and then calculates Keccak-256
+// hash over it. This corresponds to the DKG result hash calculation on-chain.
+// Hashes calculated off-chain and on-chain must always match.
+func (ec *ethereumChain) CalculateDKGResultHash(
+	dkgResult *relaychain.DKGResult,
+) (relaychain.DKGResultHash, error) {
+	dkgResultHash := relaychain.DKGResultHash{}
+
+	// Encode DKG result to the format described by Solidity Contract Application
+	// Binary Interface (ABI).
+	boolType, err := abi.NewType("bool")
+	if err != nil {
+		return dkgResultHash, fmt.Errorf("bool type creation failed: [%v]", err)
+	}
+	bytesType, err := abi.NewType("bytes")
+	if err != nil {
+		return dkgResultHash, fmt.Errorf("bytes type creation failed: [%v]", err)
+	}
+
+	arguments := abi.Arguments{
+		{Type: boolType},
+		{Type: bytesType},
+		{Type: bytesType},
+		{Type: bytesType},
+	}
+
+	encodedDKGResult, err := arguments.Pack(
+		dkgResult.Success,
+		dkgResult.GroupPublicKey,
+		dkgResult.Disqualified,
+		dkgResult.Inactive,
+	)
+	if err != nil {
+		return dkgResultHash, fmt.Errorf("encoding failed: [%v]", err)
+	}
+
+	// Calculate Keccak-256 hash.
+	hash := sha3.NewKeccak256()
+	hash.Write(encodedDKGResult)
+	hash.Sum(dkgResultHash[:0])
+
+	return dkgResultHash, nil
 }
 
 // GetDKGResultsVotes returns a map containing number of votes for each DKG

--- a/pkg/chain/ethereum/hash_test.go
+++ b/pkg/chain/ethereum/hash_test.go
@@ -1,0 +1,105 @@
+package ethereum
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
+)
+
+// TestCalculateDKGResultHash validates if calculated DKG result hash matches
+// expected one.
+//
+// Expected hashes has been calculated on-chain with:
+// `keccak256(abi.encode(success, groupPubKey, disqualified, inactive))`.
+func TestCalculateDKGResultHash(t *testing.T) {
+	chain := &ethereumChain{}
+
+	var tests = map[string]struct {
+		dkgResult    *relaychain.DKGResult
+		expectedHash string
+	}{
+		"dkg result has only success provided": {
+			dkgResult: &relaychain.DKGResult{
+				Success: true,
+			},
+			expectedHash: "3550dcd2ae8c05d5ca00d5fcd004b6aaf7d3b90f64e0e6078ae62f1f7a2e3f27",
+		},
+		"dkg result has only group public key provided": {
+			dkgResult: &relaychain.DKGResult{
+				GroupPublicKey: []byte{100},
+			},
+			expectedHash: "132d7294d5d6a5434295d5f5d611bd210261f4e1360cfeb1054e30e69747ea16",
+		},
+		"dkg result has only disqualified provided": {
+			dkgResult: &relaychain.DKGResult{
+				Disqualified: []byte{1, 0, 1, 0},
+			},
+			expectedHash: "19120029436cfa37c800dce5ca006c1392b7c1d3d3dce50b91e44d1dc2e41c82",
+		},
+		"dkg result has only inactive provided": {
+			dkgResult: &relaychain.DKGResult{
+				Inactive: []byte{0, 1, 1, 1},
+			},
+			expectedHash: "941ef3e2fb3c006ea88533e1f3adf7ce974d114d30161e6a6209428a39747009",
+		},
+		"dkg result has all parameters provided": {
+			dkgResult: &relaychain.DKGResult{
+				Success:        true,
+				GroupPublicKey: []byte{3, 40, 200},
+				Disqualified:   []byte{1, 0, 1, 0},
+				Inactive:       []byte{0, 1, 1, 0},
+			},
+			expectedHash: "d89ec37a4636214269a8aa8639691dc3c39157111a7321dddfcc6f6146b77fd3",
+		},
+		"dkg result has disqualified longer than 32 bytes": {
+			dkgResult: &relaychain.DKGResult{
+				Disqualified: []byte{
+					1, 0, 1, 0, 0, 0, 0, 1, 0, 0,
+					1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+					1, 0, 1, 0, 0, 0, 0, 1, 0, 0,
+					1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+					1, 0, 1, 0, 0, 0, 0, 1, 0, 0,
+					1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+				},
+			},
+			expectedHash: "b390bfe240f6cf522b4d866b069f08a96bf9d2c6a7cac6574291a8353e05562a",
+		},
+		"dkg result has group public key longer than 64 bytes": {
+			dkgResult: &relaychain.DKGResult{
+				GroupPublicKey: []byte{
+					33, 249, 72, 108, 111, 44, 64, 58, 107, 112,
+					108, 74, 214, 170, 149, 99, 212, 2, 48, 137,
+					146, 12, 128, 8, 103, 47, 13, 161, 14, 126,
+					5, 151, 0, 199, 90, 57, 31, 29, 175, 197,
+					158, 45, 138, 205, 82, 95, 171, 104, 246, 8,
+					203, 130, 138, 115, 72, 108, 232, 87, 129, 161,
+					39, 228, 55, 222, 94, 238, 85, 128, 137, 187,
+					27, 252, 25, 38, 201, 41, 127, 179, 75, 112,
+				},
+			},
+			expectedHash: "86706e29471a9a32ca95525a8f50ec9dbd0751e6eff09f0bf3630023ea464545",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// expectedEncodedResult := common.Hex2Bytes(test.expectedSerializedResult)
+			expectedHash := common.Hex2Bytes(test.expectedHash)
+
+			actualHash, err := chain.CalculateDKGResultHash(test.dkgResult)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(expectedHash, actualHash[:]) {
+				t.Errorf(
+					"\nexpected: %v\nactual:   %x\n",
+					test.expectedHash,
+					actualHash,
+				)
+			}
+		})
+	}
+}

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/ethereum/go-ethereum/crypto/sha3"
 	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
 	relayconfig "github.com/keep-network/keep-core/pkg/beacon/relay/config"
 	"github.com/keep-network/keep-core/pkg/beacon/relay/event"
@@ -410,6 +411,18 @@ func (c *localChain) OnDKGResultPublished(
 
 		delete(c.dkgResultPublicationHandlers, handlerID)
 	}), nil
+}
+
+// CalculateDKGResultHash calculates a 256-bit hash of the DKG result.
+func (c *localChain) CalculateDKGResultHash(
+	dkgResult *relaychain.DKGResult,
+) (relaychain.DKGResultHash, error) {
+	encodedDKGResult := fmt.Sprint(dkgResult)
+	dkgResultHash := relaychain.DKGResultHash(
+		sha3.Sum256([]byte(encodedDKGResult)),
+	)
+
+	return dkgResultHash, nil
 }
 
 // GetDKGResultsVotes returns a map containing number of votes for each DKG

--- a/pkg/chain/local/local_test.go
+++ b/pkg/chain/local/local_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-core/pkg/beacon/relay/event"
 
 	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
@@ -468,6 +469,36 @@ func TestLocalOnDKGResultPublishedUnsubscribe(t *testing.T) {
 		t.Fatalf("event should not be emitted - I have unsubscribed!")
 	case <-ctx.Done():
 		// ok
+	}
+}
+
+func TestCalculateDKGResultHash(t *testing.T) {
+	localChain := &localChain{}
+
+	dkgResult := &relaychain.DKGResult{
+		Success:        true,
+		GroupPublicKey: []byte{3, 40, 200},
+		Disqualified:   []byte{1, 0, 1, 0},
+		Inactive:       []byte{0, 1, 1, 0},
+	}
+	expectedHashString := "135a0a776b24afbdb70a3548d2b01d197f67972b7482df68703caeae4453134e"
+
+	actualHash, err := localChain.CalculateDKGResultHash(dkgResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedHash := relaychain.DKGResultHash{}
+	copy(
+		expectedHash[:],
+		common.Hex2Bytes(expectedHashString)[:32],
+	)
+
+	if expectedHash != actualHash {
+		t.Fatalf("\nexpected: %x\nactual:   %x\n",
+			expectedHash,
+			actualHash,
+		)
 	}
 }
 


### PR DESCRIPTION
![](https://media1.tenor.com/images/9750f39fe5f96acfce1bdf187ff0cac1/tenor.gif)

This reverts commit b10955abf68cd81f3769f1d3a6ae9459ce17f890, reversing
changes made to 6445d6fb75318149c94be642c50615b9096c5e33.

Those changes were a merge commit that merged two separate feature
branches (#610 and #609), but also nuked changes from one of them
that were ultimately desired. When both branches were merged to mainline
these changes disappeared altogether. This revert restores those changes,
hopefully returning the repository to feature harmony.