### PR TITLE
Removed entryInProgress field from operator contract

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -121,8 +121,6 @@ contract KeepRandomBeaconOperator {
     uint256 internal currentEntryStartBlock;
     SigningRequest internal signingRequest;
 
-    bool internal entryInProgress;
-
     // Seed value used for the genesis group selection.
     // https://www.wolframalpha.com/input/?i=pi+to+78+digits
     uint256 internal _genesisGroupSeed = 31415926535897932384626433832795028841971693993751058209749445923078164062862;
@@ -420,10 +418,9 @@ contract KeepRandomBeaconOperator {
         address serviceContract,
         uint256 entryVerificationAndProfitFee
     ) internal {
-        require(!entryInProgress || hasEntryTimedOut(), "Beacon is busy");
+        require(currentEntryStartBlock == 0 || hasEntryTimedOut(), "Beacon is busy");
 
         currentEntryStartBlock = block.number;
-        entryInProgress = true;
 
         uint256 groupIndex = groups.selectGroup(uint256(keccak256(previousEntry)));
         signingRequest = SigningRequest(
@@ -465,8 +462,6 @@ contract KeepRandomBeaconOperator {
             msg.sender
         );
 
-        entryInProgress = false;
-
         (uint256 groupMemberReward, uint256 submitterReward, uint256 subsidy) = newEntryRewardsBreakdown();
         groups.addGroupMemberReward(groupPubKey, groupMemberReward);
 
@@ -475,6 +470,8 @@ contract KeepRandomBeaconOperator {
         if (subsidy > 0) {
             ServiceContract(signingRequest.serviceContract).fundRequestSubsidyFeePool.value(subsidy)();
         }
+
+        currentEntryStartBlock = 0;
     }
 
     /**
@@ -544,7 +541,7 @@ contract KeepRandomBeaconOperator {
      * to be produced, see `relayEntryTimeout` value.
      */
     function hasEntryTimedOut() internal view returns (bool) {
-        return entryInProgress && block.number > currentEntryStartBlock + relayEntryTimeout;
+        return currentEntryStartBlock != 0 && block.number > currentEntryStartBlock + relayEntryTimeout;
     }
 
     /**

--- a/contracts/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
+++ b/contracts/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
@@ -40,11 +40,11 @@ contract KeepRandomBeaconOperatorPricingRewardsWithdrawStub is KeepRandomBeaconO
     }
 
     function relayEntry() public returns (uint256) {
-        entryInProgress = false;
         bytes memory groupPubKey = groups.getGroupPublicKey(signingRequest.groupIndex);
         (uint256 groupMemberReward, uint256 submitterReward, uint256 subsidy) = newEntryRewardsBreakdown();
         submitterReward; // silence local var
         subsidy; // silence local var
         groups.addGroupMemberReward(groupPubKey, groupMemberReward);
+        currentEntryStartBlock = 0;
     }
 }


### PR DESCRIPTION
Refs: #1096 

Instead of having a separate boolean field we can use `currentEntryStartBlock`.
This change lets us save some gas:
```
request:      233966 -> 228066 (- 5900)
verification: 212903 -> 212023 (- 880)
```