### PR TITLE
CODEOWNERS for smart contracts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,13 @@
-*.sol @Shadowfiend @pdyraga
+/solidity/contracts/KeepToken.sol @Shadowfiend @pdyraga
+/solidity/contracts/TokenGrant.sol @Shadowfiend @pdyraga
+/solidity/contracts/TokenGrantStake.sol @Shadowfiend @pdyraga
+/solidity/contracts/TokenStaking.sol @Shadowfiend @pdyraga
+/solidity/contracts/StakeDelegatable.sol @Shadowfiend @pdyraga
+/solidity/contracts/ManagedGrant.sol @Shadowfiend @pdyraga
+/solidity/contracts/ManagedGrantFactory.sol @Shadowfiend @pdyraga
+/solidity/contracts/AdaptiveStakingPolicy.sol @Shadowfiend @pdyraga
+/solidity/contracts/MinimumStakingPolicy.sol @Shadowfiend @pdyraga
+/solidity/contracts/GuaranteedMinimumStakingPolicy.sol @Shadowfiend @pdyraga
+/solidity/contracts/PermissiveStakingPolicy.sol @Shadowfiend @pdyraga
+/solidity/contracts/KeepRegistry.sol @Shadowfiend @pdyraga
+/solidity/contracts/Escrow.sol @Shadowfiend @pdyraga

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*.sol @Shadowfiend @pdyraga

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,10 @@
 /solidity/contracts/PermissiveStakingPolicy.sol @Shadowfiend @pdyraga
 /solidity/contracts/KeepRegistry.sol @Shadowfiend @pdyraga
 /solidity/contracts/Escrow.sol @Shadowfiend @pdyraga
+/solidity/contracts/libraries/grant/UnlockingSchedule.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/AddressArrayUtils.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/BytesLib.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/LockUtils.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/OperatorParams.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/PercentUtils.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/UIntArrayUtils.sol @Shadowfiend @pdyraga

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,4 @@
 /solidity/contracts/utils/OperatorParams.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/PercentUtils.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/UIntArrayUtils.sol @Shadowfiend @pdyraga
+/solidity/package.json @Shadowfiend @pdyraga


### PR DESCRIPTION
Setting @Shadowfiend and @pdyraga as code owners for `keep-core` smart contracts deployed to mainnet in 1.0.1 release.