### PR TITLE
Block times optimization

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -86,11 +86,11 @@ contract KeepRandomBeaconOperator {
 
     // Time in blocks after DKG result is complete and ready to be published
     // by clients.
-    uint256 public timeDKG = 7*(3+1);
+    uint256 public timeDKG = 7*(1+1);
 
     // Time in blocks it takes off-chain cluster to generate a new relay entry
     // and be ready to submit it to the chain.
-    uint256 public relayEntryGenerationTime = (3+1);
+    uint256 public relayEntryGenerationTime = (1+1);
 
     // Timeout in blocks for a relay entry to appear on the chain. Blocks are
     // counted from the moment relay request occur.

--- a/pkg/beacon/relay/state/state.go
+++ b/pkg/beacon/relay/state/state.go
@@ -66,4 +66,4 @@ const MessagingStateDelayBlocks = 1
 
 // MessagingStateActiveBlocks is a number of blocks for which a state
 // exchanging network messages as a part of its execution should be active.
-const MessagingStateActiveBlocks = 3
+const MessagingStateActiveBlocks = 1


### PR DESCRIPTION
Closes #1073

Decreased `MessagingStateActiveBlocks` in order to reduce protocols execution times. Also, `timeDKG` and `relayEntryGenerationTime` contract values were changed respectively.