### PR TITLE
Updated keep-core dependency to 1.1.0-rc for faucet

### DIFF
--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.14.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-rc.0.tgz",
-      "integrity": "sha512-9K2oeuCvDK4Q1BsPghouOdEF7Ad8iCiuX7RblIaka2h8sLRBs6proyrue+KDjfKTreOZgfqb938yiyaGnyMTEQ==",
+      "version": "1.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-rc.0.tgz",
+      "integrity": "sha512-sXusNLPAPJFq9mYR5/eOYxgJKa0Kg4ezSvTtLaPjX0ul24rIPZ67kvpfbR5ePx4MCeD/XQisHvRmp/rEsXFAig==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
@@ -1,7 +1,7 @@
 {
   "main": "issue-grant.js",
   "dependencies": {
-    "@keep-network/keep-core": ">0.14.0-rc <0.14.0",
+    "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
     "@truffle/hdwallet-provider": "^1.0.25",
     "web3": "1.2.6"
   },


### PR DESCRIPTION
The faucet will use the latest release of keep-core `1.1.0-rc`.
It's already up and running.