### PR TITLE
keep-prd: NATs

### DIFF
--- a/infrastructure/terraform/keep-prd/backend.tf
+++ b/infrastructure/terraform/keep-prd/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "keep-prd-terraform-backend-bucket"
+    prefix = "terraform/state"
+  }
+}

--- a/infrastructure/terraform/keep-prd/base.tf
+++ b/infrastructure/terraform/keep-prd/base.tf
@@ -1,0 +1,69 @@
+data "google_client_config" "default" {}
+
+# Configure the Google Cloud provider
+provider "google" {
+  version = "<= 1.19.0"
+  region  = "${var.region_data["region"]}"
+}
+
+provider "google-beta" {
+  version = "<= 1.19.0"
+  region  = "${var.region_data["region"]}"
+}
+
+provider "null" {
+  version = "<= 2.0.0"
+}
+
+provider "random" {
+  version = "<= 2.0.0"
+}
+
+provider "template" {
+  version = "<= 1.0.0"
+}
+
+/* Set your locals.
+ * Terraform doesn't allow for string interpolation in variable maps.
+ * We cheat it by defining a local. A local instance variable mapping
+ * allows for string interpolation in maps. Locals are also good for
+ * names who are a construct of multiple values, to keep module blocks
+ * clean.
+*/
+locals {
+  public_subnet_name  = "${var.environment}-${module.vpc.vpc_subnet_prefix}-pub-${var.region_data["region"]}"
+  private_subnet_name = "${var.environment}-${module.vpc.vpc_subnet_prefix}-pri-${var.region_data["region"]}"
+  gke_subnet_name     = "${var.environment}-${module.vpc.vpc_subnet_prefix}-gke-${var.region_data["region"]}"
+
+  labels {
+    contact     = "${var.contacts}"
+    environment = "${var.environment}"
+    vertical    = "${var.vertical}"
+  }
+}
+
+module "project" {
+  source                = "git@github.com:thesis/terraform-google-bootstrap-project.git?ref=0.1.0"
+  project_name          = "${var.project_name}"
+  org_id                = "${var.gcp_thesis_org_id}"
+  billing_account       = "${var.gcp_thesis_billing_account}"
+  project_owner_members = "${var.project_owner_members}"
+  project_service_list  = "${var.project_service_list}"
+  location              = "${var.region_data["region"]}"
+  labels                = "${local.labels}"
+}
+
+# Create vpc and primary subnets
+module "vpc" {
+  source           = "git@github.com:thesis/terraform-google-vpc.git?ref=0.1.0"
+  vpc_network_name = "${var.vpc_network_name}"
+  project          = "${module.project.project_id}"
+  region           = "${var.region_data["region"]}"
+  routing_mode     = "${var.routing_mode}"
+
+  public_subnet_name          = "${local.public_subnet_name}"
+  public_subnet_ip_cidr_range = "${var.public_subnet_ip_cidr_range}"
+
+  private_subnet_name          = "${local.private_subnet_name}"
+  private_subnet_ip_cidr_range = "${var.private_subnet_ip_cidr_range}"
+}

--- a/infrastructure/terraform/keep-prd/nats.tf
+++ b/infrastructure/terraform/keep-prd/nats.tf
@@ -25,6 +25,15 @@ resource "google_compute_address" "nat_gateway_zone_c" {
   labels       = "${local.labels}"
 }
 
+resource "google_compute_address" "nat_gateway_zone_f" {
+  name         = "${var.nat_gateway_ip["zone_f_name"]}"
+  project      = "${module.project.project_id}"
+  region       = "${var.region_data["region"]}"
+  address_type = "${var.nat_gateway_ip["address_type"]}"
+  network_tier = "${var.nat_gateway_ip["network_tier"]}"
+  labels       = "${local.labels}"
+}
+
 module "nat_gateway_zone_a" {
   source          = "GoogleCloudPlatform/nat-gateway/google"
   version         = "1.2.2"
@@ -63,6 +72,20 @@ module "nat_gateway_zone_c" {
   network         = "${module.vpc.vpc_network_name}"
   subnetwork      = "${module.vpc.vpc_public_subnet_self_link}"
   ip_address_name = "${google_compute_address.nat_gateway_zone_c.name}"
+  ssh_fw_rule     = false
+  instance_labels = "${local.labels}"
+}
+
+module "nat_gateway_zone_f" {
+  source          = "GoogleCloudPlatform/nat-gateway/google"
+  version         = "1.2.2"
+  name            = "${module.vpc.vpc_network_name}-"
+  project         = "${module.project.project_id}"
+  region          = "${var.region_data["region"]}"
+  zone            = "${var.region_data["zone_f"]}"
+  network         = "${module.vpc.vpc_network_name}"
+  subnetwork      = "${module.vpc.vpc_public_subnet_self_link}"
+  ip_address_name = "${google_compute_address.nat_gateway_zone_f.name}"
   ssh_fw_rule     = false
   instance_labels = "${local.labels}"
 }

--- a/infrastructure/terraform/keep-prd/nats.tf
+++ b/infrastructure/terraform/keep-prd/nats.tf
@@ -1,0 +1,68 @@
+resource "google_compute_address" "nat_gateway_zone_a" {
+  name         = "${var.nat_gateway_ip["zone_a_name"]}"
+  project      = "${module.project.project_id}"
+  region       = "${var.region_data["region"]}"
+  address_type = "${var.nat_gateway_ip["address_type"]}"
+  network_tier = "${var.nat_gateway_ip["network_tier"]}"
+  labels       = "${local.labels}"
+}
+
+resource "google_compute_address" "nat_gateway_zone_b" {
+  name         = "${var.nat_gateway_ip["zone_b_name"]}"
+  project      = "${module.project.project_id}"
+  region       = "${var.region_data["region"]}"
+  address_type = "${var.nat_gateway_ip["address_type"]}"
+  network_tier = "${var.nat_gateway_ip["network_tier"]}"
+  labels       = "${local.labels}"
+}
+
+resource "google_compute_address" "nat_gateway_zone_c" {
+  name         = "${var.nat_gateway_ip["zone_c_name"]}"
+  project      = "${module.project.project_id}"
+  region       = "${var.region_data["region"]}"
+  address_type = "${var.nat_gateway_ip["address_type"]}"
+  network_tier = "${var.nat_gateway_ip["network_tier"]}"
+  labels       = "${local.labels}"
+}
+
+module "nat_gateway_zone_a" {
+  source          = "GoogleCloudPlatform/nat-gateway/google"
+  version         = "1.2.2"
+  name            = "${module.vpc.vpc_network_name}-"
+  project         = "${module.project.project_id}"
+  region          = "${var.region_data["region"]}"
+  zone            = "${var.region_data["zone_a"]}"
+  network         = "${module.vpc.vpc_network_name}"
+  subnetwork      = "${module.vpc.vpc_public_subnet_self_link}"
+  ip_address_name = "${google_compute_address.nat_gateway_zone_a.name}"
+  ssh_fw_rule     = false
+  instance_labels = "${local.labels}"
+}
+
+module "nat_gateway_zone_b" {
+  source          = "GoogleCloudPlatform/nat-gateway/google"
+  version         = "1.2.2"
+  name            = "${module.vpc.vpc_network_name}-"
+  project         = "${module.project.project_id}"
+  region          = "${var.region_data["region"]}"
+  zone            = "${var.region_data["zone_b"]}"
+  network         = "${module.vpc.vpc_network_name}"
+  subnetwork      = "${module.vpc.vpc_public_subnet_self_link}"
+  ip_address_name = "${google_compute_address.nat_gateway_zone_b.name}"
+  ssh_fw_rule     = false
+  instance_labels = "${local.labels}"
+}
+
+module "nat_gateway_zone_c" {
+  source          = "GoogleCloudPlatform/nat-gateway/google"
+  version         = "1.2.2"
+  name            = "${module.vpc.vpc_network_name}-"
+  project         = "${module.project.project_id}"
+  region          = "${var.region_data["region"]}"
+  zone            = "${var.region_data["zone_c"]}"
+  network         = "${module.vpc.vpc_network_name}"
+  subnetwork      = "${module.vpc.vpc_public_subnet_self_link}"
+  ip_address_name = "${google_compute_address.nat_gateway_zone_c.name}"
+  ssh_fw_rule     = false
+  instance_labels = "${local.labels}"
+}

--- a/infrastructure/terraform/keep-prd/variables.tf
+++ b/infrastructure/terraform/keep-prd/variables.tf
@@ -94,10 +94,10 @@ variable "nat_gateway_ip" {
   type = "map"
 
   default = {
-    zone_a_name  = "keep-prd-nat-gateway-a-external-ip"
-    zone_b_name  = "keep-prd-nat-gateway-b-external-ip"
-    zone_c_name  = "keep-prd-nat-gateway-c-external-ip"
-    zone_f_name  = "keep-prd-nat-gateway-f-external-ip"
+    zone_a_name  = "nat-gateway-a"
+    zone_b_name  = "nat-gateway-b"
+    zone_c_name  = "nat-gateway-c"
+    zone_f_name  = "nat-gateway-f"
     address_type = "EXTERNAL"
     network_tier = "PREMIUM"
   }

--- a/infrastructure/terraform/keep-prd/variables.tf
+++ b/infrastructure/terraform/keep-prd/variables.tf
@@ -85,3 +85,18 @@ variable "private_subnet_ip_cidr_range" {
   description = "IP address range assigned to the private subnet."
   default     = "10.4.0.0/16"
 }
+
+## nat gateway vars
+### external IP address vars
+
+variable "nat_gateway_ip" {
+  type = "map"
+
+  default = {
+    zone_a_name  = "keep-prd-nat-gateway-a-external-ip"
+    zone_b_name  = "keep-prd-nat-gateway-b-external-ip"
+    zone_c_name  = "keep-prd-nat-gateway-c-external-ip"
+    address_type = "EXTERNAL"
+    network_tier = "PREMIUM"
+  }
+}

--- a/infrastructure/terraform/keep-prd/variables.tf
+++ b/infrastructure/terraform/keep-prd/variables.tf
@@ -96,6 +96,7 @@ variable "nat_gateway_ip" {
     zone_a_name  = "keep-prd-nat-gateway-a-external-ip"
     zone_b_name  = "keep-prd-nat-gateway-b-external-ip"
     zone_c_name  = "keep-prd-nat-gateway-c-external-ip"
+    zone_f_name  = "keep-prd-nat-gateway-f-external-ip"
     address_type = "EXTERNAL"
     network_tier = "PREMIUM"
   }

--- a/infrastructure/terraform/keep-prd/variables.tf
+++ b/infrastructure/terraform/keep-prd/variables.tf
@@ -1,0 +1,87 @@
+# env vars
+variable "gcp_thesis_org_id" {
+  description = "The ID for the organization the project will be created under. Local ENV VAR"
+}
+
+variable "gcp_thesis_billing_account" {
+  description = "The billing account to associate with your project.  Must be associated with org already. Local ENV VAR"
+}
+
+# generic vars
+variable "region_data" {
+  type        = "map"
+  description = "Region and zone info."
+
+  default {
+    region = "us-central1"
+    zone_a = "us-central1-a"
+    zone_b = "us-central1-b"
+    zone_c = "us-central1-c"
+    zone_f = "us-central1-f"
+  }
+}
+
+variable "contacts" {
+  description = "The person(s) who contribute to this tf stack."
+  default     = "it"
+}
+
+variable "vertical" {
+  description = "Name of the vertical that the generated resources belong to.  e.g. cfc, keep"
+  default     = "keep"
+}
+
+variable "environment" {
+  description = "Environment you're creating resources in.  Usually project name"
+  default     = "keep-prd"
+}
+
+# project vars
+variable "project_name" {
+  description = "Name for the project."
+  default     = "keep-prd"
+}
+
+variable "project_owner_members" {
+  description = "List of service and user accounts to add with owner permissions to project."
+
+  default = [
+    "user:sloan.thompson@thesis.co",
+    "user:antonio.salazarcardozo@thesis.co",
+  ]
+}
+
+variable "project_service_list" {
+  description = "List of google APIs/Services to enable with project creation"
+
+  default = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+  ]
+}
+
+# network vars
+## vpc vars
+### vpc-network
+variable "vpc_network_name" {
+  description = "The name for your vpc-network"
+  default     = "keep-prd-vpc-network"
+}
+
+variable "routing_mode" {
+  description = "The dynamic router mode for the vpc-network."
+  default     = "regional"
+}
+
+### vpc-subnet
+#### public subnet
+variable "public_subnet_ip_cidr_range" {
+  description = "IP address range assigned to the public subnet."
+  default     = "10.0.0.0/16"
+}
+
+#### private subnet
+variable "private_subnet_ip_cidr_range" {
+  description = "IP address range assigned to the private subnet."
+  default     = "10.4.0.0/16"
+}

--- a/infrastructure/terraform/keep-prd/variables.tf
+++ b/infrastructure/terraform/keep-prd/variables.tf
@@ -91,9 +91,7 @@ variable "private_subnet_ip_cidr_range" {
 ### external IP address vars
 
 variable "nat_gateway_ip" {
-  type = "map"
-
-  default = {
+  default {
     zone_a_name  = "nat-gateway-a"
     zone_b_name  = "nat-gateway-b"
     zone_c_name  = "nat-gateway-c"


### PR DESCRIPTION
Here we setup 3 NAT's across us-central1 to provide egress traffic routing for GKE and private subnet instances.

- 3 static IP's for each NAT
- us-central1-a/b/c NAT instance deployment
- Network routes for nat routing - included as network tags for devices that need to route through the NATs
- NAT firewall rules