### PR TITLE
New Phase 13 updates

### DIFF
--- a/pkg/beacon/relay/dkg2/result/gen/pb/message.proto
+++ b/pkg/beacon/relay/dkg2/result/gen/pb/message.proto
@@ -7,7 +7,7 @@ package result;
 // by the sender, as well as a marshalled signature over this hash and sender's 
 // public key which can be used to verify the signature.
 message DKGResultHashSignature {
-  bytes senderIndex = 1;
+  uint32 senderIndex = 1;
   bytes resultHash = 2;
   bytes signature = 3;
   bytes publicKey = 4;

--- a/pkg/beacon/relay/dkg2/result/marshalling.go
+++ b/pkg/beacon/relay/dkg2/result/marshalling.go
@@ -10,7 +10,7 @@ import (
 // for network communication.
 func (d *DKGResultHashSignatureMessage) Marshal() ([]byte, error) {
 	return (&pb.DKGResultHashSignature{
-		SenderIndex: d.senderIndex.Bytes(),
+		SenderIndex: uint32(d.senderIndex),
 		ResultHash:  d.resultHash[:],
 		Signature:   d.signature,
 		// PublicKey:   , // TODO: Add public key marshalling when static.PublicKey is ready
@@ -24,7 +24,7 @@ func (d *DKGResultHashSignatureMessage) Unmarshal(bytes []byte) error {
 	if err := pbMsg.Unmarshal(bytes); err != nil {
 		return err
 	}
-	d.senderIndex = member.IndexFromBytes(pbMsg.SenderIndex)
+	d.senderIndex = member.Index(pbMsg.SenderIndex)
 
 	resultHash, err := chain.DKGResultHashFromBytes(pbMsg.ResultHash)
 	if err != nil {

--- a/pkg/beacon/relay/dkg2/result/signing.go
+++ b/pkg/beacon/relay/dkg2/result/signing.go
@@ -3,10 +3,12 @@ package result
 import (
 	"fmt"
 
+	"github.com/keep-network/keep-core/pkg/operator"
+
 	relayChain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
+	"github.com/keep-network/keep-core/pkg/beacon/relay/gjkr"
 	"github.com/keep-network/keep-core/pkg/beacon/relay/member"
 	"github.com/keep-network/keep-core/pkg/chain"
-	"github.com/keep-network/keep-core/pkg/operator"
 )
 
 // SigningMember represents a member sharing preferred DKG result hash
@@ -25,7 +27,7 @@ type SigningMember struct {
 
 // NewSigningMember creates a member to execute signing DKG result hash.
 func NewSigningMember(
-	memberIndex member.Index,
+	memberIndex gjkr.MemberID,
 	operatorPrivateKey *operator.PrivateKey,
 ) *SigningMember {
 	return &SigningMember{


### PR DESCRIPTION
This PR contains couple of updates to Phase 13:
- chain handle is no longer part of member struct, it's expected to be passed to the function
- member struct keeps only member's self signature
- verification function returns a map of received signatures instead of storing them in member struct
- minor docs or naming fixes

Refs https://github.com/keep-network/keep-core/issues/639
Refs: #625 