### PR TITLE
Updated go-libp2p-bootstrap dependency version for better logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -291,11 +291,11 @@
   revision = "b497e2f366b8624394fb2e89c10ab607bebdde0b"
 
 [[projects]]
-  digest = "1:a68e2a5bc94ff67d2c7ca63fe83bef1abc43be2b8529c4924f930a777876b86c"
+  digest = "1:29685f02c1aff104cb696918561c74a8a995476fa5d27c854378fa51def58f60"
   name = "github.com/keep-network/go-libp2p-bootstrap"
   packages = ["."]
   pruneopts = ""
-  revision = "244e03bef9603337784ea1690e2bf54100a7854a"
+  revision = "e92bd71e8199b1d75295ea70846d29910e434070"
 
 [[projects]]
   digest = "1:083b726d999fff7a2fcd09b779598cddcb642628bc028e4cfe46e81b18bf0d26"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@ required = ["github.com/gogo/protobuf/protoc-gen-gogoslick", "github.com/ethereu
 # libp2p
 [[override]]
   name = "github.com/keep-network/go-libp2p-bootstrap"
-  revision = "244e03bef9603337784ea1690e2bf54100a7854a"
+  revision = "e92bd71e8199b1d75295ea70846d29910e434070"
 
 [[override]]
   name = "github.com/libp2p/go-libp2p-peer"


### PR DESCRIPTION
In the new version of go-libp2p-bootstrap we log:
```
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
```
instead of:
```
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
```

We also log when the connection has been successfully established:
```
Established connection with bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9]
```

This behaviour was changed in https://github.com/keep-network/go-libp2p-bootstrap/pull/2.

## Before
```
➜  keep-core git:(log-successful-connection) ✗ KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config config.local.2.toml start
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
-------------------------------------------------------------------------------------------------
| Node: node                                                                                    |
| Port: 0                                                                                       |
| IPs : /ip4/127.0.0.1/tcp/3920/ipfs/16Uiu2HAm82kFx5PMHWUARfKhPhg9gQVdasiySjZaPPsNUjuE59TV      |
|       /ip6/::1/tcp/3920/ipfs/16Uiu2HAm82kFx5PMHWUARfKhPhg9gQVdasiySjZaPPsNUjuE59TV            |
|       /ip4/192.168.142.66/tcp/3920/ipfs/16Uiu2HAm82kFx5PMHWUARfKhPhg9gQVdasiySjZaPPsNUjuE59TV |
-------------------------------------------------------------------------------------------------
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed
```

## After
```
➜  keep-core git:(log-successful-connection) ✗ KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config config.local.2.toml start
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
-------------------------------------------------------------------------------------------------
| Node: node                                                                                    |
| Port: 0                                                                                       |
| IPs : /ip6/::1/tcp/3920/ipfs/16Uiu2HAm82kFx5PMHWUARfKhPhg9gQVdasiySjZaPPsNUjuE59TV            |
|       /ip4/192.168.142.66/tcp/3920/ipfs/16Uiu2HAm82kFx5PMHWUARfKhPhg9gQVdasiySjZaPPsNUjuE59TV |
|       /ip4/127.0.0.1/tcp/3920/ipfs/16Uiu2HAm82kFx5PMHWUARfKhPhg9gQVdasiySjZaPPsNUjuE59TV      |
-------------------------------------------------------------------------------------------------
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Connection to bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9] failed. Retrying...
Established connection with bootstrap peer [16Uiu2HAmPTB3EVq7PKCqBDH5qRBNxdddiodxMJcvMciZfLoUkac9]
```
