### PR TITLE
Updating keep-common dependency to v0.3.1-rc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v0.3.0-rc.0.20200427145435-e24eeb9599e4
+	github.com/keep-network/keep-common v0.3.1-rc
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1
 	github.com/libp2p/go-libp2p-connmgr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -246,10 +246,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v0.3.0-rc h1:e2Vdq3TyQ6dGRNZQBykvfYZgKZwNKS+Z8DYEwoMIiuc=
-github.com/keep-network/keep-common v0.3.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
-github.com/keep-network/keep-common v0.3.0-rc.0.20200427145435-e24eeb9599e4 h1:j8W6ckP0u2tr+1CB7KkVLz2EP3B4zT+wobv81DMSSxE=
-github.com/keep-network/keep-common v0.3.0-rc.0.20200427145435-e24eeb9599e4/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v0.3.1-rc h1:5JHj/PLmafqdJNh+pI5F5rUKUHhAuo2YllPcWSoA/rc=
+github.com/keep-network/keep-common v0.3.1-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
This version points to the same code as the commit hash we used but
it's nicer to refer to a released version instead of some magical
commit.