### PR TITLE
Circle: Disable keep-dev migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,27 +339,6 @@ workflows:
             branches:
               only: master
           context: keep-dev
-      - build_initcontainer:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
-            - build_client_and_test_go
-      - migrate_contracts:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-      - publish_npm_package:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
-            - build_client_and_test_go
       - publish_keep_client:
           filters:
             branches:
@@ -367,8 +346,6 @@ workflows:
           context: keep-dev
           requires:
             - build_client_and_test_go
-            - build_initcontainer
-            - migrate_contracts
       - trigger_downstream_builds:
           filters:
             branches:
@@ -376,22 +353,12 @@ workflows:
           context: keep-dev
           requires:
             - publish_npm_package
-      - publish_contract_data:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - build_client_and_test_go
-            - migrate_contracts
       # When building the token dashboard for a master merge, wait for npm
       # package publish
       - build_token_dashboard_dapp:
           filters:
             branches:
               only: master
-          requires:
-            - publish_npm_package
       - publish_token_dashboard_dapp:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,15 +346,6 @@ workflows:
           context: keep-dev
           requires:
             - build_client_and_test_go
-      - trigger_downstream_builds:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - publish_npm_package
-      # When building the token dashboard for a master merge, wait for npm
-      # package publish
       - build_token_dashboard_dapp:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,24 @@ jobs:
           name: Load Docker images
           command: |
             docker load -i /tmp/keep-client/docker-images/keep-client.tar
+      - gcp-gcr/gcr-auth:
+          google-project-id: GOOGLE_PROJECT_ID
+          google-compute-zone: GOOGLE_COMPUTE_ZONE_A
+          # This param doesn't actually set anything, leaving here as a reminder to check when they fix it.
+          gcloud-service-key: GCLOUD_SERVICE_KEY
+      - gcp-gcr/push-image:
+          google-project-id: GOOGLE_PROJECT_ID
+          registry-url: $GCR_REGISTRY_URL
+          image: keep-client
+          tag: latest
+  publish_initcontainer_provision_keep_client:
+    executor: gcp-gcr/default
+    steps:
+      - attach_workspace:
+          at: /tmp/keep-client
+      - run:
+          name: Load Docker images
+          command: |
             docker load -i /tmp/keep-client/docker-images/initcontainer-provision-keep-client.tar
       - gcp-gcr/gcr-auth:
           google-project-id: GOOGLE_PROJECT_ID
@@ -132,11 +150,6 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-client
-          tag: latest
-      - gcp-gcr/push-image:
-          google-project-id: GOOGLE_PROJECT_ID
-          registry-url: $GCR_REGISTRY_URL
-          image: keep-client
           tag: latest
   publish_contract_data:
     executor: gcp-cli/default
@@ -395,6 +408,17 @@ workflows:
             requires:
               - build_client_and_test_go
         - publish_keep_client:
+            context: keep-test
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                only: /releases\/.*/
+            requires:
+              - build_client_and_test_go
+              - build_initcontainer
+              - migrate_contracts
+        - publish_initcontainer_provision_keep_client:
             context: keep-test
             filters:
               tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ workflows:
           filters:
             branches:
               ignore: master
-  build-test-migrate-publish-keep-dev:
+  build-test-publish-keep-dev:
     jobs:
       - build_client_and_test_go:
           filters:


### PR DESCRIPTION
### Intro

We've hit a new phase of the system and as a result won't be iterating as frequently on contracts.  To save build time and some build failure frustration we need to work through I'm disabling `migrate_contracts` and associated jobs in the keep-dev workflow.

We'll be preserving client build / publish jobs.

### What We Did

All against the keep-dev workflow

- Separated the `keep-client` and `initcontainer-provision-keep-client` publish steps into separate jobs.  We need to be able to publish only the keep-client image for keep-dev as of this PR.  To accommodate that we split the publish step.
- Renamed the keep-dev workflow to remove `migrate`
- Removed `migrate_contracts`
- Removed `build_initcontainer`
- Removed `trigger_downstream_builds`
- Removed `publish_npm_package`
- Removed `publish_contract_data`
- Removed `requires` for `migrate_contracts` and `publish_npm_package`