### PR TITLE
Network security implementation RFC updates

### DIFF
--- a/docs/rfc/rfc-2-network-security-implementation.adoc
+++ b/docs/rfc/rfc-2-network-security-implementation.adoc
@@ -144,13 +144,12 @@ was not seen before, then the message is accepted.
 All peers in the network have a streaming view of the latest chain state that 
 notifies in an event-style when a given address falls below the minimum stake.
 
-If stake drops down below the required minimum for some peer, all connections 
-to that peer are dropped and any unprocessed messages from that peer are 
-immediately discarded. Once the peer increases its stake so that it is above 
-the required minimum, it must initialize its connections with any disconnected 
-peers once again in order to be able to communicate with them. In such case, all
-unprocessed messages should be sent again.
-
+If a peer's stake drops below the required minimum, all connections to that peer 
+are dropped and any unprocessed messages from that peer are immediately 
+discarded. Once the peer's stake returns to at or above the required minimum, 
+it must initialize its connections with any disconnected peers once again in 
+order to be able to communicate with them. All unprocessed messages will be 
+retried.
 
 ==== Message Confidentiality
 
@@ -183,9 +182,9 @@ connection attempts from that peer to the peer who blacklisted it are rejected.
 
 In the Keep network, peers may form groups selected to execute various protocols. 
 The output of the group formation protocol is a list of on-chain addresses. 
-When peer joins a group, it includes its public static key in every single 
+When a peer joins a group, it includes its public static key in every single 
 message sent to the group. The public key is used by other peers in the group 
-to derive the on-chain address of that peer and check if the given peer is 
+to derive the on-chain address of that peer, and check if the given peer is 
 eligible to join and communicate within the group.
 
 [bibliography]


### PR DESCRIPTION
Closes: #774 

> It's hard to implement the previous version of the network security RFC because of libp2p interface limitations. Knowing more about what are our use cases and what are limitations and possibilities of libp2p, we should revisit network security implementation RFC to provide a minimal but secure implementation that we can ship for the first public beacon release.

Summary of changes:

- Removed information about application-level message requirements

    It is not required to enforce attributability, integrity, and optional confidentiality of the message on the application level. They can be enforced on a network level as well.

- Simplified message attributability and integrity model

    We do not need to maintain and increment nonces by one for each other peer individually. It's enough that each sender maintains a global nonce for all messages it sends and have all messages with a non-unique nonce discarded.

- Implement message encryption with ECDH

    We do not want to use Noise for encryption, ECDH is enough for all our use cases if we can ensure attributability and integrity of messages.

- Added link to discussion about libp2p security changes

    Here: https://www.flowdock.com/app/cardforcoin/tech/threads/hKOcyS8EPmZ7PBvpnMQixy0di1e

- Simplified group formation protocol

    Since we do not use individual nonces for every two peers communicating, we don't have to negotiate nonces with every other group member when joining the group.