### PR TITLE
fixed link "View in Block Explorer"

### DIFF
--- a/solidity/dashboard/src/components/AuthorizationHistory.jsx
+++ b/solidity/dashboard/src/components/AuthorizationHistory.jsx
@@ -28,7 +28,7 @@ const AuthorizationHistory = ({ contracts }) => {
         <Column
           header="contract details"
           field="details"
-          renderContent={(contractAddress) => (
+          renderContent={({ contractAddress }) => (
             <a href={ETHERSCAN_DEFAULT_URL + contractAddress} rel="noopener noreferrer" target="_blank">
               View in Block Explorer
             </a>

--- a/solidity/dashboard/src/components/AuthorizeContracts.jsx
+++ b/solidity/dashboard/src/components/AuthorizeContracts.jsx
@@ -25,7 +25,7 @@ const AuthorizeContracts = ({
         <Column
           header="contract details"
           field="details"
-          renderContent={(contractAddress) => (
+          renderContent={({ contractAddress }) => (
             <a href={ETHERSCAN_DEFAULT_URL + contractAddress} rel="noopener noreferrer" target="_blank">
               View in Block Explorer
             </a>


### PR DESCRIPTION
Fixes incorrect links in the "Authorize Contracts" and "Authorization History" blocks in the web interface.
Fixes #1577