### PR TITLE
demo.js renamed to delegate-tokens.js, removed grant parts

### DIFF
--- a/contracts/solidity/dashboard/README.md
+++ b/contracts/solidity/dashboard/README.md
@@ -45,7 +45,7 @@ npm install
 * run package.json demo scripts individually:
 ```
 truffle migrate --reset
-truffle exec ./scripts/demo.js
+truffle exec ./scripts/delegate-tokens.js
 ```
 * Go to the dashboard directory `cd dashboard` and run `npm install`
 

--- a/contracts/solidity/package.json
+++ b/contracts/solidity/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf build",
     "compile": "npm run clean && truffle compile --contracts_build_directory=./build/truffle",
     "test": "npm run clean && truffle compile && truffle test",
-    "demo": "truffle migrate --reset && truffle exec ./scripts/demo.js",
+    "demo": "truffle migrate --reset && truffle exec ./scripts/delegate-tokens.js",
     "lint": "solium --dir ./contracts"
   },
   "author": "Satoshi Nakamoto 🤪",

--- a/contracts/solidity/scripts/delegate-tokens.js
+++ b/contracts/solidity/scripts/delegate-tokens.js
@@ -1,8 +1,6 @@
 const KeepToken = artifacts.require("./KeepToken.sol");
 const TokenStaking = artifacts.require("./TokenStaking.sol");
-const TokenGrant = artifacts.require("./TokenGrant.sol");
 const KeepRandomBeaconOperator = artifacts.require("./KeepRandomBeaconOperator.sol");
-const Registry = artifacts.require("Registry")
 
 function formatAmount(amount, decimals) {
   return web3.utils.toBN(amount).mul(web3.utils.toBN(10).pow(web3.utils.toBN(decimals)))
@@ -21,17 +19,10 @@ module.exports = async function () {
     const accounts = await getAccounts();
     const token = await KeepToken.deployed();
     const tokenStaking = await TokenStaking.deployed();
-    const tokenGrant = await TokenGrant.deployed();
     const operatorContract = await KeepRandomBeaconOperator.deployed();
-    const registry = await Registry.deployed()
 
     let owner = accounts[0]; // The address of an owner of the staked tokens.
     // accounts[1]...[4] Operators for owner delegated stake and receivers of the rewards.
-
-    // Token Grants demo accounts
-    let grantee = accounts[0];
-    let grantManager = accounts[5];
-    let granteeOperator = accounts[6];
 
     // Stake delegate tokens for first 5 accounts as operators,
     // including the first account where owner operating for themself.
@@ -62,50 +53,6 @@ module.exports = async function () {
         console.log(`successfully staked KEEP tokens for account ${operator}`)
       }
     }
-
-    // Make sure grant manager has some tokens to be able to create a grant.
-    await token.transfer(grantManager, formatAmount(140000, 18), { from: owner })
-
-    // Grant tokens to grantee.
-    let amount = formatAmount(70000, 18);
-    let vestingDuration = web3.utils.toBN(86400).mul(web3.utils.toBN(60));
-    let start = (await web3.eth.getBlock('latest')).timestamp;
-    let cliff = web3.utils.toBN(86400).mul(web3.utils.toBN(10));
-    let revocable = false; // Can not stake revocable token grants. More info in RFC14 
-
-    await token.approveAndCall(
-      tokenGrant.address,
-      amount,
-      Buffer.concat([
-        Buffer.from(grantee.substr(2), 'hex'),
-        web3.utils.toBN(vestingDuration).toBuffer('be', 32),
-        web3.utils.toBN(start).toBuffer('be', 32),
-        web3.utils.toBN(cliff).toBuffer('be', 32),
-        Buffer.from(revocable ? "01" : "00", 'hex'),
-      ]),
-      { from: grantManager }
-    )
-    let grantId = (await tokenGrant.getPastEvents())[0].args[0].toNumber()
-
-    await token.approveAndCall(
-      tokenGrant.address,
-      amount,
-      Buffer.concat([
-        Buffer.from(grantee.substr(2), 'hex'),
-        web3.utils.toBN(vestingDuration).toBuffer('be', 32),
-        web3.utils.toBN(start).toBuffer('be', 32),
-        web3.utils.toBN(cliff).toBuffer('be', 32),
-        Buffer.from(revocable ? "01" : "00", 'hex'),
-      ]),
-      { from: grantManager }
-    )
-
-    const grantDelegation = '0x' + Buffer.concat([
-      Buffer.from(owner.substr(2), 'hex'), // magpie
-      Buffer.from(granteeOperator.substr(2), 'hex'), // operator
-      Buffer.from(owner.substr(2), 'hex') // authorizer
-    ]).toString('hex');
-    await tokenGrant.stake(grantId, tokenStaking.address, formatAmount(7000, 18), grantDelegation, { from: grantee })
   } catch (err) {
     console.error('unexpected error:', err)
     process.exit(1)

--- a/docs/development/local-keep-network.adoc
+++ b/docs/development/local-keep-network.adoc
@@ -344,11 +344,11 @@ Saving artifacts...
 == Keep token staking
 
 Each Keep peer needs to have a minimum number of KEEP tokens staked under its
-account. The `demo.js` script transfers KEEP tokens and stake them for all
+account. The `delegate-tokens.js` script transfers KEEP tokens and stake them for all
 addresses available.
 
 ```
-$ truffle exec ./scripts/demo.js --network local
+$ truffle exec ./scripts/delegate-tokens.js --network local
 
 Using network 'local'.
 

--- a/docs/rfc/rfc-13-continuous-delivery.adoc
+++ b/docs/rfc/rfc-13-continuous-delivery.adoc
@@ -176,7 +176,7 @@ KEEP_ACCOUNT_PASSWORD=eth-account-passphrase \
   truffle exec ./unlock-eth-accounts.js --network keep_dev
 
 # stake ETH accounts
-truffle exec ./demo.js --network keep_dev
+truffle exec ./delegate-tokens.js --network keep_dev
 ```
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,7 +37,7 @@ truffle migrate --reset --network local
 KEEP_CORE_SOL_ARTIFACTS_PATH=$(realpath $KEEP_CORE_SOL_PATH/build/contracts)
 
 printf "${LOG_START}Initializing contracts...${LOG_END}"
-truffle exec scripts/demo.js --network local
+truffle exec scripts/delegate-tokens.js --network local
 
 printf "${LOG_START}Updating keep-core client config...${LOG_END}"
 KEEP_CORE_CONFIG_FILE_PATH=$KEEP_CORE_CONFIG_FILE_PATH \


### PR DESCRIPTION
We have used `demo.js` for a long time as a way to initialize local development environments. `demo.js` was implemented to set up KEEP token dashboard dApp a long time ago. For local development, we don't need grants. For a quick dApp demo setup, we do. The thing is that we rarely use `demo.js` for dApp setup and it became just a local multi-client development environment setup script.

Here we strip `demo.js` to only the required token delegations part and rename it to `delegate-tokens.js`. We will separately develop a script for staking dApp setup and put this code in a separate file.