### PR TITLE
Update create grant params

### DIFF
--- a/solidity/dashboard/src/services/token-grants.service.js
+++ b/solidity/dashboard/src/services/token-grants.service.js
@@ -47,24 +47,21 @@ const createGrant = async (web3Context, data, onTransationHashCallback) => {
 
   /**
    * Extra data contains the following values:
-   * grantee (20 bytes) Address of the grantee.
-   * cliff (32 bytes) Duration in seconds of the cliff after which tokens will begin to unlock.
-   * start (32 bytes) Timestamp at which unlocking will start.
-   * revocable (1 byte) Whether the token grant is revocable or not (1 or 0).
-   * stakingPolicyAddress (20 bytes) The staking policy as an address
+   * from Address of the grant manager.
+   * grantee Address of the grantee.
+   * cliff Duration in seconds of the cliff after which tokens will begin to unlock.
+   * start Timestamp at which unlocking will start.
+   * revocable Whether the token grant is revocable or not (1 or 0).
+   * stakingPolicyAddress The staking policy as an address
    */
   const stakingPolicyAddress = revocable ?
     getGuaranteedMinimumStakingPolicyContractAddress() :
     getPermissiveStakingPolicyContractAddress()
 
-  const extraData = Buffer.concat([
-    Buffer.from(grantee.substr(2), 'hex'),
-    web3Utils.toBN(duration).toBuffer('be', 32),
-    web3Utils.toBN(start).toBuffer('be', 32),
-    web3Utils.toBN(cliff).toBuffer('be', 32),
-    Buffer.from(revocable ? '01' : '00', 'hex'),
-    Buffer.from(stakingPolicyAddress.substr(2), 'hex'),
-  ])
+  const extraData = web3Context.eth.abi.encodeParameters(
+    ['address', 'address', 'uint256', 'uint256', 'uint256', 'bool', 'address'],
+    [yourAddress, grantee, duration, start, cliff, revocable, stakingPolicyAddress]
+  );
 
   const formattedAmount = web3Utils.toBN(amount).mul(web3Utils.toBN(10).pow(web3Utils.toBN(18))).toString()
 


### PR DESCRIPTION
We no longer need to pack parameters, we switched from `abi.encodePacked()` to `abi.encode()` in the grant contract.