### PR TITLE
Changing version of moment to a fixed 2.24.0

### DIFF
--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -10,7 +10,7 @@
     "less": "^3.9.0",
     "less-plugin-clean-css": "^1.5.1",
     "less-watch-compiler": "^1.10.0",
-    "moment": "^2.20.1",
+    "moment": "2.24.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",


### PR DESCRIPTION
Changing version because caret ^ bumped it to 2.25.1 which throws an error described [here](https://github.com/moment/moment/issues/5484)