### PR TITLE
Do not permit to undelegate  before initialization period passed

### DIFF
--- a/contracts/solidity/contracts/TokenStaking.sol
+++ b/contracts/solidity/contracts/TokenStaking.sol
@@ -151,7 +151,12 @@ contract TokenStaking is StakeDelegatable {
             "May not set undelegation block in the past"
         );
         uint256 oldParams = operators[_operator].packedParams;
+        uint256 existingCreationBlock = oldParams.getCreationBlock();
         uint256 existingUndelegationBlock = oldParams.getUndelegationBlock();
+        require(
+            _undelegationBlock > existingCreationBlock.add(initializationPeriod),
+            "Cannot undelegate in initialization period, use cancelStake instead"
+        );
         require(
             // Undelegation not in progress OR
             existingUndelegationBlock == 0 ||

--- a/contracts/solidity/test/TestTokenStake.js
+++ b/contracts/solidity/test/TestTokenStake.js
@@ -240,7 +240,7 @@ contract('TokenStaking', function(accounts) {
     await delegate(operatorOne)
 
     await stakingContract.cancelStake(operatorOne, {from: operatorOne})
-    // ok, no exception
+    // ok, no revert
   })
 
   it("should not allow third party to cancel delegation", async () => {
@@ -258,7 +258,7 @@ contract('TokenStaking', function(accounts) {
 
       await mineBlocks(initializationPeriod)
       await stakingContract.undelegate(operatorOne, {from: operatorOne})
-      // ok, no exceptions
+      // ok, no revert
     })
 
     it("should not allow third party to undelegate", async () => {
@@ -268,6 +268,26 @@ contract('TokenStaking', function(accounts) {
       await expectThrowWithMessage(
         stakingContract.undelegate(operatorOne, {from: operatorTwo}),
         "Only operator or the owner of the stake can undelegate"
+      )
+    })
+
+    it("should permit undelegating at the block when initialization " + 
+    "period passed", async () => {
+      await delegate(operatorOne)
+
+      await mineBlocks(initializationPeriod)
+      await stakingContract.undelegate(operatorOne, {from: operatorOne})
+      // ok, no revert
+    })
+
+    it("should not permit undelegating at the block before initialization " + 
+    "period passed", async () => {
+      await delegate(operatorOne)
+
+      await mineBlocks(initializationPeriod - 1)
+      await expectThrowWithMessage(
+        stakingContract.undelegate(operatorOne, {from: operatorOne}),
+        "Cannot undelegate in initialization period, use cancelStake instead"
       )
     })
 
@@ -284,7 +304,7 @@ contract('TokenStaking', function(accounts) {
       )
 
       await stakingContract.undelegate(operatorOne, {from: operatorOne})
-      // ok, no exceptions
+      // ok, no revert
     })
 
     it("should let the owner postpone undelegation", async () => {
@@ -297,7 +317,7 @@ contract('TokenStaking', function(accounts) {
         operatorOne,
         {from: ownerOne}
       )
-      // ok, no exceptions
+      // ok, no revert
     })
 
     it("should not let the operator postpone undelegation", async () => {
@@ -326,7 +346,7 @@ contract('TokenStaking', function(accounts) {
         currentBlock + 10,
         {from: operatorOne}
       )
-      // ok, no exceptions
+      // ok, no revert
     })
 
     it("should not allow third party to undelegate", async () => {
@@ -357,7 +377,33 @@ contract('TokenStaking', function(accounts) {
         currentBlock + 1,
         {from: operatorOne}
       )
-      // ok, no exceptions
+      // ok, no revert
+    })
+
+    it("should permit undelegating at the block when initialization " +
+    "period passed", async () => {
+      await delegate(operatorOne)
+
+      let currentBlock = await latestBlock()
+      await stakingContract.undelegateAt(
+        operatorOne, currentBlock + initializationPeriod + 1,
+        {from: operatorOne}
+      )
+      // ok, no revert
+    })
+
+    it("should not permit undelegating at the block before initialization " + 
+    "period passed", async () => {
+      await delegate(operatorOne)
+
+      let currentBlock = await latestBlock()
+      await expectThrowWithMessage(
+        stakingContract.undelegateAt(
+          operatorOne, currentBlock + initializationPeriod,
+          {from: operatorOne}
+        ),
+        "Cannot undelegate in initialization period, use cancelStake instead"
+      )
     })
 
     it("should not permit undelegating in the past", async () => {
@@ -393,7 +439,7 @@ contract('TokenStaking', function(accounts) {
         currentBlock + 10,
         {from: operatorOne}
       )
-      // ok, no exceptions
+      // ok, no revert
     })
 
     it("should let the owner postpone undelegation", async () => {
@@ -409,7 +455,7 @@ contract('TokenStaking', function(accounts) {
         currentBlock + 10,
         {from: ownerOne}
       )
-      // ok, no exceptions
+      // ok, no revert
     })
 
     it("should not let the operator postpone undelegation", async () => {


### PR DESCRIPTION
Closes: #1433 

In #1469 we added functionality allowing to set `undelegatedAt` in the future. In this PR, we are making sure `undelegate` cannot be called before the initialization period is over. A similar mechanism is employed for `undelegateAt` from #1469 - it is not possible to set future undelegation to a block that is within the initialization period.

Additionally:
- we cover future undelegations with unit tests for `activeStake`
- We group `eligibleStake` and `activeStake` tests inside two `describe`s
- we modify `isUndelegating` condition to use `!=0` instead of `>`; in our case, there is no real difference here but `!=` might be a little easier to reason about
