### PR TITLE
Peer discovery tweaks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199
+	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155740-1b1604f5fb8e
 	github.com/keep-network/keep-common v0.2.0-rc
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155740-1b1604f5fb8e
+	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524
 	github.com/keep-network/keep-common v0.2.0-rc
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155326-64b2893c0922 h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155326-64b2893c0922/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155740-1b1604f5fb8e h1:NjmMgUNPhpcm5dbJp+occJCVVQaDSutah2YeOnCjzzk=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155740-1b1604f5fb8e/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524 h1:iOBE6U3YmgJ+VB2DnO5bNH9rmVWSiGUY1xgyjKOEGH8=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZtP3Jzj2sxqd2g=
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,14 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199 h1:4EmAF2XUHK1kwXBhg75OO9hgTkJGK7snwJZlpbu+Yy8=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420145833-13f76693dff9 h1:c9etgoBwTXFvLFcRPO6Ln+7LXV0tmUB57jLoQWOKKWo=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420145833-13f76693dff9/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420153718-cc2214ae1ae9 h1:6/M5S62C7qSr1Az74iZlDOySWx+4DDw+huKA5TciXDk=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420153718-cc2214ae1ae9/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155326-64b2893c0922 h1:8Z0K0XuKhOj/LifDGsGSOcZCnd3wmZMs/kHiX+e4AV0=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155326-64b2893c0922/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155740-1b1604f5fb8e h1:NjmMgUNPhpcm5dbJp+occJCVVQaDSutah2YeOnCjzzk=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420155740-1b1604f5fb8e/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZtP3Jzj2sxqd2g=
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -53,10 +53,6 @@ const (
 	// FirewallCheckTick is the amount of time between periodic checks of all
 	// firewall rules against all peers connected to this one.
 	FirewallCheckTick = time.Minute * 10
-	// BootstrapCheckPeriod is the amount of time between periodic checks
-	// for ensuring we are connected to an appropriate number of bootstrap
-	// peers.
-	BootstrapCheckPeriod = 10 * time.Second
 )
 
 // Config defines the configuration for the libp2p network provider.
@@ -180,15 +176,13 @@ func (cm *connectionManager) AddrStrings() []string {
 // ConnectOptions allows to set various options used by libp2p.
 type ConnectOptions struct {
 	RoutingTableRefreshPeriod time.Duration
-	BootstrapMinPeerThreshold int
 }
 
-// Defaults from libp2p.
 func defaultConnectOptions() *ConnectOptions {
 	var options ConnectOptions
 
-	options.RoutingTableRefreshPeriod = 1 * time.Hour
-	options.BootstrapMinPeerThreshold = 4
+	// Half of the default value from libp2p.
+	options.RoutingTableRefreshPeriod = 30 * time.Minute
 
 	return &options
 }
@@ -206,13 +200,6 @@ type ConnectOption func(options *ConnectOptions)
 func WithRoutingTableRefreshPeriod(period time.Duration) ConnectOption {
 	return func(options *ConnectOptions) {
 		options.RoutingTableRefreshPeriod = period
-	}
-}
-
-// WithBootstrapMinPeerThreshold set a minimal peer threshold for bootstrap process.
-func WithBootstrapMinPeerThreshold(threshold int) ConnectOption {
-	return func(options *ConnectOptions) {
-		options.BootstrapMinPeerThreshold = threshold
 	}
 }
 
@@ -286,7 +273,6 @@ func Connect(
 	if err := provider.bootstrap(
 		ctx,
 		config.Peers,
-		connectOptions.BootstrapMinPeerThreshold,
 	); err != nil {
 		return nil, fmt.Errorf("Failed to bootstrap nodes with err: %v", err)
 	}
@@ -392,7 +378,6 @@ func parseMultiaddresses(addresses []string) []ma.Multiaddr {
 func (p *provider) bootstrap(
 	ctx context.Context,
 	bootstrapPeers []string,
-	minPeerThreshold int,
 ) error {
 	peerInfos, err := extractMultiAddrFromPeers(bootstrapPeers)
 	if err != nil {
@@ -400,10 +385,6 @@ func (p *provider) bootstrap(
 	}
 
 	bootstrapConfig := bootstrap.BootstrapConfigWithPeers(peerInfos)
-
-	// TODO: allow this to be a configurable value
-	bootstrapConfig.Period = BootstrapCheckPeriod
-	bootstrapConfig.MinPeerThreshold = minPeerThreshold
 
 	// TODO: use the io.Closer to shutdown the bootstrapper when we build out
 	// a shutdown process.


### PR DESCRIPTION
Closes  #1639 

Here we introduce some tweaks related to peer discovery:
- Reduced the DHT refresh round period from `1 hour` to `30 minutes`. This change should make peer discovery a bit faster especially for edge peers. Also, this value should not harm performance with too frequent refreshes.
- Increased bootstrap round period from `10 seconds` to the default value of `30 seconds`. This change should help for problems with `libp2p` dial backoffs which can occur when an offline peer is dialled to often by frequent bootstrap rounds. Also, there are no benefits from running bootstrap round every `10 seconds` so `30 seconds` seems to be a reasonable value.
- Adjusted code to the new`go-libp2p-bootstrap` library version. 