### PR TITLE
Alternative DKG phase 14

### DIFF
--- a/docs/random-beacon/dkg/alternative.adoc
+++ b/docs/random-beacon/dkg/alternative.adoc
@@ -1,0 +1,428 @@
+= DKG alternative result submission
+
+_Escalating votes_ was originally chosen as the protocol
+for DKG result submission
+due to its favorable gas costs.
+By reducing the frequency of group creation,
+it is feasible to use _full verification_ instead.
+_Full verification_ costs significantly more gas
+in the expected typical scenario,
+but is also more robust.
+
+With the _full verification_ alternative,
+competing submissions are not presented.
+Instead, the participants agree on a result off-chain, sign it,
+and the first available participant submits the result on-chain
+as soon as eligible.
+
+== Basic description
+Each participant _P~i~_ calculates the result they believe to be correct;
+this is called the _preferred result_ of _P~i~_.
+The participants sign broadcast their _preferred results_.
+Each participant should sign and broadcast one _preferred result_;
+signing more than one _preferred result_ can be proven on-chain
+and will be heavily penalized.
+
+After receiving the _preferred results_ of other participants,
+_P~i~_ counts the signatures on each result.
+The result with at least _H_ signatures is the _quorum result_.
+The _quorum result_ is published on-chain along with its signatures.
+
+The contract checks that the result is correct
+and has at least _H_ valid signatures.
+If the checks pass,
+a new group is successfully created.
+
+== Multiple quorum results
+It is possible that there is more than one _quorum result_.
+This always requires that at least one participant
+has signed two different results.
+Additionally, either the honest majority assumption has been violated
+or the honest participants are split over different results.
+
+There are multiple different ways to deal with this.
+
+[upperalpha]
+. Accept either result
+because under honest majority both must have at least one honest signer
+. Discard signatures from disqualified participants
+and reject all results because no honest quorum was achieved
+. Discard signatures from disqualified participants
+and attempt to reconstruct a valid result,
+aborting only if the results are incompatible
+
+== Option A: accept either
+Option A has a very simple on-chain implementation.
+It is sufficient to accept the first submission
+with at least _H_ signatures
+and reject any further submissions.
+Members who provably sign multiple submissions
+can be removed from the group on the fly.
+
+However, because signing two different results is forbidden,
+neither result has the support of _H_ not-provably-misbehaving participants.
+This would permit an adversary to force the creation of
+a group where the adversary has a linchpin position.
+
+Let the results be _a_ and _b_.
+Let the number of honest participants
+signing each result be _h~a~_ and _h~b~_ respectively.
+Let the malicious participants be _m~a~_ and _m~b~_,
+and _m~ab~_ for those who sign both results.
+Let _ia_ and _dq_ be the number
+of inactive and disqualified participants.
+
+==== No honest majority
+If this attack happens because the honest majority assumption has failed,
+it is dubious whether it matters
+because the adversary has better attacks available.
+If the honest participants number less than _H_,
+the adversary could outnumber them
+by simply not signing the honest participants' preferred result.
+Signing multiple results can be proven on-chain
+and thus heavily penalized.
+In this scenario option A does not seem to meaningfully reduce security.
+
+_h~a~ < H_
+
+_h~b~ = 0_
+
+_h~a~ + m~a~ + m~ab~ >= H_
+
+_m~b~ + m~ab~ >= H_
+
+_ia + dq + m~ab~ =< M~nofail~_
+
+If _m~ab~_ were to instead sign only _b_,
+the adversary could avoid the punishment
+and guarantee that result _b_ is selected.
+
+The adversary can completely control the group formed by _b_,
+while in _a_ the adversary is only guaranteed a linchpin position
+(the ability to prevent entries from being created
+and to deny submitter rewards to other participants)
+unless _m~a~ + m~ab~ >= H_
+(requiring _m~a~, m~b~ > M~nofail~_ thus _h~a~ < M~nofail~_;
+a rather hopeless situation under any option).
+
+==== Split honest majority
+The other alternative is
+that the honest majority is split over different results,
+and the adversary signs results selectively to manipulate the outcome.
+
+_h~a~ + h~b~ >= H_
+
+_m~a~ + m~ab~ + m~b~ =< M_
+
+_h~a~ + m~a~ + m~ab~ >= H_
+
+_h~b~ + m~b~ + m~ab~ >= H_
+
+_ia~a~ + dq~a~ + m~ab~ =< M~nofail~_
+
+_ia~b~ + dq~b~ + m~ab~ =< M~nofail~_
+
+_h~a~ + m~a~ < H_
+
+_h~b~ + m~b~ < H_
+
+If the honest majority is irreconcilably split
+and the results _a_ and _b_ have different _QUAL_
+and thus different group public keys,
+the adversary is able to guarantee itself a linchpin position
+regardless of the winning result.
+
+If the honest majority agrees on _QUAL_ and _Y_,
+the adversary can obtain a linchpin position
+if _a_ sets many participants from _h~b~_ as inactive,
+and vice versa.
+Otherwise the resulting group will be capable of
+producing signatures without contribution from the adversary.
+
+By having _m~ab~_ sign only one of the two results,
+the adversary could choose the more favorable outcome
+and avoid the penalties for signing conflicting results.
+
+=== Option B: reject both
+Option B provides the most robust guarantees
+but is complex to implement on-chain.
+
+It is not enough to accept
+the first result to be signed by at least _H_ members
+because some of those signatures could be invalidated later.
+The first result that appears to meet quorum
+would have to be set as the _tentative result_,
+as it could become invalid as proofs of misbehavior are submitted.
+
+Signatures by each member need to be tracked,
+and members disqualified for multiple signatures
+must be recorded in a special blacklist.
+
+Because an adversary could submit a result with exactly _H_ signatures,
+and afterwards invalidate some of them,
+it is necessary that signatures can be added to the _tentative result_.
+
+A separate finalization after submission time has run out
+would remove disqualified signatures
+and determine whether the _tentative result_ remains valid.
+(No other result could become valid;
+if the _tentative result_ is invalidated
+it is impossible for any result to gain _H_ valid signatures.)
+
+=== Option C: try to reconstruct a valid result
+In option C,
+conflicting results can be reconciled
+to obtain one acceptable outcome.
+Results are not treated as immutable units,
+but rather as sets of votes for each component.
+
+Two or more conflicting results can be reconciled
+if they agree on _Y_ (and implicitly _QUAL_).
+If multiple results with the same _Y~a~_
+have at least _H_ valid signatures across them,
+_Y~a~_ can be considered the true group public key.
+
+_IA_ and _DQ_ could be reconciled thus:
+
+. _P~i~_ is disqualified if at least _H_ valid signatures
+support results where _P~i~_ is disqualified.
+. _P~i~_ is inactive if at least _H_ valid signatures
+support results where _P~i~_ is either inactive or disqualified,
+and _P~i~_ is not disqualified due to the previous clause.
+
+If neither of the above apply,
+_P~i~_ is deemed to be neither disqualified nor inactive.
+(Other solutions could also be just as viable.)
+
+Reconciling conflicting but compatible results
+could reduce the impact
+of honest members splitting across multiple results;
+a disagreement on a single participant's inactivity
+could cause divergence and DKG failure without reconciliation.
+
+However, reconciling results is only useful if the broadcast channel fails,
+and on-chain reconciliation is unnecessarily complex and expensive.
+Reconciling conflicting results would be best performed
+by the participants first broadcasting their _preferred results_,
+then applying reconciliation,
+and finally broadcasting their signatures for the reconciled result.
+
+== Phase 13': Result determination
+In the result determination phase,
+each participant _P~i~_ constructs the canonical representation
+of the result they believe to be correct,
+and prepares to store it:
+
+_P~i~_ calculates the group public key share _Y~j~_
+of each member, including inactive and disqualified ones.
+
+(_This section is not strictly required for early implementations:_
+
+_P~i~_ proceeds to construct a merkle tree of these public key shares;
+the merkle root of this tree is _MerkleRoot~Y~_.
+
+_End section_)
+
+The on-chain representation of the result is formed of:
+
+* a unique identifier of this particular run of the DKG protocol _DkgID_
+* the group public key _Y_
+* the set of inactive members _IA_
+* the set of disqualified members _DQ_
+* (_MerkleRoot~Y~_ if used)
+
+The _inner hash_ of the result is `sha3(Y, MerkleRoot_Y, IA, DQ)`.
+The _outer hash_ is `sha3(DkgID, inner_hash)`.
+
+_P~i~_ then signs the _outer hash_ of this _preferred result_,
+and broadcasts the hash and the signature to other participants.
+Agreement on this hash is sufficient to ensure agreement on the result,
+including each good participant's public key shares.
+
+== Phase 14': Result submission
+_P~i~_ receives the result signature messages from other participants,
+and proceeds to determine the ultimate outcome of the DKG.
+
+The result supported by at least _H_ participants
+is called the _quorum result_.
+If the honest majority assumption holds,
+a _quorum result_ must have been signed by at least one honest participant.
+
+How _P~i~_ should proceed depends on whether a _quorum result_ exists,
+and whether it matches _P~i~_'s _preferred result_:
+
+* If there is no _quorum result_,
+quorum has not been achieved and the DKG ends inconclusively.
+
+* If there is a single _quorum result_
+and it matches the _preferred result_,
+a new group is formed correctly and _P~i~_ is able to participate in it.
+_P~i~_ stores the public key shares _Y~j~_ until the group expires,
+and prepares to submit the result on-chain if needed.
+
+* If there is a single _quorum result_
+that does not match the _preferred result_,
+a new group is formed correctly but _P~i~_ may not be able to participate.
+If the _quorum result_ is _reconcilable_ with the _preferred result_;
+meaning it has the same _Y_ (and _MerkleRoot~Y~_),
+and _P~i~_ is among the ultimately qualified participants;
+_P~i~_ can replace their _preferred result_ with the _quorum result_.
+Otherwise _P~i~_ could not participate without more complex reconciliation.
+
+At this point,
+different solutions for handling multiple quorum results diverge.
+
+=== Option A
+* If there are multiple _quorum results_,
+and one of them matches the _preferred result_,
+_P~i~_ should attempt to submit the _preferred result_.
+
+* If there are multiple _quorum results_,
+none of which matches the _preferred result_,
+but one or more results are _reconcilable_,
+_P~i~_ should wait to see which result is submitted first.
+
+* If there are multiple _quorum results_,
+all _non-reconcilable_,
+_P~i~_ cannot participate further.
+
+If the DKG ends inconclusively,
+no result is submitted on-chain.
+
+If a group is formed correctly and _P~i~_ is able to participate,
+the result is submitted on-chain
+by the first eligible participant able to do so.
+Eligibility to submit the result is calculated as in _Phase 13_.
+The on-chain submission consists of the result
+along with its signatures,
+each accompanied by the member index of the signer.
+
+==== Processing submissions on-chain
+When a result is submitted,
+the contract checks that
+the _DkgID_ of the result matches the DKG execution,
+each signature on the result is valid,
+and at least _H_ signatures are present.
+
+If the checks pass:
+
+* Each inactive (included in the set _IA_ of the _tentative result_),
+disqualified (included in the set _DQ_ of the _tentative result_),
+and _blacklisted_ member
+is removed from the group
+* _Y_ is stored as the group public key
+* (If used, _MerkleRoot~Y~_ is stored
+as the merkle root of the group public key shares)
+* The submitter is rewarded
+* The group is formed successfully
+and can now be selected for producing beacon entries
+
+==== Misbehavior proofs
+If any participant _P~m~_ has signed two or more different results,
+any participant may publish a _misbehavior proof_ on-chain.
+This _misbehavior proof_ contains
+the unique _DkgID_,
+the member index _m_ of the accused _P~m~_,
+two different _signatures_ and the corresponding _inner hashes_.
+The contract reconstructs the _outer hashes_ using the provided _DkgID_
+(to prevent replay attacks),
+and checks the signatures.
+If both signatures are valid,
+_P~m~_ is heavily penalized and removed from the group.
+The submitter of a valid proof
+leading to a removal from the group
+is rewarded _R~dkg_tattletale~_.
+
+_Misbehavior proofs_ can be published at any time
+regardless of eligibility to submit DKG results.
+A valid _misbehavior proof_ on a past DKG
+can be used if the DKG produced a group which is still active,
+and the misbehaving member is still in the group.
+
+=== Option B
+* If there are multiple _quorum results_,
+quorum cannot be reached after invalidating the members
+who signed multiple results,
+so the DKG will end inconclusively
+once the _misbehavior proofs_ are published.
+
+If a group is formed correctly and _P~i~_ is able to participate,
+the result is submitted on-chain
+by the first eligible participant able to do so.
+Eligibility to submit the result is calculated as in _Phase 13_.
+The on-chain submission consists of the result,
+along with its signatures by non-disqualified participants,
+each accompanied by the member index of the signer.
+
+==== Misbehavior proofs
+Misbehavior proofs are created and checked
+as in option A.
+If the proof is valid,
+_P~m~_ is added to the _blacklist_,
+but not penalized or removed from the group immediately.
+The submitter of a valid proof
+leading to a new _blacklist_ entry
+is rewarded _R~dkg_tattletale~_.
+
+==== Processing submissions on-chain
+When a result candidate is submitted,
+the contract checks that
+the _DkgID_ of the result matches the DKG execution,
+each signature on the result is valid,
+and at least _H_ signatures are present.
+If the checks pass,
+the result candidate is designated as the _tentative result_
+and stored along with indices of the signers
+(signatures themselves can be discarded);
+the submitter is recorded as the _result submitter_
+along with the number of signers.
+
+After the _tentative result_ has been determined,
+any participant can add signatures to it
+by submitting one or more signatures
+with the signers' member indices. 
+If all submitted signatures are valid,
+the signers' indices are added to the _tentative result_;
+the submitter is recorded as a _result supporter_
+along with the number of new signers
+whose indices were not already included
+in the signers of the _tentative result_.
+
+After a specified time period has elapsed,
+any participant can _finalize_ the DKG.
+Upon finalization:
+
+1. Each member on the _blacklist_ is penalized heavily.
+
+2. If there is no _tentative result_:
+the DKG aborts and the group is not formed.
+The _finalizer_ (the participant making the finalization transaction)
+is paid _R~dkg_inconclusive~_ to cover gas costs.
+
+3.  Each member on the _blacklist_ is removed
+from the signers of the _tentative result_, if present.
+
+4. If the number of remaining signers on the _tentative result_
+is less than _H_:
+the DKG aborts and the group is not formed.
+The _finalizer_ is paid _R~dkg_inconclusive~_.
+
+5. If at least _H_ signers are remaining on the _tentative result_:
+** Each inactive (included in the set _IA_ of the _tentative result_),
+disqualified (included in the set _DQ_ of the _tentative result_),
+and _blacklisted_ member
+is removed from the group
+** _Y_ is stored as the group public key
+** (If used, _MerkleRoot~Y~_ is stored
+as the merkle root of the group public key shares)
+** Contributors are rewarded:
+*** The _result submitter_ is paid a constant amount _R~dkg_submit_base~_
+plus _R~dkg_submit_signer~_ per each signer in the original submission
+*** Each _result supporter_ is paid _R~dkg_support_signer~_
+per each new signer they added to the result
+*** The _finalizer_ is paid _R~dkg_finalized~_
+** The group is formed successfully
+and can now be selected for producing beacon entries
+
+=== Option C
+TBD


### PR DESCRIPTION
Closes: #623 
Refs: #625 

Having DKG happen less often makes more expensive protocols viable. This DKG
result submission protocol removes the voting, instead requiring signatures from
a majority of participants.

Under some circumstances multiple results may conflict. While it is possible to
preclude such edge cases, it requires significant on-chain complexity.
Permitting these edge cases does not appear to significantly weaken the security
of the system, as any adversary able to exploit them would have other options
regardless. Specifications and analysis are included for the two alternatives.