### PR TITLE
You Can Quote Me On That: Add quotes to quickstart volume and env parameters

### DIFF
--- a/docs/keep-client-quickstart.adoc
+++ b/docs/keep-client-quickstart.adoc
@@ -103,10 +103,10 @@ export KEEP_CLIENT_CONFIG_DIR=$(pwd)/config
 export KEEP_CLIENT_PERSISTENCE_DIR=$(pwd)/persistence
 
 docker run -dit \
---volume $KEEP_CLIENT_PERSISTENCE_DIR:/mnt/keep-client/persistence \
---volume $KEEP_CLIENT_CONFIG_DIR:/mnt/keep-client/config \
---env KEEP_ETHEREUM_PASSWORD=$KEEP_CLIENT_ETHEREUM_PASSWORD \
---env LOG_LEVEL=debug \
+--volume "$KEEP_CLIENT_PERSISTENCE_DIR:/mnt/keep-client/persistence" \
+--volume "$KEEP_CLIENT_CONFIG_DIR:/mnt/keep-client/config" \
+--env "KEEP_ETHEREUM_PASSWORD=$KEEP_CLIENT_ETHEREUM_PASSWORD" \
+--env "LOG_LEVEL=debug" \
 -p 3919:3919 \
 gcr.io/keep-test-f3e0/keep-client --config /mnt/keep-client/config/keep-client-config.toml start
 ```


### PR DESCRIPTION
In some cases previously-set variables can contain spaces, so if these
parameters aren't wrapped in quotes you can get unexpected and
hard-to-track-down docker errors.