### PR TITLE
Bumping up contracts version to 1.2.0-pre

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.1.0-pre",
+  "version": "1.2.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.1.0-pre",
+  "version": "1.2.0-pre",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We tagged `1.1.0-rc` so it is time to bump up contracts to `1.2.0-pre`.

See https://github.com/keep-network/keep-core/pull/1722