### PR TITLE
Disable solium linter suggestions to use transfer()

### DIFF
--- a/contracts/solidity/.soliumrc.json
+++ b/contracts/solidity/.soliumrc.json
@@ -12,6 +12,7 @@
       "error",
       4
     ],
-    "security/no-block-members": ["off", ["timestamp"]]
+    "security/no-block-members": ["off", ["timestamp"]],
+    "security/no-call-value": "off"
   }
 }


### PR DESCRIPTION
After EIP-1884 it is no longer safe to use transfer() and send() as they limit forwarded gas to 2300 and might cause issues for recipient contracts. It is how recommended to use call() instead and implement additional checks to prevent reentrancy attacks.