### PR TITLE
keep-dev: migrate keep-client standard peers to `StatefulSet`

### DIFF
--- a/infrastructure/kube/keep-dev/keep-client-standard-peer.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-standard-peer.yaml
@@ -15,8 +15,8 @@ spec:
     app: keep-client
     type: standard-peer
 ---
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: keep-client-standard-peer
   labels:
@@ -29,6 +29,15 @@ spec:
     matchLabels:
       app: keep-client
       type: standard-peer
+  serviceName: keep-client-standard-peer
+  volumeClaimTemplates:
+  - metadata:
+      name: keep-client-standard-peer
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 5Mi
   template:
     metadata:
       labels:
@@ -67,18 +76,5 @@ spec:
           - name: keep-client-standard-peer
             mountPath: /mnt/keep-client/config
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-standard-peer
-        persistentVolumeClaim:
-          claimName: keep-client-standard-peer
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: keep-client-standard-peer
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Mi
+
+


### PR DESCRIPTION
We found a bug in the current deployment where all 5 keep-client
standard peers can share the same config file.  This is due to each
Deployment replica sharing the same persistent volume.  To maintain a
single config file for each standard peer we've migrated to StatefulSet.
This allows us to use a `volumeClaimTemplates` entry and produce 5
unique persistent volume claims for each standard peer replica, this
results in the behavior we want, where each config produced by an
InitContainer run is persisted independently, ensuring a unique config
for each client.

----

I think my commit message explains it well enough so I'll let that stand for the description.  I've already deployed this config to `keep-dev`, the resulting config ETH account addresses look like so:

```
sthompson22 ~ $ kubectl exec -it keep-client-standard-peer-0 cat /mnt/keep-client/config/keep-client-config.toml | grep Address
Address = "0xa23bec2e1D91B6DD39E110Fdad3A8bedcB314d99"
sthompson22 ~ $ kubectl exec -it keep-client-standard-peer-1 cat /mnt/keep-client/config/keep-client-config.toml | grep Address
Address = "0x41e30135B980bDD48B6aDA42638b5396FE2D11c6"
[ethereum.ContractAddresses]
sthompson22 ~ $ kubectl exec -it keep-client-standard-peer-2 cat /mnt/keep-client/config/keep-client-config.toml | grep Address
Address = "0x9166105F2215b24392Fb2C03c20b4f7E631F86a4"
[ethereum.ContractAddresses]
sthompson22 ~ $ kubectl exec -it keep-client-standard-peer-3 cat /mnt/keep-client/config/keep-client-config.toml | grep Address
Address = "0xA5B7985d5265C00e99b6768b7392D6216e3e82d3"
[ethereum.ContractAddresses]
sthompson22 ~ $ kubectl exec -it keep-client-standard-peer-4 cat /mnt/keep-client/config/keep-client-config.toml | grep Address
Address = “0x62474daA93c1974687D0D09D53124f73d43B0F93”
```