### PR TITLE
Token grant cancel stake bug fix

### DIFF
--- a/contracts/solidity/contracts/TokenGrant.sol
+++ b/contracts/solidity/contracts/TokenGrant.sol
@@ -356,6 +356,8 @@ contract TokenGrant {
             msg.sender == _operator || msg.sender == grants[grantId].grantee,
             "Only operator or grantee can cancel the delegation."
         );
+        grants[grantId].staked = grants[grantId].staked.sub(grantStakes[_operator].amount);
+
 
         TokenStaking(grantStakes[_operator].stakingContract).cancelStake(_operator);
     }


### PR DESCRIPTION
Closes: #1446 

This PR fixes a bug in the `cancelstake` function in the `TokenGrant` contract. we should subtract the staked amount from the grant as we do in the`recoverStake`. Otherwise, the grantee will never be able to withdraw the total amount of grant.

TODO:
- [ ] TokenGrant tests