### PR TITLE
Retry on group selection

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -142,8 +142,8 @@ func (ec *ethereumChain) GetSelectedParticipants() ([]chain.StakerAddress, error
 		}
 
 		stakerAddresses = make([]chain.StakerAddress, len(participants))
-		for _, participant := range participants {
-			stakerAddresses = append(stakerAddresses, participant.Bytes())
+		for i, participant := range participants {
+			stakerAddresses[i] = participant.Bytes()
 		}
 
 		return nil


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/1238
Closes #1247

In this PR we are adding a retry functionality for a group selection result fetch. Calling for selected participants will be repeated 4 times in 250ms intervals. This is a workaround for handling a situation when Infura's load balancer returns a block number which is behind the actual block number, probably due to a delay. In this case we get the on-chain error `Ticket submission in progress` even though the ticket submission was over. It results in an empty byte array off-chain and failure in Dkg group selection.

