### PR TITLE
Increasing the delay to 1 sec and up to 10 retries to get participants

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -165,8 +165,8 @@ func (ec *ethereumChain) GetSelectedParticipants() ([]chain.StakerAddress, error
 }
 
 func (ec *ethereumChain) withRetry(fn func() error) error {
-	const numberOfRetries = 4
-	const delay = 250 * time.Millisecond
+	const numberOfRetries = 10
+	const delay = time.Second
 
 	for i := 1; ; i++ {
 		err := fn()


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/1598

In this PR we increase the delay to 1 sec. between retries (10) to fetch selected participants in case of Infura's synchronization issue.