### PR TITLE
Fix mineBlocks, improve tests to be less error-prone

### DIFF
--- a/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupExpiration.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconOperatorGroupExpiration.js
@@ -37,7 +37,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     // If current block is larger than group registration block by group active time then
     // it is not necessary to mine any blocks cause the group is already expired
     if (currentBlock - groupRegistrationBlock <= groupActiveTime) {
-      await mineBlocks(groupActiveTime - (currentBlock - groupRegistrationBlock));
+      await mineBlocks(groupActiveTime - (currentBlock - groupRegistrationBlock) + 1);
     }
   }
 

--- a/contracts/solidity/test/TestKeepRandomBeaconOperatorPricingRewards.js
+++ b/contracts/solidity/test/TestKeepRandomBeaconOperatorPricingRewards.js
@@ -34,7 +34,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});
 
-    let delayFactor = await operatorContract.delayFactor();        
+    let delayFactor = await operatorContract.delayFactor.call();        
 
     let expectedDelayFactor = web3.utils.toBN(10000000000000000);
     assert.isTrue(expectedDelayFactor.eq(delayFactor));
@@ -44,9 +44,9 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});
 
-    mineBlocks(await operatorContract.relayEntryGenerationTime());
+    mineBlocks((await operatorContract.relayEntryGenerationTime()).addn(1));
 
-    let delayFactor = await operatorContract.delayFactor();
+    let delayFactor = await operatorContract.delayFactor.call();
 
     let expectedDelayFactor = web3.utils.toBN(10000000000000000);
     assert.isTrue(expectedDelayFactor.eq(delayFactor));
@@ -56,9 +56,9 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});
 
-    mineBlocks((await operatorContract.relayEntryGenerationTime()).addn(1));
+    mineBlocks((await operatorContract.relayEntryGenerationTime()).addn(2));
 
-    let delayFactor = await operatorContract.delayFactor();
+    let delayFactor = await operatorContract.delayFactor.call();
 
     let expectedDelayFactor = web3.utils.toBN('9896104600694443');
     assert.isTrue(expectedDelayFactor.eq(delayFactor));
@@ -68,9 +68,9 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});
 
-    mineBlocks((await operatorContract.relayEntryTimeout()).subn(1));
+    mineBlocks(await operatorContract.relayEntryTimeout());
 
-    let delayFactor = await operatorContract.delayFactor();        
+    let delayFactor = await operatorContract.delayFactor.call();        
 
     let expectedDelayFactor = web3.utils.toBN('271267361111');
     assert.isTrue(expectedDelayFactor.eq(delayFactor));        
@@ -96,7 +96,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     // 10020 * 140000 * 150% (fluctuation margin)
     let expectedSubmitterReward = web3.utils.toBN("2104200000");
     
-    let rewards = await operatorContract.getNewEntryRewardsBreakdown(); 
+    let rewards = await operatorContract.getNewEntryRewardsBreakdown.call(); 
 
     assert.isTrue(
       expectedGroupMemberReward.eq(rewards.groupMemberReward),
@@ -122,7 +122,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});  
 
-    mineBlocks(await operatorContract.relayEntryGenerationTime()); 
+    mineBlocks((await operatorContract.relayEntryGenerationTime()).addn(1)); 
 
     // No delay so entire group member base reward is paid and nothing
     // goes to the subsidy pool.
@@ -134,7 +134,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     // 10050 * 150000 * 150% (fluctuation margin)
     let expectedSubmitterReward = web3.utils.toBN("2261250000");
     
-    let rewards = await operatorContract.getNewEntryRewardsBreakdown(); 
+    let rewards = await operatorContract.getNewEntryRewardsBreakdown.call(); 
     
     assert.isTrue(
       expectedGroupMemberReward.eq(rewards.groupMemberReward),
@@ -160,7 +160,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});  
 
-    mineBlocks((await operatorContract.relayEntryGenerationTime()).addn(1));  
+    mineBlocks((await operatorContract.relayEntryGenerationTime()).addn(2));  
 
     // There is one block of delay so the delay factor is 0.9896104600694443.
     // Group member reward should be scaled by the delay factor: 
@@ -191,7 +191,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     // 127168000 - 125846720 - 66060 = 1255220
     let expectedSubsidy = web3.utils.toBN("1255220");              
 
-    let rewards = await operatorContract.getNewEntryRewardsBreakdown(); 
+    let rewards = await operatorContract.getNewEntryRewardsBreakdown.call(); 
     
     assert.isTrue(
       expectedGroupMemberReward.eq(rewards.groupMemberReward),
@@ -217,7 +217,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate}); 
 
-    mineBlocks((await operatorContract.relayEntryTimeout()).subn(1));
+    mineBlocks(await operatorContract.relayEntryTimeout());
 
     // There is one block left before the timeout so the delay factor is 
     // 0.0000271267361111.
@@ -249,7 +249,7 @@ contract('KeepRandomBeaconOperator', function(accounts) {
     // 88448000000 - 2399296 - 4422280034 = 84023320670
     let expectedSubsidy = web3.utils.toBN("84023320670");    
 
-    let rewards = await operatorContract.getNewEntryRewardsBreakdown();
+    let rewards = await operatorContract.getNewEntryRewardsBreakdown.call();
     
     assert.isTrue(
       expectedGroupMemberReward.eq(rewards.groupMemberReward),

--- a/contracts/solidity/test/helpers/mineBlocks.js
+++ b/contracts/solidity/test/helpers/mineBlocks.js
@@ -1,5 +1,5 @@
 export default function mineBlocks(blocks) {
-    for (let i = 0; i <= blocks; i++) {
+    for (let i = 0; i < blocks; i++) {
       web3.currentProvider.send({
         jsonrpc: "2.0",
         method: "evm_mine",


### PR DESCRIPTION
Having `let i = 0; i <= blocks; i++` in `mineBlocks.js`, we were mining more blocks than asked for. This is best illustrated with the following snippet:

```
console.log('I am now at ' + await web3.eth.getBlockNumber())
console.log('I am asking to mine 10')
await mineBlocks(10)
console.log('I am now at ' + await web3.eth.getBlockNumber())
```

Having `let i = 0; i <= blocks; i++`, the result is:
```
I am now at 25
I am asking to mine 10
I am now at 36
```

Having `let i = 0; i < blocks; i++`, the result is:
```
I am now at 25
I am asking to mine 10
I am now at 35
```

We changed `<` to `<=` in 651da31644ca7d8ced8aa60927226fed26dcf1eb to fix failing tests but apparently, the problem was not in `mineBlocks.js` but in the tests.

In `TestKeepRandomBeaconOperatorGroupExpiration.js` instead of expiring group with:
```
await mineBlocks(groupActiveTime - (currentBlock - groupRegistrationBlock));
```

we should expire group with:
```
await mineBlocks(groupActiveTime - (currentBlock - groupRegistrationBlock) + 1);
```

When we `runExpirationTest`, we CALL view function instead of submitting a new transaction. For a CALL function, a new block is not mined.

For example, if `groupRegistrationBlock = 28` and `groupActiveTime = 20`, group is expired at block `49` and still active at block `48`. Inside `Groups.sol` library we consider the group as expired if:
```
group registration block height + group active time < block.number
```

For this reason, view CALL needs to be executed at block `49` if we want to have the group expired.

In this commit, we also modify tests for pricing rewards to use view CALLs instead of submitting transactions calling view functions calculating delay factor or rewards. This approach is much less
error-prone.