### PR TITLE
Hardcode callback gas limit

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -492,6 +492,11 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         // contract for the callback
         uint256 gasLimit = callbackFee.div(gasPriceCeiling);
 
+        // Make sure not to spend more than 6 million gas on a callback.
+        // This is to protect members from relay entry failure and potential
+        // slashing in case of any changes in .call() gas limit.
+        gasLimit = gasLimit > 6000000 ? 6000000 : gasLimit;
+
         bytes memory callbackReturnData;
         uint256 gasBeforeCallback = gasleft();
         (, callbackReturnData) = currentRequestServiceContract.call.gas(

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -492,10 +492,10 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         // contract for the callback
         uint256 gasLimit = callbackFee.div(gasPriceCeiling);
 
-        // Make sure not to spend more than 6 million gas on a callback.
+        // Make sure not to spend more than 2 million gas on a callback.
         // This is to protect members from relay entry failure and potential
         // slashing in case of any changes in .call() gas limit.
-        gasLimit = gasLimit > 6000000 ? 6000000 : gasLimit;
+        gasLimit = gasLimit > 2000000 ? 2000000 : gasLimit;
 
         bytes memory callbackReturnData;
         uint256 gasBeforeCallback = gasleft();

--- a/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
+++ b/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
@@ -382,6 +382,11 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
      * @param callbackGas Gas required for the callback.
      */
     function entryFeeEstimate(uint256 callbackGas) public view returns(uint256) {
+        require(
+            callbackGas <= 2000000,
+            "Callback gas exceeds 2000000 gas limit"
+        );
+
         (
             uint256 entryVerificationFee,
             uint256 dkgContributionFee,

--- a/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
+++ b/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
@@ -221,7 +221,7 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
      * once a new relay entry has been generated. Callback contract must
      * declare public `__beaconCallback(uint256)` function that is going to be
      * executed with the result, once ready.
-     * @param callbackGas Gas required for the callback.
+     * @param callbackGas Gas required for the callback (6 million gas max).
      * The customer needs to ensure they provide a sufficient callback gas
      * to cover the gas fee of executing the callback. Any surplus is returned
      * to the customer. If the callback gas amount turns to be not enough to
@@ -232,6 +232,11 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         address callbackContract,
         uint256 callbackGas
     ) public nonReentrant payable returns (uint256) {
+        require(
+            callbackGas <= 6000000,
+            "Callback gas exceeds 6000000 gas limit"
+        );
+
         require(
             msg.value >= entryFeeEstimate(callbackGas),
             "Payment is less than required minimum."

--- a/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
+++ b/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
@@ -221,7 +221,7 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
      * once a new relay entry has been generated. Callback contract must
      * declare public `__beaconCallback(uint256)` function that is going to be
      * executed with the result, once ready.
-     * @param callbackGas Gas required for the callback (6 million gas max).
+     * @param callbackGas Gas required for the callback (2 million gas max).
      * The customer needs to ensure they provide a sufficient callback gas
      * to cover the gas fee of executing the callback. Any surplus is returned
      * to the customer. If the callback gas amount turns to be not enough to
@@ -233,8 +233,8 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         uint256 callbackGas
     ) public nonReentrant payable returns (uint256) {
         require(
-            callbackGas <= 6000000,
-            "Callback gas exceeds 6000000 gas limit"
+            callbackGas <= 2000000,
+            "Callback gas exceeds 2000000 gas limit"
         );
 
         require(


### PR DESCRIPTION
Make sure not to spend more than 2 million gas on a callback. This is to protect members from relay entry failure and potential slashing in case of any changes in .call() gas limit.