### PR TITLE
Firewall: define your own rules for connections with remote peers

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
@@ -82,7 +83,7 @@ func pingRequest(c *cli.Context) error {
 		ctx,
 		libp2pConfig,
 		privKey,
-		net.NoFirewall,
+		firewall.Disabled,
 		retransmission.NewTimeTicker(ctx, 50*time.Millisecond),
 	)
 	if err != nil {

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
-	"github.com/keep-network/keep-core/pkg/chain/local"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
@@ -70,17 +69,8 @@ func pingRequest(c *cli.Context) error {
 		privKey      *key.NetworkPrivate
 	)
 
-	bootstrapPeerPrivKey, bootstrapPeerPubKey := getBootstrapPeerNetworkKey()
-	standardPeerPrivKey, standardPeerPubKey := getStandardPeerNetworkKey()
-
-	stakeMonitor := local.NewStakeMonitor(big.NewInt(200))
-
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(
-		bootstrapPeerPubKey,
-	))
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(
-		standardPeerPubKey,
-	))
+	bootstrapPeerPrivKey, _ := getBootstrapPeerNetworkKey()
+	standardPeerPrivKey, _ := getStandardPeerNetworkKey()
 
 	if isBootstrapNode {
 		privKey = bootstrapPeerPrivKey
@@ -92,7 +82,7 @@ func pingRequest(c *cli.Context) error {
 		ctx,
 		libp2pConfig,
 		privKey,
-		stakeMonitor,
+		net.NoFirewall,
 		retransmission.NewTimeTicker(ctx, 50*time.Millisecond),
 	)
 	if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/beacon"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum"
+	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
@@ -97,7 +98,7 @@ func Start(c *cli.Context) error {
 		ctx,
 		config.LibP2P,
 		networkPrivateKey,
-		stakeMonitor,
+		firewall.MinimumStakePolicy(stakeMonitor),
 		retransmission.NewTicker(blockCounter.WatchBlocks(ctx)),
 	)
 	if err != nil {

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -9,6 +9,16 @@ import (
 	"github.com/keep-network/keep-core/pkg/net/key"
 )
 
+// Disabled is an empty Firewall implementation enforcing no rules
+// on the connection.
+var Disabled = &noFirewall{}
+
+type noFirewall struct{}
+
+func (nf *noFirewall) Validate(remotePeerPublicKey *ecdsa.PublicKey) error {
+	return nil
+}
+
 // MinimumStakePolicy is a net.Firewall rule making sure the remote peer
 // has a minimum stake of KEEP.
 func MinimumStakePolicy(stakeMonitor chain.StakeMonitor) net.Firewall {

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -1,0 +1,41 @@
+package firewall
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/net/key"
+)
+
+// MinimumStakePolicy is a net.Firewall rule making sure the remote peer
+// has a minimum stake of KEEP.
+func MinimumStakePolicy(stakeMonitor chain.StakeMonitor) net.Firewall {
+	return &minimumStakePolicy{stakeMonitor: stakeMonitor}
+}
+
+type minimumStakePolicy struct {
+	stakeMonitor chain.StakeMonitor
+}
+
+func (msp *minimumStakePolicy) Validate(
+	remotePeerPublicKey *ecdsa.PublicKey,
+) error {
+	networkPublicKey := key.NetworkPublic(*remotePeerPublicKey)
+	hasMinimumStake, err := msp.stakeMonitor.HasMinimumStake(
+		key.NetworkPubKeyToEthAddress(&networkPublicKey),
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"could not validate remote peer's minimum stake: [%v]",
+			err,
+		)
+	}
+
+	if !hasMinimumStake {
+		return fmt.Errorf("remote peer has no minimum stake")
+	}
+
+	return nil
+}

--- a/pkg/net/key/ethereum_key.go
+++ b/pkg/net/key/ethereum_key.go
@@ -1,6 +1,7 @@
 package key
 
 import (
+	"crypto/ecdsa"
 	"crypto/elliptic"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -76,4 +77,10 @@ func Libp2pKeyToNetworkKey(publicKey libp2pcrypto.PubKey) *NetworkPublic {
 		return (*NetworkPublic)(networkKey)
 	}
 	return nil
+}
+
+// NetworkKeyToECDSAKey takes the public NetworkKey and turns it into
+// ecdsa.PublicKey from Go standard library.
+func NetworkKeyToECDSAKey(publicKey *NetworkPublic) *ecdsa.PublicKey {
+	return (*btcec.PublicKey)(publicKey).ToECDSA()
 }

--- a/pkg/net/libp2p/authenticated_connection.go
+++ b/pkg/net/libp2p/authenticated_connection.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/keep-network/keep-core/pkg/chain"
+	keepNet "github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/gen/pb"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/security/handshake"
@@ -30,7 +30,7 @@ type authenticatedConnection struct {
 	remotePeerID        peer.ID
 	remotePeerPublicKey libp2pcrypto.PubKey
 
-	stakeMonitor chain.StakeMonitor
+	firewall keepNet.Firewall
 }
 
 // newAuthenticatedInboundConnection is the connection that's formed by
@@ -43,13 +43,13 @@ func newAuthenticatedInboundConnection(
 	unauthenticatedConn net.Conn,
 	localPeerID peer.ID,
 	privateKey libp2pcrypto.PrivKey,
-	stakeMonitor chain.StakeMonitor,
+	firewall keepNet.Firewall,
 ) (*authenticatedConnection, error) {
 	ac := &authenticatedConnection{
 		Conn:                unauthenticatedConn,
 		localPeerID:         localPeerID,
 		localPeerPrivateKey: privateKey,
-		stakeMonitor:        stakeMonitor,
+		firewall:            firewall,
 	}
 
 	if err := ac.runHandshakeAsResponder(); err != nil {
@@ -59,17 +59,9 @@ func newAuthenticatedInboundConnection(
 		return nil, fmt.Errorf("connection handshake failed [%v]", err)
 	}
 
-	hasMinimumStake, err := ac.checkRemotePeerStake()
-	if err != nil {
+	if err := ac.checkFirewallRules(); err != nil {
 		ac.Close()
-		return nil, fmt.Errorf("connection handshake failed [%v]", err)
-	}
-
-	if !hasMinimumStake {
-		ac.Close()
-		return nil, fmt.Errorf(
-			"connection handshake failed - remote peer has no minimum stake",
-		)
+		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
 	}
 
 	return ac, nil
@@ -85,7 +77,7 @@ func newAuthenticatedOutboundConnection(
 	localPeerID peer.ID,
 	privateKey libp2pcrypto.PrivKey,
 	remotePeerID peer.ID,
-	stakeMonitor chain.StakeMonitor,
+	firewall keepNet.Firewall,
 ) (*authenticatedConnection, error) {
 	remotePublicKey, err := remotePeerID.ExtractPublicKey()
 	if err != nil {
@@ -101,7 +93,7 @@ func newAuthenticatedOutboundConnection(
 		localPeerPrivateKey: privateKey,
 		remotePeerID:        remotePeerID,
 		remotePeerPublicKey: remotePublicKey,
-		stakeMonitor:        stakeMonitor,
+		firewall:            firewall,
 	}
 
 	if err := ac.runHandshakeAsInitiator(); err != nil {
@@ -109,31 +101,21 @@ func newAuthenticatedOutboundConnection(
 		return nil, fmt.Errorf("connection handshake failed [%v]", err)
 	}
 
-	hasMinimumStake, err := ac.checkRemotePeerStake()
-	if err != nil {
+	if err := ac.checkFirewallRules(); err != nil {
 		ac.Close()
-		return nil, fmt.Errorf("connection handshake failed [%v]", err)
-	}
-
-	if !hasMinimumStake {
-		ac.Close()
-		return nil, fmt.Errorf(
-			"connection handshake failed - remote peer has no minimum stake",
-		)
+		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
 	}
 
 	return ac, nil
 }
 
-func (ac *authenticatedConnection) checkRemotePeerStake() (bool, error) {
+func (ac *authenticatedConnection) checkFirewallRules() error {
 	networkKey, ok := ac.remotePeerPublicKey.(*key.NetworkPublic)
 	if !ok {
-		return false, fmt.Errorf("unexpected type of remote peer's public key")
+		return fmt.Errorf("unexpected type of remote peer's public key")
 	}
 
-	return ac.stakeMonitor.HasMinimumStake(
-		key.NetworkPubKeyToEthAddress(networkKey),
-	)
+	return ac.firewall.Validate(key.NetworkKeyToECDSAKey(networkKey))
 }
 
 func (ac *authenticatedConnection) runHandshakeAsInitiator() error {

--- a/pkg/net/libp2p/authenticated_connection_test.go
+++ b/pkg/net/libp2p/authenticated_connection_test.go
@@ -2,17 +2,16 @@ package libp2p
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"io"
-	"math/big"
 	"net"
 	"reflect"
 	"testing"
 	"time"
 
 	protoio "github.com/gogo/protobuf/io"
-	"github.com/keep-network/keep-core/pkg/chain"
-	"github.com/keep-network/keep-core/pkg/chain/local"
+	keepNet "github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/gen/pb"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/security/handshake"
@@ -24,9 +23,9 @@ func TestPinnedAndMessageKeyMismatch(t *testing.T) {
 	initiator := createTestConnectionConfig(t)
 	responder := createTestConnectionConfig(t)
 
-	stakeMonitor := local.NewStakeMonitor(big.NewInt(200))
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(initiator.pubKey))
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(responder.pubKey))
+	firewall := newMockFirewall()
+	firewall.updatePeer(initiator.pubKey, true)
+	firewall.updatePeer(responder.pubKey, true)
 
 	initiatorConn, responderConn := newConnPair()
 
@@ -53,7 +52,7 @@ func TestPinnedAndMessageKeyMismatch(t *testing.T) {
 		responderConn,
 		responder.peerID,
 		responder.privKey,
-		stakeMonitor,
+		firewall,
 	)
 	if err == nil {
 		t.Fatal("should not have successfully completed handshake")
@@ -123,12 +122,12 @@ func TestHandshake(t *testing.T) {
 	initiator := createTestConnectionConfig(t)
 	responder := createTestConnectionConfig(t)
 
-	stakeMonitor := local.NewStakeMonitor(big.NewInt(200))
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(initiator.pubKey))
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(responder.pubKey))
+	firewall := newMockFirewall()
+	firewall.updatePeer(initiator.pubKey, true)
+	firewall.updatePeer(responder.pubKey, true)
 
 	authnInboundConn, authnOutboundConn, inboundError, outboundError :=
-		connectInitiatorAndResponder(initiator, responder, stakeMonitor, t)
+		connectInitiatorAndResponder(initiator, responder, firewall, t)
 	if inboundError != nil {
 		t.Fatal(inboundError)
 	}
@@ -154,25 +153,25 @@ func TestHandshake(t *testing.T) {
 	}
 }
 
-func TestHandshakeNoInitiatorStake(t *testing.T) {
+func TestHandshakeInitiatorBlockedByFirewallRules(t *testing.T) {
 	_, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	initiator := createTestConnectionConfig(t)
 	responder := createTestConnectionConfig(t)
 
-	stakeMonitor := local.NewStakeMonitor(big.NewInt(200))
-	// only responder is staked
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(responder.pubKey))
+	firewall := newMockFirewall()
+	// only responder meets firewall rules
+	firewall.updatePeer(responder.pubKey, true)
 
 	_, _, inboundError, outboundError :=
-		connectInitiatorAndResponder(initiator, responder, stakeMonitor, t)
+		connectInitiatorAndResponder(initiator, responder, firewall, t)
 
 	if inboundError != nil {
 		t.Fatal(inboundError)
 	}
 
-	expectedOutboundError := fmt.Errorf("connection handshake failed - remote peer has no minimum stake")
+	expectedOutboundError := fmt.Errorf("connection handshake failed: [remote peer does not meet firewall criteria]")
 	if !reflect.DeepEqual(expectedOutboundError, outboundError) {
 		t.Fatalf(
 			"unexpected outbound connection error\nexpected: %v\nactual: %v",
@@ -182,21 +181,21 @@ func TestHandshakeNoInitiatorStake(t *testing.T) {
 	}
 }
 
-func TestHandshakeNoResponderStake(t *testing.T) {
+func TestHandshakeResponderBlockedByFirewallRules(t *testing.T) {
 	_, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	initiator := createTestConnectionConfig(t)
 	responder := createTestConnectionConfig(t)
 
-	stakeMonitor := local.NewStakeMonitor(big.NewInt(200))
-	// only initiator is staked
-	stakeMonitor.StakeTokens(key.NetworkPubKeyToEthAddress(initiator.pubKey))
+	firewall := newMockFirewall()
+	// only initiator meets firewall rules
+	firewall.updatePeer(initiator.pubKey, true)
 
 	_, _, inboundError, outboundError :=
-		connectInitiatorAndResponder(initiator, responder, stakeMonitor, t)
+		connectInitiatorAndResponder(initiator, responder, firewall, t)
 
-	expectedInboundError := fmt.Errorf("connection handshake failed - remote peer has no minimum stake")
+	expectedInboundError := fmt.Errorf("connection handshake failed: [remote peer does not meet firewall criteria]")
 	if !reflect.DeepEqual(expectedInboundError, inboundError) {
 		t.Fatalf(
 			"unexpected outbound connection error\nexpected: %v\nactual: %v",
@@ -213,7 +212,7 @@ func TestHandshakeNoResponderStake(t *testing.T) {
 func connectInitiatorAndResponder(
 	initiator *testConnectionConfig,
 	responder *testConnectionConfig,
-	stakeMonitor chain.StakeMonitor,
+	firewall keepNet.Firewall,
 	t *testing.T,
 ) (
 	authnInboundConn *authenticatedConnection,
@@ -237,7 +236,7 @@ func connectInitiatorAndResponder(
 			initiatorPeerID,
 			initiatorPrivKey,
 			responderPeerID,
-			stakeMonitor,
+			firewall,
 		)
 		done <- struct{}{}
 	}(initiatorConn, initiator.peerID, initiator.privKey, responder.peerID)
@@ -246,7 +245,7 @@ func connectInitiatorAndResponder(
 		responderConn,
 		responder.peerID,
 		responder.privKey,
-		stakeMonitor,
+		firewall,
 	)
 
 	<-done // handshake is done
@@ -277,4 +276,29 @@ func createTestConnectionConfig(t *testing.T) *testConnectionConfig {
 // on one end should be matched with writes on the other).
 func newConnPair() (net.Conn, net.Conn) {
 	return net.Pipe()
+}
+
+func newMockFirewall() *mockFirewall {
+	return &mockFirewall{
+		meetsCriteria: make(map[uint64]bool),
+	}
+}
+
+type mockFirewall struct {
+	meetsCriteria map[uint64]bool
+}
+
+func (mf *mockFirewall) Validate(remotePeerPublicKey *ecdsa.PublicKey) error {
+	if !mf.meetsCriteria[remotePeerPublicKey.X.Uint64()] {
+		return fmt.Errorf("remote peer does not meet firewall criteria")
+	}
+	return nil
+}
+
+func (mf *mockFirewall) updatePeer(
+	remotePeerPublicKey *key.NetworkPublic,
+	meetsCriteria bool,
+) {
+	x := key.NetworkKeyToECDSAKey(remotePeerPublicKey).X.Uint64()
+	mf.meetsCriteria[x] = meetsCriteria
 }

--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/btcsuite/btcd/btcec"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/gen/pb"
@@ -357,5 +355,5 @@ func extractPublicKey(peer peer.ID) (*ecdsa.PublicKey, error) {
 		return nil, fmt.Errorf("public key is of type other than Secp256k1")
 	}
 
-	return (*btcec.PublicKey)(secp256k1PublicKey).ToECDSA(), nil
+	return key.NetworkKeyToECDSAKey(secp256k1PublicKey), nil
 }

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -52,7 +52,7 @@ const (
 const (
 	// FirewallCheckTick is the amount of time between periodic checks of all
 	// firewall rules against all peers connected to this one.
-	FirewallCheckTick = time.Minute * 1
+	FirewallCheckTick = time.Minute * 10
 	// BootstrapCheckPeriod is the amount of time between periodic checks
 	// for ensuring we are connected to an appropriate number of bootstrap
 	// peers.

--- a/pkg/net/libp2p/libp2p_test.go
+++ b/pkg/net/libp2p/libp2p_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
@@ -27,7 +28,7 @@ func TestProviderReturnsType(t *testing.T) {
 		ctx,
 		generateDeterministicNetworkConfig(),
 		privKey,
-		net.NoFirewall,
+		firewall.Disabled,
 		idleTicker(),
 	)
 	if err != nil {
@@ -57,7 +58,7 @@ func TestProviderReturnsChannel(t *testing.T) {
 		ctx,
 		generateDeterministicNetworkConfig(),
 		privKey,
-		net.NoFirewall,
+		firewall.Disabled,
 		idleTicker(),
 	)
 	if err != nil {
@@ -96,7 +97,7 @@ func TestSendReceive(t *testing.T) {
 		ctx,
 		config,
 		privKey,
-		net.NoFirewall,
+		firewall.Disabled,
 		idleTicker(),
 	)
 	if err != nil {
@@ -171,7 +172,7 @@ func TestProviderSetAnnouncedAddresses(t *testing.T) {
 		ctx,
 		config,
 		privateKey,
-		net.NoFirewall,
+		firewall.Disabled,
 		idleTicker(),
 	)
 	if err != nil {

--- a/pkg/net/libp2p/libp2p_test.go
+++ b/pkg/net/libp2p/libp2p_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/keep-network/keep-core/pkg/chain/local"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
@@ -29,7 +27,7 @@ func TestProviderReturnsType(t *testing.T) {
 		ctx,
 		generateDeterministicNetworkConfig(),
 		privKey,
-		local.NewStakeMonitor(big.NewInt(200)),
+		net.NoFirewall,
 		idleTicker(),
 	)
 	if err != nil {
@@ -59,7 +57,7 @@ func TestProviderReturnsChannel(t *testing.T) {
 		ctx,
 		generateDeterministicNetworkConfig(),
 		privKey,
-		local.NewStakeMonitor(big.NewInt(200)),
+		net.NoFirewall,
 		idleTicker(),
 	)
 	if err != nil {
@@ -98,7 +96,7 @@ func TestSendReceive(t *testing.T) {
 		ctx,
 		config,
 		privKey,
-		local.NewStakeMonitor(big.NewInt(200)),
+		net.NoFirewall,
 		idleTicker(),
 	)
 	if err != nil {
@@ -173,7 +171,7 @@ func TestProviderSetAnnouncedAddresses(t *testing.T) {
 		ctx,
 		config,
 		privateKey,
-		local.NewStakeMonitor(big.NewInt(200)),
+		net.NoFirewall,
 		idleTicker(),
 	)
 	if err != nil {

--- a/pkg/net/libp2p/transport.go
+++ b/pkg/net/libp2p/transport.go
@@ -6,7 +6,7 @@ import (
 
 	secio "github.com/libp2p/go-libp2p-secio"
 
-	"github.com/keep-network/keep-core/pkg/chain"
+	keepNet "github.com/keep-network/keep-core/pkg/net"
 	libp2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"
@@ -24,13 +24,13 @@ var _ sec.SecureConn = (*authenticatedConnection)(nil)
 type transport struct {
 	localPeerID     peer.ID
 	privateKey      libp2pcrypto.PrivKey
-	stakeMonitor    chain.StakeMonitor
+	firewall        keepNet.Firewall
 	encryptionLayer sec.SecureTransport
 }
 
 func newEncryptedAuthenticatedTransport(
 	pk libp2pcrypto.PrivKey,
-	stakeMonitor chain.StakeMonitor,
+	firewall keepNet.Firewall,
 ) (*transport, error) {
 	id, err := peer.IDFromPrivateKey(pk)
 	if err != nil {
@@ -45,7 +45,7 @@ func newEncryptedAuthenticatedTransport(
 	return &transport{
 		localPeerID:     id,
 		privateKey:      pk,
-		stakeMonitor:    stakeMonitor,
+		firewall:        firewall,
 		encryptionLayer: encryptionLayer,
 	}, nil
 }
@@ -64,7 +64,7 @@ func (t *transport) SecureInbound(
 		encryptedConnection,
 		t.localPeerID,
 		t.privateKey,
-		t.stakeMonitor,
+		t.firewall,
 	)
 }
 
@@ -88,6 +88,6 @@ func (t *transport) SecureOutbound(
 		t.localPeerID,
 		t.privateKey,
 		remotePeerID,
-		t.stakeMonitor,
+		t.firewall,
 	)
 }

--- a/pkg/net/libp2p/unicast_channel_test.go
+++ b/pkg/net/libp2p/unicast_channel_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
 
 	"github.com/keep-network/keep-core/pkg/net"
@@ -196,7 +197,7 @@ func withNetwork(
 			Port: 8081,
 		},
 		privKey1,
-		net.NoFirewall,
+		firewall.Disabled,
 		retransmission.NewTicker(make(chan uint64)),
 	)
 	if err != nil {
@@ -215,7 +216,7 @@ func withNetwork(
 			Port: 8082,
 		},
 		privKey2,
-		net.NoFirewall,
+		firewall.Disabled,
 		retransmission.NewTicker(make(chan uint64)),
 	)
 	if err != nil {

--- a/pkg/net/libp2p/unicast_channel_test.go
+++ b/pkg/net/libp2p/unicast_channel_test.go
@@ -2,13 +2,11 @@ package libp2p
 
 import (
 	"context"
-	"math/big"
 	"testing"
 	"time"
 
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
 
-	"github.com/keep-network/keep-core/pkg/chain/local"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/multiformats/go-multiaddr"
@@ -186,8 +184,6 @@ func withNetwork(
 		t.Fatal(err)
 	}
 
-	stakeMonitor := local.NewStakeMonitor(big.NewInt(0))
-
 	provider1, err := Connect(
 		ctx,
 		Config{
@@ -200,7 +196,7 @@ func withNetwork(
 			Port: 8081,
 		},
 		privKey1,
-		stakeMonitor,
+		net.NoFirewall,
 		retransmission.NewTicker(make(chan uint64)),
 	)
 	if err != nil {
@@ -219,7 +215,7 @@ func withNetwork(
 			Port: 8082,
 		},
 		privKey2,
-		stakeMonitor,
+		net.NoFirewall,
 		retransmission.NewTicker(make(chan uint64)),
 	)
 	if err != nil {

--- a/pkg/net/local/local.go
+++ b/pkg/net/local/local.go
@@ -105,7 +105,7 @@ type localConnectionManager struct {
 func (lcm *localConnectionManager) ConnectedPeers() []string {
 	lcm.mutex.Lock()
 	defer lcm.mutex.Unlock()
-	connectedPeers := make([]string, len(lcm.peers))
+	var connectedPeers []string
 	for peer := range lcm.peers {
 		connectedPeers = append(connectedPeers, peer)
 	}

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -166,13 +166,3 @@ type Firewall interface {
 	// describing what is wrong.
 	Validate(remotePeerPublicKey *ecdsa.PublicKey) error
 }
-
-// NoFirewall is an empty Firewall implementation enforcing no rules
-// on the connection.
-var NoFirewall = &noFirewall{}
-
-type noFirewall struct{}
-
-func (nf *noFirewall) Validate(remotePeerPublicKey *ecdsa.PublicKey) error {
-	return nil
-}

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -153,15 +153,12 @@ type BroadcastChannel interface {
 type BroadcastChannelFilter func(*ecdsa.PublicKey) bool
 
 // Firewall represents a set of rules the remote peer has to conform to so that
-// a connection with that peer can be established. The rules are checked when
-// a new connection is established and periodically for all active connections.
-// If some of the expectations defined by firewall rules are no longer met, the
-// connection is dropped.
+// a connection with that peer can be approved.
 type Firewall interface {
 
 	// Validate takes the remote peer public key and executes all the checks
-	// needed to decide whether the connection with the remote peer should be
-	// established and maintained.
+	// needed to decide whether the connection with the remote peer can be
+	// approved.
 	// If expectations are not met, this function should return an error
 	// describing what is wrong.
 	Validate(remotePeerPublicKey *ecdsa.PublicKey) error

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -151,3 +151,28 @@ type BroadcastChannel interface {
 // public key as its argument and returns true if the message should be
 // processed or false otherwise.
 type BroadcastChannelFilter func(*ecdsa.PublicKey) bool
+
+// Firewall represents a set of rules the remote peer has to conform to so that
+// a connection with that peer can be established. The rules are checked when
+// a new connection is established and periodically for all active connections.
+// If some of the expectations defined by firewall rules are no longer met, the
+// connection is dropped.
+type Firewall interface {
+
+	// Validate takes the remote peer public key and executes all the checks
+	// needed to decide whether the connection with the remote peer should be
+	// established and maintained.
+	// If expectations are not met, this function should return an error
+	// describing what is wrong.
+	Validate(remotePeerPublicKey *ecdsa.PublicKey) error
+}
+
+// NoFirewall is an empty Firewall implementation enforcing no rules
+// on the connection.
+var NoFirewall = &noFirewall{}
+
+type noFirewall struct{}
+
+func (nf *noFirewall) Validate(remotePeerPublicKey *ecdsa.PublicKey) error {
+	return nil
+}

--- a/pkg/net/watchtower/watchtower.go
+++ b/pkg/net/watchtower/watchtower.go
@@ -93,13 +93,13 @@ func (g *Guard) start(ctx context.Context) {
 				// Ensure we mark the peer as being checked before
 				// executing the async stake check.
 				g.markAsChecking(connectedPeer)
-				go g.manageConnectionByFirewall(connectedPeer)
+				go g.checkFirewallRules(connectedPeer)
 			}
 		}
 	}
 }
 
-func (g *Guard) manageConnectionByFirewall(peer string) {
+func (g *Guard) checkFirewallRules(peer string) {
 	defer g.completedCheck(peer)
 
 	peerPublicKey, err := g.getPeerPublicKey(peer)

--- a/pkg/net/watchtower/watchtower.go
+++ b/pkg/net/watchtower/watchtower.go
@@ -1,16 +1,16 @@
-// Package watchtower continuously monitors the on-chain stake of all connected
-// peers, and disconnects peers which fall below the minimum stake.
+// Package watchtower continuously monitors firewal rules compliance of all
+// connected peers, and disconnects peers which do not comply to the rules.
 package watchtower
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/ipfs/go-log"
 
-	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/key"
 )
@@ -21,7 +21,7 @@ var logger = log.Logger("keep-net-watchtower")
 type Guard struct {
 	duration time.Duration
 
-	stakeMonitor chain.StakeMonitor
+	firewall net.Firewall
 
 	connectionManager net.ConnectionManager
 
@@ -35,12 +35,12 @@ type Guard struct {
 func NewGuard(
 	ctx context.Context,
 	duration time.Duration,
-	stakeMonitor chain.StakeMonitor,
+	firewall net.Firewall,
 	connectionManager net.ConnectionManager,
 ) *Guard {
 	guard := &Guard{
 		duration:          duration,
-		stakeMonitor:      stakeMonitor,
+		firewall:          firewall,
 		connectionManager: connectionManager,
 		peerCrossList:     make(map[string]bool),
 	}
@@ -93,17 +93,14 @@ func (g *Guard) start(ctx context.Context) {
 				// Ensure we mark the peer as being checked before
 				// executing the async stake check.
 				g.markAsChecking(connectedPeer)
-				go g.manageConnectionByStake(ctx, connectedPeer)
+				go g.manageConnectionByFirewall(connectedPeer)
 			}
 		}
 	}
 }
 
-func (g *Guard) manageConnectionByStake(ctx context.Context, peer string) {
+func (g *Guard) manageConnectionByFirewall(peer string) {
 	defer g.completedCheck(peer)
-
-	newContext, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
 
 	peerPublicKey, err := g.getPeerPublicKey(peer)
 	if err != nil {
@@ -118,27 +115,18 @@ func (g *Guard) manageConnectionByStake(ctx context.Context, peer string) {
 		return
 	}
 
-	hasMinimumStake, err := g.validatePeerStake(
-		newContext, peerPublicKey,
-	)
-	if err != nil {
-		// network issues with geth shouldn't cause disconnects from the
-		// network. Rather we'll abort the check and try again later.
-		logger.Warningf("error validating peer stake, retrying later: [%v].", err)
-		return
-	}
+	if err := g.firewall.Validate(peerPublicKey); err != nil {
 
-	if !hasMinimumStake {
-		// if a peer doesn't have at least the min stake, disconnect them.
 		logger.Warningf(
-			"dropping the connection - peer [%v] has no minimal stake",
+			"dropping the connection; firewal rules not satisfied for peer [%v]: [%v] ",
 			peer,
+			err,
 		)
 		g.connectionManager.DisconnectPeer(peer)
 	}
 }
 
-func (g *Guard) getPeerPublicKey(peer string) (*key.NetworkPublic, error) {
+func (g *Guard) getPeerPublicKey(peer string) (*ecdsa.PublicKey, error) {
 	peerPublicKey, err := g.connectionManager.GetPeerPublicKey(peer)
 	if err != nil {
 		return nil, err
@@ -149,23 +137,5 @@ func (g *Guard) getPeerPublicKey(peer string) (*key.NetworkPublic, error) {
 			"failed to resolve valid public key for peer %s", peer,
 		)
 	}
-	return peerPublicKey, nil
-}
-
-func (g *Guard) validatePeerStake(
-	ctx context.Context,
-	peerPublicKey *key.NetworkPublic,
-) (bool, error) {
-	hasMinimumStake, err := g.stakeMonitor.HasMinimumStake(
-		key.NetworkPubKeyToEthAddress(peerPublicKey),
-	)
-	if err != nil {
-		return false, fmt.Errorf(
-			"Failed to get stake information for key [%s] with error: [%v]",
-			peerPublicKey,
-			err,
-		)
-	}
-
-	return hasMinimumStake, nil
+	return key.NetworkKeyToECDSAKey(peerPublicKey), nil
 }

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -16,7 +16,7 @@ const Reimbursements = artifacts.require("./libraries/operator/Reimbursements.so
 const Registry = artifacts.require("./Registry.sol");
 
 let initializationPeriod = 518400; // ~6 days
-const undelegationPeriod = 7776000; // ~3 months
+let undelegationPeriod = 7776000; // ~3 months
 const withdrawalDelay = 86400; // 1 day
 const dkgContributionMargin = 1; // 1%
 
@@ -25,6 +25,7 @@ module.exports = async function(deployer, network) {
   // Set the stake initialization period to 1 block for local development and testnet.
   if (network === 'local' || network === 'ropsten' || network === 'keep_dev') {
     initializationPeriod = 1;
+    undelegationPeriod = 60;
   }
 
   await deployer.deploy(ModUtils);


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1588

So far we had just one rule we had to enforce when establishing a connection: the remote peer needs to have a minimum stake and the minimum stake has to be maintained for the entire lifetime of the connection.

It is still the case but we are discovering that more rules are needed and that we need exceptions from some of the rules in certain circumstances.

For example, for ECDSA client, we should require a minimum stake if the client has no active keeps. If the given client does no longer have a minimum stake but it has a number of active keeps we should let the client join the network and execute signing for those remaining keeps.

To do that, we introduce `net.Firewall` interface which is a facade behind which we can hide even the most sophisticated remote peer validation rules. Instead of passing `chain.StakeMonitor` all the way down to libp2p internals, we now pass `net.Firewall` with a specific minimum stake policy defined in `firewall.go`.

From the functional side, no big changes here. However, this will allow defining more complex connection filtering rules for `keep-ecdsa`.

Bonus:
- Set testnet stake undelegation period to one minute

    Default undelegation period is 3 months and it is hard to execute various test scenarios with it. For testnet, stake initialization period is set to 1 second so adding a custom value for stake undelegation period does not seem weird.

- Extracted network key -> ECDSA key translation details to a separate function
- Fixed local implementation of `ConnectedPeers` function
- Increased firewall check tick from 1 minute to 10 minutes

    It does not make sense to check the minimum stake every minute. It only
generates noise and costs. 10 minutes check should be enough.

If you are not convinced yet, I'd like to note we are eliminating `libp2p->chain` dependency and we no longer have to create fake stake monitors for tests; we can use `net.NoFirewall` instead.
