### PR TITLE
Fix TestTokenGrantWithdraw test

### DIFF
--- a/contracts/solidity/test/token_grant/TestTokenGrantWithdraw.js
+++ b/contracts/solidity/test/token_grant/TestTokenGrantWithdraw.js
@@ -44,10 +44,10 @@ contract('TokenGrant/Withdraw', function(accounts) {
       initializationPeriod, 
       undelegationPeriod
     );
-    grantContract = await TokenGrant.new(
-      tokenContract.address, 
-      stakingContract.address
-    );
+
+    grantContract = await TokenGrant.new(tokenContract.address);
+
+    await grantContract.authorizeStakingContract(stakingContract.address);
 
     grantStart = await latestTime();
 


### PR DESCRIPTION
Instead of passing staking contract as a constructor parameter we should authorize it with `authorizeStakingContract` function.

In #1458 we changed the relationship between `TokenGrant` and `TokenStaking` contract and updated `TokenGrant` constructor from `constructor(address _tokenAddress, address _stakingContract) public` to `constructor(address _tokenAddress)`. The test implemented in #1464 used the previous definition. We merged those two PRs one after another and `master` build crushed.