### PR TITLE
WatchBlocks function for BlockCounter

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"context"
 	"crypto/ecdsa"
 
 	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
@@ -8,10 +9,9 @@ import (
 )
 
 // BlockCounter is an interface that provides the ability to wait for a certain
-// number of abstract blocks. It provides for two ways to wait, one blocking and
-// one chan-based. Block height is expected to increase monotonically, though
-// the time between blocks will depend on the underlying implementation. See
-// LocalBlockCounter() for a local implementation.
+// number of abstract blocks or watch as they are mined.
+// Block height is expected to increase monotonically, though
+// the time between blocks depends on the underlying implementation.
 type BlockCounter interface {
 	// WaitForBlockHeight blocks at the caller until the given block height is
 	// reached. If the number of blocks is zero or negative or if the given
@@ -26,6 +26,13 @@ type BlockCounter interface {
 
 	// CurrentBlock returns the current block height.
 	CurrentBlock() (uint64, error)
+
+	// WatchBlocks returns a channel that will emit new block numbers as they
+	// are mined. When the context provided as the parameter ends, new blocks
+	// are no longer pushed to the channel and the channel is closed. If there
+	// is no reader for the channel or reader is too slow, block updates can be
+	// dropped.
+	WatchBlocks(ctx context.Context) <-chan uint64
 }
 
 // StakeMonitor is an interface that provides ability to check and monitor

--- a/pkg/chain/ethereum/blockcounter_test.go
+++ b/pkg/chain/ethereum/blockcounter_test.go
@@ -102,3 +102,81 @@ func TestExecuteBlockHandlerOnlyOnce(t *testing.T) {
 		}
 	}
 }
+
+func TestWatchBlocks(t *testing.T) {
+	blockCounter := &ethereumBlockCounter{
+		latestBlockHeight:   uint64(1),
+		waiters:             make(map[uint64][]chan uint64),
+		subscriptionChannel: make(chan block),
+	}
+	go blockCounter.receiveBlocks()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	watcher1 := blockCounter.WatchBlocks(ctx1)
+	watcher2 := blockCounter.WatchBlocks(ctx2)
+
+	watcher1ReceivedCount := 0
+	watcher2ReceivedCount := 0
+	go func() {
+		for range watcher1 {
+			watcher1ReceivedCount++
+		}
+	}()
+	go func() {
+		for range watcher2 {
+			watcher2ReceivedCount++
+		}
+	}()
+
+	blockCounter.subscriptionChannel <- block{Number: "2"}
+	time.Sleep(50 * time.Millisecond)
+	cancel1()
+	blockCounter.subscriptionChannel <- block{Number: "3"}
+	time.Sleep(50 * time.Millisecond)
+	cancel2()
+	blockCounter.subscriptionChannel <- block{Number: "4"}
+	time.Sleep(50 * time.Millisecond)
+
+	if watcher1ReceivedCount != 1 {
+		t.Errorf("watcher 1 should receive [1] block, has [%v]", watcher1ReceivedCount)
+	}
+	if watcher2ReceivedCount != 2 {
+		t.Errorf("watcher 2 should receive [2] block, has [%v]", watcher2ReceivedCount)
+	}
+}
+
+func TestWatchBlocksIsNonBlocking(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	blockCounter := &ethereumBlockCounter{
+		latestBlockHeight:   uint64(1),
+		waiters:             make(map[uint64][]chan uint64),
+		subscriptionChannel: make(chan block),
+	}
+	go blockCounter.receiveBlocks()
+
+	_ = blockCounter.WatchBlocks(ctx)        // does not read blocks
+	watcher := blockCounter.WatchBlocks(ctx) // does read blocks
+
+	var receivedCount uint64
+	go func() {
+		for range watcher {
+			receivedCount++
+		}
+	}()
+
+	blockCounter.subscriptionChannel <- block{Number: "2"}
+	time.Sleep(10 * time.Millisecond)
+	blockCounter.subscriptionChannel <- block{Number: "3"}
+	time.Sleep(10 * time.Millisecond)
+
+	if receivedCount != 2 {
+		t.Fatalf("watcher should receive [2] blocks, has [%v]", receivedCount)
+	}
+}


### PR DESCRIPTION
Refs #1251

## The change

`WatchBlocks` returns a channel that will emit new block numbers as they are mined. When the context provided as the parameter ends, new blocks are no longer pushed to the channel and the channel is closed. If there is no reader for the channel or reader is too slow, block updates can be
dropped.

Here we provide two implementations: ethereum and local.

`WatchBlocks` will be used to trigger network message retransmissions periodically.


## What's wrong with our network interface? 

For any protocol, each state exchanging messages consist of three phases: delay phase, initialization phase, and active phase. During the delay phase, we do nothing - this is an additional time given for every participant to enter the state. During initialization, we send all messages. During the active phase, we wait for a certain time for messages from all other participants to arrive. 

All transitions are synchronized on new blocks appearing on-chain. 

Since libp2p pubsub does not guarantee delivery we retransmit messages for a certain number of times with the configured interval to increase the message delivery rate. Retransmission options are configurable in the toml file. 

Retransmissions are time-synchronized and state machine transitions are block-synchronized. That's the first problem.

Another problem is with the delay phase - if we assume two or more clients can receive delayed information about new blocks, there is no guarantee one or two blocks for the delay phase are enough to let them sync, especially with very short block times. What's more, if we assume retransmissions will help to alleviate the pain with imperfect synchronizations, the question about the need for the existence of the delay phase arises. 

## The remedy

We need to bind together state transitions and retransmissions of network messages. We need to assume broadcast channel works in a "beacon mode" retransmitting message with certain intervals for the entire lifetime of the given state. 

This way, we'll go from this:
```
======== [Delay]  ========
|           .            |
|           .            |
|        (silence)       |
|           .            |
|           .            |
==== [Initialization] ====
|        message ->      |
======== [Active] ========
|  retransmission #1 ->  |
|           .            |
|  retransmission #2 ->  |
|           .            |
|  retransmission #3 ->  |
|           .            |
|           .            |
|           .            |
|           .            |
|           .            |
|        (silence)       |
|           .            |
|           .            |
|           .            |
|           .            |
==========================
```

To this:
```
==== [Initialization] ====
|        message ->      |
======== [Active] ========
|  retransmission #1 ->  |
|           .            |
|  retransmission #2 ->  |
|           .            |
|  retransmission #3 ->  |
|           .            |
|  retransmission #4 ->  |
|           .            |
|  retransmission #5 ->  |
|           .            |
|  retransmission #6 ->  |
|           .            |
|  retransmission #7 ->  |     
|           .            |
|  retransmission #8 ->  |
==========================
```