### PR TITLE
GCP Staking: One too many zeros

### DIFF
--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
@@ -132,7 +132,7 @@ async function stakeOperator(operatorAddress, contractOwnerAddress, authorizer) 
 
   await keepTokenContract.methods.approveAndCall(
     tokenStakingContract.address,
-    formatAmount(20000000, 18),
+    formatAmount(2000000, 18),
     delegation).send({from: contractOwnerAddress})
 
   console.log(`Staked!`);


### PR DESCRIPTION
Off by a bit here, we're staking 20M KEEP for each keep-client
deployment.  WHile this is normally fine we'll run out of tokens before
we can get to the desired number of clients for scaling tests against
Ropsten.