### PR TITLE
Emit events on Registry updates

### DIFF
--- a/contracts/solidity/contracts/Registry.sol
+++ b/contracts/solidity/contracts/Registry.sol
@@ -31,6 +31,12 @@ contract Registry {
     mapping(address => ContractStatus) public operatorContracts;
 
     event OperatorContractApproved(address operatorContract);
+    event OperatorContractDisabled(address operatorContract);
+
+    event GovernanceUpdated();
+    event RegistryKeeperUpdated();
+    event PanicButtonUpdated();
+    event OperatorContractUpgraderUpdated(address serviceContract, address upgrader);
 
     modifier onlyGovernance() {
         require(governance == msg.sender, "Not authorized");
@@ -55,18 +61,22 @@ contract Registry {
 
     function setGovernance(address _governance) public onlyGovernance {
         governance = _governance;
+        emit GovernanceUpdated();
     }
 
     function setRegistryKeeper(address _registryKeeper) public onlyGovernance {
         registryKeeper = _registryKeeper;
+        emit RegistryKeeperUpdated();
     }
 
     function setPanicButton(address _panicButton) public onlyGovernance {
         panicButton = _panicButton;
+        emit PanicButtonUpdated();
     }
 
     function setOperatorContractUpgrader(address _serviceContract, address _operatorContractUpgrader) public onlyGovernance {
         operatorContractUpgraders[_serviceContract] = _operatorContractUpgrader;
+        emit OperatorContractUpgraderUpdated(_serviceContract, _operatorContractUpgrader);
     }
 
     function approveOperatorContract(address operatorContract) public onlyRegistryKeeper {
@@ -86,6 +96,7 @@ contract Registry {
         );
 
         operatorContracts[operatorContract] = ContractStatus.Disabled;
+        emit OperatorContractDisabled(operatorContract);
     }
 
     function isNewOperatorContract(address operatorContract) public view returns (bool) {


### PR DESCRIPTION
Events are cheap and will let us monitor Registry changes if needed.