### PR TITLE
v1.3.0-pre

### DIFF
--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc",
+    "@keep-network/keep-core": ">1.3.0-pre <1.3.0-rc",
     "bignumber.js": "9.0.0",
     "formik": "^2.1.3",
     "less": "^3.9.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.2.0-pre",
+  "version": "1.3.0-pre",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We've released [1.2.0-rc](https://github.com/keep-network/keep-core/pull/1765) so we need to increment the pre.

