### PR TITLE
keep-client-quickstart: "persistence"

### DIFF
--- a/docs/keep-client-quickstart.adoc
+++ b/docs/keep-client-quickstart.adoc
@@ -72,8 +72,10 @@ Run this from the `keep-client-deployment-bundle` directory:
 ```
 export KEEP_CLIENT_ETHEREUM_PASSWORD=$(cat eth-account-password.txt)
 export KEEP_CLIENT_CONFIG_DIR=$(pwd)/config
+export KEEP_CLIENT_PERSISTENCE_DIR=$(pwd)/persistence
 
 docker run -dit \
+--volume $KEEP_CLIENT_PERSISTENCE_DIR:/mnt/keep-client/persistence \
 --volume $KEEP_CLIENT_CONFIG_DIR:/mnt/keep-client/config \
 --env KEEP_ETHEREUM_PASSWORD=$KEEP_CLIENT_ETHEREUM_PASSWORD \
 -p 3919:3919 \


### PR DESCRIPTION
Here we provide a proper persistence dir for Docker started keep-clients.

A new directory `persistence` will be included with the deployment bundles.  We'll lean on this to setup persistence to the host machine via a new `--volume` mount on the `docker run` command.  As long as the operator uses the included directory on every app start, group context should survive through restarts.