### PR TITLE
Fix a list of accounts to select from a hardware wallet

### DIFF
--- a/solidity/dashboard/src/components/ChooseWallet.jsx
+++ b/solidity/dashboard/src/components/ChooseWallet.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import * as Icons from "./Icons"
 import { useWeb3Context } from "./WithWeb3Context"
 import { useModal } from "../hooks/useModal"
@@ -78,10 +78,16 @@ const Wallet = ({
   modalProps,
 }) => {
   const { ModalComponent, openModal, closeModal } = useModal()
-  const { connectAppWithWallet, accounts, setAccount } = useWeb3Context()
+  const { connectAppWithWallet, setAccount } = useWeb3Context()
+  const [accounts, setAccounts] = useState(null)
 
   const onSelectProvider = async (providerName) => {
-    await connectAppWithWallet(providerName)
+    const firstAccountAsSelected = providerName === "METAMASK"
+    const availableAccounts = await connectAppWithWallet(
+      providerName,
+      firstAccountAsSelected
+    )
+    setAccounts(availableAccounts)
   }
 
   const onSelectAccount = (account) => {
@@ -124,8 +130,7 @@ const Wallet = ({
           if (providerName === "LEDGER") {
             return
           }
-          const firstAccountAsSelected = providerName === "METAMASK"
-          await connectAppWithWallet(providerName, firstAccountAsSelected)
+          await onSelectProvider(providerName)
         }}
       >
         {icon}

--- a/solidity/dashboard/src/components/Web3ContextProvider.jsx
+++ b/solidity/dashboard/src/components/Web3ContextProvider.jsx
@@ -74,11 +74,11 @@ export default class Web3ContextProvider extends React.Component {
         web3,
         provider: providerName,
         yourAddress: firstAccountAsSelected ? accounts[0] : null,
-        accounts,
         networkType: await web3.eth.net.getNetworkType(),
       },
       this.setData
     )
+    return accounts
   }
 
   setData = async () => {


### PR DESCRIPTION
Refs: #1761

If the user selects the ledger wallet and closes modal and then selects the trezor wallet, it will see the accounts from a ledger wallet because they were stored in the web3 context state. This update fixes it and stores the available accounts in the component state.