### PR TITLE
Remove go paillier dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -283,14 +283,6 @@
   revision = "b497e2f366b8624394fb2e89c10ab607bebdde0b"
 
 [[projects]]
-  digest = "1:49ad34519824c6236d200b0f8d07a071a6cb32714f7dda837a2651cee3acd442"
-  name = "github.com/keep-network/paillier"
-  packages = ["."]
-  pruneopts = ""
-  revision = "79cb054ad9bbe9f6b7a433bb7e4f892e92e1f8b3"
-  source = "https://github.com/keep-network/paillier"
-
-[[projects]]
   digest = "1:083b726d999fff7a2fcd09b779598cddcb642628bc028e4cfe46e81b18bf0d26"
   name = "github.com/koron/go-ssdp"
   packages = ["."]
@@ -1027,7 +1019,6 @@
     "github.com/gogo/protobuf/sortkeys",
     "github.com/ipfs/go-datastore",
     "github.com/ipfs/go-datastore/sync",
-    "github.com/keep-network/paillier",
     "github.com/libp2p/go-addr-util",
     "github.com/libp2p/go-conn-security",
     "github.com/libp2p/go-libp2p",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -145,11 +145,6 @@ required = ["github.com/gogo/protobuf/protoc-gen-gogoslick", "github.com/ethereu
   source = "https://github.com/keep-network/cli.git"
 
 [[constraint]]
-  name = "github.com/keep-network/paillier"
-  revision = "79cb054ad9bbe9f6b7a433bb7e4f892e92e1f8b3"
-  source = "https://github.com/keep-network/paillier"
-
-[[constraint]]
   name = "github.com/dfinity/go-dfinity-crypto"
   revision = "1cfc23c8f712378febdf621f27e49dd67846e901"
   source = "https://github.com/keep-network/go-dfinity-crypto.git"


### PR DESCRIPTION
Remove paillier dependency from Gopkg.toml file. We no longer use paillier after extracting tecdsa to separate repo.

Refs https://github.com/keep-network/keep-core/issues/770