### PR TITLE
Add adaptive staking policy

### DIFF
--- a/solidity/contracts/AdaptiveStakingPolicy.sol
+++ b/solidity/contracts/AdaptiveStakingPolicy.sol
@@ -29,6 +29,10 @@ contract AdaptiveStakingPolicy is GrantStakingPolicy {
         // Multiplier for the minimum stake;
         // with a minimumMultiplier = 5
         // the policy permits staking 5 times the minimum stake.
+        // If the multiplier is 0,
+        // only the unlocked amount,
+        // including stakeahead if applicable,
+        // can be staked.
         uint256 minimumMultiplier,
         // Stakeahead time in seconds;
         // the policy permits staking the amount that will be unlocked

--- a/solidity/contracts/AdaptiveStakingPolicy.sol
+++ b/solidity/contracts/AdaptiveStakingPolicy.sol
@@ -1,0 +1,73 @@
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "./libraries/grant/UnlockingSchedule.sol";
+import "./GrantStakingPolicy.sol";
+import "./TokenStaking.sol";
+
+/// @title AdaptiveStakingPolicy
+/// @dev A staking policy which allows the grantee
+/// to always stake the defined minimum stake,
+/// or the unlocked amount if greater.
+///
+/// This is necessary for staking revocable token grants safely.
+/// If the entire revocable grant can be staked,
+/// the yet-to-be-unlocked amount becomes ineffective as collateral
+/// if the grant is revoked.
+/// To avoid this issue,
+/// only the unlocked amount can be staked.
+///
+/// However, grants that feature a cliff pose a problem
+/// as no tokens are unlocked until the cliff is reached.
+/// Small grants may also take a long time
+/// to unlock enough tokens to be able to stake.
+/// To permit all grants to stake from the beginning,
+/// the policy defines a minimum which can always be staked
+/// even if the grant doesn't have enough unlocked tokens.
+contract AdaptiveStakingPolicy is GrantStakingPolicy {
+    using SafeMath for uint256;
+    using UnlockingSchedule for uint256;
+    uint256 minimumStake;
+    uint256 stakeaheadTime;
+    bool useCliff;
+
+    constructor(
+        address _stakingContract,
+        uint256 minimumMultiplier,
+        uint256 _stakeaheadTime,
+        bool _useCliff
+    ) public {
+        minimumStake = TokenStaking(_stakingContract).minimumStake().mul(minimumMultiplier);
+        stakeaheadTime = _stakeaheadTime;
+        useCliff = _useCliff;
+    }
+
+    function getStakeableAmount (
+        uint256 _now,
+        uint256 grantedAmount,
+        uint256 duration,
+        uint256 start,
+        uint256 cliff,
+        uint256 withdrawn
+    ) public view returns (uint256) {
+        uint256 unlocked = _now.add(stakeaheadTime).getUnlockedAmount(
+            grantedAmount,
+            duration,
+            start,
+            (useCliff ? cliff : 0)
+        );
+        uint256 remainingInGrant = grantedAmount.sub(withdrawn);
+        uint256 unlockedInGrant = unlocked.sub(withdrawn);
+
+        // Less than minimum stake remaining
+        //   -> may stake what is remaining in grant
+        if (remainingInGrant < minimumStake) { return remainingInGrant; }
+        // At least minimum stake remaining in grant,
+        // but unlocked amount is less than the minimum stake
+        //   -> may stake the minimum stake
+        if (unlockedInGrant < minimumStake) { return minimumStake; }
+        // More than minimum stake unlocked in grant
+        //   -> may stake the unlocked amount
+        return unlockedInGrant;
+    }
+}

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -279,10 +279,10 @@ describe('AdaptiveStakingPolicy', async () => {
     it("should calculate stakeable amount correctly before cliff", async () => {
       expect(await withCliff(1499, largeGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
-        "Should permit minimum stake with large grant before cliff");
+        "Should permit multiple of minimum stake with large grant before cliff");
       expect(await withCliff(1499, mediumGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
-        "Should permit minimum stake with medium grant before cliff");
+        "Should permit multiple of minimum stake with medium grant before cliff");
       expect(await withCliff(1499, smallGrant, 0)).to.eq.BN(
         smallGrant,
         "Should permit entire grant with small grant before cliff");
@@ -301,7 +301,7 @@ describe('AdaptiveStakingPolicy', async () => {
         "Should permit half with large grant just after cliff");
       expect(await withCliff(1500, mediumGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
-        "Should permit minimum with medium grant just after cliff");
+        "Should permit multiple of minimum with medium grant just after cliff");
       expect(await withCliff(1500, smallGrant, 0)).to.eq.BN(
         smallGrant,
         "Should permit entire grant with small grant just after cliff");
@@ -314,7 +314,7 @@ describe('AdaptiveStakingPolicy', async () => {
         "Should permit three quarters with large grant halfway through");
       expect(await withCliff(2000, mediumGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
-        "Should permit minimum with medium grant halfway through");
+        "Should permit multiple of minimum with medium grant halfway through");
       expect(await withCliff(2000, smallGrant, 0)).to.eq.BN(
         smallGrant,
         "Should permit entire grant with small grant halfway through");

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -288,6 +288,12 @@ describe('AdaptiveStakingPolicy', async () => {
         "Should permit entire grant with small grant before cliff");
     });
 
+    it("should ignore cliff if specified", async () => {
+      expect(await withoutCliff(1250, largeGrant, 0)).to.eq.BN(
+        tokens(1875000),
+        "Should permit stakeahead with large grant before cliff");
+    });
+
     // cliff at 1000, stakeahead of 500
     it("should calculate stakeable amount correctly just after cliff", async () => {
       expect(await withCliff(1500, largeGrant, 0)).to.eq.BN(

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -276,7 +276,7 @@ describe('AdaptiveStakingPolicy', async () => {
   }
 
   describe("with nothing withdrawn", async () => {
-    it("should withCliff stakeable amount correctly before cliff", async () => {
+    it("should calculate stakeable amount correctly before cliff", async () => {
       expect(await withCliff(1499, largeGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
         "Should permit minimum stake with large grant before cliff");
@@ -289,32 +289,32 @@ describe('AdaptiveStakingPolicy', async () => {
     });
 
     // cliff at 1000, stakeahead of 500
-    it("should withCliff stakeable amount correctly just after cliff", async () => {
+    it("should calculate stakeable amount correctly just after cliff", async () => {
       expect(await withCliff(1500, largeGrant, 0)).to.eq.BN(
         tokens(2500000),
-        "Should permit unlocked amount with large grant just after cliff");
+        "Should permit half with large grant just after cliff");
       expect(await withCliff(1500, mediumGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
-        "Should permit minimum stake with medium grant just after cliff");
+        "Should permit minimum with medium grant just after cliff");
       expect(await withCliff(1500, smallGrant, 0)).to.eq.BN(
         smallGrant,
         "Should permit entire grant with small grant just after cliff");
     });
 
     // stakeahead of 500, so 75% is unlocked
-    it("should withCliff stakeable amount correctly halfway through", async () => {
+    it("should calculate stakeable amount correctly halfway through", async () => {
       expect(await withCliff(2000, largeGrant, 0)).to.eq.BN(
         tokens(3750000),
-        "Should permit unlocked amount with large grant halfway through");
+        "Should permit three quarters with large grant halfway through");
       expect(await withCliff(2000, mediumGrant, 0)).to.eq.BN(
         minimumStake.muln(minimumMultiplier),
-        "Should permit unlocked amount with medium grant halfway through");
+        "Should permit minimum with medium grant halfway through");
       expect(await withCliff(2000, smallGrant, 0)).to.eq.BN(
         smallGrant,
         "Should permit entire grant with small grant halfway through");
     });
 
-    it("should withCliff stakeable amount correctly after unlocking period", async () => {
+    it("should calculate stakeable amount correctly after unlocking period", async () => {
       expect(await withCliff(3000, largeGrant, 0)).to.eq.BN(
         largeGrant,
         "Should permit unlocked amount with large grant after unlocking period");
@@ -328,25 +328,24 @@ describe('AdaptiveStakingPolicy', async () => {
   })
 
   describe("with all unlocked tokens withdrawn", async () => {
-    it("should withCliff stakeable amount correctly just after cliff", async () => {
+    it("should calculate stakeable amount correctly just after cliff", async () => {
       expect(await withCliff(2000, largeGrant, tokens(2500000))).to.eq.BN(
         tokens(1250000),
-        "Should permit minimum stake with large grant just after cliff");
+        "Should permit a quarter with large grant just after cliff");
       expect(await withCliff(2000, mediumGrant, tokens(250000))).to.eq.BN(
         tokens(250000),
-        "Should permit minimum stake with medium grant just after cliff");
-      expect(await withCliff(1500, smallGrant, tokens(12500))).to.eq.BN(
-        tokens(37500),
+        "Should permit remaining amount with medium grant just after cliff");
+      expect(await withCliff(2000, smallGrant, tokens(25000))).to.eq.BN(
+        tokens(25000),
         "Should permit remaining amount with small grant just after cliff");
     });
 
-    // good numbers stop here
-    it("should withCliff stakeable amount correctly at three quarters", async () => {
-      expect(await withCliff(2500, largeGrant, tokens(375000))).to.eq.BN(
-        minimumStake.muln(minimumMultiplier),
-        "Should permit minimum stake with large grant at three quarters");
-      expect(await withCliff(2500, mediumGrant, tokens(187500))).to.eq.BN(
-        tokens(62500),
+    it("should calculate stakeable amount correctly at three quarters", async () => {
+      expect(await withCliff(2500, largeGrant, tokens(3750000))).to.eq.BN(
+        tokens(1250000),
+        "Should permit remaining amount with large grant at three quarters");
+      expect(await withCliff(2500, mediumGrant, tokens(375000))).to.eq.BN(
+        tokens(125000),
         "Should permit remaining amount with medium grant at three quarters");
       expect(await withCliff(2500, smallGrant, tokens(37500))).to.eq.BN(
         tokens(12500),
@@ -355,28 +354,28 @@ describe('AdaptiveStakingPolicy', async () => {
   })
 
   describe("with half of unlocked tokens withdrawn", async () => {
-    it("should withCliff stakeable amount correctly just after cliff", async () => {
-      expect(await withCliff(1500, largeGrant, tokens(62500))).to.eq.BN(
-        minimumStake,
-        "Should permit minimum stake with large grant just after cliff");
-      expect(await withCliff(1500, mediumGrant, tokens(31250))).to.eq.BN(
-        minimumStake,
-        "Should permit minimum stake with medium grant just after cliff");
-      expect(await withCliff(1500, smallGrant, tokens(6250))).to.eq.BN(
-        tokens(43750),
+    it("should calculate stakeable amount correctly just after cliff", async () => {
+      expect(await withCliff(2000, largeGrant, tokens(1250000))).to.eq.BN(
+        tokens(2500000),
+        "Should permit half with large grant just after cliff");
+      expect(await withCliff(2000, mediumGrant, tokens(125000))).to.eq.BN(
+        tokens(375000),
+        "Should permit remaining amount with medium grant just after cliff");
+      expect(await withCliff(2000, smallGrant, tokens(12500))).to.eq.BN(
+        tokens(37500),
         "Should permit remaining amount with small grant just after cliff");
     });
 
-    it("should withCliff stakeable amount correctly halfway through", async () => {
-      expect(await withCliff(2000, largeGrant, tokens(125000))).to.eq.BN(
-        tokens(125000),
-        "Should permit remaining unlocked amount with large grant halfway through");
-      expect(await withCliff(2000, mediumGrant, tokens(62500))).to.eq.BN(
-        minimumStake,
-        "Should permit minimum stake with medium grant halfway through");
-      expect(await withCliff(2000, smallGrant, tokens(12500))).to.eq.BN(
-        tokens(37500),
-        "Should permit remaining amount with small grant halfway through");
+    it("should calculate stakeable amount correctly at three quarters", async () => {
+      expect(await withCliff(2500, largeGrant, tokens(1875000))).to.eq.BN(
+        tokens(3125000),
+        "Should permit remaining amount with large grant at three quarters");
+      expect(await withCliff(2500, mediumGrant, tokens(187500))).to.eq.BN(
+        tokens(312500),
+        "Should permit remaining amount with medium grant at three quarters");
+      expect(await withCliff(2500, smallGrant, tokens(18750))).to.eq.BN(
+        tokens(31250),
+        "Should permit remaining amount with small grant at three quarters");
     });
   })
 });


### PR DESCRIPTION
Customize stakeahead (in seconds and whether it considers cliff), and set the policy minimum as a multiple of the staking contract minimum.