### PR TITLE
Add stake-timeout flag to keep-client start

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/config"
@@ -19,7 +20,10 @@ import (
 )
 
 // StartCommand contains the definition of the start command-line subcommand.
-var StartCommand cli.Command
+var (
+	StartCommand cli.Command
+	logger       = log.Logger("keep-start")
+)
 
 const (
 	bootstrapFlag     = "bootstrap"
@@ -178,7 +182,7 @@ func waitForStake(stakeMonitor chain.StakeMonitor, address string, timeout int) 
 		if hasMinimumStake {
 			return nil
 		}
-		fmt.Printf("%s stake is below required minimum, wait duration: %d minutes \n", address, waitMins)
+		logger.Infof("below min stake for %d min \n", address, waitMins)
 		time.Sleep(time.Minute)
 		waitMins++
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -22,10 +22,11 @@ import (
 var StartCommand cli.Command
 
 const (
-	bootstrapFlag    = "bootstrap"
-	portFlag         = "port"
-	portShort        = "p"
-	stakeTimeoutFlag = "stake-timeout"
+	bootstrapFlag     = "bootstrap"
+	portFlag          = "port"
+	portShort         = "p"
+	waitForStakeFlag  = "wait-for-stake"
+	waitForStakeShort = "w"
 )
 
 const startDescription = `Starts the Keep client in the foreground. Currently this only consists of the
@@ -43,7 +44,7 @@ func init() {
 					Name: portFlag + "," + portShort,
 				},
 				&cli.IntFlag{
-					Name: stakeTimeoutFlag,
+					Name: waitForStakeFlag + "," + waitForStakeShort,
 				},
 			},
 		}
@@ -85,8 +86,8 @@ func Start(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("error obtaining stake monitor handle [%v]", err)
 	}
-	if c.Int(stakeTimeoutFlag) != 0 {
-		err = waitForStake(stakeMonitor, config.Ethereum.Account.Address, c.Int(stakeTimeoutFlag))
+	if c.Int(waitForStakeFlag) != 0 {
+		err = waitForStake(stakeMonitor, config.Ethereum.Account.Address, c.Int(waitForStakeFlag))
 		if err != nil {
 			return err
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -182,7 +182,7 @@ func waitForStake(stakeMonitor chain.StakeMonitor, address string, timeout int) 
 		if hasMinimumStake {
 			return nil
 		}
-		logger.Infof("below min stake for %d min \n", address, waitMins)
+		logger.Warningf("below min stake for %d min \n", address, waitMins)
 		time.Sleep(time.Minute)
 		waitMins++
 	}


### PR DESCRIPTION
Currently, the keep client immediately exits unsuccessfully if the operator address does not meet the following conditions:
- operator address in the configuration is correct and it has KEEP tokens delegated
- operator contract has been authorized to operate on stake

This is not ideal for certain use cases. To handle those use cases I would like the node to wait for a specified amount of time to allow the address to meet the conditions above before crashing.

This PR adds a `-w`/`--wait-for-stake` integer flag which will cause the node to crash after that number of minutes if the address is still in violation of any conditions listed above. Until the stake is found or the timeout is reached, every minute the node will log a WARN-level message about the missing stake.

If the flag is omitted, the start function will follow the same code path as before. 

Running the client using an operator address with no stake produces the following output:
```
keep-client --config /root/config/keep-client-config.toml start --stake-timeout 3
04:02:43.701 DEBUG keep-block: subscribing to new blocks blockcounter.go:163
0x87ea311606Cc04d86e956CcD7cc0926ea40dbf54 stake is below required minimum, wait duration: 0 minutes
0x87ea311606Cc04d86e956CcD7cc0926ea40dbf54 stake is below required minimum, wait duration: 1 minutes
0x87ea311606Cc04d86e956CcD7cc0926ea40dbf54 stake is below required minimum, wait duration: 2 minutes
04:08:44.913 CRITI  keep-main: timed out waiting for 0x87ea311606Cc04d86e956CcD7cc0926ea40dbf54 to have required minimum stake main.go:77
```
 