### PR TITLE
Signing group member as a relay entry timeout tattletale

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -78,13 +78,13 @@ func Initialize(
 				request.GroupPublicKey,
 				request.BlockNumber,
 			)
-		} else {
-			go node.MonitorRelayEntry(
-				relayChain,
-				request.BlockNumber,
-				chainConfig,
-			)
 		}
+
+		go node.MonitorRelayEntry(
+			relayChain,
+			request.BlockNumber,
+			chainConfig,
+		)
 	})
 
 	relayChain.OnGroupSelectionStarted(func(event *event.GroupSelectionStart) {


### PR DESCRIPTION
Close: #1234 

The previous relay request event handler behaviour was:
- If I am a member of the selected group, I participate in the threshold signing,
- If I am not a member of the selected group, I monitor the chain for a new entry and report timeout if needed.

However, there is nothing wrong in being the signing group member and also a tattletale reporting relay entry timeout. It can help them reduce the penalty they suffer due to the timeout and heal the beacon without any additional out-of-group actors.

Here we change the relay request event handler behaviour to *always* monitor the chain as a potential tattletale. If the given staker is a group member, it will also participate in threshold signing.