### PR TITLE
keep-dev: push deploy infra

### DIFF
--- a/infrastructure/terraform/keep-dev/main.tf
+++ b/infrastructure/terraform/keep-dev/main.tf
@@ -216,9 +216,10 @@ module "push_deployment_infrastructure" {
   }
 
   utility_box {
-    name = "${var.utility_box["name"]}"
-    zone = "${var.region_data["zone_a"]}"
-    tags = "${module.nat_gateway_zone_a.routing_tag_regional},${var.utility_box["tags"]}"
+    name         = "${var.utility_box["name"]}"
+    machine_type = "${var.utility_box["machine_type"]}"
+    zone         = "${var.region_data["zone_a"]}"
+    tags         = "${module.nat_gateway_zone_a.routing_tag_regional},${var.utility_box["tags"]}"
   }
 
   labels = "${local.labels}"

--- a/infrastructure/terraform/keep-dev/variables.tf
+++ b/infrastructure/terraform/keep-dev/variables.tf
@@ -229,7 +229,8 @@ variable "jumphost" {
 
 variable "utility_box" {
   default {
-    name = "keep-dev-utility-box"
-    tags = "gke-subnet"
+    name         = "keep-dev-utility-box"
+    tags         = "gke-subnet"
+    machine_type = "g1-small"
   }
 }


### PR DESCRIPTION
We're working on a solution for managing Keep contracts via Circle.  To
facilitate this we need a way to interact with both the ETH private
testnet and kubectl for a private cluster.  Push deploy infrastructure
will give us this path.

-------------

Goes with: https://github.com/keep-network/keep-core/pull/743

I'll need to modify the init script for the utility box to take optional installs, and to optionally install `truffle`.  Will do that in a separate PR.


#### Manual access test
I forgot (and had to redo) a couple commands along the way.

```
sthompson22@Sloans-MacBook-Pro:~/projects/keep-core/infrastructure/terraform/keep-dev(sthompson22/keep-dev/push-deployment-infrastructure⚡) » gcloud compute ssh keep-dev-jumphost --zone=us-central1-a                                 1 ↵
Warning: Permanently added 'compute.8319189047072498875' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 4.15.0-1029-gcp x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Mon Apr 22 20:22:31 UTC 2019

  System load:  0.0               Processes:           88
  Usage of /:   11.9% of 9.52GB   Users logged in:     0
  Memory usage: 36%               IP address for ens4: 10.0.0.5
  Swap usage:   0%

 * Ubuntu's Kubernetes 1.14 distributions can bypass Docker and use containerd
   directly, see https://bit.ly/ubuntu-containerd or try it now with

     snap install microk8s --classic

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.



The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

sthompson22@keep-dev-jumphost:~$ gcloud compute keep-dev-utility-box --internal-ip
ERROR: (gcloud.compute) Invalid choice: 'keep-dev-utility-box'.
Maybe you meant:
  gcloud compute

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
sthompson22@keep-dev-jumphost:~$ gcloud compute ssh keep-dev-utility-box --internal-ip
WARNING: The public SSH key file for gcloud does not exist.
WARNING: The private SSH key file for gcloud does not exist.
WARNING: You do not have an SSH key for gcloud.
WARNING: SSH keygen will be executed to generate a key.
Generating public/private rsa key pair.
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Your identification has been saved in /home/sthompson22/.ssh/google_compute_engine.
Your public key has been saved in /home/sthompson22/.ssh/google_compute_engine.pub.
The key fingerprint is:
SHA256:8ZrmM2YuhyQMe8FkZYbGfhKjEJWs1ttD2hBTHEF1N94 sthompson22@keep-dev-jumphost
The key's randomart image is:
+---[RSA 2048]----+
|.+.o+BB. . o     |
|. ooO+  . o o    |
| o.Boo  .  . E   |
|..oo=..  o       |
|.  +B+  S .      |
|  .o++.  o       |
|   . o..+        |
|      oo*        |
|       *oo       |
+----[SHA256]-----+
Did you mean zone [us-central1-a] for instance: [keep-dev-utility-box]
 (Y/n)?  Y

Updating project ssh metadata...⠛Updated [https://www.googleapis.com/compute/v1/projects/keep-dev-fe24].
Updating project ssh metadata...done.
Waiting for SSH key to propagate.
Warning: Permanently added 'compute.1289826282293666910' (ECDSA) to the list of known hosts.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    19  100    19    0     0   1266      0 --:--:-- --:--:-- --:--:--  1266
Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 4.15.0-1029-gcp x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Mon Apr 22 20:23:45 UTC 2019

  System load:  0.0               Processes:           89
  Usage of /:   14.1% of 9.52GB   Users logged in:     0
  Memory usage: 37%               IP address for ens4: 10.2.0.11
  Swap usage:   0%


  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

25 packages can be updated.
13 updates are security updates.


sthompson22@keep-dev-utility-box:~$ kubectl get pods
The connection to the server localhost:8080 was refused - did you specify the right host or port?
sthompson22@keep-dev-utility-box:~$ gcloud container clusters get-credentials keep-dev --region us-central1 --internal-ip --project=keep-dev-fe24
Fetching cluster endpoint and auth data.
kubeconfig entry generated for keep-dev.
sthompson22@keep-dev-utility-box:~$ kubectl get pods
NAME                                            READY   STATUS    RESTARTS   AGE
eth-dashboard-5f45c48b7f-7tm46                  1/1     Running   0          26d
eth-miner-node-856f94fc9b-4z27b                 1/1     Running   0          10d
eth-miner-node-856f94fc9b-6pb5k                 1/1     Running   0          26d
eth-miner-node-856f94fc9b-n6jln                 1/1     Running   0          6d
eth-miner-node-856f94fc9b-qjc57                 1/1     Running   0          10d
eth-miner-node-856f94fc9b-xrw9s                 1/1     Running   0          10d
eth-miner-node-856f94fc9b-zvfmn                 0/1     Evicted   0          10d
eth-tx-node-5b8b5d9585-5bvvk                    1/1     Running   0          26d
helm-openvpn-85f5ffd464-4fslc                   1/1     Running   0          28d
keep-client-bootstrap-peer-0-79db5d6b86-7tp2k   1/1     Running   0          3d
keep-client-standard-peer-0-79cf786cdd-4vmgc    1/1     Running   0          3d
keep-client-standard-peer-1-84c6c5667-44kg8     1/1     Running   0          3d
keep-client-standard-peer-2-68bcfc7495-bvrf5    1/1     Running   0          3d
keep-client-standard-peer-3-79ff89fdf8-z7wq7    1/1     Running   0          3d
sthompson22@keep-dev-utility-box:~$
```

closes issue https://github.com/keep-network/keep-core/issues/754