### PR TITLE
Adding signature safety margin on DKG result

### DIFF
--- a/pkg/beacon/relay/dkg/result/integration_test.go
+++ b/pkg/beacon/relay/dkg/result/integration_test.go
@@ -14,7 +14,7 @@ import (
 func TestExecute_IA_members24_phase13(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -39,5 +39,5 @@ func TestExecute_IA_members24_phase13(t *testing.T) {
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertNoMisbehavingMembers(t, result)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 3, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 3, 5, 6}...)
 }

--- a/pkg/beacon/relay/dkg/result/submission.go
+++ b/pkg/beacon/relay/dkg/result/submission.go
@@ -61,11 +61,15 @@ func (sm *SubmittingMember) SubmitDKGResult(
 		)
 	}
 
-	if len(signatures) < config.HonestThreshold {
+	// Chain rejects the result if it has less than 25% safety margin.
+	// If there are not enough signatures to preserve the margin, it does not
+	// make sense to submit the result.
+	signatureThreshold := config.HonestThreshold + (config.GroupSize-config.HonestThreshold)/2
+	if len(signatures) < signatureThreshold {
 		return fmt.Errorf(
-			"could not submit result with [%v] signatures for honest threshold [%v]",
+			"could not submit result with [%v] signatures for signature threshold [%v]",
 			len(signatures),
-			config.HonestThreshold,
+			signatureThreshold,
 		)
 	}
 

--- a/pkg/beacon/relay/dkg/result/submission_test.go
+++ b/pkg/beacon/relay/dkg/result/submission_test.go
@@ -32,6 +32,7 @@ func TestSubmitDKGResult(t *testing.T) {
 		1: []byte{101},
 		2: []byte{102},
 		3: []byte{103},
+		4: []byte{104},
 	}
 
 	tStep := config.ResultPublicationBlockStep
@@ -130,6 +131,7 @@ func TestConcurrentPublishResult(t *testing.T) {
 		1: []byte{101},
 		2: []byte{102},
 		3: []byte{103},
+		4: []byte{104},
 	}
 
 	var tests = map[string]struct {

--- a/pkg/beacon/relay/gjkr/integration_test.go
+++ b/pkg/beacon/relay/gjkr/integration_test.go
@@ -205,7 +205,7 @@ func TestExecute_IA_member1_phase8(t *testing.T) {
 func TestExecute_IA_members35_phase10(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -226,12 +226,12 @@ func TestExecute_IA_members35_phase10(t *testing.T) {
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{1, 2, 4}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{1, 2, 4, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, group.MemberIndex(3), group.MemberIndex(5))
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 2, 4}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 2, 4, 6}...)
 }
 
 // Phase 2 test case - a member sends an invalid ephemeral public key message.
@@ -523,7 +523,7 @@ func TestExecute_DQ_member4_falseAccusation_phase5(t *testing.T) {
 func TestExecute_DQ_member2_accusesInactiveMember_phase5(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -569,12 +569,12 @@ func TestExecute_DQ_member2_accusesInactiveMember_phase5(t *testing.T) {
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{1, 2}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 }
 
 // Phase 8 test case - a member sends an invalid member public key share points
@@ -672,7 +672,7 @@ func TestExecute_DQ_members25_revealWrongPrivateKey_phase9(t *testing.T) {
 func TestExecute_DQ_members14_invalidPublicKeyShare_phase9(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -704,12 +704,12 @@ func TestExecute_DQ_members14_invalidPublicKeyShare_phase9(t *testing.T) {
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{2, 3, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{2, 3, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{1, 4}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{2, 3, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{2, 3, 5, 6}...)
 }
 
 // Phase 9 test case - a member misbehaved by performing a false accusation
@@ -771,7 +771,7 @@ func TestExecute_DQ_member4_falseAccusation_phase9(t *testing.T) {
 func TestExecute_DQ_member2_accusesInactiveMember_phase9(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -816,12 +816,12 @@ func TestExecute_DQ_member2_accusesInactiveMember_phase9(t *testing.T) {
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{1, 2}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 }
 
 // Phase 9 test case - a member misbehaved by sending shares which
@@ -832,7 +832,7 @@ func TestExecute_DQ_member2_accusesInactiveMember_phase9(t *testing.T) {
 func TestExecute_DQ_members12_cannotDecryptTheirShares_phase9(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -883,12 +883,12 @@ func TestExecute_DQ_members12_cannotDecryptTheirShares_phase9(t *testing.T) {
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{1, 2}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 }
 
 // Phase 11 test case - a member misbehaved by not revealing its private key
@@ -899,7 +899,7 @@ func TestExecute_DQ_members12_cannotDecryptTheirShares_phase9(t *testing.T) {
 func TestExecute_DQ_member2_notRevealsDisqualifiedQualMemberKey_phase11(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -936,12 +936,12 @@ func TestExecute_DQ_member2_notRevealsDisqualifiedQualMemberKey_phase11(t *testi
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{1, 2}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 }
 
 // Phase 11 test case - a member misbehaved by revealing key of an operating
@@ -993,7 +993,7 @@ func TestExecute_DQ_member2_revealedKeyOfOperatingMember_phase11(t *testing.T) {
 func TestExecute_DQ_member5_revealsWrongPrivateKey_phase11(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -1034,12 +1034,12 @@ func TestExecute_DQ_member5_revealsWrongPrivateKey_phase11(t *testing.T) {
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{1, 2, 3}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{1, 2, 3, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{4, 5}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 2, 3}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 2, 3, 6}...)
 }
 
 // Phase 11 test case - a member misbehaved by revealing private key generated for
@@ -1049,7 +1049,7 @@ func TestExecute_DQ_member5_revealsWrongPrivateKey_phase11(t *testing.T) {
 func TestExecute_DQ_member2_revealsInactiveNonQualMemberKey_phase11(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -1094,12 +1094,12 @@ func TestExecute_DQ_member2_revealsInactiveNonQualMemberKey_phase11(t *testing.T
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{1, 2}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{3, 4, 5, 6}...)
 }
 
 // Phase 11 test case - a member misbehaved by sending shares which
@@ -1113,7 +1113,7 @@ func TestExecute_DQ_member2_revealsInactiveNonQualMemberKey_phase11(t *testing.T
 func TestExecute_DQ_member3_revealsDisqualifiedNonQualMemberKey_phase11(t *testing.T) {
 	t.Parallel()
 
-	groupSize := 5
+	groupSize := 6
 	honestThreshold := 3
 	seed := dkgtest.RandomSeed(t)
 
@@ -1174,12 +1174,12 @@ func TestExecute_DQ_member3_revealsDisqualifiedNonQualMemberKey_phase11(t *testi
 
 	dkgtest.AssertDkgResultPublished(t, result)
 	dkgtest.AssertSuccessfulSignersCount(t, result, groupSize-2)
-	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{1, 2, 5}...)
+	dkgtest.AssertSuccessfulSigners(t, result, []group.MemberIndex{1, 2, 5, 6}...)
 	dkgtest.AssertMemberFailuresCount(t, result, 2)
 	dkgtest.AssertSamePublicKey(t, result)
 	dkgtest.AssertMisbehavingMembers(t, result, []group.MemberIndex{3, 4}...)
 	dkgtest.AssertValidGroupPublicKey(t, result)
-	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 2, 5}...)
+	dkgtest.AssertResultSupportingMembers(t, result, []group.MemberIndex{1, 2, 5, 6}...)
 }
 
 func TestExecute_InvalidMemberIndex(t *testing.T) {

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -198,10 +198,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         dkgResultVerification.timeDKG = 5*(1+5) + 2*(1+10) + 20;
         dkgResultVerification.resultPublicationBlockStep = resultPublicationBlockStep;
         dkgResultVerification.groupSize = groupSize;
-        // TODO: For now, the required number of signatures is equal to group
-        // threshold. This should be updated to keep a safety margin for
-        // participants misbehaving during signing.
-        dkgResultVerification.signatureThreshold = groupThreshold;
+        dkgResultVerification.signatureThreshold = groupThreshold + (groupSize - groupThreshold) / 2;
     }
 
     /**

--- a/solidity/contracts/libraries/operator/DKGResultVerification.sol
+++ b/solidity/contracts/libraries/operator/DKGResultVerification.sol
@@ -45,9 +45,6 @@ library DKGResultVerification {
      * group selection protocol.
      * @param groupSelectionEndBlock Block height at which the group selection
      * protocol ended.
-     *
-     * @return true if submitter is eligible to submit and the result is valid;
-     * Otherwise, transaction is reverted.
      */
     function verify(
         Storage storage self,
@@ -58,7 +55,7 @@ library DKGResultVerification {
         uint256[] memory signingMemberIndices,
         address[] memory members,
         uint256 groupSelectionEndBlock
-    ) public view returns (bool) {
+    ) public view {
         require(submitterMemberIndex > 0, "Invalid submitter index");
         require(
             members[submitterMemberIndex - 1] == msg.sender,
@@ -97,7 +94,5 @@ library DKGResultVerification {
 
             require(members[signingMemberIndices[i] - 1] == recoveredAddress, "Invalid signature");
         }
-
-        return true;
     }
 }

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
@@ -1,0 +1,52 @@
+pragma solidity 0.5.17;
+
+import "../KeepRandomBeaconOperator.sol";
+
+
+contract KeepRandomBeaconOperatorDKGResultStub is KeepRandomBeaconOperator {
+    constructor(address _serviceContract, address _stakingContract)
+        public
+        KeepRandomBeaconOperator(_serviceContract, _stakingContract)
+    {
+        groupSelection.ticketSubmissionTimeout = 100;
+    }
+
+    function setGroupSize(uint256 size) public {
+        groupSize = size;
+        groupSelection.groupSize = size;
+        dkgResultVerification.groupSize = size;
+    }
+
+    function setGroupThreshold(uint256 threshold) public {
+        groupThreshold = threshold;
+        dkgResultVerification.signatureThreshold = threshold;
+    }
+
+    function setDKGResultSignatureThreshold(uint256 threshold) public {
+        dkgResultVerification.signatureThreshold = threshold;
+    }
+
+    function setResultPublicationBlockStep(uint256 step) public {
+        resultPublicationBlockStep = step;
+    }
+
+    function getGroupSelectionRelayEntry() public view returns (uint256) {
+        return groupSelection.seed;
+    }
+
+    function getTicketSubmissionStartBlock() public view returns (uint256) {
+        return groupSelection.ticketSubmissionStartBlock;
+    }
+
+    function isGroupSelectionInProgress() public view returns (bool) {
+        return groupSelection.inProgress;
+    }
+
+    function setGasPriceCeiling(uint256 _gasPriceCeiling) public {
+        gasPriceCeiling = _gasPriceCeiling;
+    }
+
+    function timeDKG() public view returns (uint256) {
+        return dkgResultVerification.timeDKG;
+    }
+}

--- a/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
+++ b/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
@@ -17,6 +17,8 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     operator3 = accounts[3],
     operator4 = accounts[4],
     operator5 = accounts[5],
+    operator6 = accounts[6],
+    operator7 = accounts[7],
     authorizer = owner,
     selectedParticipants, signatures, signingMemberIndices = [],
     misbehaved = '0x0305', // disqualified operator with selected member index 3 and inactive with 5
@@ -36,21 +38,25 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     token = contracts.token
     stakingContract = contracts.stakingContract
     operatorContract = contracts.operatorContract
-    operatorContract.setGroupSize(5, {from: owner})
-    operatorContract.setGroupThreshold(3, {from: owner})
-
+    operatorContract.setGroupSize(7, {from: owner})
+    operatorContract.setGroupThreshold(4, {from: owner})
+    
     let minimumStake = await stakingContract.minimumStake()
     await stakeDelegate(stakingContract, token, owner, operator1, owner, authorizer, minimumStake, {from: owner})
     await stakeDelegate(stakingContract, token, owner, operator2, owner, authorizer, minimumStake, {from: owner})
     await stakeDelegate(stakingContract, token, owner, operator3, owner, authorizer, minimumStake, {from: owner})
     await stakeDelegate(stakingContract, token, owner, operator4, owner, authorizer, minimumStake, {from: owner})
     await stakeDelegate(stakingContract, token, owner, operator5, owner, authorizer, minimumStake, {from: owner})
-
+    await stakeDelegate(stakingContract, token, owner, operator6, owner, authorizer, minimumStake, {from: owner})
+    await stakeDelegate(stakingContract, token, owner, operator7, owner, authorizer, minimumStake, {from: owner})
+    
     await stakingContract.authorizeOperatorContract(operator1, operatorContract.address, {from: authorizer})
     await stakingContract.authorizeOperatorContract(operator2, operatorContract.address, {from: authorizer})
     await stakingContract.authorizeOperatorContract(operator3, operatorContract.address, {from: authorizer})
     await stakingContract.authorizeOperatorContract(operator4, operatorContract.address, {from: authorizer})
     await stakingContract.authorizeOperatorContract(operator5, operatorContract.address, {from: authorizer})
+    await stakingContract.authorizeOperatorContract(operator6, operatorContract.address, {from: authorizer})
+    await stakingContract.authorizeOperatorContract(operator7, operatorContract.address, {from: authorizer})
 
     time.increase((await stakingContract.initializationPeriod()).addn(1));
 
@@ -60,6 +66,8 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     let tickets3 = generateTickets(groupSelectionRelayEntry, operator3, 1)
     let tickets4 = generateTickets(groupSelectionRelayEntry, operator4, 1)
     let tickets5 = generateTickets(groupSelectionRelayEntry, operator5, 1)
+    let tickets6 = generateTickets(groupSelectionRelayEntry, operator6, 1)
+    let tickets7 = generateTickets(groupSelectionRelayEntry, operator7, 1)
 
     await operatorContract.submitTicket(
       packTicket(tickets1[0].valueHex, tickets1[0].virtualStakerIndex, operator1),
@@ -84,6 +92,16 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     await operatorContract.submitTicket(
       packTicket(tickets5[0].valueHex, tickets5[0].virtualStakerIndex, operator5),
       {from: operator5}
+    )
+
+    await operatorContract.submitTicket(
+      packTicket(tickets6[0].valueHex, tickets6[0].virtualStakerIndex, operator6),
+      {from: operator6}
+    )
+
+    await operatorContract.submitTicket(
+      packTicket(tickets7[0].valueHex, tickets7[0].virtualStakerIndex, operator7),
+      {from: operator7}
     )
 
     let ticketSubmissionStartBlock = await operatorContract.getTicketSubmissionStartBlock()
@@ -122,5 +140,7 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[2]) == -1, "Member should not be registered")
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[3]) != -1, "Member should be registered")
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[4]) == -1, "Member should not be registered")
+    assert.isTrue(registeredMembers.indexOf(selectedParticipants[5]) != -1, "Member should be registered")
+    assert.isTrue(registeredMembers.indexOf(selectedParticipants[6]) != -1, "Member should be registered")
   })
 })

--- a/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
+++ b/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
@@ -1,15 +1,15 @@
 const blsData = require("../helpers/data")
-const {contract, web3, accounts} = require("@openzeppelin/test-environment")
-const {time} = require("@openzeppelin/test-helpers")
+const { contract, web3, accounts } = require("@openzeppelin/test-environment")
+const { time } = require("@openzeppelin/test-helpers")
 var assert = require('chai').assert
 const initContracts = require('../helpers/initContracts')
 const sign = require('../helpers/signature')
 const stakeDelegate = require('../helpers/stakeDelegate')
 const packTicket = require('../helpers/packTicket')
 const generateTickets = require('../helpers/generateTickets')
-const {createSnapshot, restoreSnapshot} = require("../helpers/snapshot.js")
+const { createSnapshot, restoreSnapshot } = require("../helpers/snapshot.js")
 
-describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
+describe('KeepRandomBeaconOperator/DkgMisbehavior', function () {
   let token, stakingContract, operatorContract,
     owner = accounts[0],
     operator1 = accounts[1],
@@ -26,7 +26,7 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     resultHash = web3.utils.soliditySha3(groupPubKey, misbehaved)
 
   before(async () => {
-    
+
     let contracts = await initContracts(
       contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
@@ -38,25 +38,21 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     token = contracts.token
     stakingContract = contracts.stakingContract
     operatorContract = contracts.operatorContract
-    operatorContract.setGroupSize(7, {from: owner})
-    operatorContract.setGroupThreshold(4, {from: owner})
-    
+    operatorContract.setGroupSize(5, { from: owner })
+    operatorContract.setGroupThreshold(3, { from: owner })
+
     let minimumStake = await stakingContract.minimumStake()
-    await stakeDelegate(stakingContract, token, owner, operator1, owner, authorizer, minimumStake, {from: owner})
-    await stakeDelegate(stakingContract, token, owner, operator2, owner, authorizer, minimumStake, {from: owner})
-    await stakeDelegate(stakingContract, token, owner, operator3, owner, authorizer, minimumStake, {from: owner})
-    await stakeDelegate(stakingContract, token, owner, operator4, owner, authorizer, minimumStake, {from: owner})
-    await stakeDelegate(stakingContract, token, owner, operator5, owner, authorizer, minimumStake, {from: owner})
-    await stakeDelegate(stakingContract, token, owner, operator6, owner, authorizer, minimumStake, {from: owner})
-    await stakeDelegate(stakingContract, token, owner, operator7, owner, authorizer, minimumStake, {from: owner})
-    
-    await stakingContract.authorizeOperatorContract(operator1, operatorContract.address, {from: authorizer})
-    await stakingContract.authorizeOperatorContract(operator2, operatorContract.address, {from: authorizer})
-    await stakingContract.authorizeOperatorContract(operator3, operatorContract.address, {from: authorizer})
-    await stakingContract.authorizeOperatorContract(operator4, operatorContract.address, {from: authorizer})
-    await stakingContract.authorizeOperatorContract(operator5, operatorContract.address, {from: authorizer})
-    await stakingContract.authorizeOperatorContract(operator6, operatorContract.address, {from: authorizer})
-    await stakingContract.authorizeOperatorContract(operator7, operatorContract.address, {from: authorizer})
+    await stakeDelegate(stakingContract, token, owner, operator1, owner, authorizer, minimumStake, { from: owner })
+    await stakeDelegate(stakingContract, token, owner, operator2, owner, authorizer, minimumStake, { from: owner })
+    await stakeDelegate(stakingContract, token, owner, operator3, owner, authorizer, minimumStake, { from: owner })
+    await stakeDelegate(stakingContract, token, owner, operator4, owner, authorizer, minimumStake, { from: owner })
+    await stakeDelegate(stakingContract, token, owner, operator5, owner, authorizer, minimumStake, { from: owner })
+
+    await stakingContract.authorizeOperatorContract(operator1, operatorContract.address, { from: authorizer })
+    await stakingContract.authorizeOperatorContract(operator2, operatorContract.address, { from: authorizer })
+    await stakingContract.authorizeOperatorContract(operator3, operatorContract.address, { from: authorizer })
+    await stakingContract.authorizeOperatorContract(operator4, operatorContract.address, { from: authorizer })
+    await stakingContract.authorizeOperatorContract(operator5, operatorContract.address, { from: authorizer })
 
     time.increase((await stakingContract.initializationPeriod()).addn(1));
 
@@ -66,42 +62,30 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     let tickets3 = generateTickets(groupSelectionRelayEntry, operator3, 1)
     let tickets4 = generateTickets(groupSelectionRelayEntry, operator4, 1)
     let tickets5 = generateTickets(groupSelectionRelayEntry, operator5, 1)
-    let tickets6 = generateTickets(groupSelectionRelayEntry, operator6, 1)
-    let tickets7 = generateTickets(groupSelectionRelayEntry, operator7, 1)
 
     await operatorContract.submitTicket(
       packTicket(tickets1[0].valueHex, tickets1[0].virtualStakerIndex, operator1),
-      {from: operator1}
+      { from: operator1 }
     )
 
     await operatorContract.submitTicket(
       packTicket(tickets2[0].valueHex, tickets2[0].virtualStakerIndex, operator2),
-      {from: operator2}
+      { from: operator2 }
     )
 
     await operatorContract.submitTicket(
       packTicket(tickets3[0].valueHex, tickets3[0].virtualStakerIndex, operator3),
-      {from: operator3}
+      { from: operator3 }
     )
 
     await operatorContract.submitTicket(
       packTicket(tickets4[0].valueHex, tickets4[0].virtualStakerIndex, operator4),
-      {from: operator4}
+      { from: operator4 }
     )
 
     await operatorContract.submitTicket(
       packTicket(tickets5[0].valueHex, tickets5[0].virtualStakerIndex, operator5),
-      {from: operator5}
-    )
-
-    await operatorContract.submitTicket(
-      packTicket(tickets6[0].valueHex, tickets6[0].virtualStakerIndex, operator6),
-      {from: operator6}
-    )
-
-    await operatorContract.submitTicket(
-      packTicket(tickets7[0].valueHex, tickets7[0].virtualStakerIndex, operator7),
-      {from: operator7}
+      { from: operator5 }
     )
 
     let ticketSubmissionStartBlock = await operatorContract.getTicketSubmissionStartBlock()
@@ -116,9 +100,9 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
     signingMemberIndices = []
     signatures = undefined
 
-    for(let i = 0; i < selectedParticipants.length; i++) {
+    for (let i = 0; i < selectedParticipants.length; i++) {
       let signature = await sign(resultHash, selectedParticipants[i])
-      signingMemberIndices.push(i+1)
+      signingMemberIndices.push(i + 1)
       if (signatures == undefined) signatures = signature
       else signatures += signature.slice(2, signature.length)
     }
@@ -133,14 +117,12 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function() {
   })
 
   it("should be able to save group members based on misbehaved data", async () => {
-    await operatorContract.submitDkgResult(1, groupPubKey, misbehaved, signatures, signingMemberIndices, {from: selectedParticipants[0]})
+    await operatorContract.submitDkgResult(1, groupPubKey, misbehaved, signatures, signingMemberIndices, { from: selectedParticipants[0] })
     let registeredMembers = await operatorContract.getGroupMembers(groupPubKey)
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[0]) != -1, "Member should be registered")
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[1]) != -1, "Member should be registered")
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[2]) == -1, "Member should not be registered")
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[3]) != -1, "Member should be registered")
     assert.isTrue(registeredMembers.indexOf(selectedParticipants[4]) == -1, "Member should not be registered")
-    assert.isTrue(registeredMembers.indexOf(selectedParticipants[5]) != -1, "Member should be registered")
-    assert.isTrue(registeredMembers.indexOf(selectedParticipants[6]) != -1, "Member should be registered")
   })
 })

--- a/solidity/test/random_beacon_operator/TestPublishDkgResult.js
+++ b/solidity/test/random_beacon_operator/TestPublishDkgResult.js
@@ -10,7 +10,7 @@ const { contract, accounts, web3 } = require("@openzeppelin/test-environment")
 const { expectRevert, time } = require("@openzeppelin/test-helpers")
 const stakeDelegate = require('../helpers/stakeDelegate')
 
-describe.only('KeepRandomBeaconOperator/PublishDkgResult', function () {
+describe('KeepRandomBeaconOperator/PublishDkgResult', function () {
 
   const groupSize = 20;
   const groupThreshold = 11;


### PR DESCRIPTION
Close https://github.com/keep-network/keep-core/issues/1585

In this PR we are increasing the DKG nofail signature threshold to 75%.  It gives us a 25% safety margin for relay entry signing.