### PR TITLE
keep-client: fixxxxxx config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,33 +308,33 @@ workflows:
       - build_client_and_test_go:
           context: keep-dev
       - build_initcontainer:
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_client_and_test_go
       - migrate_contracts:
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go
       - publish_docker_images:
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go
             - build_initcontainer
             - migrate_contracts
       - publish_contract_data:
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go
@@ -343,9 +343,9 @@ workflows:
           requires:
             - migrate_contracts
       - publish_staking_dapp:
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_staking_dapp


### PR DESCRIPTION
This fixes what was done in https://github.com/keep-network/keep-core/pull/1193.  In my haste to start testing I forgot that for `int` in config we have to do some stupidity in the provisioner script so they don't get set as `float` in the config file.

Here we do that.

This was deployed and tested in `keep-dev`, apps boot as expected.