### PR TITLE
Emit an event when staking contract is authorized in TokenGrant

### DIFF
--- a/solidity/contracts/TokenGrant.sol
+++ b/solidity/contracts/TokenGrant.sol
@@ -29,6 +29,8 @@ contract TokenGrant {
     event TokenGrantStaked(uint256 indexed grantId, uint256 amount, address operator);
     event TokenGrantRevoked(uint256 id);
 
+    event StakingContractAuthorized(address indexed grantManager, address stakingContract);
+
     struct Grant {
         address grantManager; // Token grant manager.
         address grantee; // Address to which granted tokens are going to be withdrawn.
@@ -86,6 +88,7 @@ contract TokenGrant {
             "Staking contract address can't be zero"
         );
         stakingContracts[msg.sender][_stakingContract] = true;
+        emit StakingContractAuthorized(msg.sender, _stakingContract);
     }
 
     /// @notice Gets the amount of granted tokens to the specified address.


### PR DESCRIPTION
This is a security-critical action so it is worth having some sort of a notification we can watch for.