### PR TITLE
Improve how group public key is logged when unregistering group

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -76,7 +76,7 @@ func Initialize(
 	})
 
 	relayChain.OnGroupRegistered(func(registration *event.GroupRegistration) {
-		fmt.Printf("New group registered [%+v]\n", registration)
+		fmt.Printf("New group registered on chain [%+v]\n", registration)
 		go groupRegistry.UnregisterDeletedGroups()
 	})
 

--- a/pkg/beacon/relay/group_registry.go
+++ b/pkg/beacon/relay/group_registry.go
@@ -69,15 +69,16 @@ func (gr *GroupRegistry) UnregisterDeletedGroups() {
 	defer gr.mutex.Unlock()
 
 	for publicKey := range gr.myGroups {
-		isGroupRegistered, err := gr.relayChain.IsGroupRegistered([]byte(publicKey))
+		publicKeyBytes := []byte(publicKey)
+		isGroupRegistered, err := gr.relayChain.IsGroupRegistered(publicKeyBytes)
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Group removal eligibility failed: [%v]\n", err)
+			fmt.Fprintf(os.Stderr, "Group removal eligibility check failed: [%v]\n", err)
 		}
 
 		if !isGroupRegistered {
 			delete(gr.myGroups, publicKey)
-			fmt.Printf("Unregistering a group which was removed on chain [%v]\n", publicKey)
+			fmt.Printf("Unregistering a group which was removed on chain [%+v]\n", publicKeyBytes)
 		}
 	}
 }


### PR DESCRIPTION
Refs #633

We need to use `%+v` formatting string to print the group public key in the same format as in all other places in the application. The previous formatting was displaying a key as a garbled text with a lot of `�`characters.

I have also updated the message in `beacon.go` to clearly express that the group was registered on-chain - it does not mean that the group was added to the registry by the client.