### PR TITLE
Enable pubsub strict message verification

### DIFF
--- a/pkg/net/libp2p/channel_manager.go
+++ b/pkg/net/libp2p/channel_manager.go
@@ -31,6 +31,7 @@ func newChannelManager(
 		ctx,
 		p2phost,
 		pubsub.WithMessageSigning(true),
+		pubsub.WithStrictSignatureVerification(true),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When the strict message verification option is enabled in pubsub, peers
enforce message signing. Unsigned messages are immediately dropped. We
explicitly enable this as the package default is false.