### PR TITLE
Dual interface + `abi.decode` for managed grants

### DIFF
--- a/solidity/contracts/ManagedGrantFactory.sol
+++ b/solidity/contracts/ManagedGrantFactory.sol
@@ -61,7 +61,7 @@ contract ManagedGrantFactory {
         );
     }
 
-    function createGrant(
+    function createManagedGrant(
         address grantee,
         uint256 amount,
         uint256 duration,

--- a/solidity/contracts/ManagedGrantFactory.sol
+++ b/solidity/contracts/ManagedGrantFactory.sol
@@ -42,10 +42,23 @@ contract ManagedGrantFactory {
         bytes memory _extraData
     ) public {
         require(KeepToken(_token) == token, "Invalid token contract");
-
-        token.safeTransferFrom(_from, address(this), _amount);
-
-        grantFundingPool[_from] += _amount;
+        (address _grantee,
+         uint256 _duration,
+         uint256 _start,
+         uint256 _cliff,
+         bool _revocable) = abi.decode(
+             _extraData,
+             (address, uint256, uint256, uint256, bool)
+        );
+        _createGrant(
+            _grantee,
+            _amount,
+            _duration,
+            _start,
+            _cliff,
+            _revocable,
+            _from
+        );
     }
 
     function createGrant(
@@ -56,11 +69,30 @@ contract ManagedGrantFactory {
         uint256 cliff,
         bool revocable
     ) public returns (address _managedGrant) {
-        require(
-            grantFundingPool[msg.sender] >= amount,
-            "Insufficient funding"
+        return _createGrant(
+            grantee,
+            amount,
+            duration,
+            start,
+            cliff,
+            revocable,
+            msg.sender
         );
-        grantFundingPool[msg.sender] -= amount;
+    }
+
+    function _createGrant(
+        address grantee,
+        uint256 amount,
+        uint256 duration,
+        uint256 start,
+        uint256 cliff,
+        bool revocable,
+        address _from
+    ) internal returns (address _managedGrant) {
+        require(grantee != address(0), "Grantee address can't be zero.");
+        require(cliff <= duration, "Unlocking cliff duration must be less or equal total unlocking duration.");
+
+        token.safeTransferFrom(_from, address(this), amount);
 
         GrantStakingPolicy stakingPolicy = revocable
             ? revocableStakingPolicy

--- a/solidity/contracts/ManagedGrantFactory.sol
+++ b/solidity/contracts/ManagedGrantFactory.sol
@@ -78,12 +78,12 @@ contract ManagedGrantFactory {
         );
         _managedGrant = address(managedGrant);
 
-        bytes memory grantData = abi.encodePacked(
+        bytes memory grantData = abi.encode(
             _managedGrant,
             duration,
             start,
             cliff,
-            revocable ? 0x01 : 0x00,
+            revocable,
             address(stakingPolicy)
         );
 

--- a/solidity/contracts/TokenGrant.sol
+++ b/solidity/contracts/TokenGrant.sol
@@ -222,22 +222,19 @@ contract TokenGrant {
     function receiveApproval(address _from, uint256 _amount, address _token, bytes memory _extraData) public {
         require(ERC20Burnable(_token) == token, "Token contract must be the same one linked to this contract.");
         require(_amount <= token.balanceOf(_from), "Sender must have enough amount.");
-        require(_extraData.length == 137, "Invalid extra data length.");
-
-        address _grantee = _extraData.toAddress(0);
-        uint256 _duration = _extraData.toUint(20);
-        uint256 _start = _extraData.toUint(52);
-        uint256 _cliff = _extraData.toUint(84);
+        (address _grantee,
+         uint256 _duration,
+         uint256 _start,
+         uint256 _cliff,
+         bool _revocable,
+         address _stakingPolicy) = abi.decode(
+             _extraData,
+             (address, uint256, uint256, uint256, bool, address)
+        );
 
         require(_grantee != address(0), "Grantee address can't be zero.");
         require(_cliff <= _duration, "Unlocking cliff duration must be less or equal total unlocking duration.");
 
-        bool _revocable;
-        if (_extraData.slice(116, 1)[0] == 0x01) {
-            _revocable = true;
-        }
-
-        address _stakingPolicy = _extraData.toAddress(117);
         require(_stakingPolicy != address(0), "Staking policy can't be zero.");
 
         uint256 id = numGrants++;

--- a/solidity/test/helpers/grantTokens.js
+++ b/solidity/test/helpers/grantTokens.js
@@ -7,14 +7,10 @@ async function grantTokens(
     unlockingDuration, start, cliff,
     revocable,
     stakingPolicy) {
-  let grantData = Buffer.concat([
-    Buffer.from(grantee.substr(2), 'hex'),
-    web3.utils.toBN(unlockingDuration).toBuffer('be', 32),
-    web3.utils.toBN(start).toBuffer('be', 32),
-    web3.utils.toBN(cliff).toBuffer('be', 32),
-    Buffer.from(revocable ? "01" : "00", 'hex'),
-    Buffer.from(stakingPolicy.substr(2), 'hex'),
-  ]);
+  let grantData = web3.eth.abi.encodeParameters(
+    ['address', 'uint256', 'uint256', 'uint256', 'bool', 'address'],
+    [grantee, unlockingDuration.toNumber(), start.toNumber(), cliff.toNumber(), revocable, stakingPolicy]
+  );
 
   await token.approveAndCall(grantContract.address, amount, grantData, {from: from})
   return (await grantContract.getPastEvents())[0].args[0].toNumber()

--- a/solidity/test/token_grant/TestManagedGrantFactory.js
+++ b/solidity/test/token_grant/TestManagedGrantFactory.js
@@ -83,7 +83,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
         factory.address, grantAmount, {from: grantCreator}
       );
       grantStart = await time.latest();
-      let managedGrantAddress = await factory.createGrant.call(
+      let managedGrantAddress = await factory.createManagedGrant.call(
         grantee,
         grantAmount,
         grantUnlockingDuration,
@@ -92,7 +92,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
         false,
         {from: grantCreator}
       );
-      await factory.createGrant(
+      await factory.createManagedGrant(
         grantee,
         grantAmount,
         grantUnlockingDuration,
@@ -115,7 +115,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
       );
       grantStart = await time.latest();
       await expectRevert(
-        factory.createGrant(
+        factory.createManagedGrant(
           grantee,
           grantAmount,
           grantUnlockingDuration,
@@ -135,7 +135,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
       );
       grantStart = await time.latest();
       await expectRevert(
-        factory.createGrant(
+        factory.createManagedGrant(
           grantee,
           grantAmount.addn(1),
           grantUnlockingDuration,


### PR DESCRIPTION
Refs: #1529 

Using `abi.decode` instead of tightly packed `_extraData` in `receiveApproval` adds a slight overhead of unnecessary calldata bytes, but makes the parsing of the arguments simpler.

Providing a dual interface of `receiveApproval` which doesn't return values, and `createManagedGrant` which returns the managed grant address, but requires prior setup in the token, accommodates both on-chain and dApp use-cases without requiring workarounds.