### PR TITLE
Stake delegation RFC updates

### DIFF
--- a/docs/rfc/rfc-5-stake-delegation-specification.adoc
+++ b/docs/rfc/rfc-5-stake-delegation-specification.adoc
@@ -168,12 +168,10 @@ any condition is unfulfilled, processing aborts):
 and sets the variables accordingly to the _delegation order_, and binds the
 owner with the operator. The state of agreement between the owner and the
 operator is set to `active`, and the agreement state change time is set to
-current time,
-  
-5. The _operator_ can now use this delegated stake for operating.
+current time.footnote:[Ability to increase the delegated stake can be
+implemented via undelegating and delegating stake again with the new amount.]
 
-6. Ability to increase the delegated stake can be implemented via undelegating
-and delegating stake again with the new amount.
+5. The _operator_ can now use this delegated stake for operating.
 
 [#undelegating]
 ==== Undelegating a stake


### PR DESCRIPTION
Based on [flowdock discussion](https://www.flowdock.com/app/cardforcoin/tech/threads/sqDMez_soKmXGJ-7OCz_xp5D-x4) implement some minor tweaks to the specification:

* Remove requirement for operator to have no tokens
* Add clarification for delegate stake top up
* Add clarification for delegation order requirements
* Add requirement for operator to sign owner address