### PR TITLE
Remove active groups threshold

### DIFF
--- a/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/contracts/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -169,7 +169,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
         groupSelection.ticketSubmissionTimeout = 12;
         groupSelection.groupSize = groupSize;
-        groups.activeGroupsThreshold = 5;
+
         groups.groupActiveTime = 3000;
 
         dkgResultVerification.timeDKG = 5*(1+5) + 2*(1+10);

--- a/contracts/solidity/contracts/libraries/operator/Groups.sol
+++ b/contracts/solidity/contracts/libraries/operator/Groups.sol
@@ -16,10 +16,6 @@ library Groups {
     }
 
     struct Storage {
-        // The minimal number of groups that should not expire to protect the
-        // minimal network throughput.
-        uint256 activeGroupsThreshold;
-    
         // Time in blocks after which a group expires.
         uint256 groupActiveTime;
 
@@ -195,11 +191,6 @@ library Groups {
     /**
      * @dev Gets the cutoff time in blocks until which the given group is
      * considered as an active group assuming it hasn't been terminated before.
-     * The group may not be marked as expired even though its active
-     * time has passed if one of the rules inside `selectGroup` function are not
-     * met (e.g. minimum active group threshold). Hence, this value informs when
-     * the group may no longer be considered as active but it does not mean that
-     * the group will be immediatelly considered not as such.
      */
     function groupActiveTimeOf(
         Storage storage self,
@@ -274,19 +265,11 @@ library Groups {
      * @dev Goes through groups starting from the oldest one that is still
      * active and checks if it hasn't expired. If so, updates the information
      * about expired groups so that all expired groups are marked as such.
-     * It does not mark more than `activeGroupsThreshold` active groups as
-     * expired.
      */
-    function expireOldGroups(
-        Storage storage self
-    ) internal {
+    function expireOldGroups(Storage storage self) internal {
         // move expiredGroupOffset as long as there are some groups that should
-        // be marked as expired and we are above activeGroupsThreshold of
-        // active groups.
-        while(
-            groupActiveTimeOf(self, self.groups[self.expiredGroupOffset]) < block.number &&
-            numberOfGroups(self) > self.activeGroupsThreshold
-        ) {
+        // be marked as expired
+        while(groupActiveTimeOf(self, self.groups[self.expiredGroupOffset]) < block.number) {
             self.expiredGroupOffset++;
         }
 

--- a/contracts/solidity/contracts/stubs/GroupsExpirationStub.sol
+++ b/contracts/solidity/contracts/stubs/GroupsExpirationStub.sol
@@ -7,7 +7,6 @@ contract GroupsExpirationStub {
 
     constructor() public {
         groups.groupActiveTime = 20;
-        groups.activeGroupsThreshold = 5;
         groups.relayEntryTimeout = 10;
     }
 

--- a/contracts/solidity/contracts/stubs/GroupsTerminationStub.sol
+++ b/contracts/solidity/contracts/stubs/GroupsTerminationStub.sol
@@ -7,7 +7,6 @@ contract GroupsTerminationStub {
 
     constructor() public {
         groups.groupActiveTime = 5;
-        groups.activeGroupsThreshold = 1;
     }
 
     function addGroup(bytes memory groupPubKey) public {
@@ -22,10 +21,6 @@ contract GroupsTerminationStub {
 
     function terminateGroup(uint256 groupIndex) public {
         groups.terminatedGroups.push(groupIndex);
-    }
-
-    function setActiveGroupsThreshold(uint256 threshold) public {
-        groups.activeGroupsThreshold = threshold;
     }
 
     function selectGroup(uint256 seed) public returns(uint256) {

--- a/contracts/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
+++ b/contracts/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
@@ -12,7 +12,6 @@ contract KeepRandomBeaconOperatorPricingRewardsWithdrawStub is KeepRandomBeaconO
         address _stakingContract
     ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
         groups.groupActiveTime = 5;
-        groups.activeGroupsThreshold = 1;
         groups.relayEntryTimeout = 10;
     }
 

--- a/contracts/solidity/contracts/stubs/KeepRandomBeaconOperatorRewardsStub.sol
+++ b/contracts/solidity/contracts/stubs/KeepRandomBeaconOperatorRewardsStub.sol
@@ -9,7 +9,6 @@ contract KeepRandomBeaconOperatorRewardsStub is KeepRandomBeaconOperator {
         address _stakingContract
     ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
         groups.groupActiveTime = 5;
-        groups.activeGroupsThreshold = 1;
         groups.relayEntryTimeout = 10;
     }
 

--- a/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupExpiration.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupExpiration.js
@@ -4,12 +4,11 @@ const GroupsExpirationStub = artifacts.require('./stubs/GroupsExpirationStub.sol
 import expectThrowWithMessage from './helpers/expectThrowWithMessage';
 const Groups = artifacts.require("./libraries/operator/Groups.sol");
 
-contract('GroupsExpirationStub', function(accounts) {
+contract('KeepRandomBeaconOperator', function(accounts) {
 
   let groups;
 
   const groupActiveTime = 20;
-  const activeGroupsThreshold = 5;
   const relayEntryTimeout = 10;
 
   before(async () => {
@@ -86,15 +85,7 @@ contract('GroupsExpirationStub', function(accounts) {
     });
     it("EAA beacon_value = 0", async function() {
       let selectedIndex = await runExpirationTest(3, 1, 0);
-      assert.equal(0, selectedIndex); // min active threshold does not let to move offset
-    });
-    it("EAAAA beacon_value = 0", async function() {
-      let selectedIndex = await runExpirationTest(5, 1, 0);
-      assert.equal(0, selectedIndex); // min active threshold does not let to move offset
-    });
-    it("EAAAAA beacon_value = 0", async function() {
-      let selectedIndex = await runExpirationTest(6, 1, 0);
-      assert.equal(1, selectedIndex); // min active threshold does allow to move offset
+      assert.equal(1, selectedIndex);
     });
     it("EEEEAAAAAA beacon_value = 0", async function() { 
       let selectedIndex = await runExpirationTest(10, 4, 0);
@@ -146,19 +137,19 @@ contract('GroupsExpirationStub', function(accounts) {
     });
     it("EEEEEEEEEA beacon_value = 0", async function() {
       let selectedIndex = await runExpirationTest(10, 9, 0);
-      assert.equal(5, selectedIndex); // min active threshold does not let to move offset further than to 5
+      assert.equal(9, selectedIndex);
     });
     it("EEEEEEEEEA beacon_value = 1", async function() {
       let selectedIndex = await runExpirationTest(10, 9, 1);
-      assert.equal(6, selectedIndex); // min active threshold does not let to move offset further than to 5
+      assert.equal(9, selectedIndex);
     });
     it("EEEEEEEEEA beacon_value = 10", async function() {
       let selectedIndex = await runExpirationTest(10, 9, 10);
-      assert.equal(5, selectedIndex); // min active threshold does not let to move offset further than to 5
+      assert.equal(9, selectedIndex);
     });
     it("EEEEEEEEEA beacon_value = 11", async function() {
       let selectedIndex = await runExpirationTest(10, 9, 11);
-      assert.equal(6, selectedIndex); // min active threshold does not let to move offset further than to 5
+      assert.equal(9, selectedIndex);
     });
   });
   
@@ -166,8 +157,7 @@ contract('GroupsExpirationStub', function(accounts) {
   // - we check whether the first group is stale and assert it is not since
   //   an active group cannot be stale
   it("should not mark group as stale if it is active", async function() {
-    let groupsCount = activeGroupsThreshold + 1
-    await addGroups(groupsCount);
+    await addGroups(6);
 
     let pubKey = await groups.getGroupPublicKey(0);
 
@@ -183,9 +173,10 @@ contract('GroupsExpirationStub', function(accounts) {
  there are other expired groups", async function() {
     let groupsCount = 15
     await addGroups(groupsCount);
-    await expireGroup(9); // expire first 10 groups (we index from 0)
+    await expireGroup(8); // move height to expire first 9 groups (we index from 0)
 
-    await groups.selectGroup(0);
+    // this will move height by one and expire 9 + 1 groups
+    await groups.selectGroup(0); 
 
     for (var i = 10; i < groupsCount; i++) {
       let pubKey = await groups.getGroupPublicKey(i);
@@ -203,9 +194,10 @@ contract('GroupsExpirationStub', function(accounts) {
  there are other stale groups", async function() {
     let groupsCount = 15
     await addGroups(groupsCount);
-    await expireGroup(9); // expire first 10 groups (we index from 0)
+    await expireGroup(8); // move height to expire first 9 groups (we index from 0)
 
-    await groups.selectGroup(0);
+    // this will move height by one and expire 9 + 1 groups
+    await groups.selectGroup(0); 
 
     await mineBlocks(relayEntryTimeout);
 
@@ -213,21 +205,19 @@ contract('GroupsExpirationStub', function(accounts) {
       let pubKey = await groups.getGroupPublicKey(i);
       let isStale = await groups.isStaleGroup(pubKey);
 
-      assert.equal(isStale, false, "Group should not be marked as stale")
+      assert.equal(isStale, false, `Group at index ${i} should not be marked as stale`)
     }
   });
 
-  // - we start with [AAAAA]
+  // - we start with [AAAAAA]
   // - we mine as many blocks as needed to have all the groups qualify as stale
   // - we check whether the group at position 0 is stale
   // - group should not be marked as stale since it is not marked as expired
   //   (no group selection was triggered); group can be stale only if it has
-  //   been marked as expired - `selectGroup` may decide not to mark group as
-  //   expired even though it reached its expiration time (minimum threshold)
+  //   been marked as expired
   it("should not mark group as stale if its expiration time passed but\
  it is not marked as such", async function() {
-    let groupsCount = activeGroupsThreshold + 1
-    await addGroups(groupsCount);
+    await addGroups(6);
 
     let pubKey = await groups.getGroupPublicKey(0);
 
@@ -246,8 +236,7 @@ contract('GroupsExpirationStub', function(accounts) {
   //   relay request timeout did not pass since the group expiration block
   it("should not mark group as stale if it is expired but\
  can be still signing relay entry", async function() {
-    let groupsCount = activeGroupsThreshold + 1
-    await addGroups(groupsCount);
+    await addGroups(6);
 
     let pubKey = await groups.getGroupPublicKey(0);
 
@@ -267,8 +256,7 @@ contract('GroupsExpirationStub', function(accounts) {
   //   relay request timeout did pass since the group expiration block
   it("should mark group as stale if it is expired and\
  can be no longer signing relay entry", async function() {
-     let groupsCount = activeGroupsThreshold + 1
-     await addGroups(groupsCount);
+     await addGroups(6);
  
      let pubKey = await groups.getGroupPublicKey(0);
  
@@ -286,8 +274,7 @@ contract('GroupsExpirationStub', function(accounts) {
    // - we check whether group with a non-existing public key is stale and
    //   we assert the check should fail
    it("should fail stale check if group could not be found", async function() {
-    let groupsCount = activeGroupsThreshold + 1
-    await addGroups(groupsCount);
+    await addGroups(6);
 
     let pubKey = "0x1337"; // group with such pub key does not exist
     await expectThrowWithMessage(

--- a/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupTermination.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupTermination.js
@@ -4,17 +4,15 @@ import {createSnapshot, restoreSnapshot} from "./helpers/snapshot";
 const GroupsTerminationStub = artifacts.require('./stubs/GroupsTerminationStub.sol')
 const Groups = artifacts.require("./libraries/operator/Groups.sol");
 
-contract('GroupsTerminationStub', function(accounts) {
+contract('KeepRandomBeaconOperator', function(accounts) {
     let groups;
 
     const groupActiveTime = 5;
-    const activeGroupsThreshold = 1;
 
     before(async () => {
       const groupsLibrary = await Groups.new();
       await GroupsTerminationStub.link("Groups", groupsLibrary.address);
       groups = await GroupsTerminationStub.new();
-      groups.setActiveGroupsThreshold(activeGroupsThreshold);
     });
 
     beforeEach(async () => {
@@ -172,49 +170,6 @@ contract('GroupsTerminationStub', function(accounts) {
       it("EEETTATAAT beacon_value = 5", async function() {
         let selectedIndex = await runTerminationTest(10, 3, [3, 4, 6, 9], 5);
         assert.equal(8, selectedIndex)
-      })
-    })
-
-    describe("should include terminated groups when checking the minimum active groups threshold", async () => {    
-      beforeEach(async () => {
-        await groups.setActiveGroupsThreshold(5); 
-      });      
-      /*
-        We do not expire any more groups because the minimum active threshold
-        condition is not met (4 < 5) and we do not take the terminated group
-        into account for group selection.
-      */
-      it("EEEET beacon_value = 0, active threshold = 5", async function() {
-        let selectedIndex = await runTerminationTest(5, 4, [4], 0);
-        assert.equal(0, selectedIndex)
-      })
-      it("EEEET beacon_value = 3, active threshold = 5", async function() {
-        let selectedIndex = await runTerminationTest(5, 4, [4], 3);
-        assert.equal(3, selectedIndex)
-      })
-      it("EEEET beacon_value = 4, active threshold = 5", async function() {
-        let selectedIndex = await runTerminationTest(5, 4, [4], 4);
-        assert.equal(0, selectedIndex)
-      })
-      /*
-        We do not expire any more groups because the minimum active threshold
-        condition would not be met (5 = 5) and we do not take the terminated
-        group into account for group selection.
-      */
-      it("EEEEET beacon_value = 0, active threshold = 5", async function() {
-        groups.setActiveGroupsThreshold(5); 
-        let selectedIndex = await runTerminationTest(6, 5, [5], 0);
-        assert.equal(0, selectedIndex)
-      })
-      it("EEEEET beacon_value = 4, active threshold = 5", async function() {
-        groups.setActiveGroupsThreshold(5); 
-        let selectedIndex = await runTerminationTest(6, 5, [5], 4);
-        assert.equal(4, selectedIndex)
-      })
-      it("EEEEET beacon_value = 5, active threshold = 5", async function() {
-        groups.setActiveGroupsThreshold(5); 
-        let selectedIndex = await runTerminationTest(6, 5, [5], 5);
-        assert.equal(0, selectedIndex)
       })
     })
 


### PR DESCRIPTION
Refs: #932 

The reason for having the active groups threshold was to not go down to zero groups and render the beacon unresponsive.

_However,_
This could still happen if groups were not responding to requests.
This could not happen if beacon was serving enough requests.

_Also,_
This was easy to repair - just deploy another operator contract and genesis.

_And more importantly,_
This was conflicting with unstaking.

Operator can undelegate their stake, wait for the undelegation period and that's all! Operator is gone from the staking contract but it is still a group member!

The solution is to make group active time equal to stake undelegation period and always expire old groups. Here we take care of the latter.

Now:
- we don't have any problems with stake undelegation and group membership
- even if groups go down to zero, we can redeploy new operator contract and genesis

