### PR TITLE
tracking-only: Deploy keep-test keep-client to separate node pool

### DIFF
--- a/infrastructure/kube/keep-test/keep-client-0-ropsten-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-ropsten-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - key: keep-client-config.toml
               path: keep-client-config.toml
       nodeSelector:
-        pool-type: separate-keep-client-test
+        pool-type: separate-keep-client-test-bigger
       tolerations:
       - key: app
         operator: Equal

--- a/infrastructure/kube/keep-test/keep-client-1-ropsten-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-ropsten-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - key: keep-client-config.toml
               path: keep-client-config.toml
       nodeSelector:
-        pool-type: separate-keep-client-test
+        pool-type: separate-keep-client-test-bigger
       tolerations:
       - key: app
         operator: Equal

--- a/infrastructure/kube/keep-test/keep-client-2-ropsten-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-ropsten-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - key: keep-client-config.toml
               path: keep-client-config.toml
       nodeSelector:
-        pool-type: separate-keep-client-test
+        pool-type: separate-keep-client-test-bigger
       tolerations:
       - key: app
         operator: Equal

--- a/infrastructure/kube/keep-test/keep-client-3-ropsten-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-ropsten-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - key: keep-client-config.toml
               path: keep-client-config.toml
       nodeSelector:
-        pool-type: separate-keep-client-test
+        pool-type: separate-keep-client-test-bigger
       tolerations:
       - key: app
         operator: Equal

--- a/infrastructure/kube/keep-test/keep-client-4-ropsten-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-ropsten-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - key: keep-client-config.toml
               path: keep-client-config.toml
       nodeSelector:
-        pool-type: separate-keep-client-test
+        pool-type: separate-keep-client-test-bigger
       tolerations:
       - key: app
         operator: Equal


### PR DESCRIPTION
There's a bit of unknown around discarded messages in keep-test relay
requests.  There is some conjecture that limited compute resources in
the default deployment could be responsible.  Here we attach runnning
keep-clients to a purpose built node pool for testing this theory.

---- 