### PR TITLE
Bumping up contracts version to 1.1.0-pre

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.15.0-pre",
+  "version": "1.1.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "0.15.0-pre",
+  "version": "1.1.0-pre",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We published `1.0.0` so it's time for `1.1.0-pre`.

See `releases/mainnet/v1.0.0` @ a0a44da42a488d561cd0f68fa3d62e51577b103d
