### PR TITLE
Log which member shares are used to recover signature

### DIFF
--- a/pkg/beacon/relay/entry/states.go
+++ b/pkg/beacon/relay/entry/states.go
@@ -121,6 +121,11 @@ func (scs *signatureCompleteState) ActiveBlocks() uint64 {
 func (scs *signatureCompleteState) Initiate() error {
 	seenShares := make(map[group.MemberIndex]*bn256.G1)
 	seenShares[scs.MemberIndex()] = scs.selfSignatureShare
+	fmt.Printf(
+		"[member:%v] auto-accepting self signature share [%v]\n",
+		scs.MemberIndex(),
+		scs.MemberIndex(),
+	)
 
 	for _, message := range scs.previousPhaseMessages {
 		share := new(bn256.G1)
@@ -134,6 +139,11 @@ func (scs *signatureCompleteState) Initiate() error {
 				err,
 			)
 		} else {
+			fmt.Printf(
+				"[member:%v] accepting signature share from member [%v]\n",
+				scs.MemberIndex(),
+				message.senderID,
+			)
 			seenShares[message.senderID] = share
 		}
 	}


### PR DESCRIPTION
When debugging network connectivity problems in our private testnet we decided it would be nice to know exactly which group members signature shares were received. Here we add simple logging with this information.

```
[member:2] auto-accepting self signature share [2]
[member:2] accepting signature share from member [4]
[member:2] accepting signature share from member [3]
[member:2] accepting signature share from member [5]
[member:2] accepting signature share from member [1]
[member:2] restoring signature from [5] shares...
```