### PR TITLE
Updating keep-core contracts dependency 1.1.2

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "1.1.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1554,9 +1554,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-pre.0.tgz",
-      "integrity": "sha512-aHV0ZUyhlond4qgW5Dz6dbh9BZPc7i1H9pEtBQuBkr6JgvMnRexUadLYNFixMbZrSJKj9KiyYI/oJ+wK4eJJiQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.2.tgz",
+      "integrity": "sha512-BEpq/hdqmPZeGc3/EMdbgGeQQgspf41UYsDaFJxOb86UxpKe59aAqOV8eJYFGNec28KFa5l7bl7ucMWqilrbww==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "1.1.0-pre",
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc",
+    "@keep-network/keep-core": "1.1.2",
     "bignumber.js": "9.0.0",
     "formik": "^2.1.3",
     "less": "^3.9.0",


### PR DESCRIPTION
After releasing beacon contracts to mainnet we are setting the
dependency to keep-core 1.1.2 mainnet version.

Also, updated the version of dashboard to `1.1.0-pre` since `1.0.0` has been
released with `v1.1.2` tag of `keep-core`.