### PR TITLE
Set result publication block step to 6 blocks

### DIFF
--- a/pkg/beacon/relay/groupselection/groupselection.go
+++ b/pkg/beacon/relay/groupselection/groupselection.go
@@ -23,11 +23,11 @@ var logger = log.Logger("keep-groupselection")
 // protocol.
 const (
 	// The number of blocks one round takes.
-	roundDuration = uint64(3)
+	roundDuration = uint64(6)
 
 	// The delay in blocks after all rounds complete to ensure all transactions
 	// are mined
-	miningLag = uint64(6)
+	miningLag = uint64(12)
 )
 
 // Result represents the result of group selection protocol. It contains the
@@ -43,7 +43,7 @@ type Result struct {
 //
 // To minimize the submitter's cost by minimizing the number of redundant
 // tickets that are not selected into the group, tickets are submitted in
-// N rounds, each round taking 3 blocks.
+// N rounds, each round taking 6 blocks.
 // As the basic principle, the number of leading zeros in the ticket
 // value is subtracted from the number of rounds to determine the round
 // the ticket should be submitted in:
@@ -57,7 +57,7 @@ type Result struct {
 // the candidate not yet submitted to determine if continuing with
 // ticket submission still makes sense.
 //
-// After the last round, there is a 6 blocks mining lag allowing all
+// After the last round, there is a 12 blocks mining lag allowing all
 // outstanding ticket submissions to have a higher chance of being
 // mined before the deadline.
 func CandidateToNewGroup(

--- a/pkg/beacon/relay/groupselection/groupselection_test.go
+++ b/pkg/beacon/relay/groupselection/groupselection_test.go
@@ -61,7 +61,7 @@ func TestSubmitTickets(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			chainConfig := &config.Chain{
 				GroupSize:               test.groupSize,
-				TicketSubmissionTimeout: 12,
+				TicketSubmissionTimeout: 24,
 			}
 
 			chain := &stubGroupInterface{

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -185,7 +185,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         // the candidate not yet submitted to determine if continuing with
         // ticket submission still makes sense.
         //
-        // After 33 blocks, there is a 12 blocks mining lag allowing all
+        // After 66 blocks, there is a 12 blocks mining lag allowing all
         // outstanding ticket submissions to have a higher chance of being
         // mined before the deadline.
         groupSelection.ticketSubmissionTimeout = 6 * 11 + 12;

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -171,7 +171,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         // that are not selected into the group, the following approach is
         // recommended:
         //
-        // Tickets are submitted in 11 rounds, each round taking 3 blocks.
+        // Tickets are submitted in 11 rounds, each round taking 6 blocks.
         // As the basic principle, the number of leading zeros in the ticket
         // value is subtracted from the number of rounds to determine the round
         // the ticket should be submitted in:
@@ -185,10 +185,10 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         // the candidate not yet submitted to determine if continuing with
         // ticket submission still makes sense.
         //
-        // After 33 blocks, there is a 6 blocks mining lag allowing all
+        // After 33 blocks, there is a 12 blocks mining lag allowing all
         // outstanding ticket submissions to have a higher chance of being
         // mined before the deadline.
-        groupSelection.ticketSubmissionTimeout = 3 * 11 + 6;
+        groupSelection.ticketSubmissionTimeout = 6 * 11 + 12;
 
         groupSelection.groupSize = groupSize;
 

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -78,7 +78,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
     /// @dev Time in blocks after which the next group member is eligible
     /// to submit the result.
-    uint256 public resultPublicationBlockStep = 3;
+    uint256 public resultPublicationBlockStep = 6;
 
     /// @dev Timeout in blocks for a relay entry to appear on the chain. Blocks
     /// are counted from the moment relay request occur.

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
@@ -31,10 +31,6 @@ contract KeepRandomBeaconOperatorDKGResultStub is KeepRandomBeaconOperator {
         dkgResultVerification.signatureThreshold = threshold;
     }
 
-    function setResultPublicationBlockStep(uint256 step) public {
-        resultPublicationBlockStep = step;
-    }
-
     function getGroupSelectionRelayEntry() public view returns (uint256) {
         return groupSelection.seed;
     }

--- a/solidity/test/random_beacon_operator/TestPricingRewards.js
+++ b/solidity/test/random_beacon_operator/TestPricingRewards.js
@@ -5,6 +5,11 @@ const {createSnapshot, restoreSnapshot} = require("../helpers/snapshot.js")
 const {contract, accounts, web3} = require("@openzeppelin/test-environment")
 const {time} = require("@openzeppelin/test-helpers")
 
+const BN = web3.utils.BN
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
 describe('KeepRandomBeaconOperator/PricingRewards', function() {
   let serviceContract;
   let operatorContract;
@@ -36,10 +41,8 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate, from: accounts[0]});
 
-    let delayFactor = await operatorContract.delayFactor.call();        
-
-    let expectedDelayFactor = web3.utils.toBN(10000000000000000);
-    assert.isTrue(expectedDelayFactor.eq(delayFactor));
+    let delayFactor = await operatorContract.delayFactor.call();
+    expect(delayFactor).to.eq.BN('10000000000000000') 
   });
 
   it("should correctly evaluate delay factor at the first submission block", async () => {
@@ -49,21 +52,23 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     await time.advanceBlockTo(web3.utils.toBN(await web3.eth.getBlockNumber()).addn(1));
 
     let delayFactor = await operatorContract.delayFactor.call();
-
-    let expectedDelayFactor = web3.utils.toBN(10000000000000000);
-    assert.isTrue(expectedDelayFactor.eq(delayFactor));
+    expect(delayFactor).to.eq.BN('10000000000000000') 
   });
 
   it("should correctly evaluate delay factor at the second submission block", async () => {
+    let startBlock = await operatorContract.currentRequestStartBlock()
     let entryFeeEstimate = await serviceContract.entryFeeEstimate(0);
     await serviceContract.methods['requestRelayEntry()']({value: entryFeeEstimate, from: accounts[0]});
 
     await time.advanceBlockTo(web3.utils.toBN(await web3.eth.getBlockNumber()).addn(2));
 
     let delayFactor = await operatorContract.delayFactor.call();
-
-    let expectedDelayFactor = web3.utils.toBN('9896104600694443');
-    assert.isTrue(expectedDelayFactor.eq(delayFactor));
+    // currentRequestStartBlock = 0
+    // T_received = 2
+    // T_deadline = 0 + 384 + 1 = 385
+    // T_begin = 0 + 1 = 1
+    // [(T_deadline - T_received) / (T_deadline - T_begin)]^2 = [(385 - 2) / (385 - 1)]^2
+    expect(delayFactor).to.eq.BN('9947984483506943')                                  
   });
 
   it("should correctly evaluate delay factor in the last block before timeout", async () => {
@@ -74,9 +79,12 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     await time.advanceBlockTo(relayEntryTimeout.addn(await web3.eth.getBlockNumber()));
 
     let delayFactor = await operatorContract.delayFactor.call();        
-
-    let expectedDelayFactor = web3.utils.toBN('271267361111');
-    assert.isTrue(expectedDelayFactor.eq(delayFactor));        
+    // currentRequestStartBlock = 0
+    // T_received = 384
+    // T_deadline = 0 + 384 + 1 = 385
+    // T_begin = 0 + 1 = 1
+    // [(T_deadline - T_received) / (T_deadline - T_begin)]^2 = [(385 - 384) / (385 - 1)]^2
+    expect(delayFactor).to.eq.BN('67816840277')       
   });
 
   it("should correctly evaluate rewards for entry submitted " + 
@@ -100,18 +108,9 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     
     let rewards = await operatorContract.getNewEntryRewardsBreakdown.call(); 
 
-    assert.isTrue(
-      expectedGroupMemberReward.eq(rewards.groupMemberReward),
-      "unexpected group member reward"
-    );
-    assert.isTrue(
-      expectedSubmitterReward.eq(rewards.submitterReward),
-      "unexpected submitter reward"
-    );
-    assert.isTrue(
-      expectedSubsidy.eq(rewards.subsidy),
-      "unexpected subsidy"
-    );
+    expect(rewards.groupMemberReward).to.eq.BN(expectedGroupMemberReward)
+    expect(rewards.submitterReward).to.eq.BN(expectedSubmitterReward)
+    expect(rewards.subsidy).to.eq.BN(expectedSubsidy)
   });
 
   it("should correctly evaluate rewards for entry submitted " +
@@ -137,18 +136,9 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     
     let rewards = await operatorContract.getNewEntryRewardsBreakdown.call(); 
     
-    assert.isTrue(
-      expectedGroupMemberReward.eq(rewards.groupMemberReward),
-      "unexpected group member reward"
-    );
-    assert.isTrue(
-      expectedSubmitterReward.eq(rewards.submitterReward),
-      "unexpected submitter reward"
-    );
-    assert.isTrue(
-      expectedSubsidy.eq(rewards.subsidy),
-      "unexpected subsidy"
-    );
+    expect(rewards.groupMemberReward).to.eq.BN(expectedGroupMemberReward)
+    expect(rewards.submitterReward).to.eq.BN(expectedSubmitterReward)
+    expect(rewards.subsidy).to.eq.BN(expectedSubsidy)
   });  
 
   it("should correctly evaluate rewards for the entry submitted " + 
@@ -162,10 +152,10 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
 
     await time.advanceBlockTo(web3.utils.toBN(await web3.eth.getBlockNumber()).addn(2));
 
-    // There is one block of delay so the delay factor is 0.9896104600694443.
+    // There is one block of delay so the delay factor is 0.9947984483506943.
     // Group member reward should be scaled by the delay factor: 
-    // 1987000 * 0.9896104600694443 = ~1966355
-    let expectedGroupMemberReward = web3.utils.toBN("1966355");
+    // 1987000 * 0.9947984483506943 = ~1966355
+    let expectedGroupMemberReward = web3.utils.toBN("1976664");
 
     // The entire entry verification fee is paid to the submitter 
     // regardless of their gas expenditure. The submitter is free to spend 
@@ -174,10 +164,10 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     // 
     // To incentivize a race for the submitter position, the submitter 
     // receives delay penalty * group size * 0.05 as an extra reward:
-    // 1987000 * (1 - 0.9896104600694443) * 64 * 5% = ~66060
+    // 1987000 * (1 - 0.9947984483506943) * 64 * 5% = ~33073
     //
-    // 70070000000 + 66060 = 70070066060          
-    let expectedSubmitterReward = web3.utils.toBN("70070066060");  
+    // 70070000000 + 33073 = 70070033073          
+    let expectedSubmitterReward = web3.utils.toBN("70070033073");  
 
     // If the amount paid out to the signing group in group rewards and the 
     // submitter’s extra reward is less than the profit margin, the 
@@ -185,26 +175,17 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     // incentivize customers to request entries.
     //
     // profit margin: 1987000 * 64 = 127168000
-    // paid member rewards: 1966355 * 64 = 125846720
-    // submitter extra reward: 66060
+    // paid member rewards: 1976664 * 64 = 126506496
+    // submitter extra reward: 33073
     // 
-    // 127168000 - 125846720 - 66060 = 1255220
-    let expectedSubsidy = web3.utils.toBN("1255220");              
+    // 127168000 - 126506496 - 33073 = 628431
+    let expectedSubsidy = web3.utils.toBN("628431");              
 
     let rewards = await operatorContract.getNewEntryRewardsBreakdown.call(); 
     
-    assert.isTrue(
-      expectedGroupMemberReward.eq(rewards.groupMemberReward),
-      "unexpected group member reward"
-    );
-    assert.isTrue(
-      expectedSubmitterReward.eq(rewards.submitterReward),
-      "unexpected submitter reward"
-    );
-    assert.isTrue(
-      expectedSubsidy.eq(rewards.subsidy),
-      "unexpected subsidy"
-    );
+    expect(rewards.groupMemberReward).to.eq.BN(expectedGroupMemberReward)
+    expect(rewards.submitterReward).to.eq.BN(expectedSubmitterReward)
+    expect(rewards.subsidy).to.eq.BN(expectedSubsidy)
   });  
 
   it("should correctly evaluate rewards for the entry submitted " + 
@@ -220,10 +201,10 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     await time.advanceBlockTo(relayEntryTimeout.addn(await web3.eth.getBlockNumber()));
 
     // There is one block left before the timeout so the delay factor is 
-    // 0.0000271267361111.
+    // 0.000067816840277.
     // Group member reward should be scaled by the delay factor: 
-    // 1382000000 * 0.0000271267361111 = ~37489
-    let expectedGroupMemberReward = web3.utils.toBN("37489");  
+    // 1382000000 * 0.0000067816840277 = ~9372
+    let expectedGroupMemberReward = web3.utils.toBN("9372");  
 
     // The entire entry verification fee is paid to the submitter 
     // regardless of their gas expenditure. The submitter is free to spend 
@@ -232,10 +213,10 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     // 
     // To incentivize a race for the submitter position, the submitter 
     // receives delay penalty * group size * 0.05 as an extra reward:
-    // 1382000000 * (1 - 0.0000271267361111) * 64 * 5% = ~4422280034
+    // 1382000000 * (1 - 0.0000067816840277) * 64 * 5% = ~4422370008
     //
-    // 100040000000 + 4422280034 = 104462280034          
-    let expectedSubmitterReward = web3.utils.toBN("104462280034"); 
+    // 100040000000 + 4422370008 = 104462370008          
+    let expectedSubmitterReward = web3.utils.toBN("104462370008"); 
 
     // If the amount paid out to the signing group in group rewards and the 
     // submitter’s extra reward is less than the profit margin, the 
@@ -243,25 +224,16 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
     // incentivize customers to request entries.
     //
     // profit margin: 1382000000 * 64 = 88448000000
-    // paid member rewards: 37489 * 64 = 2399296
+    // paid member rewards: 9372 * 64 = 599808
     // submitter extra reward: 4422280034
     // 
-    // 88448000000 - 2399296 - 4422280034 = 84023320670
-    let expectedSubsidy = web3.utils.toBN("84023320670");    
+    // 88448000000 - 599808 - 4422370008 = 84025030184
+    let expectedSubsidy = web3.utils.toBN("84025030184");    
 
     let rewards = await operatorContract.getNewEntryRewardsBreakdown.call();
     
-    assert.isTrue(
-      expectedGroupMemberReward.eq(rewards.groupMemberReward),
-      "unexpected group member reward"
-    );
-    assert.isTrue(
-      expectedSubmitterReward.eq(rewards.submitterReward),
-      "unexpected submitter reward"
-    );
-    assert.isTrue(
-      expectedSubsidy.eq(rewards.subsidy),
-      "unexpected subsidy"
-    );
+    expect(rewards.groupMemberReward).to.eq.BN(expectedGroupMemberReward)
+    expect(rewards.submitterReward).to.eq.BN(expectedSubmitterReward)
+    expect(rewards.subsidy).to.eq.BN(expectedSubsidy)
   });
 });

--- a/solidity/test/random_beacon_operator/TestPublishDkgResult.js
+++ b/solidity/test/random_beacon_operator/TestPublishDkgResult.js
@@ -15,7 +15,7 @@ describe('KeepRandomBeaconOperator/PublishDkgResult', function () {
   const groupSize = 20;
   const groupThreshold = 11;
   const dkgResultSignatureThreshold = 15;
-  const resultPublicationBlockStep = 3;
+  const resultPublicationBlockStep = 6;
 
   let resultPublicationTime, token, stakingContract, operatorContract,
     owner = accounts[0], beneficiary = accounts[4], ticket,
@@ -46,7 +46,6 @@ describe('KeepRandomBeaconOperator/PublishDkgResult', function () {
     await operatorContract.setGroupSize(groupSize);
     await operatorContract.setGroupThreshold(groupThreshold);
     await operatorContract.setDKGResultSignatureThreshold(dkgResultSignatureThreshold);
-    await operatorContract.setResultPublicationBlockStep(resultPublicationBlockStep);
 
     const operator1StakingWeight = 100;
     const operator2StakingWeight = 200;


### PR DESCRIPTION
6 blocks result publication step gives an operator one hour to react before the relay entry timeout happens. It should also help to minimize ETH expenses by avoiding the situation when two or more members submit at the same time because of slow new block times.
Same about ticket submission round duration which has been adjusted accordingly to 6 blocks with 12 blocks mining lag.