### PR TITLE
Add custom txpool params to geth arguments

### DIFF
--- a/infrastructure/kube/keep-dev/eth-tx-ropsten-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/eth-tx-ropsten-statefulset.yaml
@@ -36,5 +36,5 @@ spec:
         volumeMounts:
           - name: eth-tx
             mountPath: /root/.ethereum
-        args: ["--testnet", "--datadir=/root/.ethereum", "--syncmode=light", "--rpc", "--rpcapi=eth,web3,personal", "--rpcport=8545", "--rpcaddr=0.0.0.0", "--rpccorsdomain=\"\"", "--rpcvhosts=*", "--ws", "--wsport=8546", "--wsaddr=0.0.0.0", "--wsorigins=*"]
+        args: ["--testnet", "--datadir=/root/.ethereum", "--syncmode=light", "--rpc", "--rpcapi=eth,web3,personal", "--rpcport=8545", "--rpcaddr=0.0.0.0", "--rpccorsdomain=\"\"", "--rpcvhosts=*", "--ws", "--wsport=8546", "--wsaddr=0.0.0.0", "--wsorigins=*", "--txpool.accountslots 128", "--txpool.accountqueue 512"]
 


### PR DESCRIPTION
Refs #1112 

Add custom `txpool.accountslots` and `txpool.accountqueue` parameters to `geth` arguments list. By default, `geth` sets these params to `16` and `64` which is not sufficient when group size has a value equal to `64`. This causes transactions dropping and ticket submission fail as result.
