### PR TITLE
[Stake delegation] Remove potential after-slashing stake leftovers

### DIFF
--- a/contracts/solidity/contracts/StakeDelegatable.sol
+++ b/contracts/solidity/contracts/StakeDelegatable.sol
@@ -26,9 +26,6 @@ contract StakeDelegatable {
     // Stake balances.
     mapping(address => uint256) public stakeBalances;
 
-    // Stake balances.
-    mapping(address => uint256) public initialStakeBalances;
-
     // Stake delegation mappings.
     mapping(address => address) public operatorToOwner;
     mapping(address => address) public magpieToOwner;

--- a/contracts/solidity/contracts/TokenGrant.sol
+++ b/contracts/solidity/contracts/TokenGrant.sol
@@ -237,8 +237,6 @@ contract TokenGrant is StakeDelegatable {
     
         // Transfer tokens to beneficiary's grants stake balance.
         stakeBalances[operator] = stakeBalances[operator].add(available);
-        // Set initialStakeBalances to track stake leftovers.
-        initialStakeBalances[operator] = available;
 
         if (address(stakingProxy) != address(0)) {
             stakingProxy.emitStakedEvent(operator, available);
@@ -267,7 +265,7 @@ contract TokenGrant is StakeDelegatable {
         require(available > 0, "Must have available granted amount to unstake.");
 
         // Remove tokens from granted stake balance.
-        stakeBalances[_operator] = stakeBalances[_operator].sub(initialStakeBalances[_operator]);
+        stakeBalances[_operator] = 0;
 
         emit InitiatedTokenGrantUnstake(_id);
         if (address(stakingProxy) != address(0)) {


### PR DESCRIPTION
Current way we are dealing with `stakeBalances[]` might lead to stake leftover accumulation after introduction of slashing. We don't know at the moment how we want to deal with it, therefore I'm proposing that we set `stakeBalances[]` to zero in `initiateUnstake()`.