### PR TITLE
On-chain system parameters update

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -171,7 +171,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         stakingContract = TokenStaking(_stakingContract);
 
         groups.stakingContract = TokenStaking(_stakingContract);
-        groups.groupActiveTime = 7 days;
+        groups.groupActiveTime = 86400 * 7 / 15; // 7 days equivalent in 15s blocks
 
         // There are 39 blocks to submit group selection tickets. To minimize
         // the submitter's cost by minimizing the number of redundant tickets

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -171,7 +171,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         stakingContract = TokenStaking(_stakingContract);
 
         groups.stakingContract = TokenStaking(_stakingContract);
-        groups.groupActiveTime = TokenStaking(_stakingContract).undelegationPeriod();
+        groups.groupActiveTime = 7 days;
 
         // There are 39 blocks to submit group selection tickets. To minimize
         // the submitter's cost by minimizing the number of redundant tickets

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -64,7 +64,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     TokenStaking internal stakingContract;
 
     // Each signing group member reward expressed in wei.
-    uint256 public groupMemberBaseReward = 145*1e11; // 14500 Gwei, 10% of operational cost
+    uint256 public groupMemberBaseReward = 1000000*1e11; // 1M Gwei
 
     // Gas price ceiling value used to calculate the gas price for reimbursement
     // next to the actual gas price from the transaction. We use gas price

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -17,8 +17,8 @@ const DKGResultVerification = artifacts.require("./libraries/operator/DKGResultV
 const Reimbursements = artifacts.require("./libraries/operator/Reimbursements.sol");
 const Registry = artifacts.require("./Registry.sol");
 
-let initializationPeriod = 518400; // ~6 days
-const undelegationPeriod = 7776000; // ~3 months
+let initializationPeriod = 43200; // ~12 hours
+let undelegationPeriod = 7776000; // ~3 months
 const withdrawalDelay = 86400; // 1 day
 const dkgContributionMargin = 5; // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
 

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -20,7 +20,7 @@ const Registry = artifacts.require("./Registry.sol");
 let initializationPeriod = 518400; // ~6 days
 const undelegationPeriod = 7776000; // ~3 months
 const withdrawalDelay = 86400; // 1 day
-const dkgContributionMargin = 1; // 1%
+const dkgContributionMargin = 5; // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
 
 module.exports = async function(deployer, network) {
 

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -14,7 +14,7 @@ async function initContracts(KeepToken, TokenStaking, KeepRandomBeaconService,
     serviceContractImplV1, serviceContractProxy, serviceContract,
     operatorContract;
 
-  let dkgContributionMargin = 1, // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
+  let dkgContributionMargin = 5, // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
     withdrawalDelay = 1,
     stakeInitializationPeriod = 30, // In seconds
     stakeUndelegationPeriod = 300; // In seconds

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -14,7 +14,7 @@ async function initContracts(KeepToken, TokenStaking, KeepRandomBeaconService,
     serviceContractImplV1, serviceContractProxy, serviceContract,
     operatorContract;
 
-  let dkgContributionMargin = 1, // 1%
+  let dkgContributionMargin = 1, // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
     withdrawalDelay = 1,
     stakeInitializationPeriod = 30, // In seconds
     stakeUndelegationPeriod = 300; // In seconds

--- a/solidity/test/random_beacon_service/TestPricingFees.js
+++ b/solidity/test/random_beacon_service/TestPricingFees.js
@@ -51,7 +51,7 @@ describe('KeepRandomBeaconService/PricingFees', function() {
         let fees = await serviceContract.entryFeeBreakdown();
         let dkgContributionFee = fees.dkgContributionFee;
 
-        let expectedDkgContributionFee = 185; // 1234 * (13+2) * 1% = 185.1
+        let expectedDkgContributionFee = 925; // 1234 * (13+2) * 5% = 925.5
         assert.equal(expectedDkgContributionFee, dkgContributionFee);
     });
 
@@ -70,11 +70,11 @@ describe('KeepRandomBeaconService/PricingFees', function() {
         );
 
         // entry verification fee = 12 * 200 = 2400
-        // dkg contribution fee = (14 + 2) * 200 * 1% = 32
+        // dkg contribution fee = (14 + 2) * 200 * 5% = 160
         // group profit fee = 13 * 3 = 39
         // callback fee = (10961 + 7) * 200 = 2193600
-        // entry fee = 2400 + 32 + 39 + 2193600 = 3761671
-        let expectedEntryFeeEstimate = 2196071;
+        // entry fee = 2400 + 160 + 39 + 2193600 = 2196199
+        let expectedEntryFeeEstimate = 2196199;
         assert.equal(expectedEntryFeeEstimate, entryFeeEstimate)
     });
 });


### PR DESCRIPTION
Refs: #1545 

- Group member base reward: `1000000 * 1e11 wei = 1M Gwei`. 
    It gives group reward of `64*1M Gwei`.
- Group active time: `86400 * 7 / 15 blocks = ~7 days`.
- Stake initialization period: `43200 seconds = 12 hours`.
- Stake undelegation period: `7776000 seconds = 3 months`.
- DKG contribution margin: `5%`.
- Result publication block step stays at `3 blocks`.