### PR TITLE
TBTC-less bonding: Allow bonding before tBTC is out

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1607,24 +1607,6 @@
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
-    "@keep-network/tbtc": {
-      "version": "0.15.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-0.15.0-rc.0.tgz",
-      "integrity": "sha512-gpvccLpXW2HV9fDZSzvyG6B1+sCtiITrnySz3BUr8iSqazA+LfgofY0WY+bs562oBYidQePeJip1tLJ0AEqK4A==",
-      "requires": {
-        "@keep-network/keep-ecdsa": ">0.16.0-rc <0.16.0",
-        "@summa-tx/bitcoin-spv-sol": "^3.0.0",
-        "@summa-tx/relay-sol": "^2.0.1",
-        "openzeppelin-solidity": "2.3.0"
-      },
-      "dependencies": {
-        "openzeppelin-solidity": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-        }
-      }
-    },
     "@ledgerhq/devices": {
       "version": "4.78.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-4.78.0.tgz",
@@ -1889,33 +1871,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
       "integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ=="
-    },
-    "@summa-tx/bitcoin-spv-sol": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.0.0.tgz",
-      "integrity": "sha512-zyY0o1i5wGdaM8yK6JYlaUzNmZSdsGipXeEQpM7bNDW5d9/CzVOvbP1pOT97wOok2QYJG6f4oU8vf18OWzxkgQ=="
-    },
-    "@summa-tx/relay-sol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@summa-tx/relay-sol/-/relay-sol-2.0.1.tgz",
-      "integrity": "sha512-AmE9v6sRW/PwoJiZ2C2HVfrPVVOkf9HNuEOqo4ewfZzbJsKp4AFm/dZ6+IcXWBiY28gdhS70OFSvqb85KKWkNg==",
-      "requires": {
-        "@summa-tx/bitcoin-spv-sol": "^2.2.0",
-        "bn.js": "^5.1.1",
-        "dotenv": "^8.2.0"
-      },
-      "dependencies": {
-        "@summa-tx/bitcoin-spv-sol": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.2.0.tgz",
-          "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
-        },
-        "bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
-        }
-      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc",
     "@keep-network/keep-ecdsa": "0.16.0-rc.0",
-    "@keep-network/tbtc": "0.15.0-rc.0",
     "bignumber.js": "9.0.0",
     "formik": "^2.1.3",
     "less": "^3.9.0",

--- a/solidity/dashboard/src/components/AuthorizeContracts.jsx
+++ b/solidity/dashboard/src/components/AuthorizeContracts.jsx
@@ -60,7 +60,7 @@ const AuthorizeContracts = ({
         noDataMessage="No contracts to authorize."
       >
         <Column
-          header="opeartor address"
+          header="operator address"
           field="operatorAddress"
           renderContent={({ operatorAddress }) => (
             <AddressShortcut address={operatorAddress} />

--- a/solidity/dashboard/src/components/BondingSection.jsx
+++ b/solidity/dashboard/src/components/BondingSection.jsx
@@ -15,7 +15,7 @@ export const BondingSection = ({ data }) => {
     >
       <DataTable data={data} itemFieldId="operatorAddress">
         <Column
-          header="opeartor"
+          header="operator"
           field="operatorAddress"
           renderContent={({ operatorAddress }) => (
             <AddressShortcut address={operatorAddress} />

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -4,7 +4,6 @@ import TokenGrant from "@keep-network/keep-core/artifacts/TokenGrant.json"
 import KeepRandomBeaconOperator from "@keep-network/keep-core/artifacts/KeepRandomBeaconOperator.json"
 import BondedECDSAKeepFactory from "@keep-network/keep-ecdsa/artifacts/BondedECDSAKeepFactory.json"
 import KeepBonding from "@keep-network/keep-ecdsa/artifacts/KeepBonding.json"
-import TBTCSystem from "@keep-network/tbtc/artifacts/TBTCSystem.json"
 import KeepRegistry from "@keep-network/keep-core/artifacts/KeepRegistry.json"
 import GuaranteedMinimumStakingPolicy from "@keep-network/keep-core/artifacts/GuaranteedMinimumStakingPolicy.json"
 import PermissiveStakingPolicy from "@keep-network/keep-core/artifacts/PermissiveStakingPolicy.json"
@@ -160,8 +159,4 @@ export function getKeepRandomBeaconOperatorAddress() {
 
 export function getBondedECDSAKeepFactoryAddress() {
   return getContractAddress(BondedECDSAKeepFactory)
-}
-
-export function getTBTCSystemAddress() {
-  return getContractAddress(TBTCSystem)
 }

--- a/solidity/dashboard/src/services/tbtc-authorization.service.js
+++ b/solidity/dashboard/src/services/tbtc-authorization.service.js
@@ -346,7 +346,16 @@ const fetchOperatorsOf = async (web3Context, yourAddress) => {
   }
 
   if (ownerOperators.length === 0) {
-    ownerOperators[0] = yourAddress
+    const ownerAddress = await contractService.makeCall(
+      web3Context,
+      TOKEN_STAKING_CONTRACT_NAME,
+      "ownerOf",
+      yourAddress
+    )
+
+    if (ownerAddress !== "0x0000000000000000000000000000000000000000") {
+      ownerOperators[0] = yourAddress
+    }
   }
 
   return ownerOperators

--- a/solidity/dashboard/src/services/tbtc-authorization.service.js
+++ b/solidity/dashboard/src/services/tbtc-authorization.service.js
@@ -1,5 +1,5 @@
 import { contractService } from "./contracts.service"
-import { TOKEN_STAKING_CONTRACT_NAME } from "../constants/constants"
+import { TOKEN_STAKING_CONTRACT_NAME, TOKEN_GRANT_CONTRACT_NAME } from "../constants/constants"
 import {
   BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
   KEEP_BONDING_CONTRACT_NAME,
@@ -330,6 +330,13 @@ const fetchOperatorsOf = async (web3Context, yourAddress) => {
     "operatorsOf",
     yourAddress
   )
+
+  ownerOperators.push(...await contractService.makeCall(
+    web3Context,
+    TOKEN_GRANT_CONTRACT_NAME,
+    "getGranteeOperators",
+    yourAddress,
+  ))
 
   const managedGrantAddresses = await fetchManagedGrantAddresses(
     web3Context,

--- a/solidity/dashboard/src/services/tbtc-authorization.service.js
+++ b/solidity/dashboard/src/services/tbtc-authorization.service.js
@@ -8,11 +8,11 @@ import { isSameEthAddress } from "../utils/general.utils"
 import {
   CONTRACT_DEPLOY_BLOCK_NUMBER,
   getBondedECDSAKeepFactoryAddress,
-  getTBTCSystemAddress,
+  // getTBTCSystemAddress,
 } from "../contracts"
 import web3Utils from "web3-utils"
 
-const tBTCSystemAddress = getTBTCSystemAddress()
+// const tBTCSystemAddress = getTBTCSystemAddress()
 const bondedECDSAKeepFactoryAddress = getBondedECDSAKeepFactoryAddress()
 
 const fetchTBTCAuthorizationData = async (web3Context) => {
@@ -52,10 +52,10 @@ const fetchTBTCAuthorizationData = async (web3Context) => {
         bondedECDSAKeepFactoryAddress
       )
 
-      const isTBTCSystemAuthorized = await isTbtcSystemAuthorized(
-        web3Context,
-        operatorAddress
-      )
+      // const isTBTCSystemAuthorized = await isTbtcSystemAuthorized(
+      //   web3Context,
+      //   operatorAddress
+      // )
 
       const authorizerOperator = {
         operatorAddress: operatorAddress,
@@ -66,11 +66,11 @@ const fetchTBTCAuthorizationData = async (web3Context) => {
             operatorContractAddress: bondedECDSAKeepFactoryAddress,
             isAuthorized: isBondedECDSAKeepFactoryAuthorized,
           },
-          {
-            contractName: "TBTCSystem",
-            operatorContractAddress: tBTCSystemAddress,
-            isAuthorized: isTBTCSystemAuthorized,
-          },
+          // {
+          //   contractName: "TBTCSystem",
+          //   operatorContractAddress: tBTCSystemAddress,
+          //   isAuthorized: isTBTCSystemAuthorized,
+          // },
         ],
       }
 
@@ -83,11 +83,13 @@ const fetchTBTCAuthorizationData = async (web3Context) => {
 
 const isTbtcSystemAuthorized = async (web3Context, operatorAddress) => {
   try {
+    throw "nope"
+
     const sortitionPoolAddress = await contractService.makeCall(
       web3Context,
       BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
       "getSortitionPool",
-      tBTCSystemAddress
+      // tBTCSystemAddress
     )
 
     return await contractService.makeCall(
@@ -127,10 +129,10 @@ const authorizeTBTCSystem = async (
   try {
     const sortitionPoolAddress = await fetchSortitionPoolForTbtc(web3Context)
 
-    await keepBondingContract.methods
-      .authorizeSortitionPoolContract(operatorAddress, sortitionPoolAddress)
-      .send({ from: yourAddress })
-      .on("transactionHash", onTransactionHashCallback)
+    // await keepBondingContract.methods
+    //   .authorizeSortitionPoolContract(operatorAddress, sortitionPoolAddress)
+    //   .send({ from: yourAddress })
+    //   .on("transactionHash", onTransactionHashCallback)
   } catch (error) {
     throw error
   }
@@ -215,7 +217,7 @@ const getBondingData = async (web3Context) => {
         web3Context,
         operators[i],
         bondedECDSAKeepFactoryAddress,
-        sortitionPoolAddress
+        sortitionPoolAddress,
       )
 
       const bondedEth = operatorBondingDataMap.get(
@@ -252,12 +254,13 @@ const fetchStakedEvents = async (web3Context) => {
 }
 
 const fetchSortitionPoolForTbtc = async (web3Context) => {
-  return contractService.makeCall(
-    web3Context,
-    BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
-    "getSortitionPool",
-    tBTCSystemAddress
-  )
+  return "0x0000000000000000000000000000000000000000"
+  // return contractService.makeCall(
+  //   web3Context,
+  //   BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
+  //   "getSortitionPool",
+  //   tBTCSystemAddress
+  // )
 }
 
 const fetchDelegationInfo = async (web3Context, operatorAddress) => {
@@ -341,15 +344,15 @@ const fetchAvailableAmount = async (
   web3Context,
   operator,
   bondedECDSAKeepFactoryAddress,
-  authorizedSortitionPool
+  authorizedSortitionPool,
 ) => {
   return contractService.makeCall(
     web3Context,
     KEEP_BONDING_CONTRACT_NAME,
-    "availableUnbondedValue",
+    "unbondedValue", // "availableUnbondedValue",
     operator,
-    bondedECDSAKeepFactoryAddress,
-    authorizedSortitionPool
+    // bondedECDSAKeepFactoryAddress,
+    // authorizedSortitionPool
   )
 }
 


### PR DESCRIPTION
This PR comments out a few of the bits and pieces around bond funding to allow it to be deployable despite tBTC contracts not yet being deployed. This will allow bootstrapping of available bonds and keep-ecdsa nodes so that once tBTC goes live, operators will already be available to back deposits.

Additionally, this fixes a few small bugs:
- Non-operators don't see the option to set available bond on their own address.
- Owners with grants properly see their operators in the bonding list.