### PR TITLE
Valuable Resolutions: Pass payment value to error resolver

### DIFF
--- a/pkg/chain/gen/contract_non_const_methods.go.tmpl
+++ b/pkg/chain/gen/contract_non_const_methods.go.tmpl
@@ -27,7 +27,11 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 		return transaction, {{$contract.ShortVar}}.errorResolver.ResolveError(
 			err,
 			{{$contract.ShortVar}}.transactorOptions.From,
-			nil,
+			{{if $method.Payable -}}
+			value
+			{{- else -}}
+			nil
+			{{- end -}},
 			"{{$method.LowerName}}",
 			{{$method.Params}}
 		)


### PR DESCRIPTION
In generated contracts, payment value was not forward through the error
resolver in case of gas estimation errors, so any error resolution call
would fail to include payment, leading to the call playing out
differently than the original estimation call.