### PR TITLE
Add delegated authorization functionality

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -428,7 +428,7 @@ contract TokenStaking is StakeDelegatable {
         address _operator,
         address _operatorContract
     ) public view returns (uint256 balance) {
-        bool isAuthorized = authorizations[_operatorContract][_operator];
+        bool isAuthorized = isAuthorizedForOperator(_operator, _operatorContract);
 
         uint256 operatorParams = operators[_operator].packedParams;
         uint256 createdAt = operatorParams.getCreationTimestamp();

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -255,9 +255,10 @@ contract TokenStaking is StakeDelegatable {
         onlyApprovedOperatorContract(msg.sender) {
 
         uint256 totalAmountToBurn = 0;
+        address authoritySource = getAuthoritySource(msg.sender);
         for (uint i = 0; i < misbehavedOperators.length; i++) {
             address operator = misbehavedOperators[i];
-            require(authorizations[msg.sender][operator], "Not authorized");
+            require(authorizations[authoritySource][operator], "Not authorized");
 
             uint256 operatorParams = operators[operator].packedParams;
             require(
@@ -301,9 +302,10 @@ contract TokenStaking is StakeDelegatable {
         address[] memory misbehavedOperators
     ) public onlyApprovedOperatorContract(msg.sender) {
         uint256 totalAmountToBurn = 0;
+        address authoritySource = getAuthoritySource(msg.sender);
         for (uint i = 0; i < misbehavedOperators.length; i++) {
             address operator = misbehavedOperators[i];
-            require(authorizations[msg.sender][operator], "Not authorized");
+            require(authorizations[authoritySource][operator], "Not authorized");
 
             uint256 operatorParams = operators[operator].packedParams;
             require(

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -475,4 +475,10 @@ contract TokenStaking is StakeDelegatable {
         );
         delegatedAuthority[msg.sender] = delegatedAuthoritySource;
     }
+
+    function getDelegatedAuthority(
+        address delegatedAuthorityRecipient
+    ) public view returns (address) {
+        return delegatedAuthority[delegatedAuthorityRecipient];
+    }
 }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -476,9 +476,13 @@ contract TokenStaking is StakeDelegatable {
         delegatedAuthority[msg.sender] = delegatedAuthoritySource;
     }
 
-    function getDelegatedAuthority(
-        address delegatedAuthorityRecipient
+    function getAuthoritySource(
+        address operatorContract
     ) public view returns (address) {
-        return delegatedAuthority[delegatedAuthorityRecipient];
+        address delegatedAuthoritySource = delegatedAuthority[operatorContract];
+        if (delegatedAuthoritySource == address(0)) {
+            return operatorContract;
+        }
+        return getAuthoritySource(delegatedAuthoritySource);
     }
 }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -391,7 +391,7 @@ contract TokenStaking is StakeDelegatable {
         address _operator,
         address _operatorContract
     ) public view returns (uint256 balance) {
-        bool isAuthorized = authorizations[_operatorContract][_operator];
+        bool isAuthorized = isAuthorizedForOperator(_operator, _operatorContract);
 
         uint256 operatorParams = operators[_operator].packedParams;
         uint256 createdAt = operatorParams.getCreationTimestamp();

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -48,16 +48,8 @@ contract TokenStaking is StakeDelegatable {
     mapping(address => address) internal delegatedAuthority;
 
     modifier onlyApprovedOperatorContract(address operatorContract) {
-        bool directlyApproved = registry.isApprovedOperatorContract(operatorContract);
-        bool indirectlyApproved;
-
-        if (!directlyApproved) {
-            address authorityDelegator = delegatedAuthority[operatorContract];
-            indirectlyApproved = registry.isApprovedOperatorContract(authorityDelegator);
-        }
-
         require(
-            directlyApproved || indirectlyApproved,
+            registry.isApprovedOperatorContract(getAuthoritySource(operatorContract)),
             "Operator contract is not approved"
         );
         _;
@@ -362,13 +354,7 @@ contract TokenStaking is StakeDelegatable {
      * @param _operatorContract address of operator contract.
      */
     function isAuthorizedForOperator(address _operator, address _operatorContract) public view returns (bool) {
-        bool directlyAuthorized = authorizations[_operatorContract][_operator];
-        bool indirectlyAuthorized;
-        if (!directlyAuthorized) {
-            address authorityDelegator = delegatedAuthority[_operatorContract];
-            indirectlyAuthorized = authorizations[authorityDelegator][_operator];
-        }
-        return directlyAuthorized || indirectlyAuthorized;
+        return authorizations[getAuthoritySource(_operatorContract)][_operator];
     }
 
     /**

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -479,6 +479,13 @@ contract TokenStaking is StakeDelegatable {
         delegatedAuthority[msg.sender] = delegatedAuthoritySource;
     }
 
+    /// @notice Get the source of the operator contract's authority.
+    /// If the contract uses delegated authority,
+    /// returns the original source of the delegated authority.
+    /// If the contract doesn't use delegated authority,
+    /// returns the contract itself.
+    /// Authorize `getAuthoritySource(operatorContract)`
+    /// to grant `operatorContract` the authority to penalize an operator.
     function getAuthoritySource(
         address operatorContract
     ) public view returns (address) {

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -6,6 +6,21 @@ import "./utils/PercentUtils.sol";
 import "./Registry.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 
+// An operator contract can delegate authority to other operator contracts
+// by implementing the AuthorityDelegator interface.
+//
+// To delegate authority,
+// the recipient of delegated authority must call `claimDelegatedAuthority`,
+// specifying the contract it wants delegated authority from.
+// The staking contract calls `delegator.__isRecognized(recipient)`
+// and if the call returns `true`,
+// the named delegator contract is set as the recipient's authority delegator.
+// Any future checks of registry approval or per-operator authorization
+// will transparently mirror the delegator's status.
+//
+// Authority can be delegated recursively;
+// an operator contract receiving delegated authority
+// can recognize other operator contracts as recipients of its authority.
 interface AuthorityDelegator {
     function __isRecognized(address delegatedAuthorityRecipient) external returns (bool);
 }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -354,6 +354,9 @@ contract TokenStaking is StakeDelegatable {
     /**
      * @dev Authorizes operator contract to access staked token balance of
      * the provided operator. Can only be executed by stake operator authorizer.
+     * Contracts using delegated authority
+     * cannot be authorized with `authorizeOperatorContract`.
+     * Instead, authorize `getAuthoritySource(_operatorContract)`.
      * @param _operator address of stake operator.
      * @param _operatorContract address of operator contract.
      */
@@ -361,6 +364,10 @@ contract TokenStaking is StakeDelegatable {
         public
         onlyOperatorAuthorizer(_operator)
         onlyApprovedOperatorContract(_operatorContract) {
+        require(
+            getAuthoritySource(_operatorContract) == _operatorContract,
+            "Contract uses delegated authority"
+        );
         authorizations[_operatorContract][_operator] = true;
     }
 

--- a/solidity/contracts/stubs/DelegatedAuthorityStub.sol
+++ b/solidity/contracts/stubs/DelegatedAuthorityStub.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.5.4;
 
+import "../TokenStaking.sol";
+
 contract DelegatedAuthorityStub {
     address recognizedContract;
 
@@ -9,5 +11,12 @@ contract DelegatedAuthorityStub {
 
     function __isRecognized(address _contract) public view returns (bool) {
         return _contract == recognizedContract;
+    }
+
+    function claimAuthorityRecursively(
+        address stakingContract,
+        address source
+    ) public {
+        TokenStaking(stakingContract).claimDelegatedAuthority(source);
     }
 }

--- a/solidity/contracts/stubs/DelegatedAuthorityStub.sol
+++ b/solidity/contracts/stubs/DelegatedAuthorityStub.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.4;
+
+contract DelegatedAuthorityStub {
+    address recognizedContract;
+
+    constructor(address _recognizedContract) public {
+        recognizedContract = _recognizedContract;
+    }
+
+    function __isRecognized(address _contract) public view returns (bool) {
+        return _contract == recognizedContract;
+    }
+}

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -1,0 +1,111 @@
+import increaseTime, {duration, increaseTimeTo} from '../helpers/increaseTime';
+import latestTime from '../helpers/latestTime';
+import expectThrowWithMessage from '../helpers/expectThrowWithMessage'
+import {createSnapshot, restoreSnapshot} from "../helpers/snapshot"
+
+const BN = web3.utils.BN
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
+// Depending on test network increaseTimeTo can be inconsistent and add
+// extra time. As a workaround we subtract timeRoundMargin in all cases
+// that test times before initialization/undelegation periods end.
+const timeRoundMargin = duration.minutes(1)
+
+const KeepToken = artifacts.require('./KeepToken.sol');
+const TokenStaking = artifacts.require('./TokenStaking.sol');
+const Registry = artifacts.require("./Registry.sol");
+const DelegatedAuthorityStub = artifacts.require("./stubs/DelegatedAuthorityStub.sol");
+
+const initializationPeriod = 10;
+const undelegationPeriod = 30;
+
+let token, registry, stakingContract, authorityDelegator, badAuthorityDelegator;
+let minimumStake, stakingAmount;
+
+contract("TokenStaking/DelegatedAuthority", async (accounts) => {
+  const owner = accounts[0];
+  const operator = accounts[1];
+  const magpie = accounts[2];
+  const authorizer = accounts[3];
+  const recognizedContract = accounts[4];
+  const unrecognizedContract = accounts[5];
+  const unapprovedContract = accounts[6];
+
+  before(async () => {
+    token = await KeepToken.new();
+    registry = await Registry.new();
+
+    stakingContract = await TokenStaking.new(
+      token.address, registry.address, initializationPeriod, undelegationPeriod
+    );
+    minimumStake = await stakingContract.minimumStake();
+    stakingAmount = minimumStake.muln(20);
+    let tx = await delegate(operator, stakingAmount);
+    let createdAt = (await web3.eth.getBlock(tx.receipt.blockNumber)).timestamp
+    await increaseTimeTo(createdAt + initializationPeriod + 1)
+
+    authorityDelegator = await DelegatedAuthorityStub.new(recognizedContract);
+    badAuthorityDelegator = await DelegatedAuthorityStub.new(unapprovedContract);
+    await registry.approveOperatorContract(authorityDelegator.address);
+  })
+
+  beforeEach(async () => {
+    await createSnapshot()
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot()
+  })
+
+  async function delegate(operator, amount) {
+    let data = Buffer.concat([
+      Buffer.from(magpie.substr(2), 'hex'),
+      Buffer.from(operator.substr(2), 'hex'),
+      Buffer.from(authorizer.substr(2), 'hex')
+    ]);
+    
+    return token.approveAndCall(
+      stakingContract.address, amount, 
+      '0x' + data.toString('hex'), 
+      {from: owner}
+    );
+  }
+
+  async function hasDelegatedAuthorization(operatorContract) {
+    return stakingContract.isAuthorizedForOperator(operator, operatorContract);
+  }
+
+  describe("claimDelegatedAuthority", async () => {
+    it("lets contracts claim delegated authority", async () => {
+      await stakingContract.claimDelegatedAuthority(
+        authorityDelegator.address,
+        {from: recognizedContract}
+      );
+
+      expect(await stakingContract.getDelegatedAuthority(recognizedContract))
+        .to.equal(authorityDelegator.address);
+    })
+
+    it("doesn't give unrecognized contracts delegated authority", async () => {
+      await expectThrowWithMessage(
+        stakingContract.claimDelegatedAuthority(
+          authorityDelegator.address,
+          {from: unrecognizedContract}
+        ),
+        "Unrecognized claimant"
+      );
+    })
+
+    it("doesn't give delegated authority through unapproved contracts", async () => {
+      await expectThrowWithMessage(
+        stakingContract.claimDelegatedAuthority(
+          badAuthorityDelegator.address,
+          {from: unapprovedContract}
+        ),
+        "Operator contract is not approved"
+      );
+    })
+  })
+})

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -186,6 +186,19 @@ contract("TokenStaking/DelegatedAuthority", async (accounts) => {
     })
   })
 
+  describe("authorizeOperatorContract", async () => {
+    it("doesn't authorize contracts using delegated authority", async () => {
+      await expectThrowWithMessage(
+        stakingContract.authorizeOperatorContract(
+          operator,
+          recognizedContract,
+          {from: authorizer}
+        ),
+        "Contract uses delegated authority"
+      );
+    })
+  })
+
   describe("slash", async () => {
     it("uses delegated authorization correctly", async () => {
       await expectThrowWithMessage(

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -239,4 +239,14 @@ contract("TokenStaking/DelegatedAuthority", async (accounts) => {
         .to.eq.BN(stakingAmount);
     })
   })
+
+  describe("activeStake", async () => {
+    it("uses delegated authorization correctly", async () => {
+      expect(await stakingContract.activeStake(operator, recognizedContract))
+        .to.eq.BN(0);
+      await authorize(authorityDelegator);
+      expect(await stakingContract.activeStake(operator, recognizedContract))
+        .to.eq.BN(stakingAmount);
+    })
+  })
 })

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -74,10 +74,10 @@ contract("TokenStaking/DelegatedAuthority", async (accounts) => {
       Buffer.from(operator.substr(2), 'hex'),
       Buffer.from(authorizer.substr(2), 'hex')
     ]);
-    
+
     return token.approveAndCall(
-      stakingContract.address, amount, 
-      '0x' + data.toString('hex'), 
+      stakingContract.address, amount,
+      '0x' + data.toString('hex'),
       {from: owner}
     );
   }
@@ -227,6 +227,16 @@ contract("TokenStaking/DelegatedAuthority", async (accounts) => {
         {from: recognizedContract}
       );
       // no error
+    })
+  })
+
+  describe("eligibleStake", async () => {
+    it("uses delegated authorization correctly", async () => {
+      expect(await stakingContract.eligibleStake(operator, recognizedContract))
+        .to.eq.BN(0);
+      await authorize(authorityDelegator);
+      expect(await stakingContract.eligibleStake(operator, recognizedContract))
+        .to.eq.BN(stakingAmount);
     })
   })
 })

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -185,4 +185,48 @@ contract("TokenStaking/DelegatedAuthority", async (accounts) => {
       expect(await hasDelegatedAuthorization(recursivelyAuthorizedContract)).to.be.true;
     })
   })
+
+  describe("slash", async () => {
+    it("uses delegated authorization correctly", async () => {
+      await expectThrowWithMessage(
+        stakingContract.slash(
+          minimumStake,
+          [operator],
+          {from: recognizedContract}
+        ),
+        "Not authorized"
+      );
+      await authorize(authorityDelegator);
+      await stakingContract.slash(
+        minimumStake,
+        [operator],
+        {from: recognizedContract}
+      );
+      // no error
+    })
+  })
+
+  describe("seize", async () => {
+    it("uses delegated authorization correctly", async () => {
+      await expectThrowWithMessage(
+        stakingContract.seize(
+          minimumStake,
+          100,
+          magpie,
+          [operator],
+          {from: recognizedContract}
+        ),
+        "Not authorized"
+      );
+      await authorize(authorityDelegator);
+      await stakingContract.seize(
+        minimumStake,
+        100,
+        magpie,
+        [operator],
+        {from: recognizedContract}
+      );
+      // no error
+    })
+  })
 })


### PR DESCRIPTION
Refs: #1490 

In #1519 individual keeps can't ask the factory to place locks on operators on their behalf, because only one lock per operator contract is permitted. To get around this, keep factories need a way to delegate their authority to keeps. The method in this PR lets keeps claim delegated authorization, which is verified by calling the factory. After authorization has been delegated, the keep's authorization status matches that of the factory, covering approval and panic button status in the registry and individual operators' authorization.