### PR TITLE
Switch back to libp2p/go-libp2p-pubsub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/keep-network/keep-core
 
 go 1.12
 
-replace (
-	github.com/libp2p/go-libp2p-pubsub => github.com/keep-network/go-libp2p-pubsub v0.0.3-0.20200121091942-499109b16542
-	github.com/urfave/cli => github.com/keep-network/cli v1.20.0
-)
+replace github.com/urfave/cli => github.com/keep-network/cli v1.20.0
 
 require (
 	github.com/BurntSushi/toml v0.3.1
@@ -22,7 +19,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/libp2p/go-libp2p-kad-dht v0.3.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.4
-	github.com/libp2p/go-libp2p-pubsub v0.2.2
+	github.com/libp2p/go-libp2p-pubsub v0.2.6-0.20200127182502-25c434f5f772
 	github.com/libp2p/go-yamux v1.2.4 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/multiformats/go-multiaddr v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,10 @@ github.com/libp2p/go-libp2p-peerstore v0.1.0/go.mod h1:2CeHkQsr8svp4fZ+Oi9ykN1HB
 github.com/libp2p/go-libp2p-peerstore v0.1.3/go.mod h1:BJ9sHlm59/80oSkpWgr1MyY1ciXAXV397W6h1GH/uKI=
 github.com/libp2p/go-libp2p-peerstore v0.1.4 h1:d23fvq5oYMJ/lkkbO4oTwBp/JP+I/1m5gZJobNXCE/k=
 github.com/libp2p/go-libp2p-peerstore v0.1.4/go.mod h1:+4BDbDiiKf4PzpANZDAT+knVdLxvqh7hXOujessqdzs=
+github.com/libp2p/go-libp2p-pubsub v0.2.2 h1:izqwK39/GCamt8BiyZiSmow8eiF8cDti/Y/PPOv8AWs=
+github.com/libp2p/go-libp2p-pubsub v0.2.2/go.mod h1:Jscj3fk23R5mCrOwb625xjVs5ZEyTZcx/OlTwMDqU+g=
+github.com/libp2p/go-libp2p-pubsub v0.2.6-0.20200127182502-25c434f5f772 h1:u16t4PwsIqui9FzASxM4eDO8P8+uoc0IzLnUHgV8RUc=
+github.com/libp2p/go-libp2p-pubsub v0.2.6-0.20200127182502-25c434f5f772/go.mod h1:BCOicGpswT+5P6WB6jbnW0bcLUwmzskTg7HRwivwEXM=
 github.com/libp2p/go-libp2p-record v0.1.1 h1:ZJK2bHXYUBqObHX+rHLSNrM3M8fmJUlUHrodDPPATmY=
 github.com/libp2p/go-libp2p-record v0.1.1/go.mod h1:VRgKajOyMVgP/F0L5g3kH7SVskp17vFi2xheb5uMJtg=
 github.com/libp2p/go-libp2p-routing v0.0.1/go.mod h1:N51q3yTr4Zdr7V8Jt2JIktVU+3xBBylx1MZeVA6t1Ys=


### PR DESCRIPTION
We had to switch to our fork because of the PR we submitted to libp2p allowing to configure size of validation queue with `WithValidateQueueSize` function:

https://github.com/libp2p/go-libp2p-pubsub/pull/255/

This PR is merged so we can go back to the `libp2p/go-libp2p-pubsub`. Since there was no official release from the time our PR was merged, we are attached to a commit in `go-libp2p-pubsub` `master`.