### PR TITLE
Beacon smart contracts docs reformatted

### DIFF
--- a/solidity/contracts/IRandomBeacon.sol
+++ b/solidity/contracts/IRandomBeacon.sol
@@ -1,107 +1,96 @@
 pragma solidity 0.5.17;
 
-/**
- * @title Keep Random Beacon
- *
- * @notice Keep Random Beacon generates verifiable randomness that is resistant
- * to bad actors both in the relay network and on the anchoring blockchain.
- */
+
+/// @title Keep Random Beacon
+///
+/// @notice Keep Random Beacon generates verifiable randomness that is resistant
+/// to bad actors both in the relay network and on the anchoring blockchain.
 interface IRandomBeacon {
-    /**
-     * @notice Event emitted for each new relay entry generated. It contains
-     * request ID allowing to associate the generated relay entry with relay
-     * request created previously with `requestRelayEntry` function. Event is
-     * emitted no matter if callback was executed or not.
-     *
-     * @param requestId Relay request ID for which entry was generated.
-     * @param entry Generated relay entry.
-     */
+
+    /// @notice Event emitted for each new relay entry generated. It contains
+    /// request ID allowing to associate the generated relay entry with relay
+    /// request created previously with `requestRelayEntry` function. Event is
+    /// emitted no matter if callback was executed or not.
+    ///
+    /// @param requestId Relay request ID for which entry was generated.
+    /// @param entry Generated relay entry.
     event RelayEntryGenerated(uint256 requestId, uint256 entry);
 
-    /**
-     * @notice Provides the customer with an estimated entry fee in wei to use
-     * in the request. The fee estimate is only valid for the transaction it is
-     * called in, so the customer must make the request immediately after
-     * obtaining the estimate. Insufficient payment will lead to the request
-     * being rejected and the transaction reverted.
-     *
-     * The customer may decide to provide more ether for an entry fee than
-     * estimated by this function. This is especially helpful when callback gas
-     * cost fluctuates. Any surplus between the passed fee and the actual cost
-     * of producing an entry and executing a callback is returned back to the
-     * customer.
-     * @param callbackGas Gas required for the callback.
-     */
+    /// @notice Provides the customer with an estimated entry fee in wei to use
+    /// in the request. The fee estimate is only valid for the transaction it is
+    /// called in, so the customer must make the request immediately after
+    /// obtaining the estimate. Insufficient payment will lead to the request
+    /// being rejected and the transaction reverted.
+    ///
+    /// The customer may decide to provide more ether for an entry fee than
+    /// estimated by this function. This is especially helpful when callback gas
+    /// cost fluctuates. Any surplus between the passed fee and the actual cost
+    /// of producing an entry and executing a callback is returned back to the
+    /// customer.
+    /// @param callbackGas Gas required for the callback.
     function entryFeeEstimate(uint256 callbackGas)
         external
         view
         returns (uint256);
 
-    /**
-     * @notice Submits a request to generate a new relay entry. Executes
-     * callback on the provided callback contract with the generated entry and
-     * emits `RelayEntryGenerated(uint256 requestId, uint256 entry)` event.
-     * Callback contract has to declare public `__beaconCallback(uint256)`
-     * function that is going to be executed with the result, once ready.
-     * It is recommended to implement `IRandomBeaconConsumer` interface to
-     * ensure the correct callback function signature.
-     *
-     * @dev Beacon does not support concurrent relay requests. No new requests
-     * should be made while the beacon is already processing another request.
-     * Requests made while the beacon is busy will be rejected and the
-     * transaction reverted.
-
-     * @param callbackContract Callback contract address. Callback is called
-     * once a new relay entry has been generated. Must declare public
-     * `__beaconCallback(uint256)` function. It is recommended to implement
-     * `IRandomBeaconConsumer` interface to ensure the correct callback function
-     * signature.
-     * @param callbackGas Gas required for the callback.
-     * The customer needs to ensure they provide a sufficient callback gas
-     * to cover the gas fee of executing the callback. Any surplus is returned
-     * to the customer. If the callback gas amount turns to be not enough to
-     * execute the callback, callback execution is skipped.
-     * @return An uint256 representing uniquely generated relay request ID
-     */
+    /// @notice Submits a request to generate a new relay entry. Executes
+    /// callback on the provided callback contract with the generated entry and
+    /// emits `RelayEntryGenerated(uint256 requestId, uint256 entry)` event.
+    /// Callback contract has to declare public `__beaconCallback(uint256)`
+    /// function that is going to be executed with the result, once ready.
+    /// It is recommended to implement `IRandomBeaconConsumer` interface to
+    /// ensure the correct callback function signature.
+    ///
+    /// @dev Beacon does not support concurrent relay requests. No new requests
+    /// should be made while the beacon is already processing another request.
+    /// Requests made while the beacon is busy will be rejected and the
+    /// transaction reverted.
+    ///
+    /// @param callbackContract Callback contract address. Callback is called
+    /// once a new relay entry has been generated. Must declare public
+    /// `__beaconCallback(uint256)` function. It is recommended to implement
+    /// `IRandomBeaconConsumer` interface to ensure the correct callback function
+    /// signature.
+    /// @param callbackGas Gas required for the callback.
+    /// The customer needs to ensure they provide a sufficient callback gas
+    /// to cover the gas fee of executing the callback. Any surplus is returned
+    /// to the customer. If the callback gas amount turns to be not enough to
+    /// execute the callback, callback execution is skipped.
+    /// @return An uint256 representing uniquely generated relay request ID
     function requestRelayEntry(
         address callbackContract,
         uint256 callbackGas
     ) external payable returns (uint256);
 
-    /**
-     * @notice Submits a request to generate a new relay entry. Emits
-     * `RelayEntryGenerated(uint256 requestId, uint256 entry)` event for the
-     * generated entry.
-     *
-     * @dev Beacon does not support concurrent relay requests. No new requests
-     * should be made while the beacon is already processing another request.
-     * Requests made while the beacon is busy will be rejected and the
-     * transaction reverted.
-     *
-     * @return An uint256 representing uniquely generated relay request ID
-     */
+    /// @notice Submits a request to generate a new relay entry. Emits
+    /// `RelayEntryGenerated(uint256 requestId, uint256 entry)` event for the
+    /// generated entry.
+    ///
+    /// @dev Beacon does not support concurrent relay requests. No new requests
+    /// should be made while the beacon is already processing another request.
+    /// Requests made while the beacon is busy will be rejected and the
+    /// transaction reverted.
+    ///
+    /// @return An uint256 representing uniquely generated relay request ID
     function requestRelayEntry() external payable returns (uint256);
 }
 
-/**
- * @title Keep Random Beacon Consumer
- *
- * @notice Receives Keep Random Beacon relay entries with `__beaconCallback`
- * function. Contract implementing this interface does not have to be the one
- * requesting relay entry but it is the one receiving the requested relay entry
- * once it is produced.
- *
- * @dev Use this interface to indicate the contract receives relay entries from
- * the beacon and to ensure the correctness of callback function signature.
- */
+
+/// @title Keep Random Beacon Consumer
+///
+/// @notice Receives Keep Random Beacon relay entries with `__beaconCallback`
+/// function. Contract implementing this interface does not have to be the one
+/// requesting relay entry but it is the one receiving the requested relay entry
+/// once it is produced.
+///
+/// @dev Use this interface to indicate the contract receives relay entries from
+/// the beacon and to ensure the correctness of callback function signature.
 interface IRandomBeaconConsumer {
 
-  /**
-   * @notice Receives relay entry produced by Keep Random Beacon. This function
-   * should be called only by Keep Random Beacon.
-   *
-   * @param relayEntry Relay entry (random number) produced by Keep Random
-   * Beacon.
-   */
+  /// @notice Receives relay entry produced by Keep Random Beacon. This function
+  /// should be called only by Keep Random Beacon.
+  ///
+  /// @param relayEntry Relay entry (random number) produced by Keep Random
+  /// Beacon.
   function __beaconCallback(uint256 relayEntry) external;
 }

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -19,13 +19,11 @@ interface ServiceContract {
     function fundDkgFeePool() external payable;
 }
 
-/**
- * @title KeepRandomBeaconOperator
- * @dev Keep client facing contract for random beacon security-critical operations.
- * Handles group creation and expiration, BLS signature verification and incentives.
- * The contract is not upgradeable. New functionality can be implemented by deploying
- * new versions following Keep client update and re-authorization by the stakers.
- */
+/// @title KeepRandomBeaconOperator
+/// @notice Keep client facing contract for random beacon security-critical operations.
+/// Handles group creation and expiration, BLS signature verification and incentives.
+/// The contract is not upgradeable. New functionality can be implemented by deploying
+/// new versions following Keep client update and re-authorization by the stakers.
 contract KeepRandomBeaconOperator is ReentrancyGuard {
     using SafeMath for uint256;
     using PercentUtils for uint256;
@@ -35,22 +33,21 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     using DKGResultVerification for DKGResultVerification.Storage;
 
     event OnGroupRegistered(bytes groupPubKey);
-
     event DkgResultSubmittedEvent(
         uint256 memberIndex,
         bytes groupPubKey,
         bytes misbehaved
     );
-
     event RelayEntryRequested(bytes previousEntry, bytes groupPublicKey);
     event RelayEntrySubmitted();
-
     event GroupSelectionStarted(uint256 newEntry);
-
-    event GroupMemberRewardsWithdrawn(address indexed beneficiary, address operator, uint256 amount, uint256 groupIndex);
-
+    event GroupMemberRewardsWithdrawn(
+        address indexed beneficiary,
+        address operator,
+        uint256 amount,
+        uint256 groupIndex
+    );
     event RelayEntryTimeoutReported(uint256 indexed groupIndex);
-
     event UnauthorizedSigningReported(uint256 indexed groupIndex);
 
     GroupSelection.Storage groupSelection;
@@ -63,58 +60,58 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
     TokenStaking internal stakingContract;
 
-    // Each signing group member reward expressed in wei.
+    /// @dev Each signing group member reward expressed in wei.
     uint256 public groupMemberBaseReward = 1000000*1e9; // 1M Gwei
 
-    // Gas price ceiling value used to calculate the gas price for reimbursement
-    // next to the actual gas price from the transaction. We use gas price
-    // ceiling to defend against malicious miner-submitters who can manipulate
-    // transaction gas price.
+    /// @dev Gas price ceiling value used to calculate the gas price for reimbursement
+    /// next to the actual gas price from the transaction. We use gas price
+    /// ceiling to defend against malicious miner-submitters who can manipulate
+    /// transaction gas price.
     uint256 public gasPriceCeiling = 30*1e9; // (30 Gwei = 30 * 10^9 wei)
 
-    // Size of a group in the threshold relay.
+    /// @dev Size of a group in the threshold relay.
     uint256 public groupSize = 64;
 
-    // Minimum number of group members needed to interact according to the
-    // protocol to produce a relay entry.
+    /// @dev Minimum number of group members needed to interact according to the
+    /// protocol to produce a relay entry.
     uint256 public groupThreshold = 33;
 
-    // Time in blocks after which the next group member is eligible
-    // to submit the result.
+    /// @dev Time in blocks after which the next group member is eligible
+    /// to submit the result.
     uint256 public resultPublicationBlockStep = 3;
 
-    // Timeout in blocks for a relay entry to appear on the chain. Blocks are
-    // counted from the moment relay request occur.
-    //
-    // Timeout is never shorter than the time needed by clients to generate
-    // relay entry and the time it takes for the last group member to become
-    // eligible to submit the result plus at least one block to submit it.
+    /// @dev Timeout in blocks for a relay entry to appear on the chain. Blocks
+    /// are counted from the moment relay request occur.
+    ///
+    /// Timeout is never shorter than the time needed by clients to generate
+    /// relay entry and the time it takes for the last group member to become
+    /// eligible to submit the result plus at least one block to submit it.
     uint256 public relayEntryTimeout = groupSize.mul(resultPublicationBlockStep);
 
-    // Gas required to verify BLS signature and produce successful relay
-    // entry. Excludes callback and DKG gas. The worst case (most expensive)
-    // scenario.
+    /// @dev Gas required to verify BLS signature and produce successful relay
+    /// entry. Excludes callback and DKG gas. The worst case (most expensive)
+    /// scenario.
     uint256 public entryVerificationGasEstimate = 280000;
 
-    // Gas required to submit DKG result. Excludes initiation of group selection.
+    /// @dev Gas required to submit DKG result. Excludes initiation of group selection.
     uint256 public dkgGasEstimate = 1740000;
 
-    // Gas required to trigger DKG (starting group selection).
+    /// @dev Gas required to trigger DKG (starting group selection).
     uint256 public groupSelectionGasEstimate = 200000;
 
-    // Reimbursement for the submitter of the DKG result. This value is set when
-    // a new DKG request comes to the operator contract.
-    //
-    // When submitting DKG result, the submitter is reimbursed with the actual cost
-    // and some part of the fee stored in this field may be returned to the service
-    // contract.
+    /// @dev Reimbursement for the submitter of the DKG result. This value is set
+    /// when a new DKG request comes to the operator contract.
+    ///
+    /// When submitting DKG result, the submitter is reimbursed with the actual cost
+    /// and some part of the fee stored in this field may be returned to the service
+    /// contract.
     uint256 public dkgSubmitterReimbursementFee;
 
-    // Seed value used for the genesis group selection.
-    // https://www.wolframalpha.com/input/?i=pi+to+78+digits
+    /// @dev Seed value used for the genesis group selection.
+    /// https://www.wolframalpha.com/input/?i=pi+to+78+digits
     uint256 internal constant _genesisGroupSeed = 31415926535897932384626433832795028841971693993751058209749445923078164062862;
 
-    // Service contract that triggered current group selection.
+    /// @dev Service contract that triggered current group selection.
     ServiceContract internal groupSelectionStarterContract;
 
     // current relay request data
@@ -127,9 +124,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     address internal currentRequestServiceContract;
 
 
-    /**
-     * @dev Triggers group selection if there are no active groups.
-     */
+    /// @notice Triggers group selection if there are no active groups.
     function genesis() public payable {
         // If we run into a very unlikely situation when there are no active
         // groups on the contract because of slashing and groups terminated
@@ -203,28 +198,22 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         dkgResultVerification.signatureThreshold = groupThreshold + (groupSize - groupThreshold) / 2;
     }
 
-    /**
-     * @dev Adds service contract
-     * @param serviceContract Address of the service contract.
-     */
+    /// @notice Adds service contract
+    /// @param serviceContract Address of the service contract.
     function addServiceContract(address serviceContract) public onlyServiceContractUpgrader {
         serviceContracts.push(serviceContract);
     }
 
-    /**
-     * @dev Removes service contract
-     * @param serviceContract Address of the service contract.
-     */
+    /// @notice Removes service contract
+    /// @param serviceContract Address of the service contract.
     function removeServiceContract(address serviceContract) public onlyServiceContractUpgrader {
         serviceContracts.removeAddress(serviceContract);
     }
 
-    /**
-     * @dev Triggers the selection process of a new candidate group.
-     * @param _newEntry New random beacon value that stakers will use to
-     * generate their tickets.
-     * @param submitter Operator of this contract.
-     */
+    /// @notice Triggers the selection process of a new candidate group.
+    /// @param _newEntry New random beacon value that stakers will use to
+    /// generate their tickets.
+    /// @param submitter Operator of this contract.
     function createGroup(uint256 _newEntry, address payable submitter) public payable onlyServiceContract {
         uint256 groupSelectionStartFee = groupSelectionGasEstimate.mul(gasPriceCeiling);
 
@@ -258,6 +247,9 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         dkgSubmitterReimbursementFee = _payment;
     }
 
+    /// @notice Checks if it is possible to fire a new group selection.
+    /// Triggering new group selection is only possible when there is no
+    /// pending group selection or when the pending group selection timed out.
     function isGroupSelectionPossible() public view returns (bool) {
         if (!groupSelection.inProgress) {
             return true;
@@ -273,58 +265,49 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         return block.number > dkgTimeout;
     }
 
-    /**
-     * @dev Submits ticket to request to participate in a new candidate group.
-     * @param ticket Bytes representation of a ticket that holds the following:
-     * - ticketValue: first 8 bytes of a result of keccak256 cryptography hash
-     *   function on the combination of the group selection seed (previous
-     *   beacon output), staker-specific value (address) and virtual staker index.
-     * - stakerValue: a staker-specific value which is the address of the staker.
-     * - virtualStakerIndex: 4-bytes number within a range of 1 to staker's weight;
-     *   has to be unique for all tickets submitted by the given staker for the
-     *   current candidate group selection.
-     */
+    /// @notice Submits ticket to request to participate in a new candidate group.
+    /// @param ticket Bytes representation of a ticket that holds the following:
+    /// - ticketValue: first 8 bytes of a result of keccak256 cryptography hash
+    ///   function on the combination of the group selection seed (previous
+    ///   beacon output), staker-specific value (address) and virtual staker index.
+    /// - stakerValue: a staker-specific value which is the address of the staker.
+    /// - virtualStakerIndex: 4-bytes number within a range of 1 to staker's weight;
+    ///   has to be unique for all tickets submitted by the given staker for the
+    ///   current candidate group selection.
     function submitTicket(bytes32 ticket) public {
-        uint256 stakingWeight = stakingContract.eligibleStake(msg.sender, address(this)).div(groupSelection.minimumStake);
+        uint256 stakingWeight = stakingContract.eligibleStake(
+            msg.sender, address(this)
+        ).div(groupSelection.minimumStake);
         groupSelection.submitTicket(ticket, stakingWeight);
     }
 
-    /**
-     * @dev Gets the timeout in blocks after which group candidate ticket
-     * submission is finished.
-     */
+    /// @notice Gets the timeout in blocks after which group candidate ticket
+    /// submission is finished.
     function ticketSubmissionTimeout() public view returns (uint256) {
         return groupSelection.ticketSubmissionTimeout;
     }
 
-    /**
-     * @dev Gets the submitted group candidate tickets so far.
-     */
+    /// @notice Gets the submitted group candidate tickets so far.
     function submittedTickets() public view returns (uint64[] memory) {
         return groupSelection.tickets;
     }
 
-    /**
-     * @dev Gets selected participants in ascending order of their tickets.
-     */
+    /// @notice Gets selected participants in ascending order of their tickets.
     function selectedParticipants() public view returns (address[] memory) {
         return groupSelection.selectedParticipants();
     }
 
-    /**
-     * @dev Submits result of DKG protocol. It is on-chain part of phase 14 of
-     * the protocol.
-     *
-     * @param submitterMemberIndex Claimed submitter candidate group member index
-     * @param groupPubKey Generated candidate group public key
-     * @param misbehaved Bytes array of misbehaved (disqualified or inactive)
-     * group members indexes in ascending order; Indexes reflect positions of
-     * members in the group as outputted by the group selection protocol.
-     * @param signatures Concatenation of signatures from members supporting the
-     * result.
-     * @param signingMembersIndexes Indices of members corresponding to each
-     * signature.
-     */
+    /// @notice Submits result of DKG protocol. It is on-chain part of phase 14 of
+    /// the protocol.
+    /// @param submitterMemberIndex Claimed submitter candidate group member index
+    /// @param groupPubKey Generated candidate group public key
+    /// @param misbehaved Bytes array of misbehaved (disqualified or inactive)
+    /// group members indexes in ascending order; Indexes reflect positions of
+    /// members in the group as outputted by the group selection protocol.
+    /// @param signatures Concatenation of signatures from members supporting the
+    /// result.
+    /// @param signingMembersIndexes Indices of members corresponding to each
+    /// signature.
     function submitDkgResult(
         uint256 submitterMemberIndex,
         bytes memory groupPubKey,
@@ -351,12 +334,11 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         groupSelection.stop();
     }
 
-    /**
-     * @dev Compare the reimbursement fee calculated based on the current transaction gas
-     * price and the current price feed estimate with the DKG reimbursement fee calculated
-     * and paid at the moment when the DKG was requested. If there is any surplus, it will
-     * be returned to the DKG fee pool of the service contract which triggered the DKG.
-     */
+    /// @notice Compare the reimbursement fee calculated based on the current
+    /// transaction gas price and the current price feed estimate with the DKG
+    /// reimbursement fee calculated and paid at the moment when the DKG was
+    /// requested. If there is any surplus, it will be returned to the DKG fee
+    /// pool of the service contract which triggered the DKG.
     function reimburseDkgSubmitter() internal {
         uint256 gasPrice = gasPriceCeiling;
         // We need to check if tx.gasprice is non-zero as a workaround to a bug
@@ -378,19 +360,18 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
             // Return surplus to the contract that started DKG.
             groupSelectionStarterContract.fundDkgFeePool.value(surplus)();
         } else {
-            // If submitter used higher gas price reimburse only dkgSubmitterReimbursementFee max.
+            // If submitter used higher gas price reimburse only
+            // dkgSubmitterReimbursementFee max.
             reimbursementFee = dkgSubmitterReimbursementFee;
             dkgSubmitterReimbursementFee = 0;
             beneficiary.call.value(reimbursementFee)("");
         }
     }
 
-    /**
-     * @dev Creates a request to generate a new relay entry, which will include a
-     * random number (by signing the previous entry's random number).
-     * @param requestId Request Id trackable by service contract
-     * @param previousEntry Previous relay entry
-     */
+    /// @notice Creates a request to generate a new relay entry, which will include
+    /// a random number (by signing the previous entry's random number).
+    /// @param requestId Request Id trackable by service contract
+    /// @param previousEntry Previous relay entry
     function sign(
         uint256 requestId,
         bytes memory previousEntry
@@ -432,11 +413,9 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         emit RelayEntryRequested(previousEntry, groupPubKey);
     }
 
-    /**
-     * @dev Creates a new relay entry and stores the associated data on the chain.
-     * @param _groupSignature Group BLS signature over the concatenation of the
-     * previous entry and seed.
-     */
+    /// @notice Creates a new relay entry and stores the associated data on the chain.
+    /// @param _groupSignature Group BLS signature over the concatenation of the
+    /// previous entry and seed.
     function relayEntry(bytes memory _groupSignature) public nonReentrant {
         require(isEntryInProgress(), "Entry was submitted");
         require(!hasEntryTimedOut(), "Entry timed out");
@@ -475,16 +454,16 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         stakingContract.beneficiaryOf(msg.sender).call.value(submitterReward)("");
 
         if (subsidy > 0) {
-            currentRequestServiceContract.call.gas(35000).value(subsidy)(abi.encodeWithSignature("fundRequestSubsidyFeePool()"));
+            currentRequestServiceContract.call.gas(35000).value(subsidy)(
+                abi.encodeWithSignature("fundRequestSubsidyFeePool()")
+            );
         }
 
         currentRequestStartBlock = 0;
     }
 
-    /**
-     * @dev Executes customer specified callback for the relay entry request.
-     * @param entry The generated random number.
-     */
+    /// @notice Executes customer specified callback for the relay entry request.
+    /// @param entry The generated random number.
     function executeCallback(uint256 entry) internal {
         uint256 callbackFee = currentRequestCallbackFee;
 
@@ -519,10 +498,13 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         );
     }
 
-    /**
-     * @dev Get rewards breakdown in wei for successful entry for the current signing request.
-     */
-    function newEntryRewardsBreakdown() internal view returns(uint256 groupMemberReward, uint256 submitterReward, uint256 subsidy) {
+    /// @notice Get rewards breakdown in wei for successful entry for the
+    /// current signing request.
+    function newEntryRewardsBreakdown() internal view returns(
+        uint256 groupMemberReward,
+        uint256 submitterReward,
+        uint256 subsidy
+    ) {
         uint256 decimals = 1e16; // Adding 16 decimals to perform float division.
 
         uint256 delayFactor = DelayFactor.calculate(
@@ -547,33 +529,27 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         subsidy = groupProfitFee().sub(groupMemberReward.mul(groupSize)).sub(submitterExtraReward);
     }
 
-    /**
-     * @dev Returns true if generation of a new relay entry is currently in
-     * progress.
-     */
+    /// @notice Returns true if generation of a new relay entry is currently in
+    /// progress.
     function isEntryInProgress() public view returns (bool) {
         return currentRequestStartBlock != 0;
     }
 
-    /**
-     * @dev Returns true if the currently ongoing new relay entry generation
-     * operation timed out. There is a certain timeout for a new relay entry
-     * to be produced, see `relayEntryTimeout` value.
-     */
+    /// @notice Returns true if the currently ongoing new relay entry generation
+    /// operation timed out. There is a certain timeout for a new relay entry
+    /// to be produced, see `relayEntryTimeout` value.
     function hasEntryTimedOut() internal view returns (bool) {
         return currentRequestStartBlock != 0 && block.number > currentRequestStartBlock + relayEntryTimeout;
     }
 
-    /**
-     * @dev Function used to inform about the fact the currently ongoing
-     * new relay entry generation operation timed out. As a result, the group
-     * which was supposed to produce a new relay entry is immediately
-     * terminated and a new group is selected to produce a new relay entry.
-     * All members of the group are punished by seizing minimum stake of
-     * their tokens. The submitter of the transaction is rewarded with a
-     * tattletale reward which is limited to min(1, 20 / group_size) of the
-     * maximum tattletale reward.
-     */
+    /// @notice Function used to inform about the fact the currently ongoing
+    /// new relay entry generation operation timed out. As a result, the group
+    /// which was supposed to produce a new relay entry is immediately
+    /// terminated and a new group is selected to produce a new relay entry.
+    /// All members of the group are punished by seizing minimum stake of
+    /// their tokens. The submitter of the transaction is rewarded with a
+    /// tattletale reward which is limited to min(1, 20 / group_size) of the
+    /// maximum tattletale reward.
     function reportRelayEntryTimeout() public {
         require(hasEntryTimedOut(), "Entry did not time out");
         groups.reportRelayEntryTimeout(currentRequestGroupIndex, groupSize);
@@ -594,91 +570,75 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         emit RelayEntryTimeoutReported(currentRequestGroupIndex);
     }
 
-    /**
-     * @dev Gets group profit fee expressed in wei.
-     */
+    /// @notice Gets group profit fee expressed in wei.
     function groupProfitFee() public view returns(uint256) {
         return groupMemberBaseReward.mul(groupSize);
     }
 
-    /**
-     * @dev Checks if the specified account has enough active stake to become
-     * network operator and that this contract has been authorized for potential
-     * slashing.
-     *
-     * Having the required minimum of active stake makes the operator eligible
-     * to join the network. If the active stake is not currently undelegating,
-     * operator is also eligible for work selection.
-     *
-     * @param staker Staker's address
-     * @return True if has enough active stake to participate in the network,
-     * false otherwise.
-     */
+    /// @notice Checks if the specified account has enough active stake to become
+    /// network operator and that this contract has been authorized for potential
+    /// slashing.
+    ///
+    /// Having the required minimum of active stake makes the operator eligible
+    /// to join the network. If the active stake is not currently undelegating,
+    /// operator is also eligible for work selection.
+    ///
+    /// @param staker Staker's address
+    /// @return True if has enough active stake to participate in the network,
+    /// false otherwise.
     function hasMinimumStake(address staker) public view returns(bool) {
         return stakingContract.hasMinimumStake(staker, address(this));
     }
 
-    /**
-     * @dev Checks if group with the given public key is registered.
-     */
+    /// @notice Checks if group with the given public key is registered.
     function isGroupRegistered(bytes memory groupPubKey) public view returns(bool) {
         return groups.isGroupRegistered(groupPubKey);
     }
 
-    /**
-     * @dev Checks if a group with the given public key is a stale group.
-     * Stale group is an expired group which is no longer performing any
-     * operations. It is important to understand that an expired group may
-     * still perform some operations for which it was selected when it was still
-     * active. We consider a group to be stale when it's expired and when its
-     * expiration time and potentially executed operation timeout are both in
-     * the past.
-     */
+    /// @notice Checks if a group with the given public key is a stale group.
+    /// Stale group is an expired group which is no longer performing any
+    /// operations. It is important to understand that an expired group may
+    /// still perform some operations for which it was selected when it was still
+    /// active. We consider a group to be stale when it's expired and when its
+    /// expiration time and potentially executed operation timeout are both in
+    /// the past.
     function isStaleGroup(bytes memory groupPubKey) public view returns(bool) {
         return groups.isStaleGroup(groupPubKey);
     }
 
-    /**
-     * @notice Gets the number of active groups as currently marked in the
-     * contract. This is the state from when the expired groups were last updated
-     * without accounting for recent expirations.
-     *
-     * @dev Even if numberOfGroups() > 0, it is still possible requesting for
-     * a new relay entry will revert with "no active groups" failure message.
-     * This function returns the number of active groups as they are currently
-     * marked on-chain. However, during relay request, before group selection,
-     * we run group expiration and it may happen that some groups seen as active
-     * turns out to be expired.
-     */
+    /// @notice Gets the number of active groups as currently marked in the
+    /// contract. This is the state from when the expired groups were last updated
+    /// without accounting for recent expirations.
+    ///
+    /// @dev Even if numberOfGroups() > 0, it is still possible requesting for
+    /// a new relay entry will revert with "no active groups" failure message.
+    /// This function returns the number of active groups as they are currently
+    /// marked on-chain. However, during relay request, before group selection,
+    /// we run group expiration and it may happen that some groups seen as active
+    /// turns out to be expired.
     function numberOfGroups() public view returns(uint256) {
         return groups.numberOfGroups();
     }
 
-    /**
-     * @dev Returns accumulated group member rewards for provided group.
-     */
+    /// @notice Returns accumulated group member rewards for provided group.
     function getGroupMemberRewards(bytes memory groupPubKey) public view returns (uint256) {
         return groups.groupMemberRewards[groupPubKey];
     }
 
-    /**
-     * @notice Return whether the given operator
-     * has withdrawn their rewards from the given group.
-     */
+    /// @notice Return whether the given operator has withdrawn their rewards
+    /// from the given group.
     function hasWithdrawnRewards(address operator, uint256 groupIndex)
         public view returns (bool) {
         return groups.hasWithdrawnRewards(operator, groupIndex);
     }
 
-    /**
-     * @dev Withdraws accumulated group member rewards for operator
-     * using the provided group index.
-     * Once the accumulated reward is withdrawn from the selected group,
-     * the operator is flagged as withdrawn.
-     * Rewards can be withdrawn only from stale group.
-     * @param operator Operator address.
-     * @param groupIndex Group index.
-     */
+    /// @notice Withdraws accumulated group member rewards for operator
+    /// using the provided group index.
+    /// Once the accumulated reward is withdrawn from the selected group,
+    /// the operator is flagged as withdrawn.
+    /// Rewards can be withdrawn only from stale group.
+    /// @param operator Operator address
+    /// @param groupIndex Group index
     function withdrawGroupMemberRewards(address operator, uint256 groupIndex)
         public nonReentrant {
         uint256 accumulatedRewards = groups.withdrawFromGroup(operator, groupIndex);
@@ -688,51 +648,39 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         }
     }
 
-    /**
-    * @dev Gets the index of the first active group.
-    */
+    /// @notice Gets the index of the first active group.
     function getFirstActiveGroupIndex() public view returns (uint256) {
         return groups.expiredGroupOffset;
     }
 
-    /**
-    * @dev Gets group public key.
-    */
+    /// @notice Gets public key of the group with the given index.
     function getGroupPublicKey(uint256 groupIndex) public view returns (bytes memory) {
         return groups.getGroupPublicKey(groupIndex);
     }
 
-    /**
-     * @dev Returns fee for entry verification in wei. Does not include group
-     * profit fee, DKG contribution or callback fee.
-     */
+    /// @notice Returns fee for entry verification in wei. Does not include group
+    /// profit fee, DKG contribution or callback fee.
     function entryVerificationFee() public view returns (uint256) {
         return entryVerificationGasEstimate.mul(gasPriceCeiling);
     }
 
-    /**
-     * @dev Returns fee for group creation in wei. Includes the cost of DKG
-     * and the cost of triggering group selection.
-     */
+    /// @notice Returns fee for group creation in wei. Includes the cost of DKG
+    /// and the cost of triggering group selection.
     function groupCreationFee() public view returns (uint256) {
         return dkgGasEstimate.add(groupSelectionGasEstimate).mul(gasPriceCeiling);
     }
 
-    /**
-     * @dev Returns members of the given group by group public key.
-     */
+    /// @notice Returns members of the given group by group public key.
     function getGroupMembers(bytes memory groupPubKey) public view returns (address[] memory members) {
         return groups.getGroupMembers(groupPubKey);
     }
 
-    /**
-     * @dev Reports unauthorized signing for the provided group. Must provide
-     * a valid signature of the tattletale address as a message. Successful signature
-     * verification means the private key has been leaked and all group members
-     * should be punished by seizing their tokens. The submitter of this proof is
-     * rewarded with 5% of the total seized amount scaled by the reward adjustment
-     * parameter and the rest 95% is burned.
-     */
+    /// @notice Reports unauthorized signing for the provided group. Must provide
+    /// a valid signature of the tattletale address as a message. Successful signature
+    /// verification means the private key has been leaked and all group members
+    /// should be punished by seizing their tokens. The submitter of this proof is
+    /// rewarded with 5% of the total seized amount scaled by the reward adjustment
+    /// parameter and the rest 95% is burned.
     function reportUnauthorizedSigning(
         uint256 groupIndex,
         bytes memory signedMsgSender

--- a/solidity/contracts/KeepRandomBeaconService.sol
+++ b/solidity/contracts/KeepRandomBeaconService.sol
@@ -3,48 +3,36 @@ pragma solidity 0.5.17;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "@openzeppelin/upgrades/contracts/upgradeability/Proxy.sol";
 
-/**
- * @title Keep Random Beacon service
- * @dev A proxy contract to provide upgradable Random Beacon functionality.
- * All calls to this proxy contract are delegated to the implementation contract.
- */
+/// @title Keep Random Beacon service
+/// @notice A proxy contract to provide upgradable Random Beacon functionality.
+/// All calls to this proxy contract are delegated to the implementation contract.
 contract KeepRandomBeaconService is Proxy {
     using SafeMath for uint256;
 
-    /**
-     * @dev Storage slot with the admin of the contract.
-     * This is the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1.
-     * It is validated in the constructor.
-     */
+    /// @dev Storage slot with the admin of the contract.
+    /// This is the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1.
+    /// It is validated in the constructor.
     bytes32 internal constant ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
-    /**
-     * @dev Storage slot with the address of the current implementation.
-     * This is the keccak-256 hash of "eip1967.proxy.implementation"
-     * subtracted by 1. It is validated in the constructor.
-     */
+    /// @dev Storage slot with the address of the current implementation.
+    /// This is the keccak-256 hash of "eip1967.proxy.implementation"
+    /// subtracted by 1. It is validated in the constructor.
     bytes32 internal constant IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
-    /**
-     * @dev Storage slot with the upgrade time delay. Upgrade time delay
-     * defines a period for implementation upgrade. This is the keccak-256
-     * hash of "network.keep.randombeacon.proxy.upgradeTimeDelay"
-     * subtracted by 1. It is validated in the constructor.
-     */
+    /// @dev Storage slot with the upgrade time delay. Upgrade time delay
+    /// defines a period for implementation upgrade. This is the keccak-256
+    /// hash of "network.keep.randombeacon.proxy.upgradeTimeDelay"
+    /// subtracted by 1. It is validated in the constructor.
     bytes32 internal constant UPGRADE_TIME_DELAY_SLOT = 0x73bbd307af06a74c12a4f925288c98f759a1ee8fee7eae47a0c215cb63ef2c6b;
 
-    /**
-     * @dev Storage slot with the new implementation address. This is the
-     * keccak-256 hash of "network.keep.randombeacon.proxy.upgradeImplementation"
-     * subtracted by 1. It is validated in the constructor.
-     */
+    /// @dev Storage slot with the new implementation address. This is the
+    /// keccak-256 hash of "network.keep.randombeacon.proxy.upgradeImplementation"
+    /// subtracted by 1. It is validated in the constructor.
     bytes32 internal constant UPGRADE_IMPLEMENTATION_SLOT = 0x3c3c1acab6a17c8ef7a1d07995c8ed2942488afd9e13cf89bd5c6e4828160276;
 
-    /**
-     * @dev Storage slot with the implementation address upgrade initiation.
-     * This is the keccak-256 hash of "network.keep.randombeacon.proxy.upgradeInitiatedTimestamp"
-     * subtracted by 1. It is validated in the constructor.
-     */
+    /// @dev Storage slot with the implementation address upgrade initiation.
+    /// This is the keccak-256 hash of "network.keep.randombeacon.proxy.upgradeInitiatedTimestamp"
+    /// subtracted by 1. It is validated in the constructor.
     bytes32 internal constant UPGRADE_INIT_TIMESTAMP_SLOT = 0xb49edbaf3913780c2ef1ff781deec1eb653eab7236ff107428d60052d0f0d18d;
 
     /// @notice Implementation initialization data to be used on the second step
@@ -80,14 +68,12 @@ contract KeepRandomBeaconService is Proxy {
         setAdmin(msg.sender);
     }
 
-    /**
-     * @notice Starts upgrade of the current vendor implementation.
-     * @dev It is the first part of the two-step implementation address update
-     * process. The function emits an event containing the new value and current
-     * block timestamp.
-     * @param _newImplementation Address of the new vendor implementation contract.
-     * @param _data Delegate call data for implementation initialization.
-     */
+    /// @notice Starts upgrade of the current vendor implementation.
+    /// @dev It is the first part of the two-step implementation address update
+    /// process. The function emits an event containing the new value and current
+    /// block timestamp.
+    /// @param _newImplementation Address of the new vendor implementation contract.
+    /// @param _data Delegate call data for implementation initialization.
     function upgradeTo(address _newImplementation, bytes memory _data)
         public
         onlyAdmin
@@ -113,13 +99,11 @@ contract KeepRandomBeaconService is Proxy {
         emit UpgradeStarted(_newImplementation, block.timestamp);
     }
 
-    /**
-     * @notice Finalizes implementation address upgrade.
-     * @dev It is the second part of the two-step implementation address update
-     * process. The function emits an event containing the new implementation
-     * address. It can be called after upgrade time delay period has passed since
-     * upgrade initiation.
-     */
+    /// @notice Finalizes implementation address upgrade.
+    /// @dev It is the second part of the two-step implementation address update
+    /// process. The function emits an event containing the new implementation
+    /// address. It can be called after upgrade time delay period has passed since
+    /// upgrade initiation.
     function completeUpgrade() public onlyAdmin {
         require(upgradeInitiatedTimestamp() > 0, "Upgrade not initiated");
 
@@ -144,13 +128,11 @@ contract KeepRandomBeaconService is Proxy {
         emit UpgradeCompleted(newImplementation);
     }
 
-    /**
-     * @notice Initializes implementation contract.
-     * @dev Delegates a call to the implementation with provided data. It is
-     * expected that data contains details of function to be called.
-     * @param _implementation Address of the new vendor implementation contract.
-     * @param _data Delegate call data for implementation initialization.
-     */
+    /// @notice Initializes implementation contract.
+    /// @dev Delegates a call to the implementation with provided data. It is
+    /// expected that data contains details of function to be called.
+    /// @param _implementation Address of the new vendor implementation contract.
+    /// @param _data Delegate call data for implementation initialization.
     function initializeImplementation(
         address _implementation,
         bytes memory _data
@@ -162,30 +144,24 @@ contract KeepRandomBeaconService is Proxy {
         require(success, string(returnData));
     }
 
-    /**
-     * @notice Asserts correct slot for provided key.
-     * @dev To avoid clashing with implementation's fields the proxy contract
-     * defines its' fields on specific slots. Slot is calculated as hash of a
-     * string subtracted by 1 to reduce chances of a possible attack.
-     * For details see EIP-1967.
-     */
+    /// @notice Asserts correct slot for provided key.
+    /// @dev To avoid clashing with implementation's fields the proxy contract
+    /// defines its' fields on specific slots. Slot is calculated as hash of a
+    /// string subtracted by 1 to reduce chances of a possible attack.
+    /// For details see EIP-1967.
     function assertSlot(bytes32 slot, bytes memory key) internal pure {
         assert(slot == bytes32(uint256(keccak256(key)) - 1));
     }
 
-    /**
-     * @dev Gets the address of the current implementation.
-     * @return address of the current implementation.
-     */
+    /// @dev Gets the address of the current implementation.
+    /// @return address of the current implementation.
     function implementation() public view returns (address) {
         return _implementation();
     }
 
-    /**
-     * @dev Returns the current implementation. Implements function from `Proxy`
-     * contract.
-     * @return Address of the current implementation
-     */
+    /// @notice Returns the current implementation. Implements function from `Proxy`
+    /// contract.
+    /// @return Address of the current implementation
     function _implementation() internal view returns (address impl) {
         bytes32 slot = IMPLEMENTATION_SLOT;
         /* solium-disable-next-line */
@@ -194,10 +170,8 @@ contract KeepRandomBeaconService is Proxy {
         }
     }
 
-    /**
-     * @dev Sets the address of the current implementation.
-     * @param _implementation address representing the new implementation to be set.
-     */
+    /// @notice Sets the address of the current implementation.
+    /// @param _implementation address representing the new implementation to be set.
     function setImplementation(address _implementation) internal {
         bytes32 slot = IMPLEMENTATION_SLOT;
         /* solium-disable-next-line */
@@ -268,10 +242,8 @@ contract KeepRandomBeaconService is Proxy {
         }
     }
 
-    /**
-     * @notice The admin slot.
-     * @return The contract owner's address.
-     */
+    /// @notice The admin slot.
+    /// @return The contract owner's address.
     function admin() public view returns (address adm) {
         bytes32 slot = ADMIN_SLOT;
         /* solium-disable-next-line */
@@ -280,10 +252,8 @@ contract KeepRandomBeaconService is Proxy {
         }
     }
 
-    /**
-     * @dev Sets the address of the proxy admin.
-     * @param _newAdmin Address of the new proxy admin.
-     */
+    /// @notice Sets the address of the proxy admin.
+    /// @param _newAdmin Address of the new proxy admin.
     function setAdmin(address _newAdmin) internal {
         bytes32 slot = ADMIN_SLOT;
         /* solium-disable-next-line */
@@ -292,9 +262,7 @@ contract KeepRandomBeaconService is Proxy {
         }
     }
 
-    /**
-     * @dev Throws if called by any account other than the contract owner.
-     */
+    /// @notice Throws if called by any account other than the contract owner.
     modifier onlyAdmin() {
         require(msg.sender == admin(), "Caller is not the admin");
         _;

--- a/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
+++ b/solidity/contracts/KeepRandomBeaconServiceImplV1.sol
@@ -22,15 +22,15 @@ interface OperatorContract {
     function isGroupSelectionPossible() external view returns (bool);
 }
 
-/**
- * @title KeepRandomBeaconServiceImplV1
- * @dev Initial version of service contract that works under Keep Random
- * Beacon proxy and allows upgradability. The purpose of the contract is to have
- * up-to-date logic for threshold random number generation. Updated contracts
- * must inherit from this contract and have to be initialized under updated version name
- * Warning: you can't set constants directly in the contract and must use initialize()
- * please see openzeppelin upgradeable contracts approach for more info.
- */
+/// @title KeepRandomBeaconServiceImplV1
+/// @notice Initial version of service contract that works under Keep Random
+/// Beacon proxy and allows upgradability. The purpose of the contract is to have
+/// up-to-date logic for threshold random number generation. Updated contracts
+/// must inherit from this contract and have to be initialized under updated version
+/// name.
+/// @dev Warning: you can't set constants directly in the contract and must use
+/// initialize() please see openzeppelin upgradeable contracts approach for more
+/// info.
 contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
     using SafeMath for uint256;
     using PercentUtils for uint256;
@@ -38,33 +38,34 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
 
     event RelayEntryRequested(uint256 requestId);
 
-    // Fraction in % of the estimated cost of DKG that is included
-    // in relay request fee.
+    /// @dev Fraction in % of the estimated cost of DKG that is included
+    /// in relay request fee.
     uint256 internal _dkgContributionMargin;
 
-    // Every relay request payment includes DKG contribution that is added to
-    // the DKG fee pool, once the pool value reaches the required minimum, a new
-    // relay entry will trigger the creation of a new group. Expressed in wei.
+    /// @dev Every relay request payment includes DKG contribution that is added to
+    /// the DKG fee pool, once the pool value reaches the required minimum, a new
+    /// relay entry will trigger the creation of a new group. Expressed in wei.
     uint256 internal _dkgFeePool;
 
-    // Rewards not paid out to the operators are sent to request subsidy pool to
-    // subsidize new requests: 1% of the subsidy pool is returned to the requester's
-    // surplus address. Expressed in wei.
+    /// @dev Rewards not paid out to the operators are sent to request subsidy pool to
+    /// subsidize new requests: 1% of the subsidy pool is returned to the requester's
+    /// surplus address. Expressed in wei.
     uint256 internal _requestSubsidyFeePool;
 
-    // Each service contract tracks its own requests and these are independent
-    // from operator contracts which track signing requests instead.
+    /// @dev Each service contract tracks its own requests and these are independent
+    /// from operator contracts which track signing requests instead.
     uint256 internal _requestCounter;
 
+    /// @dev Previous entry value produced by the beacon.
     bytes internal _previousEntry;
 
-    // The cost of executing executeCallback() code of this contract, includes
-    // everything but the logic of the external contract called.
-    // The value is used to estimate the cost of executing a callback and is
-    // used for calculating callback call surplus reimbursement for requestor.
-    //
-    // This value has to be updated in case of EVM opcode price change, but since
-    // upgrading service contract is easy, it is not a worrisome problem.
+    /// @dev The cost of executing executeCallback() code of this contract, includes
+    /// everything but the logic of the external contract called.
+    /// The value is used to estimate the cost of executing a callback and is
+    /// used for calculating callback call surplus reimbursement for requestor.
+    ///
+    /// This value has to be updated in case of EVM opcode price change, but since
+    /// upgrading service contract is easy, it is not a worrisome problem.
     uint256 internal _baseCallbackGas;
 
     struct Callback {
@@ -76,24 +77,23 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
 
     mapping(uint256 => Callback) internal _callbacks;
 
-    // KeepRegistry contract with a list of approved operator contracts and upgraders.
+    /// @dev KeepRegistry contract with a list of approved operator contracts and upgraders.
     address internal _registry;
 
     address[] internal _operatorContracts;
 
-    // Mapping to store new implementation versions that inherit from this contract.
+    /// @dev Mapping to store new implementation versions that inherit from this contract.
     mapping (string => bool) internal _initialized;
 
-    // Seed used as the first random beacon value.
-    // It's a G1 point G * PI =
-    // G * 31415926535897932384626433832795028841971693993751058209749445923078164062862
-    // Where G is the generator of G1 abstract cyclic group.
+    /// @dev Seed used as the first random beacon value.
+    /// It's a G1 point G * PI =
+    /// G * 31415926535897932384626433832795028841971693993751058209749445923078164062862
+    /// Where G is the generator of G1 abstract cyclic group.
     bytes constant internal _beaconSeed =
     hex"15c30f4b6cf6dbbcbdcc10fe22f54c8170aea44e198139b776d512d8f027319a1b9e8bfaf1383978231ce98e42bafc8129f473fc993cf60ce327f7d223460663";
 
-    /**
-     * @dev Throws if called by any account other than the operator contract upgrader authorized for this service contract.
-     */
+    /// @dev Throws if called by any account other than the operator contract
+    /// upgrader authorized for this service contract.
     modifier onlyOperatorContractUpgrader() {
         address operatorContractUpgrader = KeepRegistry(_registry).operatorContractUpgraderFor(address(this));
         require(operatorContractUpgrader == msg.sender, "Caller is not operator contract upgrader");
@@ -104,12 +104,10 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         _initialized["KeepRandomBeaconServiceImplV1"] = true;
     }
 
-    /**
-     * @dev Initialize Keep Random Beacon service contract implementation.
-     * @param dkgContributionMargin Fraction in % of the estimated cost of DKG that is included in relay
-     * request fee.
-     * @param registry KeepRegistry contract linked to this contract.
-     */
+    /// @notice Initialize Keep Random Beacon service contract implementation.
+    /// @param dkgContributionMargin Fraction in % of the estimated cost of DKG that is included in relay
+    /// request fee.
+    /// @param registry KeepRegistry contract linked to this contract.
     function initialize(
         uint256 dkgContributionMargin,
         address registry
@@ -126,17 +124,13 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         _baseCallbackGas = 10203;
     }
 
-    /**
-     * @dev Checks if this contract is initialized.
-     */
+    /// @notice Checks if this contract is initialized.
     function initialized() public view returns (bool) {
         return _initialized["KeepRandomBeaconServiceImplV1"];
     }
 
-    /**
-     * @dev Adds operator contract
-     * @param operatorContract Address of the operator contract.
-     */
+    /// @notice Adds operator contract
+    /// @param operatorContract Address of the operator contract.
     function addOperatorContract(address operatorContract) public onlyOperatorContractUpgrader {
         require(
             KeepRegistry(_registry).isApprovedOperatorContract(operatorContract),
@@ -145,34 +139,27 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         _operatorContracts.push(operatorContract);
     }
 
-    /**
-     * @dev Removes operator contract
-     * @param operatorContract Address of the operator contract.
-     */
+    /// @notice Removes operator contract
+    /// @param operatorContract Address of the operator contract.
     function removeOperatorContract(address operatorContract) public onlyOperatorContractUpgrader {
         _operatorContracts.removeAddress(operatorContract);
     }
 
-    /**
-     * @dev Add funds to DKG fee pool.
-     */
+    /// @notice Add funds to DKG fee pool.
     function fundDkgFeePool() public payable {
         _dkgFeePool += msg.value;
     }
 
-    /**
-     * @dev Add funds to request subsidy fee pool.
-     */
+    /// @notice Add funds to request subsidy fee pool.
     function fundRequestSubsidyFeePool() public payable {
         _requestSubsidyFeePool += msg.value;
     }
 
-    /**
-     * @dev Selects an operator contract from the available list using modulo operation
-     * with seed value weighted by the number of active groups on each operator contract.
-     * @param seed Cryptographically generated random value.
-     * @return Address of operator contract.
-     */
+    /// @notice Selects an operator contract from the available list using modulo
+    /// operation with seed value weighted by the number of active groups on each
+    /// operator contract.
+    /// @param seed Cryptographically generated random value.
+    /// @return Address of operator contract.
     function selectOperatorContract(uint256 seed) public view returns (address) {
 
         uint256 totalNumberOfGroups;
@@ -206,28 +193,25 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         return approvedContracts[selectedContract];
     }
 
-    /**
-     * @dev Creates a request to generate a new relay entry, which will include
-     * a random number (by signing the previous entry's random number).
-     * @return An uint256 representing uniquely generated entry Id.
-     */
+    /// @notice Creates a request to generate a new relay entry, which will include
+    /// a random number (by signing the previous entry's random number).
+    /// @return An uint256 representing uniquely generated entry Id.
     function requestRelayEntry() public payable returns (uint256) {
         return requestRelayEntry(address(0), 0);
     }
 
-    /**
-     * @dev Creates a request to generate a new relay entry (random number).
-     * @param callbackContract Callback contract address. Callback is called
-     * once a new relay entry has been generated. Callback contract must
-     * declare public `__beaconCallback(uint256)` function that is going to be
-     * executed with the result, once ready.
-     * @param callbackGas Gas required for the callback (2 million gas max).
-     * The customer needs to ensure they provide a sufficient callback gas
-     * to cover the gas fee of executing the callback. Any surplus is returned
-     * to the customer. If the callback gas amount turns to be not enough to
-     * execute the callback, callback execution is skipped.
-     * @return An uint256 representing uniquely generated relay request ID. It is also returned as part of the event.
-     */
+    /// @notice Creates a request to generate a new relay entry (random number).
+    /// @param callbackContract Callback contract address. Callback is called
+    /// once a new relay entry has been generated. Callback contract must
+    /// declare public `__beaconCallback(uint256)` function that is going to be
+    /// executed with the result, once ready.
+    /// @param callbackGas Gas required for the callback (2 million gas max).
+    /// The customer needs to ensure they provide a sufficient callback gas
+    /// to cover the gas fee of executing the callback. Any surplus is returned
+    /// to the customer. If the callback gas amount turns to be not enough to
+    /// execute the callback, callback execution is skipped.
+    /// @return An uint256 representing uniquely generated relay request ID. It
+    /// is also returned as part of the event.
     function requestRelayEntry(
         address callbackContract,
         uint256 callbackGas
@@ -293,12 +277,11 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         return requestId;
     }
 
-    /**
-     * @dev Store valid entry returned by operator contract and call customer specified callback if required.
-     * @param requestId Request id tracked internally by this contract.
-     * @param entry The generated random number.
-     * @param submitter Relay entry submitter.
-     */
+    /// @notice Store valid entry returned by operator contract and call customer
+    /// specified callback if required.
+    /// @param requestId Request id tracked internally by this contract.
+    /// @param entry The generated random number.
+    /// @param submitter Relay entry submitter.
     function entryCreated(uint256 requestId, bytes memory entry, address payable submitter) public {
         require(
             _operatorContracts.contains(msg.sender),
@@ -312,12 +295,10 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         createGroupIfApplicable(entryAsNumber, submitter);
     }
 
-    /**
-     * @dev Executes customer specified callback for the relay entry request.
-     * @param requestId Request id tracked internally by this contract.
-     * @param entry The generated random number.
-     * @return Address to receive callback surplus.
-     */
+    /// @notice Executes customer specified callback for the relay entry request.
+    /// @param requestId Request id tracked internally by this contract.
+    /// @param entry The generated random number.
+    /// @return Address to receive callback surplus.
     function executeCallback(uint256 requestId, uint256 entry) public returns (address payable surplusRecipient) {
         require(
             _operatorContracts.contains(msg.sender),
@@ -337,12 +318,10 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         delete _callbacks[requestId];
     }
 
-    /**
-     * @dev Triggers the selection process of a new candidate group if the DKG
-     * fee pool equals or exceeds DKG cost estimate.
-     * @param entry The generated random number.
-     * @param submitter Relay entry submitter - operator.
-     */
+    /// @notice Triggers the selection process of a new candidate group if the
+    /// DKG fee pool equals or exceeds DKG cost estimate.
+    /// @param entry The generated random number.
+    /// @param submitter Relay entry submitter - operator.
     function createGroupIfApplicable(uint256 entry, address payable submitter) internal {
         address latestOperatorContract = _operatorContracts[_operatorContracts.length.sub(1)];
         uint256 groupCreationFee = OperatorContract(latestOperatorContract).groupCreationFee();
@@ -353,17 +332,13 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         }
     }
 
-    /**
-     * @dev Get base callback gas required for relay entry callback.
-     */
+    /// @notice Get base callback gas required for relay entry callback.
     function baseCallbackGas() public view returns(uint256) {
         return _baseCallbackGas;
     }
 
-    /**
-     * @dev Get the minimum payment in wei for relay entry callback.
-     * @param _callbackGas Gas required for the callback.
-     */
+    /// @notice Get the minimum payment in wei for relay entry callback.
+    /// @param _callbackGas Gas required for the callback.
     function callbackFee(
         uint256 _callbackGas,
         uint256 _gasPriceCeiling
@@ -377,10 +352,8 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         return callbackGas.mul(_gasPriceCeiling);
     }
 
-    /**
-     * @dev Get the entry fee estimate in wei for relay entry request.
-     * @param callbackGas Gas required for the callback.
-     */
+    /// @notice Get the entry fee estimate in wei for relay entry request.
+    /// @param callbackGas Gas required for the callback.
     function entryFeeEstimate(uint256 callbackGas) public view returns(uint256) {
         require(
             callbackGas <= 2000000,
@@ -400,9 +373,7 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
             .add(callbackFee(callbackGas, gasPriceCeiling));
     }
 
-    /**
-     * @dev Get the entry fee breakdown in wei for relay entry request.
-     */
+    /// @notice Get the entry fee breakdown in wei for relay entry request.
     function entryFeeBreakdown() public view returns(
         uint256 entryVerificationFee,
         uint256 dkgContributionFee,
@@ -448,16 +419,12 @@ contract KeepRandomBeaconServiceImplV1 is ReentrancyGuard, IRandomBeacon {
         );
     }
 
-    /**
-     * @dev Gets the previous relay entry value.
-     */
+    /// @notice Gets the previous relay entry value.
     function previousEntry() public view returns(bytes memory) {
         return _previousEntry;
     }
 
-    /**
-     * @dev Gets version of the current implementation.
-     */
+    /// @notice Gets version of the current implementation.
     function version() public pure returns (string memory) {
         return "V1";
     }

--- a/solidity/contracts/libraries/operator/DKGResultVerification.sol
+++ b/solidity/contracts/libraries/operator/DKGResultVerification.sol
@@ -28,24 +28,22 @@ library DKGResultVerification {
         uint256 signatureThreshold;
     }
 
-    /**
-     * @dev Verifies the submitted DKG result against supporting member
-     * signatures and if the submitter is eligible to submit at the current block.
-     *
-     * @param submitterMemberIndex Claimed submitter candidate group member index
-     * @param groupPubKey Generated candidate group public key
-     * @param misbehaved Bytes array of misbehaved (disqualified or inactive)
-     * group members indexes; Indexes reflect positions of members in the group,
-     * as outputted by the group selection protocol.
-     * @param signatures Concatenation of signatures from members supporting the
-     * result.
-     * @param signingMemberIndices Indices of members corresponding to each
-     * signature.
-     * @param members Addresses of candidate group members as outputted by the
-     * group selection protocol.
-     * @param groupSelectionEndBlock Block height at which the group selection
-     * protocol ended.
-     */
+    /// @notice Verifies the submitted DKG result against supporting member
+    /// signatures and if the submitter is eligible to submit at the current block.
+    ///
+    /// @param submitterMemberIndex Claimed submitter candidate group member index
+    /// @param groupPubKey Generated candidate group public key
+    /// @param misbehaved Bytes array of misbehaved (disqualified or inactive)
+    /// group members indexes; Indexes reflect positions of members in the group,
+    /// as outputted by the group selection protocol.
+    /// @param signatures Concatenation of signatures from members supporting the
+    /// result.
+    /// @param signingMemberIndices Indices of members corresponding to each
+    /// signature.
+    /// @param members Addresses of candidate group members as outputted by the
+    /// group selection protocol.
+    /// @param groupSelectionEndBlock Block height at which the group selection
+    /// protocol ended.
     function verify(
         Storage storage self,
         uint256 submitterMemberIndex,

--- a/solidity/contracts/libraries/operator/DelayFactor.sol
+++ b/solidity/contracts/libraries/operator/DelayFactor.sol
@@ -5,10 +5,8 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 library DelayFactor {
     using SafeMath for uint256;
 
-    /**
-     * @dev Gets delay factor for rewards calculation.
-     * @return Integer representing floating-point number with 16 decimals places.
-     */
+    /// @notice Gets delay factor for rewards calculation.
+    /// @return Integer representing floating-point number with 16 decimals places.
     function calculate(
         uint256 currentRequestStartBlock,
         uint256 relayEntryTimeout

--- a/solidity/contracts/libraries/operator/GroupSelection.sol
+++ b/solidity/contracts/libraries/operator/GroupSelection.sol
@@ -3,27 +3,26 @@ pragma solidity 0.5.17;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../../utils/BytesLib.sol";
 
-/**
- * The group selection protocol is an interactive method of selecting candidate
- * group from the set of all stakers given a pseudorandom seed value.
- *
- * The protocol produces a representative result, where each staker's profit is
- * proportional to the number of tokens they have staked. Produced candidate
- * groups are of constant size.
- *
- * Group selection protocol accepts seed as an input - a pseudorandom value
- * used to construct candidate tickets. Each candidate group member can
- * submit their tickets. The maximum number of tickets one can submit depends
- * on their staking weight - relation of the minimum stake to the candidate's
- * stake.
- *
- * There is a certain timeout, expressed in blocks, when tickets can be
- * submitted. Each ticket is a mix of staker's address, virtual staker index
- * and group selection seed. Candidate group members are selected based on
- * the best tickets submitted. There has to be a minimum number of tickets
- * submitted, equal to the candidate group size so that the protocol can
- * complete successfully.
- */
+/// @title Group Selection
+/// @notice The group selection protocol is an interactive method of selecting
+/// candidate group from the set of all stakers given a pseudorandom seed value.
+///
+/// The protocol produces a representative result, where each staker's profit is
+/// proportional to the number of tokens they have staked. Produced candidate
+/// groups are of constant size.
+///
+/// Group selection protocol accepts seed as an input - a pseudorandom value
+/// used to construct candidate tickets. Each candidate group member can
+/// submit their tickets. The maximum number of tickets one can submit depends
+/// on their staking weight - relation of the minimum stake to the candidate's
+/// stake.
+///
+/// There is a certain timeout, expressed in blocks, when tickets can be
+/// submitted. Each ticket is a mix of staker's address, virtual staker index
+/// and group selection seed. Candidate group members are selected based on
+/// the best tickets submitted. There has to be a minimum number of tickets
+/// submitted, equal to the candidate group size so that the protocol can
+/// complete successfully.
 library GroupSelection {
 
     using SafeMath for uint256;
@@ -80,12 +79,10 @@ library GroupSelection {
         uint256 groupSize;
     }
 
-    /**
-     * @dev Starts group selection protocol.
-     * @param _seed pseudorandom seed value used as an input for the group
-     * selection. All submitted tickets needs to have the seed mixed-in into the
-     * value.
-     */
+    /// @notice Starts group selection protocol.
+    /// @param _seed pseudorandom seed value used as an input for the group
+    /// selection. All submitted tickets needs to have the seed mixed-in into the
+    /// value.
     function start(Storage storage self, uint256 _seed) public {
         // We execute the minimum required cleanup here needed in case the
         // previous group selection failed and did not clean up properly in
@@ -96,31 +93,27 @@ library GroupSelection {
         self.ticketSubmissionStartBlock = block.number;
     }
 
-    /**
-     * @dev Stops group selection protocol clearing up all the submitted
-     * tickets. This function may be expensive if not executed as a part of
-     * another transaction consuming a lot of gas and as a result, getting
-     * gas refund for clearing up the storage.
-     */
+    /// @notice Stops group selection protocol clearing up all the submitted
+    /// tickets. This function may be expensive if not executed as a part of
+    /// another transaction consuming a lot of gas and as a result, getting
+    /// gas refund for clearing up the storage.
     function stop(Storage storage self) public {
         cleanupCandidates(self);
         cleanupTickets(self);
         self.inProgress = false;
     }
 
-    /**
-     * @dev Submits ticket to request to participate in a new candidate group.
-     * @param ticket Bytes representation of a ticket that holds the following:
-     * - ticketValue: first 8 bytes of a result of keccak256 cryptography hash
-     *   function on the combination of the group selection seed (previous
-     *   beacon output), staker-specific value (address) and virtual staker index.
-     * - stakerValue: a staker-specific value which is the address of the staker.
-     * - virtualStakerIndex: 4-bytes number within a range of 1 to staker's weight;
-     *   has to be unique for all tickets submitted by the given staker for the
-     *   current candidate group selection.
-     * @param stakingWeight Ratio of the minimum stake to the candidate's
-     * stake.
-     */
+    /// @notice Submits ticket to request to participate in a new candidate group.
+    /// @param ticket Bytes representation of a ticket that holds the following:
+    /// - ticketValue: first 8 bytes of a result of keccak256 cryptography hash
+    ///   function on the combination of the group selection seed (previous
+    ///   beacon output), staker-specific value (address) and virtual staker index.
+    /// - stakerValue: a staker-specific value which is the address of the staker.
+    /// - virtualStakerIndex: 4-bytes number within a range of 1 to staker's weight;
+    ///   has to be unique for all tickets submitted by the given staker for the
+    ///   current candidate group selection.
+    /// @param stakingWeight Ratio of the minimum stake to the candidate's
+    /// stake.
     function submitTicket(
         Storage storage self,
         bytes32 ticket,
@@ -150,19 +143,16 @@ library GroupSelection {
         );
     }
 
-
-    /**
-     * @dev Submits ticket to request to participate in a new candidate group.
-     * @param ticketValue First 8 bytes of a result of keccak256 cryptography hash
-     * function on the combination of the group selection seed (previous
-     * beacon output), staker-specific value (address) and virtual staker index.
-     * @param stakerValue Staker-specific value which is the address of the staker.
-     * @param virtualStakerIndex 4-bytes number within a range of 1 to staker's weight;
-     * has to be unique for all tickets submitted by the given staker for the
-     * current candidate group selection.
-     * @param stakingWeight Ratio of the minimum stake to the candidate's
-     * stake.
-     */
+    /// @notice Submits ticket to request to participate in a new candidate group.
+    /// @param ticketValue First 8 bytes of a result of keccak256 cryptography hash
+    /// function on the combination of the group selection seed (previous
+    /// beacon output), staker-specific value (address) and virtual staker index.
+    /// @param stakerValue Staker-specific value which is the address of the staker.
+    /// @param virtualStakerIndex 4-bytes number within a range of 1 to staker's weight;
+    /// has to be unique for all tickets submitted by the given staker for the
+    /// current candidate group selection.
+    /// @param stakingWeight Ratio of the minimum stake to the candidate's
+    /// stake.
     function submitTicket(
         Storage storage self,
         uint64 ticketValue,
@@ -187,14 +177,11 @@ library GroupSelection {
         )) {
             addTicket(self, ticketValue);
         } else {
-            // TODO: should we slash instead of reverting?
             revert("Invalid ticket");
         }
     }
 
-    /**
-     * @dev Performs full verification of the ticket.
-     */
+    /// @notice Performs full verification of the ticket.
     function isTicketValid(
         uint64 ticketValue,
         uint256 stakerValue,
@@ -225,11 +212,9 @@ library GroupSelection {
         return isVirtualStakerIndexValid && isStakerValueValid && isTicketValueValid;
     }
 
-    /**
-     * @dev Adds a new, verified ticket. Ticket is accepted when it is lower
-     * than the currently highest ticket or when the number of tickets is still
-     * below the group size.
-     */
+    /// @notice Adds a new, verified ticket. Ticket is accepted when it is lower
+    /// than the currently highest ticket or when the number of tickets is still
+    /// below the group size.
     function addTicket(Storage storage self, uint64 newTicketValue) internal {
         uint256[] memory previousTicketIndex = readPreviousTicketIndices(self);
         uint256[] memory ordered = getTicketValueOrderedIndices(
@@ -292,9 +277,7 @@ library GroupSelection {
         storePreviousTicketIndices(self, previousTicketIndex);
     }
 
-    /**
-     * @dev Use binary search to find an index for a new ticket in the tickets[] array
-     */
+    /// @notice Use binary search to find an index for a new ticket in the tickets[] array
     function findReplacementIndex(
         Storage storage self,
         uint64 newTicketValue,
@@ -338,13 +321,12 @@ library GroupSelection {
         self.previousTicketIndices = compressed;
     }
 
-    /**
-     * @dev Creates an array of ticket indexes based on their values in the ascending order:
-     *
-     * ordered[n-1] = tail
-     * ordered[n-2] = previousTicketIndex[tail]
-     * ordered[n-3] = previousTicketIndex[ordered[n-2]]
-     */
+    /// @notice Creates an array of ticket indexes based on their values in the
+    ///  ascending order:
+    ///
+    /// ordered[n-1] = tail
+    /// ordered[n-2] = previousTicketIndex[tail]
+    /// ordered[n-3] = previousTicketIndex[ordered[n-2]]
     function getTicketValueOrderedIndices(
         Storage storage self,
         uint256[] memory previousIndices
@@ -362,9 +344,7 @@ library GroupSelection {
         return ordered;
     }
 
-    /**
-     * @dev Gets selected participants in ascending order of their tickets.
-     */
+    /// @notice Gets selected participants in ascending order of their tickets.
     function selectedParticipants(Storage storage self) public view returns (address[] memory) {
         require(
             block.number >= self.ticketSubmissionStartBlock.add(self.ticketSubmissionTimeout),
@@ -385,20 +365,16 @@ library GroupSelection {
         return selected;
     }
 
-    /**
-     * @dev Clears up data of the group selection tickets.
-     */
+    /// @notice Clears up data of the group selection tickets.
     function cleanupTickets(Storage storage self) internal {
         delete self.tickets;
         self.tail = 0;
     }
 
-    /**
-     * @dev Clears up data of the group selection candidates.
-     * This operation may have a significant cost if not executed as a part of
-     * another transaction consuming a lot of gas and as a result, getting
-     * gas refund for clearing up the storage.
-     */
+    /// @notice Clears up data of the group selection candidates.
+    /// This operation may have a significant cost if not executed as a part of
+    /// another transaction consuming a lot of gas and as a result, getting
+    /// gas refund for clearing up the storage.
     function cleanupCandidates(Storage storage self) internal {
         for (uint i = 0; i < self.tickets.length; i++) {
             delete self.candidate[self.tickets[i]];

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -62,9 +62,7 @@ library Groups {
         TokenStaking stakingContract;
     }
 
-    /**
-     * @dev Adds group.
-     */
+    /// @notice Adds a new group.
     function addGroup(
         Storage storage self,
         bytes memory groupPubKey
@@ -73,17 +71,15 @@ library Groups {
         self.groups.push(Group(groupPubKey, uint64(block.number), false));
     }
 
-    /**
-     * @dev Sets addresses of members for the group with the given public key
-     * eliminating members at positions pointed by the misbehaved array.
-     * @param groupPubKey Group public key.
-     * @param members Group member addresses as outputted by the group selection
-     * protocol.
-     * @param misbehaved Bytes array of misbehaved (disqualified or inactive)
-     * group members indexes in ascending order; Indexes reflect positions of
-     * members in the group as outputted by the group selection protocol -
-     * member indexes start from 1.
-     */
+    /// @notice Sets addresses of members for the group with the given public key
+    /// eliminating members at positions pointed by the misbehaved array.
+    /// @param groupPubKey Group public key.
+    /// @param members Group member addresses as outputted by the group selection
+    /// protocol.
+    /// @param misbehaved Bytes array of misbehaved (disqualified or inactive)
+    /// group members indexes in ascending order; Indexes reflect positions of
+    /// members in the group as outputted by the group selection protocol -
+    /// member indexes start from 1.
     function setGroupMembers(
         Storage storage self,
         bytes memory groupPubKey,
@@ -104,9 +100,8 @@ library Groups {
         }
     }
 
-    /**
-     * @dev Adds group member reward per group so the accumulated amount can be withdrawn later.
-     */
+    /// @notice Adds group member reward per group so the accumulated amount can
+    /// be withdrawn later.
     function addGroupMemberReward(
         Storage storage self,
         bytes memory groupPubKey,
@@ -115,9 +110,7 @@ library Groups {
         self.groupMemberRewards[groupPubKey] = self.groupMemberRewards[groupPubKey].add(amount);
     }
 
-    /**
-     * @dev Returns accumulated group member rewards for provided group.
-     */
+    /// @notice Returns accumulated group member rewards for provided group.
     function getGroupMemberRewards(
         Storage storage self,
         bytes memory groupPubKey
@@ -125,9 +118,7 @@ library Groups {
         return self.groupMemberRewards[groupPubKey];
     }
 
-    /**
-     * @dev Gets group public key.
-     */
+    /// @notice Gets group public key.
     function getGroupPublicKey(
         Storage storage self,
         uint256 groupIndex
@@ -135,9 +126,7 @@ library Groups {
         return self.groups[groupIndex].groupPubKey;
     }
 
-    /**
-     * @dev Gets group member.
-     */
+    /// @notice Gets group member.
     function getGroupMember(
         Storage storage self,
         bytes memory groupPubKey,
@@ -145,10 +134,8 @@ library Groups {
     ) internal view returns (address) {
         return self.groupMembers[groupPubKey][memberIndex];
     }
-
-    /**
-     * @dev Terminates group.
-     */
+    
+    /// @notice Terminates group.
     function terminateGroup(
         Storage storage self,
         uint256 groupIndex
@@ -157,9 +144,7 @@ library Groups {
         self.activeTerminatedGroups.push(groupIndex);
     }
 
-    /**
-     * @dev Checks if group with the given index is terminated.
-     */
+    /// @notice Checks if group with the given index is terminated.
     function isGroupTerminated(
         Storage storage self,
         uint256 groupIndex
@@ -167,9 +152,7 @@ library Groups {
         return self.groups[groupIndex].terminated;
     }
 
-    /**
-     * @dev Checks if group with the given public key is registered.
-     */
+    /// @notice Checks if group with the given public key is registered.
     function isGroupRegistered(
         Storage storage self,
         bytes memory groupPubKey
@@ -179,10 +162,8 @@ library Groups {
         return self.groupIndices[groupPubKey] > 0;
     }
 
-    /**
-     * @dev Gets the cutoff time in blocks until which the given group is
-     * considered as an active group assuming it hasn't been terminated before.
-     */
+    /// @notice Gets the cutoff time in blocks until which the given group is
+    /// considered as an active group assuming it hasn't been terminated before.
     function groupActiveTimeOf(
         Storage storage self,
         Group memory group
@@ -190,11 +171,9 @@ library Groups {
         return uint256(group.registrationBlockHeight).add(self.groupActiveTime);
     }
 
-    /**
-     * @dev Gets the cutoff time in blocks after which the given group is
-     * considered as stale. Stale group is an expired group which is no longer
-     * performing any operations.
-     */
+    /// @notice Gets the cutoff time in blocks after which the given group is
+    /// considered as stale. Stale group is an expired group which is no longer
+    /// performing any operations.
     function groupStaleTime(
         Storage storage self,
         Group memory group
@@ -202,15 +181,13 @@ library Groups {
         return groupActiveTimeOf(self, group).add(self.relayEntryTimeout);
     }
 
-    /**
-     * @dev Checks if a group with the given public key is a stale group.
-     * Stale group is an expired group which is no longer performing any
-     * operations. It is important to understand that an expired group may
-     * still perform some operations for which it was selected when it was still
-     * active. We consider a group to be stale when it's expired and when its
-     * expiration time and potentially executed operation timeout are both in
-     * the past.
-     */
+    /// @notice Checks if a group with the given public key is a stale group.
+    /// Stale group is an expired group which is no longer performing any
+    /// operations. It is important to understand that an expired group may
+    /// still perform some operations for which it was selected when it was still
+    /// active. We consider a group to be stale when it's expired and when its
+    /// expiration time and potentially executed operation timeout are both in
+    /// the past.
     function isStaleGroup(
         Storage storage self,
         bytes memory groupPubKey
@@ -223,15 +200,13 @@ library Groups {
         return isExpired && isStale;
     }
 
-    /**
-     * @dev Checks if a group with the given index is a stale group.
-     * Stale group is an expired group which is no longer performing any
-     * operations. It is important to understand that an expired group may
-     * still perform some operations for which it was selected when it was still
-     * active. We consider a group to be stale when it's expired and when its
-     * expiration time and potentially executed operation timeout are both in
-     * the past.
-     */
+    /// @notice Checks if a group with the given index is a stale group.
+    /// Stale group is an expired group which is no longer performing any
+    /// operations. It is important to understand that an expired group may
+    /// still perform some operations for which it was selected when it was still
+    /// active. We consider a group to be stale when it's expired and when its
+    /// expiration time and potentially executed operation timeout are both in
+    /// the past.
     function isStaleGroup(
         Storage storage self,
         uint256 groupIndex
@@ -239,21 +214,17 @@ library Groups {
         return groupStaleTime(self, self.groups[groupIndex]) < block.number;
     }
 
-    /**
-     * @dev Gets the number of active groups. Expired and terminated groups are
-     * not counted as active.
-     */
+    /// @notice Gets the number of active groups. Expired and terminated groups are
+    /// not counted as active.
     function numberOfGroups(
         Storage storage self
     ) internal view returns(uint256) {
         return self.groups.length.sub(self.expiredGroupOffset).sub(self.activeTerminatedGroups.length);
     }
 
-    /**
-     * @dev Goes through groups starting from the oldest one that is still
-     * active and checks if it hasn't expired. If so, updates the information
-     * about expired groups so that all expired groups are marked as such.
-     */
+    /// @notice Goes through groups starting from the oldest one that is still
+    /// active and checks if it hasn't expired. If so, updates the information
+    /// about expired groups so that all expired groups are marked as such.
     function expireOldGroups(Storage storage self) public {
         // Move expiredGroupOffset as long as there are some groups that should
         // be marked as expired. It is possible that expired group offset will
@@ -280,14 +251,12 @@ library Groups {
         }
     }
 
-    /**
-     * @dev Returns an index of a randomly selected active group. Terminated and
-     * expired groups are not considered as active.
-     * Before new group is selected, information about expired groups
-     * is updated. At least one active group needs to be present for this
-     * function to succeed.
-     * @param seed Random number used as a group selection seed.
-     */
+    /// @notice Returns an index of a randomly selected active group. Terminated
+    /// and expired groups are not considered as active.
+    /// Before new group is selected, information about expired groups
+    /// is updated. At least one active group needs to be present for this
+    /// function to succeed.
+    /// @param seed Random number used as a group selection seed.
     function selectGroup(
         Storage storage self,
         uint256 seed
@@ -300,10 +269,8 @@ library Groups {
         return shiftByTerminatedGroups(self, shiftByExpiredGroups(self, selectedGroup));
     }
 
-    /**
-     * @dev Evaluates the shift of selected group index based on the number of
-     * expired groups.
-     */
+    /// @notice Evaluates the shift of selected group index based on the number of
+    /// expired groups.
     function shiftByExpiredGroups(
         Storage storage self,
         uint256 selectedIndex
@@ -311,10 +278,8 @@ library Groups {
         return self.expiredGroupOffset.add(selectedIndex);
     }
 
-    /**
-     * @dev Evaluates the shift of selected group index based on the number of
-     * non-expired, terminated groups.
-     */
+    /// @notice Evaluates the shift of selected group index based on the number of
+    /// non-expired, terminated groups.
     function shiftByTerminatedGroups(
         Storage storage self,
         uint256 selectedIndex
@@ -329,15 +294,13 @@ library Groups {
         return shiftedIndex;
     }
 
-    /**
-     * @dev Withdraws accumulated group member rewards for operator
-     * using the provided group index.
-     * Once the accumulated reward is withdrawn from the selected group,
-     * the operator is flagged as withdrawn.
-     * Rewards can be withdrawn only from stale group.
-     * @param operator Operator address.
-     * @param groupIndex Group index.
-     */
+    /// @notice Withdraws accumulated group member rewards for operator
+    /// using the provided group index.
+    /// Once the accumulated reward is withdrawn from the selected group,
+    /// the operator is flagged as withdrawn.
+    /// Rewards can be withdrawn only from stale group.
+    /// @param operator Operator address.
+    /// @param groupIndex Group index.
     function withdrawFromGroup(
         Storage storage self,
         address operator,
@@ -359,11 +322,8 @@ library Groups {
         }
     }
 
-    /**
-     * @dev Returns members of the given group by group public key.
-     *
-     * @param groupPubKey Group public key.
-     */
+    /// @notice Returns members of the given group by group public key.
+    /// @param groupPubKey Group public key.
     function getGroupMembers(
         Storage storage self,
         bytes memory groupPubKey
@@ -371,9 +331,7 @@ library Groups {
         return self.groupMembers[groupPubKey];
     }
 
-    /**
-     * @dev Returns addresses of all the members in the provided group.
-     */
+    /// @notice Returns addresses of all the members in the provided group.
     function getGroupMembers(
         Storage storage self,
         uint256 groupIndex
@@ -382,17 +340,15 @@ library Groups {
         return self.groupMembers[groupPubKey];
     }
 
-    /**
-     * @dev Reports unauthorized signing for the provided group. Must provide
-     * a valid signature of the group address as a message. Successful signature
-     * verification means the private key has been leaked and all group members
-     * should be punished by seizing their tokens. The submitter of this proof is
-     * rewarded with 5% of the total seized amount scaled by the reward adjustment
-     * parameter and the rest 95% is burned. Group has to be active or expired.
-     * Unauthorized signing cannot be reported for stale or terminated group.
-     * In case of reporting unauthorized signing for stale group,
-     * terminated group, or when the signature is inavlid, function reverts.
-     */
+    /// @notice Reports unauthorized signing for the provided group. Must provide
+    /// a valid signature of the group address as a message. Successful signature
+    /// verification means the private key has been leaked and all group members
+    /// should be punished by seizing their tokens. The submitter of this proof is
+    /// rewarded with 5% of the total seized amount scaled by the reward adjustment
+    /// parameter and the rest 95% is burned. Group has to be active or expired.
+    /// Unauthorized signing cannot be reported for stale or terminated group.
+    /// In case of reporting unauthorized signing for stale group,
+    /// terminated group, or when the signature is inavlid, function reverts.
     function reportUnauthorizedSigning(
         Storage storage self,
         uint256 groupIndex,
@@ -447,10 +403,8 @@ library Groups {
         }
     }
 
-    /**
-     * @notice Return whether the given operator
-     * has withdrawn their rewards from the given group.
-     */
+    /// @notice Return whether the given operator
+    /// has withdrawn their rewards from the given group.
     function hasWithdrawnRewards(
         Storage storage self,
         address operator,

--- a/solidity/contracts/libraries/operator/Reimbursements.sol
+++ b/solidity/contracts/libraries/operator/Reimbursements.sol
@@ -8,17 +8,15 @@ library Reimbursements {
     using SafeMath for uint256;
     using BytesLib for bytes;
 
-    /**
-     * @dev Reimburses callback execution cost and surplus based on actual gas
-     * usage to the submitter's beneficiary address and if necessary to the
-     * callback requestor (surplus recipient).
-     * @param stakingContract Staking contract to get the address of the beneficiary
-     * @param gasPriceCeiling Gas price ceiling in wei
-     * @param gasLimit Gas limit set for the callback
-     * @param gasSpent Gas spent by the submitter on the callback
-     * @param callbackFee Fee paid for the callback by the requestor
-     * @param callbackReturnData Data containing surplus recipient address
-     */
+    /// @notice Reimburses callback execution cost and surplus based on actual gas
+    /// usage to the submitter's beneficiary address and if necessary to the
+    /// callback requestor (surplus recipient).
+    /// @param stakingContract Staking contract to get the address of the beneficiary
+    /// @param gasPriceCeiling Gas price ceiling in wei
+    /// @param gasLimit Gas limit set for the callback
+    /// @param gasSpent Gas spent by the submitter on the callback
+    /// @param callbackFee Fee paid for the callback by the requestor
+    /// @param callbackReturnData Data containing surplus recipient address
     function reimburseCallback(
         TokenStaking stakingContract,
         uint256 gasPriceCeiling,


### PR DESCRIPTION
We want to use the same format of documentation as in the rest of Keep contracts.

No major content changes, just log formatting.