### PR TITLE
Do not allow to recover stake without first undelegating

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -199,12 +199,17 @@ contract TokenStaking is StakeDelegatable {
     }
 
     /**
-     * @notice Recovers staked tokens and transfers them back to the owner. Recovering
-     * tokens can only be performed when the operator is finished undelegating.
+     * @notice Recovers staked tokens and transfers them back to the owner.
+     * Recovering tokens can only be performed when the operator finished
+     * undelegating.
      * @param _operator Operator address.
      */
     function recoverStake(address _operator) public {
         uint256 operatorParams = operators[_operator].packedParams;
+        require(
+            operatorParams.getUndelegationTimestamp() != 0,
+            "Can not recover without first undelegating"
+        );
         require(
             block.timestamp > operatorParams.getUndelegationTimestamp().add(undelegationPeriod),
             "Can not recover stake before undelegation period is over."

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -528,6 +528,18 @@ contract('TokenStaking', function(accounts) {
   })
 
   describe("recoverStake", async () => {
+    it("should not allow to recover stake without undelegating first", async () => {
+      let tx = await delegate(operatorOne, stakingAmount)
+      let createdAt = (await web3.eth.getBlock(tx.receipt.blockNumber)).timestamp
+  
+      await increaseTimeTo(createdAt + initializationPeriod + undelegationPeriod)
+  
+      await expectThrowWithMessage(
+        stakingContract.recoverStake(operatorOne),
+        "Can not recover without first undelegating"
+      )
+    })
+
     it("should not allow to recover stake before undelegation period is over", async () => {
       let tx = await delegate(operatorOne, stakingAmount)
       let createdAt = (await web3.eth.getBlock(tx.receipt.blockNumber)).timestamp


### PR DESCRIPTION
Fixes: #1520 

In `recoverStake()` we were not checking if undelegation block is non-zero. As a result, the require for undelegation period to be over was always `true` when the stake hasn't been undelegated first:
```
block.number > operatorParams.getUndelegationBlock().add(undelegationPeriod)
```

This allowed owner to recover the stake without undelegating it first.

We fix this problem in this PR adding a non-zero check for undelegation block in `recoverStake()`.

Bonus: grouped `cancelStake`, `recoverStake`, and `delegate` tests in three `describe`s.