### PR TITLE
Adding 'await' expression to keepRandomBeaconService.initialize()

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
@@ -115,7 +115,7 @@ contract KeepRandomBeaconServiceImplV1 is Ownable, DelayedWithdrawal {
             totalNumberOfGroups += OperatorContract(_operatorContracts[i]).numberOfGroups();
         }
 
-        require(totalNumberOfGroups > 0, "Total number of groups must be greater that zero.");
+        require(totalNumberOfGroups > 0, "Total number of groups must be greater than zero.");
 
         uint256 selectedIndex = seed % totalNumberOfGroups;
 

--- a/contracts/solidity/migrations/2_deploy_contracts.js
+++ b/contracts/solidity/migrations/2_deploy_contracts.js
@@ -12,10 +12,6 @@ const KeepRandomBeaconOperatorStub = artifacts.require("./KeepRandomBeaconOperat
 const withdrawalDelay = 86400; // 1 day
 const minPayment = 1;
 
-const genesisEntry = web3.utils.toBN('31415926535897932384626433832795028841971693993751058209749445923078164062862');
-const genesisSeed = web3.utils.toBN('27182818284590452353602874713526624977572470936999595749669676277240766303535');
-const genesisGroupPubKey = '0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d0';
-
 module.exports = async function(deployer) {
   await deployer.deploy(ModUtils);
   await deployer.link(ModUtils, AltBn128);


### PR DESCRIPTION
Closes #994 

In this PR we are fixing an issue that happens occasionally when running Keep Nodes and sending a request for a new relay entry. 
Scenerio: First, we sent the `genesis` request and we made sure that there is at least 1 group available. Next, we sent a request for a new `relay entry` and this is the error that we got: `Total number of groups must be greater than zero.` 
The reason for the above was that the async `keepRandomBeaconService.initialize()` function didn't pause until it fulfilled its promise. The consequence was not seeing operator contract in the service contract on-chain.