### PR TITLE
Customize managed grant staking policy

### DIFF
--- a/solidity/contracts/TokenGrant.sol
+++ b/solidity/contracts/TokenGrant.sol
@@ -157,6 +157,7 @@ contract TokenGrant {
      * @return cliff The duration, in seconds, before which none of the tokens
      *                in the token will be unlocked, and after which a linear
      *                amount based on the age of the grant will be unlocked.
+     * @return policy The address of the grant's staking policy.
      */
     function getGrantUnlockingSchedule(
         uint256 _id
@@ -164,13 +165,15 @@ contract TokenGrant {
         address grantManager,
         uint256 duration,
         uint256 start,
-        uint256 cliff
+        uint256 cliff,
+        address policy
     ) {
         return (
             grants[_id].grantManager,
             grants[_id].duration,
             grants[_id].start,
-            grants[_id].cliff
+            grants[_id].cliff,
+            address(grants[_id].stakingPolicy)
         );
     }
 

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -43,9 +43,7 @@ module.exports = async function(deployer, network) {
   await deployer.deploy(
     ManagedGrantFactory,
     KeepToken.address,
-    TokenGrant.address,
-    PermissiveStakingPolicy.address,
-    GuaranteedMinimumStakingPolicy.address
+    TokenGrant.address
   );
   await deployer.deploy(GroupSelection);
   await deployer.link(GroupSelection, KeepRandomBeaconOperator);

--- a/solidity/test/token_grant/TestManagedGrantFactory.js
+++ b/solidity/test/token_grant/TestManagedGrantFactory.js
@@ -119,6 +119,9 @@ describe('TokenGrant/ManagedGrantFactory', () => {
 
       let returnedCliff = schedule[3];
       expect(returnedCliff).to.eq.BN(grantStart.add(grantCliff));
+
+      let returnedPolicy = schedule[4];
+      expect(returnedPolicy).to.equal(permissivePolicy.address);
     });
 
     it("works with receiveApproval", async () => {
@@ -151,6 +154,9 @@ describe('TokenGrant/ManagedGrantFactory', () => {
 
       let returnedCliff = schedule[3];
       expect(returnedCliff).to.eq.BN(grantStart.add(grantCliff));
+
+      let returnedPolicy = schedule[4];
+      expect(returnedPolicy).to.equal(permissivePolicy.address);
     });
 
     it("doesn't let one grant more than they've approved on the token", async () => {

--- a/solidity/test/token_grant/TestManagedGrantFactory.js
+++ b/solidity/test/token_grant/TestManagedGrantFactory.js
@@ -60,8 +60,6 @@ describe('TokenGrant/ManagedGrantFactory', () => {
     factory = await ManagedGrantFactory.new(
       token.address,
       tokenGrant.address,
-      permissivePolicy.address,
-      minimumPolicy.address,
       {from: grantCreator}
     );
   });
@@ -87,6 +85,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
         grantStart,
         grantCliff,
         false,
+        permissivePolicy.address,
         {from: grantCreator}
       );
       await factory.createManagedGrant(
@@ -96,6 +95,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
         grantStart,
         grantCliff,
         false,
+        permissivePolicy.address,
         {from: grantCreator}
       );
       let event = (await factory.getPastEvents())[0];
@@ -124,8 +124,8 @@ describe('TokenGrant/ManagedGrantFactory', () => {
     it("works with receiveApproval", async () => {
       grantStart = await time.latest();
       let extraData = web3.eth.abi.encodeParameters(
-        ['address', 'uint256', 'uint256', 'uint256', 'bool'],
-        [grantee, grantUnlockingDuration.toNumber(), grantStart.toNumber(), grantCliff.toNumber(), false]
+        ['address', 'uint256', 'uint256', 'uint256', 'bool', 'address'],
+        [grantee, grantUnlockingDuration.toNumber(), grantStart.toNumber(), grantCliff.toNumber(), false, permissivePolicy.address]
       );
       await token.approveAndCall(
         factory.address, grantAmount, extraData, {from: grantCreator}
@@ -167,6 +167,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
           grantStart,
           grantCliff,
           false,
+          permissivePolicy.address,
           {from: unrelatedAddress}
         ),
         "SafeERC20: low-level call failed -- Reason given: SafeERC20: low-level call failed."
@@ -187,6 +188,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
           grantStart,
           grantCliff,
           false,
+          permissivePolicy.address,
           {from: unrelatedAddress}
         ),
         "SafeERC20: low-level call failed -- Reason given: SafeERC20: low-level call failed."


### PR DESCRIPTION
Provide the policy as an argument when creating a grant, and also return a grant's staking policy address in its unlocking schedule.