### PR TITLE
Add utility for uint256 sets

### DIFF
--- a/contracts/solidity/contracts/utils/SetUtils.sol
+++ b/contracts/solidity/contracts/utils/SetUtils.sol
@@ -1,19 +1,24 @@
 pragma solidity ^0.5.4;
 
 library SetUtils {
+    /// @notice The UintSet is like an array of unique `uint256`s,
+    /// but additionally supports O(1) membership tests and removals.
+    /// @dev Because the UintSet relies on a mapping,
+    /// it can only be used in storage, not in memory.
     struct UintSet {
         // members[positions[item] - 1] = item
         uint256[] members;
         mapping(uint256 => uint256) positions;
     }
 
+    /// @notice Check whether the UintSet `self` contains `item`
     function contains(UintSet storage self, uint256 item)
         internal view returns (bool) {
         return (self.positions[item] != 0);
     }
 
-    // Insert item to set
-    // If already present, do nothing
+    /// @notice Insert `item` to UintSet `self`.
+    /// If already present, do nothing.
     function insert(UintSet storage self, uint256 item) internal {
         if (!contains(self, item)) {
             self.members.push(item);
@@ -21,8 +26,8 @@ library SetUtils {
         }
     }
 
-    // Remove item from set
-    // If not already present, do nothing
+    /// @notice Remove `item` from UintSet `self`.
+    /// If not already present, do nothing.
     function remove(UintSet storage self, uint256 item) internal {
         uint256 positionPlusOne = self.positions[item];
         if (positionPlusOne != 0) {
@@ -39,6 +44,7 @@ library SetUtils {
         }
     }
 
+    /// @notice Return the members of the UintSet `self`.
     function enumerate(UintSet storage self)
         internal view returns (uint256[] memory) {
         return self.members;

--- a/contracts/solidity/contracts/utils/SetUtils.sol
+++ b/contracts/solidity/contracts/utils/SetUtils.sol
@@ -1,0 +1,46 @@
+pragma solidity ^0.5.4;
+
+library SetUtils {
+    struct UintSet {
+        // members[positions[item] - 1] = item
+        uint256[] members;
+        mapping(uint256 => uint256) positions;
+    }
+
+    function contains(UintSet storage self, uint256 item)
+        internal view returns (bool) {
+        return (self.positions[item] != 0);
+    }
+
+    // Insert item to set
+    // If already present, do nothing
+    function insert(UintSet storage self, uint256 item) internal {
+        if (!contains(self, item)) {
+            self.members.push(item);
+            self.positions[item] = self.members.length;
+        }
+    }
+
+    // Remove item from set
+    // If not already present, do nothing
+    function remove(UintSet storage self, uint256 item) internal {
+        uint256 positionPlusOne = self.positions[item];
+        if (positionPlusOne != 0) {
+            uint256 memberCount = self.members.length;
+            if (positionPlusOne != memberCount) {
+                // Not the last member,
+                // so we need to move the last member into the emptied position.
+                uint256 lastMember = self.members[memberCount - 1];
+                self.members[positionPlusOne - 1] = lastMember;
+                self.positions[lastMember] = positionPlusOne;
+            }
+            self.members.length--;
+            self.positions[item] = 0;
+        }
+    }
+
+    function enumerate(UintSet storage self)
+        internal view returns (uint256[] memory) {
+        return self.members;
+    }
+}

--- a/contracts/solidity/test/utils/TestSetUtils.sol
+++ b/contracts/solidity/test/utils/TestSetUtils.sol
@@ -1,0 +1,134 @@
+pragma solidity ^0.5.4;
+
+import "truffle/Assert.sol";
+import "../../contracts/utils/SetUtils.sol";
+
+
+contract TestSetUtils {
+    using SetUtils for SetUtils.UintSet;
+
+    mapping(uint256 => SetUtils.UintSet) sets;
+
+    function testContainsWhenEmpty() public {
+        SetUtils.UintSet storage set = sets[0];
+
+        Assert.isFalse(set.contains(0), "Empty set should not contain 0");
+        Assert.isFalse(set.contains(1), "Empty set should not contain 1");
+    }
+
+    function testContainsWithItems() public {
+        SetUtils.UintSet storage set = sets[1];
+
+        Assert.isFalse(set.contains(0), "Set should not contain 0 before insertion");
+        set.insert(0);
+        Assert.isTrue(set.contains(0), "Set should contain 0 after insertion");
+
+        Assert.isFalse(set.contains(1), "Set should not contain 1 before insertion");
+        set.insert(1);
+        Assert.isTrue(set.contains(1), "Set should contain 1 after insertion");
+    }
+
+    function testInsertUnique() public {
+        SetUtils.UintSet storage set = sets[2];
+
+        set.insert(1);
+        set.insert(0);
+        set.insert(2);
+        checkThisDamnEquality3(
+            set.enumerate(),
+            [1, 0, 2],
+            "Unique elements should be inserted"
+        );
+    }
+
+    function testInsertDuplicate() public {
+        SetUtils.UintSet storage set = sets[3];
+
+        set.insert(1);
+        set.insert(1);
+        checkThisDamnEquality1(
+            set.enumerate(),
+            [1],
+            "Duplicate elements should not be inserted"
+        );
+    }
+
+    function testRemoveLast() public {
+        SetUtils.UintSet storage set = sets[4];
+
+        set.insert(1);
+        set.insert(0);
+        set.insert(2);
+        checkThisDamnEquality3(
+            set.enumerate(),
+            [1, 0, 2],
+            "Elements should be inserted correctly"
+        );
+
+        set.remove(2);
+        checkThisDamnEquality2(
+            set.enumerate(),
+            [1, 0],
+            "Removing the last element should retain the order of others"
+        );
+    }
+
+    function testRemoveNonLast() public {
+        SetUtils.UintSet storage set = sets[4];
+
+        set.insert(1);
+        set.insert(0);
+        set.insert(2);
+        checkThisDamnEquality3(
+            set.enumerate(),
+            [1, 0, 2],
+            "Elements should be inserted correctly"
+        );
+
+        set.remove(1);
+        checkThisDamnEquality2(
+            set.enumerate(),
+            [2, 0],
+            "Removing an element from the middle should replace it with the last"
+        );
+    }
+
+    function checkThisDamnEquality1(
+        uint256[] memory arrD,
+        uint8[1] memory arrS,
+        string memory err
+    ) internal {
+        uint256[] memory arrM = new uint256[](1);
+        for (uint256 i = 0; i < arrS.length; i++) {
+            arrM[i] = uint256(arrS[i]);
+        }
+
+        Assert.equal(arrD, arrM, err);
+    }
+
+    function checkThisDamnEquality2(
+        uint256[] memory arrD,
+        uint8[2] memory arrS,
+        string memory err
+    ) internal {
+        uint256[] memory arrM = new uint256[](2);
+        for (uint256 i = 0; i < arrS.length; i++) {
+            arrM[i] = uint256(arrS[i]);
+        }
+
+        Assert.equal(arrD, arrM, err);
+    }
+
+    function checkThisDamnEquality3(
+        uint256[] memory arrD,
+        uint8[3] memory arrS,
+        string memory err
+    ) internal {
+        uint256[] memory arrM = new uint256[](3);
+        for (uint256 i = 0; i < arrS.length; i++) {
+            arrM[i] = uint256(arrS[i]);
+        }
+
+        Assert.equal(arrD, arrM, err);
+    }
+}

--- a/contracts/solidity/test/utils/TestSetUtils.sol
+++ b/contracts/solidity/test/utils/TestSetUtils.sol
@@ -74,7 +74,7 @@ contract TestSetUtils {
     }
 
     function testRemoveNonLast() public {
-        SetUtils.UintSet storage set = sets[4];
+        SetUtils.UintSet storage set = sets[5];
 
         set.insert(1);
         set.insert(0);
@@ -90,6 +90,26 @@ contract TestSetUtils {
             set.enumerate(),
             [2, 0],
             "Removing an element from the middle should replace it with the last"
+        );
+    }
+
+    function testRemoveNonMember() public {
+        SetUtils.UintSet storage set = sets[6];
+
+        set.insert(1);
+        set.insert(0);
+        set.insert(2);
+        checkThisDamnEquality3(
+            set.enumerate(),
+            [1, 0, 2],
+            "Elements should be inserted correctly"
+        );
+
+        set.remove(3);
+        checkThisDamnEquality3(
+            set.enumerate(),
+            [1, 0, 2],
+            "Removing a non-member should not change the set"
         );
     }
 


### PR DESCRIPTION
`UintSet` behaves like an array with unique members, but also supports O(1) membership tests and removals. Not currently suitable for in-memory use due to the mapping backend.