### PR TITLE
Setup script updates

### DIFF
--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -36,11 +36,6 @@ export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LD_LIBRARY_PATH}"
 echo "Installing command line developer tools..."
 xcode-select --install || true
 
-if ! [ -x "$(command -v protoc-gen-gogoslick)" ]; then
-  echo 'WARNING: protoc-gen-gogoslick command is not available'
-  echo 'WARNING: please check whether $GOPATH/bin is added to your $PATH'
-fi
-
 echo "Installing contracts/solidity npm and requirements..."
 brew list npm &>/dev/null || brew install npm
 cd ../contracts/solidity && npm install && cd ../../scripts
@@ -53,5 +48,10 @@ echo "*** Please configure PATH, LD_LIBRARY_PATH, DYLD_LIBRARY_PATH  ***"
 echo "*** environment variables in your shell configuration file.    ***"
 echo "*** Ex. for bash shell - ~/.bash_profile, for zsh - ~/.zshrc   ***"
 echo "******************************************************************"
+
+if ! [ -x "$(command -v protoc-gen-gogoslick)" ]; then
+  echo 'WARNING: protoc-gen-gogoslick command is not available'
+  echo 'WARNING: please check whether $GOPATH/bin is added to your $PATH'
+fi
 
 echo "Ready to rock! See above for any extra environment-related instructions."


### PR DESCRIPTION
There are some improvements to macos-setup.sh

- While executing the script I encountered some troubles with unexpected termination if `protoc-gen-gogoslick` is not available. This was caused by an unnecessary `exit 1` command. After a discussion with @pdyraga I've removed it.

- There were also some troubles with `bn`. After investigation we discovered that it is no longer used, so I've removed it as well.

- Apart that, truffle is needed in order to start a local network. I've added it to the installation script for convenience.