### PR TITLE
DKG contribution margin set to 3%

### DIFF
--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -20,7 +20,7 @@ const KeepRegistry = artifacts.require("./KeepRegistry.sol");
 
 let initializationPeriod = 43200; // ~12 hours
 let undelegationPeriod = 7776000; // ~3 months
-const dkgContributionMargin = 5; // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
+const dkgContributionMargin = 3; // 3%
 
 module.exports = async function(deployer, network) {
 


### PR DESCRIPTION
Closes #1660 

Quoting from the referenced issue:
> 5% gives 1/20 behavior in the worst-case scenario where all submitters use the maximum gas. If submitters use less gas we generate more groups and become time-constrained faster. Assuming money spent on ticket submission uses the same average gas price as DKG submission, this doesn't have unexpected adverse effects on staker finances which are calculated on a max-gas basis (or specifically, the average-case ticket submission costs will mirror the worst-case costs proportionally).
>
> Normal gas costs tend to be in the range of 6 ~ 12 gwei, meaning that 1 ~ 2% would give expected behavior most of the time but increase the entry frequency required for the system to stay up without intervention by 2.5 ~ 5x in the worst-case. We do not necessarily need to change it as this higher rate of DKG just means that the average-case robustness of the beacon is better than the worst-case the parameters were calculated with, but the group lifespan of 7 days means that we could safely go to 2~3% DKG contribution to improve operator profit after subtracting ticket submission costs.