### PR TITLE
Circle: Mr Clean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,13 @@ jobs:
             export CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY
             mkdir -p /tmp/keep-client/contracts
             solidity/scripts/circleci-migrate-contracts.sh
+      - run:
+          name: Clean Migration Directory
+          command:
+            export BUILD_TAG=$CIRCLE_SHA1
+            solidity/scripts/circleci-clean-migration-directory.sh
+          when: always
+
       - persist_to_workspace:
           root: /tmp/keep-client
           paths:

--- a/solidity/scripts/circleci-clean-migration-directory.sh
+++ b/solidity/scripts/circleci-clean-migration-directory.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+
+if [[ -z $GOOGLE_PROJECT_NAME || -z $GOOGLE_PROJECT_ID || -z $BUILD_TAG || -z $GOOGLE_REGION || -z $GOOGLE_COMPUTE_ZONE_A ]]; then
+  echo "one or more required variables are undefined"
+  exit 1
+fi
+
+UTILITYBOX_IP=$(gcloud compute instances --project $GOOGLE_PROJECT_ID describe $GOOGLE_PROJECT_NAME-utility-box --zone $GOOGLE_COMPUTE_ZONE_A --format json | jq .networkInterfaces[0].networkIP -r)
+
+# Setup ssh environment
+gcloud compute config-ssh --project $GOOGLE_PROJECT_ID -q
+cat >> ~/.ssh/config << EOF
+Host *
+  StrictHostKeyChecking no
+
+Host utilitybox
+  HostName $UTILITYBOX_IP
+  IdentityFile ~/.ssh/google_compute_engine
+  ProxyCommand ssh -W %h:%p $GOOGLE_PROJECT_NAME-jumphost.$GOOGLE_COMPUTE_ZONE_A.$GOOGLE_PROJECT_ID
+EOF
+
+ssh utilitybox rm -rf /tmp/$BUILD_TAG

--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -75,8 +75,3 @@ echo "<<<<<<START Contract Copy START<<<<<<"
 echo "scp utilitybox:/tmp/$BUILD_TAG/solidity/build/contracts/* /tmp/keep-client/contracts"
 scp utilitybox:/tmp/$BUILD_TAG/solidity/build/contracts/* /tmp/keep-client/contracts
 echo ">>>>>>FINISH Contract Copy>>>>>>"
-
-echo "<<<<<<START Migration Dir Cleanup START<<<<<<"
-echo "ssh utilitybox rm -rf /tmp/$BUILD_TAG"
-ssh utilitybox rm -rf /tmp/$BUILD_TAG
-echo ">>>>>>FINISH Migration Dir Cleanup FINISH>>>>>>"


### PR DESCRIPTION
### Intro 

When Circle migrations were implemented I did not account for the frequency of failed migrations _(this is a separate issue we're going to address, albeit a more complicated one than what we have here)_.  In the current state, if the `migrate_contracts` job fails the utilitybox cleanup that removes migration artifacts for a given build doesn't run.  After a number of failed builds _(somewhere around 10)_, the utilitybox disk fills up and migrations are hosed.

With keep-core, keep-ecdsa, and tbtc migrations all running agains the same utilitybox, failed migrations can stack up in short order.

We need a way to cleanup the migration dir whether the `migrate_contracts` job passes or fails.

### What We Did

- Move the `clean` step from `circleci-migrate-contracts.sh` to its own script.
  - NOTE: I thought about using a command line arg with current script to trigger a "clean only" or "regular" migration run.  It ended up looking weird because the "regular" path didn't include the clean step, since it's executed via separate Circle `run` step.  I figure it will just cause more confusion when someone else looks at what's going on here.  Instead we took a bit of duplication to keep what's happening obvious.

- Include new `run` step in the `migrate_contracts` job that has `when: always` set.  This will run the new clean script right after the migration step runs.

### Testing

 - [ ] Clean executes on migration pass
-  [ ] Clean executes on migraation fail