### PR TITLE
Cancel share exchange context before completing signature

### DIFF
--- a/pkg/beacon/relay/entry/entry.go
+++ b/pkg/beacon/relay/entry/entry.go
@@ -136,6 +136,11 @@ func SignAndSubmit(
 		}
 	}
 
+	// If we jumped outside the message loop, we have enough valid shares
+	// and we can complete the signature. There is no need to continue
+	// signature shares exchange and the context can be cancelled.
+	cancelCtx()
+
 	signature, err := completeSignature(signer, receivedValidShares, honestThreshold)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #1690 

When member jumps outside the message loop, it has enough valid shares and can complete the signature in the next step. Because of that, share exchange context can be cancelled at this stage because there is no more sense to continue the communication with other members. This way we can save some resources and eliminate useless message retransmissions.