### PR TITLE
Remove operator signature description from rfc-5

### DIFF
--- a/docs/rfc/rfc-5-stake-delegation-specification.adoc
+++ b/docs/rfc/rfc-5-stake-delegation-specification.adoc
@@ -79,8 +79,10 @@ tokens, it should be noted that a malicious operator can exploit stake slashing
 to destroy tokens and thus the entire staked amount is indeed at stake.
 
 The operator address is used to provide network functionality by
-<<operating, participating in various operations>>and can unilaterally 
-<<undelegating, finish delegation>> and <<restoring, restore the tokens to the owner>>.
+<<operating, participating in various operations>>.
+
+The operator can unilaterally <<undelegating, finish delegation>> 
+and <<restoring, restore the tokens to the owner>>.
 
 === Magpie
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1190

In this PR we are removing signature notion from the stake delegation order description. No additional signature is required from the operator to stake the tokens by the owner.