### PR TITLE
Service contract implementation initialization call moved to the complete upgrade step

### DIFF
--- a/solidity/contracts/KeepRandomBeaconService.sol
+++ b/solidity/contracts/KeepRandomBeaconService.sol
@@ -88,7 +88,7 @@ contract KeepRandomBeaconService is Proxy {
      * @param _newImplementation Address of the new vendor implementation contract.
      * @param _data Delegate call data for implementation initialization.
      */
-    function upgradeToAndCall(address _newImplementation, bytes memory _data)
+    function upgradeTo(address _newImplementation, bytes memory _data)
         public
         onlyAdmin
     {

--- a/solidity/contracts/examples/KeepRandomBeaconServiceUpgradeExample.sol
+++ b/solidity/contracts/examples/KeepRandomBeaconServiceUpgradeExample.sol
@@ -30,6 +30,7 @@ contract KeepRandomBeaconServiceUpgradeExample is KeepRandomBeaconServiceImplV1 
         public
     {
         require(!initialized(), "Contract is already initialized.");
+        require(registry != address(0), "Incorrect registry address");
         _initialized["KeepRandomBeaconImplV2"] = true;
         // Example of adding new data to the existing storage.
         _newVar = 1234;

--- a/solidity/test/random_beacon_service/TestUpgrade.js
+++ b/solidity/test/random_beacon_service/TestUpgrade.js
@@ -9,7 +9,7 @@ const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
+contract('KeepRandomBeaconService/Upgrade', function(accounts) {
 
   let proxy
   let implementationV1

--- a/solidity/test/random_beacon_service/TestUpgrade.js
+++ b/solidity/test/random_beacon_service/TestUpgrade.js
@@ -17,19 +17,19 @@ contract('KeepRandomBeaconService/Upgrade', function(accounts) {
   
   let initializeCallData
 
-  const admin = accounts[0]
-  const nonAdmin = accounts[1]
+  const admin = accounts[1]
+  const nonAdmin = accounts[2]
 
   before(async () => {
-    implementationV1 = await ServiceContractImplV1.new()
-    implementationV2 = await ServiceContractImplV2.new()
+    implementationV1 = await ServiceContractImplV1.new({from: admin})
+    implementationV2 = await ServiceContractImplV2.new({from: admin})
     
     initializeCallData = implementationV1.contract.methods.initialize(
       100, 200, '0x0000000000000000000000000000000000000001'
     ).encodeABI()
 
     proxy = await ServiceContractProxy.new(
-      implementationV1.address, initializeCallData
+      implementationV1.address, initializeCallData, {from: admin}
     )
   })
 

--- a/solidity/test/random_beacon_service/TestUpgrade.js
+++ b/solidity/test/random_beacon_service/TestUpgrade.js
@@ -74,9 +74,9 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
   })
 
-  describe("upgradeToAndCall", async () => {
+  describe("upgradeTo", async () => {
     it("sets timestamp", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData,
         {from: admin}
@@ -90,7 +90,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
 
     it("sets new implementation", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData,
         {from: admin}
@@ -109,7 +109,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
   
     it("sets initialization call data", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData,
         {from: admin}
@@ -123,12 +123,12 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
   
     it("supports empty initialization call data", async () => {
-      await proxy.upgradeToAndCall(implementationV2.address, [], {from: admin})
+      await proxy.upgradeTo(implementationV2.address, [], {from: admin})
       assert.notExists(await proxy.initializationData.call(implementationV2.address));
     })
   
     it("emits an event", async () => {
-      const receipt = await proxy.upgradeToAndCall(
+      const receipt = await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData,
         {from: admin}
@@ -143,12 +143,12 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
   
     it("allows implementation overwrite", async () => {
       const address3 = '0x4566716c07617c5854fe7dA9aE5a1219B19CCd27'
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData,
         {from: admin}
       )
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         address3, 
         initializeCallData,
         {from: admin}
@@ -163,12 +163,12 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
   
     it("allows implementation data overwrite", async () => {
       const initializeCallData2 = '0x123456'
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData,
         {from: admin}
       )
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address, 
         initializeCallData2,
         {from: admin}
@@ -183,7 +183,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
   
     it("reverts on zero address", async () => {
       await expectRevert(
-        proxy.upgradeToAndCall(
+        proxy.upgradeTo(
           constants.ZERO_ADDRESS, 
           initializeCallData, 
           {from: admin}
@@ -194,7 +194,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
   
     it("reverts on the same address", async () => {
       await expectRevert(
-        proxy.upgradeToAndCall(
+        proxy.upgradeTo(
           implementationV1.address,
           initializeCallData,
           {from: admin}
@@ -205,7 +205,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
   
     it("reverts when called by non-admin", async () => {
       await expectRevert(
-        proxy.upgradeToAndCall(
+        proxy.upgradeTo(
           implementationV2.address,
           initializeCallData,
           {from: nonAdmin}
@@ -224,7 +224,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
 
     it("reverts for non-elapsed timer", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address,
         initializeCallData,
         {from: admin}
@@ -239,7 +239,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
 
     it("clears timestamp", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address,
         initializeCallData,
         {from: admin}
@@ -253,7 +253,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
 
     it("sets implementation", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address,
         initializeCallData,
         {from: admin}
@@ -271,7 +271,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
 
     it("emits an event", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address,
         initializeCallData,
         {from: admin}
@@ -288,7 +288,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
 
     it("supports empty initialization call data", async () => {
       const address3 = '0x4566716c07617c5854fe7dA9aE5a1219B19CCd27'
-      await proxy.upgradeToAndCall(address3, [], {from: admin})
+      await proxy.upgradeTo(address3, [], {from: admin})
       await time.increase(await proxy.upgradeTimeDelay());
 
       await proxy.completeUpgrade({from: admin});
@@ -306,7 +306,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
         100, 200, constants.ZERO_ADDRESS
       ).encodeABI()
 
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address,
         failingData,
         {from: admin}
@@ -321,7 +321,7 @@ contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
     })
 
     it("finalizes upgrade procedure", async () => {
-      await proxy.upgradeToAndCall(
+      await proxy.upgradeTo(
         implementationV2.address,
         initializeCallData,
         {from: admin}

--- a/solidity/test/random_beacon_service/TestUpgrade.js
+++ b/solidity/test/random_beacon_service/TestUpgrade.js
@@ -1,4 +1,3 @@
-import {bls} from '../helpers/data';
 import {duration, increaseTimeTo} from '../helpers/increaseTime';
 import expectThrow from '../helpers/expectThrow';
 import {initContracts} from '../helpers/initContracts';
@@ -11,7 +10,7 @@ const {expectEvent, time} = require("@openzeppelin/test-helpers");
 
 contract('KeepRandomBeaconService/Upgrade', function(accounts) {
 
-  let operatorContract, serviceContractProxy, serviceContract, serviceContractImplV2, serviceContractV2,
+  let serviceContractProxy, serviceContract, serviceContractImplV2, serviceContractV2,
     account_one = accounts[0],
     account_two = accounts[1];
 
@@ -24,23 +23,11 @@ contract('KeepRandomBeaconService/Upgrade', function(accounts) {
       artifacts.require('./stubs/KeepRandomBeaconOperatorStub.sol')
     );
 
-    operatorContract = contracts.operatorContract;
     serviceContract = contracts.serviceContract;
     serviceContractProxy = await ServiceContractProxy.at(serviceContract.address);
 
     serviceContractImplV2 = await ServiceContractImplV2.new();
     serviceContractV2 = await ServiceContractImplV2.at(serviceContractProxy.address);
-
-    // Using stub method to add first group to help testing.
-    await operatorContract.registerNewGroup(bls.groupPubKey);
-    operatorContract.setGroupSize(3);
-    let group = await operatorContract.getGroupPublicKey(0);
-    await operatorContract.setGroupMembers(group, [accounts[0], accounts[1], accounts[2]]);
-
-    // Modify state so we can test later that eternal storage works as expected after upgrade
-    let entryFeeEstimate = await serviceContract.entryFeeEstimate(0)
-    await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate});
-    await operatorContract.relayEntry(bls.groupSignature);
   });
 
   beforeEach(async () => {

--- a/solidity/test/random_beacon_service/TestUpgrade.js
+++ b/solidity/test/random_beacon_service/TestUpgrade.js
@@ -1,209 +1,342 @@
-import {duration, increaseTimeTo} from '../helpers/increaseTime';
-import expectThrow from '../helpers/expectThrow';
-import {initContracts} from '../helpers/initContracts';
-import latestTime from "../helpers/latestTime";
-import {createSnapshot, restoreSnapshot} from "../helpers/snapshot";
-import expectThrowWithMessage from "../helpers/expectThrowWithMessage";
-const ServiceContractProxy = artifacts.require('./KeepRandomBeaconService.sol');
-const ServiceContractImplV2 = artifacts.require('./examples/KeepRandomBeaconServiceUpgradeExample.sol');
-const {expectEvent, time} = require("@openzeppelin/test-helpers");
+import {createSnapshot, restoreSnapshot} from "../helpers/snapshot"
+const {BN, constants, expectEvent, expectRevert, time} = require("@openzeppelin/test-helpers")
 
-contract('KeepRandomBeaconService/Upgrade', function(accounts) {
+const ServiceContractProxy = artifacts.require('./KeepRandomBeaconService.sol')
+const ServiceContractImplV1 = artifacts.require('./KeepRandomBeaconServiceImplV1.sol')
+const ServiceContractImplV2 = artifacts.require('./examples/KeepRandomBeaconServiceUpgradeExample.sol')
 
-  let serviceContractProxy, serviceContract, serviceContractImplV2, serviceContractV2,
-    account_one = accounts[0],
-    account_two = accounts[1];
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
+contract.only('KeepRandomBeaconService/Upgrade', function(accounts) {
+
+  let proxy
+  let implementationV1
+  let implementationV2
+  
+  let initializeCallData
+
+  const admin = accounts[0]
+  const nonAdmin = accounts[1]
 
   before(async () => {
-    let contracts = await initContracts(
-      artifacts.require('./KeepToken.sol'),
-      artifacts.require('./TokenStaking.sol'),
-      ServiceContractProxy,
-      artifacts.require('./KeepRandomBeaconServiceImplV1.sol'),
-      artifacts.require('./stubs/KeepRandomBeaconOperatorStub.sol')
-    );
+    implementationV1 = await ServiceContractImplV1.new()
+    implementationV2 = await ServiceContractImplV2.new()
+    
+    initializeCallData = implementationV1.contract.methods.initialize(
+      100, 200, '0x0000000000000000000000000000000000000001'
+    ).encodeABI()
 
-    serviceContract = contracts.serviceContract;
-    serviceContractProxy = await ServiceContractProxy.at(serviceContract.address);
-
-    serviceContractImplV2 = await ServiceContractImplV2.new();
-    serviceContractV2 = await ServiceContractImplV2.at(serviceContractProxy.address);
-  });
+    proxy = await ServiceContractProxy.new(
+      implementationV1.address, initializeCallData
+    )
+  })
 
   beforeEach(async () => {
     await createSnapshot()
-  });
+  })
 
   afterEach(async () => {
     await restoreSnapshot()
-  });
+  })
 
-  it("should set first account as admin", async function() {
-    assert.equal(
-        await serviceContractProxy.admin(),
-        account_one,
-        "Account one should be set as admin"
-    );
-  });
+  describe("constructor", async () => {
+    it("sets admin", async () => {
+      assert.equal(
+        await proxy.admin(), 
+        admin, 
+        "Unexpected admin"
+      )
+    })
 
-  it("upgrade time delay should be set", async function() {
-    assert.equal(
-        (await serviceContractProxy.upgradeTimeDelay()).toNumber(),
+    it("sets upgrade time delay to one day", async () => {
+      assert.equal(
+        (await proxy.upgradeTimeDelay()).toNumber(),
         86400, // 1 day
         "Upgrade time delay should be one day"
-    );
-  });
+      )
+    })
 
-  it("should be able to check if the implementation contract was initialized", async function() {
-    assert.isTrue(
-        await serviceContract.initialized(),
-        "Implementation contract should be initialized."
-    );
-  });
+    it("initializes implementation", async () => {
+      assert.isTrue(
+        await implementationV1.initialized(),
+        "Implementation contract should be initialized"
+      )
+    })
 
-  it("should fail to upgrade implementation if called by not contract admin", async function() {
-    const initialize = serviceContractV2.contract.methods
-        .initialize(
-            100,
-            duration.days(0),
-            '0x0000000000000000000000000000000000000001'
-        ).encodeABI();
+    it("sets implementation", async () => {
+      assert.equal(
+        await proxy.implementation(),
+        implementationV1.address,
+        "Unexpected implementation contract address"
+      )
+    })
+  })
 
-    await expectThrowWithMessage(
-        serviceContractProxy.upgradeToAndCall(
-            serviceContractImplV2.address,
-            initialize,
-            {from: account_two}
+  describe("upgradeToAndCall", async () => {
+    it("sets timestamp", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData,
+        {from: admin}
+      )
+
+      const expectedTimestamp = await time.latest()
+
+      expect(await proxy.upgradeInitiatedTimestamp()).to.eq.BN(
+        expectedTimestamp
+      )
+    })
+
+    it("sets new implementation", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData,
+        {from: admin}
+      )
+  
+      assert.equal(
+        await proxy.newImplementation(),
+        implementationV2.address,
+        "Unexpected new implementation contract address"
+      )
+      assert.equal(
+        await proxy.implementation(),
+        implementationV1.address,
+        "Unexpected implementation contract address"
+      )
+    })
+  
+    it("sets initialization call data", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData,
+        {from: admin}
+      )
+  
+      assert.equal(
+        await proxy.initializationData(implementationV2.address),
+        initializeCallData,
+        "Unexpected initialization call data"
+      )
+    })
+  
+    it("supports empty initialization call data", async () => {
+      await proxy.upgradeToAndCall(implementationV2.address, [], {from: admin})
+      assert.notExists(await proxy.initializationData.call(implementationV2.address));
+    })
+  
+    it("emits an event", async () => {
+      const receipt = await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData,
+        {from: admin}
+      )
+  
+      const expectedTimestamp = await time.latest()
+      expectEvent(receipt, "UpgradeStarted", {
+        implementation: implementationV2.address,
+        timestamp: expectedTimestamp
+      })
+    })
+  
+    it("allows implementation overwrite", async () => {
+      const address3 = '0x4566716c07617c5854fe7dA9aE5a1219B19CCd27'
+      await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData,
+        {from: admin}
+      )
+      await proxy.upgradeToAndCall(
+        address3, 
+        initializeCallData,
+        {from: admin}
+      )
+  
+      assert.equal(
+        await proxy.newImplementation(),
+        address3,
+        "Unexpected new implementation contract address"
+      )
+    })
+  
+    it("allows implementation data overwrite", async () => {
+      const initializeCallData2 = '0x123456'
+      await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData,
+        {from: admin}
+      )
+      await proxy.upgradeToAndCall(
+        implementationV2.address, 
+        initializeCallData2,
+        {from: admin}
+      )
+  
+      assert.equal(
+        await proxy.initializationData.call(implementationV2.address), 
+        initializeCallData2,
+        "unexpected initialization call data"
+      )
+    })
+  
+    it("reverts on zero address", async () => {
+      await expectRevert(
+        proxy.upgradeToAndCall(
+          constants.ZERO_ADDRESS, 
+          initializeCallData, 
+          {from: admin}
         ),
-        "Caller is not the admin"
-    );
-  });
+        "Implementation address can't be zero."
+      )
+    })
+  
+    it("reverts on the same address", async () => {
+      await expectRevert(
+        proxy.upgradeToAndCall(
+          implementationV1.address,
+          initializeCallData,
+          {from: admin}
+        ), 
+        "Implementation address must be different from the current one."
+      )
+    })
+  
+    it("reverts when called by non-admin", async () => {
+      await expectRevert(
+        proxy.upgradeToAndCall(
+          implementationV2.address,
+          initializeCallData,
+          {from: nonAdmin}
+        ),
+        "Caller is not the admin."
+      )
+    })
+  })
 
-  it("should be able to upgrade implementation and initialize it with new data", async function() {
-    let previousEntryBefore = await serviceContractV2.previousEntry();
-    const firstImplAddress = await serviceContractProxy.implementation();
+  describe("completeUpgrade", async () => {
+    it("reverts for non-initiated upgrade", async () => {
+      await expectRevert(
+        proxy.completeUpgrade({from: admin}),
+        "Upgrade not initiated"
+      )
+    })
 
-    assert.notEqual(
-        firstImplAddress,
-        serviceContractImplV2.address,
-        "Implementation should be other than V2 address at the beginning"
-    );
+    it("reverts for non-elapsed timer", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address,
+        initializeCallData,
+        {from: admin}
+      )
 
-    assert.equal(
-        await serviceContractProxy.upgradeInitiatedTimestamp(),
-        0,
-        "Upgrade initiated timestamp should be 0 at the beginning"
-    );
+      await time.increase((await proxy.upgradeTimeDelay()).subn(2))
 
-    const initialize = serviceContractV2.contract.methods
-        .initialize(
-            100,
-            duration.days(0),
-            '0x0000000000000000000000000000000000000001'
-        ).encodeABI();
+      await expectRevert(
+        proxy.completeUpgrade({ from: admin }), 
+        "Timer not elapsed"
+      )
+    })
 
-    let receipt = await serviceContractProxy.upgradeToAndCall(
-        serviceContractImplV2.address,
-        initialize
-    );
+    it("clears timestamp", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address,
+        initializeCallData,
+        {from: admin}
+      )
 
-    const upgradeStartedTime = await time.latest();
+      await time.increase(await proxy.upgradeTimeDelay())
 
-    expectEvent(receipt, "UpgradeStarted", {
-      implementation: serviceContractImplV2.address,
-      timestamp: upgradeStartedTime
+      await proxy.completeUpgrade({from: admin})
+
+      expect(await proxy.upgradeInitiatedTimestamp()).to.eq.BN(0)
+    })
+
+    it("sets implementation", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address,
+        initializeCallData,
+        {from: admin}
+      )
+
+      await time.increase(await proxy.upgradeTimeDelay())
+
+      await proxy.completeUpgrade({from: admin})
+
+      assert.equal(
+        await proxy.implementation(),
+        implementationV2.address,
+        "Unexpected new implementation address"
+      )
+    })
+
+    it("emits an event", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address,
+        initializeCallData,
+        {from: admin}
+      )
+
+      await time.increase(await proxy.upgradeTimeDelay())
+
+      const receipt = await proxy.completeUpgrade({from: admin})
+
+      await expectEvent(receipt, "UpgradeCompleted", {
+        implementation: implementationV2.address
+      })
+    })
+
+    it("supports empty initialization call data", async () => {
+      const address3 = '0x4566716c07617c5854fe7dA9aE5a1219B19CCd27'
+      await proxy.upgradeToAndCall(address3, [], {from: admin})
+      await time.increase(await proxy.upgradeTimeDelay());
+
+      await proxy.completeUpgrade({from: admin});
     });
 
-    assert.equal(
-        await serviceContractProxy.implementation(),
-        firstImplAddress,
-        "Implementation should remain the same before upgrade is completed"
-    );
+    it("reverts when called by non-admin", async () => {
+      await expectRevert(
+        proxy.completeUpgrade({from: nonAdmin}),
+        "Caller is not the admin."
+      )
+    })
 
-    assert.equal(
-        await serviceContractProxy.newImplementation(),
-        serviceContractImplV2.address,
-        "New implementation should be set to V2 address"
-    );
+    it("reverts when initialization fails", async () => {
+      const failingData = implementationV1.contract.methods.initialize(
+        100, 200, constants.ZERO_ADDRESS
+      ).encodeABI()
 
-    assert.equal(
-        (await serviceContractProxy.upgradeInitiatedTimestamp()).toNumber(),
-        upgradeStartedTime,
-        "Upgrade initiated timestamp should be set correctly"
-    );
+      await proxy.upgradeToAndCall(
+        implementationV2.address,
+        failingData,
+        {from: admin}
+      )
 
-    await increaseTimeTo(await latestTime()+duration.days(1));
+      await time.increase(await proxy.upgradeTimeDelay())
 
-    // Getting data from new contract shouldn't
-    // be possible before upgrade is completed.
-    await expectThrow(serviceContractV2.getNewVar());
+      await expectRevert(
+        proxy.completeUpgrade({from: admin}),
+        "Incorrect registry address"
+      )
+    })
 
-    receipt = await serviceContractProxy.completeUpgrade();
+    it("finalizes upgrade procedure", async () => {
+      await proxy.upgradeToAndCall(
+        implementationV2.address,
+        initializeCallData,
+        {from: admin}
+      )
 
-    expectEvent(receipt, "UpgradeCompleted", {
-      implementation: serviceContractImplV2.address,
-    });
+      await time.increase(await proxy.upgradeTimeDelay())
 
-    assert.equal(
-        await serviceContractProxy.implementation(),
-        serviceContractImplV2.address,
-        "Implementation should be changed to V2 address"
-    );
+      await proxy.completeUpgrade({from: admin})
 
-    assert.equal(
-        await serviceContractProxy.newImplementation(),
-        serviceContractImplV2.address,
-        "New implementation should remain set to V2 address"
-    );
-
-    assert.equal(
-        await serviceContractProxy.upgradeInitiatedTimestamp(),
-        0,
-        "Upgrade initiated timestamp should be 0 at the end"
-    );
-
-    assert.isTrue(
-        await serviceContractV2.initialized(),
-        "Implementation contract should be initialized."
-    );
-
-    let newVar = await serviceContractV2.getNewVar();
-    assert.equal(
-        newVar,
+      let v2 = await ServiceContractImplV2.at(proxy.address)
+      assert.equal(
+        await v2.getNewVar(),
         1234,
-        "Should be able to get new data from upgraded contract."
-    );
-
-    let previousEntryAfter = await serviceContractV2.previousEntry()
-    assert.equal(
-        previousEntryBefore,
-        previousEntryAfter,
-        "Should keep previous storage after upgrade."
-    );
-  });
-
-  it("should not allow to complete upgrade before the delay passes", async () => {
-    const initialize = serviceContractV2.contract.methods
-    .initialize(
-        100,
-        duration.days(0),
-        '0x0000000000000000000000000000000000000001'
-    ).encodeABI();
-
-    await serviceContractProxy.upgradeToAndCall(
-        serviceContractImplV2.address,
-        initialize
-    );
-
-    const upgradeStartedTime = await latestTime();
-
-    // almost there, but not yet!
-    await increaseTimeTo(upgradeStartedTime + duration.days(1) - duration.minutes(1))
-
-    // Must wait for the entire upgrade time delay before completing the upgrade
-    await expectThrowWithMessage(
-      serviceContractProxy.completeUpgrade(),
-      "Timer not elapsed"
-    );
+        "Should be able to get new data from upgraded contract"
+      )
+    })
   })
 });


### PR DESCRIPTION
See https://github.com/keep-network/keep-ecdsa/pull/327

Previously, we initialized the implementation contract in the first step of the upgrade and that was giving us some possibility to interact with the new contract before it should actually be used. In the worst case, this could work as an upgrade backdoor on our side allowing us to upgrade the
system faster, without keeping the one day delay promise.

Here, we move the initialization call to complete upgrade function.

We use mapping to store implementation initialization data as it is allocating storage based on keccak256 hash of the key and entry so it lowers the possibility of clashing with implementation fields. See: https://solidity.readthedocs.io/en/v0.5.15/miscellaneous.html#mappings-and-dynamic-arrays

Complete upgrade function can be now executed only by the admin. This is to make this process future-proof and safeguard from programmer's mistake of using `msg.sender` in initialize function.

This changes the upgrade promise a little. With `onlyAdmin` restriction, we promise to do not upgrade the system sooner than one day after we announce the upgrade but there is no guarantee this will be carried out in the timeframe.

Still, we had a similar chance without `onlyAdmin` but it was just more expensive - we could announce a new upgrade with identical implementation contract and this would effectively postpone the upgrade.

Bonus point: Rewritten unit tests for proxy upgrade. Split a long test into multiple smaller scenarios and covered paths not previously tested. Simplified setup - all we need are three contracts.