### PR TITLE
Fix typo in group reward

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -64,7 +64,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     TokenStaking internal stakingContract;
 
     // Each signing group member reward expressed in wei.
-    uint256 public groupMemberBaseReward = 1000000*1e11; // 1M Gwei
+    uint256 public groupMemberBaseReward = 1000000*1e9; // 1M Gwei
 
     // Gas price ceiling value used to calculate the gas price for reimbursement
     // next to the actual gas price from the transaction. We use gas price


### PR DESCRIPTION
1M gwei is 1,000,000 * 1e9. The previous group reward was expressed as a multiple of 100 gwei,
and the 1e11 unit remained in the new calculation of #1653 