### PR TITLE
Token Staking- get delegation info fix

### DIFF
--- a/contracts/solidity/contracts/TokenStaking.sol
+++ b/contracts/solidity/contracts/TokenStaking.sol
@@ -150,13 +150,13 @@ contract TokenStaking is StakeDelegatable {
     /**
      * @dev Gets stake delegation info for the given operator.
      * @param _operator Operator address.
-     * @return createdAt The time when the stake has been delegated.
      * @return amount The amount of tokens the given operator delegated.
+     * @return createdAt The time when the stake has been delegated.
      * @return undelegatedAt The time when undelegation has been requested.
      * If undelegation has not been requested, 0 is returned.
      */
     function getDelegationInfo(address _operator)
-    public view returns (uint256 createdAt, uint256 amount, uint256 undelegatedAt) {
+    public view returns (uint256 amount, uint256 createdAt, uint256 undelegatedAt) {
         return operators[_operator].packedParams.unpack();
     }
 

--- a/contracts/solidity/test/TestTokenStake.js
+++ b/contracts/solidity/test/TestTokenStake.js
@@ -57,7 +57,7 @@ contract('TestTokenStake', function(accounts) {
     ]);
 
     // Stake tokens using approveAndCall pattern
-    await token.approveAndCall(stakingContract.address, stakingAmount, '0x' + data.toString('hex'), {from: account_one});
+    const { receipt } = await token.approveAndCall(stakingContract.address, stakingAmount, '0x' + data.toString('hex'), {from: account_one});
 
     // Ending balances
     let account_one_ending_balance = await token.balanceOf.call(account_one);
@@ -65,6 +65,11 @@ contract('TestTokenStake', function(accounts) {
 
     assert.equal(account_one_ending_balance.eq(account_one_starting_balance.sub(stakingAmount)), true, "Staking amount should be transferred from owner balance");
     assert.equal(account_one_operator_stake_balance.eq(stakingAmount), true, "Staking amount should be added to the operator balance");
+
+    const { amount, undelegatedAt, createdAt } = await stakingContract.getDelegationInfo.call(account_one_operator)
+    assert.equal(amount.eq(stakingAmount), true, "The amount should be the same as staked")
+    assert.equal(undelegatedAt.eq(web3.utils.toBN(0)), true, "Undelegated at should be 0")
+    assert.equal(createdAt.eq(web3.utils.toBN(receipt.blockNumber)), true, "The block number should be the same as in receipt")
 
     // Cancel stake
     await stakingContract.cancelStake(account_one_operator, {from: account_one});


### PR DESCRIPTION
This PR fixes incorrect order of returned properties from the getDelegationInfo function.