### PR TITLE
Message dissemination is disabled by default and can be configured

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -20,11 +20,22 @@
 	# relay subcommand).
 	KeepRandomBeaconService = "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
 
-# [LibP2P]
-# 	Peers = ["/ip4/127.0.0.1/tcp/3919/ipfs/njOXcNpVTweO3fmX72OTgDX9lfb1AYiiq4BN6Da1tFy9nT3sRT2h1"]
-# 	Port = 3920
-#   # Uncomment to override the node's default addresses announced in the network
-#   # AnnouncedAddresses = ["/dns4/example.com/tcp/3919", "/ip4/80.70.60.50/tcp/3919"]
+[LibP2P]
+ 	Peers = ["/ip4/127.0.0.1/tcp/3919/ipfs/njOXcNpVTweO3fmX72OTgDX9lfb1AYiiq4BN6Da1tFy9nT3sRT2h1"]
+ 	Port = 3920
+	#
+	# Uncomment to override the node's default addresses announced in the network
+	# AnnouncedAddresses = ["/dns4/example.com/tcp/3919", "/ip4/80.70.60.50/tcp/3919"]    
+	#
+	# Uncomment to enable courtesy message dissemination for topics this node is
+	# not subscribed to. Messages will be forwarded to peers for the duration
+	# specified as a value in seconds.
+	# Message dissemination is disabled by default and should be enabled only
+	# on selected bootstrap nodes. It is not a good idea to enable dissemination
+	# on non-bootstrap node as it may clutter communication and eventually lead
+	# to blacklisting the node.
+	#
+	# DisseminationTime = 90
 
 [Storage]
   DataDir = "/my/secure/location"

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -33,7 +33,7 @@
 	# Message dissemination is disabled by default and should be enabled only
 	# on selected bootstrap nodes. It is not a good idea to enable dissemination
 	# on non-bootstrap node as it may clutter communication and eventually lead
-	# to blacklisting the node.
+	# to blacklisting the node. The maximum allowed value is 90 seconds.
 	#
 	# DisseminationTime = 90
 

--- a/pkg/net/libp2p/channel_manager.go
+++ b/pkg/net/libp2p/channel_manager.go
@@ -158,7 +158,7 @@ func (cm *channelManager) shutdownForwarder(name string) {
 	cm.forwarderSubscriptionsMutex.Lock()
 	defer cm.forwarderSubscriptionsMutex.Unlock()
 
-	logger.Debugf("shutting down message forwarder for channel: [%v]", name)
+	logger.Infof("shutting down message forwarder for channel: [%v]", name)
 
 	forwarderSubscription, ok := cm.forwarderSubscriptions[name]
 

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -271,9 +271,9 @@ func Connect(
 	ticker *retransmission.Ticker,
 	options ...ConnectOption,
 ) (net.Provider, error) {
-	if config.DisseminationTime > MaximumDisseminationTime {
+	if config.DisseminationTime < 0 || config.DisseminationTime > MaximumDisseminationTime {
 		return nil, fmt.Errorf(
-			"maximum allowed message dissemination time is [%v]",
+			"dissemination time mut be in range [0, %v]",
 			MaximumDisseminationTime,
 		)
 	}


### PR DESCRIPTION
We introduced message dissemination to handle cases when nodes from the
same topic are not connected with each other and topic messages are not
relayed between them. It helped with message delivery but also caused
problems with throttled message validation on slow clients.

Message dissemination is enabled only for relay entries and given that:
- we have now 6 * 64 blocks to submit entry before the timeout,
- client tries to connect to all bootstrap nodes from the list,
- in most cases, dissemination is not needed and it's just a last-resort
option when something goes wrong with the network,

we should enable it only on selected bootstrap nodes. All clients tries
to connect to all bootstrap nodes so dissemination on bootstrap nodes
should be enough. Even more, since bootstrap nodes also try to form a
dense mesh with all other bootstrap nodes, it is fine to enable
forwarder on just some part of bootstrap nodes.

Here we disable forwarder (dissemination) by default and let to enable
it in the config allowing to parametrize the dissemination timeout. This
should help with fine-tuning the network for early days based on the
load and number of clients.