### PR TITLE
DKGResultVerification.verify byte inputs validation

### DIFF
--- a/solidity/contracts/libraries/operator/DKGResultVerification.sol
+++ b/solidity/contracts/libraries/operator/DKGResultVerification.sol
@@ -83,6 +83,7 @@ library DKGResultVerification {
         require(signatures.length % 65 == 0, "Malformed signatures array");
         require(signaturesCount == signingMemberIndices.length, "Unexpected signatures count");
         require(signaturesCount >= self.signatureThreshold, "Too few signatures");
+        require(signaturesCount <= self.groupSize, "Too many signatures");
 
         bytes32 resultHash = keccak256(abi.encodePacked(groupPubKey, misbehaved));
 

--- a/solidity/contracts/libraries/operator/DKGResultVerification.sol
+++ b/solidity/contracts/libraries/operator/DKGResultVerification.sol
@@ -71,6 +71,8 @@ library DKGResultVerification {
             "Submitter not eligible"
         );
 
+        require(groupPubKey.length == 128, "Malformed group public key");
+
         uint256 signaturesCount = signatures.length / 65;
         require(signatures.length >= 65, "Too short signatures array");
         require(signatures.length % 65 == 0, "Malformed signatures array");

--- a/solidity/contracts/libraries/operator/DKGResultVerification.sol
+++ b/solidity/contracts/libraries/operator/DKGResultVerification.sol
@@ -73,6 +73,11 @@ library DKGResultVerification {
 
         require(groupPubKey.length == 128, "Malformed group public key");
 
+        require(
+            misbehaved.length <= self.groupSize - self.signatureThreshold,
+            "Malformed misbehaved bytes"
+        );
+
         uint256 signaturesCount = signatures.length / 65;
         require(signatures.length >= 65, "Too short signatures array");
         require(signatures.length % 65 == 0, "Malformed signatures array");

--- a/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
+++ b/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
@@ -6,6 +6,7 @@ import stakeDelegate from '../helpers/stakeDelegate'
 import packTicket from '../helpers/packTicket'
 import generateTickets from '../helpers/generateTickets'
 import {createSnapshot, restoreSnapshot} from '../helpers/snapshot'
+import {bls} from '../helpers/data';
 
 contract('KeepRandomBeaconOperator/DkgMisbehavior', function(accounts) {
   let token, stakingContract, operatorContract,
@@ -18,7 +19,7 @@ contract('KeepRandomBeaconOperator/DkgMisbehavior', function(accounts) {
     authorizer = owner,
     selectedParticipants, signatures, signingMemberIndices = [],
     misbehaved = '0x0305', // disqualified operator3, inactive operator5
-    groupPubKey = '0x1000000000000000000000000000000000000000000000000000000000000000',
+    groupPubKey = bls.groupPubKey,
     resultHash = web3.utils.soliditySha3(groupPubKey, misbehaved)
 
   before(async () => {


### PR DESCRIPTION
Closes: #1524

Three additional validations added to `bytes` input parameters in `DKGResultVerification.verify` to limit the possibility of arbitrarily moving bytes between `groupPubKey` and `misbehaved` by the submitter:
- `groupPubKey` must have exactly `128` bytes

  It is altbn128 G2 point in uncompressed form; it must have `128` bytes.

- `misbehaved` can be up to `group_size - signature_threshold` bytes

  `misbehaved` can be empty or can have some elements but it can never have more elements than the group size minus the minimum DKG result signature threshold. No group member will vote on the result where it is marked as misbehaving. If the result is going to be accepted, it must have at least the minimum signature threshold. Hence, the maximum number of members indicated as misbehaving is `group_size - signature_threshold`. If the number of elements in `misbehaved` is higher than the client is broken or it's trying to cheat.

- number of signatures supporting the result can not be higher than the group size

  The number of possible valid signatures should be limited by `members` array passed to `verify` function as a parameter. However, since `DKGResultVerification` library keeps a group size in its storage, it makes sense to do all the validation possible to make sure the internal state is consistent.

#1524, as per audit, recommends adding a salt between the group public key and misbehaved. This PR does not contain this change as I don't see a clear advantage of this, given that:
- group public key should never be the same
- we collected unique signatures from at least a threshold group members
- we validate member eligibility to submit the result; if two or more members become eligible (possible when some of them become inactive or are late), we are fine with them racing for submission by design.