### PR TITLE
RFC 12: Keep Network Interface

### DIFF
--- a/docs/rfc/rfc-12-keep-network-interface.adoc
+++ b/docs/rfc/rfc-12-keep-network-interface.adoc
@@ -112,7 +112,8 @@ upgrade process.
 
 The keep registry serves the role of the master list (see RFC 11 for more details) 
 and tracks sanctioned staking contracts, operator contracts (including keep 
-factories) and vendors. It ensures that only approved contracts are used.
+factories) and vendors. It ensures that only approved contracts are used. 
+A new type of keep can be added without upgradeable registry. 
 
 === Pseudocode
 
@@ -167,7 +168,7 @@ contract ECDSAKeep {
 ```
 contract KeepRegistry {
 
-    function getECDSAKeepVendor() address {
+    function getKeepVendor(string keepType) address {
         // (...)
     }
 }
@@ -179,7 +180,7 @@ contract Application {
     address internal _keepRegistry;
 
     function openDeposit() {
-        address vendor = KeepRegistry(_keepRegistry).getECDSAKeepVendor()    
+        address vendor = KeepRegistry(_keepRegistry).getKeepVendor("ECDSA")    
         vendor.openKeep(
             threshold, 
             groupSize, 


### PR DESCRIPTION
Closes: https://github.com/keep-network/tbtc/issues/109

The goal of this proposal is to specify the interface between application and
keeps on a top of which the application is built. This proposal specifies
mechanism of creating and registering keeps. This proposal introduces two types
of keeps: tECDSA keep and Bonded tECDSA keep.