### PR TITLE
Panic button per operator contract with a possibility of being disabled

### DIFF
--- a/solidity/contracts/Registry.sol
+++ b/solidity/contracts/Registry.sol
@@ -8,7 +8,9 @@ pragma solidity 0.5.17;
 contract Registry {
     enum ContractStatus {New, Approved, Disabled}
 
-    // Governance role is to enable recovery from key compromise by rekeying other roles.
+    // Governance role is to enable recovery from key compromise by rekeying
+    // other roles. Also, it can disable operator contract panic buttons
+    // permanently.
     address internal governance;
 
     // Registry Keeper maintains approved operator contracts. Each operator
@@ -16,9 +18,22 @@ contract Registry {
     // used by a service contract.
     address internal registryKeeper;
 
-    // The Panic Button can disable malicious or malfunctioning contracts
-    // that have been previously approved by the Registry Keeper.
-    address internal panicButton;
+    // Each operator contract has a Panic Button which can disable malicious
+    // or malfunctioning contract that have been previously approved by the
+    // Registry Keeper.
+    //
+    // New operator contract added to the registry has a default panic button
+    // value assigned (defaultPanicButton). Panic button for each operator
+    // contract can be later updated by Governance to individual value.
+    //
+    // It is possible to disable panic button for individual contract by
+    // setting the panic button to zero address. In such case, operator contract
+    // can not be disabled and is permanently approved in the registry.
+    mapping(address => address) public panicButtons;
+
+    // Default panic button for each new operator contract added to the
+    // registry. Can be later updated for each contract.
+    address internal defaultPanicButton;
 
     // Each service contract has a Operator Contract Upgrader whose purpose
     // is to manage operator contracts for that specific service contract.
@@ -34,7 +49,12 @@ contract Registry {
 
     event GovernanceUpdated();
     event RegistryKeeperUpdated();
-    event PanicButtonUpdated();
+    event DefaultPanicButtonUpdated();
+    event OperatorContractPanicButtonDisabled(address operatorContract);
+    event OperatorContractPanicButtonUpdated(
+        address operatorContract,
+        address panicButton
+    );
     event OperatorContractUpgraderUpdated(
         address serviceContract,
         address upgrader
@@ -50,15 +70,33 @@ contract Registry {
         _;
     }
 
-    modifier onlyPanicButton() {
+    modifier onlyPanicButton(address _operatorContract) {
+        address panicButton = panicButtons[_operatorContract];
+        require(panicButton != address(0), "Panic button disabled");
         require(panicButton == msg.sender, "Not authorized");
+        _;
+    }
+
+    modifier onlyForNewContract(address _operatorContract) {
+        require(
+            isNewOperatorContract(_operatorContract),
+            "Not a new operator contract"
+        );
+        _;
+    }
+
+    modifier onlyForApprovedContract(address _operatorContract) {
+        require(
+            isApprovedOperatorContract(_operatorContract),
+            "Not an approved operator contract"
+        );
         _;
     }
 
     constructor() public {
         governance = msg.sender;
         registryKeeper = msg.sender;
-        panicButton = msg.sender;
+        defaultPanicButton = msg.sender;
     }
 
     function setGovernance(address _governance) public onlyGovernance {
@@ -71,9 +109,45 @@ contract Registry {
         emit RegistryKeeperUpdated();
     }
 
-    function setPanicButton(address _panicButton) public onlyGovernance {
-        panicButton = _panicButton;
-        emit PanicButtonUpdated();
+    function setDefaultPanicButton(address _panicButton) public onlyGovernance {
+        defaultPanicButton = _panicButton;
+        emit DefaultPanicButtonUpdated();
+    }
+
+    function setOperatorContractPanicButton(
+        address _operatorContract,
+        address _panicButton
+    ) public onlyForApprovedContract(_operatorContract) onlyGovernance {
+        require(
+            panicButtons[_operatorContract] != address(0),
+            "Disabled panic button cannot be updated"
+        );
+        require(
+            _panicButton != address(0),
+            "Panic button must be non-zero address"
+        );
+
+        panicButtons[_operatorContract] = _panicButton;
+
+        emit OperatorContractPanicButtonUpdated(
+            _operatorContract,
+            _panicButton
+        );
+    }
+
+    function disableOperatorContractPanicButton(address _operatorContract)
+        public
+        onlyForApprovedContract(_operatorContract)
+        onlyGovernance
+    {
+        require(
+            panicButtons[_operatorContract] != address(0),
+            "Panic button already disabled"
+        );
+
+        panicButtons[_operatorContract] = address(0);
+
+        emit OperatorContractPanicButtonDisabled(_operatorContract);
     }
 
     function setOperatorContractUpgrader(
@@ -89,26 +163,19 @@ contract Registry {
 
     function approveOperatorContract(address operatorContract)
         public
+        onlyForNewContract(operatorContract)
         onlyRegistryKeeper
     {
-        require(
-            isNewOperatorContract(operatorContract),
-            "Only new operator contracts can be approved"
-        );
-
         operatorContracts[operatorContract] = ContractStatus.Approved;
+        panicButtons[operatorContract] = defaultPanicButton;
         emit OperatorContractApproved(operatorContract);
     }
 
     function disableOperatorContract(address operatorContract)
         public
-        onlyPanicButton
+        onlyForApprovedContract(operatorContract)
+        onlyPanicButton(operatorContract)
     {
-        require(
-            isApprovedOperatorContract(operatorContract),
-            "Only approved operator contracts can be disabled"
-        );
-
         operatorContracts[operatorContract] = ContractStatus.Disabled;
         emit OperatorContractDisabled(operatorContract);
     }

--- a/solidity/contracts/Registry.sol
+++ b/solidity/contracts/Registry.sol
@@ -6,8 +6,7 @@ pragma solidity 0.5.17;
  * @dev Governance owned registry of approved contracts and roles.
  */
 contract Registry {
-
-    enum ContractStatus { New, Approved, Disabled }
+    enum ContractStatus {New, Approved, Disabled}
 
     // Governance role is to enable recovery from key compromise by rekeying other roles.
     address internal governance;
@@ -36,7 +35,10 @@ contract Registry {
     event GovernanceUpdated();
     event RegistryKeeperUpdated();
     event PanicButtonUpdated();
-    event OperatorContractUpgraderUpdated(address serviceContract, address upgrader);
+    event OperatorContractUpgraderUpdated(
+        address serviceContract,
+        address upgrader
+    );
 
     modifier onlyGovernance() {
         require(governance == msg.sender, "Not authorized");
@@ -74,12 +76,21 @@ contract Registry {
         emit PanicButtonUpdated();
     }
 
-    function setOperatorContractUpgrader(address _serviceContract, address _operatorContractUpgrader) public onlyGovernance {
+    function setOperatorContractUpgrader(
+        address _serviceContract,
+        address _operatorContractUpgrader
+    ) public onlyGovernance {
         operatorContractUpgraders[_serviceContract] = _operatorContractUpgrader;
-        emit OperatorContractUpgraderUpdated(_serviceContract, _operatorContractUpgrader);
+        emit OperatorContractUpgraderUpdated(
+            _serviceContract,
+            _operatorContractUpgrader
+        );
     }
 
-    function approveOperatorContract(address operatorContract) public onlyRegistryKeeper {
+    function approveOperatorContract(address operatorContract)
+        public
+        onlyRegistryKeeper
+    {
         require(
             isNewOperatorContract(operatorContract),
             "Only new operator contracts can be approved"
@@ -89,7 +100,10 @@ contract Registry {
         emit OperatorContractApproved(operatorContract);
     }
 
-    function disableOperatorContract(address operatorContract) public onlyPanicButton {
+    function disableOperatorContract(address operatorContract)
+        public
+        onlyPanicButton
+    {
         require(
             isApprovedOperatorContract(operatorContract),
             "Only approved operator contracts can be disabled"
@@ -99,15 +113,27 @@ contract Registry {
         emit OperatorContractDisabled(operatorContract);
     }
 
-    function isNewOperatorContract(address operatorContract) public view returns (bool) {
+    function isNewOperatorContract(address operatorContract)
+        public
+        view
+        returns (bool)
+    {
         return operatorContracts[operatorContract] == ContractStatus.New;
     }
 
-    function isApprovedOperatorContract(address operatorContract) public view returns (bool) {
+    function isApprovedOperatorContract(address operatorContract)
+        public
+        view
+        returns (bool)
+    {
         return operatorContracts[operatorContract] == ContractStatus.Approved;
     }
 
-    function operatorContractUpgraderFor(address _serviceContract) public view returns (address) {
+    function operatorContractUpgraderFor(address _serviceContract)
+        public
+        view
+        returns (address)
+    {
         return operatorContractUpgraders[_serviceContract];
     }
 }

--- a/solidity/contracts/stubs/RegistryStub.sol
+++ b/solidity/contracts/stubs/RegistryStub.sol
@@ -2,8 +2,8 @@ pragma solidity 0.5.17;
 
 import "../Registry.sol";
 
-contract RegistryStub is Registry {
 
+contract RegistryStub is Registry {
     function getGovernance() public view returns (address) {
         return governance;
     }
@@ -12,7 +12,15 @@ contract RegistryStub is Registry {
         return registryKeeper;
     }
 
-    function getPanicButton() public view returns (address) {
-        return panicButton;
+    function getDefaultPanicButton() public view returns (address) {
+        return defaultPanicButton;
+    }
+
+    function getPanicButtonForContract(address operatorContract)
+        public
+        view
+        returns (address)
+    {
+        return panicButtons[operatorContract];
     }
 }

--- a/solidity/test/TestRegistry.js
+++ b/solidity/test/TestRegistry.js
@@ -1,12 +1,12 @@
-const {createSnapshot, restoreSnapshot} = require("./helpers/snapshot.js")
-const {accounts, contract} = require("@openzeppelin/test-environment")
-const {expectRevert} = require("@openzeppelin/test-helpers")
+const { createSnapshot, restoreSnapshot } = require("./helpers/snapshot.js")
+const { accounts, contract } = require("@openzeppelin/test-environment")
+const { expectRevert } = require("@openzeppelin/test-helpers")
 var assert = require('chai').assert
 
 const Registry = contract.fromArtifact('RegistryStub');
 
 describe('Registry', () => {
-    
+
     const owner = accounts[0]
     const governance = accounts[1]
     const panicButton = accounts[2]
@@ -23,40 +23,40 @@ describe('Registry', () => {
     let registry
 
     before(async () => {
-        registry = await Registry.new({from: owner})
-        await registry.setGovernance(governance, {from: owner})
-        await registry.setPanicButton(panicButton, {from: governance})
-        await registry.setRegistryKeeper(registryKeeper, {from: governance})
+        registry = await Registry.new({ from: owner })
+        await registry.setGovernance(governance, { from: owner })
+        await registry.setPanicButton(panicButton, { from: governance })
+        await registry.setRegistryKeeper(registryKeeper, { from: governance })
         await registry.setOperatorContractUpgrader(
-            serviceContract1, 
+            serviceContract1,
             operatorContractUpgrader,
-            {from: governance}
+            { from: governance }
         )
     })
 
     beforeEach(async () => {
         await createSnapshot()
     })
-    
+
     afterEach(async () => {
         await restoreSnapshot()
     })
 
     describe("setGovernance", async () => {
         it("can be called by governance", async () => {
-            await registry.setGovernance(someoneElse, {from: governance})
+            await registry.setGovernance(someoneElse, { from: governance })
             // ok, no revert
         })
 
         it("can not be called by non-governance", async () => {
             await expectRevert(
-                registry.setGovernance(someoneElse, {from: owner}),
+                registry.setGovernance(someoneElse, { from: owner }),
                 "Not authorized"
             )
         })
 
         it("updates governance", async () => {
-            await registry.setGovernance(someoneElse, {from: governance})
+            await registry.setGovernance(someoneElse, { from: governance })
             assert.equal(
                 await registry.getGovernance(),
                 someoneElse,
@@ -67,19 +67,19 @@ describe('Registry', () => {
 
     describe("setRegistryKeeper", async () => {
         it("can be called by governance", async () => {
-            await registry.setRegistryKeeper(someoneElse, {from: governance})
+            await registry.setRegistryKeeper(someoneElse, { from: governance })
             // ok, no revert
         })
 
         it("can not be called by non-governance", async () => {
             await expectRevert(
-                registry.setRegistryKeeper(someoneElse, {from: owner}),
+                registry.setRegistryKeeper(someoneElse, { from: owner }),
                 "Not authorized"
             )
         })
 
         it("updates registry keeper", async () => {
-            await registry.setRegistryKeeper(someoneElse, {from: governance})
+            await registry.setRegistryKeeper(someoneElse, { from: governance })
             assert.equal(
                 await registry.getRegistryKeeper(),
                 someoneElse,
@@ -90,19 +90,19 @@ describe('Registry', () => {
 
     describe("setPanicButton", async () => {
         it("can be called by governance", async () => {
-            await registry.setPanicButton(someoneElse, {from: governance})
+            await registry.setPanicButton(someoneElse, { from: governance })
             // ok, no revert
         })
 
         it("can not be called by non-governance", async () => {
             await expectRevert(
-                registry.setPanicButton(someoneElse, {from: owner}),
+                registry.setPanicButton(someoneElse, { from: owner }),
                 "Not authorized"
             )
         })
 
         it("updates panic button", async () => {
-            await registry.setPanicButton(someoneElse, {from: governance})
+            await registry.setPanicButton(someoneElse, { from: governance })
             assert.equal(
                 await registry.getPanicButton(),
                 someoneElse,
@@ -114,9 +114,9 @@ describe('Registry', () => {
     describe("setOperatorContractUpgrader", async () => {
         it("can be called by governance", async () => {
             await registry.setOperatorContractUpgrader(
-                serviceContract1, 
-                someoneElse, 
-                {from: governance}
+                serviceContract1,
+                someoneElse,
+                { from: governance }
             )
             // ok, no revert
         })
@@ -125,8 +125,8 @@ describe('Registry', () => {
             await expectRevert(
                 registry.setOperatorContractUpgrader(
                     serviceContract1,
-                    someoneElse, 
-                    {from: owner}
+                    someoneElse,
+                    { from: owner }
                 ),
                 "Not authorized"
             )
@@ -136,13 +136,13 @@ describe('Registry', () => {
             await registry.setOperatorContractUpgrader(
                 serviceContract1,
                 someoneElse,
-                {from: governance}
+                { from: governance }
             )
 
             await registry.setOperatorContractUpgrader(
                 serviceContract2,
                 operatorContractUpgrader,
-                {from: governance}
+                { from: governance }
             )
 
             assert.equal(
@@ -162,8 +162,8 @@ describe('Registry', () => {
     describe("approveOperatorContract", async () => {
         it("can be called by registry keeper", async () => {
             await registry.approveOperatorContract(
-                operatorContract1, 
-                {from: registryKeeper}
+                operatorContract1,
+                { from: registryKeeper }
             )
             // ok, no revert
         })
@@ -172,7 +172,7 @@ describe('Registry', () => {
             await expectRevert(
                 registry.approveOperatorContract(
                     operatorContract1,
-                    {from: owner}
+                    { from: owner }
                 ),
                 "Not authorized"
             )
@@ -181,7 +181,7 @@ describe('Registry', () => {
         it("approves operator contract", async () => {
             await registry.approveOperatorContract(
                 operatorContract1,
-                {from: registryKeeper}
+                { from: registryKeeper }
             )
 
             assert.isTrue(
@@ -197,13 +197,13 @@ describe('Registry', () => {
         it("cannot be called for already approved contract", async () => {
             await registry.approveOperatorContract(
                 operatorContract1,
-                {from: registryKeeper}
+                { from: registryKeeper }
             )
 
             await expectRevert(
                 registry.approveOperatorContract(
                     operatorContract1,
-                    {from: registryKeeper}
+                    { from: registryKeeper }
 
                 ),
                 "Only new operator contracts can be approved"
@@ -213,17 +213,17 @@ describe('Registry', () => {
         it("cannot be called for disabled contract", async () => {
             await registry.approveOperatorContract(
                 operatorContract1,
-                {from: registryKeeper}
+                { from: registryKeeper }
             )
             await registry.disableOperatorContract(
                 operatorContract1,
-                {from: panicButton}
+                { from: panicButton }
             )
 
             await expectRevert(
                 registry.approveOperatorContract(
                     operatorContract1,
-                    {from: registryKeeper}
+                    { from: registryKeeper }
 
                 ),
                 "Only new operator contracts can be approved"
@@ -235,14 +235,14 @@ describe('Registry', () => {
         beforeEach(async () => {
             await registry.approveOperatorContract(
                 operatorContract1,
-                {from: registryKeeper}
+                { from: registryKeeper }
             )
         })
 
         it("can be called by panic button", async () => {
             await registry.disableOperatorContract(
-                operatorContract1, 
-                {from: panicButton}
+                operatorContract1,
+                { from: panicButton }
             )
             // ok, no revert
         })
@@ -251,7 +251,7 @@ describe('Registry', () => {
             await expectRevert(
                 registry.disableOperatorContract(
                     operatorContract1,
-                    {from: owner}
+                    { from: owner }
                 ),
                 "Not authorized"
             )
@@ -259,8 +259,8 @@ describe('Registry', () => {
 
         it("disables operator contract", async () => {
             await registry.disableOperatorContract(
-                operatorContract1, 
-                {from: panicButton}
+                operatorContract1,
+                { from: panicButton }
             )
 
             assert.isFalse(
@@ -271,14 +271,14 @@ describe('Registry', () => {
 
         it("cannot be called for already disabled contract", async () => {
             await registry.disableOperatorContract(
-                operatorContract1, 
-                {from: panicButton}
+                operatorContract1,
+                { from: panicButton }
             )
 
             await expectRevert(
                 registry.disableOperatorContract(
-                    operatorContract1, 
-                    {from: panicButton}
+                    operatorContract1,
+                    { from: panicButton }
                 ),
                 "Only approved operator contracts can be disabled"
             )
@@ -287,8 +287,8 @@ describe('Registry', () => {
         it("cannot be called for new operator contract", async () => {
             await expectRevert(
                 registry.disableOperatorContract(
-                    operatorContract2, 
-                    {from: panicButton}
+                    operatorContract2,
+                    { from: panicButton }
                 ),
                 "Only approved operator contracts can be disabled"
             )
@@ -305,8 +305,8 @@ describe('Registry', () => {
 
         it("returns false for approved operator contract", async () => {
             await registry.approveOperatorContract(
-                operatorContract1, 
-                {from: registryKeeper}
+                operatorContract1,
+                { from: registryKeeper }
             )
 
             assert.isFalse(
@@ -317,12 +317,12 @@ describe('Registry', () => {
 
         it("returns false for disabled operator contract", async () => {
             await registry.approveOperatorContract(
-                operatorContract1, 
-                {from: registryKeeper}
-            ) 
+                operatorContract1,
+                { from: registryKeeper }
+            )
             await registry.disableOperatorContract(
                 operatorContract1,
-                {from: panicButton}
+                { from: panicButton }
             )
 
             assert.isFalse(
@@ -342,8 +342,8 @@ describe('Registry', () => {
 
         it("returns true for approved operator contract", async () => {
             await registry.approveOperatorContract(
-                operatorContract1, 
-                {from: registryKeeper}
+                operatorContract1,
+                { from: registryKeeper }
             )
 
             assert.isTrue(
@@ -354,12 +354,12 @@ describe('Registry', () => {
 
         it("returns false for disabled operator contract", async () => {
             await registry.approveOperatorContract(
-                operatorContract1, 
-                {from: registryKeeper}
-            ) 
+                operatorContract1,
+                { from: registryKeeper }
+            )
             await registry.disableOperatorContract(
                 operatorContract1,
-                {from: panicButton}
+                { from: panicButton }
             )
 
             assert.isFalse(

--- a/solidity/test/TestRegistry.js
+++ b/solidity/test/TestRegistry.js
@@ -9,9 +9,10 @@ describe('Registry', () => {
 
     const owner = accounts[0]
     const governance = accounts[1]
-    const panicButton = accounts[2]
+    const defaultPanicButton = accounts[2]
     const registryKeeper = accounts[3]
     const operatorContractUpgrader = accounts[4]
+    const individualContractPanicButton = accounts[5]
 
     const someoneElse = "0x524f2E0176350d950fA630D9A5a59A0a190DAf48"
 
@@ -25,7 +26,7 @@ describe('Registry', () => {
     before(async () => {
         registry = await Registry.new({ from: owner })
         await registry.setGovernance(governance, { from: owner })
-        await registry.setPanicButton(panicButton, { from: governance })
+        await registry.setDefaultPanicButton(defaultPanicButton, { from: governance })
         await registry.setRegistryKeeper(registryKeeper, { from: governance })
         await registry.setOperatorContractUpgrader(
             serviceContract1,
@@ -88,25 +89,91 @@ describe('Registry', () => {
         })
     })
 
-    describe("setPanicButton", async () => {
+    describe("setDefaultPanicButton", async () => {
         it("can be called by governance", async () => {
-            await registry.setPanicButton(someoneElse, { from: governance })
+            await registry.setDefaultPanicButton(someoneElse, { from: governance })
             // ok, no revert
         })
 
         it("can not be called by non-governance", async () => {
             await expectRevert(
-                registry.setPanicButton(someoneElse, { from: owner }),
+                registry.setDefaultPanicButton(someoneElse, { from: owner }),
                 "Not authorized"
             )
         })
 
-        it("updates panic button", async () => {
-            await registry.setPanicButton(someoneElse, { from: governance })
+        it("updates default panic button", async () => {
+            await registry.setDefaultPanicButton(someoneElse, { from: governance })
             assert.equal(
-                await registry.getPanicButton(),
+                await registry.getDefaultPanicButton(),
                 someoneElse,
                 "Unexpected registry keeper"
+            )
+        })
+    })
+
+    describe("setOperatorContractPanicButton", async () => {
+        beforeEach(async () => {
+            await registry.approveOperatorContract(
+                operatorContract1,
+                { from: registryKeeper }
+            )
+        })
+
+        it("can be called by governance", async () => {
+            await registry.setOperatorContractPanicButton(
+                operatorContract1,
+                someoneElse,
+                { from: governance }
+            )
+            // ok, no revert
+        })
+
+        it("can not be called by non-governance", async () => {
+            await expectRevert(
+                registry.setOperatorContractPanicButton(
+                    operatorContract1,
+                    someoneElse,
+                    { from: owner }
+                ),
+                "Not authorized"
+            )
+        })
+
+        it("can not be called with zero panic button address", async () => {
+            await expectRevert(
+                registry.setOperatorContractPanicButton(
+                    operatorContract1,
+                    "0x0000000000000000000000000000000000000000",
+                    { from: governance }
+                ),
+                "Panic button must be non-zero address"
+            )
+        })
+
+        it("updates contract panic button", async () => {
+            await registry.setOperatorContractPanicButton(
+                operatorContract1,
+                someoneElse,
+                { from: governance }
+            )
+            assert.equal(
+                await registry.getPanicButtonForContract(operatorContract1),
+                someoneElse,
+                "Unexpected operator contract panic button"
+            )
+        })
+
+        it("does not update default panic button", async () => {
+            await registry.setOperatorContractPanicButton(
+                operatorContract1,
+                someoneElse,
+                { from: governance }
+            )
+            assert.equal(
+                await registry.getDefaultPanicButton(),
+                defaultPanicButton,
+                "Unexpected default panic button"
             )
         })
     })
@@ -194,6 +261,19 @@ describe('Registry', () => {
             )
         })
 
+        it("sets contract's panic button to the default one", async () => {
+            await registry.approveOperatorContract(
+                operatorContract1,
+                { from: registryKeeper }
+            )
+
+            assert.equal(
+                await registry.getPanicButtonForContract(operatorContract1),
+                defaultPanicButton,
+                "not a default panic button"
+            )
+        })
+
         it("cannot be called for already approved contract", async () => {
             await registry.approveOperatorContract(
                 operatorContract1,
@@ -206,7 +286,7 @@ describe('Registry', () => {
                     { from: registryKeeper }
 
                 ),
-                "Only new operator contracts can be approved"
+                "Not a new operator contract"
             )
         })
 
@@ -217,7 +297,7 @@ describe('Registry', () => {
             )
             await registry.disableOperatorContract(
                 operatorContract1,
-                { from: panicButton }
+                { from: defaultPanicButton }
             )
 
             await expectRevert(
@@ -226,7 +306,7 @@ describe('Registry', () => {
                     { from: registryKeeper }
 
                 ),
-                "Only new operator contracts can be approved"
+                "Not a new operator contract"
             )
         })
     })
@@ -239,12 +319,28 @@ describe('Registry', () => {
             )
         })
 
-        it("can be called by panic button", async () => {
+        it("can be called by default panic button", async () => {
             await registry.disableOperatorContract(
                 operatorContract1,
-                { from: panicButton }
+                { from: defaultPanicButton }
             )
             // ok, no revert
+        })
+
+        it("cannot be called by default panic button if contract has its own", async () => {
+            await registry.setOperatorContractPanicButton(
+                operatorContract1,
+                individualContractPanicButton,
+                { from: governance }
+            )
+
+            await expectRevert(
+                registry.disableOperatorContract(
+                    operatorContract1,
+                    { from: defaultPanicButton }
+                ),
+                "Not authorized"
+            )
         })
 
         it("can not be called by non-registry-keeper", async () => {
@@ -260,7 +356,7 @@ describe('Registry', () => {
         it("disables operator contract", async () => {
             await registry.disableOperatorContract(
                 operatorContract1,
-                { from: panicButton }
+                { from: defaultPanicButton }
             )
 
             assert.isFalse(
@@ -269,18 +365,51 @@ describe('Registry', () => {
             )
         })
 
-        it("cannot be called for already disabled contract", async () => {
+        it("disables operator contract with individual panic button", async () => {
+            await registry.setOperatorContractPanicButton(
+                operatorContract1,
+                individualContractPanicButton,
+                { from: governance }
+            )
+
             await registry.disableOperatorContract(
                 operatorContract1,
-                { from: panicButton }
+                { from: individualContractPanicButton }
+            )
+
+            assert.isFalse(
+                await registry.isApprovedOperatorContract(operatorContract1),
+                "operator contract should not be approved"
+            )
+        })
+
+        it("cannot be called if panic button has been disabled", async () => {
+            await registry.disableOperatorContractPanicButton(
+                operatorContract1,
+                { from: governance }
             )
 
             await expectRevert(
                 registry.disableOperatorContract(
                     operatorContract1,
-                    { from: panicButton }
+                    { from: defaultPanicButton }
                 ),
-                "Only approved operator contracts can be disabled"
+                "Panic button disabled"
+            )
+        })
+
+        it("cannot be called for already disabled contract", async () => {
+            await registry.disableOperatorContract(
+                operatorContract1,
+                { from: defaultPanicButton }
+            )
+
+            await expectRevert(
+                registry.disableOperatorContract(
+                    operatorContract1,
+                    { from: defaultPanicButton }
+                ),
+                "Not an approved operator contract"
             )
         })
 
@@ -288,9 +417,9 @@ describe('Registry', () => {
             await expectRevert(
                 registry.disableOperatorContract(
                     operatorContract2,
-                    { from: panicButton }
+                    { from: defaultPanicButton }
                 ),
-                "Only approved operator contracts can be disabled"
+                "Not an approved operator contract"
             )
         })
     })
@@ -322,7 +451,7 @@ describe('Registry', () => {
             )
             await registry.disableOperatorContract(
                 operatorContract1,
-                { from: panicButton }
+                { from: defaultPanicButton }
             )
 
             assert.isFalse(
@@ -359,7 +488,7 @@ describe('Registry', () => {
             )
             await registry.disableOperatorContract(
                 operatorContract1,
-                { from: panicButton }
+                { from: defaultPanicButton }
             )
 
             assert.isFalse(

--- a/solidity/test/TestRegistry.js
+++ b/solidity/test/TestRegistry.js
@@ -151,6 +151,26 @@ describe('Registry', () => {
             )
         })
 
+        it("can not be called on contracts with disabled panic button", async () => {
+            await registry.disableOperatorContractPanicButton(
+                operatorContract1,
+                { from: governance }
+            )
+            assert.equal(
+                await registry.panicButtons(operatorContract1),
+                "0x0000000000000000000000000000000000000000",
+                "Panic button not disabled correctly"
+            )
+            await expectRevert(
+                registry.setOperatorContractPanicButton(
+                    operatorContract1,
+                    someoneElse,
+                    { from: governance }
+                ),
+                "Disabled panic button cannot be updated"
+              )
+        })
+
         it("updates contract panic button", async () => {
             await registry.setOperatorContractPanicButton(
                 operatorContract1,


### PR DESCRIPTION
Closes: #1600

We now allow specifying a panic button per operator contract. Such individual panic buttons can be disabled what makes the operator contract permanently approved. There is a default panic button value that is assigned to each new operator contract.

The only role which can disable a panic button for operator contract is governance. We don't want the registry keeper to have a power of permanently approving operator contracts if this action can not be later undone.