### PR TITLE
Group expiration step 1: create a group structure

### DIFF
--- a/contracts/solidity/contracts/KeepGroupImplV1.sol
+++ b/contracts/solidity/contracts/KeepGroupImplV1.sol
@@ -59,7 +59,12 @@ contract KeepGroupImplV1 is Ownable {
 
     mapping(uint256 => Proof) internal _proofs;
 
-    bytes[] internal _groups;
+    struct Group {
+        bytes groupId;
+        uint registrationTime;
+    }
+
+    Group[] internal _groups;
     mapping (bytes => address[]) internal _groupMembers;
 
     mapping (string => bool) internal _initialized;
@@ -295,7 +300,7 @@ contract KeepGroupImplV1 is Ownable {
         // TODO: Remove this section once dispute logic is implemented,
         // implement conflict resolution logic described in Phase 14,
         // make sure only valid members are stored.
-        _groups.push(groupPublicKey);
+        _groups.push(Group(groupPublicKey, block.number));
         address[] memory members = orderedParticipants();
         for (uint i = 0; i < _groupSize; i++) {
             _groupMembers[groupPublicKey].push(members[i]);
@@ -470,7 +475,7 @@ contract KeepGroupImplV1 is Ownable {
      * @param previousEntry Previous random beacon value.
      */
     function selectGroup(uint256 previousEntry) public view returns(bytes memory) {
-        return _groups[previousEntry % _groups.length];
+        return _groups[previousEntry % _groups.length].groupId;
     }
 
     /**


### PR DESCRIPTION
The first step for implementing group expiration is the creation of a minimalistic group structure that will hold `groupId`, group identificator (dkg group pub key) and `registrationTime` for tracking group registration time.

Refs:#663