### PR TITLE
[RFC] Group expiration minimal specification

### DIFF
--- a/docs/rfc/rfc-6-group-expiration-minimal-specification.adoc
+++ b/docs/rfc/rfc-6-group-expiration-minimal-specification.adoc
@@ -88,6 +88,8 @@ decrease the _active group counter_ by one. Then the next group is selected and
 its status is verified until an active group is found or the number of active
 groups falls below the _active groups threshold_.
 
+Expired groups need not be tracked for an unlimited time. They might be removed
+when deemed unnecessary for current network operations.
 
 [bibliography]
 == Related Links


### PR DESCRIPTION
Closes: #622 

Introducing a minimal specification of group expiration.

The group expiration enables groups to expire when particular
conditions are met. In this proposal, the group expiration happens
when the group aged by an arbitrary number of blocks.