### PR TITLE
Bumping up version to 0.12.0-pre.x

### DIFF
--- a/contracts/solidity/package-lock.json
+++ b/contracts/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.11.0-rc",
+  "version": "0.12.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/contracts/solidity/package.json
+++ b/contracts/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.11.0-rc",
+  "version": "0.12.0-pre.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After releasing `0.11.0-rc` we are bumping up the version to `0.12.0-pre.x` for further development.