### PR TITLE
Broadcast channel forwarder tweaks

### DIFF
--- a/pkg/beacon/relay/node.go
+++ b/pkg/beacon/relay/node.go
@@ -139,17 +139,9 @@ func (n *Node) JoinGroupIfEligible(
 				)
 			}()
 		}
-	} else {
-		go n.forwardDKGMessages(channelName)
 	}
 
 	return
-}
-
-// ForwardDKGMessages enables the ability to forward DKG messages
-// to other nodes even if this node has not been selected to the group.
-func (n *Node) forwardDKGMessages(name string) {
-	n.netProvider.BroadcastChannelForwarderFor(name)
 }
 
 // ForwardSignatureShares enables the ability to forward signature shares

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -116,9 +116,10 @@ func (p *provider) BroadcastChannelForwarderFor(name string) {
 	logger.Infof("requested message forwarder for channel: [%v]", name)
 
 	// TTL for a single message forwarder should be limited to avoid unnecessary
-	// resource consumption. One hour seems to be a reasonable value as no
-	// single protocol execution will exceed this time.
-	ttl := 1 * time.Hour
+	// resource consumption. This value should not exceed libp2p time-cache
+	// duration which holds seen messages, to prevent an uncontrolled
+	// message propagation.
+	ttl := 90 * time.Second
 
 	if err := p.broadcastChannelManager.newForwarder(name, ttl); err != nil {
 		logger.Warningf(


### PR DESCRIPTION
Refs #1652

Current settings of the channel forwarder can cause an uncontrolled message propagation because forwarders live for `1` hour and libp2p `pubsub` cache holds seen messages only for `2` minutes. Because of that, a message can continuously flow in the network even if it is no longer relevant for anyone. If we have a significant number of `keep-core` clients in the network and there is a high rate of messages in general, the network can be congested. As a consequence, clients will experience resource usage peaks which can be deadly in certain environments. To prevent such problems we:
- remove broadcast channel messages forwarding for DKG
- reduce broadcast channel messages forwarders TTL for relay entries from `1` hour to `90` seconds

