### PR TITLE
keep-test: temp branch to get 0.11.0-rc out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,75 +336,75 @@ workflows:
       jobs:
         - keep_test_approval:
             type: approval
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
         - build_client_and_test_go:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - keep_test_approval
         - build_initcontainer:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - migrate_contracts
               - build_client_and_test_go
         - migrate_contracts:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_client_and_test_go
         - publish_keep_client:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_client_and_test_go
               - build_initcontainer
               - migrate_contracts
         - publish_contract_data:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_client_and_test_go
               - migrate_contracts
         - build_token_dashboard_dapp:
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - migrate_contracts
         - publish_token_dashboard_dapp:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_token_dashboard_dapp
   docs:

--- a/contracts/solidity/scripts/circleci-migrate-contracts.sh
+++ b/contracts/solidity/scripts/circleci-migrate-contracts.sh
@@ -59,10 +59,10 @@ ssh utilitybox << EOF
 
   ./node_modules/.bin/truffle migrate --reset --network $TRUFFLE_NETWORK
   echo ">>>>>>FINISH Contract Migration FINISH>>>>>>"
-  echo "<<<<<<START Tenderly Push START<<<<<<"
-  tenderly login --authentication-method token --token $TENDERLY_TOKEN
-  tenderly push --networks $ETH_NETWORK_ID --tag keep-core --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG
-  echo "<<<<<<FINISH Tenderly Push FINISH<<<<<<"
+  # echo "<<<<<<START Tenderly Push START<<<<<<"
+  # tenderly login --authentication-method token --token $TENDERLY_TOKEN
+  # tenderly push --networks $ETH_NETWORK_ID --tag keep-core --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG
+  # echo "<<<<<<FINISH Tenderly Push FINISH<<<<<<"
 EOF
 
 echo "<<<<<<START Contract Copy START<<<<<<"


### PR DESCRIPTION
tl;dr tenderly is borked and is going to take some investigation to fix.  See https://www.flowdock.com/app/cardforcoin/ops/threads/8fNd--guwuuUkNlAGYUTM8rP06p Opening this temporarily to get a keep-test Circle workflow through.