### PR TITLE
Extension of network message protbuf

### DIFF
--- a/pkg/net/gen/pb/message.proto
+++ b/pkg/net/gen/pb/message.proto
@@ -24,6 +24,12 @@ message NetworkMessage {
   // Channel names are Keccak(StakingPubKey1 || ... || StakingPubKeyN) of
   // all valid group members.
   bytes channel = 5;
+
+  // Unique identifier of the message.
+  string checksum = 6;
+
+  // Used to determine retransmission round which sent the message.
+  int32 retransmissionSequence = 7;
 }
 
 message Identity {


### PR DESCRIPTION
Refs #1138 

Added `checksum` and `retransmissionSequence` in network message protobuf in order to
handle retransmission in a correct way.