### PR TITLE
Fix logged message on signature verification

### DIFF
--- a/pkg/beacon/relay/dkg/result/signing.go
+++ b/pkg/beacon/relay/dkg/result/signing.go
@@ -139,10 +139,10 @@ func (sm *SigningMember) VerifyDKGResultSignatures(
 		)
 		if err != nil {
 			logger.Infof(
-				"[member: %v] verification of signature from sender [%d] failed: [%+v]",
+				"[member: %v] verification of signature from sender [%d] failed: [%v]",
 				sm.index,
 				message.senderIndex,
-				message,
+				err,
 			)
 			continue
 		}


### PR DESCRIPTION
Just one tiny fix. 
Log verification error instead of the verified message.