### PR TITLE
Updated faucet to use 1.1.1-rc contracts

### DIFF
--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-rc.0.tgz",
-      "integrity": "sha512-sXusNLPAPJFq9mYR5/eOYxgJKa0Kg4ezSvTtLaPjX0ul24rIPZ67kvpfbR5ePx4MCeD/XQisHvRmp/rEsXFAig==",
+      "version": "1.1.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.1-rc.0.tgz",
+      "integrity": "sha512-U6rola47/P+bU+Wr9EmbNFgAZPOqGtB9dlkd4HF+ca8SkMPrj/VqvYg2Sg84fsy4i+vHT6YQ41HJtzWb3wqSCA==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
@@ -1,7 +1,7 @@
 {
   "main": "issue-grant.js",
   "dependencies": {
-    "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
+    "@keep-network/keep-core": ">1.1.1-rc <1.1.1",
     "@truffle/hdwallet-provider": "^1.0.25",
     "web3": "1.2.6"
   },


### PR DESCRIPTION
Updated faucet keep-core dependency to use contracts deployed with version 1.1.1-rc.