### PR TITLE
Release 1.1.0-rc (Ropsten)

### DIFF
--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc",
+    "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
     "bignumber.js": "9.0.0",
     "formik": "^2.1.3",
     "less": "^3.9.0",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.1.0-pre",
+  "version": "1.1.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.1.0-pre",
+  "version": "1.1.0-rc",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Contracts version bumped up to `1.1.0-rc`