### PR TITLE
Fix table rendering- dapp

### DIFF
--- a/solidity/dashboard/src/components/DataTable.jsx
+++ b/solidity/dashboard/src/components/DataTable.jsx
@@ -5,7 +5,6 @@ export class DataTable extends React.Component {
     super(props)
     this.state = {
       headers: [],
-      fields: [],
     }
   }
 
@@ -15,35 +14,33 @@ export class DataTable extends React.Component {
 
   initializeDataTable = () => {
     const headers = []
-    const fields = []
     React.Children.forEach(this.props.children, (children) => {
       headers.push(children.props.header)
-      fields.push({
-        fieldName: children.props.field,
-        renderContent: children.props.renderContent,
-      })
     })
-    this.setState({ headers, fields })
+    this.setState({ headers })
   }
 
   renderItemRow = (item) => {
-    const columns = this.state.fields.map((field, index) => {
-      return (
-        <td key={`${item[this.props.itemFieldId]}-${field.fieldName}-${item[field.fieldName]}`}>
-          <span className="responsive-header">{this.state.headers[index]}</span>
-          {field.renderContent ?
-            field.renderContent(item) :
-            item[field.fieldName]
-          }
-        </td>
-      )
-    })
-
     return (
       <tr key={item[this.props.itemFieldId]}>
-        {columns}
+        {React.Children.map(this.props.children, (column) => {
+          return (
+            <td key={`${item[this.props.itemFieldId]}-${column.props.field}-${item[column.props.field]}`}>
+              <span className="responsive-header">{column.props.header}</span>
+              {this.renderColumnContent(column, item)}
+            </td>
+          )
+        })
+        }
       </tr>
     )
+  }
+
+  renderColumnContent = (column, item) => {
+    if (!column.props.renderContent) {
+      return item[column.props.field]
+    }
+    return column.props.renderContent(item)
   }
 
   renderHeader = (header) => (


### PR DESCRIPTION
In the previous implementation, the `DataTable` component was saving the` renderContent` property in the local state in the `componentDidMount` hook. Thus the 'renderContent' always pointed to the function passed to the component at the beginning. Because of this, the [authorization function](https://github.com/keep-network/keep-core/blob/master/solidity/dashboard/src/pages/AuthorizerPage.jsx#L30) fails.