### PR TITLE
Log getting selected participant retries on info level

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -157,27 +157,22 @@ func (ec *ethereumChain) GetSelectedParticipants() ([]chain.StakerAddress, error
 	// retry calling for selected participants up to 4 times.
 	// Synchronization issue can occur on any setup where we have more than one
 	// Ethereum clients behind a load balancer.
-	if err := ec.withRetry(fetchParticipants); err != nil {
-		return nil, err
-	}
-
-	return stakerAddresses, nil
-}
-
-func (ec *ethereumChain) withRetry(fn func() error) error {
 	const numberOfRetries = 10
 	const delay = time.Second
 
 	for i := 1; ; i++ {
-		err := fn()
+		err := fetchParticipants()
 		if err != nil {
-			logger.Errorf("Error occurred [%v]; on [%v] retry", err, i)
 			if i == numberOfRetries {
-				return err
+				return nil, err
 			}
 			time.Sleep(delay)
+			logger.Infof(
+				"Retrying getting selected participants; attempt [%v]",
+				i,
+			)
 		} else {
-			return nil
+			return stakerAddresses, nil
 		}
 	}
 }


### PR DESCRIPTION
Experience shows that this situation happens very often on Infura-like deployments and ERRORs produced there were adding too much noise. Especially that in almost all cases the second attempt was successful. 

We do not want to clutter logs with ERRORs that are not really errors - we need to accept
that it's how most ETH clients load balancers work.