### PR TITLE
keep-client-quickstart: Patching holes v.1

### DIFF
--- a/docs/keep-client-quickstart.adoc
+++ b/docs/keep-client-quickstart.adoc
@@ -26,7 +26,7 @@ The application needs ingress/egress access on port `3919`.
 
 The ingress port is configurable and can be set in the included `keep-client-config.toml` file.
 
-`Port` is in section `[libp2p]`
+`Port` is in section `[libp2p]`.
 
 == Starting The Client
 


### PR DESCRIPTION
We've started testing with external parties (Figment), and we've already run into a couple derps.

1. Missing pipe on the `relay request` command
2. Not exposing the keep-client port when running on pure Docker


Patched both of those issues up here.
