### PR TITLE
Create local copy of transactor options for modifications

### DIFF
--- a/pkg/chain/gen/contract_non_const_methods.go.tmpl
+++ b/pkg/chain/gen/contract_non_const_methods.go.tmpl
@@ -10,6 +10,12 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	{{ end -}}
 	transactionOptions ...options.TransactionOptions,
 ) (*types.Transaction, error) {
+	if len(transactionOptions) > 1 {
+        return nil, fmt.Errorf(
+            "more than one transaction options not allowed",
+        )
+    }
+
 	{{$logger}}.Debug(
 		"submitting transaction {{$method.LowerName}}\n",
 		{{$method.Params}}
@@ -21,20 +27,14 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
 	{{$contract.ShortVar}}.transactionMutex.Lock()
 	defer {{$contract.ShortVar}}.transactionMutex.Unlock()
 
+	// create a copy
+	transactorOptions := bind.TransactOpts(*{{$contract.ShortVar}}.transactorOptions) 
+	
 	{{if $method.Payable -}}
-	transactorOptions := &(*{{$contract.ShortVar}}.transactorOptions) // create a copy
 	transactorOptions.Value = value
-	{{- else -}}
-	transactorOptions := {{$contract.ShortVar}}.transactorOptions
 	{{- end }}
 
     if len(transactionOptions) > 0 {
-        if len(transactionOptions) > 1 {
-            return nil, fmt.Errorf(
-                "could not process multiple transaction options sets",
-            )
-        }
-
         if customGasLimit := transactionOptions[0].GasLimit; customGasLimit != 0 {
             transactorOptions.GasLimit = customGasLimit
         }
@@ -44,7 +44,7 @@ func ({{$contract.ShortVar}} *{{$contract.Class}}) {{$method.CapsName}}(
     }
 
 	transaction, err := {{$contract.ShortVar}}.contract.{{$method.CapsName}}(
-		transactorOptions,
+		&transactorOptions,
 		{{$method.Params}}
 	)
 


### PR DESCRIPTION
Refs: keep-network/keep-common#11
Refs: #1105 

We were creating a new copy of transactor options only when the function was payable. As a result, any modification of either `GasLimit` or `GasPrice` was propagated to the contract-level transactor options and could make another function call fail.

What is more, the way we were creating a local copy of transactor options was wrong - instead of creating a new instance of the structure we were creating a new instance of a pointer with the same value as the original one.

The code was modified to always create a new copy of transactor options and the way we create a copy was fixed.