### PR TITLE
Fixed failing test after renaming magpie to beneficiary

### DIFF
--- a/solidity/test/token_stake/TestTokenStakeLock.js
+++ b/solidity/test/token_stake/TestTokenStakeLock.js
@@ -260,7 +260,7 @@ describe('TokenStaking/Lock', () => {
 
       await expectRevert(
         stakingContract.seize(
-          minimumStake, 100, magpie, [operator],
+          minimumStake, 100, beneficiary, [operator],
           {from: operatorContract}
         ),
         "Stake is released"


### PR DESCRIPTION
We had two PRs merged one after another - one PR added additional test
using `magpie` name and another PR renamed `magpie` to `beneficiary` so
when they both landed in `master`, that new test started failing.