### PR TITLE
Reduce operator contract size

### DIFF
--- a/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupSelection.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupSelection.js
@@ -65,10 +65,6 @@ contract('TestKeepRandomBeaconOperatorGroupSelection', function(accounts) {
     await restoreSnapshot()
   });
 
-  it("should fail to get selected tickets before submission period is over", async function() {
-    await expectThrow(operatorContract.selectedTickets());
-  });
-
   it("should fail to get selected participants before submission period is over", async function() {
     await expectThrow(operatorContract.selectedParticipants());
   });
@@ -165,8 +161,6 @@ contract('TestKeepRandomBeaconOperatorGroupSelection', function(accounts) {
     }
 
     mineBlocks(await operatorContract.ticketReactiveSubmissionTimeout());
-    let selectedTickets = await operatorContract.selectedTickets();
-    assert.equal(selectedTickets.length, groupSize, "Should be trimmed to groupSize length.");
 
     let selectedParticipants = await operatorContract.selectedParticipants();
     assert.equal(selectedParticipants.length, groupSize, "Should be trimmed to groupSize length.");


### PR DESCRIPTION
Refs: #1095 

Reduces operator contract size from 23237 to 22992 bytes

* Make functions internal where possible
* Refactor code without onlyEligibleSubmitter modifier
* Remove selectedTickets() and use selectedParticipants() array for verifying recovered addresses from signatures
