### PR TITLE
Docker Publish: Contextual Tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,12 +144,12 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-client
-          tag: latest
+          tag: DOCKER_IMAGE_TAG
       - gcp-gcr/push-image:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-client
-          tag: latest
+          tag: DOCKER_IMAGE_TAG
   publish_contract_data:
     executor: gcp-cli/default
     steps:
@@ -267,7 +267,7 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-dapp-token-dashboard
-          tag: latest
+          tag: DOCKER_IMAGE_TAG
 
   generate_docs_tex:
     docker:
@@ -345,51 +345,51 @@ workflows:
   build-test-migrate-publish-keep-dev:
     jobs:
       - build_client_and_test_go:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
       - build_initcontainer:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_client_and_test_go
       - migrate_contracts:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
       - publish_npm_package:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_client_and_test_go
       - publish_keep_client:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - build_client_and_test_go
             - build_initcontainer
             - migrate_contracts
       - trigger_downstream_builds:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - publish_npm_package
       - publish_contract_data:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - build_client_and_test_go
@@ -403,9 +403,9 @@ workflows:
           requires:
             - publish_npm_package
       - publish_token_dashboard_dapp:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - build_token_dashboard_dapp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,8 +234,7 @@ jobs:
           name: Run Docker build
           working_directory: ~/project/solidity/dashboard
           command: |
-            docker build \
-              -t keep-dapp-token-dashboard:$DOCKER_IMAGE_TAG .
+            docker build --tag keep-dapp-token-dashboard .
       - run:
           name: Save keep-dapp-token-dashboard image
           working_directory: ~/project/solidity/dashboard
@@ -258,7 +257,7 @@ jobs:
       - run:
           name: Tag Docker image
           command: |
-            docker tag keep-dapp-token-dashboard $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-dapp-token-dashboard
+            docker tag keep-dapp-token-dashboard $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-dapp-token-dashboard:$DOCKER_IMAGE_TAG
       - gcp-gcr/gcr-auth:
           google-project-id: GOOGLE_PROJECT_ID
           google-compute-zone: GOOGLE_COMPUTE_ZONE_A
@@ -346,35 +345,35 @@ workflows:
   build-test-migrate-publish-keep-dev:
     jobs:
       - build_client_and_test_go:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
       - build_initcontainer:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_client_and_test_go
       - migrate_contracts:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
       - publish_npm_package:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_client_and_test_go
       - publish_keep_client:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: Run Docker build
           command: |
             docker build --build-arg GITHUB_TOKEN=$GITHUB_TOKEN --target gobuild -t go-build-env .
-            docker build --build-arg GITHUB_TOKEN=$GITHUB_TOKEN -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client .
+            docker build --build-arg GITHUB_TOKEN=$GITHUB_TOKEN -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client:$DOCKER_IMAGE_TAG .
       - run:
           name: Run Go tests
           command: |
@@ -74,7 +74,7 @@ jobs:
           name: Save keep-client image
           command: |
             mkdir -p /tmp/keep-client/docker-images
-            docker save -o /tmp/keep-client/docker-images/keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client
+            docker save -o /tmp/keep-client/docker-images/keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client:$DOCKER_IMAGE_TAG
       - persist_to_workspace:
           root: /tmp/keep-client
           paths:
@@ -93,11 +93,11 @@ jobs:
             cp /tmp/keep-client/contracts/* infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
             cd infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
             docker build \
-              -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client .
+              -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client:$DOCKER_IMAGE_TAG .
       - run:
           name: Save initcontainer-provision-keep-client image
           command: |
-            docker save -o /tmp/keep-client/docker-images/initcontainer-provision-keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client
+            docker save -o /tmp/keep-client/docker-images/initcontainer-provision-keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client:$DOCKER_IMAGE_TAG
       - persist_to_workspace:
           root: /tmp/keep-client
           paths:
@@ -144,12 +144,12 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-client
-          tag: DOCKER_IMAGE_TAG
+          tag: $DOCKER_IMAGE_TAG
       - gcp-gcr/push-image:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-client
-          tag: DOCKER_IMAGE_TAG
+          tag: $DOCKER_IMAGE_TAG
   publish_contract_data:
     executor: gcp-cli/default
     steps:
@@ -234,7 +234,8 @@ jobs:
           name: Run Docker build
           working_directory: ~/project/solidity/dashboard
           command: |
-            docker build --tag keep-dapp-token-dashboard .
+            docker build \
+              -t keep-dapp-token-dashboard:$DOCKER_IMAGE_TAG .
       - run:
           name: Save keep-dapp-token-dashboard image
           working_directory: ~/project/solidity/dashboard
@@ -267,7 +268,7 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-dapp-token-dashboard
-          tag: DOCKER_IMAGE_TAG
+          tag: $DOCKER_IMAGE_TAG
 
   generate_docs_tex:
     docker:


### PR DESCRIPTION
### Intro

We've been rolling on `latest` image publishes across our keep-dev and keep-test environments for awhile.  While this is fine for our dev environment, it's time we work against properly versioned images for our test/Ropsten environment.

### What we did

Circle builds that run against a git tag generate a Circle env var `CIRCLE_TAG`.  This is perfect for our Docker image tagging needs.  However, the `CIRCLE_TAG` enviroment variable isn't generated for builds that don't run on a tag.  e.g. all keep-dev / master builds.  We already use environment based Circle contexts to factor out environment specific configs from the Circle config space, so it's a natural fit to handle this in the same way.  The Circle Context environment variable is `DOCKER_IMAGE_TAG`.  For keep-dev it's set to `latest`, and for keep-test it's set to `$CIRCLE_TAG`.

### Test build

https://app.circleci.com/pipelines/github/keep-network/keep-core/6356/workflows/8a1eeca1-6605-4243-b842-8efa9969891a