### PR TITLE
Roll forward to v1.0.2

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.0.0
+        image: keepnetwork/token-dashboard:v1.0.2
         ports:
           - containerPort: 80


### PR DESCRIPTION
Patch release of the token-dashboard that includes ETH bonding and `BondedECDSAKeepFactory` Authorization for keep-ecdsa operators.