### PR TITLE
Upgradeable Dashboard: Add contract resolution step to dashboard build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,14 +407,14 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
         - build_client_and_test_go:
             context: keep-test
             filters:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - keep_test_approval
         - build_initcontainer:
@@ -423,7 +423,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - migrate_contracts
               - build_client_and_test_go
@@ -433,7 +433,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - build_client_and_test_go
         - publish_keep_client:
@@ -442,7 +442,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - build_client_and_test_go
               - build_initcontainer
@@ -453,7 +453,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - build_client_and_test_go
               - migrate_contracts
@@ -463,7 +463,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - migrate_contracts
         - trigger_downstream_builds:
@@ -472,7 +472,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - publish_npm_package
         - build_token_dashboard_dapp:
@@ -480,7 +480,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - publish_npm_package
         - publish_token_dashboard_dapp:
@@ -489,7 +489,7 @@ workflows:
               tags:
                 only: /^v.*/
               branches:
-                ignore: /.*/
+                only: /releases\/.*/
             requires:
               - build_token_dashboard_dapp
   docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,11 @@ jobs:
           docker_layer_caching: true
       - checkout
       - run:
+          name: Resolve latest contracts
+          working_directory: ~/project/solidity/dashboard
+          command: |
+            npm upgrade @keep-network/keep-core
+      - run:
           name: Run Docker build
           working_directory: ~/project/solidity/dashboard
           command: |

--- a/solidity/dashboard/Dockerfile
+++ b/solidity/dashboard/Dockerfile
@@ -16,9 +16,6 @@ COPY package-lock.json /app/package-lock.json
 # Install from lockfile.
 RUN npm ci
 
-# Resolve latest build of keep-core.
-RUN npm update @keep-network/keep-core
-
 COPY src /app/src
 COPY public /app/public
 


### PR DESCRIPTION
This step ensures that the latest contract version will be resolved even
if docker layer caching is in place. It also makes it so that new
releases can bump the contract build and dashboard build both, knowing
the dashboard build will correctly resolve the contract build.

Also included: running keep-test builds on release branches, which start
with `releases\/`.

---------

After this, I think the release process for keep-core is this:
- Create a new release branch.
- Bump the changes.
- Commit + push.
- Approve the build.
- *PR optional.*