### PR TITLE
keep-dev: publish contract data to /keep-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/keep-client
-      - gcp-cli/install        
+      - gcp-cli/install
       - gcp-cli/initialize:
           google-project-id: GOOGLE_PROJECT_ID
           google-compute-zone: GOOGLE_COMPUTE_ZONE_A
@@ -168,7 +168,7 @@ jobs:
           name: Upload contract data
           command: |
             cd /tmp/keep-client/contracts
-            gsutil -m cp * gs://keep-dev-contract-data
+            gsutil -m cp * gs://keep-dev-contract-data/keep-core
 
   generate_docs_tex:
     docker:
@@ -261,7 +261,7 @@ workflows:
       - publish_contract_data:
           filters:
             branches:
-              only: master        
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go


### PR DESCRIPTION
We're now publishing contract data from multiple repos.  As a result
there's some name overlap that required separation of contract data
publishing.  To keep everything in the same directory structure we're
setting up a dir for each repo that publishes contract data.

BONUS: Killed some trailing whitespace (that I introduced).