### PR TITLE
Keep group contract - earliest block to fetch selected participants/tickets - bugfix

### DIFF
--- a/contracts/solidity/contracts/KeepGroupImplV1.sol
+++ b/contracts/solidity/contracts/KeepGroupImplV1.sol
@@ -125,7 +125,7 @@ contract KeepGroupImplV1 is Ownable {
     function selectedTickets() public view returns (uint256[] memory) {
 
         require(
-            block.number > _submissionStart + _timeoutChallenge,
+            block.number >= _submissionStart + _timeoutChallenge,
             "Ticket submission challenge period must be over."
         );
 
@@ -161,7 +161,7 @@ contract KeepGroupImplV1 is Ownable {
     function selectedParticipants() public view returns (address[] memory) {
 
         require(
-            block.number > _submissionStart + _timeoutChallenge,
+            block.number >= _submissionStart + _timeoutChallenge,
             "Ticket submission challenge period must be over."
         );
 


### PR DESCRIPTION
Closes: #729 

When ticket submission started at block `10`, and challenge timeout is `4`, we should be able to fetch tickets when block `14` has been sealed - candidates could challenge in block `11`, `12`, `13`, and `14`. Actual behaviour was different than expected - Keep group contract allowed to fetch selected tickets no earlier than after block `15` has been sealed.

`block.number` in view function is the latest block, so the one that was sealed, not the one currently being mined.

`block.number` for function executed inside transaction is evaluated at the moment when this transaction is mined, so it's block including the transaction.

Say we started at `_submissionStart = 10` and `_timeoutChallenge = 4`. When block `14` has been sealed, we can no longer submit tickets (because transaction will be processed in block `15` or later) and we should be able to get those selected tickets. However, for a view function, `block.number` is the latest sealed block, so it's `14`.

That's why we should use `>=` instead of `>`.

Showcase of `block.number` behavior:
```
contract BlockCheck { 
    event BlockEvent(uint256 number);

    function get() public { emit BlockEvent(block.number); } 
    function get2() public view returns (uint256) { return block.number; }
    
}
```

After deploying the contract:
And then (after deploying this contract):
```
> events.watch(function(error, event) { if(!error) console.log(JSON.stringify(event)); });
> blockcheck.get({from: web3.eth.accounts[0], gas:3000000});
"0x798cb2225b5e6f8fd0bae21c11b5750f1cc5bf8ef03daa6b30790d639487df47"
> blockcheck.get2.call()
30866
(...)
> 
{"address":"0x0f712abd97212fc441157585163560ee5d046972","args":{"number":"30867"},"blockHash":"0xdf985fb55a3894c1c70a9ebe268f34346f364a711b0b6dc616d851b80dc76bf7","blockNumber":30867,"event":"BlockEvent","logIndex":0,"removed":false,"transactionHash":"0x798cb2225b5e6f8fd0bae21c11b5750f1cc5bf8ef03daa6b30790d639487df47","transactionIndex":0}
```

```
> eth.getTransaction("0x798cb2225b5e6f8fd0bae21c11b5750f1cc5bf8ef03daa6b30790d639487df47");
{
  blockHash: "0xdf985fb55a3894c1c70a9ebe268f34346f364a711b0b6dc616d851b80dc76bf7",
  blockNumber: 30867,
  from: "0xfa3da235947aab49d439f3bcb46effd1a7237e32",
  gas: 3000000,
  gasPrice: 1000000000,
  hash: "0x798cb2225b5e6f8fd0bae21c11b5750f1cc5bf8ef03daa6b30790d639487df47",
  input: "0x6d4ce63c",
  nonce: 732,
  r: "0x2229eaf3b5e382c4d40a6fd1eeb3e8b1b7f19d81f9dc3c8ba821b054d0e59ebf",
  s: "0x2c380f4d1150dba2aedffee470c9030d6e9f2d22348644bc34ccc89d2431d22a",
  to: "0x0f712abd97212fc441157585163560ee5d046972",
  transactionIndex: 0,
  v: "0x8bd",
  value: 0
}
```