### PR TITLE
keep-prd: Service/Ingress Static IPs

### DIFF
--- a/infrastructure/terraform/keep-prd/ip.tf
+++ b/infrastructure/terraform/keep-prd/ip.tf
@@ -1,0 +1,19 @@
+resource "google_compute_address" "electrum_service" {
+  project = "${module.project.project_id}"
+  name    = "${var.electrum_server_service_ip_name}"
+  region  = "${var.region_data["region"]}"
+}
+
+resource "google_compute_global_address" "tbtc_dapp_ingress" {
+  project      = "${module.project.project_id}"
+  name         = "${var.tbtc_dapp_ingress_ip["name"]}"
+  address_type = "${var.tbtc_dapp_ingress_ip["address_type"]}"
+  ip_version   = "${var.tbtc_dapp_ingress_ip["ip_version"]}"
+}
+
+resource "google_compute_global_address" "token_dashboard_ingress" {
+  project      = "${module.project.project_id}"
+  name         = "${var.token_dashboard_ingress_ip["name"]}"
+  address_type = "${var.token_dashboard_ingress_ip["address_type"]}"
+  ip_version   = "${var.token_dashboard_ingress_ip["ip_version"]}"
+}

--- a/infrastructure/terraform/keep-prd/ip.tf
+++ b/infrastructure/terraform/keep-prd/ip.tf
@@ -2,6 +2,7 @@ resource "google_compute_address" "electrum_service" {
   project = "${module.project.project_id}"
   name    = "${var.electrum_server_service_ip_name}"
   region  = "${var.region_data["region"]}"
+  labels  = "${local.labels}"
 }
 
 resource "google_compute_global_address" "tbtc_dapp_ingress" {
@@ -9,6 +10,7 @@ resource "google_compute_global_address" "tbtc_dapp_ingress" {
   name         = "${var.tbtc_dapp_ingress_ip["name"]}"
   address_type = "${var.tbtc_dapp_ingress_ip["address_type"]}"
   ip_version   = "${var.tbtc_dapp_ingress_ip["ip_version"]}"
+  labels       = "${local.labels}"
 }
 
 resource "google_compute_global_address" "token_dashboard_ingress" {
@@ -16,4 +18,5 @@ resource "google_compute_global_address" "token_dashboard_ingress" {
   name         = "${var.token_dashboard_ingress_ip["name"]}"
   address_type = "${var.token_dashboard_ingress_ip["address_type"]}"
   ip_version   = "${var.token_dashboard_ingress_ip["ip_version"]}"
+  labels       = "${local.labels}"
 }

--- a/infrastructure/terraform/keep-prd/variables.tf
+++ b/infrastructure/terraform/keep-prd/variables.tf
@@ -69,7 +69,7 @@ variable "editor_iam_members" {
 }
 
 variable "project_service_list" {
-  description = "List of google APIs/Services to enable with project creation"
+  description = "List of google APIs/Services to enable with project creation."
 
   default = [
     "compute.googleapis.com",
@@ -117,6 +117,34 @@ variable "nat_gateway_ip" {
     zone_f_name  = "keep-prd-nat-gateway-f-external-ip"
     address_type = "EXTERNAL"
     network_tier = "PREMIUM"
+  }
+}
+
+## Static IPs
+### Electrum Service
+
+variable "electrum_server_service_ip_name" {
+  description = "The name for the IP asset in GCP."
+  default     = "electrum-server-service"
+}
+
+### tbtc-dapp Ingress
+
+variable "tbtc_dapp_ingress_ip" {
+  default {
+    name         = "tbtc-dapp-ingress"
+    address_type = "EXTERNAL"
+    ip_version   = "IPV4"
+  }
+}
+
+### token-dashboard Ingress
+
+variable "token_dashboard_ingress_ip" {
+  default {
+    name         = "token-dashboard-ingress"
+    address_type = "EXTERNAL"
+    ip_version   = "IPV4"
   }
 }
 


### PR DESCRIPTION
### Intro

Before we can setup Service and Ingress configurations we need to have some static ip's available to assign to these resources.  Here we do that for services going live next week.

### What we did 

- Regional IP for Electrum LoadBalancer Service
- Global IP for tbtc-dapp Ingress
- Global IP for token-dashboard

GCP requires a global IP for Ingress resources.  I believe this is because an Ingress object is region agnostic.

All of these are applied to the environment and are available.