### PR TITLE
Removing a symlink for local development

### DIFF
--- a/solidity/artifacts
+++ b/solidity/artifacts
@@ -1,1 +1,0 @@
-build/contracts


### PR DESCRIPTION
This PR removes an accidentally merged symlink which was used for local development. 