### PR TITLE
[RFC] Upgradeable contract components

### DIFF
--- a/docs/rfc/rfc-9-upgradeable-contract-components.adoc
+++ b/docs/rfc/rfc-9-upgradeable-contract-components.adoc
@@ -157,11 +157,19 @@ and adding it to the available operator contracts of a service contract.
 As stakers authorize the new operator contract,
 the service contract can gradually migrate
 to use the new operator contract over older versions.
+Support for obsolete operator contracts can be withdrawn
+when a sufficiently overwhelming supermajority of stakers
+has authorized and begun to operate using the new version.
 
 Operator contracts can be upgraded
 without losing service contract state,
 but critical state is held within the operator contract
 and cannot be migrated.
+
+If the operator contract's interface is changed,
+the service contract should be updated as well.
+If customer continuity is required,
+the operator contract can support both versions of the interface.
 
 ==== Service contract upgrades
 


### PR DESCRIPTION
closes #725 

By splitting work contracts to front-end and back-end components, secure upgrades can be achieved without excessive headache. Immutable back-end contracts maintain system integrity towards stakers, while front-end contracts can abstract and delegate over multiple back-ends to provide a smooth customer experience.

Responses to questions in #133 : 

>What conditions trigger a “hard fork”-style whole-system upgrade?

Only upgrades to the token contract require a full "hard fork". Upgrades to staking contracts or work contracts can be gracefully accommodated.

In individual work contracts, the front-end upgrade rules determine this. If front-end code is immutable, only upgradeable with new backends, any upgrades that require changing the rules of the front-end necessitate a hard fork on the specific contract. If eternal storage is used, a hard fork is required if the storage needs changing.

>What does a whole-system upgrade consist of? e.g., what happens to the relay and its relay groups? [1] What happens to keeps?

With a frontend hard fork, the relay would need to be restarted with some initial entry (possibly from the entries produced on the previous frontend). If the entries are kept in eternal storage, the relay could continue directly.

Groups would be backend-specific, so whether groups are kept depends on whether old backends are kept.

>What do softer upgrades look like (e.g., client upgrades)?

Deploying a new backend contract, adding it to the frontend's backends, waiting for the frontend to start creating groups on the new backend.

>[1]- One concrete question for the relay is, say we want to change the curve on which we run BLS key generation and signing. How do we manage this? In particular, do we require all active relay groups to regenerate their keys post-upgrade? Do we support two curves in parallel? Do we drop all groups and restart the relay? Working out some of the implications of these decisions would be good. Several of them will likely apply to other places as well (e.g., Threshold ECDSA likely will have similar questions about crypto upgrades).

The upgrade scheme provides an elegant way to support curves in parallel. Changing the curve would only be a matter of deploying a new backend contract and staking clients that support it; no restart required. From the perspective of the customers, only use-cases that involve specifically validating entries would be impacted as they would need to accommodate the new curve. Similar solutions are likely viable with tBTC as well.