### PR TITLE
Circle: Upgrade + GCR Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           root: /tmp/docs
           paths:
             - solidity/*
-  build_image_test_go:
+  build_client_and_test_go:
     executor: docker-git
     steps:
       - setup_remote_docker:
@@ -69,7 +69,7 @@ jobs:
           root: /tmp/images
           paths:
             - keep-client
-  publish_image:
+  publish_client:
     executor: gcp-gcr/default
     steps:
       - attach_workspace:
@@ -150,15 +150,15 @@ workflows:
       - test_solidity
   build-test-publish:
     jobs:
-      - build_image_test_go:
+      - build_client_and_test_go:
           context: keep-dev
-      - publish_image:
+      - publish_client:
           filters:
             branches:
               only: master
           context: keep-dev
           requires:
-            - build_image_test_go
+            - build_client_and_test_go
   docs:
     jobs:
       - generate_docs_tex


### PR DESCRIPTION
There are a few forces at play with this PR but the impetus of the work is to round out the last tasks for continuous deployment. The work here goes in conjunction with https://github.com/keep-network/keep-core/pull/676 and https://github.com/thesis/infrastructure/pull/56

#### Other Changes

- Upgraded circle config from `2.0` to `2.1`

- Introduced an Orb: https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
  - This is used for both auth to the container registry and image publishing
  - We use this orb because someones already done the work for us and it's relatively straight forward to configure.

- Factored `build` out into a separate job.  This is so we could build images once and use them for both testing and publishing jobs.

- Created a `build-test-publish` workflow.  This is so that we can `require` both `build` and `test_go` to pass before publishing.  

#### Misc

- Mounting the keep-client image between jobs is slow.  Will probably want to make this faster in the future. We can do this by publishing a tainted image to the registry, then pulling it for testing, then retagging/republishing after testing.  We may be able to make the image smaller, or find some other way to speed-up.

- We did not factor out the existing GCP auth mechanism in the `upload_docs` job to use auth provided by the GCR orb.  We could do this but I wanted to have the init PR be as few changes as possible for sanity.

Note on Circle Contexts:  As part of this were introducing a new Circle Context organizational method.  Now we'll have a context for each project when needed.  This context will hold env vars related to the specific project and nothing else.  This will mirror the 1:1 relation between project/env.


Closes https://github.com/keep-network/keep-core/issues/721