### PR TITLE
Updated gas estimates for entry verification and DKG

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -97,12 +97,10 @@ contract KeepRandomBeaconOperator {
     // Gas required to verify BLS signature and produce successful relay
     // entry. Excludes callback and DKG gas.
     // TODO: Update once alt_bn128 gas costs reduction is implemented.
-    // TODO: Update if we change group size.
-    uint256 public entryVerificationGasEstimate = 1240000;
+    uint256 public entryVerificationGasEstimate = 523000;
 
     // Gas required to submit DKG result.
-    // TODO: Update if we change group size.
-    uint256 public dkgGasEstimate = 2260000;
+    uint256 public dkgGasEstimate = 8100000;
 
     // Reimbursement for the submitter of the DKG result.
     // This value is set when a new DKG request comes to the operator contract.


### PR DESCRIPTION
Refs: #1112 
Refs: #1096 

- DKG gas estimate reflects now the cost of DKG for a group of 64 members.
- Relay entry verification reflects now the cost of verification after all the recent optimizations.