### PR TITLE
Expose information allowing to resume entry signing, reduce contract size

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -120,9 +120,9 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
     // current relay request data
     uint256 internal currentRequestId;
-    uint256 internal currentEntryStartBlock;
-    uint256 internal currentRequestGroupIndex;
-    bytes internal currentRequestPreviousEntry;
+    uint256 public currentEntryStartBlock;
+    uint256 public currentRequestGroupIndex;
+    bytes public currentRequestPreviousEntry;
     uint256 internal  currentRequestEntryVerificationAndProfitFee;
     uint256 internal currentRequestCallbackFee;
     address internal currentRequestServiceContract;
@@ -418,16 +418,15 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     ) internal {
         require(!isEntryInProgress() || hasEntryTimedOut(), "Beacon is busy");
 
-        currentEntryStartBlock = block.number;
-
         uint256 groupIndex = groups.selectGroup(uint256(keccak256(previousEntry)));
-        
+
         currentRequestId = requestId;
+        currentEntryStartBlock = block.number;
         currentRequestEntryVerificationAndProfitFee = entryVerificationAndProfitFee;
         currentRequestCallbackFee = callbackFee;
         currentRequestGroupIndex = groupIndex;
         currentRequestPreviousEntry = previousEntry;
-        currentRequestServiceContract = serviceContract;        
+        currentRequestServiceContract = serviceContract;
 
         bytes memory groupPubKey = groups.getGroupPublicKey(groupIndex);
         emit RelayEntryRequested(previousEntry, groupPubKey);
@@ -547,7 +546,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
      * @dev Returns true if generation of a new relay entry is currently in
      * progress.
      */
-    function isEntryInProgress() internal view returns (bool) {
+    function isEntryInProgress() public view returns (bool) {
         return currentEntryStartBlock != 0;
     }
 

--- a/solidity/contracts/libraries/operator/DelayFactor.sol
+++ b/solidity/contracts/libraries/operator/DelayFactor.sol
@@ -1,0 +1,47 @@
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+library DelayFactor {
+    using SafeMath for uint256;
+
+    /**
+     * @dev Gets delay factor for rewards calculation.
+     * @return Integer representing floating-point number with 16 decimals places.
+     */
+    function calculate(
+        uint256 currentEntryStartBlock,
+        uint256 relayEntryTimeout
+    ) public view returns(uint256 delayFactor) {
+        uint256 decimals = 1e16; // Adding 16 decimals to perform float division.
+
+        // T_deadline is the earliest block when no submissions are accepted
+        // and an entry timed out. The last block the entry can be published in is
+        //     currentEntryStartBlock + relayEntryTimeout
+        // and submission are no longer accepted from block
+        //     currentEntryStartBlock + relayEntryTimeout + 1.
+        uint256 deadlineBlock = currentEntryStartBlock.add(relayEntryTimeout).add(1);
+
+        // T_begin is the earliest block the result can be published in.
+        // Relay entry can be generated instantly after relay request is
+        // registered on-chain so a new entry can be published at the next
+        // block the earliest.
+        uint256 submissionStartBlock = currentEntryStartBlock.add(1);
+
+        // Use submissionStartBlock block as entryReceivedBlock if entry submitted earlier than expected.
+        uint256 entryReceivedBlock = block.number <= submissionStartBlock ? submissionStartBlock:block.number;
+
+        // T_remaining = T_deadline - T_received
+        uint256 remainingBlocks = deadlineBlock.sub(entryReceivedBlock);
+
+        // T_deadline - T_begin
+        uint256 submissionWindow = deadlineBlock.sub(submissionStartBlock);
+
+        // delay factor = [ T_remaining / (T_deadline - T_begin)]^2
+        //
+        // Since we add 16 decimal places to perform float division, we do:
+        // delay factor = [ T_temaining * decimals / (T_deadline - T_begin)]^2 / decimals =
+        //    = [T_remaining / (T_deadline - T_begin) ]^2 * decimals
+        delayFactor = ((remainingBlocks.mul(decimals).div(submissionWindow))**2).div(decimals);
+    }
+}

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
@@ -35,7 +35,7 @@ contract KeepRandomBeaconOperatorPricingRewardsWithdrawStub is KeepRandomBeaconO
     }
 
     function relayEntry() public returns (uint256) {
-        bytes memory groupPubKey = groups.getGroupPublicKey(signingRequest.groupIndex);
+        bytes memory groupPubKey = groups.getGroupPublicKey(currentRequestGroupIndex);
         (uint256 groupMemberReward, uint256 submitterReward, uint256 subsidy) = newEntryRewardsBreakdown();
         submitterReward; // silence local var
         subsidy; // silence local var

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
@@ -47,6 +47,9 @@ contract KeepRandomBeaconOperatorPricingStub is KeepRandomBeaconOperator {
     }
 
     function delayFactor() public view returns(uint256) {
-        return super.getDelayFactor();
+        return DelayFactor.calculate(
+            currentEntryStartBlock,
+            relayEntryTimeout
+        );
     }
 }

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
@@ -34,7 +34,7 @@ contract KeepRandomBeaconOperatorPricingStub is KeepRandomBeaconOperator {
         groupSelectionGasEstimate = gas;
     }
 
-    function setGasPriceCeiling(uint256 _gasPriceCeiling) public onlyOwner {
+    function setGasPriceCeiling(uint256 _gasPriceCeiling) public {
         gasPriceCeiling = _gasPriceCeiling;
     }
 

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -15,6 +15,7 @@ const GroupSelection = artifacts.require("./libraries/operator/GroupSelection.so
 const Groups = artifacts.require("./libraries/operator/Groups.sol");
 const DKGResultVerification = artifacts.require("./libraries/operator/DKGResultVerification.sol");
 const Reimbursements = artifacts.require("./libraries/operator/Reimbursements.sol");
+const DelayFactor = artifacts.require("./libraries/operator/DelayFactor.sol");
 const Registry = artifacts.require("./Registry.sol");
 
 let initializationPeriod = 43200; // ~12 hours
@@ -51,6 +52,8 @@ module.exports = async function(deployer, network) {
   await deployer.link(Groups, KeepRandomBeaconOperator);
   await deployer.deploy(DKGResultVerification);
   await deployer.link(DKGResultVerification, KeepRandomBeaconOperator);
+  await deployer.deploy(DelayFactor);
+  await deployer.link(DelayFactor, KeepRandomBeaconOperator);
   await deployer.deploy(Reimbursements);
   await deployer.link(Reimbursements, KeepRandomBeaconOperator);
   await deployer.link(BLS, KeepRandomBeaconOperator);

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -4,6 +4,7 @@ const BLS = contract.fromArtifact('BLS');
 const GroupSelection = contract.fromArtifact('GroupSelection');
 const Groups = contract.fromArtifact('Groups');
 const DKGResultVerification = contract.fromArtifact("DKGResultVerification");
+const DelayFactor = contract.fromArtifact("DelayFactor");
 const Reimbursements = contract.fromArtifact("Reimbursements");
 const Registry = contract.fromArtifact("Registry");
 
@@ -47,11 +48,12 @@ async function initContracts(KeepToken, TokenStaking, KeepRandomBeaconService,
   await Groups.detectNetwork()
   await Groups.link("BLS", bls.address);
   const groups = await Groups.new({from: accounts[0]});
-
+  const delayFactor = await DelayFactor.new({from: accounts[0]});
   const dkgResultVerification = await DKGResultVerification.new({from: accounts[0]});
 
   const reimbursements = await Reimbursements.new({from: accounts[0]});
 
+  await KeepRandomBeaconOperator.link("DelayFactor", delayFactor.address);
   await KeepRandomBeaconOperator.link("GroupSelection", groupSelection.address);
   await KeepRandomBeaconOperator.link("Groups", groups.address);
   await KeepRandomBeaconOperator.link("DKGResultVerification", dkgResultVerification.address);


### PR DESCRIPTION
The mail goal is to expose the information allowing to resume relay entry signing after client crash. With the changes here, the client can call `isEntryInProgress()`, and then looking at
`currentEntryStartBlock`, `currentRequestGroupIndex`, and `currentRequestPreviousEntry` join the signing process.

This was not straightforward and I was head-slapped by operator contract size problem. To be able to make the mentioned information public, I had to do two changes to reduce operator contract size:
- Extracted delay factor calculation to a library. It let me save `~78 bytes`.
- Eliminated `SigningRequest` struct. It let me save `~286 bytes`.

At overall, with all the changes here, the operator contract size increased from `24728` to `24887`, as computed with:
```
    let bytecode = operatorContract.constructor._json.bytecode;
    let bytecodeSize = bytecode.length / 2; // size in bytes
```

I encourage to review this PR commit by commit - it's easier to inspect the changes here this way.

To compare gas costs, I executed 7 requests on `master` and on this branch:

request TX `master` branch costs vs
request TX `reduce` branch costs:
```
361620, 229020, 229020, 243657, 243657, 243657, 243657
361615, 229015, 229015, 229015, 229015, 229015, 229015
```

entry TX `master` branch costs vs
entry TX `reduce` branch costs:
```
235481, 220481, 252087, 237075, 220481, 237087, 237087
236569, 221569, 221557, 221569, 221569, 221557, 221569
```