### PR TITLE
keep-dev: update Keel chart

### DIFF
--- a/infrastructure/terraform/keep-dev/variables.tf
+++ b/infrastructure/terraform/keep-dev/variables.tf
@@ -119,7 +119,7 @@ variable "gke_cluster" {
     daily_maintenance_window_start_time = "00:00"
     network_policy_enabled              = false
     network_policy_provider             = "PROVIDER_UNSPECIFIED"
-    logging_service                     = "logging.googleapis.com/kubernetes"
+    logging_service                     = "logging.googleapis.com"
   }
 }
 
@@ -205,7 +205,7 @@ variable "keel" {
   default {
     name      = "helm-keel"
     namespace = "tiller"
-    version   = "0.8.13"
+    version   = "0.8.16"
   }
 }
 


### PR DESCRIPTION
I noticed that we were running into some memory pointer issues in keel
on startup.  I took a stab at updating to the latest chart and seeing if
that would sort things out, it did.

Small bonus in the form of the logging API change.  The tl;dr here is that in frustration one day I disabled stackdriver monitoring in the console, instead of using Terraform.  This resulted in a mismatch of Terraform config and deployed state.  This change brings config in-line with deployed state.

---

As a refresher Keel is the software we use to do automated deployments after an image is published.