### PR TITLE
Docs: run-random-beacon Update

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -357,7 +357,7 @@ Once you've got your KEEP token grant you can manage it with our https://dashboa
 
 ==== Bootstrap Peers
 
-====
+[.small]
 ```
 "/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH",
 "/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY",
@@ -367,7 +367,6 @@ Once you've got your KEEP token grant you can manage it with our https://dashboa
 "/dns4/bootstrap-1.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAkuTUKNh6HkfvWBEkftZbqZHPHi3Kak5ZUygAxvsdQ2UgG",
 "/dns4/bootstrap-2.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAmQirGruZBvtbLHr5SDebsYGcq6Djw7ijF3gnkqsdQs3wK"
 ```
-====
 
 ==== Contracts
 

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -75,7 +75,8 @@ Application configurations are stored in a `.toml` file and passed to the applic
 
 ==== Sample
 
-```
+[source,toml]
+----
 # Ethereum host connection info.
 [ethereum]
   URL = "ws://127.0.0.1:8546"
@@ -107,7 +108,7 @@ Application configurations are stored in a `.toml` file and passed to the applic
 # Storage is encrypted
 [Storage]
   DataDir = "/my/secure/location"
-```
+----
 
 ==== Parameters
 
@@ -228,19 +229,21 @@ https://hub.docker.com/r/keepnetwork/keep-client/
 === Run Image
 This is a sample run command for illustration purposes only.
 
-```
+[source,bash]
+----
 export KEEP_CLIENT_ETHEREUM_PASSWORD=$(cat .secrets/eth-account-password.txt)
 export KEEP_CLIENT_CONFIG_DIR=$(pwd)/config
 export KEEP_CLIENT_PERSISTENCE_DIR=$(pwd)/persistence
 
-docker run -dit \
+docker run -d \
+--entrypoint /usr/local/bin/keep-client
 --volume $KEEP_CLIENT_PERSISTENCE_DIR:/mnt/keep-client/persistence \
 --volume $KEEP_CLIENT_CONFIG_DIR:/mnt/keep-client/config \
 --env KEEP_ETHEREUM_PASSWORD=$KEEP_CLIENT_ETHEREUM_PASSWORD \
 --env LOG_LEVEL=debug \
 -p 3919:3919 \
-keep-client --config /mnt/keep-client/config/keep-client-config.toml start
-```
+keepnetwork/keep-client:<version> --config /mnt/keep-client/config/keep-client-config.toml start
+----
 
 == Deployment Considerations
 
@@ -262,12 +265,13 @@ network:
 
 === Configurable Values
 
-```
+[source,bash]
+----
 LOG_LEVEL=DEBUG
 IPFS_LOGGING_FMT=nocolor
 GOLOG_FILE=/var/log/keep/keep.log
 GOLOG_TRACING_FILE=/var/log/keep/trace.json
-```
+----
 
 === Startup
 ```
@@ -344,9 +348,10 @@ To use the faucet you need to pass your Ethereum account to the faucet endpoint 
 `?account=<eth-account-address>`.
 
 Curl Example:
-```
+[source,bash]
+----
 curl 'https://us-central1-keep-test-f3e0.cloudfunctions.net/keep-faucet-ropsten?account=0x0eC14BC7cCA82c942Cf276F6BbD0413216dDB2bE'
-```
+----
 
 Browser Example:
 ```


### PR DESCRIPTION
A few housekeeping items here:

1. `docker run` command cleanup.  Here we set an entrypoint to explicitly override the `ENTRYPOINT` set in the `Dockerfile`.  Without it you will have two `--config` flags set on the running process running the command provided in this doc.  Somehow we've turned out ok here but it's caused some confusion with testers.  Also removed the `-it` arguments from the command as they're not strictly required unless you're overriding `ENTRYPOINT` with `bash` or `sh`.

2. Some syntax highlighting motivated by the comments in https://github.com/keep-network/keep-ecdsa/pull/396

3. Small text for bootstrap peers.  `docs.keep.network` renders the peers on multiple lines without this option set.