### PR TITLE
Set signing ID for genesis entry to 0

### DIFF
--- a/pkg/beacon/relay/genesis.go
+++ b/pkg/beacon/relay/genesis.go
@@ -54,7 +54,7 @@ func GenesisRelayEntry() *event.Entry {
 	}.Compress()
 
 	return &event.Entry{
-		SigningId:     big.NewInt(int64(1)),
+		SigningId:     big.NewInt(int64(0)),
 		Value:         new(big.Int).SetBytes(genesisGroupSignature),
 		GroupPubKey:   genesisGroupPubKey,
 		PreviousEntry: genesisEntryValue,


### PR DESCRIPTION
During the work on upgradeable contract components we changed the
way how entry counters work. The genesis relay entry should be now
submitted with signing ID = 0.

Before:
```
➜  keep-core git:(master) ✗ LOG_LEVEL="keep*=DEBUG" KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config config.local.1.toml relay genesis
12:21:25.327 DEBUG keep-ethut: packing parameters for method [relayEntry] with ABI [function relayEntry(uint256 _signingId, uint256 _groupSignature, bytes _groupPubKey, uint256 _previousEntry, uint256 _seed) returns()]: [[+1 +10920102476789591414949377782104707130412218726336356788412941355500907533021 [31 25 84 179 49 68 219 43 92 144 218 8 158 139 222 40 126 199 8 157 93 100 51 243 182 190 202 239 219 103 139 27 42 157 227 141 20 190 242 207 154 252 60 105 138 66 17 250 122 218 123 79 3 106 45 254 240 220 18 43 66 50 89 208] +31415926535897932384626433832795028841971693993751058209749445923078164062862 +27182818284590452353602874713526624977572470936999595749669676277240766303535]] error_resolver.go:66
12:21:25.327 DEBUG keep-ethut: resolving error for contract call [{From:[101 234 85 193 241 4 145 3 132 37 114 93 192 13 255 234 178 161 226 138] To:[40 12 206 243 218 125 73 161 150 22 143 15 2 62 75 109 19 89 212 115] Gas:0 GasPrice:<nil> Value:<nil> Data:[68 34 155 193 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 24 36 143 24 186 254 180 25 15 29 56 97 207 3 3 172 11 252 46 86 29 247 255 73 203 114 106 3 188 100 18 221 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 160 69 116 200 199 93 110 136 172 210 143 126 70 125 172 151 181 198 12 56 56 217 218 217 147 144 11 223 64 33 82 34 142 60 24 238 15 190 1 189 185 5 108 250 188 235 238 26 65 62 124 51 224 160 161 175 65 33 15 67 10 151 2 141 47 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 64 31 25 84 179 49 68 219 43 92 144 218 8 158 139 222 40 126 199 8 157 93 100 51 243 182 190 202 239 219 103 139 27 42 157 227 141 20 190 242 207 154 252 60 105 138 66 17 250 122 218 123 79 3 106 45 254 240 220 18 43 66 50 89 208]}] error_resolver.go:81
2019/07/16 12:21:25 error in submitting genesis relay entry: [contract failed with: [[Provided group was not selected to produce entry for this request.]] (original error [failed to estimate gas needed: gas required exceeds allowance (8000000) or always failing transaction])]
```

After:
```
➜  keep-core git:(master) ✗ LOG_LEVEL="keep*=DEBUG" KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config config.local.1.toml relay genesis
Submitted genesis relay entry: [&{SigningId:+0 Value:+10920102476789591414949377782104707130412218726336356788412941355500907533021 GroupPubKey:[31 25 84 179 49 68 219 43 92 144 218 8 158 139 222 40 126 199 8 157 93 100 51 243 182 190 202 239 219 103 139 27 42 157 227 141 20 190 242 207 154 252 60 105 138 66 17 250 122 218 123 79 3 106 45 254 240 220 18 43 66 50 89 208] PreviousEntry:+31415926535897932384626433832795028841971693993751058209749445923078164062862 Timestamp:2019-07-16 16:21:59.665984 +0000 UTC Seed:+27182818284590452353602874713526624977572470936999595749669676277240766303535 BlockNumber:93174}]
```