### PR TITLE
Return the chanID as a number

### DIFF
--- a/solidity/dashboard/src/connectors/utils.js
+++ b/solidity/dashboard/src/connectors/utils.js
@@ -28,7 +28,7 @@ export const getChainId = () => {
     return 1337
   }
   // For KEEP internal testnet, ropsten and mainnet `chainId == networkId`
-  return getFirstNetworkIdFromArtifact()
+  return Number(getFirstNetworkIdFromArtifact())
 }
 
 export const getWsUrl = () => {


### PR DESCRIPTION
The hardware wallet providers require a `chainId` param as a number but the `getChainId` function returned this param as a string. This update addresses it and makes that a `getChainId` function returns a number.