### PR TITLE
Hardcoded the number of libp2p broadcast channel subscription workers to 32

### DIFF
--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	subscriptionWorkers = runtime.NumCPU()
+	subscriptionWorkers = 32
 	messageWorkers      = runtime.NumCPU()
 )
 


### PR DESCRIPTION
Closes: #1328 

The only way to read from libp2p pubsub is through the `Subscription`. Subscription has a function `Next()` which reads from an internal channel and returns a value. That internal channel has a buffer for `32` elements and if we do not read fast enough, messages are dropped.

In our libp2p broadcast channel code, we have a worker that reads from `Next()` and puts the message into a buffered channel for further processing. If that channel is full, we drop a message and log a warning. This situation has never happened yet during our tests.

However, we see a lot of warnings from libp2p about subscriber being too slow. It seems that setting the number of worker goroutines to `runtime.NumCPU()` may not be enough.

Writing to a 1-element-buffer channel takes twice as much as read. Our worker goroutine is not only reading - it is both reading and writing. Hence, it may take longer to process a message than to publish a new one in `Subscription`.

The internal buffer of `Subscription` should probably be configurable. If this buffer was `64` instead of `32`, we would not have any problems. Until the size of this channel is configurable (libp2p pubsub contribution awaits! 🙌 ) we increase the number of goroutines to `32` to be able to consume all messages from that buffer.

For each phase of DKG, we send `64` messages. If we consume `32` messages
from `Subscription` buffer, the rest can still stay there and wait for further processing.

Again, this solution is not perfect and it would be better to just increase that buffer but until we can not do it, here is what we need to do. While testing this locally with 10 clients I have not observed even a single "subscriber too slow" warning.