### PR TITLE
keep-test: Disable staking on relay submitter

### DIFF
--- a/infrastructure/kube/keep-test/keep-network-relay-request-cronjob.yaml
+++ b/infrastructure/kube/keep-test/keep-network-relay-request-cronjob.yaml
@@ -5,14 +5,14 @@ metadata:
   name: keep-network-relay-request-submitter
   labels:
     app: keep-network
-    type: relay-request-submitter
+    type: relay-requester
 spec:
   schedule: '*/5 * * * *'
   jobTemplate:
     metadata:
       labels:
         app: keep-network
-        type: relay-request-submitter
+        type: relay-requester
     spec:
       activeDeadlineSeconds: 600
       template:
@@ -42,7 +42,7 @@ spec:
             image: gcr.io/keep-test-f3e0/keep-client-initcontainer
             env:
               - name: KEEP_CLIENT_TYPE
-                value: standard
+                value: relay-requester
               - name: KEEP_CLIENT_ETH_ACCOUNT_PASSWORD
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Not a ton to say here.  We're extending the functionality we introduced in https://github.com/keep-network/keep-core/pull/1104 to `keep-test.

