### PR TITLE
Keep Relay: submit request script

### DIFF
--- a/contracts/solidity/scripts/request-relay-entry.js
+++ b/contracts/solidity/scripts/request-relay-entry.js
@@ -10,7 +10,7 @@ module.exports = async function() {
     let crypto = require("crypto");
     let KeepRandomBeaconContractAddress = await KeepRandomBeacon.at(keepRandomBeaconProxy.address);
 
-    // Generate 32 bit sort of random number
+    // Generate 32 byte sort of random number
     try {
       relayEntrySeed = crypto.randomBytes(32);
     }


### PR DESCRIPTION
Now that the relay loop is gone we need a trivial way to submit requests to a network that is running Keep clients and has Keep contracts deployed.

Here we provide a script that submits a single entry.  The script uses existing dependencies so we should be able to run this out of the box.

It's meant to be used with `truffle`, allowing the user to submit test runs either locally or to the cloud with a truffle profile change.

We'll roll this up into a `keep-dev` deployment that runs requests on a cron.  (Separate PR)

#### Testing

Sample Output:

```
sthompson22@99-0-0-9:~/projects/keep-core/contracts/solidity/scripts(sthompson22/scripts/relay-submit⚡) » truffle exec ./request-relay-entry.js --network keep_dev
Using network 'keep_dev'.

---Transaction Summary---
From:0x0f0977c4161a371b5e5ee6a8f43eb798cd1ae1db
To:0x9d28652e7777946a5cf1e738e38024cb14993be9
BlockNumber:133616
TotalGas:144316
TransactionHash:0x36699f36d144cac5711fe8f07de102a4dc0b2b5053e3205bb7ee3341b3861787
--------------------------
```