### PR TITLE
Disconnect the unstaked - improvements

### DIFF
--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -153,8 +153,14 @@ func (cm *connectionManager) GetPeerPublicKey(connectedPeer string) (*key.Networ
 	return key.Libp2pKeyToNetworkKey(peerPublicKey), nil
 }
 
-func (cm *connectionManager) DisconnectPeer(connectedPeer string) {
-	connections := cm.Network().ConnsToPeer(peer.ID(connectedPeer))
+func (cm *connectionManager) DisconnectPeer(peerHash string) {
+	peerID, err := peer.IDB58Decode(peerHash)
+	if err != nil {
+		logger.Errorf("failed to decode peer hash: [%v] [%v]", peerHash, err)
+		return
+	}
+
+	connections := cm.Network().ConnsToPeer(peerID)
 	for _, connection := range connections {
 		if err := connection.Close(); err != nil {
 			logger.Errorf("failed to disconnect: [%v]", err)


### PR DESCRIPTION
Closes #304 

This PR fixes two problems with unstaked peers disconnection.

**Summary**

- Fixed the problem with bootstrap peer connections validation. Actually, validation was not performed because of the empty peers list received from the config. In such a case, a guard condition in `Connect` function caused a function return so neither the connection manager nor the watchtower process was triggered. Instead of doing the return, a logger info call was added.

- Fixed the reconnection problem. In fact, the problem was not about reconnection. It was just a bug in `connectionManager`'s `DisconnectPeer` method. Specifically, the peer's hash was directly converted to `peer.ID` type instead of doing a `B58` decoding first. 