### PR TITLE
Apply expiration correctly when calculating number of groups

### DIFF
--- a/solidity/test/random_beacon_operator/TestGroupExpiration.js
+++ b/solidity/test/random_beacon_operator/TestGroupExpiration.js
@@ -62,7 +62,7 @@ describe('KeepRandomBeaconOperator/GroupExpiration', function() {
   }
 
   it("should be able to count the number of active groups", async function() {
-    let expectedGroupCount = 23;
+    let expectedGroupCount = 18;
     await addGroups(expectedGroupCount);
     let numberOfGroups = await groups.numberOfGroups();
     assert.equal(Number(numberOfGroups), expectedGroupCount, "Unexpected number of groups");


### PR DESCRIPTION
We can return an up-to-date count of groups by calculating expired and terminated groups in view functions, and only applying those changes in `expireOldGroups()`.