### PR TITLE
DKG contribution fee set to 1% and group active time to ~2 weeks

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -164,7 +164,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         stakingContract = TokenStaking(_stakingContract);
 
         groups.stakingContract = TokenStaking(_stakingContract);
-        groups.groupActiveTime = 86400 * 7 / 15; // 7 days equivalent in 15s blocks
+        groups.groupActiveTime = 86400 * 14 / 15; // 14 days equivalent in 15s blocks
 
         // There are 78 blocks to submit group selection tickets. To minimize
         // the submitter's cost by minimizing the number of redundant tickets

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -20,7 +20,7 @@ const KeepRegistry = artifacts.require("./KeepRegistry.sol");
 
 let initializationPeriod = 43200; // ~12 hours
 let undelegationPeriod = 7776000; // ~3 months
-const dkgContributionMargin = 3; // 3%
+const dkgContributionMargin = 1; // 1%
 
 module.exports = async function(deployer, network) {
 


### PR DESCRIPTION
The current (`master`) value of DKG contribution margin is 3% and group active time is ~one week. Here we propose to set DKG contribution margin to 1% and increase group active time to ~two weeks.

### 3% contribution

#### Actual gas price of 20 Gwei

Operator contract uses gas price ceiling to calculate fee required for executing
a new group selection and DKG. With a gas price ceiling of `30Gwei`, the fee is:
`30000000000 * (200000+ 1740000) = 58200000000000000`

Assuming the actual gas price is `20Gwei`, operator spends
`(30000000000 * 200000) + (20000000000 * 1740000) = 40800000000000000`
on triggering group selection and DKG result submission (start group selection
reimbursement of `200k` gas is always multiplied by the price ceiling).

As a result, `58200000000000000 - 40800000000000000 = 17400000000000000` is
returned back to the service contract right after the genesis DKG. For each
new relay request, `58200000000000000 * 3% = 1746000000000000` is added to the
DKG fee pool of the service contract:
<details>
17400000000000000 + 1746000000000000 = 19146000000000000

19146000000000000 + 1746000000000000 = 20892000000000000
20892000000000000 + 1746000000000000 = 22638000000000000
22638000000000000 + 1746000000000000 = 24384000000000000
26130000000000000 + 1746000000000000 = 27876000000000000
27876000000000000 + 1746000000000000 = 29622000000000000
29622000000000000 + 1746000000000000 = 31368000000000000
31368000000000000 + 1746000000000000 = 33114000000000000
33114000000000000 + 1746000000000000 = 34860000000000000
34860000000000000 + 1746000000000000 = 36606000000000000
36606000000000000 + 1746000000000000 = 38352000000000000
38352000000000000 + 1746000000000000 = 40098000000000000
40098000000000000 + 1746000000000000 = 41844000000000000
41844000000000000 + 1746000000000000 = 43590000000000000
43590000000000000 + 1746000000000000 = 45336000000000000
45336000000000000 + 1746000000000000 = 47082000000000000
47082000000000000 + 1746000000000000 = 48828000000000000
48828000000000000 + 1746000000000000 = 50574000000000000
50574000000000000 + 1746000000000000 = 52320000000000000
52320000000000000 + 1746000000000000 = 54066000000000000
54066000000000000 + 1746000000000000 = 55812000000000000
55812000000000000 + 1746000000000000 = 57558000000000000
57558000000000000 + 1746000000000000 = 59304000000000000
</details>

After 23 entries, new DKG is started.
`59304000000000000 - 58200000000000000 = 1104000000000000` stays in the pool and
`17400000000000000` is returned back to the pool after the DKG. It means we have
`1104000000000000 + 17400000000000000 = 18504000000000000` in the pool and we
need 22 relay entries for a new group selection.

#### Actual gas price of 20 Gwei

For the actual gas price of `10Gwei`, operator spends
`(30000000000 * 200000) + (10000000000 * 1740000) = 23400000000000000`
on triggering group selection and DKG result submission.

As a result, `58200000000000000 - 23400000000000000 = 34800000000000000` is
returned back to the service contract. For each new relay request,
`58200000000000000 * 3% = 1746000000000000` is added to the
DKG fee pool of the service contract:

<details>
34800000000000000 + 1746000000000000 = 36546000000000000

36546000000000000 + 1746000000000000 = 38292000000000000
38292000000000000 + 1746000000000000 = 40038000000000000
40038000000000000 + 1746000000000000 = 41784000000000000
41784000000000000 + 1746000000000000 = 43530000000000000
43530000000000000 + 1746000000000000 = 45276000000000000
45276000000000000 + 1746000000000000 = 47022000000000000
47022000000000000 + 1746000000000000 = 48768000000000000
48768000000000000 + 1746000000000000 = 50514000000000000
50514000000000000 + 1746000000000000 = 52260000000000000
52260000000000000 + 1746000000000000 = 54006000000000000
54006000000000000 + 1746000000000000 = 55752000000000000
55752000000000000 + 1746000000000000 = 57498000000000000
57498000000000000 + 1746000000000000 = 59244000000000000
</details>

After 14 entries, new DKG is started.
`59244000000000000 - 58200000000000000 = 1044000000000000` stays in the pool and
34800000000000000 is returned back to the pool after the DKG. It means we have
`1044000000000000 + 34800000000000000 = 35844000000000000` in the pool and we need 12 relay entries for a new group selection.

### 2% contribution

#### Actual gas price of 20 Gwei

Assuming DKG contribution margin of 2%, each relay entry generates
`58200000000000000 * 2% = 1164000000000000` DKG contribution fee.

Assuming the actual gas price of 20Gwei, operator spends
`(30000000000 * 200000) + (20000000000 * 1740000) = 40800000000000000`
on triggering group selection and DKG result submission.

As a result, `58200000000000000 - 40800000000000000 = 17400000000000000` is
returned back to the service contract right after genesis DKG. For each new
relay request, `1164000000000000` is added to the DKG fee pool of the service
contract:
<details>
17400000000000000 + 1164000000000000 = 18564000000000000

18564000000000000 + 1164000000000000 = 19728000000000000
19728000000000000 + 1164000000000000 = 20892000000000000
20892000000000000 + 1164000000000000 = 22056000000000000
22056000000000000 + 1164000000000000 = 23220000000000000
23220000000000000 + 1164000000000000 = 24384000000000000
24384000000000000 + 1164000000000000 = 25548000000000000
25548000000000000 + 1164000000000000 = 26712000000000000
26712000000000000 + 1164000000000000 = 27876000000000000
27876000000000000 + 1164000000000000 = 29040000000000000
29040000000000000 + 1164000000000000 = 30204000000000000
30204000000000000 + 1164000000000000 = 31368000000000000
31368000000000000 + 1164000000000000 = 32532000000000000
32532000000000000 + 1164000000000000 = 33696000000000000
33696000000000000 + 1164000000000000 = 34860000000000000
34860000000000000 + 1164000000000000 = 36024000000000000
36024000000000000 + 1164000000000000 = 37188000000000000
37188000000000000 + 1164000000000000 = 38352000000000000
38352000000000000 + 1164000000000000 = 39516000000000000
39516000000000000 + 1164000000000000 = 40680000000000000
40680000000000000 + 1164000000000000 = 41844000000000000
41844000000000000 + 1164000000000000 = 43008000000000000
43008000000000000 + 1164000000000000 = 44172000000000000
44172000000000000 + 1164000000000000 = 45336000000000000
45336000000000000 + 1164000000000000 = 46500000000000000
46500000000000000 + 1164000000000000 = 47664000000000000
47664000000000000 + 1164000000000000 = 48828000000000000
48828000000000000 + 1164000000000000 = 49992000000000000
49992000000000000 + 1164000000000000 = 51156000000000000
51156000000000000 + 1164000000000000 = 52320000000000000
52320000000000000 + 1164000000000000 = 53484000000000000
53484000000000000 + 1164000000000000 = 54648000000000000
54648000000000000 + 1164000000000000 = 55812000000000000
55812000000000000 + 1164000000000000 = 56976000000000000
56976000000000000 + 1164000000000000 = 58140000000000000
58140000000000000 + 1164000000000000 = 59304000000000000
</details>

After 36 entries, new DKG is started.
`59304000000000000 - 58200000000000000 = 1104000000000000` stays in the pool and
`17400000000000000` is returned back to the pool after the DKG. It means we have
`1104000000000000 + 17400000000000000 = 18504000000000000` in the pool and we
need 36 relay entries for a new group selection.

#### Actual gas price of 10 Gwei

For actual gas price of 10Gwei, operator spends
`(30000000000 * 200000) + (10000000000 * 1740000) = 23400000000000000`
on triggering group selection and DKG result submission.

As a result, `58200000000000000 - 23400000000000000 = 34800000000000000` is
returned back to the service contract. For each new relay request,
`58200000000000000 * 2% = 1164000000000000` is added to the
DKG fee pool of the service contract:

<details>
34800000000000000 + 1164000000000000 = 35964000000000000

35964000000000000 + 1164000000000000 = 37128000000000000
37128000000000000 + 1164000000000000 = 38292000000000000
38292000000000000 + 1164000000000000 = 39456000000000000
39456000000000000 + 1164000000000000 = 40620000000000000
40620000000000000 + 1164000000000000 = 41784000000000000
41784000000000000 + 1164000000000000 = 42948000000000000
42948000000000000 + 1164000000000000 = 44112000000000000
44112000000000000 + 1164000000000000 = 45276000000000000
45276000000000000 + 1164000000000000 = 46440000000000000
46440000000000000 + 1164000000000000 = 47604000000000000
47604000000000000 + 1164000000000000 = 48768000000000000
48768000000000000 + 1164000000000000 = 49932000000000000
49932000000000000 + 1164000000000000 = 51096000000000000
51096000000000000 + 1164000000000000 = 52260000000000000
52260000000000000 + 1164000000000000 = 53424000000000000
53424000000000000 + 1164000000000000 = 54588000000000000
54588000000000000 + 1164000000000000 = 55752000000000000
55752000000000000 + 1164000000000000 = 56916000000000000
56916000000000000 + 1164000000000000 = 58080000000000000
58080000000000000 + 1164000000000000 = 59244000000000000
</details>

After 21 entries, new DKG is started.
`59244000000000000 - 58200000000000000 = 1044000000000000` stays in the pool and
`34800000000000000` is returned back to the pool after the DKG. It means we have
`1044000000000000 + 34800000000000000 = 35844000000000000` in the pool and we need 21 relay entries for a new group selection.

### 1% contribution

#### Actual gas price of 20 Gwei

Assuming DKG contribution margin of 1%, each relay entry generates
`58200000000000000 * 1% = 582000000000000` DKG contribution fee.

Assuming the actual gas price of 20Gwei, operator spends
`(30000000000 * 200000) + (20000000000 * 1740000) = 40800000000000000`
on triggering group selection and DKG result submission.

As a result, `58200000000000000 - 40800000000000000 = 17400000000000000` is
returned back to the service contract right after genesis DKG. For each new
relay request, 582000000000000 is added to the DKG fee pool of the service
contract:

<details>
17400000000000000 + 582000000000000 = 17982000000000000

17982000000000000 + 582000000000000 = 18564000000000000
18564000000000000 + 582000000000000 = 19146000000000000
19146000000000000 + 582000000000000 = 19728000000000000
19728000000000000 + 582000000000000 = 20310000000000000
20310000000000000 + 582000000000000 = 20892000000000000
20892000000000000 + 582000000000000 = 21474000000000000
21474000000000000 + 582000000000000 = 22056000000000000
22056000000000000 + 582000000000000 = 22638000000000000
22638000000000000 + 582000000000000 = 23220000000000000
23220000000000000 + 582000000000000 = 23802000000000000
23802000000000000 + 582000000000000 = 24384000000000000
24384000000000000 + 582000000000000 = 24966000000000000
24966000000000000 + 582000000000000 = 25548000000000000
25548000000000000 + 582000000000000 = 26130000000000000
26130000000000000 + 582000000000000 = 26712000000000000
26712000000000000 + 582000000000000 = 27294000000000000
27294000000000000 + 582000000000000 = 27876000000000000
27876000000000000 + 582000000000000 = 28458000000000000
28458000000000000 + 582000000000000 = 29040000000000000
29040000000000000 + 582000000000000 = 29622000000000000
29622000000000000 + 582000000000000 = 30204000000000000
30204000000000000 + 582000000000000 = 30786000000000000
30786000000000000 + 582000000000000 = 31368000000000000
31368000000000000 + 582000000000000 = 31950000000000000
31950000000000000 + 582000000000000 = 32532000000000000
32532000000000000 + 582000000000000 = 33114000000000000
33114000000000000 + 582000000000000 = 33696000000000000
33696000000000000 + 582000000000000 = 34278000000000000
34278000000000000 + 582000000000000 = 34860000000000000
34860000000000000 + 582000000000000 = 35442000000000000
35442000000000000 + 582000000000000 = 36024000000000000
36024000000000000 + 582000000000000 = 36606000000000000
36606000000000000 + 582000000000000 = 37188000000000000
37188000000000000 + 582000000000000 = 37770000000000000
37770000000000000 + 582000000000000 = 38352000000000000
38352000000000000 + 582000000000000 = 38934000000000000
38934000000000000 + 582000000000000 = 39516000000000000
39516000000000000 + 582000000000000 = 40098000000000000
40098000000000000 + 582000000000000 = 40680000000000000
40680000000000000 + 582000000000000 = 41262000000000000
41262000000000000 + 582000000000000 = 41844000000000000
41844000000000000 + 582000000000000 = 42426000000000000
42426000000000000 + 582000000000000 = 43008000000000000
43008000000000000 + 582000000000000 = 43590000000000000
43590000000000000 + 582000000000000 = 44172000000000000
44172000000000000 + 582000000000000 = 44754000000000000
44754000000000000 + 582000000000000 = 45336000000000000
45336000000000000 + 582000000000000 = 45918000000000000
45918000000000000 + 582000000000000 = 46500000000000000
46500000000000000 + 582000000000000 = 47082000000000000
47082000000000000 + 582000000000000 = 47664000000000000
47664000000000000 + 582000000000000 = 48246000000000000
48246000000000000 + 582000000000000 = 48828000000000000
48828000000000000 + 582000000000000 = 49410000000000000
49410000000000000 + 582000000000000 = 49992000000000000
49992000000000000 + 582000000000000 = 50574000000000000
50574000000000000 + 582000000000000 = 51156000000000000
51156000000000000 + 582000000000000 = 51738000000000000
51738000000000000 + 582000000000000 = 52320000000000000
52320000000000000 + 582000000000000 = 52902000000000000
52902000000000000 + 582000000000000 = 53484000000000000
53484000000000000 + 582000000000000 = 54066000000000000
54066000000000000 + 582000000000000 = 54648000000000000
54648000000000000 + 582000000000000 = 55230000000000000
55230000000000000 + 582000000000000 = 55812000000000000
55812000000000000 + 582000000000000 = 56394000000000000
56394000000000000 + 582000000000000 = 56976000000000000
56976000000000000 + 582000000000000 = 57558000000000000
57558000000000000 + 582000000000000 = 58140000000000000
58140000000000000 + 582000000000000 = 58722000000000000
</details>

After 71 new entries, new DKG is started.
`58722000000000000 - 58200000000000000 = 522000000000000` stays in the pool and
`17400000000000000` is returned back to the pool after the DKG. It means we have
`522000000000000 + 17400000000000000 = 17922000000000000` in the pool and we
need another 71 relay entries for a new group selection.

For actual gas price of 10Gwei, operator spends
`(30000000000 * 200000) + (10000000000 * 1740000) = 23400000000000000`
on triggering group selection and DKG result submission.

As a result, `58200000000000000 - 23400000000000000 = 34800000000000000` is
returned back to the service contract. For each new relay request,
`58200000000000000 * 1% = 582000000000000` is added to the
DKG fee pool of the service contract:

<details>
34800000000000000 + 582000000000000 = 35382000000000000

35382000000000000 + 582000000000000 = 35964000000000000
35964000000000000 + 582000000000000 = 36546000000000000
36546000000000000 + 582000000000000 = 37128000000000000
37128000000000000 + 582000000000000 = 37710000000000000
37710000000000000 + 582000000000000 = 38292000000000000
38292000000000000 + 582000000000000 = 38874000000000000
38874000000000000 + 582000000000000 = 39456000000000000
39456000000000000 + 582000000000000 = 40038000000000000
40038000000000000 + 582000000000000 = 40620000000000000
40620000000000000 + 582000000000000 = 41202000000000000
41202000000000000 + 582000000000000 = 41784000000000000
41784000000000000 + 582000000000000 = 42366000000000000
42366000000000000 + 582000000000000 = 42948000000000000
42948000000000000 + 582000000000000 = 43530000000000000
43530000000000000 + 582000000000000 = 44112000000000000
44112000000000000 + 582000000000000 = 44694000000000000
44694000000000000 + 582000000000000 = 45276000000000000
45276000000000000 + 582000000000000 = 45858000000000000
45858000000000000 + 582000000000000 = 46440000000000000
46440000000000000 + 582000000000000 = 47022000000000000
47022000000000000 + 582000000000000 = 47604000000000000
47604000000000000 + 582000000000000 = 48186000000000000
48186000000000000 + 582000000000000 = 48768000000000000
48768000000000000 + 582000000000000 = 49350000000000000
49350000000000000 + 582000000000000 = 49932000000000000
49932000000000000 + 582000000000000 = 50514000000000000
50514000000000000 + 582000000000000 = 51096000000000000
51096000000000000 + 582000000000000 = 51678000000000000
51678000000000000 + 582000000000000 = 52260000000000000
52260000000000000 + 582000000000000 = 52842000000000000
52842000000000000 + 582000000000000 = 53424000000000000
53424000000000000 + 582000000000000 = 54006000000000000
54006000000000000 + 582000000000000 = 54588000000000000
54588000000000000 + 582000000000000 = 55170000000000000
55170000000000000 + 582000000000000 = 55752000000000000
55752000000000000 + 582000000000000 = 56334000000000000
56334000000000000 + 582000000000000 = 56916000000000000
56916000000000000 + 582000000000000 = 57498000000000000
57498000000000000 + 582000000000000 = 58080000000000000
58080000000000000 + 582000000000000 = 58662000000000000
</details>

After 41 entries, new DKG is started.
`58662000000000000 - 58200000000000000 = 462000000000000` stays in the pool and
`34800000000000000` is returned back to the pool after the DKG. It means we have
`462000000000000 + 34800000000000000 = 35262000000000000` in the pool and we need 42 relay entries for a new group selection.

### Summary 

For 3% contribution margin and 30Gwei gas price ceiling, we need:
- 22 entries to generate a group with actual gas price of 20Gwei
- 12 entries to generate a group with actual gas price of 10Gwei

For 2% contribution margin and 30Gwei gas price ceiling, we need:
- 36 entries to generate a group with actual gas price of 20Gwei
- 21 entries to generate a group with actual gas price of 10Gwei

For 1% contribution margin and 30Gwei gas price ceiling, we need:
- 71 entries to generate a group with actual gas price of 20Gwei
- 42 entries to generate a group with actual gas price of 10Gwei

One ticket submission TX costs 140k gas on average. With today's ETH price,
each ticket submission costs:

With today's ETH price, each ticket submission costs:

- 0.0014 ETH = $0.30 assuming 10Gwei gas price,
- 0.0028 ETH = $0.60 assuming 20Gwei gas price.

For 3% contribution margin and 20Gwei gas price:
operator yields 22 * 1M Gwei = $4.6 from 22 entries and then has to invest $0.3 again

For 3% contribution margin and 10Gwei gas price:
operator yields 12 * 1M Gwei = $2.51 from 12 entries and then has to invest $0.3 again

For 2% contribution margin and 20Gwei gas price:
operator yields 36 * 1M Gwei = $7.53 from 36 entries and then has to invest $0.3 again

For 2% contribution margin and 10Gwei gas price:
operator yields 21 * 1M Gwei = $4.39 from 21 entries and then has to invest $0.3 again

For 1% contribution margin and 20Gwei gas price:
operator yields 71 * 1M Gwei = $14.84 from 71 entries and then has to invest $0.3 again

For 1% contribution margin and 10Gwei gas price:
operator yields 42 * 1M Gwei = $8.57 from 42 entries and then has to invest $0.3 again


Given that we expect the actual gas price to be closer to 10 than 20 Gwei, 1%
contribution margin with twice as much group lifetime as 2% seems to be a better
option. Also, we need to keep in mind that the withdrawal is done per group.
1% option provides better yield and requires two times fewer withdrawals than 2%
option.

