### PR TITLE
keep-dev: utility-box update

### DIFF
--- a/infrastructure/terraform/keep-dev/main.tf
+++ b/infrastructure/terraform/keep-dev/main.tf
@@ -212,7 +212,7 @@ module "pull_deployment_infrastructure" {
 }
 
 module "push_deployment_infrastructure" {
-  source                 = "git@github.com:thesis/infrastructure.git//terraform/modules/gcp_push_deploy?ref=sthompson22/push-infra/utility-box-nodejs"
+  source                 = "git@github.com:thesis/infrastructure.git//terraform/modules/gcp_push_deploy"
   project                = "${module.project.project_id}"
   region                 = "${var.region_data["region"]}"
   vpc_network_name       = "${module.vpc.vpc_network_name}"


### PR DESCRIPTION
Updating the packages installed on the utility box. This will give us a newer version of node and npm.  I've already `terraform plan/applied` the contents of this PR:

```
sthompson22@keep-dev-utility-box:~$ npm --version
6.7.0
sthompson22
```
```
sthompson22@keep-dev-utility-box:~$ node --version
v11.15.0
```