### PR TITLE
Roll faucet forward to v0.14.0-rc

### DIFF
--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
@@ -70,9 +70,9 @@ exports.issueGrant = async (request, response) => {
       )
     } else {
       const granteeAccount = account
-      const unlockingDuration = web3.utils.toBN(0)
       const start = web3.utils.toBN(Math.floor(Date.now() / 1000))
       const cliff = web3.utils.toBN(172800)
+      const unlockingDuration = cliff
       const revocable = true
       const tokens = web3.utils.toBN(300000)
       console.log(`Fetching existing balance for account [${granteeAccount}]...`)

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
@@ -96,14 +96,11 @@ exports.issueGrant = async (request, response) => {
         console.log(
           `Submitting grant for [${grantAmount}] to [${granteeAccount}]...`,
         )
-        const grantData = Buffer.concat([
-          Buffer.from(granteeAccount.substr(2), 'hex', 20),
-          unlockingDuration.toBuffer('be', 32),
-          start.toBuffer('be', 32),
-          cliff.toBuffer('be', 32),
-          Buffer.from(revocable ? '01' : '00', 'hex'),
-          Buffer.from(permissiveStakingPolicyAddress.substr(2), 'hex', 20)
-        ])
+        const grantData =
+          web3.eth.abi.encodeParameters(
+            ["address", "address", "uint256", "uint256", "uint256", "bool", "address"],
+            [keepContractOwnerAddress, granteeAccount, unlockingDuration, start, cliff, revocable, permissiveStakingPolicyAddress]
+        )
 
         console.log("Test submission...")
         // Try calling; if this throws, we'll have a proper error message thanks

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.1.tgz",
-      "integrity": "sha512-QEZnIUj99sFSkc/BAYiW+W7Xq7IQEJOaanD0t6/wC1Bn1/CrqpZxTwXTTeKOIh31ONhOjMP4d3utsypgGay/dQ==",
+      "version": "0.14.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-rc.0.tgz",
+      "integrity": "sha512-9K2oeuCvDK4Q1BsPghouOdEF7Ad8iCiuX7RblIaka2h8sLRBs6proyrue+KDjfKTreOZgfqb938yiyaGnyMTEQ==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -52,9 +52,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.36",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
-          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+          "version": "12.12.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.37.tgz",
+          "integrity": "sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg=="
         },
         "aes-js": {
           "version": "3.0.0",
@@ -99,9 +99,9 @@
           }
         },
         "ethers": {
-          "version": "4.0.46",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.46.tgz",
-          "integrity": "sha512-/dPMzzpInhtiip4hKFvsDiJKeRk64IhyA+Po7CtNXneQFSOCYXg8eBFt+jXbxUQyApgWnWOtYxWdfn9+CvvxDA==",
+          "version": "4.0.47",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
           "requires": {
             "aes-js": "3.0.0",
             "bn.js": "^4.4.0",
@@ -178,9 +178,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.20",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.20.tgz",
-              "integrity": "sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw=="
+              "version": "10.17.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
             }
           }
         },
@@ -281,9 +281,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.20",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.20.tgz",
-              "integrity": "sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw=="
+              "version": "10.17.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
             },
             "elliptic": {
               "version": "6.3.3",

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
@@ -1,7 +1,7 @@
 {
   "main": "issue-grant.js",
   "dependencies": {
-    "@keep-network/keep-core": ">0.13.0-rc <0.13.0",
+    "@keep-network/keep-core": ">0.14.0-rc <0.14.0",
     "@truffle/hdwallet-provider": "^1.0.25",
     "web3": "1.2.6"
   },


### PR DESCRIPTION
Here we do a few things:

- Roll the faucet forward to `v0.14.0-rc` contracts
- Update `approveAndCall` to work with ^
- Include a cliff and `revocable` status for faucet grants to help combat script kiddies (by allowing us to revoke grants)