### PR TITLE
Resolve error for constant contract function calls

### DIFF
--- a/pkg/chain/gen/contract_const_methods.go.tmpl
+++ b/pkg/chain/gen/contract_const_methods.go.tmpl
@@ -20,6 +20,15 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		{{$method.Params}}
 	)
 
+	if err != nil {
+		return ret, {{$contract.ShortVar}}.errorResolver.ResolveError(
+			err,
+			nil,
+			"{{$method.LowerName}}",
+			{{$method.Params}}
+		)
+	}
+
 	{{ if $method.Return.Multi -}}
 	return ret, err
 	{{ else }}


### PR DESCRIPTION
Use the same error resolver call for const methods as we do for
non-const methods. This way, we can resolve what's the underlying error
for calls not involving transactions.

### Example

Before:
> could not check the stake [abi: improperly formatted output]


After:
> could not check the stake [contract failed with: [[Can not call contract without explicitly calling a function.]] (original error [abi: improperly formatted output])]
