### PR TITLE
Local ETH Deployment: Pause for the cause

### DIFF
--- a/infrastructure/scripts/up
+++ b/infrastructure/scripts/up
@@ -1,6 +1,8 @@
 #!/bin/bash
 DIRNAME=`dirname $0`
 kubectl create -f $DIRNAME/../kube/lcl/dashboard.yaml
+sleep 20
 kubectl create -f $DIRNAME/../kube/lcl/miner-nodes.yaml
+sleep 20
 kubectl create -f $DIRNAME/../kube/lcl/tx-nodes.yaml
 echo "EthStats Dashboard address: http://localhost:3000"


### PR DESCRIPTION
Depending on the state of your local chain we can have some peering
and sync issues when bringing everything up at the same time.  After
a few test runs things are more reliable with a pause in between
each deployment.  Here we add that pause to the up script.  While
this doesn't feel as pew pew lasers, it does make for a better
experience.