### PR TITLE
run-random-beacon: Ropsten Contract Update

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -369,7 +369,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0x9D5e69987A2E62AE08761DA1449A35B60d5C9634`
+|`0x7E63E99B90980fF8C81d03928a5533904E8Fc78a`
 |===
 
 [%header,cols=2*]
@@ -378,49 +378,49 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0x792141474C258B680d7F1B5a114bc98C11e17CA6`
+|`0x3470Ba3f9e26B1761f686BA46e3c4AfF61c1BB56`
 
 |KeepRandomBeaconOperator
-|`0x6Ef5B74f40c3f9a910669aC84A0d27B83edc031c`
+|`0x46677cE196a83ebdD22956987EADe88725F31cAF`
 |===
 
 == Staking
 
 === Terminology
 
-address:: Hexadecimal string consisting of 40 characters prefixed with "0x" uniquely identifying Ethereum account; 
+address:: Hexadecimal string consisting of 40 characters prefixed with "0x" uniquely identifying Ethereum account;
 derived from ECDSA public key of the party. Example address: `0xb2560a01e4b8b5cb0ac549fa39c7ae255d80e943`.
 
-owner:: The address owning KEEP tokens or KEEP token grant. The owner’s participation is not required in the day-to-day 
+owner:: The address owning KEEP tokens or KEEP token grant. The owner’s participation is not required in the day-to-day
 operations on the stake, so cold storage can be accommodated to the maximum extent.
 
-operator:: The address of a party authorized to operate in the network on behalf of a given owner. The operator handles 
-the everyday operations on the delegated stake without actually owning the staked tokens. An operator can not simply 
-transfer away delegated tokens, however, it should be noted that operator's misbehaviour may result in slashing tokens 
+operator:: The address of a party authorized to operate in the network on behalf of a given owner. The operator handles
+the everyday operations on the delegated stake without actually owning the staked tokens. An operator can not simply
+transfer away delegated tokens, however, it should be noted that operator's misbehaviour may result in slashing tokens
 and thus the entire staked amount is indeed at stake.
 
-beneficiary:: the address where the rewards for participation and all reimbursements are sent, earned by an operator, 
+beneficiary:: the address where the rewards for participation and all reimbursements are sent, earned by an operator,
 on behalf of an owner
 
-delegated stake:: an owner's staked tokens, delegated to the operator by the owner. Delegation enables KEEP owners to 
+delegated stake:: an owner's staked tokens, delegated to the operator by the owner. Delegation enables KEEP owners to
 have their wallets offline and their stake operated by operators on their behalf.
 
 operator contract:: Ethereum smart contract handling operations that may have an impact on staked tokens.
 
-authorizer:: the address appointed by owner to authorize operator contract on behalf of the owner. Operator contract 
+authorizer:: the address appointed by owner to authorize operator contract on behalf of the owner. Operator contract
 must be pre-approved by authorizer before the operator is eligible to use it and join the specific part of the network.
 
 === Delegating tokens
 
-KEEP tokens are delegated by the owner. During the delegation, the owner needs to appoint an operator, beneficiary, 
-and authorizer. Owner may delegate owned tokens or tokens from a grant. Owner may decide to delegate just a portion 
-of owned tokens or just a part of tokens from a grant. Owner may delegate multiple times to different operators. 
+KEEP tokens are delegated by the owner. During the delegation, the owner needs to appoint an operator, beneficiary,
+and authorizer. Owner may delegate owned tokens or tokens from a grant. Owner may decide to delegate just a portion
+of owned tokens or just a part of tokens from a grant. Owner may delegate multiple times to different operators.
 Tokens can be delegated using Tokens page in https://dashboard.test.keep.network[KEEP token dashboard] and a certain minimum stake defined by the system is required to be provided in the delegation. The more stake is delegated, the higher chance to be selected to relay group.
 
-Delegation takes immediate effect but can be cancelled within one week without additional delay. After one week 
+Delegation takes immediate effect but can be cancelled within one week without additional delay. After one week
 operator appointed during the delegation becomes eligible for work selection.
 
 === Authorizations
-Before operator is considered as eligible for work selection, authorizer appointed during the delegation needs to review 
+Before operator is considered as eligible for work selection, authorizer appointed during the delegation needs to review
 and authorize Keep Random Beacon smart contract. Smart contracts can be authorized using KEEP token dashboard. Authorized operator contracts may slash or seize tokens in case of operator's misbehavior.
 


### PR DESCRIPTION
We ran a redeployment of v0.13.0-rc today so that we could refresh the
token supply.  Here we reference those new contract addresses.