### PR TITLE
[Stake delegation] Enable unstaking even if no tokens are available

### DIFF
--- a/contracts/solidity/contracts/TokenGrant.sol
+++ b/contracts/solidity/contracts/TokenGrant.sol
@@ -262,7 +262,7 @@ contract TokenGrant is StakeDelegatable {
 
         // Calculate granted amount that was staked.
         uint256 available = grants[_id].amount.sub(grants[_id].released);
-        require(available > 0, "Must have available granted amount to unstake.");
+        require(available >= 0, "Must have available granted amount to unstake.");
 
         // Remove tokens from granted stake balance.
         stakeBalances[_operator] = stakeBalances[_operator].sub(available);


### PR DESCRIPTION
Allow to `initiateUnstaking()` even if there are zero available tokens.

This attempts to prevent from blocking unstaking when all stake will be slashed.