### PR TITLE
Cache stake

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524
-	github.com/keep-network/keep-common v0.2.0-rc
+	github.com/keep-network/keep-common v0.2.0-rc.0.20200421130859-6b2ce47fbb15
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1
 	github.com/libp2p/go-libp2p-connmgr v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524
-	github.com/keep-network/keep-common v0.2.0-rc.0.20200421130859-6b2ce47fbb15
+	github.com/keep-network/keep-common v0.2.0-rc.0.20200421142700-dbf1de3de236
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1
 	github.com/libp2p/go-libp2p-connmgr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZt
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-common v0.2.0-rc.0.20200421130859-6b2ce47fbb15 h1:WGWv7EN9BbuyfUJ4nZdjMhG84Y/tUTxXM8CJqHXwQOI=
 github.com/keep-network/keep-common v0.2.0-rc.0.20200421130859-6b2ce47fbb15/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v0.2.0-rc.0.20200421142700-dbf1de3de236 h1:1w/vBBNqWNyYRoA6fJUYQWUqrazmP72vvTZoXnhF6SQ=
+github.com/keep-network/keep-common v0.2.0-rc.0.20200421142700-dbf1de3de236/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524 h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZtP3Jzj2sxqd2g=
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v0.2.0-rc.0.20200421130859-6b2ce47fbb15 h1:WGWv7EN9BbuyfUJ4nZdjMhG84Y/tUTxXM8CJqHXwQOI=
+github.com/keep-network/keep-common v0.2.0-rc.0.20200421130859-6b2ce47fbb15/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -60,6 +60,7 @@ func (msp *minimumStakePolicy) Validate(
 	// Similarly, if the client has no minimum stake the last time
 	// HasMinimumStake was executed, we have to ask the chain about the current
 	// status.
+	msp.cache.Sweep()
 	if msp.cache.Has(address) {
 		return nil
 	}

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -3,6 +3,9 @@ package firewall
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"time"
+
+	"github.com/keep-network/keep-common/pkg/cache"
 
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/net"
@@ -19,23 +22,49 @@ func (nf *noFirewall) Validate(remotePeerPublicKey *ecdsa.PublicKey) error {
 	return nil
 }
 
+// MinimumStakeCachePeriod is the time period the cache maintains the result of
+// the last HasMinimumStake result. We use the cache to minimize calls to
+// Ethereum client.
+const MinimumStakeCachePeriod = 12 * time.Hour
+
+var errNoMinimumStake = fmt.Errorf("remote peer has no minimum stake")
+
 // MinimumStakePolicy is a net.Firewall rule making sure the remote peer
 // has a minimum stake of KEEP.
 func MinimumStakePolicy(stakeMonitor chain.StakeMonitor) net.Firewall {
-	return &minimumStakePolicy{stakeMonitor: stakeMonitor}
+	return &minimumStakePolicy{
+		stakeMonitor: stakeMonitor,
+		cache:        cache.NewTimeCache(MinimumStakeCachePeriod),
+	}
 }
 
 type minimumStakePolicy struct {
 	stakeMonitor chain.StakeMonitor
+	cache        *cache.TimeCache
 }
 
 func (msp *minimumStakePolicy) Validate(
 	remotePeerPublicKey *ecdsa.PublicKey,
 ) error {
 	networkPublicKey := key.NetworkPublic(*remotePeerPublicKey)
-	hasMinimumStake, err := msp.stakeMonitor.HasMinimumStake(
-		key.NetworkPubKeyToEthAddress(&networkPublicKey),
-	)
+	address := key.NetworkPubKeyToEthAddress(&networkPublicKey)
+
+	// First, check in the in-memory time cache to minimize hits to ETH client.
+	// If the Keep client with the given chain address is in the cache it means
+	// it has had a minimum stake the last HasMinimumStake was executed and
+	// caching period has not elapsed yet.
+	//
+	// If the caching period elapsed, this check will return false and we
+	// have to ask the chain about the current status.
+	//
+	// Similarly, if the client has no minimum stake the last time
+	// HasMinimumStake was executed, we have to ask the chain about the current
+	// status.
+	if msp.cache.Has(address) {
+		return nil
+	}
+
+	hasMinimumStake, err := msp.stakeMonitor.HasMinimumStake(address)
 	if err != nil {
 		return fmt.Errorf(
 			"could not validate remote peer's minimum stake: [%v]",
@@ -44,8 +73,12 @@ func (msp *minimumStakePolicy) Validate(
 	}
 
 	if !hasMinimumStake {
-		return fmt.Errorf("remote peer has no minimum stake")
+		return errNoMinimumStake
 	}
+
+	// Add this address to the cache. We'll not hit HasMinimumStake again
+	// for the entire caching period.
+	msp.cache.Add(address)
 
 	return nil
 }

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -1,0 +1,102 @@
+package firewall
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-common/pkg/cache"
+	"github.com/keep-network/keep-core/pkg/chain/local"
+	"github.com/keep-network/keep-core/pkg/net/key"
+)
+
+var minimumStake = big.NewInt(1000)
+var cachingPeriod = time.Second
+
+func TestHasMinimumStake(t *testing.T) {
+	stakeMonitor := local.NewStakeMonitor(minimumStake)
+	policy := &minimumStakePolicy{
+		stakeMonitor: stakeMonitor,
+		cache:        cache.NewTimeCache(cachingPeriod),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	remotePeerAddress := key.NetworkPubKeyToEthAddress(remotePeerPublicKey)
+
+	stakeMonitor.StakeTokens(remotePeerAddress)
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
+	}
+}
+
+func TestHasNoMinimumStake(t *testing.T) {
+	stakeMonitor := local.NewStakeMonitor(minimumStake)
+	policy := &minimumStakePolicy{
+		stakeMonitor: stakeMonitor,
+		cache:        cache.NewTimeCache(cachingPeriod),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinimumStake {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinimumStake,
+		)
+	}
+}
+
+func TestCachesActiveKeepMembers(t *testing.T) {
+	stakeMonitor := local.NewStakeMonitor(minimumStake)
+	policy := &minimumStakePolicy{
+		stakeMonitor: stakeMonitor,
+		cache:        cache.NewTimeCache(cachingPeriod),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	remotePeerAddress := key.NetworkPubKeyToEthAddress(remotePeerPublicKey)
+	stakeMonitor.StakeTokens(remotePeerAddress)
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
+	}
+
+	stakeMonitor.UnstakeTokens(remotePeerAddress)
+
+	// still caching the old result
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
+	}
+
+	time.Sleep(time.Second)
+
+	// no longer caches the previous result
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinimumStake {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinimumStake,
+		)
+	}
+}


### PR DESCRIPTION
For every connection handshake, we store in a time cache the result of `HasMinimumStake` call for the particular operator to minimize Ethereum client calls in case that operator has no minimum stake and tries to connect with us all the time.

Closes: https://github.com/keep-network/keep-core/issues/1627
Depends on: https://github.com/keep-network/keep-common/pull/32