### PR TITLE
Split ticket generation into initial and reactive submission tickets

### DIFF
--- a/pkg/beacon/relay/groupselection/groupselection.go
+++ b/pkg/beacon/relay/groupselection/groupselection.go
@@ -42,16 +42,19 @@ func SubmitTickets(
 	if err != nil {
 		return err
 	}
-	tickets, err :=
+	initialSubmissionTickets, reactiveSubmissionTickets, err :=
 		generateTickets(
 			newEntry.Bytes(),
 			staker.ID(),
 			availableStake,
 			chainConfig.MinimumStake,
+			chainConfig.NaturalThreshold,
 		)
 	if err != nil {
 		return err
 	}
+
+	tickets := append(initialSubmissionTickets, reactiveSubmissionTickets...)
 
 	submissionTimeout, err := blockCounter.BlockHeightWaiter(
 		startBlockHeight + chainConfig.TicketReactiveSubmissionTimeout,
@@ -144,27 +147,47 @@ func toChainTicket(ticket *ticket) (*relaychain.Ticket, error) {
 }
 
 // generateTickets generates a set of tickets for the given staker and relay
-// entry value given the specified minimum stake. Returns the resulting
-// tickets in sorted order, or an error if there were issues computing the
-// tickets.
+// entry value given the specified stake parameters and natural threshold.
+// It returns the tickets in two slices:
+// - initialSubmissionTickets contains tickets with values below the natural
+//   threshold. These tickets should be submitted first as they have the highest
+//   chance of being selected to the group.
+// - reactiveSubmissionTickets contains tickets with values equal to or above
+//   the natural threshold. These tickets should be submitted in the reactive
+//   submission phase if there is still a chance to become a group member.
+//
+// Tickets are returned sorted in ascending order by their value.
 func generateTickets(
 	beaconValue []byte, // V_i
 	stakerValue []byte, // Q_j
 	availableStake *big.Int, // S_j
 	minimumStake *big.Int,
-) ([]*ticket, error) {
+	naturalThreshold *big.Int,
+) (
+	initialSubmissionTickets []*ticket,
+	reactiveSubmissionTickets []*ticket,
+	err error,
+) {
 	stakingWeight := (&big.Int{}).Quo(availableStake, minimumStake) // W_j
 
 	tickets := make([]*ticket, 0)
 	for virtualStaker := int64(1); virtualStaker <= stakingWeight.Int64(); virtualStaker++ {
 		ticket, err := newTicket(beaconValue, stakerValue, big.NewInt(virtualStaker))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		tickets = append(tickets, ticket)
 	}
 
 	sort.Stable(byValue(tickets))
 
-	return tickets, nil
+	for _, ticket := range tickets {
+		if ticket.intValue().Cmp(naturalThreshold) < 0 {
+			initialSubmissionTickets = append(initialSubmissionTickets, ticket)
+		} else {
+			reactiveSubmissionTickets = append(reactiveSubmissionTickets, ticket)
+		}
+	}
+
+	return initialSubmissionTickets, reactiveSubmissionTickets, nil
 }

--- a/pkg/beacon/relay/groupselection/groupselection_test.go
+++ b/pkg/beacon/relay/groupselection/groupselection_test.go
@@ -13,41 +13,125 @@ import (
 	"github.com/keep-network/keep-core/pkg/subscription"
 )
 
-func TestGenerateTickets(t *testing.T) {
-	minimumStake := big.NewInt(1)
-	availableStake := big.NewInt(10)
+var stakingAddress = []byte("staking address")
+var previousBeaconOutput = []byte("test beacon output")
+
+func naturalThreshold() *big.Int { // 2^256 / 2
+	return new(big.Int).Div(
+		new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil),
+		big.NewInt(2),
+	)
+}
+
+func TestAllTicketsGenerated(t *testing.T) {
+	minimumStake := big.NewInt(20)
+	availableStake := big.NewInt(1000)
 	virtualStakers := availableStake.Int64() / minimumStake.Int64()
 
-	stakingAddress := []byte("staking address")
-	previousBeaconOutput := []byte("test beacon output")
-
-	tickets, err := generateTickets(
+	initialTickets, reactiveTickets, err := generateTickets(
 		previousBeaconOutput,
 		stakingAddress,
 		availableStake,
 		minimumStake,
+		naturalThreshold(),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// We should have 10 tickets
-	if len(tickets) != int(virtualStakers) {
+	// We should have 1000/20 = 50 tickets
+	allTicketsCount := len(initialTickets) + len(reactiveTickets)
+	if allTicketsCount != int(virtualStakers) {
 		t.Fatalf(
-			"expected [%d] tickets, received [%d] tickets",
+			"expected [%d] tickets, has [%d] tickets",
 			virtualStakers,
-			len(tickets),
+			allTicketsCount,
 		)
 	}
+}
 
-	for i := 0; i < len(tickets)-1; i++ {
-		// Tickets should be sorted in ascending order
-		if tickets[i].intValue().Cmp(tickets[i+1].intValue()) > 0 {
-			t.Fatalf("tickets not sorted by their value")
+func TestTicketsGeneratedInOrder(t *testing.T) {
+	minimumStake := big.NewInt(1)
+	availableStake := big.NewInt(100)
+
+	initialTickets, reactiveTickets, err := generateTickets(
+		previousBeaconOutput,
+		stakingAddress,
+		availableStake,
+		minimumStake,
+		naturalThreshold(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allTickets := append(initialTickets, reactiveTickets...)
+
+	// Tickets should be sorted in ascending order
+	for i := 0; i < len(allTickets)-1; i++ {
+		value := allTickets[i].intValue()
+		nextValue := allTickets[i+1].intValue()
+
+		if value.Cmp(nextValue) > 0 {
+			t.Errorf("tickets not sorted in ascending order")
 		}
+	}
+}
 
-		if tickets[i].proof.virtualStakerIndex.Cmp(big.NewInt(0)) <= 0 {
-			t.Fatal("virtual staker index should be greater than 0")
+func TestInitialTicketsGeneatedBelowNaturalThreshold(t *testing.T) {
+	minimumStake := big.NewInt(1)
+	availableStake := big.NewInt(10000)
+
+	initialTickets, _, err := generateTickets(
+		previousBeaconOutput,
+		stakingAddress,
+		availableStake,
+		minimumStake,
+		naturalThreshold(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All initial submission tickets should have value below the natural
+	// threshold
+	for _, ticket := range initialTickets {
+		if ticket.intValue().Cmp(naturalThreshold()) >= 0 {
+			t.Errorf(
+				"initial submission ticket value should be below natural "+
+					"threshold\nvalue:     [%v]\nthreshold: [%v]",
+				ticket.intValue(),
+				naturalThreshold(),
+			)
+		}
+	}
+}
+
+func TestReactiveTicketsGeneatedAboveNaturalThreshold(t *testing.T) {
+	minimumStake := big.NewInt(1)
+	availableStake := big.NewInt(10000)
+
+	_, reactiveTickets, err := generateTickets(
+		previousBeaconOutput,
+		stakingAddress,
+		availableStake,
+		minimumStake,
+		naturalThreshold(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All reactive submission tickets should have value equal or above
+	// the natural threshold
+	for _, ticket := range reactiveTickets {
+		if ticket.intValue().Cmp(naturalThreshold()) <= 0 {
+			t.Errorf(
+				"reactive submission ticket value should not be below natural "+
+					"threshold\nvalue:     [%v]\nthreshold: [%v]",
+				ticket.intValue(),
+				naturalThreshold(),
+			)
 		}
 	}
 }


### PR DESCRIPTION
Refs #548 

We are now generating two types of tickets:

- *initial submission tickets* are tickets with values below the natural threshold. These tickets should be submitted first as they have the highest chance of being selected to the group,

- *reactive submission tickets* are tickets with values equal to or above the natural threshold. These tickets should be submitted in the reactive submission phase if there is still a chance to become a group member.

Currently, we submit all those tickets - initial submission tickets first and then reactive submission tickets. Ticket submission code will be refactored later to separate initial ticket submission from reactive ticket submission.