### PR TITLE
Service Contract Keeper and non-ownable KeepRandomBeaconOperator contract

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -142,9 +142,9 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         startGroupSelection(_genesisGroupSeed, msg.value);
     }
 
-    modifier onlyServiceContractKeeper() {
+    modifier onlyServiceContractUpgrader() {
         require(
-            registry.serviceContractKeeperFor(address(this)) == msg.sender,
+            registry.serviceContractUpgraderFor(address(this)) == msg.sender,
             "Not authorized"
         );
         _;
@@ -207,7 +207,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
      * @dev Adds service contract
      * @param serviceContract Address of the service contract.
      */
-    function addServiceContract(address serviceContract) public onlyServiceContractKeeper {
+    function addServiceContract(address serviceContract) public onlyServiceContractUpgrader {
         serviceContracts.push(serviceContract);
     }
 
@@ -215,7 +215,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
      * @dev Removes service contract
      * @param serviceContract Address of the service contract.
      */
-    function removeServiceContract(address serviceContract) public onlyServiceContractKeeper {
+    function removeServiceContract(address serviceContract) public onlyServiceContractUpgrader {
         serviceContracts.removeAddress(serviceContract);
     }
 

--- a/solidity/contracts/Registry.sol
+++ b/solidity/contracts/Registry.sol
@@ -41,14 +41,14 @@ contract Registry {
     // service contract’s operator contract list, and deprecate old ones.
     mapping(address => address) public operatorContractUpgraders;
 
-    // Operator contract may have a Service Contract Keeper whose purpose is
+    // Operator contract may have a Service Contract Upgrader whose purpose is
     // to manage service contracts for that specific operator contract.
-    // Service Contract Keeper can add and remove service contracts
+    // Service Contract Upgrader can add and remove service contracts
     // from the list of service contracts approved to work with the operator
     // contract. List of service contracts is maintained in the operator
     // contract and is optional - not every operator contract needs to have
     // a list of service contracts it wants to cooperate with.
-    mapping(address => address) public serviceContractKeepers;
+    mapping(address => address) public serviceContractUpgraders;
 
     // The registry of operator contracts
     mapping(address => ContractStatus) public operatorContracts;
@@ -68,7 +68,7 @@ contract Registry {
         address serviceContract,
         address upgrader
     );
-    event ServiceContractKeeperUpdated(
+    event ServiceContractUpgraderUpdated(
         address operatorContract,
         address keeper
     );
@@ -174,14 +174,14 @@ contract Registry {
         );
     }
 
-    function setServiceContractKeeper(
+    function setServiceContractUpgrader(
         address _operatorContract,
-        address _serviceContractKeeper
+        address _serviceContractUpgrader
     ) public onlyGovernance {
-        serviceContractKeepers[_operatorContract] = _serviceContractKeeper;
-        emit ServiceContractKeeperUpdated(
+        serviceContractUpgraders[_operatorContract] = _serviceContractUpgrader;
+        emit ServiceContractUpgraderUpdated(
             _operatorContract,
-            _serviceContractKeeper
+            _serviceContractUpgrader
         );
     }
 
@@ -228,11 +228,11 @@ contract Registry {
         return operatorContractUpgraders[_serviceContract];
     }
 
-    function serviceContractKeeperFor(address _operatorContract)
+    function serviceContractUpgraderFor(address _operatorContract)
         public
         view
         returns (address)
     {
-        return serviceContractKeepers[_operatorContract];
+        return serviceContractUpgraders[_operatorContract];
     }
 }

--- a/solidity/contracts/Registry.sol
+++ b/solidity/contracts/Registry.sol
@@ -41,6 +41,15 @@ contract Registry {
     // service contract’s operator contract list, and deprecate old ones.
     mapping(address => address) public operatorContractUpgraders;
 
+    // Operator contract may have a Service Contract Keeper whose purpose is
+    // to manage service contracts for that specific operator contract.
+    // Service Contract Keeper can add and remove service contracts
+    // from the list of service contracts approved to work with the operator
+    // contract. List of service contracts is maintained in the operator
+    // contract and is optional - not every operator contract needs to have
+    // a list of service contracts it wants to cooperate with.
+    mapping(address => address) public serviceContractKeepers;
+
     // The registry of operator contracts
     mapping(address => ContractStatus) public operatorContracts;
 
@@ -58,6 +67,10 @@ contract Registry {
     event OperatorContractUpgraderUpdated(
         address serviceContract,
         address upgrader
+    );
+    event ServiceContractKeeperUpdated(
+        address operatorContract,
+        address keeper
     );
 
     modifier onlyGovernance() {
@@ -161,6 +174,17 @@ contract Registry {
         );
     }
 
+    function setServiceContractKeeper(
+        address _operatorContract,
+        address _serviceContractKeeper
+    ) public onlyGovernance {
+        serviceContractKeepers[_operatorContract] = _serviceContractKeeper;
+        emit ServiceContractKeeperUpdated(
+            _operatorContract,
+            _serviceContractKeeper
+        );
+    }
+
     function approveOperatorContract(address operatorContract)
         public
         onlyForNewContract(operatorContract)
@@ -202,5 +226,13 @@ contract Registry {
         returns (address)
     {
         return operatorContractUpgraders[_serviceContract];
+    }
+
+    function serviceContractKeeperFor(address _operatorContract)
+        public
+        view
+        returns (address)
+    {
+        return serviceContractKeepers[_operatorContract];
     }
 }

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorCallbackStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorCallbackStub.sol
@@ -6,8 +6,13 @@ contract KeepRandomBeaconOperatorCallbackStub is KeepRandomBeaconOperator {
 
     constructor(
         address _serviceContract,
-        address _stakingContract
-    ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;
         resultPublicationBlockStep = 3;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
@@ -4,10 +4,15 @@ import "../KeepRandomBeaconOperator.sol";
 
 
 contract KeepRandomBeaconOperatorDKGResultStub is KeepRandomBeaconOperator {
-    constructor(address _serviceContract, address _stakingContract)
-        public
-        KeepRandomBeaconOperator(_serviceContract, _stakingContract)
-    {
+    constructor(
+        address _serviceContract,
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
         groupSelection.ticketSubmissionTimeout = 100;
     }
 

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorGroupSelectionStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorGroupSelectionStub.sol
@@ -5,8 +5,13 @@ import "../KeepRandomBeaconOperator.sol";
 contract KeepRandomBeaconOperatorGroupSelectionStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
-        address _stakingContract
-    ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
         groupSelection.ticketSubmissionTimeout = 65;
     }
 

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
@@ -9,8 +9,13 @@ contract KeepRandomBeaconOperatorPricingRewardsWithdrawStub is KeepRandomBeaconO
 
     constructor(
         address _serviceContract,
-        address _stakingContract
-    ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
         groups.groupActiveTime = 5;
         groups.relayEntryTimeout = 10;
     }

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
@@ -6,8 +6,13 @@ contract KeepRandomBeaconOperatorPricingStub is KeepRandomBeaconOperator {
 
     constructor(
         address _serviceContract,
-        address _stakingContract
-    ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
     }
 
     function registerNewGroup(bytes memory groupPublicKey) public {

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorRewardsStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorRewardsStub.sol
@@ -6,8 +6,13 @@ contract KeepRandomBeaconOperatorRewardsStub is KeepRandomBeaconOperator {
 
     constructor(
         address _serviceContract,
-        address _stakingContract
-    ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
         groups.groupActiveTime = 5;
         groups.relayEntryTimeout = 10;
     }

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorStub.sol
@@ -10,8 +10,13 @@ contract KeepRandomBeaconOperatorStub is KeepRandomBeaconOperator {
 
     constructor(
         address _serviceContract,
-        address _stakingContract
-    ) KeepRandomBeaconOperator(_serviceContract, _stakingContract) public {
+        address _stakingContract,
+        address _registryContract
+    ) KeepRandomBeaconOperator(
+        _serviceContract,
+        _stakingContract,
+        _registryContract
+    ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;
         resultPublicationBlockStep = 3;

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -72,6 +72,15 @@ module.exports = async function(deployer, network) {
       initialize
   );
 
-  await deployer.deploy(KeepRandomBeaconOperator, KeepRandomBeaconService.address, TokenStaking.address);
-  await deployer.deploy(KeepRandomBeaconOperatorStatistics, KeepRandomBeaconOperator.address);
+  await deployer.deploy(
+    KeepRandomBeaconOperator, 
+    KeepRandomBeaconService.address, 
+    TokenStaking.address,
+    Registry.address
+  );
+
+  await deployer.deploy(
+    KeepRandomBeaconOperatorStatistics,
+    KeepRandomBeaconOperator.address
+  );
 };

--- a/solidity/test/TestRegistry.js
+++ b/solidity/test/TestRegistry.js
@@ -13,7 +13,7 @@ describe('Registry', () => {
     const registryKeeper = accounts[3]
     const operatorContractUpgrader = accounts[4]
     const individualContractPanicButton = accounts[5]
-    const serviceContractKeeper = accounts[6]
+    const serviceContractUpgrader = accounts[6]
 
     const someoneElse = "0x524f2E0176350d950fA630D9A5a59A0a190DAf48"
 
@@ -274,11 +274,11 @@ describe('Registry', () => {
         })
     })
 
-    describe("setServiceContractKeeper", async () => {
+    describe("setServiceContractUpgrader", async () => {
         it("can be called by governance", async () => {
-            await registry.setServiceContractKeeper(
+            await registry.setServiceContractUpgrader(
                 operatorContract1,
-                serviceContractKeeper,
+                serviceContractUpgrader,
                 { from: governance }
             )
             // ok, no revert
@@ -286,51 +286,51 @@ describe('Registry', () => {
 
         it("can not be called by non-governance", async () => {
             await expectRevert(
-                registry.setServiceContractKeeper(
+                registry.setServiceContractUpgrader(
                     operatorContract1,
-                    serviceContractKeeper,
+                    serviceContractUpgrader,
                     { from: owner }
                 ),
                 "Not authorized"
             )
         })
 
-        it("updated service contract keeper", async () => {
-            await registry.setServiceContractKeeper(
+        it("updates service contract upgrader", async () => {
+            await registry.setServiceContractUpgrader(
                 operatorContract1,
-                serviceContractKeeper,
+                serviceContractUpgrader,
                 { from: governance }
             )
 
-            await registry.setServiceContractKeeper(
+            await registry.setServiceContractUpgrader(
                 operatorContract2,
                 someoneElse,
                 { from: governance }
             )
 
             assert.equal(
-                await registry.serviceContractKeeperFor(operatorContract1),
-                serviceContractKeeper,
-                "Unexpected service contract keeper"
+                await registry.serviceContractUpgraderFor(operatorContract1),
+                serviceContractUpgrader,
+                "Unexpected service contract upgrader"
             )
 
             assert.equal(
-                await registry.serviceContractKeeperFor(operatorContract2),
+                await registry.serviceContractUpgraderFor(operatorContract2),
                 someoneElse,
-                "Unexpected service contract keeper"
+                "Unexpected service contract upgrader"
             )
         })
 
         it("emits an event", async () => {
-            const receipt = await registry.setServiceContractKeeper(
+            const receipt = await registry.setServiceContractUpgrader(
                 operatorContract1,
-                serviceContractKeeper,
+                serviceContractUpgrader,
                 { from: governance }
             )
 
-            expectEvent(receipt, "ServiceContractKeeperUpdated", {
+            expectEvent(receipt, "ServiceContractUpgraderUpdated", {
                 operatorContract: operatorContract1,
-                keeper: serviceContractKeeper
+                keeper: serviceContractUpgrader
             })
         })
     })

--- a/solidity/test/TestRegistry.js
+++ b/solidity/test/TestRegistry.js
@@ -13,6 +13,7 @@ describe('Registry', () => {
     const registryKeeper = accounts[3]
     const operatorContractUpgrader = accounts[4]
     const individualContractPanicButton = accounts[5]
+    const serviceContractKeeper = accounts[6]
 
     const someoneElse = "0x524f2E0176350d950fA630D9A5a59A0a190DAf48"
 
@@ -71,7 +72,7 @@ describe('Registry', () => {
             )
             expectEvent(receipt, "GovernanceUpdated", {
                 governance: someoneElse
-              })
+            })
         })
     })
 
@@ -270,6 +271,67 @@ describe('Registry', () => {
                 operatorContractUpgrader,
                 "Unexpected operator contract upgrader"
             )
+        })
+    })
+
+    describe("setServiceContractKeeper", async () => {
+        it("can be called by governance", async () => {
+            await registry.setServiceContractKeeper(
+                operatorContract1,
+                serviceContractKeeper,
+                { from: governance }
+            )
+            // ok, no revert
+        })
+
+        it("can not be called by non-governance", async () => {
+            await expectRevert(
+                registry.setServiceContractKeeper(
+                    operatorContract1,
+                    serviceContractKeeper,
+                    { from: owner }
+                ),
+                "Not authorized"
+            )
+        })
+
+        it("updated service contract keeper", async () => {
+            await registry.setServiceContractKeeper(
+                operatorContract1,
+                serviceContractKeeper,
+                { from: governance }
+            )
+
+            await registry.setServiceContractKeeper(
+                operatorContract2,
+                someoneElse,
+                { from: governance }
+            )
+
+            assert.equal(
+                await registry.serviceContractKeeperFor(operatorContract1),
+                serviceContractKeeper,
+                "Unexpected service contract keeper"
+            )
+
+            assert.equal(
+                await registry.serviceContractKeeperFor(operatorContract2),
+                someoneElse,
+                "Unexpected service contract keeper"
+            )
+        })
+
+        it("emits an event", async () => {
+            const receipt = await registry.setServiceContractKeeper(
+                operatorContract1,
+                serviceContractKeeper,
+                { from: governance }
+            )
+
+            expectEvent(receipt, "ServiceContractKeeperUpdated", {
+                operatorContract: operatorContract1,
+                keeper: serviceContractKeeper
+            })
         })
     })
 

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -58,7 +58,12 @@ async function initContracts(KeepToken, TokenStaking, KeepRandomBeaconService,
   await KeepRandomBeaconOperator.link("Groups", groups.address);
   await KeepRandomBeaconOperator.link("DKGResultVerification", dkgResultVerification.address);
   await KeepRandomBeaconOperator.link("Reimbursements", reimbursements.address);
-  operatorContract = await KeepRandomBeaconOperator.new(serviceContractProxy.address, stakingContract.address, {from: accounts[0]});
+  operatorContract = await KeepRandomBeaconOperator.new(
+    serviceContractProxy.address,
+    stakingContract.address,
+    registry.address,
+    {from: accounts[0]}
+  );
 
   await registry.approveOperatorContract(operatorContract.address, {from: accounts[0]});
 

--- a/solidity/test/random_beacon_operator/TestManageServiceContracts.js
+++ b/solidity/test/random_beacon_operator/TestManageServiceContracts.js
@@ -10,7 +10,7 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
   let registry
   let serviceContract2 = accounts[1]
   let serviceContract3 = accounts[2]
-  let serviceContractKeeper = accounts[3]
+  let serviceContractUpgrader = accounts[3]
   let someoneElse = accounts[4]
 
   let groupProfitAndEntryVerificationFee;
@@ -28,9 +28,9 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
     operatorContract = contracts.operatorContract
     registry = contracts.registry
     
-    await registry.setServiceContractKeeper(
+    await registry.setServiceContractUpgrader(
         operatorContract.address, 
-        serviceContractKeeper,
+        serviceContractUpgrader,
         {from: accounts[0]}
     )
 
@@ -53,15 +53,15 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
   });
 
   describe("addServiceContract", async () => {
-    it("can be called by service contract keeper", async () => {
+    it("can be called by service contract upgrader", async () => {
       await operatorContract.addServiceContract(
         serviceContract2, 
-          {from: serviceContractKeeper}
+          {from: serviceContractUpgrader}
       )
       // ok, no revert
     })
 
-    it("cannot be called by non-keeper", async () => {
+    it("cannot be called by non-upgrader", async () => {
       await expectRevert(
         operatorContract.addServiceContract(
           serviceContract2, 
@@ -74,7 +74,7 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
     it("adds service contract to the list", async () => {
       await operatorContract.addServiceContract(
         serviceContract2, 
-        {from: serviceContractKeeper}
+        {from: serviceContractUpgrader}
       )
 
       await operatorContract.sign(
@@ -90,15 +90,15 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
   })
 
   describe("removeServiceContract", async () => {
-    it("can be called by service contract keeper", async () => {
+    it("can be called by service contract upgrader", async () => {
       await operatorContract.removeServiceContract(
         serviceContract.address, 
-        {from: serviceContractKeeper}
+        {from: serviceContractUpgrader}
       )
       // ok, no revert
     })
 
-    it("cannot be called by non-keeper", async () => {
+    it("cannot be called by non-upgrader", async () => {
       await expectRevert(
         operatorContract.removeServiceContract(
           serviceContract.address,
@@ -111,16 +111,16 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
     it("removes service contract from the list", async () => {
       await operatorContract.addServiceContract(
         serviceContract2,
-        {from: serviceContractKeeper}
+        {from: serviceContractUpgrader}
       )
       await operatorContract.addServiceContract(
         serviceContract3,
-        {from: serviceContractKeeper}
+        {from: serviceContractUpgrader}
       )
 
       await operatorContract.removeServiceContract(
         serviceContract2,
-        {from: serviceContractKeeper}
+        {from: serviceContractUpgrader}
       )
 
       await expectRevert(

--- a/solidity/test/random_beacon_operator/TestManageServiceContracts.js
+++ b/solidity/test/random_beacon_operator/TestManageServiceContracts.js
@@ -1,0 +1,149 @@
+const {contract, accounts} = require("@openzeppelin/test-environment")
+const {expectRevert} = require("@openzeppelin/test-helpers")
+const initContracts = require('../helpers/initContracts')
+const {createSnapshot, restoreSnapshot} = require("../helpers/snapshot.js")
+const blsData = require("../helpers/data.js")
+
+describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
+  let serviceContract
+  let operatorContract
+  let registry
+  let serviceContract2 = accounts[1]
+  let serviceContract3 = accounts[2]
+  let serviceContractKeeper = accounts[3]
+  let someoneElse = accounts[4]
+
+  let groupProfitAndEntryVerificationFee;
+
+  before(async () => {
+    let contracts = await initContracts(
+      contract.fromArtifact('KeepToken'),
+      contract.fromArtifact('TokenStaking'),
+      contract.fromArtifact('KeepRandomBeaconService'),
+      contract.fromArtifact('KeepRandomBeaconServiceImplV1'),
+      contract.fromArtifact('KeepRandomBeaconOperatorStub')
+    )
+            
+    serviceContract = contracts.serviceContract
+    operatorContract = contracts.operatorContract
+    registry = contracts.registry
+    
+    await registry.setServiceContractKeeper(
+        operatorContract.address, 
+        serviceContractKeeper,
+        {from: accounts[0]}
+    )
+
+    groupProfitFee = await operatorContract.groupProfitFee()
+    entryVerificationFee = await operatorContract.entryVerificationFee()
+
+    groupProfitAndEntryVerificationFee = groupProfitFee.add(
+        entryVerificationFee
+    )
+
+    await operatorContract.registerNewGroup(blsData.groupPubKey)
+  });
+
+  beforeEach(async () => {
+    await createSnapshot()
+  });
+  
+  afterEach(async () => {
+    await restoreSnapshot()
+  });
+
+  describe("addServiceContract", async () => {
+    it("can be called by service contract keeper", async () => {
+      await operatorContract.addServiceContract(
+        serviceContract2, 
+          {from: serviceContractKeeper}
+      )
+      // ok, no revert
+    })
+
+    it("cannot be called by non-keeper", async () => {
+      await expectRevert(
+        operatorContract.addServiceContract(
+          serviceContract2, 
+          {from: someoneElse}
+        ),
+        "Not authorized" 
+      )
+    })
+
+    it("adds service contract to the list", async () => {
+      await operatorContract.addServiceContract(
+        serviceContract2, 
+        {from: serviceContractKeeper}
+      )
+
+      await operatorContract.sign(
+        1,
+        blsData.previousEntry, 
+        {
+          value: groupProfitAndEntryVerificationFee, 
+          from: serviceContract2
+        }
+      )
+      // ok, no revert
+    })
+  })
+
+  describe("removeServiceContract", async () => {
+    it("can be called by service contract keeper", async () => {
+      await operatorContract.removeServiceContract(
+        serviceContract.address, 
+        {from: serviceContractKeeper}
+      )
+      // ok, no revert
+    })
+
+    it("cannot be called by non-keeper", async () => {
+      await expectRevert(
+        operatorContract.removeServiceContract(
+          serviceContract.address,
+          {from: someoneElse}
+        ),
+        "Not authorized"
+      )
+    })
+
+    it("removes service contract from the list", async () => {
+      await operatorContract.addServiceContract(
+        serviceContract2,
+        {from: serviceContractKeeper}
+      )
+      await operatorContract.addServiceContract(
+        serviceContract3,
+        {from: serviceContractKeeper}
+      )
+
+      await operatorContract.removeServiceContract(
+        serviceContract2,
+        {from: serviceContractKeeper}
+      )
+
+      await expectRevert(
+        operatorContract.sign(
+          1, 
+          blsData.previousEntry, 
+          {
+            value: groupProfitAndEntryVerificationFee, 
+            from: serviceContract2
+          }
+        ),
+        "Caller is not a service contract"
+      )
+
+      await operatorContract.sign(
+        1, 
+        blsData.previousEntry, 
+        {
+          value: groupProfitAndEntryVerificationFee, 
+          from: serviceContract3
+        }
+      )
+      // ok, no revert - the second service contract is still there
+    })
+  })
+})

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -23,7 +23,7 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
     operatorContract = contracts.operatorContract;
     serviceContract = contracts.serviceContract;
 
-    await registryContract.setServiceContractKeeper(
+    await registryContract.setServiceContractUpgrader(
       operatorContract.address, accounts[0], {from: accounts[0]}
     )
     await operatorContract.addServiceContract(accounts[0], {from: accounts[0]})  

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -19,9 +19,13 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
       contract.fromArtifact('KeepRandomBeaconOperatorStub')
     ); 
 
+    registryContract = contracts.registry
     operatorContract = contracts.operatorContract;
     serviceContract = contracts.serviceContract;
 
+    await registryContract.setServiceContractKeeper(
+      operatorContract.address, accounts[0], {from: accounts[0]}
+    )
     await operatorContract.addServiceContract(accounts[0], {from: accounts[0]})  
 
     await operatorContract.registerNewGroup(blsData.groupPubKey);

--- a/solidity/test/random_beacon_service/TestSelectOperator.js
+++ b/solidity/test/random_beacon_service/TestSelectOperator.js
@@ -25,8 +25,18 @@ describe('TestKeepRandomBeaconService/SelectOperator', function() {
     operatorContract = contracts.operatorContract;
 
     // Create and initialize additional operator contracts
-    operatorContract2 = await OperatorContract.new(serviceContract.address, stakingContract.address, {from: accounts[0]});
-    operatorContract3 = await OperatorContract.new(serviceContract.address, stakingContract.address, {from: accounts[0]});
+    operatorContract2 = await OperatorContract.new(
+      serviceContract.address, 
+      stakingContract.address, 
+      registry.address,
+      {from: accounts[0]}
+    );
+    operatorContract3 = await OperatorContract.new(
+      serviceContract.address, 
+      stakingContract.address, 
+      registry.address,
+      {from: accounts[0]}
+    );
 
     await operatorContract.registerNewGroup("0x0", {from: accounts[0]});
     await operatorContract2.registerNewGroup("0x0", {from: accounts[0]});
@@ -102,5 +112,4 @@ describe('TestKeepRandomBeaconService/SelectOperator', function() {
       "Total number of groups must be greater than zero."
     );
   });
-
 });


### PR DESCRIPTION
Some operator contracts, such as `KeepRandomBeaconOperator`, may want to specify a list of service contracts they want to work with. Service contracts can be added and removed from that list.

Previously, `KeepRandomBeaconOperator` contract had an owner which could add and remove contracts from that list and owner was set to the address which deployed the contract.

We do not want to have our contracts ownable so here we introduce service contract keeper role, set per the operator contract. Service Contract Keeper is authorized to manage service contract list for the given operator contract. Specifically, `KeepRandomBeaconOperator` checks if the address calling `addServiceContract` and `removeServiceContract` is the service contract keeper.