### PR TITLE
Adding timeout for a relay request

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconImplV1.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconImplV1.sol
@@ -59,8 +59,12 @@ contract KeepRandomBeaconImplV1 is Ownable {
      * @param genesisEntry Initial relay entry to create first group.
      * @param genesisGroupPubKey Group to respond to the initial relay entry request.
      * @param groupContract Group contract linked to this contract.
+     * @param relayRequestTimeout Timeout in blocks for a relay entry to appear on the chain.
+     * Blocks are counted from the moment relay request occur.
      */
-    function initialize(uint256 minPayment, uint256 withdrawalDelay, uint256 genesisEntry, bytes memory genesisGroupPubKey, address groupContract)
+    function initialize(
+        uint256 minPayment, uint256 withdrawalDelay, uint256 genesisEntry, 
+        bytes memory genesisGroupPubKey, address groupContract, uint256 relayRequestTimeout)
         public
         onlyOwner
     {
@@ -71,7 +75,7 @@ contract KeepRandomBeaconImplV1 is Ownable {
         _pendingWithdrawal = 0;
         _previousEntry = genesisEntry;
         _groupContract = groupContract;
-        _relayRequestTimeout = 10;
+        _relayRequestTimeout = relayRequestTimeout;
 
         // Create initial relay entry request. This will allow relayEntry to be called once
         // to trigger the creation of the first group. Requests are removed on successful
@@ -165,6 +169,8 @@ contract KeepRandomBeaconImplV1 is Ownable {
         emit RelayEntryGenerated(requestID, groupSignature, groupPubKey, previousEntry, seed);
         GroupContract(_groupContract).runGroupSelection(groupSignature);
     }
+
+    // TODO: select a new group to serve a pending relay request if the timeout passed
 
     /**
      * @dev Gets the previous relay entry value.

--- a/contracts/solidity/contracts/examples/KeepRandomBeaconUpgradeExample.sol
+++ b/contracts/solidity/contracts/examples/KeepRandomBeaconUpgradeExample.sol
@@ -18,11 +18,14 @@ contract KeepRandomBeaconUpgradeExample is KeepRandomBeaconImplV1 {
      * >Functions can be overridden by another function with the same name and the
      * same number/types of inputs.
      */
-    function initialize(uint256 _minPayment, uint256 _withdrawalDelay, uint256 _genesisEntry, bytes memory _genesisGroupPubKey, address _groupContract)
+    function initialize(
+        uint256 _minPayment, uint256 _withdrawalDelay, uint256 _genesisEntry, 
+        bytes memory _genesisGroupPubKey, address _groupContract, uint256 _relayRequestTimeout)
         public
         onlyOwner
     {
-        super.initialize(_minPayment, _withdrawalDelay, _genesisEntry, _genesisGroupPubKey, _groupContract);
+        super.initialize(_minPayment, _withdrawalDelay, _genesisEntry, _genesisGroupPubKey, _groupContract, 
+        _relayRequestTimeout);
         _initialized["KeepRandomBeaconImplV2"] = true;
 
         // Example of adding new data to the existing storage.

--- a/contracts/solidity/migrations/2_deploy_contracts.js
+++ b/contracts/solidity/migrations/2_deploy_contracts.js
@@ -21,6 +21,7 @@ const timeoutInitial = 4;
 const timeoutSubmission = 4;
 const timeoutChallenge = 4;
 const resultPublicationBlockStep = 3;
+const relayRequestTimeout = 10;
 
 // timeDKG - Timeout in blocks after DKG result is complete and ready to be published.
 // 7 states with state.MessagingStateActiveBlocks which is set to 3
@@ -59,6 +60,7 @@ module.exports = async function(deployer) {
     withdrawalDelay,
     web3.utils.toBN('31415926535897932384626433832795028841971693993751058209749445923078164062862'),
     "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d0",
-    KeepGroup.address
+    KeepGroup.address,
+    relayRequestTimeout
   );
 };

--- a/contracts/solidity/test/TestKeepGroupSelection.js
+++ b/contracts/solidity/test/TestKeepGroupSelection.js
@@ -14,6 +14,8 @@ const KeepGroupImplV1 = artifacts.require('./KeepGroupImplV1.sol');
 
 contract('TestKeepGroupSelection', function(accounts) {
 
+  const relayRequestTimeout = 10;
+
   let token, stakingProxy, stakingContract, minimumStake, groupThreshold, groupSize,
     randomBeaconValue,
     timeoutInitial, timeoutSubmission, timeoutChallenge, timeDKG, resultPublicationBlockStep,
@@ -58,7 +60,8 @@ contract('TestKeepGroupSelection', function(accounts) {
       groupSize, timeoutInitial, timeoutSubmission, timeoutChallenge, timeDKG, resultPublicationBlockStep
     );
 
-    await keepRandomBeaconImplViaProxy.initialize(1,1, randomBeaconValue, bls.groupPubKey, keepGroupProxy.address);
+    await keepRandomBeaconImplViaProxy.initialize(1,1, randomBeaconValue, bls.groupPubKey, keepGroupProxy.address,
+      relayRequestTimeout);
     await keepRandomBeaconImplViaProxy.relayEntry(1, bls.groupSignature, bls.groupPubKey, bls.previousEntry, bls.seed);
 
     // Stake delegate tokens to operator1

--- a/contracts/solidity/test/TestKeepRandomBeaconUpgrade.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconUpgrade.js
@@ -8,6 +8,7 @@ const KeepGroup = artifacts.require('./KeepGroupStub.sol');
 
 
 contract('TestKeepRandomBeaconUpgrade', function(accounts) {
+  const relayRequestTimeout = 10;
 
   let implV1, implV2, proxy, implViaProxy, impl2ViaProxy, keepGroup,
     account_one = accounts[0],
@@ -18,8 +19,9 @@ contract('TestKeepRandomBeaconUpgrade', function(accounts) {
     implV2 = await Upgrade.new();
     proxy = await Proxy.new(implV1.address);
     implViaProxy = await KeepRandomBeaconImplV1.at(proxy.address);
-    keepGroup = await KeepGroup.new()
-    await implViaProxy.initialize(100, duration.days(0), bls.previousEntry, bls.groupPubKey, keepGroup.address);
+    keepGroup = await KeepGroup.new();
+    await implViaProxy.initialize(100, duration.days(0), bls.previousEntry, bls.groupPubKey, keepGroup.address, 
+      relayRequestTimeout);
 
     // Add a few calls that modify state so we can test later that eternal storage works as expected after upgrade
     await implViaProxy.requestRelayEntry(0, {from: account_two, value: 100});
@@ -41,7 +43,8 @@ contract('TestKeepRandomBeaconUpgrade', function(accounts) {
     await proxy.upgradeTo(implV2.address);
     
     impl2ViaProxy = await Upgrade.at(proxy.address);
-    await impl2ViaProxy.initialize(100, duration.days(0), bls.previousEntry, bls.groupPubKey, keepGroup.address);
+    await impl2ViaProxy.initialize(100, duration.days(0), bls.previousEntry, bls.groupPubKey, keepGroup.address,
+      relayRequestTimeout);
 
     let result = await impl2ViaProxy.initialized();
     assert.equal(result, true, "Implementation contract should be initialized.");

--- a/contracts/solidity/test/TestKeepRandomBeaconViaProxy.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconViaProxy.js
@@ -9,6 +9,8 @@ const KeepGroup = artifacts.require('./KeepGroupStub.sol');
 
 contract('TestKeepRandomBeaconViaProxy', function(accounts) {
 
+  const relayRequestTimeout = 10;
+
   let implV1, proxy, implViaProxy, keepGroup,
     account_one = accounts[0],
     account_two = accounts[1],
@@ -18,8 +20,9 @@ contract('TestKeepRandomBeaconViaProxy', function(accounts) {
     implV1 = await KeepRandomBeaconImplV1.new();
     proxy = await Proxy.new(implV1.address);
     implViaProxy = await KeepRandomBeaconImplV1.at(proxy.address);
-    keepGroup = await KeepGroup.new()
-    await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address);
+    keepGroup = await KeepGroup.new();
+    await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address, 
+      relayRequestTimeout);
   });
 
   it("should be able to check if the implementation contract was initialized", async function() {

--- a/contracts/solidity/test/TestPublishDkgResult.js
+++ b/contracts/solidity/test/TestPublishDkgResult.js
@@ -24,6 +24,7 @@ contract('TestPublishDkgResult', function(accounts) {
   const timeoutChallenge = 60;
   const timeDKG = 20;
   const resultPublicationBlockStep = 3;
+  const relayRequestTimeout = 10;
 
   let disqualified, inactive, resultHash,
   token, stakingProxy, stakingContract, randomBeaconValue, requestId,
@@ -66,7 +67,8 @@ contract('TestPublishDkgResult', function(accounts) {
 
     randomBeaconValue = bls.groupSignature;
 
-    await keepRandomBeaconImplViaProxy.initialize(1,1, randomBeaconValue, bls.groupPubKey, keepGroupProxy.address);
+    await keepRandomBeaconImplViaProxy.initialize(1,1, randomBeaconValue, bls.groupPubKey, keepGroupProxy.address,
+      relayRequestTimeout);
     await keepRandomBeaconImplViaProxy.relayEntry(1, bls.groupSignature, bls.groupPubKey, bls.previousEntry, bls.seed);
 
     await stakeDelegate(stakingContract, token, owner, operator1, magpie, minimumStake*2000)

--- a/contracts/solidity/test/TestRelayEntry.js
+++ b/contracts/solidity/test/TestRelayEntry.js
@@ -6,9 +6,9 @@ const KeepGroupStub = artifacts.require('./KeepGroupStub.sol');
 
 
 contract('TestRelayEntry', function() {
+  const relayRequestTimeout = 10;
 
-  let keepRandomBeaconImplV1, keepRandomBeaconProxy, keepRandomBeaconImplViaProxy, relayEntryGeneratedEvent,
-    keepGroupStub;
+  let keepRandomBeaconImplV1, keepRandomBeaconProxy, keepRandomBeaconImplViaProxy, keepGroupStub;
 
   beforeEach(async () => {
 
@@ -18,10 +18,9 @@ contract('TestRelayEntry', function() {
     keepRandomBeaconImplViaProxy = await KeepRandomBeaconImplV1.at(keepRandomBeaconProxy.address);
 
     keepGroupStub = await KeepGroupStub.new();
-    await keepRandomBeaconImplViaProxy.initialize(1,1, bls.previousEntry, bls.groupPubKey, keepGroupStub.address);
+    await keepRandomBeaconImplViaProxy.initialize(1,1, bls.previousEntry, bls.groupPubKey, keepGroupStub.address,
+      relayRequestTimeout);
     await keepRandomBeaconImplViaProxy.requestRelayEntry(bls.seed, {value: 10});
-
-    relayEntryGeneratedEvent = keepRandomBeaconImplViaProxy.RelayEntryGenerated();
   });
 
   it("should not be able to submit invalid relay entry", async function() {


### PR DESCRIPTION
Refs #663  

Maximum number of blocks that a relay request will be processing is set to 10.