### PR TITLE
keep-client: retransmission configs

### DIFF
--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-config-template.toml
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-config-template.toml
@@ -28,5 +28,11 @@
   # or DNS entries you want to route traffic through.
   AnnouncedAddresses = []
 
+  # TODO: Make these configurable
+  # Number of retransmissions for each message
+  RetransmissionCycles = 5
+  # Milliseconds interval between each retransmission of a message
+  RetransmissionInterval = 1000
+
 [Storage]
   DataDir = "Set by Kube"


### PR DESCRIPTION
We've added some retry logic to try and eliminate dropped messages.
These configurations dictate how much and how often we're retrying for
each message sent.  Hardcoding these for now, taking the values set by
the engineering team.  I'll make these configurable in the future.

----

This feature was already implemented in code [here](https://github.com/keep-network/keep-core/pull/1159).  Playing catch up in this PR to ensure the config changes make it to cloud deployed components.