### PR TITLE
Group archival fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v0.3.1-rc
+	github.com/keep-network/keep-common v0.3.1-rc.0.20200504134912-892c8dae1c8c
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-libp2p v0.4.1
 	github.com/libp2p/go-libp2p-connmgr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v0.3.1-rc h1:5JHj/PLmafqdJNh+pI5F5rUKUHhAuo2YllPcWSoA/rc=
-github.com/keep-network/keep-common v0.3.1-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v0.3.1-rc.0.20200504134912-892c8dae1c8c h1:c82m3Rv5vrwoerlCajkGr5GSCWuU8bw/cBJV2TfZYOI=
+github.com/keep-network/keep-common v0.3.1-rc.0.20200504134912-892c8dae1c8c/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/beacon/relay/registry/groups_test.go
+++ b/pkg/beacon/relay/registry/groups_test.go
@@ -141,7 +141,7 @@ func TestUnregisterStaleGroups(t *testing.T) {
 		t.Fatalf("Group2 was expected to be unregistered, but is still present")
 	}
 	if len(persistenceMock.archivedGroups) != 1 ||
-		persistenceMock.archivedGroups[0] != hex.EncodeToString(signer2.GroupPublicKeyBytes()) {
+		persistenceMock.archivedGroups[0] != hex.EncodeToString(signer2.GroupPublicKeyBytesCompressed()) {
 		t.Fatalf("Group2 was expected to be archived")
 	}
 

--- a/pkg/beacon/relay/registry/storage.go
+++ b/pkg/beacon/relay/registry/storage.go
@@ -12,7 +12,7 @@ import (
 type storage interface {
 	save(membership *Membership) error
 	readAll() (<-chan *Membership, <-chan error)
-	archive(groupPublicKey string) error
+	archive(groupPublicKey []byte) error
 }
 
 type persistentStorage struct {
@@ -34,6 +34,10 @@ func (ps *persistentStorage) save(membership *Membership) error {
 	hexGroupPublicKey := hex.EncodeToString(membership.Signer.GroupPublicKeyBytesCompressed())
 
 	return ps.handle.Save(membershipBytes, hexGroupPublicKey, "/membership_"+fmt.Sprint(membership.Signer.MemberID()))
+}
+
+func (ps *persistentStorage) archive(groupPublicKeyCompressed []byte) error {
+	return ps.handle.Archive(hex.EncodeToString(groupPublicKeyCompressed))
 }
 
 func (ps *persistentStorage) readAll() (<-chan *Membership, <-chan error) {
@@ -106,8 +110,4 @@ func (ps *persistentStorage) readAll() (<-chan *Membership, <-chan error) {
 	}()
 
 	return outputMemberships, outputErrors
-}
-
-func (ps *persistentStorage) archive(groupName string) error {
-	return ps.handle.Archive(groupName)
 }


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-common/pull/34

When we save membership in the storage, we execute `GroupPublicKeyBytesCompressed()` on the membership passed as a parameter so that we can evaluate the name of the directory where we want to put the serialized membership.

Groups registry, on the other hand, holds group public key in an uncompressed form so that memberships can be quickly fetched from the registry when on-chain events occur.

When the group registry was asking the storage to archive group, it was passing uncompressed public key and the storage could not locate the directory to archive.

It is fixed here - storage expects compressed public key in archive function and group registry passes group public key in compressed form. 

I have also updated error handling in the `UnregsterStaleGroup` loop. We now explicitly skip the rest of the step execution in case of an error. The previous version worked just fine because `isStaleGroup` is `false` on error, but having the explicit `continue` instructions is cleaner and less error-prone.