### PR TITLE
Log on behalf of which group entry submitter acts

### DIFF
--- a/pkg/beacon/relay/entry/submission.go
+++ b/pkg/beacon/relay/entry/submission.go
@@ -82,7 +82,11 @@ func (res *relayEntrySubmitter) submitRelayEntry(
 			subscription.Unsubscribe()
 			close(onSubmittedResultChan)
 
-			fmt.Printf("[member:%v] Submitting relay entry..\n", res.index)
+			fmt.Printf(
+				"[member:%v] Submitting relay entry on behalf of the group [%v]...\n",
+				res.index,
+				groupPublicKey,
+			)
 			entry := &event.Entry{
 				SigningId:     signingId,
 				Value:         newEntry,


### PR DESCRIPTION
To debug various problems in our testnet we decided it is good to know on behalf of which group the relay entry submitter is acting so that we can compare this value with the public key of the group selected to sign the entry.


> [member:1] Submitting relay entry on behalf of the group [[136 125 6 117 115 130 97 119 162 125 255 59 93 238 218 59 222 219 153 71 80 219 167 216 0 98 215 189 226 92 143 248 20 232 69 233 145 46 125 124 51 197 170 75 40 166 213 73 126 44 7 50 235 51 238 103 68 139 160 223 13 150 140 202]]...

We log the group public key in a not very concise way but it's the same way how it's currently logged in all other places. This needs to be addressed at some point.