### PR TITLE
Add IAM viewer role to keep-dev and keep-test, and add kborg to both as viewer

### DIFF
--- a/infrastructure/terraform/keep-dev/iam.tf
+++ b/infrastructure/terraform/keep-dev/iam.tf
@@ -5,6 +5,13 @@ module "iam_members_editor" {
   members = "${var.editor_iam_members}"
 }
 
+module "iam_members_viewer" {
+  source  = "git@github.com:thesis/infrastructure.git//terraform/modules/gcp_iam_member"
+  project = "${module.project.project_id}"
+  role    = "${var.viewer_iam_role}"
+  members = "${var.viewer_iam_members}"
+}
+
 module "iam_members_storage_objectviewer" {
   source  = "git@github.com:thesis/infrastructure.git//terraform/modules/gcp_iam_member"
   project = "${module.project.project_id}"

--- a/infrastructure/terraform/keep-dev/variables.tf
+++ b/infrastructure/terraform/keep-dev/variables.tf
@@ -59,6 +59,15 @@ variable "editor_iam_members" {
   default = ["user:jakub.nowakowski@thesis.co", "user:nicholas.evans@thesis.co", "user:nik.grinkevich@thesis.co", "user:piotr.dyraga@thesis.co", "user:rafal.czajkowski@thesis.co"]
 }
 
+# module IAM members: viewer
+variable "viewer_iam_role" {
+  default = "roles/viewer"
+}
+
+variable "viewer_iam_members" {
+  default = ["user:kristen.borges@thesis.co"]
+}
+
 # module IAM members: storage.objectViewer
 variable "storage_objectviewer_iam_role" {
   default = "roles/storage.objectViewer"

--- a/infrastructure/terraform/keep-test/iam.tf
+++ b/infrastructure/terraform/keep-test/iam.tf
@@ -1,0 +1,6 @@
+module "iam_members_viewer" {
+  source  = "git@github.com:thesis/infrastructure.git//terraform/modules/gcp_iam_member"
+  project = "${module.project.project_id}"
+  role    = "${var.viewer_iam_role}"
+  members = "${var.viewer_iam_members}"
+}

--- a/infrastructure/terraform/keep-test/variables.tf
+++ b/infrastructure/terraform/keep-test/variables.tf
@@ -53,6 +53,15 @@ variable "project_owner_members" {
   ]
 }
 
+# module IAM members: viewer
+variable "viewer_iam_role" {
+  default = "roles/viewer"
+}
+
+variable "viewer_iam_members" {
+  default = ["user:kristen.borges@thesis.co"]
+}
+
 # bucket vars
 ## backend bucket
 variable "backend_bucket_name" {


### PR DESCRIPTION
While reviewing #1411 - and the associated flowdock threads (linked in that PR) describing the process, I got the impression there were a lot more steps than are visible via commits in that PR, and that having some visibility into the GCP console for those environments would be helpful.

This adds the iam "viewer" role to both `keep-dev` and `keep-test` and adds me as a viewer in each of those environments.