### PR TITLE
Optimize ticket submissions by compressing previous ticket data

### DIFF
--- a/contracts/solidity/contracts/stubs/GroupsSelectionStub.sol
+++ b/contracts/solidity/contracts/stubs/GroupsSelectionStub.sol
@@ -33,6 +33,6 @@ contract GroupSelectionStub {
     * getPreviousTicketIndex(2) = 0
     */
     function getPreviousTicketIndex(uint256 higherTicketValueIndex) public view returns (uint256) {
-        return groupSelection.previousTicketIndex[higherTicketValueIndex];
+        return uint256(uint8(groupSelection.previousTicketIndices[higherTicketValueIndex]));
     }
 }


### PR DESCRIPTION
Using `bytes` for previous ticket data in storage and uncompressing it into `uint256[]` in memory reduces `SLOAD` costs by a factor of 32 when constructing the ordering of previous tickets. This isn't detectable with the tested group size of 3, but starts to be significant with 32 or more members.

Related to #1099, has a simpler on-chain-only implementation, and gives some of the desired benefit.