### PR TITLE
keep-prd: Full Token Dashboard Deploy

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: gcr.io/keep-prd-210b/keep-dapp-token-dashboard:v0.1.0
+        image: keepnetwork/token-dashboard:v1.0.0
         ports:
           - containerPort: 80


### PR DESCRIPTION
Here we update the Deployment to fetch token-dashboard version 1.0.0 from our public Dockerhub repo.

This went out as part of the Random Beacon deploy.