### PR TITLE
Fix pre-commit failure for G2Point

### DIFF
--- a/pkg/beacon/relay/dkg2/dkg.go
+++ b/pkg/beacon/relay/dkg2/dkg.go
@@ -215,7 +215,7 @@ func convertResult(gjkrResult *gjkr.Result, groupSize int) *relayChain.DKGResult
 	// We convert the point G2, to compress the point correctly
 	// (ensuring we encode the parity bit).
 	if gjkrResult.GroupPublicKey != nil {
-		altbn128GroupPublicKey := altbn128.G2Point{gjkrResult.GroupPublicKey}
+		altbn128GroupPublicKey := altbn128.G2Point{G2: gjkrResult.GroupPublicKey}
 		groupPublicKey = altbn128GroupPublicKey.Compress()
 	}
 


### PR DESCRIPTION
pre-commit validation fails due to an error in G2Point definition in `dkg.go`. This PR fixes the issue.