### PR TITLE
Set keep-core contracts dependency to >0.15.0-pre <0.15.0-rc

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -985,9 +985,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@keep-network/keep-core": {
-      "version": "0.14.0-pre.8",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.8.tgz",
-      "integrity": "sha512-P7ozgh9a5qe7RhD26G3ELdMEcapTAdQL+IC/EcRXsuvDF96s05t6DecTAbxJakumcpDjwzgnbbqW7OAjlmpApw==",
+      "version": "0.15.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.0.tgz",
+      "integrity": "sha512-cfrhRJX9+zkimYQ/6ASoX3inZIQ3V1dx2YDDgmoVzctm93yDKcz++fWiGSz6PXbYOUMq8Svj+a1Sv5KJSg2WLg==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -1051,9 +1051,9 @@
           }
         },
         "ethers": {
-          "version": "4.0.46",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.46.tgz",
-          "integrity": "sha512-/dPMzzpInhtiip4hKFvsDiJKeRk64IhyA+Po7CtNXneQFSOCYXg8eBFt+jXbxUQyApgWnWOtYxWdfn9+CvvxDA==",
+          "version": "4.0.47",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
           "requires": {
             "aes-js": "3.0.0",
             "bn.js": "^4.4.0",
@@ -1127,9 +1127,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.19",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
-              "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
+              "version": "10.17.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
             }
           }
         },
@@ -1230,9 +1230,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.19",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
-              "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
+              "version": "10.17.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
             },
             "elliptic": {
               "version": "6.3.3",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.1.3",
     "moment": "^2.20.1",
     "web3": "^1.2.4",
-    "@keep-network/keep-core": ">0.14.0-rc <0.14.0"
+    "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc"
   },
   "scripts": {
     "build-css": "lessc --clean-css src/css/app.less src/app.css",


### PR DESCRIPTION
After tagging `v0.15.0-rc` and deploying `0.15.0-pre` contracts to NPM
registry we can update the dependency in KEEP token dashboard.