### PR TITLE
Circle: Kill Docker image tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: Run Docker build
           command: |
             docker build --build-arg GITHUB_TOKEN=$GITHUB_TOKEN --target gobuild -t go-build-env .
-            docker build --build-arg GITHUB_TOKEN=$GITHUB_TOKEN -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client:$DOCKER_IMAGE_TAG .
+            docker build --build-arg GITHUB_TOKEN=$GITHUB_TOKEN -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client .
       - run:
           name: Run Go tests
           command: |
@@ -62,7 +62,7 @@ jobs:
           name: Save keep-client image
           command: |
             mkdir -p /tmp/keep-client/docker-images
-            docker save -o /tmp/keep-client/docker-images/keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client:$DOCKER_IMAGE_TAG
+            docker save -o /tmp/keep-client/docker-images/keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-client
       - persist_to_workspace:
           root: /tmp/keep-client
           paths:
@@ -81,11 +81,11 @@ jobs:
             cp /tmp/keep-client/contracts/* infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
             cd infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
             docker build \
-              -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client:$DOCKER_IMAGE_TAG .
+              -t $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client .
       - run:
           name: Save initcontainer-provision-keep-client image
           command: |
-            docker save -o /tmp/keep-client/docker-images/initcontainer-provision-keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client:$DOCKER_IMAGE_TAG
+            docker save -o /tmp/keep-client/docker-images/initcontainer-provision-keep-client.tar $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-client
       - persist_to_workspace:
           root: /tmp/keep-client
           paths:
@@ -132,12 +132,12 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-client
-          tag: $DOCKER_IMAGE_TAG
+          tag: latest
       - gcp-gcr/push-image:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-client
-          tag: $DOCKER_IMAGE_TAG
+          tag: latest
   publish_contract_data:
     executor: gcp-cli/default
     steps:
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Tag Docker image
           command: |
-            docker tag keep-dapp-token-dashboard $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-dapp-token-dashboard:$DOCKER_IMAGE_TAG
+            docker tag keep-dapp-token-dashboard $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-dapp-token-dashboard
       - gcp-gcr/gcr-auth:
           google-project-id: GOOGLE_PROJECT_ID
           google-compute-zone: GOOGLE_COMPUTE_ZONE_A
@@ -260,7 +260,7 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-dapp-token-dashboard
-          tag: $DOCKER_IMAGE_TAG
+          tag: latest
 
   generate_docs_tex:
     docker:
@@ -370,16 +370,16 @@ workflows:
             - build_initcontainer
             - migrate_contracts
       - trigger_downstream_builds:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - publish_npm_package
       - publish_contract_data:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go
@@ -393,9 +393,9 @@ workflows:
           requires:
             - publish_npm_package
       - publish_token_dashboard_dapp:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_token_dashboard_dapp


### PR DESCRIPTION
This doesn't work the way we expect with tag builds so I'm reverting for now.  Will pick this up soon with a proper solution.

Namely - Using the Circle context to try and set `$DOCKER_IMAGE_TAG=$CIRCLE_TAG` takes the literal `$CIRCLE_TAG`