### PR TITLE
Do not cancel the context before entry makes it to the chain

### DIFF
--- a/pkg/beacon/relay/entry/entry.go
+++ b/pkg/beacon/relay/entry/entry.go
@@ -136,11 +136,6 @@ func SignAndSubmit(
 		}
 	}
 
-	// If we jumped outside the message loop, we have enough valid shares
-	// and we can complete the signature. There is no need to continue
-	// signature shares exchange and the context can be cancelled.
-	cancelCtx()
-
 	signature, err := completeSignature(signer, receivedValidShares, honestThreshold)
 	if err != nil {
 		return err


### PR DESCRIPTION
Refs #1690 

We added `cancelCtx()` call to cancel signature shares retransmission if the current member has enough shares to reconstruct signature. From a selfish perspective of that member it absolutely makes sense but from a broader perspective it does not and it slows down relay entry submission.

Specifically, if members 10-64 collected enough shares to reconstruct entry, they stop broadcasting. If members 1-9 still do not have enough shares, none of them will be able to publish the result and we'll have to wait until member 10 is eligible.

Retransmitting shares until the entry is on-chain makes sense.