### PR TITLE
ropsten-faucet: Roll forward and friends

### DIFF
--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/deploy-faucet.sh
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/deploy-faucet.sh
@@ -2,4 +2,5 @@ gcloud functions deploy keep-faucet-ropsten \
   --trigger-http \
   --runtime nodejs10 \
   --entry-point issueGrant \
+  --max-instances 5 \
   --set-env-vars KEEP_CONTRACT_OWNER_ADDRESS=$KEEP_CONTRACT_OWNER_ADDRESS,KEEP_CONTRACT_OWNER_PRIVATE_KEY=$KEEP_CONTRACT_OWNER_PRIVATE_KEY,ETHEREUM_HOST=$ETHEREUM_HOST,ETHEREUM_NETWORK_ID=$ETHEREUM_NETWORK_ID

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
@@ -72,8 +72,8 @@ exports.issueGrant = async (request, response) => {
       const granteeAccount = account
       const unlockingDuration = web3.utils.toBN(0)
       const start = web3.utils.toBN(Math.floor(Date.now() / 1000))
-      const cliff = web3.utils.toBN(0)
-      const revocable = false
+      const cliff = web3.utils.toBN(172800)
+      const revocable = true
       const tokens = web3.utils.toBN(300000)
       console.log(`Fetching existing balance for account [${granteeAccount}]...`)
       const grantBalanceString = await tokenGrant.methods

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
-      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
+      "version": "0.13.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.1.tgz",
+      "integrity": "sha512-QEZnIUj99sFSkc/BAYiW+W7Xq7IQEJOaanD0t6/wC1Bn1/CrqpZxTwXTTeKOIh31ONhOjMP4d3utsypgGay/dQ==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -52,9 +52,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
-          "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
         },
         "aes-js": {
           "version": "3.0.0",
@@ -178,9 +178,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.19",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
-              "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
+              "version": "10.17.20",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.20.tgz",
+              "integrity": "sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw=="
             }
           }
         },
@@ -281,9 +281,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.19",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
-              "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
+              "version": "10.17.20",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.20.tgz",
+              "integrity": "sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw=="
             },
             "elliptic": {
               "version": "6.3.3",


### PR DESCRIPTION
We did a fresh migration of `v0.13.0` against Ropsten.  Here we update the faucet to use that new version.  This is already deployed.

---

In addition to the roll forward we've limited the number of faucet invocations that can be run at a time and made grants revocable with a cliff.  This is to help mitigate scripts draining token supply.