### PR TITLE
Token grants with plug-in staking policies

### DIFF
--- a/solidity/contracts/EmployeeStakingPolicy.sol
+++ b/solidity/contracts/EmployeeStakingPolicy.sol
@@ -19,19 +19,19 @@ contract EmployeeStakingPolicy is GrantStakingPolicy {
 
     function getStakeableAmount (
         uint256 _now,
-        uint256 amount,
+        uint256 grantedAmount,
         uint256 duration,
         uint256 start,
         uint256 cliff,
         uint256 withdrawn
     ) public view returns (uint256) {
         uint256 unlocked = _now.getUnlockedAmount(
-            amount,
+            grantedAmount,
             duration,
             start,
             cliff
         );
-        uint256 remainingInGrant = amount.sub(withdrawn);
+        uint256 remainingInGrant = grantedAmount.sub(withdrawn);
         uint256 unlockedInGrant = unlocked.sub(withdrawn);
 
         // Less than minimum stake remaining

--- a/solidity/contracts/EmployeeStakingPolicy.sol
+++ b/solidity/contracts/EmployeeStakingPolicy.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "./libraries/grant/UnlockingSchedule.sol";
+import "./GrantStakingPolicy.sol";
+
+/// @title EmployeeStakingPolicy
+/// @dev A staking policy which allows the grantee
+/// to always stake the defined minimum stake,
+/// or the unlocked amount if greater.
+contract EmployeeStakingPolicy is GrantStakingPolicy {
+    using SafeMath for uint256;
+    using UnlockingSchedule for uint256;
+    uint256 minimumStake;
+
+    constructor(uint256 _minimumStake) public {
+        minimumStake = _minimumStake;
+    }
+
+    function getStakeableAmount (
+        uint256 _now,
+        uint256 amount,
+        uint256 duration,
+        uint256 start,
+        uint256 cliff,
+        uint256 withdrawn
+    ) public view returns (uint256) {
+        uint256 unlocked = _now.getUnlockedAmount(
+            amount,
+            duration,
+            start,
+            cliff
+        );
+        uint256 remainingInGrant = amount.sub(withdrawn);
+        uint256 unlockedInGrant = unlocked.sub(withdrawn);
+
+        // Less than minimum stake remaining
+        //   -> may stake what is remaining in grant
+        if (remainingInGrant < minimumStake) { return remainingInGrant; }
+        // At least minimum stake remaining in grant,
+        // but unlocked amount is less than the minimum stake
+        //   -> may stake the minimum stake
+        if (unlockedInGrant < minimumStake) { return minimumStake; }
+        // More than minimum stake unlocked in grant
+        //   -> may stake the unlocked amount
+        return unlockedInGrant;
+    }
+}

--- a/solidity/contracts/GrantStakingPolicy.sol
+++ b/solidity/contracts/GrantStakingPolicy.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.4;
+
+/// @title GrantStakingPolicy
+/// @dev A staking policy defines the function `getStakeableAmount`
+/// which calculates how many tokens may be staked from a token grant.
+contract GrantStakingPolicy {
+    function getStakeableAmount(
+        uint256 _now,
+        uint256 amount,
+        uint256 duration,
+        uint256 start,
+        uint256 cliff,
+        uint256 withdrawn) public view returns (uint256);
+}

--- a/solidity/contracts/GrantStakingPolicy.sol
+++ b/solidity/contracts/GrantStakingPolicy.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.5.4;
 contract GrantStakingPolicy {
     function getStakeableAmount(
         uint256 _now,
-        uint256 amount,
+        uint256 grantedAmount,
         uint256 duration,
         uint256 start,
         uint256 cliff,

--- a/solidity/contracts/PermissiveStakingPolicy.sol
+++ b/solidity/contracts/PermissiveStakingPolicy.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "./GrantStakingPolicy.sol";
+
+/// @title PermissiveStakingPolicy
+/// @dev A staking policy which allows the grantee to stake the entire grant,
+/// regardless of its unlocking status.
+contract PermissiveStakingPolicy is GrantStakingPolicy {
+    using SafeMath for uint256;
+
+    function getStakeableAmount (
+        uint256 _now,
+        uint256 amount,
+        uint256 duration,
+        uint256 start,
+        uint256 cliff,
+        uint256 withdrawn
+    ) public view returns (uint256) {
+        // Can always stake the entire remaining amount.
+        return amount.sub(withdrawn);
+    }
+}

--- a/solidity/contracts/PermissiveStakingPolicy.sol
+++ b/solidity/contracts/PermissiveStakingPolicy.sol
@@ -11,13 +11,13 @@ contract PermissiveStakingPolicy is GrantStakingPolicy {
 
     function getStakeableAmount (
         uint256 _now,
-        uint256 amount,
+        uint256 grantedAmount,
         uint256 duration,
         uint256 start,
         uint256 cliff,
         uint256 withdrawn
     ) public view returns (uint256) {
         // Can always stake the entire remaining amount.
-        return amount.sub(withdrawn);
+        return grantedAmount.sub(withdrawn);
     }
 }

--- a/solidity/contracts/TokenGrant.sol
+++ b/solidity/contracts/TokenGrant.sol
@@ -358,7 +358,6 @@ contract TokenGrant {
      * Magpie address (20 bytes) where the rewards for participation are sent and operator's (20 bytes) address.
      */
     function stake(uint256 _id, address _stakingContract, uint256 _amount, bytes memory _extraData) public {
-        require(!grants[_id].revocable, "Revocable grants can not be staked.");
         require(grants[_id].grantee == msg.sender, "Only grantee of the grant can stake it.");
         require(
             stakingContracts[grants[_id].grantManager][_stakingContract],

--- a/solidity/contracts/libraries/grant/UnlockingSchedule.sol
+++ b/solidity/contracts/libraries/grant/UnlockingSchedule.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+library UnlockingSchedule {
+    using SafeMath for uint256;
+
+    function getUnlockedAmount(
+        uint256 _now,
+        uint256 amount,
+        uint256 duration,
+        uint256 start,
+        uint256 cliff
+    ) internal pure returns (uint256) {
+        bool cliffNotReached = _now < cliff;
+        if (cliffNotReached) { return 0; }
+
+        uint256 timeElapsed = _now.sub(start);
+
+        bool unlockingPeriodFinished = timeElapsed >= duration;
+        if (unlockingPeriodFinished) { return amount; }
+
+        return amount.mul(timeElapsed).div(duration);
+    }
+}

--- a/solidity/contracts/libraries/grant/UnlockingSchedule.sol
+++ b/solidity/contracts/libraries/grant/UnlockingSchedule.sol
@@ -7,7 +7,7 @@ library UnlockingSchedule {
 
     function getUnlockedAmount(
         uint256 _now,
-        uint256 amount,
+        uint256 grantedAmount,
         uint256 duration,
         uint256 start,
         uint256 cliff
@@ -18,8 +18,8 @@ library UnlockingSchedule {
         uint256 timeElapsed = _now.sub(start);
 
         bool unlockingPeriodFinished = timeElapsed >= duration;
-        if (unlockingPeriodFinished) { return amount; }
+        if (unlockingPeriodFinished) { return grantedAmount; }
 
-        return amount.mul(timeElapsed).div(duration);
+        return grantedAmount.mul(timeElapsed).div(duration);
     }
 }

--- a/solidity/contracts/utils/BytesLib.sol
+++ b/solidity/contracts/utils/BytesLib.sol
@@ -426,4 +426,29 @@ library BytesLib {
             result := keccak256(add(add(_bytes, 32), _start), _length)
         }
     }
+
+    function toBytes(address _address) internal pure returns (bytes memory) {
+        bytes memory result = new bytes(20);
+        for (uint256 i = 0; i < 20; i++) {
+            result[i] = bytes20(_address)[i];
+        }
+    }
+
+    function overwrite(
+        bytes memory _bytes,
+        uint256 _start,
+        bytes memory _source,
+        uint256 _sourceStart,
+        uint256 _length
+    ) internal pure {
+        uint256 _end = _start + _length;
+        uint256 _sourceEnd = _sourceStart + _length;
+        require(
+            _bytes.length >= _end && _source.length >= _sourceEnd,
+            "Overwrite out of bounds"
+        );
+        for (uint256 i = 0; i < _length; i++) {
+            _bytes[_start + i] = _source[_sourceStart + i];
+        }
+    }
 }

--- a/solidity/test/helpers/grantTokens.js
+++ b/solidity/test/helpers/grantTokens.js
@@ -3,13 +3,15 @@ export default async function grantTokens(
     token, amount,
     from, grantee,
     vestingDuration, start, cliff,
-    revocable) {
+    revocable,
+    stakingPolicy) {
   let grantData = Buffer.concat([
     Buffer.from(grantee.substr(2), 'hex'),
     web3.utils.toBN(vestingDuration).toBuffer('be', 32),
     web3.utils.toBN(start).toBuffer('be', 32),
     web3.utils.toBN(cliff).toBuffer('be', 32),
     Buffer.from(revocable ? "01" : "00", 'hex'),
+    Buffer.from(stakingPolicy.substr(2), 'hex'),
   ]);
 
   await token.approveAndCall(grantContract.address, amount, grantData, {from: from})

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -1,0 +1,196 @@
+const BN = web3.utils.BN
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
+const PermissiveStakingPolicy = artifacts.require('./PermissiveStakingPolicy.sol');
+const EmployeeStakingPolicy = artifacts.require('./EmployeeStakingPolicy.sol');
+
+contract('PermissiveStakingPolicy', function(accounts) {
+  let policy;
+  let amount = 10000;
+  let start = 1000;
+  let duration = 2000;
+  let cliff = 1500;
+  let withdrawn = 4000;
+
+  before(async () => {
+    policy = await PermissiveStakingPolicy.new();
+  });
+
+  async function calculate(atTimestamp, withdrawnAmount) {
+    return await policy.getStakeableAmount(
+      atTimestamp,
+      amount,
+      duration,
+      start,
+      cliff,
+      withdrawnAmount
+    );
+  }
+
+  it("should permit staking all tokens before cliff", async function() {
+    expect(await calculate(1400, 0)).to.eq.BN(amount);
+  });
+
+  it("should permit staking all tokens after cliff", async function() {
+    expect(await calculate(1600, 0)).to.eq.BN(amount);
+  });
+
+  it("should permit staking all tokens after unlocking", async function() {
+    expect(await calculate(3100, 0)).to.eq.BN(amount);
+  });
+
+  it("should permit staking remaining tokens before cliff", async function() {
+    expect(await calculate(1400, withdrawn)).to.eq.BN(amount - withdrawn);
+  });
+
+  it("should permit staking remaining tokens after cliff", async function() {
+    expect(await calculate(1600, withdrawn)).to.eq.BN(amount - withdrawn);
+  });
+
+  it("should permit staking remaining tokens after unlocking", async function() {
+    expect(await calculate(3100, withdrawn)).to.eq.BN(amount - withdrawn);
+  });
+});
+
+contract('EmployeeStakingPolicy', function(accounts) {
+  let policy;
+  let minimumStake = 2000;
+  let largeGrant = 10000;
+  let mediumGrant = 5000;
+  let smallGrant = 1000;
+  let start = 1000;
+  let duration = 2000;
+  let cliff = 1500;
+  let withdrawn = 4000;
+
+  before(async () => {
+    policy = await EmployeeStakingPolicy.new(minimumStake);
+  });
+
+  async function calculate(atTimestamp, givenAmount, withdrawnAmount) {
+    return await policy.getStakeableAmount(
+      atTimestamp,
+      givenAmount,
+      duration,
+      start,
+      cliff,
+      withdrawnAmount
+    );
+  }
+
+  describe("with nothing withdrawn", async () => {
+    it("should calculate stakeable amount correctly before cliff", async () => {
+      expect(await calculate(1499, largeGrant, 0)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with large grant before cliff");
+      expect(await calculate(1499, mediumGrant, 0)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with medium grant before cliff");
+      expect(await calculate(1499, smallGrant, 0)).to.eq.BN(
+        smallGrant,
+        "Should permit entire grant with small grant before cliff");
+    });
+
+    it("should calculate stakeable amount correctly just after cliff", async () => {
+      expect(await calculate(1500, largeGrant, 0)).to.eq.BN(
+        2500,
+        "Should permit unlocked amount with large grant just after cliff");
+      expect(await calculate(1500, mediumGrant, 0)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with medium grant just after cliff");
+      expect(await calculate(1500, smallGrant, 0)).to.eq.BN(
+        smallGrant,
+        "Should permit entire grant with small grant just after cliff");
+    });
+
+    it("should calculate stakeable amount correctly halfway through", async () => {
+      expect(await calculate(2000, largeGrant, 0)).to.eq.BN(
+        5000,
+        "Should permit unlocked amount with large grant halfway through");
+      expect(await calculate(2000, mediumGrant, 0)).to.eq.BN(
+        2500,
+        "Should permit unlocked amount with medium grant halfway through");
+      expect(await calculate(2000, smallGrant, 0)).to.eq.BN(
+        smallGrant,
+        "Should permit entire grant with small grant halfway through");
+    });
+
+    it("should calculate stakeable amount correctly after unlocking period", async () => {
+      expect(await calculate(3000, largeGrant, 0)).to.eq.BN(
+        largeGrant,
+        "Should permit unlocked amount with large grant after unlocking period");
+      expect(await calculate(3000, mediumGrant, 0)).to.eq.BN(
+        mediumGrant,
+        "Should permit unlocked amount with medium grant after unlocking period");
+      expect(await calculate(3000, smallGrant, 0)).to.eq.BN(
+        smallGrant,
+        "Should permit entire grant with small grant after unlocking period");
+    });
+  })
+
+  describe("with all unlocked tokens withdrawn", async () => {
+    it("should calculate stakeable amount correctly just after cliff", async () => {
+      expect(await calculate(1500, largeGrant, 2500)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with large grant just after cliff");
+      expect(await calculate(1500, mediumGrant, 1250)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with medium grant just after cliff");
+      expect(await calculate(1500, smallGrant, 250)).to.eq.BN(
+        750,
+        "Should permit remaining amount with small grant just after cliff");
+    });
+
+    it("should calculate stakeable amount correctly halfway through", async () => {
+      expect(await calculate(2000, largeGrant, 5000)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with large grant halfway through");
+      expect(await calculate(2000, mediumGrant, 2500)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with medium grant halfway through");
+      expect(await calculate(2000, smallGrant, 500)).to.eq.BN(
+        500,
+        "Should permit remaining amount with small grant halfway through");
+    });
+
+    it("should calculate stakeable amount correctly at three quarters", async () => {
+      expect(await calculate(2500, largeGrant, 7500)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with large grant at three quarters");
+      expect(await calculate(2500, mediumGrant, 3750)).to.eq.BN(
+        1250,
+        "Should permit remaining amount with medium grant at three quarters");
+      expect(await calculate(2500, smallGrant, 750)).to.eq.BN(
+        250,
+        "Should permit remaining amount with small grant at three quarters");
+    });
+  })
+
+  describe("with half of unlocked tokens withdrawn", async () => {
+    it("should calculate stakeable amount correctly just after cliff", async () => {
+      expect(await calculate(1500, largeGrant, 1250)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with large grant just after cliff");
+      expect(await calculate(1500, mediumGrant, 625)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with medium grant just after cliff");
+      expect(await calculate(1500, smallGrant, 125)).to.eq.BN(
+        875,
+        "Should permit remaining amount with small grant just after cliff");
+    });
+
+    it("should calculate stakeable amount correctly halfway through", async () => {
+      expect(await calculate(2000, largeGrant, 2500)).to.eq.BN(
+        2500,
+        "Should permit remaining unlocked amount with large grant halfway through");
+      expect(await calculate(2000, mediumGrant, 1250)).to.eq.BN(
+        minimumStake,
+        "Should permit minimum stake with medium grant halfway through");
+      expect(await calculate(2000, smallGrant, 250)).to.eq.BN(
+        750,
+        "Should permit remaining amount with small grant halfway through");
+    });
+  })
+});

--- a/solidity/test/token_grant/TestTokenGrantRevoke.js
+++ b/solidity/test/token_grant/TestTokenGrantRevoke.js
@@ -13,10 +13,11 @@ const KeepToken = artifacts.require('./KeepToken.sol');
 const TokenStaking = artifacts.require('./TokenStaking.sol');
 const TokenGrant = artifacts.require('./TokenGrant.sol');
 const Registry = artifacts.require("./Registry.sol");
+const EmployeeStakingPolicy = artifacts.require('./EmployeeStakingPolicy.sol');
 
-contract('TokenGrant/Revoke', function(accounts) {
+contract.only('TokenGrant/Revoke', function(accounts) {
 
-  let tokenContract, registryContract, grantContract, stakingContract;
+  let tokenContract, registryContract, grantContract, stakingContract, employeePolicy;
 
   const tokenOwner = accounts[0],
     grantee = accounts[1];
@@ -44,6 +45,8 @@ contract('TokenGrant/Revoke', function(accounts) {
     
     await grantContract.authorizeStakingContract(stakingContract.address);
 
+    employeePolicy = await EmployeeStakingPolicy.new(await stakingContract.minimumStake());
+
     grantStart = await latestTime();
 
     grantId = await grantTokens(
@@ -56,6 +59,7 @@ contract('TokenGrant/Revoke', function(accounts) {
       grantStart, 
       grantCliff, 
       grantRevocable,
+      employeePolicy.address
     );
   });
 
@@ -120,6 +124,7 @@ contract('TokenGrant/Revoke', function(accounts) {
         grantStart, 
         grantCliff, 
         false,
+        employeePolicy.address
     );
     
     await expectThrowWithMessage(
@@ -153,6 +158,7 @@ contract('TokenGrant/Revoke', function(accounts) {
       grantStart, 
       grantCliff, 
       grantRevocable,
+      employeePolicy.address
       );
       
     const granteeGrantBalanceBefore = await grantContract.balanceOf.call(grantee);

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -16,10 +16,13 @@ const KeepToken = artifacts.require('./KeepToken.sol');
 const TokenStaking = artifacts.require('./TokenStaking.sol');
 const TokenGrant = artifacts.require('./TokenGrant.sol');
 const Registry = artifacts.require("./Registry.sol");
+const PermissiveStakingPolicy = artifacts.require('./PermissiveStakingPolicy.sol');
+const EmployeeStakingPolicy = artifacts.require('./EmployeeStakingPolicy.sol');
 
-contract('TokenGrant/Stake', function(accounts) {
+contract.only('TokenGrant/Stake', function(accounts) {
 
   let tokenContract, registryContract, grantContract, stakingContract,
+    permissivePolicy, employeePolicy,
     minimumStake, grantAmount;
 
   const tokenOwner = accounts[0],
@@ -52,9 +55,13 @@ contract('TokenGrant/Stake', function(accounts) {
     grantContract = await TokenGrant.new(tokenContract.address);
     
     await grantContract.authorizeStakingContract(stakingContract.address);
+
     
     grantStart = await latestTime();
     minimumStake = await stakingContract.minimumStake()
+
+    permissivePolicy = await PermissiveStakingPolicy.new()
+    employeePolicy = await EmployeeStakingPolicy.new(minimumStake);
     grantAmount = minimumStake.muln(10),
     
     // Grant tokens
@@ -67,7 +74,8 @@ contract('TokenGrant/Stake', function(accounts) {
       grantVestingDuration,
       grantStart,
       grantCliff,
-      grantRevocable
+      grantRevocable,
+      permissivePolicy.address,
     );
   });
 

--- a/solidity/test/token_grant/TestTokenGrantWithdraw.js
+++ b/solidity/test/token_grant/TestTokenGrantWithdraw.js
@@ -14,10 +14,11 @@ const KeepToken = artifacts.require('./KeepToken.sol');
 const TokenStaking = artifacts.require('./TokenStaking.sol');
 const TokenGrant = artifacts.require('./TokenGrant.sol');
 const Registry = artifacts.require("./Registry.sol");
+const PermissiveStakingPolicy = artifacts.require('./PermissiveStakingPolicy.sol');
 
-contract('TokenGrant/Withdraw', function(accounts) {
+contract.only('TokenGrant/Withdraw', function(accounts) {
 
-  let tokenContract, registryContract, grantContract, stakingContract;
+  let tokenContract, registryContract, grantContract, stakingContract, permissivePolicy;
 
   const tokenOwner = accounts[0],
     grantee = accounts[1],
@@ -49,6 +50,8 @@ contract('TokenGrant/Withdraw', function(accounts) {
     
     await grantContract.authorizeStakingContract(stakingContract.address);
 
+    permissivePolicy = await PermissiveStakingPolicy.new()
+
     grantStart = await latestTime();
 
     grantId = await grantTokens(
@@ -61,6 +64,7 @@ contract('TokenGrant/Withdraw', function(accounts) {
       grantStart, 
       grantCliff, 
       grantRevocable,
+      permissivePolicy.address
     );
   });
 


### PR DESCRIPTION
Refs: #1478

We can support grantee reassignment without changing `TokenGrant` too much, by creating `ManagedGrant` contracts that act as grantees.

To support this, I separated the unlocking schedule calculations into a library, and added functionality to set the desired `GrantStakingPolicy` when creating a token grant. This draft has two staking policy implementations: `PermissiveStakingPolicy` which lets grantees stake the entire grant, and `EmployeeStakingPolicy` which lets grantees stake the minimum stake amount at any time, or the unlocked amount if greater. Other staking policies can be developed for arbitrary customization.

This draft PR covers the use of these staking policies in the token grant contract itself, for early review. Implementing staking policies in `TokenGrant` instead of `ManagedGrant` requires slightly more changes in `TokenGrant`, but is a lot more elegant. The latter option would be feasible to implement, but it would be uglier and force some duplication of similar functionality, which is why I prefer this PR's version.