### PR TITLE
Reduce operator contract size - part 3

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -496,20 +496,15 @@ contract KeepRandomBeaconOperator {
     }
 
     /**
-     * @dev Return total number of all tokens issued.
-     */
-    function tokenSupply() public pure returns (uint256) {
-        return (10**9) * (10**18);
-    }
-
-    /**
-     * @dev Return natural threshold, the value N virtual stakers' tickets would be expected
-     * to fall below if the tokens were optimally staked, and the tickets' values were evenly
-     * distributed in the domain of the pseudorandom function.
+     * @dev Return natural threshold, the value N virtual stakers' tickets would
+     * be expected to fall below if the tokens were optimally staked, and the
+     * tickets' values were evenly distributed in the domain of the pseudorandom
+     * function.
      */
     function naturalThreshold() public view returns (uint256) {
-        uint256 space = 2**256-1; // Space consisting of all possible tickets.
-        return groupSize.mul(space.div(tokenSupply().div(minimumStake)));
+        uint256 tokenSupply = (10**9) * (10**18); // Supply of KEEP tokens
+        uint256 space = 2**256-1; // All possible ticket values
+        return groupSize.mul(space.div(tokenSupply.div(minimumStake)));
     }
 
     /**

--- a/pkg/beacon/relay/config/config.go
+++ b/pkg/beacon/relay/config/config.go
@@ -29,9 +29,6 @@ type Chain struct {
 	// MinimumStake is an on-chain value representing the minimum necessary
 	// amount a client must lock up to submit a single ticket
 	MinimumStake *big.Int
-	// TokenSupply represents the total number of tokens that can exist in
-	// the system
-	TokenSupply *big.Int
 	// NaturalThreshold is the value N virtual stakers' tickets would be
 	// expected to fall below if the tokens were optimally staked, and the
 	// tickets' values were evenly distributed in the domain of the

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -73,11 +73,6 @@ func (ec *ethereumChain) GetConfig() (*relayconfig.Chain, error) {
 		return nil, fmt.Errorf("error calling MinimumStake: [%v]", err)
 	}
 
-	tokenSupply, err := ec.keepRandomBeaconOperatorContract.TokenSupply()
-	if err != nil {
-		return nil, fmt.Errorf("error calling TokenSupply: [%v]", err)
-	}
-
 	naturalThreshold, err := ec.keepRandomBeaconOperatorContract.NaturalThreshold()
 	if err != nil {
 		return nil, fmt.Errorf("error calling NaturalThreshold: [%v]", err)
@@ -95,7 +90,6 @@ func (ec *ethereumChain) GetConfig() (*relayconfig.Chain, error) {
 		TicketReactiveSubmissionTimeout: ticketReactiveSubmissionTimeout.Uint64(),
 		ResultPublicationBlockStep:      resultPublicationBlockStep.Uint64(),
 		MinimumStake:                    minimumStake,
-		TokenSupply:                     tokenSupply,
 		NaturalThreshold:                naturalThreshold,
 		RelayEntryTimeout:               relayEntryTimeout.Uint64(),
 	}, nil

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -271,16 +271,13 @@ func ConnectWithKey(
 ) Chain {
 	bc, _ := BlockCounter()
 
-	tokenSupply, naturalThreshold := calculateGroupSelectionParameters(
-		groupSize,
-		minimumStake,
-	)
-
 	currentBlock, _ := bc.CurrentBlock()
 	group := localGroup{
 		groupPublicKey:          seedGroupPublicKey,
 		registrationBlockHeight: currentBlock,
 	}
+
+	naturalThreshold := calculateNaturalThreshold(groupSize, minimumStake)
 
 	return &localChain{
 		relayConfig: &relayconfig.Chain{
@@ -290,7 +287,6 @@ func ConnectWithKey(
 			TicketReactiveSubmissionTimeout: 3,
 			ResultPublicationBlockStep:      3,
 			MinimumStake:                    minimumStake,
-			TokenSupply:                     tokenSupply,
 			NaturalThreshold:                naturalThreshold,
 		},
 		relayEntryHandlers:       make(map[int]func(request *event.Entry)),
@@ -306,10 +302,7 @@ func ConnectWithKey(
 	}
 }
 
-func calculateGroupSelectionParameters(groupSize int, minimumStake *big.Int) (
-	tokenSupply *big.Int,
-	naturalThreshold *big.Int,
-) {
+func calculateNaturalThreshold(groupSize int, minimumStake *big.Int) *big.Int {
 	// (2^256)-1
 	ticketsSpace := new(big.Int).Sub(
 		new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil),
@@ -317,18 +310,16 @@ func calculateGroupSelectionParameters(groupSize int, minimumStake *big.Int) (
 	)
 
 	// 10^9
-	tokenSupply = new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil)
+	tokenSupply := new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil)
 
 	// groupSize * ( ticketsSpace / (tokenSupply / minimumStake) )
-	naturalThreshold = new(big.Int).Mul(
+	return new(big.Int).Mul(
 		big.NewInt(int64(groupSize)),
 		new(big.Int).Div(
 			ticketsSpace,
 			new(big.Int).Div(tokenSupply, minimumStake),
 		),
 	)
-
-	return tokenSupply, naturalThreshold
 }
 
 func selectGroup(entry *big.Int, numberOfGroups int) int {


### PR DESCRIPTION
Refs: #1095

Removed `tokenSupply` function from the operator contract - the value returned by this function was passed to off-chain client configuration but it was not used anywhere later.
