### PR TITLE
Fixing stake delegation for provisioning script

### DIFF
--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
@@ -125,7 +125,6 @@ async function isStaked(operator) {
 async function stakeOperatorAccount(operator, contractOwner) {
 
   let magpie = process.env.CONTRACT_OWNER_ETH_ACCOUNT_ADDRESS;
-  let contractOwnerSigned = await web3.eth.sign(web3.utils.soliditySha3(contractOwner), operator);
   let staked = await isStaked(operator);
 
   /*
@@ -145,20 +144,10 @@ async function stakeOperatorAccount(operator, contractOwner) {
     console.log('Unstaked operator account set, staking account!');
   }
 
-  /*
-  This is really a bit stupid.  The return from web3.eth.sign is different depending on whether or not
-  the signer is a local or remote ETH account.  We use web3.eth.sign to set contractOwnerSigned. Here
-  the bootstrap peer account already exists and is hosted on an ETH node.
-  */
-  if (process.env.KEEP_CLIENT_TYPE === 'bootstrap') {
-    var contractOwnerSignature = contractOwnerSigned;
-  } else {
-    var contractOwnerSignature = contractOwnerSigned.signature;
-  }
-
   let delegation = '0x' + Buffer.concat([
     Buffer.from(magpie.substr(2), 'hex'), 
-    Buffer.from(contractOwnerSignature.substr(2), 'hex')]).toString('hex');
+    Buffer.from(operator.substr(2), 'hex')
+  ]).toString('hex');
 
   console.log('Staking 1000000 KEEP tokens on operator account ' + operator);
 


### PR DESCRIPTION
This PR is related to changes described in [this](https://github.com/keep-network/keep-core/issues/1190) issue. The [FD discussion](https://www.flowdock.com/app/cardforcoin/tech/threads/O4zPW3hibA4SGdxBB2ZLelIvrTu)

Provisioning script(s) are failing and owner signature has to be replaced with operator address.  This is to simplify staking operation.