### PR TITLE
__beaconCallback(uint256)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199
-	github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897
+	github.com/keep-network/keep-common v0.1.1-0.20200330215727-8ca95ff9de56
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1
 	github.com/libp2p/go-libp2p-connmgr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199 h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897 h1:0T9+w0udjSNnyR07gUiIcV3bkVZmFlGx40Byq9dqAuI=
 github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
+github.com/keep-network/keep-common v0.1.1-0.20200330215727-8ca95ff9de56 h1:VVJrhWz7aqloEH7GzwFbWk36ZXTCpnMH6b5DmKMDxM8=
+github.com/keep-network/keep-common v0.1.1-0.20200330215727-8ca95ff9de56/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/chain/ethereum/utility.go
+++ b/pkg/chain/ethereum/utility.go
@@ -3,7 +3,6 @@ package ethereum
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-core/pkg/beacon/relay/event"
 	"github.com/keep-network/keep-core/pkg/gen/async"
 )
@@ -66,12 +65,7 @@ func (euc *ethereumUtilityChain) RequestRelayEntry() *async.EventEntryGeneratedP
 		onWatchError,
 	)
 
-	_, err = euc.keepRandomBeaconServiceContract.RequestRelayEntry(
-		common.BytesToAddress([]byte{}),
-		"",
-		callbackGas,
-		payment,
-	)
+	_, err = euc.keepRandomBeaconServiceContract.RequestRelayEntry(payment)
 	if err != nil {
 		promise.Fail(err)
 		return promise

--- a/solidity/contracts/IRandomBeacon.sol
+++ b/solidity/contracts/IRandomBeacon.sol
@@ -38,9 +38,11 @@ interface IRandomBeacon {
         returns (uint256);
 
     /**
-     * @notice Submits a request to generate a new relay entry. Executes the
-     * provided callback with the generated entry and emits
-     * `RelayEntryGenerated(uint256 requestId, uint256 entry)` event.
+     * @notice Submits a request to generate a new relay entry. Executes
+     * callback on the provided callback contract with the generated entry and
+     * emits `RelayEntryGenerated(uint256 requestId, uint256 entry)` event.
+     * Callback contract has to declare public `__beaconCallback(uint256)`
+     * function that is going to be executed with the result, once ready.
      *
      * @dev Beacon does not support concurrent relay requests. No new requests
      * should be made while the beacon is already processing another request.
@@ -48,10 +50,8 @@ interface IRandomBeacon {
      * transaction reverted.
 
      * @param callbackContract Callback contract address. Callback is called
-     * once a new relay entry has been generated.
-     * @param callbackMethod Callback contract method signature. String
-     * representation of your method with a single
-     * uint256 input parameter i.e. "relayEntryCallback(uint256)".
+     * once a new relay entry has been generated. Must declare public
+     * `__beaconCallback(uint256)` function.
      * @param callbackGas Gas required for the callback.
      * The customer needs to ensure they provide a sufficient callback gas
      * to cover the gas fee of executing the callback. Any surplus is returned
@@ -61,7 +61,6 @@ interface IRandomBeacon {
      */
     function requestRelayEntry(
         address callbackContract,
-        string calldata callbackMethod,
         uint256 callbackGas
     ) external payable returns (uint256);
 

--- a/solidity/contracts/examples/CallbackContract.sol
+++ b/solidity/contracts/examples/CallbackContract.sol
@@ -9,19 +9,12 @@ contract CallbackContract {
 
     uint256 internal _lastEntry;
 
-    /**
-     * @dev Example of a callback method. Method signature can be
-     * calculated as bytes4(keccak256("callback(uint256)")
-    */
-    function callback(uint256 requestResponse)
+    function __beaconCallback(uint256 entry)
         public
     {
-        _lastEntry = requestResponse;
+        _lastEntry = entry;
     }
 
-    /**
-     * @dev Returns previous entry.
-     */
     function lastEntry() public view returns (uint256)
     {
         return _lastEntry;

--- a/solidity/scripts/request-relay-entry-with-callback.js
+++ b/solidity/scripts/request-relay-entry-with-callback.js
@@ -1,10 +1,9 @@
-const crypto = require("crypto")
 const KeepRandomBeaconServiceImplV1 = artifacts.require("KeepRandomBeaconServiceImplV1.sol");
 const KeepRandomBeaconService = artifacts.require('KeepRandomBeaconService.sol');
 
 // Example usage:
-// truffle exec ./scripts/request-relay-entry-with-callback.js yourContractAddress "callbackMethodName" callbackGas
-// truffle exec ./scripts/request-relay-entry-with-callback.js 0x9F57C01059057d821c6b4B04A4598322661C934F "callback(uint256)" 20000
+// truffle exec ./scripts/request-relay-entry-with-callback.js yourContractAddress callbackGas
+// truffle exec ./scripts/request-relay-entry-with-callback.js 0x9F57C01059057d821c6b4B04A4598322661C934F 20000
 
 module.exports = async function() {
 
@@ -13,7 +12,7 @@ module.exports = async function() {
 
   try {
     let entryFeeEstimate = await contractInstance.entryFeeEstimate(process.argv[6]);
-    let tx = await contractInstance.methods['requestRelayEntry(address,string,uint256)'](
+    let tx = await contractInstance.methods['requestRelayEntry(address,uint256)'](
       process.argv[4],
       process.argv[5],
       process.argv[6],

--- a/solidity/scripts/request-relay-entry-with-callback.js
+++ b/solidity/scripts/request-relay-entry-with-callback.js
@@ -11,11 +11,10 @@ module.exports = async function() {
   const contractInstance = await KeepRandomBeaconServiceImplV1.at(keepRandomBeaconService.address)
 
   try {
-    let entryFeeEstimate = await contractInstance.entryFeeEstimate(process.argv[6]);
+    let entryFeeEstimate = await contractInstance.entryFeeEstimate(process.argv[5]);
     let tx = await contractInstance.methods['requestRelayEntry(address,uint256)'](
       process.argv[4],
       process.argv[5],
-      process.argv[6],
       {value: entryFeeEstimate}
     )
     console.log('Successfully requested relay entry with a callback. RequestId =', tx.logs[0].args.requestId.toString())

--- a/solidity/test/random_beacon_service/TestPricing.js
+++ b/solidity/test/random_beacon_service/TestPricing.js
@@ -52,12 +52,11 @@ contract('TestKeepRandomBeaconService/Pricing', function(accounts) {
     let gasPriceCeiling = web3.utils.toBN(web3.utils.toWei('20', 'gwei'))
     await operatorContract.setGasPriceCeiling(gasPriceCeiling)
 
-    let callbackGas = web3.utils.toBN(await callbackContract.callback.estimateGas(bls.groupSignature))
+    let callbackGas = web3.utils.toBN(await callbackContract.__beaconCallback.estimateGas(bls.groupSignature))
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
     
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
       callbackContract.address,
-      "callback(uint256)",
       callbackGas,
       {value: entryFeeEstimate, from: requestor}
     );
@@ -79,9 +78,8 @@ contract('TestKeepRandomBeaconService/Pricing', function(accounts) {
 
   it("should send group reward to each operator.", async function() {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0)
-    let tx = await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
+    let tx = await serviceContract.methods['requestRelayEntry(address,uint256)'](
       callbackContract.address,
-      "callback(uint256)",
       0,
       {value: entryFeeEstimate, from: requestor}
     );
@@ -131,9 +129,8 @@ contract('TestKeepRandomBeaconService/Pricing', function(accounts) {
     // subsidy = 5250000000000000 - 207407407407407 * 5 - 210648148148148 = 4002314814814817 wei
   
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0)
-    let tx = await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
+    let tx = await serviceContract.methods['requestRelayEntry(address,uint256)'](
       callbackContract.address,
-      "callback(uint256)",
       0,
       {value: entryFeeEstimate, from: requestor}
     );

--- a/solidity/test/random_beacon_service/TestPricingFees.js
+++ b/solidity/test/random_beacon_service/TestPricingFees.js
@@ -69,9 +69,9 @@ contract('KeepRandomBeaconService/PricingFees', function(accounts) {
         // entry verification fee = 12 * 200 = 2400
         // dkg contribution fee = (14 + 2) * 200 * 1% = 32
         // group profit fee = 13 * 3 = 39
-        // callback fee = (18789 + 7) * 200 = 3759200
-        // entry fee = 2400 + 32 + 39 + 3759200 = 3761671
-        let expectedEntryFeeEstimate = 3761671;
+        // callback fee = (10961 + 7) * 200 = 2193600
+        // entry fee = 2400 + 32 + 39 + 2193600 = 3761671
+        let expectedEntryFeeEstimate = 2196071;
         assert.equal(expectedEntryFeeEstimate, entryFeeEstimate)
     });
 });

--- a/solidity/test/random_beacon_service/TestRelayRequestCallback.js
+++ b/solidity/test/random_beacon_service/TestRelayRequestCallback.js
@@ -83,10 +83,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
   })
 
   it("should produce entry and execute callback if provided", async () => {
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {value: entryFeeEstimate}
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {value: entryFeeEstimate}
     );
     await operatorContract.relayEntry(bls.groupSignature, {from: operator});
 
@@ -103,10 +103,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
 
   // gas price ceiling > tx.gasprice
   it("should reimburse submitter and customer for executing callback with lower tx.gasprice", async () => {
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {
         value: entryFeeEstimate,
         from: customer
       }
@@ -135,10 +135,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
 
   // gas price ceiling == tx.gasprice
   it("should reimburse submitter and customer for executing callback with expected tx.gasprice", async () => {
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {
         value: entryFeeEstimate,
         from: customer
       }
@@ -167,10 +167,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
 
   // gas price ceiling < tx.gasprice
   it("should reimburse submitter and customer for executing callback with higher tx.gasprice", async () => {
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {
         value: entryFeeEstimate,
         from: customer
       }
@@ -204,10 +204,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
     await fundDkgPool();
 
     // Request relay entry with a callback
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {value: entryFeeEstimate}
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {value: entryFeeEstimate}
     );
   
     await operatorContract.relayEntry(bls.groupSignature, {from: operator});
@@ -237,10 +237,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
     await fundDkgPool();
 
     // Request relay entry with a callback
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {
         value: entryFeeEstimate
       }
     );
@@ -272,10 +272,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
     await fundDkgPool();
 
     // Request relay entry with a callback
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {
         value: entryFeeEstimate
       }
     );
@@ -307,10 +307,10 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
     await fundDkgPool();
   
     // Request relay entry with a callback
-    let callbackGas = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let callbackGas = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {
         value: entryFeeEstimate
       }
     );
@@ -344,8 +344,8 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
 
     let callbackGas = 1; // Requestor provides wrong gas
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {value: entryFeeEstimate}
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {value: entryFeeEstimate}
     );
     
     await operatorContract.relayEntry(bls.groupSignature, {from: operator});
@@ -364,12 +364,12 @@ contract('KeepRandomBeacon/RelayRequestCallback', function(accounts) {
   })
 
   it("should reimburse submitter when callback failed", async () => {
-    let estimate = await callbackContract.callback.estimateGas(bls.groupSignature);
+    let estimate = await callbackContract.__beaconCallback.estimateGas(bls.groupSignature);
     
     let callbackGas = estimate - 10; // Requestor provides wrong gas
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(callbackGas)
-    await serviceContract.methods['requestRelayEntry(address,string,uint256)'](
-      callbackContract.address, "callback(uint256)", callbackGas, {value: entryFeeEstimate}
+    await serviceContract.methods['requestRelayEntry(address,uint256)'](
+      callbackContract.address, callbackGas, {value: entryFeeEstimate}
     );
   
     // use the same gas price as the gas price ceiling


### PR DESCRIPTION
Closes: #1527 

See https://github.com/keep-network/keep-common/pull/22
See https://github.com/keep-network/keep-ecdsa/pull/339

Instead of allowing the customer to pass callback signature of their choice, we now expect that the callback contract delcares public `__beaconCallback(uint256)` function.

Previously, `KeepRandomBeaconServiceImplV1` allowed senders to specify an arbitrary method that would receive a callback once the beacon generated a relay entry. Arbitrary callbacks could be used to force the service contract to execute many functions within the keep contract system. For example, functions with `onlyServiceContract` modifier in the operator contract.

We still allow specifying an address of the callback contract. This could be beneficial in a situations where one contract pays for a random number for another contract.