### PR TITLE
Conservative relay entry timeout punishment for the first months

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -571,9 +571,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
      */
     function reportRelayEntryTimeout() public {
         require(hasEntryTimedOut(), "Entry did not time out");
-
-        uint256 minimumStake = stakingContract.minimumStake();
-        groups.reportRelayEntryTimeout(currentRequestGroupIndex, groupSize, minimumStake);
+        groups.reportRelayEntryTimeout(currentRequestGroupIndex, groupSize);
 
         // We could terminate the last active group. If that's the case,
         // do not try to execute signing again because there is no group

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.5.17;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../../utils/BytesLib.sol";
+import "../../utils/PercentUtils.sol";
 import "../../cryptography/AltBn128.sol";
 import "../../cryptography/BLS.sol";
 import "../../TokenStaking.sol";
@@ -8,6 +9,7 @@ import "../../TokenStaking.sol";
 
 library Groups {
     using SafeMath for uint256;
+    using PercentUtils for uint256;
     using BytesLib for bytes;
 
     // The index of a group is flagged with the most significant bit set,
@@ -18,6 +20,10 @@ library Groups {
     // and unset after reading from `groupIndices`
     // before using the value.
     uint256 constant GROUP_INDEX_FLAG = 1 << 255;
+
+    uint256 constant ONE_MONTH = 86400 * 30;
+    uint256 constant THREE_MONTHS = 3 * ONE_MONTH;
+    uint256 constant SIX_MONTHS = 6 * ONE_MONTH;
 
     struct Group {
         bytes groupPubKey;
@@ -411,12 +417,34 @@ library Groups {
         uint256 groupIndex,
         uint256 groupSize
     ) public {
-        uint256 minimumStake = self.stakingContract.minimumStake();
+        uint256 punishment = relayEntryTimeoutPunishment(self);
         terminateGroup(self, groupIndex);
         // Reward is limited to min(1, 20 / group_size) of the maximum tattletale reward, see the Yellow Paper for more details.
         uint256 rewardAdjustment = uint256(20 * 100).div(groupSize); // Reward adjustment in percentage
         rewardAdjustment = rewardAdjustment > 100 ? 100:rewardAdjustment; // Reward adjustment can be 100% max
-        self.stakingContract.seize(minimumStake, rewardAdjustment, msg.sender, getGroupMembers(self, groupIndex));
+        self.stakingContract.seize(punishment, rewardAdjustment, msg.sender, getGroupMembers(self, groupIndex));
+    }
+
+    /// @notice Evaluates relay entry timeout punishment using the following
+    /// rules:
+    /// - 1% of the minimum stake for the first 3 months,
+    /// - 50% of the minimum stake between the first 3 and 6 months,
+    /// - 100% of the minimum stake after the first 6 months.
+    function relayEntryTimeoutPunishment(
+        Storage storage self
+    ) public view returns (uint256) {
+        uint256 minimumStake = self.stakingContract.minimumStake();
+
+        uint256 minimumStakeScheduleStart = self.stakingContract.minimumStakeScheduleStart();
+        /* solium-disable-next-line security/no-block-members */
+        if (now < minimumStakeScheduleStart + THREE_MONTHS) {
+            return minimumStake.percent(1);
+        /* solium-disable-next-line security/no-block-members */
+        } else if (now < minimumStakeScheduleStart + SIX_MONTHS) {
+            return minimumStake.percent(50);
+        } else {
+            return minimumStake;
+        }
     }
 
     /**

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -409,9 +409,9 @@ library Groups {
     function reportRelayEntryTimeout(
         Storage storage self,
         uint256 groupIndex,
-        uint256 groupSize,
-        uint256 minimumStake
+        uint256 groupSize
     ) public {
+        uint256 minimumStake = self.stakingContract.minimumStake();
         terminateGroup(self, groupIndex);
         // Reward is limited to min(1, 20 / group_size) of the maximum tattletale reward, see the Yellow Paper for more details.
         uint256 rewardAdjustment = uint256(20 * 100).div(groupSize); // Reward adjustment in percentage

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -1,14 +1,18 @@
 const blsData = require("../helpers/data.js")
 const initContracts = require('../helpers/initContracts')
-const assert = require('chai').assert
 const { createSnapshot, restoreSnapshot } = require("../helpers/snapshot.js")
 const { contract, accounts, web3 } = require("@openzeppelin/test-environment")
 const { expectRevert, time } = require("@openzeppelin/test-helpers")
 const stakeDelegate = require('../helpers/stakeDelegate')
 const BLS = contract.fromArtifact('BLS');
 
+const BN = web3.utils.BN
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
 describe('KeepRandomBeaconOperator/Slashing', function () {
-  let token, stakingContract, serviceContract, operatorContract, minimumStake, largeStake, entryFeeEstimate, groupIndex,
+  let token, stakingContract, serviceContract, operatorContract, entryFeeEstimate, groupIndex,
     registry, bls,
     owner = accounts[0],
     operator1 = accounts[1],
@@ -18,6 +22,13 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
     authorizer = accounts[5],
     anotherOperatorContract = accounts[6],
     registryKeeper = accounts[7];
+
+  let scheduleStart
+  let relayRequestStartBlock
+
+  const largeStake = web3.utils.toBN("50000000000000000000000000") // 50 000 000 KEEP
+  const mediumStake = web3.utils.toBN("500000000000000000000000") // 500 000 KEEP
+  const smallStake = web3.utils.toBN("100000000000000000000000") // 100 000 KEEP
 
   before(async () => {
 
@@ -34,30 +45,28 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
     serviceContract = contracts.serviceContract
     operatorContract = contracts.operatorContract
     registry = contracts.registry
-    bls = await BLS.new()
+    bls = await BLS.new()      
 
-    groupIndex = 0
-    await operatorContract.registerNewGroup(blsData.groupPubKey)
-    await operatorContract.setGroupMembers(blsData.groupPubKey, [operator1, operator2, operator3])
+    await registry.setRegistryKeeper(registryKeeper, { from: accounts[0] })
+    await registry.approveOperatorContract(anotherOperatorContract, { from: registryKeeper })
 
-    minimumStake = await stakingContract.minimumStake()
-    largeStake = minimumStake.muln(2)
     await stakeDelegate(stakingContract, token, owner, operator1, owner, authorizer, largeStake)
-    await stakeDelegate(stakingContract, token, owner, operator2, owner, authorizer, minimumStake)
-    await stakeDelegate(stakingContract, token, owner, operator3, owner, authorizer, minimumStake)
+    await stakeDelegate(stakingContract, token, owner, operator2, owner, authorizer, mediumStake)
+    await stakeDelegate(stakingContract, token, owner, operator3, owner, authorizer, smallStake)
     await stakingContract.authorizeOperatorContract(operator1, operatorContract.address, { from: authorizer })
     await stakingContract.authorizeOperatorContract(operator2, operatorContract.address, { from: authorizer })
     await stakingContract.authorizeOperatorContract(operator3, operatorContract.address, { from: authorizer })
 
-    time.increase((await stakingContract.initializationPeriod()).addn(1));
+    scheduleStart = await stakingContract.minimumStakeScheduleStart()
 
+    time.increase((await stakingContract.initializationPeriod()).addn(1))
+
+    groupIndex = 0
+    await operatorContract.registerNewGroup(blsData.groupPubKey)
+    await operatorContract.setGroupMembers(blsData.groupPubKey, [operator1, operator2, operator3])
     entryFeeEstimate = await serviceContract.entryFeeEstimate(0)
-    await serviceContract.methods['requestRelayEntry()']({ value: entryFeeEstimate, from: accounts[0] })
-
-    await registry.setRegistryKeeper(registryKeeper, { from: accounts[0] })
-
-    await registry.approveOperatorContract(anotherOperatorContract, { from: registryKeeper })
-    await stakingContract.authorizeOperatorContract(operator1, anotherOperatorContract, { from: authorizer })
+    let tx = await serviceContract.methods['requestRelayEntry()']({ value: entryFeeEstimate, from: accounts[0] })
+    relayRequestStartBlock = web3.utils.toBN(tx.receipt.blockNumber)
   })
 
   beforeEach(async () => {
@@ -68,61 +77,223 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
     await restoreSnapshot()
   })
 
-  it("should be able to report unauthorized signing", async () => {
-    let tattletaleSignature = await bls.sign(tattletale, blsData.secretKey);
-
-    await operatorContract.reportUnauthorizedSigning(
-      groupIndex,
-      tattletaleSignature,
-      { from: tattletale }
-    )
-
-    assert.isTrue((await stakingContract.balanceOf(operator1)).eq(largeStake.sub(minimumStake)), "Unexpected operator 1 balance")
-    assert.isTrue((await stakingContract.balanceOf(operator2)).isZero(), "Unexpected operator 2 balance")
-    assert.isTrue((await stakingContract.balanceOf(operator3)).isZero(), "Unexpected operator 3 balance")
-
-    // Expecting 5% of all the seized tokens
-    let expectedTattletaleReward = minimumStake.muln(3).muln(5).divn(100)
-    assert.isTrue((await token.balanceOf(tattletale)).eq(expectedTattletaleReward), "Unexpected tattletale balance")
-
-    // Group should be terminated, expecting total number of groups to become 0
-    await expectRevert(
-      serviceContract.methods['requestRelayEntry()']({ value: entryFeeEstimate, from: accounts[0] }),
-      "Total number of groups must be greater than zero."
-    )
-  })
-
-  it("should ignore invalid report of unauthorized signing", async () => {
-    await expectRevert(
-      operatorContract.reportUnauthorizedSigning(
+  describe("reportUnauthorizedSigning", async () => {
+    it("seizes 100% of minimum stake", async () => {
+      let tattletaleSignature = await bls.sign(tattletale, blsData.secretKey);
+  
+      await operatorContract.reportUnauthorizedSigning(
         groupIndex,
-        blsData.nextGroupSignature, // Wrong signature
+        tattletaleSignature,
         { from: tattletale }
-      ),
-      "Group terminated or sig invalid"
-    )
-    // Transaction reverted no changes are applied.
+      )
+  
+      expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
+        "49900000000000000000000000" // 50000000000000000000000000 - 100000000000000000000000
+      )
+      expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
+        "400000000000000000000000" // 500000000000000000000000 - 100000000000000000000000
+      )
+      expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
+        "0" // 100000000000000000000000 - 100000000000000000000000
+      )
+  
+      // Expecting 5% of all the seized tokens
+      //
+      // minimum stake = 100000000000000000000000
+      // 3 * 100000000000000000000000 * 5% = 15000000000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("15000000000000000000000")
+  
+      // Group should be terminated, expecting total number of groups to become 0
+      await expectRevert(
+        serviceContract.methods['requestRelayEntry()']({ value: entryFeeEstimate, from: accounts[0] }),
+        "Total number of groups must be greater than zero."
+      )
+    })
+
+    it("ignore invalid report", async () => {
+      await expectRevert(
+        operatorContract.reportUnauthorizedSigning(
+          groupIndex,
+          blsData.nextGroupSignature, // Wrong signature
+          { from: tattletale }
+        ),
+        "Group terminated or sig invalid"
+      )
+    })
   })
 
-  it("should be able to report failure to produce entry after relay entry timeout", async () => {
-    let operator1balance = await stakingContract.balanceOf(operator1)
-    let operator2balance = await stakingContract.balanceOf(operator2)
-    let operator3balance = await stakingContract.balanceOf(operator3)
+  describe("reportRelayEntryTimeout", async () => {
+    it("reverts if entry did not time out", async () => {
+      await expectRevert(
+        operatorContract.reportRelayEntryTimeout({ from: tattletale }),
+        "Entry did not time out."
+      )
 
-    await expectRevert(
-      operatorContract.reportRelayEntryTimeout({ from: tattletale }),
-      "Entry did not time out."
-    )
+      await time.advanceBlockTo(relayRequestStartBlock.addn(9));
 
-    await time.advanceBlockTo(web3.utils.toBN(20).addn(await web3.eth.getBlockNumber()));
-    await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+      await expectRevert(
+        operatorContract.reportRelayEntryTimeout({ from: tattletale }),
+        "Entry did not time out."
+      )
+    })
 
-    assert.isTrue((await stakingContract.balanceOf(operator1)).eq(operator1balance.sub(minimumStake)), "Unexpected operator 1 balance")
-    assert.isTrue((await stakingContract.balanceOf(operator2)).eq(operator2balance.sub(minimumStake)), "Unexpected operator 2 balance")
-    assert.isTrue((await stakingContract.balanceOf(operator3)).eq(operator3balance.sub(minimumStake)), "Unexpected operator 3 balance")
+    it("does not revert in the first block relay entry timed out", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+      // ok, no reverts
+    })
 
-    // Expecting 5% of all the seized tokens with reward adjustment of (20 / 64) = 31%
-    let expectedTattletaleReward = minimumStake.muln(3).muln(5).divn(100).muln(31).divn(100)
-    assert.isTrue((await token.balanceOf(tattletale)).eq(expectedTattletaleReward), "Unexpected tattletale balance")
+    it("seizes 1% of minimum stake from operators at the beginning", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // minimum stake = 100000000000000000000000
+      expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
+        "49999000000000000000000000" // 50000000000000000000000000 - 1% * 100000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
+        "499000000000000000000000"  // 500000000000000000000000 - 1% * 100000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
+        "99000000000000000000000"  // 100000000000000000000000 - 1% * 100000000000000000000000 
+      )
+    })
+
+    it("rewards tattletale with 1% stake adjustment at the beginning", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // Expecting 5% of all the seized tokens with reward adjustment of (20 / 64) = 31%.
+      // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
+      // for the first three months:
+      //
+      // minimum stake = 100000000000000000000000
+      // 3 * 100000000000000000000000 * 1% * 5% * 31% = 46500000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("46500000000000000000")
+    })
+
+    it("seizes 1% of minimum stake from operators before the first 3 months end", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 89))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // minimum stake = 90000000000000000000000
+      expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
+        "49999100000000000000000000" // 50000000000000000000000000 - 1% * 90000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
+        "499100000000000000000000"  // 500000000000000000000000 - 1% * 90000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
+        "99100000000000000000000"  // 100000000000000000000000 - 1% * 90000000000000000000000
+      )
+    })
+
+    it("rewards tattletale with 1% stake adjustment before the first 3 months end", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 89))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // Expecting 5% of all the seized tokens with reward adjustment of (20 / 64) = 31%.
+      // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
+      // for the first three months:
+      //
+      // minimum stake = 90000000000000000000000
+      // 3 * 90000000000000000000000 * 1% * 5% * 31% = 41850000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("41850000000000000000")
+    })
+
+    it("seizes 50% of minimum stake from operators after the first 3 months", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 90))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // minimum stake = 90000000000000000000000
+      expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
+        "49955000000000000000000000" // 50000000000000000000000000 - 50% * 90000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
+        "455000000000000000000000"  // 500000000000000000000000 - 50% * 90000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
+        "55000000000000000000000"  // 100000000000000000000000 - 50% * 90000000000000000000000
+      )
+    })
+
+    it("rewards tattletale with 50% stake adjustment after the first 3 months", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 90))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // Expecting 5% of all the seized tokens with reward adjustment of (20 / 64) = 31%.
+      // And "all of the seized tokens" are 3 * minimum stake with 50% adjustment
+      // after the first 3 months end
+      //
+      // minimum stake = 90000000000000000000000
+      // 3 * 90000000000000000000000 * 50% * 5% * 31% = 2092500000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("2092500000000000000000")
+    })
+    
+    it("seizes 50% of minimum stake from operators before the first 6 months end", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 179))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // minimum stake = 80000000000000000000000
+      expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
+        "49960000000000000000000000" // 50000000000000000000000000 - 50% * 80000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
+        "460000000000000000000000"  // 500000000000000000000000 - 50% * 80000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
+        "60000000000000000000000"  // 100000000000000000000000 - 50% * 80000000000000000000000
+      )
+    })
+
+    it("rewards tattletale with 50% stake adjustment before the first 6 months end", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 179))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // Expecting 5% of all the seized tokens with reward adjustment of (20 / 64) = 31%.
+      // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
+      // for the first three months:
+      //
+      // minimum stake = 80000000000000000000000
+      // 3 * 80000000000000000000000 * 50% * 5% * 31% = 1860000000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("1860000000000000000000")
+    })
+
+    it("seizes 100% of minimum stake from operators after the first 6 months end", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 180))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // minimum stake = 80000000000000000000000
+      expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
+        "49920000000000000000000000" // 50000000000000000000000000 - 100% * 80000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
+        "420000000000000000000000"  // 500000000000000000000000 - 100% * 80000000000000000000000 
+      )
+      expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
+        "20000000000000000000000"  // 100000000000000000000000 - 100% * 80000000000000000000000
+      )
+    })
+
+    it("rewards tattletale with 100% stake adjustment after the first 6 months end", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10));
+      await time.increaseTo(scheduleStart.addn(86400 * 180))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      // Expecting 5% of all the seized tokens with reward adjustment of (20 / 64) = 31%.
+      // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
+      // for the first three months:
+      //
+      // minimum stake = 80000000000000000000000
+      // 3 * 80000000000000000000000 * 100% * 5% * 31% = 3720000000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("3720000000000000000000")
+    })
   })
 })


### PR DESCRIPTION
We decided to use a conservative relay entry timeout punishment for the first months of the network so that we can give time to operators to properly configure their clients and learn how to monitor their health.

The rules are as follows:
- 1% of the minimum stake for the first 3 months
- 50% of the minimum stake between the first 3 and 6 months
- 100% of the minimum stake after the first 6 months.

This change affects only relay entry timeout, all the other cases of misbehavior are still on 100% of the minimum stake.