### PR TITLE
Enable message signing in pubsub

### DIFF
--- a/pkg/net/libp2p/channel_manager.go
+++ b/pkg/net/libp2p/channel_manager.go
@@ -27,7 +27,11 @@ func newChannelManager(
 	identity *identity,
 	p2phost host.Host,
 ) (*channelManager, error) {
-	floodsub, err := pubsub.NewFloodSub(ctx, p2phost)
+	floodsub, err := pubsub.NewFloodSub(
+		ctx,
+		p2phost,
+		pubsub.WithMessageSigning(true),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This enables the pubsub option, message signing. When this option is
enabled, messages are signed with the peer's public key. This setting
does not require verification.