### PR TITLE
Bumping up dashboard dependency to keep-core contracts to >1.1.0-pre <1.1.0-rc

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -985,9 +985,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@keep-network/keep-core": {
-      "version": "0.15.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.0.tgz",
-      "integrity": "sha512-cfrhRJX9+zkimYQ/6ASoX3inZIQ3V1dx2YDDgmoVzctm93yDKcz++fWiGSz6PXbYOUMq8Svj+a1Sv5KJSg2WLg==",
+      "version": "1.1.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-pre.0.tgz",
+      "integrity": "sha512-aHV0ZUyhlond4qgW5Dz6dbh9BZPc7i1H9pEtBQuBkr6JgvMnRexUadLYNFixMbZrSJKj9KiyYI/oJ+wK4eJJiQ==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.1.3",
     "moment": "^2.20.1",
     "web3": "^1.2.4",
-    "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc"
+    "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc"
   },
   "scripts": {
     "build-css": "lessc --clean-css src/css/app.less src/app.css",


### PR DESCRIPTION
See https://github.com/keep-network/keep-core/pull/1701

After releasing 1.0.1 we are bumping up keep-core contracts dependency version to `>1.1.0-pre <1.1.0-rc`.
