### PR TITLE
v0.13.0-rc release preparation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199
-	github.com/keep-network/keep-common v0.1.1-0.20200410121208-86a57ad677d8
+	github.com/keep-network/keep-common v0.2.0-rc
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1
 	github.com/libp2p/go-libp2p-connmgr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/elastic/gosigar v0.10.5 h1:GzPQ+78RaAb4J63unidA/JavQRKrB6s8IOzN6Ib59jo=
 github.com/elastic/gosigar v0.10.5/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
-github.com/ethereum/go-ethereum v1.9.7 h1:p4O+z0MGzB7xxngHbplcYNloxkFwGkeComhkzWnq0ig=
-github.com/ethereum/go-ethereum v1.9.7/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/ethereum/go-ethereum v1.9.10 h1:jooX7tWcscpC7ytufk73t9JMCeJQ7aJF2YmZJQEuvFo=
 github.com/ethereum/go-ethereum v1.9.10/go.mod h1:lXHkVo/MTvsEXfYsmNzelZ8R1e0DTvdk/wMZJIRpaRw=
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:JpoxHjuQauoxiFMl1ie8Xc/7TfLuMZ5eOCONd1sUBHg=
@@ -246,8 +244,6 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199 h1:4EmAF2XUHK1kwXBhg75OO9hgTkJGK7snwJZlpbu+Yy8=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
-github.com/keep-network/keep-common v0.1.1-0.20200410121208-86a57ad677d8 h1:34w+kUTPzBmKx0mygUbLhu3dIPFnTZ7yI4BS9b1pjVU=
-github.com/keep-network/keep-common v0.1.1-0.20200410121208-86a57ad677d8/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
 github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZtP3Jzj2sxqd2g=
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199 h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/keep-common v0.1.1-0.20200410121208-86a57ad677d8 h1:34w+kUTPzBmKx0mygUbLhu3dIPFnTZ7yI4BS9b1pjVU=
 github.com/keep-network/keep-common v0.1.1-0.20200410121208-86a57ad677d8/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
+github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZtP3Jzj2sxqd2g=
+github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -985,9 +985,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-pre.7",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.7.tgz",
-      "integrity": "sha512-9hKgZyBheXZDLqo3jcUpeQJ4MeUaELbb7mqXVHaPoBlGL8aGm7DSb5xQLvLLkl6+aFXkWBcwDDDURtIqdjgzfw==",
+      "version": "0.13.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
+      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -1127,9 +1127,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.18",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
-              "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
+              "version": "10.17.19",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
+              "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
             }
           }
         },
@@ -1230,9 +1230,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.18",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
-              "integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
+              "version": "10.17.19",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
+              "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
             },
             "elliptic": {
               "version": "6.3.3",
@@ -1497,6 +1497,11 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@solidity-parser/parser": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
+      "integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -16335,11 +16340,6 @@
         }
       }
     },
-    "solidity-parser-antlr": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
-      "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg=="
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -17338,15 +17338,22 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle-flattener": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.2.tgz",
-      "integrity": "sha512-7qUIzaW8a4vI4nui14wsytht2oaqvqnZ1Iet2wRq2T0bCJ0wb6HByMKQhZKpU46R+n5BMTY4K5n+0ITyeNlmuQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.3.tgz",
+      "integrity": "sha512-r29fkSkV8i9oMW35KbpKR0bP4iPnzIJqlW2S+CL3BjLsxq6YnlMn9+e0BpiJIJPmeXJgeYHQvCGceucpM0Dovg==",
       "requires": {
         "@resolver-engine/imports-fs": "^0.2.2",
+        "@solidity-parser/parser": "^0.5.2",
         "find-up": "^2.1.0",
-        "mkdirp": "^0.5.1",
-        "solidity-parser-antlr": "^0.4.11",
+        "mkdirp": "^1.0.4",
         "tsort": "0.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        }
       }
     },
     "tryer": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.1.3",
     "moment": "^2.20.1",
     "web3": "^1.2.4",
-    "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc"
+    "@keep-network/keep-core": "0.13.0-rc.0"
   },
   "scripts": {
     "build-css": "lessc --clean-css src/css/app.less src/app.css",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.13.0-rc",
+  "version": "0.14.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.13.0-pre",
+  "version": "0.13.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.13.0-pre",
+  "version": "0.13.0-rc",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.13.0-rc",
+  "version": "0.14.0-pre",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The procedure:
- Updated `keep-common` dependency to `v0.2.0-rc`.
- Bumped up Solidity contracts version to `0.13.0-rc`, published to NPM registry
- Set `keep-core` contract dependency version in dashboard to `0.13.0-rc.0`, tagged `v0.13.0-rc`
- Bumped up Solidity contracts version to `0.14.0-pre`

We will update dashboard contract dependency to `>0.14.0-pre <0.14.0-rc` separately, once we publish contracts to NPM registry.