### PR TITLE
IA test scenario for DKG phase 13

### DIFF
--- a/pkg/beacon/relay/dkg/dkg_test.go
+++ b/pkg/beacon/relay/dkg/dkg_test.go
@@ -206,7 +206,7 @@ func TestExecute_IA_member1_publicKeySharePointsVerificationPhase(t *testing.T) 
 	assertValidGroupPublicKey(t, result)
 }
 
-func TestExecute_IA_member1_DKGResultSigningPhase13(t *testing.T) {
+func TestExecute_IA_member2and4_DKGResultSigningPhase13(t *testing.T) {
 	t.Parallel()
 
 	groupSize := 5
@@ -215,7 +215,8 @@ func TestExecute_IA_member1_DKGResultSigningPhase13(t *testing.T) {
 	interceptorRules := func(msg net.TaggedMarshaler) net.TaggedMarshaler {
 
 		hashSignatureMessage, ok := msg.(*result.DKGResultHashSignatureMessage)
-		if ok && hashSignatureMessage.SenderID() == group.MemberIndex(1) {
+		if ok && (hashSignatureMessage.SenderID() == group.MemberIndex(2) ||
+			hashSignatureMessage.SenderID() == group.MemberIndex(4)) {
 			return nil
 		}
 


### PR DESCRIPTION
Closes #928

Implementation of DKG phase 13 test scenario for member inactivity:

- Implemented test scenario to cover the case of dkg result hash signature message absence.
This scenario makes sure a group result is correctly published even though one of the members doesn't send his hash signature message.
