### PR TITLE
Prefer `npx truffle` to a global truffle install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: Generate solidity docs
           command: |
             cd solidity && npm install
-            node_modules/.bin/truffle compile
+            npx truffle compile
             mkdir -p output
             node scripts/generate-api-docs.js > output/index.adoc
             mkdir -p /tmp/docs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,22 +28,22 @@ npm install
 
 printf "${LOG_START}Unlocking ethereum accounts...${LOG_END}"
 KEEP_ETHEREUM_PASSWORD=$KEEP_ETHEREUM_PASSWORD \
-    truffle exec scripts/unlock-eth-accounts.js --network local
+    npx truffle exec scripts/unlock-eth-accounts.js --network local
 
 printf "${LOG_START}Migrating contracts...${LOG_END}"
 rm -rf build/
-truffle migrate --reset --network local
+npx truffle migrate --reset --network local
 
 KEEP_CORE_SOL_ARTIFACTS_PATH="$KEEP_CORE_SOL_PATH/build/contracts"
 
 printf "${LOG_START}Initializing contracts...${LOG_END}"
-truffle exec scripts/delegate-tokens.js --network local
+npx truffle exec scripts/delegate-tokens.js --network local
 
 printf "${LOG_START}Updating keep-core client configs...${LOG_END}"
 for CONFIG_FILE in $KEEP_CORE_CONFIG_DIR_PATH/*.toml
 do
     KEEP_CORE_CONFIG_FILE_PATH=$CONFIG_FILE \
-        truffle exec scripts/lcl-client-config.js --network local
+        npx truffle exec scripts/lcl-client-config.js --network local
 done
 
 printf "${LOG_START}Building keep-core client...${LOG_END}"

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -26,9 +26,6 @@ echo "Installing solidity npm and requirements..."
 brew list npm &>/dev/null || brew install npm
 cd ../solidity && npm install && cd ../scripts
 
-echo "Installing truffle..."
-npm install -g truffle
-
 if ! [ -x "$(command -v protoc-gen-gogoslick)" ]; then
   echo 'WARNING: protoc-gen-gogoslick command is not available'
   echo 'WARNING: please check whether $GOPATH/bin is added to your $PATH'


### PR DESCRIPTION
No need to install `truffle` globally and deal with dueling version issues.

Closes #1581.