### PR TITLE
[Stake delegation] Remove minimum stake requirement from delegating a stake

### DIFF
--- a/docs/rfc/rfc-5-stake-delegation-specification.adoc
+++ b/docs/rfc/rfc-5-stake-delegation-specification.adoc
@@ -158,8 +158,7 @@ any condition is unfulfilled, processing aborts):
   * _operator_ does not have any KEEP tokens,
   * _magpie_ address is set,
   * _operator_ is not involved in another active delegating contract,
-  * amount of delegated tokens is lower or equal to the owner staked tokens,
-  * amount of delegated tokens is higher or equal to the minimum stake.
+  * amount of delegated tokens is lower or equal to the owner staked tokens.
 
 4. If all conditions are satisfied the contract processes the _delegation order_
 and sets the variables accordingly to the _delegation order_, and binds the


### PR DESCRIPTION
In the [process of aligning delegating contract with the RFC](https://www.flowdock.com/app/cardforcoin/tech/threads/b7uj8mOC8k1Tc0BipBdVaQbXDis) we have touched the issue if we should check the minimum stake in the delegating contract or other contracts. We have decided to adjust the RFC to not require explicit minimum stake verification.

This PR removes explicit minimum stake verification requirement from the RFC 5.