### PR TITLE
keep-dev/test: Token Dashboard SSL

### DIFF
--- a/infrastructure/kube/keep-dev/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-dev/keep-dapp-token-dashboard-deployment.yaml
@@ -6,18 +6,18 @@ metadata:
   labels:
     keel.sh/policy: all
     app: keep-dapp
-    type: keep-token-dashboard
+    type: token-dashboard
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: keep-dapp
-      type: keep-token-dashboard
+      type: token-dashboard
   template:
     metadata:
       labels:
         app: keep-dapp
-        type: keep-token-dashboard
+        type: token-dashboard
     spec:
       containers:
       - name: keep-dapp-token-dashboard

--- a/infrastructure/kube/keep-dev/keep-dapp-token-dashboard-ingress.yaml
+++ b/infrastructure/kube/keep-dev/keep-dapp-token-dashboard-ingress.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: keep-dapp-token-dashboard
+  namespace: default
+  labels:
+    app: keep-dapp
+    type: token-dashboard
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: dashboard-dev-keep-network
+  backend:
+    serviceName: keep-dapp-token-dashboard
+    servicePort: 80

--- a/infrastructure/kube/keep-dev/keep-dapp-token-dashboard-service.yaml
+++ b/infrastructure/kube/keep-dev/keep-dapp-token-dashboard-service.yaml
@@ -5,12 +5,13 @@ metadata:
   name: keep-dapp-token-dashboard
   labels:
     app: keep-dapp
-    type: keep-token-dashboard
+    type: token-dashboard
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 80
-    name: tcp-80
+    name: http-80
   selector:
     app: keep-dapp
-    type: keep-token-dashboard
+    type: token-dashboard

--- a/infrastructure/kube/keep-test/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-test/keep-dapp-token-dashboard-deployment.yaml
@@ -7,18 +7,18 @@ metadata:
   labels:
     keel.sh/policy: all
     app: keep-dapp
-    type: keep-token-dashboard
+    type: token-dashboard
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: keep-dapp
-      type: keep-token-dashboard
+      type: token-dashboard
   template:
     metadata:
       labels:
         app: keep-dapp
-        type: keep-token-dashboard
+        type: token-dashboard
     spec:
       containers:
       - name: keep-dapp-token-dashboard

--- a/infrastructure/kube/keep-test/keep-dapp-token-dashboard-ingress.yaml
+++ b/infrastructure/kube/keep-test/keep-dapp-token-dashboard-ingress.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: keep-dapp-token-dashboard
+  namespace: default
+  labels:
+    app: keep-dapp
+    type: token-dashboard
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: dashboard-test-keep-network
+  backend:
+    serviceName: keep-dapp-token-dashboard
+    servicePort: 80

--- a/infrastructure/kube/keep-test/keep-dapp-token-dashboard-service.yaml
+++ b/infrastructure/kube/keep-test/keep-dapp-token-dashboard-service.yaml
@@ -1,35 +1,17 @@
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: keep-dapp-token-dashboard-http
-  namespace: default
-  labels:
-    app: keep-dapp
-    type: keep-token-dashboard
-  annotations:
-    kubernetes.io/ingress.class: "gce"
-    kubernetes.io/ingress.allow-http: "true"
-spec:
-  backend:
-    # This assumes service eth-dashboard exists and routes to healthy endpoints
-    serviceName: keep-dapp-token-dashboard
-    servicePort: 80
----
 apiVersion: v1
 kind: Service
 metadata:
   name: keep-dapp-token-dashboard
-  namespace: default
   labels:
     app: keep-dapp
-    type: keep-token-dashboard
+    type: token-dashboard
 spec:
   type: NodePort
   ports:
-  - name: keep-dapp-token-dashboard-http
-    port: 80
+  - port: 80
     targetPort: 80
+    name: http-80
   selector:
     app: keep-dapp
-    type: keep-token-dashboard
+    type: token-dashboard


### PR DESCRIPTION
### Intro

This turned it a bit of an adventure but here we are.  We're working on hardware wallet support for the token-dashboard, as part of that we need a proper SSL connection.

I screwed around with self-signed certs for a bit which works but decided to go ahead and just put  ourselves behind Cloudflare. 

This took upgrading our Cloudflare setup to support custom hostnames, which we've done.  This does mean that we can't use our Google Hosted Zone subdomains for frontends that need secure connections, but I'll be looking into how to handle this via Terraform (in a later step).

### What We Did

#### keep-dev

- Moved the dapp deployment behind an ingress using Cloudflare
- Separated service/ingress configs into separate files.  We've been organizing configuration file scope around configuring a single object type for a given thing.  This is still experimental, may change at some point.

#### keep-test
- Moved the dapp deployment behind an ingress using Cloudflare.

#### bonus

Shortened the `type` label for the dashboard.  It's already referenced as a `keep` thing under the `app` key.

### Testing

Both dev/test deployments have been shipped with the new configs, and aliased in Cloudflare.  Accessed both hosts from Chrome via `https` and `http` (to test redirect) and things look good:

- dashboard.dev.keep.network

<img width="980" alt="Screen Shot 2020-04-05 at 4 46 32 PM" src="https://user-images.githubusercontent.com/1664226/78509589-0bb07900-775d-11ea-9654-873be7fc97e6.png">

- dashboard.test.tbtc.network

<img width="971" alt="Screen Shot 2020-04-05 at 4 43 23 PM" src="https://user-images.githubusercontent.com/1664226/78509540-993f9900-775c-11ea-83f6-5924bfb26d0a.png">

#### A note on redirects 

Being logged out of metamask does a proper http -> https redirect when accessing the dashboard.  If you're already logged into metamask the http -> https redirect does not work, and resolves http.  Going to poke at this tomorrow.