### PR TITLE
Do not allow to submit entry more than one time

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -442,7 +442,7 @@ contract KeepRandomBeaconOperator {
      * previous entry and seed.
      */
     function relayEntry(bytes memory _groupSignature) public {
-        require(isEntryInProgress(), "Entry already submitted");
+        require(isEntryInProgress(), "Entry was submitted");
         require(!hasEntryTimedOut(), "Entry timed out");
 
         bytes memory groupPubKey = groups.getGroupPublicKey(signingRequest.groupIndex);

--- a/contracts/solidity/test/TestKeepRandomBeaconOperatorRelayEntry.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconOperatorRelayEntry.js
@@ -77,7 +77,7 @@ contract('KeepRandomBeaconOperator', (accounts) => {
     
     await expectThrowWithMessage(
       operatorContract.relayEntry(bls.groupSignature),
-      "Entry already submitted"
+      "Entry was submitted"
     );
   });
 });


### PR DESCRIPTION
Closes #1226

Operators were allowed to submit valid relay entry multiple times until the next relay request. This was wrong for at least two reasons:
- Each new entry emits an event and application listening for those events may do some action on a new entry.
- Each new entry submission costs some gas; in case two or more operators race for submitting a new entry, we should minimize the gas expenditure of losers.

I have also snaked two other minor changes in this PR:
- Separated corrupted and invalid relay entry submission tests
  I had to import `expectThrowWithMessage` for the no-duplicate-entry unit test and couldn't help myself and had to refactor and split invalid entry test to use that import as well

- Implemented `isEntryInProgressFunction`
This function wraps `currentEntryStartBlock != 0 condition`. There is a negligible gas cost of having this function but it nicely describes what are we checking and we have cleaner code this way:
  - The relay request gas cost increased by 41 units.
  - The relay entry submission gas cost increased by 35 units.
  - The size of operator contract increased by 17 bytes.