### PR TITLE
Adding a relay request timeout to block processing upcoming requests

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconImplV1.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconImplV1.sol
@@ -34,7 +34,8 @@ contract KeepRandomBeaconImplV1 is Ownable {
     address internal _groupContract;
     uint256 internal _previousEntry;
     uint256 internal _relayRequestTimeout;
-    uint256 internal _relayRequestStartBlock;
+    uint256 internal _currentRelayRequestStartBlock;
+    bool internal _relaySigningInProgess;
 
     mapping (string => bool) internal _initialized;
 
@@ -48,7 +49,6 @@ contract KeepRandomBeaconImplV1 is Ownable {
 
     mapping(uint256 => Request) internal _requests;
 
-    bool internal _relaySigningInProgess;
 
     /**
      * @dev Prevent receiving ether without explicitly calling a function.
@@ -124,11 +124,10 @@ contract KeepRandomBeaconImplV1 is Ownable {
             "At least one group needed to serve the request."
         );
 
-        uint256 relayEntryTimeout = _relayRequestStartBlock + _relayRequestTimeout;
-
-        require(!_relaySigningInProgess || block.number > relayEntryTimeout, "Relay entry request is in progress.");
+        uint256 relayEntryTimeout = _currentRelayRequestStartBlock + _relayRequestTimeout;
+        require(!(_relaySigningInProgess || !(block.number > relayEntryTimeout)), "Relay entry request is in progress.");
         
-        _relayRequestStartBlock = block.number;
+        _currentRelayRequestStartBlock = block.number;
         _relaySigningInProgess = true;
 
         bytes memory groupPubKey = GroupContract(_groupContract).selectGroup(_previousEntry);

--- a/contracts/solidity/migrations/2_deploy_contracts.js
+++ b/contracts/solidity/migrations/2_deploy_contracts.js
@@ -23,6 +23,8 @@ const timeoutChallenge = 4;
 const resultPublicationBlockStep = 3;
 const activeGroupsThreshold = 5;
 const groupActiveTime = 300;
+// Timeout in blocks for a relay entry to appear on the chain.
+// Blocks are counted from the moment relay request occur.
 const relayRequestTimeout = 10;
 
 // timeDKG - Timeout in blocks after DKG result is complete and ready to be published.

--- a/contracts/solidity/test/TestKeepRandomBeaconCallback.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconCallback.js
@@ -1,4 +1,5 @@
 import {bls} from './helpers/data';
+import mineBlocks from './helpers/mineBlocks';
 const Proxy = artifacts.require('./KeepRandomBeacon.sol');
 const KeepRandomBeacon = artifacts.require('./KeepRandomBeaconImplV1.sol');
 const KeepGroupStub = artifacts.require('./KeepGroupStub.sol');
@@ -6,6 +7,7 @@ const CallbackContract = artifacts.require('./examples/CallbackContract.sol');
 
 contract('TestKeepRandomBeaconCallback', function() {
   const relayRequestTimeout = 10;
+  const blocksForward = 20;
   let impl, proxy, keepRandomBeacon, callbackContract, keepGroupStub;
 
   before(async () => {
@@ -29,6 +31,7 @@ contract('TestKeepRandomBeaconCallback', function() {
   });
 
   it("should successfully call method on a callback contract", async function() {
+    mineBlocks(blocksForward)
     let tx = await keepRandomBeacon.methods['requestRelayEntry(uint256,address,string)'](bls.seed, callbackContract.address, "callback(uint256)", {value: 10});
     let requestId = tx.logs[0].args.requestID;
 

--- a/contracts/solidity/test/TestKeepRandomBeaconViaProxy.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconViaProxy.js
@@ -1,8 +1,10 @@
 import {bls} from './helpers/data';
-import increaseTime, { duration, increaseTimeTo } from './helpers/increaseTime';
 import latestTime from './helpers/latestTime';
-import exceptThrow from './helpers/expectThrow';
+import { duration, increaseTimeTo } from './helpers/increaseTime';
+import expectThrow from './helpers/expectThrow';
+import expectThrowWithMessage from './helpers/expectThrowWithMessage';
 import encodeCall from './helpers/encodeCall';
+import mineBlocks from './helpers/mineBlocks';
 const Proxy = artifacts.require('./KeepRandomBeacon.sol');
 const KeepRandomBeaconImplV1 = artifacts.require('./KeepRandomBeaconImplV1.sol');
 const KeepGroup = artifacts.require('./KeepGroupStub.sol');
@@ -10,6 +12,7 @@ const KeepGroup = artifacts.require('./KeepGroupStub.sol');
 contract('TestKeepRandomBeaconViaProxy', function(accounts) {
 
   const relayRequestTimeout = 10;
+  const blocksForward = 20;
 
   let implV1, proxy, implViaProxy, keepGroup,
     account_one = accounts[0],
@@ -21,88 +24,122 @@ contract('TestKeepRandomBeaconViaProxy', function(accounts) {
     proxy = await Proxy.new(implV1.address);
     implViaProxy = await KeepRandomBeaconImplV1.at(proxy.address);
     keepGroup = await KeepGroup.new();
-
-    await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address, 
-      relayRequestTimeout);
   });
 
-  it("should be able to check if the implementation contract was initialized", async function() {
-    let result = await implViaProxy.initialized();
-    assert.equal(result, true, "Implementation contract should be initialized.");
-  });
+  describe('Logic for threshold random number generation', function() {
+    beforeEach(async () => {
+      await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address, 
+        relayRequestTimeout);
+    });
+  
+    it("should be able to check if the implementation contract was initialized", async function() {
+      let result = await implViaProxy.initialized();
+      assert.equal(result, true, "Implementation contract should be initialized.");
+    });
+  
+    it("should fail to request relay entry with not enough ether", async function() {
+      await expectThrow(implViaProxy.requestRelayEntry(0, {from: account_two, value: 99}));
+    });
+  
+    it("should be able to request relay entry via implementation contract with enough ether", async function() {
+      await mineBlocks(blocksForward);
+      await implViaProxy.requestRelayEntry(0, {from: account_two, value: 100})
+  
+      assert.equal((await implViaProxy.getPastEvents())[0].event, 'RelayEntryRequested', "RelayEntryRequested event should occur on the implementation contract.");
+  
+      let contractBalance = await web3.eth.getBalance(implViaProxy.address);
+      assert.equal(contractBalance, 100, "Keep Random Beacon contract should receive ether.");
+  
+      let contractBalanceViaProxy = await web3.eth.getBalance(proxy.address);
+      assert.equal(contractBalanceViaProxy, 100, "Keep Random Beacon contract new balance should be visible via proxy.");
+    });
+  
+    it("should be able to request relay entry via proxy contract with enough ether", async function() {
+      await expectThrow(proxy.sendTransaction({from: account_two, value: 1000}));
+  
+      await web3.eth.sendTransaction({
+        from: account_two, value: 100, gas: 200000, to: proxy.address,
+        data: encodeCall('requestRelayEntry', ['uint256'], [0])
+      });
+  
+      assert.equal((await implViaProxy.getPastEvents())[0].event, 'RelayEntryRequested', "RelayEntryRequested event should occur on the proxy contract.");
+  
+      let contractBalance = await web3.eth.getBalance(implViaProxy.address);
+      assert.equal(contractBalance, 100, "Keep Random Beacon contract should receive ether.");
+  
+      let contractBalanceViaProxy = await web3.eth.getBalance(proxy.address);
+      assert.equal(contractBalanceViaProxy, 100, "Keep Random Beacon contract new balance should be visible via proxy.");
+    });
+  
+    it("owner should be able to withdraw ether from random beacon contract", async function() {
+  
+      let amount = web3.utils.toWei('1', 'ether');
+      await web3.eth.sendTransaction({
+        from: account_two, value: amount, gas: 200000, to: proxy.address,
+        data: encodeCall('requestRelayEntry', ['uint256'], [0])
+      });
+  
+      // should fail to withdraw if not owner
+      await expectThrow(implViaProxy.initiateWithdrawal({from: account_two}));
+      await expectThrow(implViaProxy.finishWithdrawal(account_two, {from: account_two}));
+  
+      await implViaProxy.initiateWithdrawal({from: account_one});
+      await expectThrow(implViaProxy.finishWithdrawal(account_three, {from: account_one}));
+  
+      let contractStartBalance = await web3.eth.getBalance(implViaProxy.address);
+      // jump in time, full withdrawal delay
+      await increaseTimeTo(await latestTime()+duration.days(30));
+  
+      let receiverStartBalance = web3.utils.fromWei(await web3.eth.getBalance(account_three), 'ether');
+      await implViaProxy.finishWithdrawal(account_three, {from: account_one});
+      let receiverEndBalance = web3.utils.fromWei(await web3.eth.getBalance(account_three), 'ether');
+      assert(Number(receiverEndBalance) > Number(receiverStartBalance), "Receiver updated balance should include received ether.");
+  
+      let contractEndBalance = await web3.eth.getBalance(implViaProxy.address);
+      assert.equal(contractEndBalance, contractStartBalance - amount, "Keep Random Beacon contract should send all ether.");
+      let contractEndBalanceViaProxy = await web3.eth.getBalance(proxy.address);
+      assert.equal(contractEndBalanceViaProxy, contractStartBalance - amount, "Keep Random Beacon contract updated balance should be visible via proxy.");
+  
+    });
+  
+    it("should fail to update minimum payment by non owner", async function() {
+      await expectThrow(implViaProxy.setMinimumPayment(123, {from: account_two}));
+    });
+  
+    it("should be able to update minimum payment by the owner", async function() {
+      await implViaProxy.setMinimumPayment(123);
+      let newMinPayment = await implViaProxy.minimumPayment();
+      assert.equal(newMinPayment, 123, "Should be able to get updated minimum payment.");
+    });
+  })
 
-  it("should fail to request relay entry with not enough ether", async function() {
-    await exceptThrow(implViaProxy.requestRelayEntry(0, {from: account_two, value: 99}));
-  });
+  describe("Relay request timeout when expecting an error", function() {
+    it("should throw an error when signing is not in progress and a block number is lower than the relay entry timeout", async function() {
+      let currentBlockNumber = await web3.eth.getBlockNumber()
+      let timeout = currentBlockNumber + blocksForward
+      await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address, timeout)
+  
+      await expectThrowWithMessage(implViaProxy.requestRelayEntry(0, {from: account_two, value: 100}), 'Relay entry request is in progress.')
+    });
+  
+    it("should throw an error when signing is in progess and a block number is lower than the relay entry timeout", async function() {
+      await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address, relayRequestTimeout)
+      await mineBlocks(blocksForward);
+  
+      await implViaProxy.requestRelayEntry(0, {from: account_two, value: 100})
+  
+      await expectThrowWithMessage(implViaProxy.requestRelayEntry(0, {from: account_two, value: 100}), 'Relay entry request is in progress.')
+    });
+  
+    it("should throw an error when signing is in progess and a block number is higher than the relay entry timeout", async function() {
+      await implViaProxy.initialize(100, duration.days(30), bls.previousEntry, bls.groupPubKey, keepGroup.address, relayRequestTimeout)
+      await implViaProxy.requestRelayEntry(0, {from: account_two, value: 100})
+      
+      await mineBlocks(blocksForward);
 
-  it("should be able to request relay entry via implementation contract with enough ether", async function() {
-    await implViaProxy.requestRelayEntry(0, {from: account_two, value: 100})
-
-    assert.equal((await implViaProxy.getPastEvents())[0].event, 'RelayEntryRequested', "RelayEntryRequested event should occur on the implementation contract.");
-
-    let contractBalance = await web3.eth.getBalance(implViaProxy.address);
-    assert.equal(contractBalance, 100, "Keep Random Beacon contract should receive ether.");
-
-    let contractBalanceViaProxy = await web3.eth.getBalance(proxy.address);
-    assert.equal(contractBalanceViaProxy, 100, "Keep Random Beacon contract new balance should be visible via proxy.");
-
-  });
-
-  it("should be able to request relay entry via proxy contract with enough ether", async function() {
-    await exceptThrow(proxy.sendTransaction({from: account_two, value: 1000}));
-
-    await web3.eth.sendTransaction({
-      from: account_two, value: 100, gas: 200000, to: proxy.address,
-      data: encodeCall('requestRelayEntry', ['uint256'], [0])
+      await expectThrowWithMessage(implViaProxy.requestRelayEntry(0, {from: account_two, value: 100}), 'Relay entry request is in progress.')
     });
 
-    assert.equal((await implViaProxy.getPastEvents())[0].event, 'RelayEntryRequested', "RelayEntryRequested event should occur on the proxy contract.");
+  })
 
-    let contractBalance = await web3.eth.getBalance(implViaProxy.address);
-    assert.equal(contractBalance, 100, "Keep Random Beacon contract should receive ether.");
-
-    let contractBalanceViaProxy = await web3.eth.getBalance(proxy.address);
-    assert.equal(contractBalanceViaProxy, 100, "Keep Random Beacon contract new balance should be visible via proxy.");
-  });
-
-  it("owner should be able to withdraw ether from random beacon contract", async function() {
-
-    let amount = web3.utils.toWei('1', 'ether');
-    await web3.eth.sendTransaction({
-      from: account_two, value: amount, gas: 200000, to: proxy.address,
-      data: encodeCall('requestRelayEntry', ['uint256'], [0])
-    });
-
-    // should fail to withdraw if not owner
-    await exceptThrow(implViaProxy.initiateWithdrawal({from: account_two}));
-    await exceptThrow(implViaProxy.finishWithdrawal(account_two, {from: account_two}));
-
-    await implViaProxy.initiateWithdrawal({from: account_one});
-    await exceptThrow(implViaProxy.finishWithdrawal(account_three, {from: account_one}));
-
-    let contractStartBalance = await web3.eth.getBalance(implViaProxy.address);
-    // jump in time, full withdrawal delay
-    await increaseTimeTo(await latestTime()+duration.days(30));
-
-    let receiverStartBalance = web3.utils.fromWei(await web3.eth.getBalance(account_three), 'ether');
-    await implViaProxy.finishWithdrawal(account_three, {from: account_one});
-    let receiverEndBalance = web3.utils.fromWei(await web3.eth.getBalance(account_three), 'ether');
-    assert(Number(receiverEndBalance) > Number(receiverStartBalance), "Receiver updated balance should include received ether.");
-
-    let contractEndBalance = await web3.eth.getBalance(implViaProxy.address);
-    assert.equal(contractEndBalance, contractStartBalance - amount, "Keep Random Beacon contract should send all ether.");
-    let contractEndBalanceViaProxy = await web3.eth.getBalance(proxy.address);
-    assert.equal(contractEndBalanceViaProxy, contractStartBalance - amount, "Keep Random Beacon contract updated balance should be visible via proxy.");
-
-  });
-
-  it("should fail to update minimum payment by non owner", async function() {
-    await exceptThrow(implViaProxy.setMinimumPayment(123, {from: account_two}));
-  });
-
-  it("should be able to update minimum payment by the owner", async function() {
-    await implViaProxy.setMinimumPayment(123);
-    let newMinPayment = await implViaProxy.minimumPayment();
-    assert.equal(newMinPayment, 123, "Should be able to get updated minimum payment.");
-  });
 });

--- a/contracts/solidity/test/helpers/expectThrowWithMessage.js
+++ b/contracts/solidity/test/helpers/expectThrowWithMessage.js
@@ -1,0 +1,10 @@
+export default async (promise, message) => {
+  try {
+    await promise;
+  } catch (error) {
+    assert.include(error.message, message);
+
+    return;
+  }
+  assert.fail('Expected throw not received');
+};


### PR DESCRIPTION
Refs: #884

In this PR we need to block upcoming requests from processing if there is one in progress. After a node generates a relay entry, then it can again start processing a new request.