### PR TITLE
Group expiration off-by-one bugfix

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -676,7 +676,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
     /**
      * @notice Gets the number of active groups as currently marked in the
-     * contract. This is the sate from when the expired groups were last updated
+     * contract. This is the state from when the expired groups were last updated
      * without accounting for recent expirations.
      *
      * @dev Even if numberOfGroups() > 0, it is still possible requesting for

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -676,8 +676,8 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
     /**
      * @notice Gets the number of active groups as currently marked in the
-     * contract. Groups marked as expired or terminated does not count as
-     * active.
+     * contract. This is the sate from when the expired groups were last updated
+     * without accounting for recent expirations.
      *
      * @dev Even if numberOfGroups() > 0, it is still possible requesting for
      * a new relay entry will revert with "no active groups" failure message.

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -134,7 +134,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
      * @dev Triggers group selection if there are no active groups.
      */
     function genesis() public payable {
-        // If we run into a very unlikely situation there are no active
+        // If we run into a very unlikely situation when there are no active
         // groups on the contract because of slashing and groups terminated
         // or because beacon has not been used for a very long time and all
         // groups expired, we first want to make a cleanup.
@@ -683,7 +683,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
      * a new relay entry will revert with "no active groups" failure message.
      * This function returns the number of active groups as they are currently
      * marked on-chain. However, during relay request, before group selection,
-     * we run group expiration and it may happen some groups seen as active
+     * we run group expiration and it may happen that some groups seen as active
      * turns out to be expired.
      */
     function numberOfGroups() public view returns(uint256) {

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -18,7 +18,7 @@ const Reimbursements = artifacts.require("./libraries/operator/Reimbursements.so
 const Registry = artifacts.require("./Registry.sol");
 
 let initializationPeriod = 518400; // ~6 days
-let undelegationPeriod = 7776000; // ~3 months
+const undelegationPeriod = 7776000; // ~3 months
 const withdrawalDelay = 86400; // 1 day
 const dkgContributionMargin = 1; // 1%
 
@@ -27,7 +27,6 @@ module.exports = async function(deployer, network) {
   // Set the stake initialization period to 1 block for local development and testnet.
   if (network === 'local' || network === 'ropsten' || network === 'keep_dev') {
     initializationPeriod = 1;
-    undelegationPeriod = 60;
   }
 
   await deployer.deploy(ModUtils);

--- a/solidity/test/random_beacon_operator/TestGroupTermination.js
+++ b/solidity/test/random_beacon_operator/TestGroupTermination.js
@@ -192,5 +192,11 @@ describe('KeepRandomBeaconOperator/GroupTermination', function() {
           "No active groups"
         );
       })
+      it("ET", async function () {
+        await expectRevert(
+          runTerminationTest(2, 1, [1], 0),
+          "No active groups"
+        );
+      })
     })
 });


### PR DESCRIPTION
We had a bug in `expireOldGroups` function of `Groups` library allowing the `expiredGroupOffset` to go too far and read from groups array at non-existing index. It resulted in blocking the beacon forever by `requestRelayEntry` reverting every single time it was called.

There are a couple of improvements here to fix this problem.

First of all, we fix the loop so that it never reads from groups array with an index equal or greater to groups array length. Secondly, in `selectGroup` function, we first `expireOldGroups` before checking if we have any active groups to proceed with. Last but not least, in `genesis` function we now run group expiration before checking the number of active groups.

There is still a little chicken and egg problem here addressed with appropriate documentation on `numberOfGroups` function. Specifically, `numberOfGroups` may return a number `> 0` and still, request relay entry will fail with no active groups message. The reason for that is because `numberOfGroups` takes into account the current state in the contract and `requestRelayEntry` modifies this state by running group expiration. If all group expired, `requestRelayEntry` can't continue and it reverts without updating chain state. There is no easy way to address this issue without a solid refactoring so I decided to explain it in `numberOfGroups` docs for now. If such a situation happens, it's now possible to run `genesis` to fix it as we'll first run group expiration there.

We found this problem because in one of the previous PRs we set the stake undelegation time to 60 sec for local and testnet environment. However, currently, the group expiration period is set to stake undelegation period. With 60-seconds undelegation, groups were expiring after 60 seconds. It complicates testing instead of making it easier so here we increase undelegation time back to the original value.