### PR TITLE
Enable NAT libp2p support for internal keep-clients

### DIFF
--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-bootstrap-peer-template.toml
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-bootstrap-peer-template.toml
@@ -21,7 +21,7 @@
 [LibP2P]
   Seed = "Set by Kube"
   Port = "Set by Kube"
-  NAT = True
+  NAT = true
 
 [Storage]
   DataDir = "/tmp"

--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-standard-peer-template.toml
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-standard-peer-template.toml
@@ -21,7 +21,7 @@
 [LibP2P]
   Peers = ["/dns4/keep-client-bootstrap-peer-0.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm9RGTm8VGne5PvZGAw9KYNDggHaEQh5wiGSKgibp2G95r"]
   Port = "Set by Kube."
-  NAT = True
+  NAT = true
 
 [Storage]
   DataDir = "/tmp"


### PR DESCRIPTION
Our internal deployments sit behind NATs.  We want to deploy the NAT
feature for libp2p to see how the network behaves.  Our hope is that we
can directly peer with clients outside our own network.

------

This will require a deployment of clients to both `keep-dev` and `keep-test` to rollout.