### PR TITLE
Substantive Subscription: Move DKG result submission to a subscriber interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 		version = "unknown"
 	}
 	if revision == "" {
+		slapadapa := "blah"
+		fmt.Printf(slapadapa)
 		revision = "unknown"
 	}
 

--- a/pkg/beacon/relay/chain/chain.go
+++ b/pkg/beacon/relay/chain/chain.go
@@ -88,6 +88,9 @@ type DistributedKeyGenerationInterface interface {
 		dkgResult *DKGResult,
 		signatures map[group.MemberIndex]operator.Signature,
 	) *async.DKGResultSubmissionPromise
+	// DKGResultSubmission returns an object that can be used to subscribe to
+	// on-chain notifications of new, valid submitted results.
+	DKGResultSubmission() subscription.DKGResultSubmissionSubscriber
 	// OnDKGResultSubmitted registers a callback that is invoked when an on-chain
 	// notification of a new, valid submitted result is seen.
 	OnDKGResultSubmitted(

--- a/pkg/beacon/relay/dkg/result/states.go
+++ b/pkg/beacon/relay/dkg/result/states.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"bytes"
+	"context"
 	"math/big"
 
 	relayChain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
@@ -43,7 +44,7 @@ func (rss *resultSigningState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (rss *resultSigningState) Initiate() error {
+func (rss *resultSigningState) Initiate(context.Context) error {
 	message, err := rss.member.SignDKGResult(rss.result, rss.relayChain)
 	if err != nil {
 		return err
@@ -140,7 +141,7 @@ func (svs *signaturesVerificationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (svs *signaturesVerificationState) Initiate() error {
+func (svs *signaturesVerificationState) Initiate(context.Context) error {
 	signatures, err := svs.member.VerifyDKGResultSignatures(svs.signatureMessages)
 	if err != nil {
 		return err
@@ -204,8 +205,9 @@ func (rss *resultSubmissionState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (rss *resultSubmissionState) Initiate() error {
+func (rss *resultSubmissionState) Initiate(ctx context.Context) error {
 	return rss.member.SubmitDKGResult(
+		ctx,
 		rss.requestID,
 		rss.result,
 		rss.signatures,

--- a/pkg/beacon/relay/dkg/result/submission_test.go
+++ b/pkg/beacon/relay/dkg/result/submission_test.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -82,6 +83,7 @@ func TestSubmitDKGResult(t *testing.T) {
 			blockCounter, _ := chainHandle.BlockCounter()
 
 			err = member.SubmitDKGResult(
+				context.TODO(),
 				requestID,
 				result,
 				signatures,
@@ -207,6 +209,7 @@ func TestConcurrentPublishResult(t *testing.T) {
 				blockCounter, _ := chainHandle.BlockCounter()
 
 				err := member1.SubmitDKGResult(
+					context.TODO(),
 					test.requestID1,
 					test.resultToPublish1,
 					signatures,
@@ -226,6 +229,7 @@ func TestConcurrentPublishResult(t *testing.T) {
 				blockCounter, _ := chainHandle.BlockCounter()
 
 				err := member2.SubmitDKGResult(
+					context.TODO(),
 					test.requestID2,
 					test.resultToPublish2,
 					signatures,

--- a/pkg/beacon/relay/gjkr/gjkr.go
+++ b/pkg/beacon/relay/gjkr/gjkr.go
@@ -1,6 +1,7 @@
 package gjkr
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -18,6 +19,7 @@ import (
 // participate in the group; if generation fails, it returns an error
 // representing what went wrong.
 func Execute(
+	ctx context.Context,
 	memberIndex group.MemberIndex,
 	blockCounter chain.BlockCounter,
 	channel net.BroadcastChannel,
@@ -46,7 +48,7 @@ func Execute(
 
 	stateMachine := state.NewMachine(channel, blockCounter, initialState)
 
-	lastState, endBlockHeight, err := stateMachine.Execute(startBlockHeight)
+	lastState, endBlockHeight, err := stateMachine.Execute(ctx, startBlockHeight)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/beacon/relay/gjkr/states.go
+++ b/pkg/beacon/relay/gjkr/states.go
@@ -1,6 +1,7 @@
 package gjkr
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/beacon/relay/group"
@@ -26,7 +27,7 @@ func (js *joinState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (js *joinState) Initiate() error {
+func (js *joinState) Initiate(context.Context) error {
 	return js.channel.Send(NewJoinMessage(js.member.ID))
 }
 
@@ -69,7 +70,7 @@ func (ekpgs *ephemeralKeyPairGenerationState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (ekpgs *ephemeralKeyPairGenerationState) Initiate() error {
+func (ekpgs *ephemeralKeyPairGenerationState) Initiate(context.Context) error {
 	message, err := ekpgs.member.GenerateEphemeralKeyPair()
 	if err != nil {
 		return err
@@ -125,7 +126,7 @@ func (skgs *symmetricKeyGenerationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (skgs *symmetricKeyGenerationState) Initiate() error {
+func (skgs *symmetricKeyGenerationState) Initiate(context.Context) error {
 	skgs.member.MarkInactiveMembers(skgs.previousPhaseMessages)
 	return skgs.member.GenerateSymmetricKeys(skgs.previousPhaseMessages)
 }
@@ -167,7 +168,7 @@ func (cs *commitmentState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (cs *commitmentState) Initiate() error {
+func (cs *commitmentState) Initiate(context.Context) error {
 	sharesMsg, commitmentsMsg, err := cs.member.CalculateMembersSharesAndCommitments()
 	if err != nil {
 		return err
@@ -241,7 +242,7 @@ func (cvs *commitmentsVerificationState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (cvs *commitmentsVerificationState) Initiate() error {
+func (cvs *commitmentsVerificationState) Initiate(context.Context) error {
 	cvs.member.MarkInactiveMembers(
 		cvs.previousPhaseSharesMessages,
 		cvs.previousPhaseCommitmentsMessages,
@@ -309,7 +310,7 @@ func (sjs *sharesJustificationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (sjs *sharesJustificationState) Initiate() error {
+func (sjs *sharesJustificationState) Initiate(context.Context) error {
 	disqualifiedMembers, err := sjs.member.ResolveSecretSharesAccusationsMessages(
 		sjs.previousPhaseAccusationsMessages,
 	)
@@ -356,7 +357,7 @@ func (qs *qualificationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (qs *qualificationState) Initiate() error {
+func (qs *qualificationState) Initiate(context.Context) error {
 	qs.member.CombineMemberShares()
 	return nil
 }
@@ -396,7 +397,7 @@ func (pss *pointsShareState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (pss *pointsShareState) Initiate() error {
+func (pss *pointsShareState) Initiate(context.Context) error {
 	message := pss.member.CalculatePublicKeySharePoints()
 	if err := pss.channel.Send(message); err != nil {
 		return err
@@ -452,7 +453,7 @@ func (pvs *pointsValidationState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (pvs *pointsValidationState) Initiate() error {
+func (pvs *pointsValidationState) Initiate(context.Context) error {
 	pvs.member.MarkInactiveMembers(pvs.previousPhaseMessages)
 	accusationMsg, err := pvs.member.VerifyPublicKeySharePoints(
 		pvs.previousPhaseMessages,
@@ -513,7 +514,7 @@ func (pjs *pointsJustificationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (pjs *pointsJustificationState) Initiate() error {
+func (pjs *pointsJustificationState) Initiate(context.Context) error {
 	disqualifiedMembers, err := pjs.member.ResolvePublicKeySharePointsAccusationsMessages(
 		pjs.previousPhaseMessages,
 	)
@@ -562,7 +563,7 @@ func (rs *keyRevealState) ActiveBlocks() uint64 {
 	return state.MessagingStateActiveBlocks
 }
 
-func (rs *keyRevealState) Initiate() error {
+func (rs *keyRevealState) Initiate(context.Context) error {
 	revealMsg, err := rs.member.RevealDisqualifiedMembersKeys()
 	if err != nil {
 		return err
@@ -619,7 +620,7 @@ func (rs *reconstructionState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (rs *reconstructionState) Initiate() error {
+func (rs *reconstructionState) Initiate(context.Context) error {
 	rs.member.MarkInactiveMembers(rs.previousPhaseMessages)
 	if err := rs.member.ReconstructDisqualifiedIndividualKeys(
 		rs.previousPhaseMessages,
@@ -663,7 +664,7 @@ func (cs *combinationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (cs *combinationState) Initiate() error {
+func (cs *combinationState) Initiate(context.Context) error {
 	cs.member.CombineGroupPublicKey()
 	return nil
 }
@@ -701,7 +702,7 @@ func (fs *finalizationState) ActiveBlocks() uint64 {
 	return state.SilentStateActiveBlocks
 }
 
-func (fs *finalizationState) Initiate() error {
+func (fs *finalizationState) Initiate(context.Context) error {
 	return nil
 }
 

--- a/pkg/beacon/relay/gjkr/states_test.go
+++ b/pkg/beacon/relay/gjkr/states_test.go
@@ -1,6 +1,7 @@
 package gjkr
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -136,7 +137,7 @@ func doStateTransition(
 	for _, state := range states {
 		fmt.Printf("[member:%v, state:%T] Executing\n", state.MemberIndex(), state)
 
-		if err := state.Initiate(); err != nil {
+		if err := state.Initiate(context.TODO()); err != nil {
 			return nil, fmt.Errorf("initiate failed [%v]", err)
 		}
 	}

--- a/pkg/beacon/relay/state/machine_test.go
+++ b/pkg/beacon/relay/state/machine_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -49,7 +50,7 @@ func TestExecute(t *testing.T) {
 
 	stateMachine := NewMachine(channel, blockCounter, initialState)
 
-	finalState, endBlockHeight, err := stateMachine.Execute(1)
+	finalState, endBlockHeight, err := stateMachine.Execute(context.TODO(), 1)
 	if err != nil {
 		t.Errorf("unexpected error [%v]", err)
 	}
@@ -106,7 +107,7 @@ type testState1 struct {
 
 func (ts testState1) DelayBlocks() uint64  { return 0 }
 func (ts testState1) ActiveBlocks() uint64 { return 2 }
-func (ts testState1) Initiate() error {
+func (ts testState1) Initiate(context.Context) error {
 	addToTestLog(ts, "initiate")
 	return nil
 }
@@ -126,7 +127,7 @@ type testState2 struct {
 
 func (ts testState2) DelayBlocks() uint64  { return 0 }
 func (ts testState2) ActiveBlocks() uint64 { return 2 }
-func (ts testState2) Initiate() error {
+func (ts testState2) Initiate(context.Context) error {
 	addToTestLog(ts, "initiate")
 	return nil
 }
@@ -147,7 +148,7 @@ type testState3 struct {
 func (ts testState3) DelayBlocks() uint64  { return 1 }
 func (ts testState3) ActiveBlocks() uint64 { return 0 }
 
-func (ts testState3) Initiate() error {
+func (ts testState3) Initiate(context.Context) error {
 	addToTestLog(ts, "initiate")
 	return nil
 }
@@ -169,7 +170,7 @@ type testState4 struct {
 
 func (ts testState4) DelayBlocks() uint64  { return 0 }
 func (ts testState4) ActiveBlocks() uint64 { return 2 }
-func (ts testState4) Initiate() error {
+func (ts testState4) Initiate(context.Context) error {
 	addToTestLog(ts, "initiate")
 	return nil
 }
@@ -189,7 +190,7 @@ type testState5 struct {
 
 func (ts testState5) DelayBlocks() uint64  { return 0 }
 func (ts testState5) ActiveBlocks() uint64 { return 0 }
-func (ts testState5) Initiate() error {
+func (ts testState5) Initiate(context.Context) error {
 	addToTestLog(ts, "initiate")
 	return nil
 }

--- a/pkg/beacon/relay/state/state.go
+++ b/pkg/beacon/relay/state/state.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"context"
+
 	"github.com/keep-network/keep-core/pkg/beacon/relay/group"
 	"github.com/keep-network/keep-core/pkg/net"
 )
@@ -24,7 +26,7 @@ type State interface {
 
 	// Initiate performs all the required calculations and sends out all the
 	// messages associated with the current state.
-	Initiate() error
+	Initiate(ctx context.Context) error
 
 	// Receive is called each time a new message arrived. Receive is expected to
 	// be called for all broadcast channel messages, including the member's own

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -1,6 +1,8 @@
 package chain
 
 import (
+	"context"
+
 	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
 )
 
@@ -20,6 +22,8 @@ type BlockCounter interface {
 	// Reading from the returned channel immediately will effectively behave the
 	// same way as calling WaitForBlockHeight.
 	BlockHeightWaiter(blockNumber uint64) (<-chan uint64, error)
+
+	ContextWithBlockDeadline(parent context.Context, blockNumber uint64) (context.Context, context.CancelFunc, error)
 
 	// CurrentBlock returns the current block height.
 	CurrentBlock() (uint64, error)

--- a/pkg/chain/ethereum/blockcounter.go
+++ b/pkg/chain/ethereum/blockcounter.go
@@ -26,6 +26,7 @@ type ethereumBlockCounter struct {
 	subscriptionChannel chan block
 	config              *ethereumChain
 	waiters             map[uint64][]chan uint64
+	waitingCancelFuncs  map[uint64][]context.CancelFunc
 }
 
 type block struct {

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -1,6 +1,7 @@
 package ethereum
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -404,6 +405,18 @@ func (ec *ethereumChain) OnDKGResultSubmitted(
 				err,
 			)
 		},
+	)
+}
+
+func (ec *ethereumChain) DKGResultSubmission() subscription.DKGResultSubmissionSubscriber {
+	// TODO Lazy-initialize a watcher for DKGResultPublishedEvent with context?
+	// TODO And then store in a struct var.
+	events := make(chan *event.DKGResultSubmission)
+	errors := make(chan error)
+	return subscription.NewDKGResultSubmissionSubscriber(
+		context.TODO(),
+		events,
+		errors,
 	)
 }
 


### PR DESCRIPTION
This is early work towards #491, which describes a different interface for handling event subscriptions. In particular, that interface is meant to be generic over event handlers and channel receivers, and is also meant to take `Context`s into account and deal with unsubscriptions cleanly.

Current PR state is super-draft, but interested in thoughts.