### PR TITLE
Setting keep-core contracts dependency to >0.14.0-pre <0.14.0-rc

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -985,9 +985,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
-      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
+      "version": "0.14.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.0.tgz",
+      "integrity": "sha512-etiQWKwtxTCA7QFQ/wsvYAu8owdddEDOEGZ3H1QMPljbyKiDuvHmdAdzeuGsou1+i9fL/XzZPv32ctWob5xT/w==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.1.3",
     "moment": "^2.20.1",
     "web3": "^1.2.4",
-    "@keep-network/keep-core": "0.13.0-rc.0"
+    "@keep-network/keep-core": ">0.14.0-pre <0.14.0-rc"
   },
   "scripts": {
     "build-css": "lessc --clean-css src/css/app.less src/app.css",


### PR DESCRIPTION
After we released `0.13.0-rc` and the first `0.14.0-pre` has been deployed to NPM package registry, we can update KEEP token dashboard contract dependency to point to the most recent version.

See https://github.com/keep-network/keep-core/pull/1593