### PR TITLE
Fix Version Bumps Past 10: Drop npm versioning sort call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
             # this is because npm show json contains a single string if there
             # is only one matching version, or an array if there are multiple,
             # and we want to look at an array always.
-            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | sort | .[-1]")
+            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
             latest_version=${latest_version:-$version}
             if [ -z $latest_version ]; then
               echo "Latest version calculation failed. Resolved info:"


### PR DESCRIPTION
Using sort sorts lexicographically which runs us into issues when we
increment pre.x to 10.  Rather than lean into sort -n, an investigation
showed that npm show already returned results sorted increasing by
version number.