### PR TITLE
keep-dev: dev.*.network hosted zones

### DIFF
--- a/infrastructure/terraform/keep-dev/dns.tf
+++ b/infrastructure/terraform/keep-dev/dns.tf
@@ -1,0 +1,15 @@
+resource "google_dns_managed_zone" "dev_keep_network" {
+  project     = "${module.project.project_id}"
+  description = "keep-dev subdomain for hosts who will be accessed from the outside world."
+  name        = "dev-keep-network"
+  dns_name    = "dev.keep.network."
+  labels      = "${local.labels}"
+}
+
+resource "google_dns_managed_zone" "dev_tbtc_network" {
+  project     = "${module.project.project_id}"
+  description = "tbtc-dev subdomain for hosts who will be accessed from the outside world."
+  name        = "dev-tbtc-network"
+  dns_name    = "dev.tbtc.network."
+  labels      = "${local.labels}"
+}


### PR DESCRIPTION
Here we provide two public domains for use in the keep-dev environment
if we need them.  It may be that we want to expose applications to the
internet from our dev env for testing or sharing.  The immediate need
here was to expose the tbtc dapp with certificate so some testing could
be done.  That uses the dev.tbtc.network domain.  I went ahead and added
dev.keep.network while I was in here.

These domains are sub-domains which are NS aliased to their respective
parents on Cloudflare, keep.network and tbtc.network.