### PR TITLE
Version Tether: Continuous packaging and versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,11 @@ jobs:
             preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
 
             # Find the latest published package version matching this preid.
-            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output ". | sort | .[-1]")
+            # Note that in jq, we wrap the result in an array and then flatten;
+            # this is because npm show json contains a single string if there
+            # is only one matching version, or an array if there are multiple,
+            # and we want to look at an array always.
+            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | sort | .[-1]")
             latest_version=${latest_version:-$version}
             if [ -z $latest_version ]; then
               echo "Latest version calculation failed. Resolved info:"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
           at: /tmp/keep-client
       - checkout
       - run:
-          name: Copy contract artifacts
+          name: Bump and publish npm package
           working_directory: ~/project/solidity
           command: |
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,9 +332,23 @@ workflows:
   solidity:
     jobs:
       - test_solidity
+  build-and-test:
+    jobs:
+      - build_client_and_test_go:
+          filters:
+            branches:
+              ignore: master
+          context: keep-dev
+      - build_token_dashboard_dapp:
+          filters:
+            branches:
+              ignore: master
   build-test-migrate-publish-keep-dev:
     jobs:
       - build_client_and_test_go:
+          filters:
+            branches:
+              only: master
           context: keep-dev
       - build_initcontainer:
           filters:
@@ -367,10 +381,10 @@ workflows:
             - build_initcontainer
             - migrate_contracts
       - trigger_downstream_builds:
-          context: keep-dev
           filters:
             branches:
               only: master
+          context: keep-dev
           requires:
             - publish_npm_package
       - publish_contract_data:
@@ -381,11 +395,6 @@ workflows:
           requires:
             - build_client_and_test_go
             - migrate_contracts
-      # When building the token dashboard for a PR, don't wait on anything.
-      - build_token_dashboard_dapp:
-          filters:
-            branches:
-              ignore: master
       # When building the token dashboard for a master merge, wait for npm
       # package publish
       - build_token_dashboard_dapp:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,11 +222,6 @@ jobs:
           docker_layer_caching: true
       - checkout
       - run:
-          name: Copy contract artifacts
-          working_directory: ~/project/solidity/dashboard
-          command: |
-            ./scripts/copy-contracts.sh /tmp/keep-client/contracts
-      - run:
           name: Run Docker build
           working_directory: ~/project/solidity/dashboard
           command: |
@@ -371,9 +366,19 @@ workflows:
           requires:
             - build_client_and_test_go
             - migrate_contracts
+      # When building the token dashboard for a PR, don't wait on anything.
       - build_token_dashboard_dapp:
+          filters:
+            branches:
+              ignore: master
+      # When building the token dashboard for a master merge, wait for npm
+      # package publish
+      - build_token_dashboard_dapp:
+          filters:
+            branches:
+              only: master
           requires:
-            - migrate_contracts
+            - publish_npm_package
       - publish_token_dashboard_dapp:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,47 @@ jobs:
             cd /tmp/keep-client/contracts
             gsutil -m cp * gs://${CONTRACT_DATA_BUCKET}/keep-core
 
+  publish_npm_package:
+    executor: docker-node
+    steps:
+      - attach_workspace:
+          at: /tmp/keep-client
+      - checkout
+      - run:
+          name: Copy contract artifacts
+          working_directory: ~/project/solidity
+          command: |
+            set -x
+            mkdir -p artifacts
+            cp -r /tmp/keep-client/contracts/* artifacts/
+            name=$(jq --raw-output .name package.json)
+            version=$(jq --raw-output .version package.json)
+            preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+
+            # Find the latest published package version matching this preid.
+            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output ". | sort | .[-1]")
+            latest_version=${latest_version:-$version}
+            if [ -z $latest_version ]; then
+              echo "Latest version calculation failed. Resolved info:"
+              echo "$name@$version ; preid $preid"
+              exit 1
+            fi
+
+            # Update package.json with the latest published package version matching this
+            # preid to prepare for bumping.
+            echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+
+            # Bump without doing any git work. Versioning is a build-time action for us.
+            # Consider including commit id? Would be +<commit id>.
+            npm version prerelease --preid=$preid --no-git-tag-version
+
+            # Fix resolved dependency versions.
+            npm update
+
+            # Publish to npm.
+            echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+            npm publish --access=public
+
   build_token_dashboard_dapp:
     executor: docker-node
     steps:
@@ -304,6 +345,14 @@ workflows:
               only: master
           context: keep-dev
           requires:
+            - build_client_and_test_go
+      - publish_npm_package:
+          filters:
+            branches:
+              only: master
+          context: keep-dev
+          requires:
+            - migrate_contracts
             - build_client_and_test_go
       - publish_keep_client:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,8 +349,6 @@ workflows:
             branches:
               only: master
           context: keep-dev
-          requires:
-            - build_client_and_test_go
       - publish_npm_package:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,16 @@ jobs:
             echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
             npm publish --access=public
 
+  trigger_downstream_builds:
+    executor: docker-node
+    steps:
+      - run:
+          name: "Rebuild downstream same-branch build(s)"
+          command: |
+            # CIRCLE_BRANCH || CIRCLE_TAG?
+            # curl CIRCLE_API_BUILD/keep-tecdsa?branch=${CIRCLE_BRANCH}
+            echo "Eventually trigger downstream for $CIRCLE_BRANCH"
+
   build_token_dashboard_dapp:
     executor: docker-node
     steps:
@@ -358,6 +368,13 @@ workflows:
             - build_client_and_test_go
             - build_initcontainer
             - migrate_contracts
+      - trigger_downstream_builds:
+          context: keep-dev
+          filters:
+            branches:
+              only: master
+          requires:
+            - publish_npm_package
       - publish_contract_data:
           filters:
             branches:
@@ -444,7 +461,8 @@ workflows:
             requires:
               - build_client_and_test_go
               - migrate_contracts
-        - build_token_dashboard_dapp:
+        - publish_npm_package:
+            context: keep-test
             filters:
               tags:
                 only: /^v.*/
@@ -452,6 +470,23 @@ workflows:
                 ignore: /.*/
             requires:
               - migrate_contracts
+        - trigger_downstream_builds:
+            context: keep-test
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/
+            requires:
+              - publish_npm_package
+        - build_token_dashboard_dapp:
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/
+            requires:
+              - publish_npm_package
         - publish_token_dashboard_dapp:
             context: keep-test
             filters:

--- a/solidity/dashboard/Dockerfile
+++ b/solidity/dashboard/Dockerfile
@@ -13,7 +13,11 @@ RUN apk add --update --no-cache \
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 
-RUN npm install
+# Install from lockfile.
+RUN npm ci
+
+# Resolve latest build of keep-core.
+RUN npm update @keep-network/keep-core
 
 COPY src /app/src
 COPY public /app/public

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -984,6 +984,16 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
+    "@keep-network/keep-core": {
+      "version": "0.12.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-pre.1.tgz",
+      "integrity": "sha512-PJAwG7ehcNecvRtQKp9rFKmBHSJgB95wfs6j0qNnJKtv/CQYKHpUiU7w8lvepzzI6sFEMmKzAewcDGIXYmkVXw==",
+      "requires": {
+        "@openzeppelin/contracts-ethereum-package": "^2.4.0",
+        "@openzeppelin/upgrades": "^2.7.2",
+        "openzeppelin-solidity": "2.4.0"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -997,6 +1007,491 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+    },
+    "@openzeppelin/contracts-ethereum-package": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
+      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
+    },
+    "@openzeppelin/upgrades": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
+      "integrity": "sha512-LzjTQPeljPsgHDPdZyH9cMCbIHZILgd2cpNcYEkdsC2IylBYRHShlbEDXJV9snnqg9JWfzPiKIqyj3XVliwtqQ==",
+      "requires": {
+        "@types/cbor": "^2.0.0",
+        "axios": "^0.18.0",
+        "bignumber.js": "^7.2.0",
+        "cbor": "^4.1.5",
+        "chalk": "^2.4.1",
+        "ethers": "^4.0.20",
+        "glob": "^7.1.3",
+        "lodash": "^4.17.15",
+        "semver": "^5.5.1",
+        "spinnies": "^0.4.2",
+        "truffle-flattener": "^1.4.0",
+        "web3": "1.2.2",
+        "web3-eth": "1.2.2",
+        "web3-eth-contract": "1.2.2",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethers": {
+          "version": "4.0.46",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.46.tgz",
+          "integrity": "sha512-/dPMzzpInhtiip4hKFvsDiJKeRk64IhyA+Po7CtNXneQFSOCYXg8eBFt+jXbxUQyApgWnWOtYxWdfn9+CvvxDA==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
+          "integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.2",
+            "web3-core": "1.2.2",
+            "web3-eth": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-shh": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
+          "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.17",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+              "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
+          "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-requestmanager": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
+          "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
+          "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
+          "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
+          "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-providers-http": "1.2.2",
+            "web3-providers-ipc": "1.2.2",
+            "web3-providers-ws": "1.2.2"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
+          "integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
+          "integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-eth-accounts": "1.2.2",
+            "web3-eth-contract": "1.2.2",
+            "web3-eth-ens": "1.2.2",
+            "web3-eth-iban": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.2.tgz",
+          "integrity": "sha512-Yn/ZMgoOLxhTVxIYtPJ0eS6pnAnkTAaJgUJh1JhZS4ekzgswMfEYXOwpMaD5eiqPJLpuxmZFnXnBZlnQ1JMXsw==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.17",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+              "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
+          "integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-shim": "github:web3-js/scrypt-shim",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
+          "integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
+          "integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-eth-contract": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
+          "integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
+          "integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
+          "integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
+          "integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
+          "requires": {
+            "web3-core-helpers": "1.2.2",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
+          "integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
+          "integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
+          "integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-net": "1.2.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+      "requires": {
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "requires": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -1153,6 +1648,14 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cbor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-2.0.0.tgz",
+      "integrity": "sha1-xievwu4i8j8jN/7LNGKKT5fGr7s=",
       "requires": {
         "@types/node": "*"
       }
@@ -2029,6 +2532,43 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+    },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "axobject-query": {
       "version": "2.1.2",
@@ -3141,6 +3681,24 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cbor": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
+      "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "commander": "^3.0.0",
+        "json-text-sequence": "^0.1",
+        "nofilter": "^1.0.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        }
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -4987,6 +5545,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -9909,6 +10472,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -10895,6 +11466,11 @@
         }
       }
     },
+    "nofilter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
+      "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -11134,6 +11710,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
       "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+    },
+    "openzeppelin-solidity": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
+      "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
     },
     "opn": {
       "version": "5.4.0",
@@ -15267,6 +15848,21 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
       "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
     },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "from": "github:web3-js/scrypt-shim",
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "scryptsy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
@@ -15739,6 +16335,11 @@
         }
       }
     },
+    "solidity-parser-antlr": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
+      "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -15832,6 +16433,61 @@
         "obuf": "^1.1.2",
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
+      }
+    },
+    "spinnies": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/spinnies/-/spinnies-0.4.3.tgz",
+      "integrity": "sha512-TTA2vWXrXJpfThWAl2t2hchBnCMI1JM5Wmb2uyI7Zkefdw/xO98LDy6/SBYwQPiYXL3swx3Eb44ZxgoS8X5wpA==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "split-string": {
@@ -16681,6 +17337,18 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
+    "truffle-flattener": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.2.tgz",
+      "integrity": "sha512-7qUIzaW8a4vI4nui14wsytht2oaqvqnZ1Iet2wRq2T0bCJ0wb6HByMKQhZKpU46R+n5BMTY4K5n+0ITyeNlmuQ==",
+      "requires": {
+        "@resolver-engine/imports-fs": "^0.2.2",
+        "find-up": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "solidity-parser-antlr": "^0.4.11",
+        "tsort": "0.0.1"
+      }
+    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -16695,6 +17363,11 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+    },
+    "tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -17944,6 +18617,32 @@
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
+      }
+    },
+    "websocket": {
+      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "websocket-driver": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -15,7 +15,8 @@
     "bignumber.js": "9.0.0",
     "formik": "^2.1.3",
     "moment": "^2.20.1",
-    "web3": "^1.2.4"
+    "web3": "^1.2.4",
+    "@keep-network/keep-core": ">0.12.0-pre <0.12.0-rc"
   },
   "scripts": {
     "build-css": "lessc --clean-css src/css/app.less src/app.css",

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -1,8 +1,8 @@
-import KeepToken from './contracts/KeepToken.json'
-import TokenStaking from './contracts/TokenStaking.json'
-import TokenGrant from './contracts/TokenGrant.json'
-import KeepRandomBeaconOperator from './contracts/KeepRandomBeaconOperator.json'
-import Registry from './contracts/Registry.json'
+import KeepToken from '@keep-network/keep-core/artifacts/KeepToken.json'
+import TokenStaking from '@keep-network/keep-core/artifacts/TokenStaking.json'
+import TokenGrant from '@keep-network/keep-core/artifacts/TokenGrant.json'
+import KeepRandomBeaconOperator from '@keep-network/keep-core/artifacts/KeepRandomBeaconOperator.json'
+import Registry from '@keep-network/keep-core/artifacts/Registry.json'
 import {
   KEEP_TOKEN_CONTRACT_NAME,
   TOKEN_STAKING_CONTRACT_NAME,

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -10,9 +10,6 @@
     "contracts/**/*.sol",
     "artifacts"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "scripts": {
     "truffle": "truffle",
     "clean": "rm -rf build",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.12.0-pre.0",
+  "version": "0.12.0-pre",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "files": [
     "contracts/**/*.sol",
-    "build"
+    "artifacts"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
This PR represents an adjustment to how we manage cross-repository
versioning, package publishing, and dependency package and contract
references. Here are the major changes:
- `package.json` for Solidity contracts is set to `<version>-pre`, with no
  numeric suffix.
- A new Circle job, `publish_npm_package`, runs on master merge. This
  This job updates the package version to `-pre.<number>`, where `<number>`
  represents a new, unpublished version.
- Contract artifacts from the contract migration are copied to an `artifacts/`
  subdirectory and included in the package.
- The package is published to the main npm repository (not the GitHub
  package repository).
- We trigger a downstream build (placeholder, didn't get a chance to hook this
  up yet, plus we should wait until this build strategy propagates to the other
  repositories).

This PR includes tweaking the imports and dependency declaration on the
token dashboard. The token dashboard `package.json` references a dependency
range that includes all `-pre` versions of `keep-core`, and the docker build
now does an explicit `npm upgrade` to fetch the latest version of `keep-core`
as part of the build.