### PR TITLE
keep-client: Quickstart Guide

### DIFF
--- a/docs/keep-client-quickstart.adoc
+++ b/docs/keep-client-quickstart.adoc
@@ -36,11 +36,13 @@ feel free.  This guide will assume you use the default paths.*
 Resulting directory should look like:
 
 ```
+.
 ├── keep-client-deployment-bundle
 │   ├── config
 │   │   ├── eth-account-keyfile
 │   │   └── keep-client-config.toml
 │   ├── eth-account-password.txt
+│   ├── keep-client-quickstart.adoc
 │   └── keep-client-snapshot.tar
 └── keep-client-deployment-bundle.tar.gz
 ```


### PR DESCRIPTION
The purpose here is to have a one page doc that illustrates how
to spin up a keep-client.  We ack that this is the simplest of
examples, but should give folks an idea of the moving parts.
The immediate aim of this document is to have something for our
private testnet participants.  This document will and should
evolve over time.

---------

All of the commands here were tested from my local machine, including unzipping the bundle and using the actual contents we will send our first testers.