### PR TITLE
Modify macos-setup.sh script to export env variables

### DIFF
--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -60,10 +60,10 @@ echo "Installing bn and it's dependencies..."
 	make install
 )
 
-echo "*************************************************************************"
-echo "*** NOTE: Please add above PATH, LD_LIBRARY_PATH, DYLD_LIBRARY_PATH   ***" 
-echo "*** export commands to your shell configuration file. 				***"
-echo "*** Ex. for bash shell - ~/.bash_profile, for zsh - ~/.zshrc          ***"
-echo "*************************************************************************"
+echo "******************************************************************"
+echo "*** Please configure PATH, LD_LIBRARY_PATH, DYLD_LIBRARY_PATH  ***"
+echo "*** environment variables in your shell configuration file.    ***"
+echo "*** Ex. for bash shell - ~/.bash_profile, for zsh - ~/.zshrc   ***"
+echo "******************************************************************"
 
 echo "Ready to rock! See above for any extra environment-related instructions."


### PR DESCRIPTION
Refs: #684 

Export `PATH`, `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH` so this script can
properly install necessary dependencies. bn library crashed without these
exports.

Add a note to include export commands in a shell configuration file.