### PR TITLE
Validate length of G1 and G2 bytes for AltBn128

### DIFF
--- a/solidity/contracts/cryptography/AltBn128.sol
+++ b/solidity/contracts/cryptography/AltBn128.sol
@@ -215,6 +215,11 @@ library AltBn128 {
      * @dev Unmarshals a point on G1 from bytes in an uncompressed form.
      */
     function g1Unmarshal(bytes memory m) internal pure returns(G1Point memory) {
+        require(
+            m.length == 64,
+            "Invalid G1 bytes length"
+        );
+
         bytes32 x;
         bytes32 y;
 
@@ -248,6 +253,11 @@ library AltBn128 {
      * @dev Unmarshals a point on G2 from bytes in an uncompressed form.
      */
     function g2Unmarshal(bytes memory m) internal pure returns(G2Point memory) {
+        require(
+            m.length == 128,
+            "Invalid G2 bytes length"
+        );
+
         bytes32 xx;
         bytes32 xy;
         bytes32 yx;
@@ -271,6 +281,11 @@ library AltBn128 {
         internal
         pure returns(G2Point memory)
     {
+        require(
+            m.length == 64,
+            "Invalid G2 compressed bytes length"
+        );
+
         bytes32 x1;
         bytes32 x2;
         uint256 temp;
@@ -372,7 +387,6 @@ library AltBn128 {
      * @dev Return true if G2 point's y^2 equals x.
      */
     function g2X2y(gfP2 memory x, gfP2 memory y) internal pure returns(bool) {
-       
         gfP2 memory y2;
         y2 = gfP2Pow(y, 2);
 

--- a/solidity/contracts/stubs/AltBn128Stub.sol
+++ b/solidity/contracts/stubs/AltBn128Stub.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.4;
+
+// it is just a stub, not a live deployment;
+// we are fine with experimental feature
+pragma experimental ABIEncoderV2;
+
+import "../cryptography/AltBn128.sol";
+
+contract AltBn128Stub {
+
+    function publicG1Unmarshal(bytes memory m) public pure returns(AltBn128.G1Point memory) {
+        return AltBn128.g1Unmarshal(m);
+    }
+
+    function publicG2Unmarshal(bytes memory m) public pure returns(AltBn128.G2Point memory) {
+        return AltBn128.g2Unmarshal(m);
+    }
+
+    function publicG2Decompress(bytes memory m) public pure returns(AltBn128.G2Point memory) {
+        return AltBn128.g2Decompress(m);
+    }
+}

--- a/solidity/test/TestBLS.js
+++ b/solidity/test/TestBLS.js
@@ -1,8 +1,9 @@
 import {bls as blsData} from './helpers/data'
+const { expectRevert } = require("@openzeppelin/test-helpers")
 
 const BLS = artifacts.require('./cryptography/BLS.sol');
 
-contract('TestBLS', function() {
+contract('BLS', function() {
   let bls;
 
   before(async () => {
@@ -84,5 +85,73 @@ contract('TestBLS', function() {
 
     let actual = await bls.verifyBytes(blsData.groupPubKey, message, signature);
     assert.isTrue(actual, "Should be able to verify valid BLS signature.");
+  })
+
+  describe("verify", async () => {
+    it("should fail for public key having less than 128 bytes", async () => {
+      await expectRevert(
+        bls.verify(
+          "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034df",
+          "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d223460663",
+          "0x112d462728e89432b0fe40251eeb6608aed4560f3dc833a9877f5010ace9b1312006dbbe2f30c6e0e3e7ec47dc078b7b6b773379d44d64e44ec4e017bfa7375c"
+        ),
+        "Invalid G2 bytes length"
+      )
+    })
+  
+    it("should fail for public key having more than 128 bytes", async () => {
+      await expectRevert(
+        bls.verify(
+          "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034dfcdcd",
+          "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d223460663",
+          "0x112d462728e89432b0fe40251eeb6608aed4560f3dc833a9877f5010ace9b1312006dbbe2f30c6e0e3e7ec47dc078b7b6b773379d44d64e44ec4e017bfa7375c"
+        ),
+        "Invalid G2 bytes length"
+      )
+    })
+  
+    it("should fail for message having less than 64 bytes", async () => {
+      await expectRevert(
+        bls.verify(
+          "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034dfcd",
+          "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d2234606",
+          "0x112d462728e89432b0fe40251eeb6608aed4560f3dc833a9877f5010ace9b1312006dbbe2f30c6e0e3e7ec47dc078b7b6b773379d44d64e44ec4e017bfa7375c"
+        ),
+        "Invalid G1 bytes length"
+      )
+    })
+
+    it("should fail for message having more than 64 bytes", async () => {
+      await expectRevert(
+        bls.verify(
+          "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034dfcd",
+          "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d22346066363",
+          "0x112d462728e89432b0fe40251eeb6608aed4560f3dc833a9877f5010ace9b1312006dbbe2f30c6e0e3e7ec47dc078b7b6b773379d44d64e44ec4e017bfa7375c"
+        ),
+        "Invalid G1 bytes length"
+      )
+    })
+
+    it("should fail for signature having less than 64 bytes", async () => {
+      await expectRevert(
+        bls.verify(
+          "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034dfcd",
+          "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d223460663",
+          "0x112d462728e89432b0fe40251eeb6608aed4560f3dc833a9877f5010ace9b1312006dbbe2f30c6e0e3e7ec47dc078b7b6b773379d44d64e44ec4e017bfa737"
+        ),
+        "Invalid G1 bytes length"
+      )
+    })
+
+    it("should fail for signature having more than 64 bytes", async () => {
+      await expectRevert(
+        bls.verify(
+          "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034dfcd",
+          "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d223460663",
+          "0x112d462728e89432b0fe40251eeb6608aed4560f3dc833a9877f5010ace9b1312006dbbe2f30c6e0e3e7ec47dc078b7b6b773379d44d64e44ec4e017bfa7375c5c"
+        ),
+        "Invalid G1 bytes length"
+      )
+    })
   })
 });

--- a/solidity/test/altbn128/TestAltBn128.js
+++ b/solidity/test/altbn128/TestAltBn128.js
@@ -1,0 +1,79 @@
+const { expectRevert } = require("@openzeppelin/test-helpers")
+
+const AltBn128Stub = artifacts.require("./stubs/AltBn128Stub.sol")
+
+contract("AltBn128", () => {
+
+    let g1 = "0x15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d223460663"
+    let g2 = "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d01659dc18b57722ecf6a4beb4d04dfe780a660c4c3bb2b165ab8486114c464c621bf37ecdba226629c20908c7f475c5b3a7628ce26d696436eab0b0148034dfcd"
+    let g2Compressed = "0x1f1954b33144db2b5c90da089e8bde287ec7089d5d6433f3b6becaefdb678b1b2a9de38d14bef2cf9afc3c698a4211fa7ada7b4f036a2dfef0dc122b423259d0"
+
+    let altBn128
+
+    before(async () => {
+        altBn128 = await AltBn128Stub.new()
+    })
+
+    describe("g1Unmarshal", async () => {
+        it("does not accept less than 64 bytes", async () => {
+            await expectRevert(
+                altBn128.publicG1Unmarshal(g1.slice(0, -2)),
+                "Invalid G1 bytes length"
+            )
+        })
+
+        it("does accept 64 bytes", async () => {
+            await altBn128.publicG1Unmarshal(g1)
+            // ok, no revert
+        })
+
+        it("does not accept more than 64 bytes", async () => {
+            await expectRevert(
+                altBn128.publicG1Unmarshal(g1 + 'ff'),
+                "Invalid G1 bytes length"
+            )
+        })
+    })
+
+    describe("g2Unmarshal", async () => {
+        it("does not accept less than 128 bytes", async () => {
+            await expectRevert(
+                altBn128.publicG2Unmarshal(g2.slice(0, -2)),
+                "Invalid G2 bytes length"
+            )
+        })
+
+        it("does accept 128 bytes", async () => {
+            await altBn128.publicG2Unmarshal(g2)
+            // ok, no revert
+        })
+
+        it("does not accept more than 128 bytes", async () => {
+            await expectRevert(
+                altBn128.publicG2Unmarshal(g2 + 'ff'),
+                "Invalid G2 bytes length"
+            )
+        })
+    })
+
+    describe("g2Decompress", async () => {
+        it("does not accept less than 64 bytes", async () => {
+            await expectRevert(
+                altBn128.publicG2Decompress(g2Compressed.slice(0, -2)),
+                "Invalid G2 compressed bytes length"
+            )
+        })
+
+        it("does accept 64 bytes", async () => {
+            await altBn128.publicG2Decompress(g2Compressed)
+            // ok, no revert
+        })
+
+        it("does not accept more than 64 bytes", async () => {
+            await expectRevert(
+                altBn128.publicG2Decompress(g2Compressed + 'ff'),
+                "Invalid G2 compressed bytes length"
+            )
+        })
+    })
+})

--- a/solidity/test/altbn128/TestAltBn128.sol
+++ b/solidity/test/altbn128/TestAltBn128.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.4;
 
 import "truffle/Assert.sol";
-import "../contracts/utils/ModUtils.sol";
-import "../contracts/cryptography/AltBn128.sol";
+import "../../contracts/utils/ModUtils.sol";
+import "../../contracts/cryptography/AltBn128.sol";
 
 contract TestAltBn128 {
 


### PR DESCRIPTION
Fixes: #1522

There were two potential issues with `AltBn128` functions and `BLS` as an effect:

- `g1Unmarshal` could be reading out-of-bounds of the signature from dirty memory.
- `g1Unmarshal` could be reading all of the signature. If more than 64 bytes were supplied, they were ignored for the purposes of signature validation.

A similar problem was with `g2Unmarshal` reading group public key and `g2Decompress`.

Here we ensure each of those functions in `AltBn128.sol` properly validates input length.
As a result, `BLS.verify` and `BLS.verifyBytes` are now safe.

All invalid input length cases are covered with unit tests both for `AltBn128` and `BLS`. Although all the requires are in `AltBn128` library and are covered by unit tests for `AltBn128`, this is such an important requirement that having `BLS.verify` tested independently as a black box makes sense. Especially that those tests are turbo-fast to execute.