### PR TITLE
DKG DQ Handling - Phase 9 - part 3

### DIFF
--- a/pkg/beacon/relay/gjkr/integration_test.go
+++ b/pkg/beacon/relay/gjkr/integration_test.go
@@ -585,6 +585,9 @@ func TestExecute_DQ_members14_invalidPublicKeyShare_phase9(t *testing.T) {
 
 // TODO Test case Phase 9: 'accuser accuse an inactive member ->
 //  expected result: disqualify accuser'.
+//  Public key share points broadcast in the previous phase are necessary to
+//  resolve an accusation against the member. Member marked as inactive in any
+//  previous phase should not be accused because the accusation can't be resolved.
 //  This case is difficult to implement for now because it needs
 //  access to member internals. In order to make an accusation against inactive
 //  member, there is a need to obtain ephemeral private key for the accused
@@ -592,6 +595,8 @@ func TestExecute_DQ_members14_invalidPublicKeyShare_phase9(t *testing.T) {
 
 // TODO Test case Phase 9: 'cannot decrypt shares ->
 //  expected result: disqualify both'.
+//  Only happens if the complainer failed to complain earlier
+//  and thus both violated the protocol.
 //  This case is difficult to implement for now because it needs
 //  access to member internals. In order to screw up shares decryption
 //  in this phase, there is a need to alter an already received message

--- a/pkg/beacon/relay/gjkr/protocol.go
+++ b/pkg/beacon/relay/gjkr/protocol.go
@@ -531,8 +531,8 @@ func (cm *CommittingMember) areSharesValidAgainstCommitments(
 //
 // Accuser is disqualified if:
 // - accused the current member
-// - revealed public key does not match the public key previously broadcast
-//   by that member
+// - the revealed private key does not match the public key previously broadcast
+//   by the accuser
 // - accused inactive or already disqualified member and as a result, we do not
 //   have enough information to resolve that accusation
 // - shares of the accused member are valid against commitments
@@ -944,8 +944,8 @@ func (sm *SharingMember) isShareValidAgainstPublicKeySharePoints(
 //
 // Accuser is disqualified if:
 // - accused the current member
-// - revealed public key does not match the public key previously broadcast
-//   by that member
+// - the revealed private key does not match the public key previously broadcast
+//   by the accuser
 // - accused inactive or already disqualified member and as a result, we do not
 //   have enough information to resolve that accusation
 // - shares of the accused member are valid against public key share points
@@ -1082,7 +1082,7 @@ func (pjm *PointsJustifyingMember) ResolvePublicKeySharePointsAccusationsMessage
 				logger.Warningf(
 					"[member:%v] member [%v] disqualified because of sending "+
 						"shares that could not be decrypted; "+
-						"member [%v] disqualified because didn't complain "+
+						"member [%v] disqualified because did not complain "+
 						"about invalid shares earlier",
 					pjm.ID,
 					accusedID,


### PR DESCRIPTION
Refs #483

This PR covers remaining disqualification cases in phase 9 of DKG (changes based on solutions developed while working on phase 5). Particular changes:

- Replaced usage of `recoverSymmetricKey` by a manual `accusedPublicKey` lookup and ECDH with the `revealedAccuserPrivateKey`. If lookup of `accusedPublicKey` fails, the accuser is disqualified as this situation means they accused an already inactive/disqualified member.

- Replaced usage of `recoverShares` by a manual `accusedSharesMessage` lookup and decryption of shares using `decryptShares` method from `PeerSharesMessage`. If lookup of `accusedSharesMessage` fails, the accuser is disqualified as this situation means they accused an already inactive member. If `decryptShares` fails, both are disqualified according to protocol spec. In this case, the accused member is disqualified because of sending undecryptable shares and the accuser because of not complaining about this fact in phase 4.

  Source from protocol specification:
  ```
  plaintext = decryptShares(
      senderIndex,
      recipientIndex,
      symkey
  )
  
  if not plaintext:
      # only happens if the complainer failed to complain earlier
      # and thus both violated protocol
      return "both"
  ```
