### PR TITLE
Fixed order of parameters in SubmitDKGResult

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -469,8 +469,8 @@ func (ec *ethereumChain) SubmitDKGResult(
 	}
 
 	if _, err = ec.keepGroupContract.SubmitDKGResult(
-		participantIndex.Int(),
 		requestID,
+		participantIndex.Int(),
 		result,
 		signaturesOnChainFormat,
 		membersIndicesOnChainFormat,

--- a/pkg/chain/ethereum/keep_group.go
+++ b/pkg/chain/ethereum/keep_group.go
@@ -197,16 +197,16 @@ func (kg *keepGroup) IsDkgResultSubmitted(requestID *big.Int) (bool, error) {
 }
 
 func (kg *keepGroup) SubmitDKGResult(
-	submitterMemberIndex *big.Int,
 	requestID *big.Int,
+	submitterMemberIndex *big.Int,
 	result *relaychain.DKGResult,
 	signatures []byte,
 	signingMembersIndexes []*big.Int,
 ) (*types.Transaction, error) {
 	return kg.transactor.SubmitDkgResult(
 		kg.transactorOpts,
-		submitterMemberIndex,
 		requestID,
+		submitterMemberIndex,
 		result.GroupPublicKey,
 		result.Disqualified,
 		result.Inactive,


### PR DESCRIPTION
Refs: #625

Request ID should go as first, then submitter ID. We had them swapped and as a result, chain used incorrect values.