### PR TITLE
Fix @keep-core/keep-network dependency- dapp

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -985,9 +985,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@keep-network/keep-core": {
-      "version": "0.12.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-pre.1.tgz",
-      "integrity": "sha512-PJAwG7ehcNecvRtQKp9rFKmBHSJgB95wfs6j0qNnJKtv/CQYKHpUiU7w8lvepzzI6sFEMmKzAewcDGIXYmkVXw==",
+      "version": "0.13.0-pre.7",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.7.tgz",
+      "integrity": "sha512-9hKgZyBheXZDLqo3jcUpeQJ4MeUaELbb7mqXVHaPoBlGL8aGm7DSb5xQLvLLkl6+aFXkWBcwDDDURtIqdjgzfw==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -1127,9 +1127,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.17",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-              "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+              "version": "10.17.18",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+              "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
             }
           }
         },
@@ -1230,9 +1230,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.17",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-              "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+              "version": "10.17.18",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+              "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
             },
             "elliptic": {
               "version": "6.3.3",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.1.3",
     "moment": "^2.20.1",
     "web3": "^1.2.4",
-    "@keep-network/keep-core": ">0.12.0-pre <0.12.0-rc"
+    "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc"
   },
   "scripts": {
     "build-css": "lessc --clean-css src/css/app.less src/app.css",

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -1,3 +1,10 @@
+import KeepToken from '@keep-network/keep-core/artifacts/KeepToken.json'
+import TokenStaking from '@keep-network/keep-core/artifacts/TokenStaking.json'
+import TokenGrant from '@keep-network/keep-core/artifacts/TokenGrant.json'
+import KeepRandomBeaconOperator from '@keep-network/keep-core/artifacts/KeepRandomBeaconOperator.json'
+import Registry from '@keep-network/keep-core/artifacts/Registry.json'
+import GuaranteedMinimumStakingPolicy from '@keep-network/keep-core/artifacts/GuaranteedMinimumStakingPolicy.json'
+import PermissiveStakingPolicy from '@keep-network/keep-core/artifacts/PermissiveStakingPolicy.json'
 import {
   KEEP_TOKEN_CONTRACT_NAME,
   TOKEN_STAKING_CONTRACT_NAME,
@@ -5,22 +12,6 @@ import {
   OPERATOR_CONTRACT_NAME,
   REGISTRY_CONTRACT_NAME,
 } from './constants/constants'
-
-const getDefaultContractsPath = () => {
-  if (process.env.NODE_ENV === 'production') {
-    return '@keep-network/keep-core/artifacts'
-  }
-
-  return './contracts'
-}
-
-const KeepToken = require(`${getDefaultContractsPath()}/KeepToken.json`)
-const TokenStaking = require(`${getDefaultContractsPath()}/TokenStaking.json`)
-const TokenGrant = require(`${getDefaultContractsPath()}/TokenGrant.json`)
-const KeepRandomBeaconOperator = require(`${getDefaultContractsPath()}/KeepRandomBeaconOperator.json`)
-const Registry = require(`${getDefaultContractsPath()}/Registry.json`)
-const GuaranteedMinimumStakingPolicy = require(`${getDefaultContractsPath()}/GuaranteedMinimumStakingPolicy.json`)
-const PermissiveStakingPolicy = require(`${getDefaultContractsPath()}/PermissiveStakingPolicy.json`)
 
 export const CONTRACT_DEPLOY_BLOCK_NUMBER = {
   [KEEP_TOKEN_CONTRACT_NAME]: 0,


### PR DESCRIPTION
This PR bumps a `@keep-network/keep-core` dependency to `>0.13.0-pre <0.13.0-rc`. Also, commit(db18ca4) was a test commit and shouldn't be merged to the master and this PR fixes it and imports artifacts from the `@keep-network/keep-core` package.