### PR TITLE
v0.13.0 - Reduce staked amount

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,93 +413,93 @@ workflows:
       jobs:
         - keep_test_approval:
             type: approval
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
         - build_client_and_test_go:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - keep_test_approval
         - build_initcontainer:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - migrate_contracts
               - build_client_and_test_go
         - migrate_contracts:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_client_and_test_go
         - publish_keep_client:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_client_and_test_go
               - build_initcontainer
               - migrate_contracts
         - publish_contract_data:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_client_and_test_go
               - migrate_contracts
         - publish_npm_package:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - migrate_contracts
         - trigger_downstream_builds:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - publish_npm_package
         - build_token_dashboard_dapp:
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - publish_npm_package
         - publish_token_dashboard_dapp:
             context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+            # filters:
+            #   tags:
+            #     only: /^v.*/
+            #   branches:
+            #     ignore: /.*/
             requires:
               - build_token_dashboard_dapp
   docs:

--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
@@ -132,7 +132,7 @@ async function stakeOperator(operatorAddress, contractOwnerAddress, authorizer) 
 
   await keepTokenContract.methods.approveAndCall(
     tokenStakingContract.address,
-    formatAmount(20000000, 18),
+    formatAmount(2000000, 18),
     delegation).send({from: contractOwnerAddress})
 
   console.log(`Staked!`);


### PR DESCRIPTION
Temp branch to patch this change into the v0.13.0 tag.
--------------
Off by a bit here, we're staking 20M KEEP for each keep-client
deployment.  While this is normally fine we'll run out of tokens before
we can get to the desired number of clients for scaling tests against
Ropsten.