### PR TITLE
[RFC] Stake delegation and undelegation

### DIFF
--- a/docs/rfc/rfc-17-undelegation.adoc
+++ b/docs/rfc/rfc-17-undelegation.adoc
@@ -135,6 +135,10 @@ can thus be packed in a single storage field.
 This makes it slightly cheaper for operator contracts
 to determine the operator's eligibility for work selection.
 
+The exact types are a recommendation,
+and the implementation is free to use larger unsigned integers
+if it yields favorable performance outcomes.
+
 ==== Operator status
 
 ----


### PR DESCRIPTION
Close: #933 
Refine stake delegation specifications and specify undelegation. Includes a mitigation to work selection manipulation attacks.

Optimized packing of operator data (if Solidity doesn't pack the token amount and creation+undelegation times into one storage field, we need to do it manually) and a specific function for determining the amount of stake an operator has, eligible for use in a specific operator contract, are provided in the staking contract to reduce costs and facilitate safer implementation of operator contracts.