### PR TITLE
Broadcast channel relay

### DIFF
--- a/pkg/altbn128/altbn128.go
+++ b/pkg/altbn128/altbn128.go
@@ -297,14 +297,3 @@ func (e *gfP2) pow(base *gfP2, exp *big.Int) *gfP2 {
 	}
 	return e
 }
-
-func UnmarshalG2Point(bytes []byte) (*G2Point, error) {
-	g2 := new(bn256.G2)
-
-	_, err := g2.Unmarshal(bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return &G2Point{g2}, nil
-}

--- a/pkg/altbn128/altbn128.go
+++ b/pkg/altbn128/altbn128.go
@@ -297,3 +297,14 @@ func (e *gfP2) pow(base *gfP2, exp *big.Int) *gfP2 {
 	}
 	return e
 }
+
+func UnmarshalG2Point(bytes []byte) (*G2Point, error) {
+	g2 := new(bn256.G2)
+
+	_, err := g2.Unmarshal(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &G2Point{g2}, nil
+}

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -104,6 +104,10 @@ func Initialize(
 			}()
 		}
 
+		go node.RelayMessagesForChannel(
+			hex.EncodeToString(request.GroupPublicKey),
+		)
+
 		go node.MonitorRelayEntry(
 			relayChain,
 			request.BlockNumber,

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -5,8 +5,6 @@ import (
 	"encoding/hex"
 	"sync"
 
-	"github.com/keep-network/keep-core/pkg/altbn128"
-
 	"github.com/ipfs/go-log"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
@@ -105,15 +103,7 @@ func Initialize(
 				)
 			}()
 		} else {
-			groupPublicKey, err := altbn128.UnmarshalG2Point(request.GroupPublicKey)
-			if err != nil {
-				logger.Warningf("could not relay messages: [%v]", err)
-			} else {
-				// Channel name used for relay entry request is the string
-				// representation of the compressed group public key G2 point.
-				name := hex.EncodeToString(groupPublicKey.Compress())
-				go node.RelayMessagesForChannel(name)
-			}
+			go node.ForwardSignatureShares(request.GroupPublicKey)
 		}
 
 		go node.MonitorRelayEntry(

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"sync"
 
+	"github.com/keep-network/keep-core/pkg/altbn128"
+
 	"github.com/ipfs/go-log"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
@@ -102,11 +104,17 @@ func Initialize(
 					request.BlockNumber,
 				)
 			}()
+		} else {
+			groupPublicKey, err := altbn128.UnmarshalG2Point(request.GroupPublicKey)
+			if err != nil {
+				logger.Warningf("could not relay messages: [%v]", err)
+			} else {
+				// Channel name used for relay entry request is the string
+				// representation of the compressed group public key G2 point.
+				name := hex.EncodeToString(groupPublicKey.Compress())
+				go node.RelayMessagesForChannel(name)
+			}
 		}
-
-		go node.RelayMessagesForChannel(
-			hex.EncodeToString(request.GroupPublicKey),
-		)
 
 		go node.MonitorRelayEntry(
 			relayChain,

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -71,10 +71,12 @@ func (n *Node) JoinGroupIfEligible(
 		}
 	}
 
+	// create temporary broadcast channel name for DKG using the
+	// group selection seed
+	channelName := newEntry.Text(16)
+
 	if len(indexes) > 0 {
-		// create temporary broadcast channel for DKG using the group selection
-		// seed
-		broadcastChannel, err := n.netProvider.BroadcastChannelFor(newEntry.Text(16))
+		broadcastChannel, err := n.netProvider.BroadcastChannelFor(channelName)
 		if err != nil {
 			logger.Errorf("failed to get broadcast channel: [%v]", err)
 			return
@@ -133,7 +135,16 @@ func (n *Node) JoinGroupIfEligible(
 				)
 			}()
 		}
+	} else {
+		go n.RelayMessagesForChannel(channelName)
 	}
 
 	return
+}
+
+// RelayMessagesForChannel enables an ability to subscribe to messages
+// from the given broadcast channel and relay them to other nodes thus
+// making the network more robust.
+func (n *Node) RelayMessagesForChannel(name string) {
+	n.netProvider.BroadcastChannelRelayFor(name)
 }

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -149,7 +149,7 @@ func (n *Node) JoinGroupIfEligible(
 // ForwardDKGMessages enables the ability to forward DKG messages
 // to other nodes even if this node has not been selected to the group.
 func (n *Node) ForwardDKGMessages(name string) {
-	n.netProvider.BroadcastChannelRelayFor(name)
+	n.netProvider.BroadcastChannelForwarderFor(name)
 }
 
 // ForwardSignatureShares enables the ability to forward signature shares
@@ -162,7 +162,7 @@ func (n *Node) ForwardSignatureShares(groupPublicKeyBytes []byte) {
 		return
 	}
 
-	n.netProvider.BroadcastChannelRelayFor(name)
+	n.netProvider.BroadcastChannelForwarderFor(name)
 }
 
 // channelNameForPublicKey takes group public key represented by marshalled

--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -140,7 +140,7 @@ func (n *Node) JoinGroupIfEligible(
 			}()
 		}
 	} else {
-		go n.ForwardDKGMessages(channelName)
+		go n.forwardDKGMessages(channelName)
 	}
 
 	return
@@ -148,7 +148,7 @@ func (n *Node) JoinGroupIfEligible(
 
 // ForwardDKGMessages enables the ability to forward DKG messages
 // to other nodes even if this node has not been selected to the group.
-func (n *Node) ForwardDKGMessages(name string) {
+func (n *Node) forwardDKGMessages(name string) {
 	n.netProvider.BroadcastChannelForwarderFor(name)
 }
 

--- a/pkg/net/libp2p/channel_manager.go
+++ b/pkg/net/libp2p/channel_manager.go
@@ -33,7 +33,7 @@ type channelManager struct {
 	retransmissionTicker *retransmission.Ticker
 
 	forwarderSubscriptionsMutex sync.Mutex
-	fowarderSubscriptions       map[string]*pubsub.Subscription
+	forwarderSubscriptions      map[string]*pubsub.Subscription
 }
 
 func newChannelManager(
@@ -55,13 +55,13 @@ func newChannelManager(
 		return nil, err
 	}
 	return &channelManager{
-		channels:              make(map[string]*channel),
-		pubsub:                floodsub,
-		peerStore:             p2phost.Peerstore(),
-		identity:              identity,
-		ctx:                   ctx,
-		retransmissionTicker:  retransmissionTicker,
-		fowarderSubscriptions: make(map[string]*pubsub.Subscription),
+		channels:               make(map[string]*channel),
+		pubsub:                 floodsub,
+		peerStore:              p2phost.Peerstore(),
+		identity:               identity,
+		ctx:                    ctx,
+		retransmissionTicker:   retransmissionTicker,
+		forwarderSubscriptions: make(map[string]*pubsub.Subscription),
 	}, nil
 }
 
@@ -124,7 +124,7 @@ func (cm *channelManager) newForwarder(name string, ttl time.Duration) error {
 	cm.forwarderSubscriptionsMutex.Lock()
 	defer cm.forwarderSubscriptionsMutex.Unlock()
 
-	if _, ok := cm.fowarderSubscriptions[name]; !ok {
+	if _, ok := cm.forwarderSubscriptions[name]; !ok {
 		forwarderSubscription, err := cm.pubsub.Subscribe(name)
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func (cm *channelManager) newForwarder(name string, ttl time.Duration) error {
 			}
 		}()
 
-		cm.fowarderSubscriptions[name] = forwarderSubscription
+		cm.forwarderSubscriptions[name] = forwarderSubscription
 	}
 
 	return nil
@@ -160,12 +160,12 @@ func (cm *channelManager) shutdownForwarder(name string) {
 
 	logger.Debugf("shutting down message forwarder for channel: [%v]", name)
 
-	fowarderSubscription, ok := cm.fowarderSubscriptions[name]
+	forwarderSubscription, ok := cm.forwarderSubscriptions[name]
 
 	if !ok {
 		return
 	}
 
-	fowarderSubscription.Cancel()
-	delete(cm.fowarderSubscriptions, name)
+	forwarderSubscription.Cancel()
+	delete(cm.forwarderSubscriptions, name)
 }

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -117,10 +117,15 @@ func (p *provider) CreateTransportIdentifier(publicKey ecdsa.PublicKey) (
 }
 
 func (p *provider) BroadcastChannelRelayFor(name string) {
-	logger.Infof("requested relay for: [%v]", name)
+	logger.Infof("requested relay for channel: [%v]", name)
 
-	if err := p.broadcastChannelManager.newRelay(name); err != nil {
-		logger.Warningf("could not create relay for [%v]: [%v]", name, err)
+	// TTL for a single relay should be limited to avoid unnecessary
+	// resource consumption. One hour seems to be a reasonable value as no
+	// single protocol execution will exceed this time.
+	ttl := 1 * time.Hour
+
+	if err := p.broadcastChannelManager.newRelay(name, ttl); err != nil {
+		logger.Warningf("could not create relay for channel [%v]: [%v]", name, err)
 	}
 }
 

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -116,16 +116,20 @@ func (p *provider) CreateTransportIdentifier(publicKey ecdsa.PublicKey) (
 	return peer.IDFromPublicKey(&networkPublicKey)
 }
 
-func (p *provider) BroadcastChannelRelayFor(name string) {
-	logger.Infof("requested relay for channel: [%v]", name)
+func (p *provider) BroadcastChannelForwarderFor(name string) {
+	logger.Infof("requested message forwarder for channel: [%v]", name)
 
-	// TTL for a single relay should be limited to avoid unnecessary
+	// TTL for a single message forwarder should be limited to avoid unnecessary
 	// resource consumption. One hour seems to be a reasonable value as no
 	// single protocol execution will exceed this time.
 	ttl := 1 * time.Hour
 
 	if err := p.broadcastChannelManager.newRelay(name, ttl); err != nil {
-		logger.Warningf("could not create relay for channel [%v]: [%v]", name, err)
+		logger.Warningf(
+			"could not create message forwarder for channel [%v]: [%v]",
+			name,
+			err,
+		)
 	}
 }
 

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -116,6 +116,14 @@ func (p *provider) CreateTransportIdentifier(publicKey ecdsa.PublicKey) (
 	return peer.IDFromPublicKey(&networkPublicKey)
 }
 
+func (p *provider) BroadcastChannelRelayFor(name string) {
+	logger.Infof("requested relay for: [%v]", name)
+
+	if err := p.broadcastChannelManager.newRelay(name); err != nil {
+		logger.Warningf("could not create relay for [%v]: [%v]", name, err)
+	}
+}
+
 type connectionManager struct {
 	host.Host
 }

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -124,7 +124,7 @@ func (p *provider) BroadcastChannelForwarderFor(name string) {
 	// single protocol execution will exceed this time.
 	ttl := 1 * time.Hour
 
-	if err := p.broadcastChannelManager.newRelay(name, ttl); err != nil {
+	if err := p.broadcastChannelManager.newForwarder(name, ttl); err != nil {
 		logger.Warningf(
 			"could not create message forwarder for channel [%v]: [%v]",
 			name,

--- a/pkg/net/local/local.go
+++ b/pkg/net/local/local.go
@@ -69,7 +69,7 @@ func (lp *localProvider) CreateTransportIdentifier(publicKey ecdsa.PublicKey) (
 	return createLocalIdentifier(&networkPublicKey), nil
 }
 
-func (lp *localProvider) BroadcastChannelRelayFor(name string) {
+func (lp *localProvider) BroadcastChannelForwarderFor(name string) {
 	//no-op
 }
 

--- a/pkg/net/local/local.go
+++ b/pkg/net/local/local.go
@@ -69,6 +69,10 @@ func (lp *localProvider) CreateTransportIdentifier(publicKey ecdsa.PublicKey) (
 	return createLocalIdentifier(&networkPublicKey), nil
 }
 
+func (lp *localProvider) BroadcastChannelRelayFor(name string) {
+	//no-op
+}
+
 // Connect returns a local instance of a net provider that does not go over the
 // network.
 func Connect() Provider {

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -63,8 +63,8 @@ type Provider interface {
 	// provided public key.
 	CreateTransportIdentifier(publicKey ecdsa.PublicKey) (TransportIdentifier, error)
 
-	// BroadcastChannelRelayFor creates a message relay for given channel name.
-	BroadcastChannelRelayFor(name string)
+	// BroadcastChannelForwarderFor creates a message relay for given channel name.
+	BroadcastChannelForwarderFor(name string)
 }
 
 // ConnectionManager is an interface which exposes peers a client is connected

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -62,6 +62,9 @@ type Provider interface {
 	// CreateTransportIdentifier creates a transport identifier based on the
 	// provided public key.
 	CreateTransportIdentifier(publicKey ecdsa.PublicKey) (TransportIdentifier, error)
+
+	// BroadcastChannelRelayFor creates a message relay for given channel name.
+	BroadcastChannelRelayFor(name string)
 }
 
 // ConnectionManager is an interface which exposes peers a client is connected


### PR DESCRIPTION
Closes #1641

Here we introduce a new behavior of the client which now subscribes to all broadcast channels and relays received messages to connected peers. This way the client acts as an auxiliary node even if they don't take part in given protocol execution. This change should make the network
more robust.