### PR TITLE
Added operator contract balance checks to the pricing test script

### DIFF
--- a/solidity/scripts/pricing-test.js
+++ b/solidity/scripts/pricing-test.js
@@ -59,7 +59,8 @@ module.exports = async function() {
                 serviceContractBalance,
                 dkgFeePool.toString(),
                 requestSubsidyFeePool.toString(),
-                dkgContributionMargin.toString()
+                dkgContributionMargin.toString(),
+                dkgFeePool.add(requestSubsidyFeePool).toString() === serviceContractBalance
             )
 
             console.log("Service Contract Summary (before request)");
@@ -73,7 +74,7 @@ module.exports = async function() {
                 operatorContractBalance,
                 rewardsSum.toString(),
                 dkgSubmitterReimbursementFee.toString(),
-                rewardsSum.add(dkgSubmitterReimbursementFee).toString()
+                rewardsSum.add(dkgSubmitterReimbursementFee).toString() === operatorContractBalance
             )
 
             console.log("Operator Contract Summary (before request)");
@@ -174,24 +175,26 @@ function ServiceContractSummary(
     balance,
     dkgFeePool,
     requestSubsidyFeePool,
-    dkgContributionMargin
+    dkgContributionMargin,
+    hasCorrectBalance
 ) {
     this.balance = balance,
     this.dkgFeePool = dkgFeePool
     this.requestSubsidyFeePool = requestSubsidyFeePool
     this.dkgContributionMargin = dkgContributionMargin
+    this.hasCorrectBalance = hasCorrectBalance
 }
 
 function OperatorContractSummary(
     balance,
     sumOfRewards,
     dkgSubmitterReimbursementFee,
-    sumOfRewardsAndDkgReimbursementFee
+    hasCorrectBalance
 ) {
     this.balance = balance
     this.sumOfRewards = sumOfRewards
     this.dkgSubmitterReimbursementFee = dkgSubmitterReimbursementFee
-    this.sumOfRewardsAndDkgReimbursementFee = sumOfRewardsAndDkgReimbursementFee
+    this.hasCorrectBalance = hasCorrectBalance
 }
 
 function PricingSummary(
@@ -224,14 +227,15 @@ ServiceContractSummary.prototype.toString = function serviceContractSummaryToStr
     return '' + this.balance + ', ' + 
         this.dkgFeePool + ', ' + 
         this.requestSubsidyFeePool + ', ' + 
-        this.dkgContributionMargin
+        this.dkgContributionMargin + ', ' + 
+        this.hasCorrectBalance + ', ';
 }
 
 OperatorContractSummary.prototype.toString = function operatorContractSummaryToString() {
     return '' + this.balance + ', ' +
         this.sumOfRewards + ', ' + 
         this.dkgSubmitterReimbursementFee + ', ' +
-        this.sumOfRewardsAndDkgReimbursementFee + ', ';
+        this.hasCorrectBalance + ', ';
 }
 
 PricingSummary.prototype.toString = function pricingSummaryToString() {

--- a/solidity/scripts/pricing-test.js
+++ b/solidity/scripts/pricing-test.js
@@ -50,8 +50,23 @@ module.exports = async function() {
                 rewardsSum = rewardsSum.add(web3.utils.toBN(prevRewards[i]));
             }
 
-            const operatorContractBalance = await web3.eth.getBalance(contractOperator.address);
+            const serviceContractBalance = await web3.eth.getBalance(contractService.address);
+            const dkgFeePool = await contractService.dkgFeePool();
+            const requestSubsidyFeePool = await contractService.requestSubsidyFeePool();
+            const dkgContributionMargin = await contractService.dkgContributionMargin();
 
+            const serviceContractSummary = new ServiceContractSummary(
+                serviceContractBalance,
+                dkgFeePool.toString(),
+                requestSubsidyFeePool.toString(),
+                dkgContributionMargin.toString()
+            )
+
+            console.log("Service Contract Summary (before request)");
+            console.table([serviceContractSummary]);
+            console.log("\n");
+
+            const operatorContractBalance = await web3.eth.getBalance(contractOperator.address);
             const dkgSubmitterReimbursementFee = await contractOperator.dkgSubmitterReimbursementFee();
 
             const operatorContractSummary = new OperatorContractSummary(
@@ -155,14 +170,26 @@ async function availableRewards(account, contractOperator, contractStatistics) {
     return accountRewards;
 }
 
+function ServiceContractSummary(
+    balance,
+    dkgFeePool,
+    requestSubsidyFeePool,
+    dkgContributionMargin
+) {
+    this.balance = balance,
+    this.dkgFeePool = dkgFeePool
+    this.requestSubsidyFeePool = requestSubsidyFeePool
+    this.dkgContributionMargin = dkgContributionMargin
+}
+
 function OperatorContractSummary(
     balance,
     sumOfRewards,
     dkgSubmitterReimbursementFee,
     sumOfRewardsAndDkgReimbursementFee
 ) {
-    this.balance = balance,
-    this.sumOfRewards = sumOfRewards,
+    this.balance = balance
+    this.sumOfRewards = sumOfRewards
     this.dkgSubmitterReimbursementFee = dkgSubmitterReimbursementFee
     this.sumOfRewardsAndDkgReimbursementFee = sumOfRewardsAndDkgReimbursementFee
 }
@@ -191,6 +218,13 @@ function PricingClient(address, balance, balanceChange, reward, rewardChange) {
     this.balanceChange = balanceChange,
     this.reward = reward,
     this.rewardChange = rewardChange
+}
+
+ServiceContractSummary.prototype.toString = function serviceContractSummaryToString() {
+    return '' + this.balance + ', ' + 
+        this.dkgFeePool + ', ' + 
+        this.requestSubsidyFeePool + ', ' + 
+        this.dkgContributionMargin
 }
 
 OperatorContractSummary.prototype.toString = function operatorContractSummaryToString() {


### PR DESCRIPTION
We can use operator contract balance check to make sure the value of
rewards stored in the contract matches the total ETH balance stored on
the contract.