### PR TITLE
utils.toBN is not a function testnet bug

### DIFF
--- a/contracts/solidity/dashboard/src/components/ContractsDataContextProvider.jsx
+++ b/contracts/solidity/dashboard/src/components/ContractsDataContextProvider.jsx
@@ -44,7 +44,7 @@ class ContractsDataContextProvider extends React.Component {
 
     getContractsInfo = async () => {
       const { web3: { web3, token, stakingContract, grantContract, yourAddress, changeDefaultContract, utils } } = this.props
-      if (!web3) {
+      if (!token.methods || !stakingContract.methods || !grantContract.methods || !yourAddress) {
         return
       }
       try {
@@ -84,6 +84,7 @@ class ContractsDataContextProvider extends React.Component {
           contractsDataIsFetching: false,
         })
       } catch (error) {
+        console.log('error', error)
         this.setState({ contractsDataIsFetching: false })
       }
     }


### PR DESCRIPTION
This PR fixes the bug below on testnet. It's difficult to reproduce the error locally- tested with contracts deployed to the keep-dev network. The bug was that the component used the web3 context before it was completely initialized.

![obraz](https://user-images.githubusercontent.com/57687279/73175127-c0993a80-4109-11ea-8663-1226e03c0c6f.png)
