### PR TITLE
Events tracking functionality

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -80,7 +80,7 @@ func Initialize(
 				if ok := pendingRelayRequests.Add(previousEntry); !ok {
 					logger.Errorf(
 						"relay entry requested event with previous entry [0x%x] has been registered already",
-						previousEntry,
+						request.PreviousEntry,
 					)
 					return
 				}
@@ -133,7 +133,7 @@ func Initialize(
 			if ok := pendingGroupSelections.Add(newEntry); !ok {
 				logger.Errorf(
 					"group selection event with seed [0x%x] has been registered already",
-					newEntry,
+					event.NewEntry,
 				)
 				return
 			}
@@ -142,7 +142,7 @@ func Initialize(
 
 			logger.Infof(
 				"group selection started with seed [0x%x] at block [%v]",
-				newEntry,
+				event.NewEntry,
 				event.BlockNumber,
 			)
 

--- a/pkg/beacon/relay/event/events_tracking.go
+++ b/pkg/beacon/relay/event/events_tracking.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// GroupSelectionTrack is used to track a start of group selection after GroupSelectionStarted
+// GroupSelectionTrack is used to track a start for group selection after GroupSelectionStarted
 // event is received. It is used to ensure that the process execution
 // is not duplicated, i.e. when the client receives the same event multiple times.
 // When event is received, it should be added in this struct. When a group
@@ -38,7 +38,7 @@ func (gst *GroupSelectionTrack) Remove(entry string) {
 	delete(gst.Data, entry)
 }
 
-// RelayRequestTrack is used to track requests of new entriees after RelayEntryRequested
+// RelayRequestTrack is used to track requests for new entries after RelayEntryRequested
 // event is received. It is used to ensure that the process execution
 // is not duplicated, i.e. when the client receives the same event multiple times.
 // When event is received, it should be added in this struct. When a new entry

--- a/pkg/beacon/relay/event/events_tracking.go
+++ b/pkg/beacon/relay/event/events_tracking.go
@@ -1,0 +1,73 @@
+package event
+
+import (
+	"sync"
+)
+
+// GroupSelectionTrack is used to track a start of group selection after GroupSelectionStarted
+// event is received. It is used to ensure that the process execution
+// is not duplicated, i.e. when the client receives the same event multiple times.
+// When event is received, it should be added in this struct. When a group
+// selection process completes (no matter if it succeeded or failed), it should
+// be removed from this struct.
+type GroupSelectionTrack struct {
+	Data  map[string]bool // <entry, bool>
+	Mutex *sync.Mutex
+}
+
+// Add inserts a new entry into a map that reflects whether a new group selection
+// has already started using an entry as a seed.
+func (gst *GroupSelectionTrack) Add(entry string) bool {
+	gst.Mutex.Lock()
+	defer gst.Mutex.Unlock()
+
+	if gst.Data[entry] {
+		return false
+	}
+
+	gst.Data[entry] = true
+
+	return true
+}
+
+// Remove clears a map from an entry that was used to start a group selection.
+func (gst *GroupSelectionTrack) Remove(entry string) {
+	gst.Mutex.Lock()
+	defer gst.Mutex.Unlock()
+
+	delete(gst.Data, entry)
+}
+
+// RelayRequestTrack is used to track requests of new entriees after RelayEntryRequested
+// event is received. It is used to ensure that the process execution
+// is not duplicated, i.e. when the client receives the same event multiple times.
+// When event is received, it should be added in this struct. When a new entry
+// generation process completes (no matter if it succeeded or failed), it should
+// be removed from this struct.
+type RelayRequestTrack struct {
+	Data  map[string]bool // <previousEntry, bool>
+	Mutex *sync.Mutex
+}
+
+// Add inserts a previous entry into a map that reflects whether a new relay entry
+// has already been requested.
+func (rrt *RelayRequestTrack) Add(previousEntry string) bool {
+	rrt.Mutex.Lock()
+	defer rrt.Mutex.Unlock()
+
+	if rrt.Data[previousEntry] {
+		return false
+	}
+
+	rrt.Data[previousEntry] = true
+
+	return true
+}
+
+// Remove clears a map from a previous entry.
+func (rrt *RelayRequestTrack) Remove(previousEntry string) {
+	rrt.Mutex.Lock()
+	defer rrt.Mutex.Unlock()
+
+	delete(rrt.Data, previousEntry)
+}

--- a/pkg/beacon/relay/event/events_tracking_test.go
+++ b/pkg/beacon/relay/event/events_tracking_test.go
@@ -1,0 +1,80 @@
+package event
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGroupSelectionTrack_Add(t *testing.T) {
+	type groupSelected struct {
+		Data  map[string]bool
+		Mutex *sync.Mutex
+	}
+	tests := map[string]struct {
+		groupSelected groupSelected
+		arg           string
+		expected      bool
+	}{
+		"adding unique entry key": {
+			groupSelected: groupSelected{Data: make(map[string]bool), Mutex: &sync.Mutex{}},
+			arg:           "0x123456",
+			expected:      true,
+		},
+		"adding unique entry key to non-empty map": {
+			groupSelected: groupSelected{Data: map[string]bool{"0x123456": true}, Mutex: &sync.Mutex{}},
+			arg:           "0x7891011",
+			expected:      true,
+		},
+		"adding existing entry key": {
+			groupSelected: groupSelected{Data: map[string]bool{"0x123456": true}, Mutex: &sync.Mutex{}},
+			arg:           "0x123456",
+			expected:      false,
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			gst := &GroupSelectionTrack{
+				Data:  test.groupSelected.Data,
+				Mutex: test.groupSelected.Mutex,
+			}
+			if actual := gst.Add(test.arg); actual != test.expected {
+				t.Errorf("GroupSelectionTrack.Add() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGroupSelectionTrack_Remove(t *testing.T) {
+	type groupSelected struct {
+		Data  map[string]bool
+		Mutex *sync.Mutex
+	}
+	tests := map[string]struct {
+		groupSelected groupSelected
+		arg           string
+		expected      bool
+	}{
+		"adding same entry key after removing it from the map": {
+			groupSelected: groupSelected{Data: map[string]bool{"0x123456": true}, Mutex: &sync.Mutex{}},
+			arg:           "0x123456",
+			expected:      true,
+		},
+		"removing from the empty map": {
+			groupSelected: groupSelected{Data: make(map[string]bool), Mutex: &sync.Mutex{}},
+			arg:           "0x123456",
+			expected:      true,
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			gst := &GroupSelectionTrack{
+				Data:  test.groupSelected.Data,
+				Mutex: test.groupSelected.Mutex,
+			}
+			gst.Remove(test.arg)
+			if actual := gst.Add(test.arg); actual != test.expected {
+				t.Errorf("GroupSelectionTrack.Remove() should have removed entry %v", test.arg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1608

In this PR we add tracking functionality for `GroupSelectionStarted` and `RelayEntryRequested` events. In prevents from receiving duplicate events that sometimes happen during the Infura deployment.