### PR TITLE
Add missing keep_dev network

### DIFF
--- a/contracts/solidity/truffle-config.js
+++ b/contracts/solidity/truffle-config.js
@@ -9,6 +9,12 @@ module.exports = {
       network_id: "*"
     },
     keep_dev: {
+      host: "localhost",
+      port: 8545,
+      network_id: "*",
+      from: "0x0F0977c4161a371B5E5eE6a8F43Eb798cD1Ae1DB"
+    },
+    keep_dev_vpn: {
       host: "eth-tx-node.default.svc.cluster.local",
       port: 8545,
       network_id: "*",


### PR DESCRIPTION
Our CircleCI build configuration expects keep_dev network to be configured as the tests are run on it. This should make our `migrate_contracts` job work.

See migration failure: https://circleci.com/gh/keep-network/keep-core/29332

We mistakenly removed this network in #975.