### PR TITLE
Local dev environment setting guide updates

### DIFF
--- a/docs/development/skaffold-managed-local-dev-environment.adoc
+++ b/docs/development/skaffold-managed-local-dev-environment.adoc
@@ -104,6 +104,12 @@ $ docker --version
 Docker version 18.09.2, build 6247962
 ```
 
+==== Memory
+
+Make sure enough memory is allocated to Docker. Assign at least `6 GB` of memory
+in Docker preferences: _Docker_ -> _Preferences_ -> _Advanced_ set Memory slider 
+to `6.0 GiB` and confirm with `Apply & Restart` button.
+
 === Kubernetes
 
 Activate Kubernetes in the Docker preferences: _Docker_ -> _Preferences_ -> 


### PR DESCRIPTION
This PR updates a guide on setting up a local dev environment. It covers:
1. Configuring Google Cloud SDK.
2. Authorizing Kubernetes to pull container images from Google Container Registry.
3. Adds more information on checking versions of the installed packages.
4. Removes section about booting up separate `geth-node`, since it's now covered by Kubernetes.