### PR TITLE
Pass protocol identifier during the handshake

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -83,6 +83,7 @@ func pingRequest(c *cli.Context) error {
 		ctx,
 		libp2pConfig,
 		privKey,
+		libp2p.ProtocolBeacon,
 		firewall.Disabled,
 		retransmission.NewTimeTicker(ctx, 50*time.Millisecond),
 	)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -120,6 +120,7 @@ func Start(c *cli.Context) error {
 		ctx,
 		config.LibP2P,
 		networkPrivateKey,
+		libp2p.ProtocolBeacon,
 		firewall.MinimumStakePolicy(stakeMonitor),
 		retransmission.NewTicker(blockCounter.WatchBlocks(ctx)),
 	)

--- a/pkg/net/gen/pb/handshake.pb.go
+++ b/pkg/net/gen/pb/handshake.pb.go
@@ -6,12 +6,13 @@ package pb
 import (
 	bytes "bytes"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -90,14 +91,16 @@ func (m *HandshakeEnvelope) GetPeerID() []byte {
 	return nil
 }
 
-// act1Message is sent in the first handshake act by the initiator to the
+// Act1Message is sent in the first handshake act by the initiator to the
 // responder. It contains randomly generated `nonce1`, an 8-byte (64-bit)
-// unsigned integer.
+// unsigned integer, and the protocol identifier.
 //
-// act1Message should be signed with initiator's static private key.
+// Act1Message should be signed with initiator's static private key.
 type Act1Message struct {
 	// nonce by initiator; 8-byte (64-bit) nonce as bytes
 	Nonce []byte `protobuf:"bytes,1,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// the identifier of the protocol the initiator is executing
+	Protocol string `protobuf:"bytes,2,opt,name=protocol,proto3" json:"protocol,omitempty"`
 }
 
 func (m *Act1Message) Reset()      { *m = Act1Message{} }
@@ -139,17 +142,26 @@ func (m *Act1Message) GetNonce() []byte {
 	return nil
 }
 
-// act2Message is sent in the second handshake act by the responder to the
+func (m *Act1Message) GetProtocol() string {
+	if m != nil {
+		return m.Protocol
+	}
+	return ""
+}
+
+// Act2Message is sent in the second handshake act by the responder to the
 // initiator. It contains randomly generated `nonce2`, an 8-byte unsigned
 // integer and `challenge` which is a result of SHA256 on the concatenated
-// bytes of `nonce1` and `nonce2`.
+// bytes of `nonce1` and `nonce2`, and the protocol identifier.
 //
-// act2Message should be signed with responder's static private key.
+// Act2Message should be signed with responder's static private key.
 type Act2Message struct {
 	// nonce from responder; 8-byte (64-bit) nonce as bytes
 	Nonce []byte `protobuf:"bytes,1,opt,name=nonce,proto3" json:"nonce,omitempty"`
 	// bytes of sha256(nonce1||nonce2)
 	Challenge []byte `protobuf:"bytes,2,opt,name=challenge,proto3" json:"challenge,omitempty"`
+	// the identifier of the protocol the responder is executing
+	Protocol string `protobuf:"bytes,3,opt,name=protocol,proto3" json:"protocol,omitempty"`
 }
 
 func (m *Act2Message) Reset()      { *m = Act2Message{} }
@@ -198,11 +210,18 @@ func (m *Act2Message) GetChallenge() []byte {
 	return nil
 }
 
-// act1Message is sent in the first handshake act by the initiator to the
+func (m *Act2Message) GetProtocol() string {
+	if m != nil {
+		return m.Protocol
+	}
+	return ""
+}
+
+// Act1Message is sent in the first handshake act by the initiator to the
 // responder. It contains randomly generated `nonce1`, an 8-byte (64-bit)
 // unsigned integer.
 //
-// act1Message should be signed with initiator's static private key.
+// Act1Message should be signed with initiator's static private key.
 type Act3Message struct {
 	// bytes of sha256(nonce1||nonce2)
 	Challenge []byte `protobuf:"bytes,1,opt,name=challenge,proto3" json:"challenge,omitempty"`
@@ -257,23 +276,24 @@ func init() {
 func init() { proto.RegisterFile("pb/handshake.proto", fileDescriptor_73dffe19bde0f856) }
 
 var fileDescriptor_73dffe19bde0f856 = []byte{
-	// 241 bytes of a gzipped FileDescriptorProto
+	// 262 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x2a, 0x48, 0xd2, 0xcf,
 	0x48, 0xcc, 0x4b, 0x29, 0xce, 0x48, 0xcc, 0x4e, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62,
 	0xce, 0x4b, 0x2d, 0x51, 0x4a, 0xe6, 0x12, 0xf4, 0x80, 0x89, 0xbb, 0xe6, 0x95, 0xa5, 0xe6, 0xe4,
 	0x17, 0xa4, 0x0a, 0x49, 0x70, 0xb1, 0xe7, 0xa6, 0x16, 0x17, 0x27, 0xa6, 0xa7, 0x4a, 0x30, 0x2a,
 	0x30, 0x6a, 0xf0, 0x04, 0xc1, 0xb8, 0x42, 0x32, 0x5c, 0x9c, 0xc5, 0x99, 0xe9, 0x79, 0x89, 0x25,
 	0xa5, 0x45, 0xa9, 0x12, 0x4c, 0x60, 0x39, 0x84, 0x80, 0x90, 0x18, 0x17, 0x5b, 0x41, 0x6a, 0x6a,
-	0x91, 0xa7, 0x8b, 0x04, 0x33, 0x58, 0x0a, 0xca, 0x53, 0x52, 0xe6, 0xe2, 0x76, 0x4c, 0x2e, 0x31,
-	0xf4, 0x85, 0x1a, 0x22, 0xc2, 0xc5, 0x9a, 0x97, 0x9f, 0x97, 0x0c, 0x33, 0x1c, 0xc2, 0x51, 0x72,
-	0x04, 0x2b, 0x32, 0xc2, 0xab, 0x08, 0x64, 0x7f, 0x72, 0x46, 0x62, 0x4e, 0x4e, 0x6a, 0x5e, 0x3a,
-	0xdc, 0x7e, 0xb8, 0x80, 0x92, 0x36, 0xd8, 0x08, 0x63, 0x5f, 0x84, 0x63, 0x11, 0x8a, 0x19, 0xd1,
-	0x14, 0x3b, 0x59, 0x5c, 0x78, 0x28, 0xc7, 0x70, 0xe3, 0xa1, 0x1c, 0xc3, 0x87, 0x87, 0x72, 0x8c,
-	0x0d, 0x8f, 0xe4, 0x18, 0x57, 0x3c, 0x92, 0x63, 0x3c, 0xf1, 0x48, 0x8e, 0xf1, 0xc2, 0x23, 0x39,
-	0xc6, 0x07, 0x8f, 0xe4, 0x18, 0x5f, 0x3c, 0x92, 0x63, 0xf8, 0xf0, 0x48, 0x8e, 0x71, 0xc2, 0x63,
-	0x39, 0x86, 0x0b, 0x8f, 0xe5, 0x18, 0x6e, 0x3c, 0x96, 0x63, 0x88, 0x62, 0x2a, 0x48, 0x4a, 0x62,
-	0x03, 0x87, 0x9f, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x37, 0x4c, 0x1a, 0x5a, 0x55, 0x01, 0x00,
-	0x00,
+	0x91, 0xa7, 0x8b, 0x04, 0x33, 0x58, 0x0a, 0xca, 0x53, 0xb2, 0xe7, 0xe2, 0x76, 0x4c, 0x2e, 0x31,
+	0xf4, 0x85, 0x1a, 0x22, 0xc2, 0xc5, 0x9a, 0x97, 0x9f, 0x97, 0x0c, 0x33, 0x1c, 0xc2, 0x11, 0x92,
+	0xe2, 0xe2, 0x00, 0xbb, 0x2b, 0x39, 0x3f, 0x07, 0x6c, 0x32, 0x67, 0x10, 0x9c, 0xaf, 0x14, 0x0b,
+	0x36, 0xc0, 0x08, 0xbf, 0x01, 0x32, 0x5c, 0x9c, 0xc9, 0x19, 0x89, 0x39, 0x39, 0xa9, 0x79, 0xe9,
+	0x70, 0xb7, 0xc1, 0x05, 0x50, 0x8c, 0x67, 0x46, 0x33, 0x5e, 0x1b, 0x6c, 0xbc, 0xb1, 0x2f, 0xc2,
+	0x93, 0x08, 0x83, 0x18, 0xd1, 0x0c, 0x72, 0xb2, 0xb8, 0xf0, 0x50, 0x8e, 0xe1, 0xc6, 0x43, 0x39,
+	0x86, 0x0f, 0x0f, 0xe5, 0x18, 0x1b, 0x1e, 0xc9, 0x31, 0xae, 0x78, 0x24, 0xc7, 0x78, 0xe2, 0x91,
+	0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0xbe, 0x78, 0x24, 0xc7, 0xf0, 0xe1,
+	0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10,
+	0xc5, 0x54, 0x90, 0x94, 0xc4, 0x06, 0xb6, 0xd0, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0xa1, 0x59,
+	0x1f, 0x3f, 0x8d, 0x01, 0x00, 0x00,
 }
 
 func (this *HandshakeEnvelope) Equal(that interface{}) bool {
@@ -328,6 +348,9 @@ func (this *Act1Message) Equal(that interface{}) bool {
 	if !bytes.Equal(this.Nonce, that1.Nonce) {
 		return false
 	}
+	if this.Protocol != that1.Protocol {
+		return false
+	}
 	return true
 }
 func (this *Act2Message) Equal(that interface{}) bool {
@@ -353,6 +376,9 @@ func (this *Act2Message) Equal(that interface{}) bool {
 		return false
 	}
 	if !bytes.Equal(this.Challenge, that1.Challenge) {
+		return false
+	}
+	if this.Protocol != that1.Protocol {
 		return false
 	}
 	return true
@@ -397,9 +423,10 @@ func (this *Act1Message) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 5)
+	s := make([]string, 0, 6)
 	s = append(s, "&pb.Act1Message{")
 	s = append(s, "Nonce: "+fmt.Sprintf("%#v", this.Nonce)+",\n")
+	s = append(s, "Protocol: "+fmt.Sprintf("%#v", this.Protocol)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -407,10 +434,11 @@ func (this *Act2Message) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 6)
+	s := make([]string, 0, 7)
 	s = append(s, "&pb.Act2Message{")
 	s = append(s, "Nonce: "+fmt.Sprintf("%#v", this.Nonce)+",\n")
 	s = append(s, "Challenge: "+fmt.Sprintf("%#v", this.Challenge)+",\n")
+	s = append(s, "Protocol: "+fmt.Sprintf("%#v", this.Protocol)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -496,6 +524,13 @@ func (m *Act1Message) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Protocol) > 0 {
+		i -= len(m.Protocol)
+		copy(dAtA[i:], m.Protocol)
+		i = encodeVarintHandshake(dAtA, i, uint64(len(m.Protocol)))
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.Nonce) > 0 {
 		i -= len(m.Nonce)
 		copy(dAtA[i:], m.Nonce)
@@ -526,6 +561,13 @@ func (m *Act2Message) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Protocol) > 0 {
+		i -= len(m.Protocol)
+		copy(dAtA[i:], m.Protocol)
+		i = encodeVarintHandshake(dAtA, i, uint64(len(m.Protocol)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.Challenge) > 0 {
 		i -= len(m.Challenge)
 		copy(dAtA[i:], m.Challenge)
@@ -615,6 +657,10 @@ func (m *Act1Message) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovHandshake(uint64(l))
 	}
+	l = len(m.Protocol)
+	if l > 0 {
+		n += 1 + l + sovHandshake(uint64(l))
+	}
 	return n
 }
 
@@ -629,6 +675,10 @@ func (m *Act2Message) Size() (n int) {
 		n += 1 + l + sovHandshake(uint64(l))
 	}
 	l = len(m.Challenge)
+	if l > 0 {
+		n += 1 + l + sovHandshake(uint64(l))
+	}
+	l = len(m.Protocol)
 	if l > 0 {
 		n += 1 + l + sovHandshake(uint64(l))
 	}
@@ -672,6 +722,7 @@ func (this *Act1Message) String() string {
 	}
 	s := strings.Join([]string{`&Act1Message{`,
 		`Nonce:` + fmt.Sprintf("%v", this.Nonce) + `,`,
+		`Protocol:` + fmt.Sprintf("%v", this.Protocol) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -683,6 +734,7 @@ func (this *Act2Message) String() string {
 	s := strings.Join([]string{`&Act2Message{`,
 		`Nonce:` + fmt.Sprintf("%v", this.Nonce) + `,`,
 		`Challenge:` + fmt.Sprintf("%v", this.Challenge) + `,`,
+		`Protocol:` + fmt.Sprintf("%v", this.Protocol) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -923,6 +975,38 @@ func (m *Act1Message) Unmarshal(dAtA []byte) error {
 				m.Nonce = []byte{}
 			}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Protocol", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowHandshake
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthHandshake
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthHandshake
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Protocol = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipHandshake(dAtA[iNdEx:])
@@ -1043,6 +1127,38 @@ func (m *Act2Message) Unmarshal(dAtA []byte) error {
 			if m.Challenge == nil {
 				m.Challenge = []byte{}
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Protocol", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowHandshake
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthHandshake
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthHandshake
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Protocol = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/net/gen/pb/handshake.proto
+++ b/pkg/net/gen/pb/handshake.proto
@@ -17,35 +17,41 @@ message HandshakeEnvelope {
   bytes peerID = 3;
 }
 
-// act1Message is sent in the first handshake act by the initiator to the
+// Act1Message is sent in the first handshake act by the initiator to the
 // responder. It contains randomly generated `nonce1`, an 8-byte (64-bit)
-// unsigned integer.
+// unsigned integer, and the protocol identifier.
 //
-// act1Message should be signed with initiator's static private key.
+// Act1Message should be signed with initiator's static private key.
 message Act1Message {
   // nonce by initiator; 8-byte (64-bit) nonce as bytes
   bytes nonce = 1;
+
+  // the identifier of the protocol the initiator is executing
+  string protocol = 2;
 }
 
-// act2Message is sent in the second handshake act by the responder to the
+// Act2Message is sent in the second handshake act by the responder to the
 // initiator. It contains randomly generated `nonce2`, an 8-byte unsigned
 // integer and `challenge` which is a result of SHA256 on the concatenated
-// bytes of `nonce1` and `nonce2`.
+// bytes of `nonce1` and `nonce2`, and the protocol identifier.
 //
-// act2Message should be signed with responder's static private key.
+// Act2Message should be signed with responder's static private key.
 message Act2Message {
   // nonce from responder; 8-byte (64-bit) nonce as bytes
   bytes nonce = 1;
 
   // bytes of sha256(nonce1||nonce2)
   bytes challenge = 2;
+
+  // the identifier of the protocol the responder is executing
+  string protocol = 3;
 }
 
-// act1Message is sent in the first handshake act by the initiator to the
+// Act1Message is sent in the first handshake act by the initiator to the
 // responder. It contains randomly generated `nonce1`, an 8-byte (64-bit)
 // unsigned integer.
 //
-// act1Message should be signed with initiator's static private key.
+// Act1Message should be signed with initiator's static private key.
 message Act3Message {
   // bytes of sha256(nonce1||nonce2)
   bytes challenge = 1;

--- a/pkg/net/libp2p/authenticated_connection.go
+++ b/pkg/net/libp2p/authenticated_connection.go
@@ -31,6 +31,8 @@ type authenticatedConnection struct {
 	remotePeerPublicKey libp2pcrypto.PubKey
 
 	firewall keepNet.Firewall
+
+	protocol string
 }
 
 // newAuthenticatedInboundConnection is the connection that's formed by
@@ -44,12 +46,14 @@ func newAuthenticatedInboundConnection(
 	localPeerID peer.ID,
 	privateKey libp2pcrypto.PrivKey,
 	firewall keepNet.Firewall,
+	protocol string,
 ) (*authenticatedConnection, error) {
 	ac := &authenticatedConnection{
 		Conn:                unauthenticatedConn,
 		localPeerID:         localPeerID,
 		localPeerPrivateKey: privateKey,
 		firewall:            firewall,
+		protocol:            protocol,
 	}
 
 	if err := ac.runHandshakeAsResponder(); err != nil {
@@ -78,6 +82,7 @@ func newAuthenticatedOutboundConnection(
 	privateKey libp2pcrypto.PrivKey,
 	remotePeerID peer.ID,
 	firewall keepNet.Firewall,
+	protocol string,
 ) (*authenticatedConnection, error) {
 	remotePublicKey, err := remotePeerID.ExtractPublicKey()
 	if err != nil {
@@ -94,6 +99,7 @@ func newAuthenticatedOutboundConnection(
 		remotePeerID:        remotePeerID,
 		remotePeerPublicKey: remotePublicKey,
 		firewall:            firewall,
+		protocol:            protocol,
 	}
 
 	if err := ac.runHandshakeAsInitiator(); err != nil {
@@ -128,7 +134,7 @@ func (ac *authenticatedConnection) runHandshakeAsInitiator() error {
 	// Act 1
 	//
 
-	initiatorAct1, err := handshake.InitiateHandshake()
+	initiatorAct1, err := handshake.InitiateHandshake(ac.protocol)
 	if err != nil {
 		return err
 	}
@@ -269,7 +275,7 @@ func (ac *authenticatedConnection) runHandshakeAsResponder() error {
 		return err
 	}
 
-	responderAct2, err := handshake.AnswerHandshake(act1Message)
+	responderAct2, err := handshake.AnswerHandshake(act1Message, ac.protocol)
 	if err != nil {
 		return err
 	}
@@ -306,7 +312,8 @@ func (ac *authenticatedConnection) runHandshakeAsResponder() error {
 
 // responderReceiveAct1 unmarshals a pb.HandshakeEnvelope from an initiator,
 // verifies that the signed messages matches the expected peer.ID, and returns
-// the handshake.Act1Message for processing by the responder.
+// the handshake.Act1Message for processing by the responder. It also makes
+// sure that the initiator is running the same protocol as the responder.
 func (ac *authenticatedConnection) responderReceiveAct1(
 	responderConnectionReader protoio.ReadCloser,
 ) (*handshake.Act1Message, error) {

--- a/pkg/net/libp2p/authenticated_connection.go
+++ b/pkg/net/libp2p/authenticated_connection.go
@@ -312,8 +312,7 @@ func (ac *authenticatedConnection) runHandshakeAsResponder() error {
 
 // responderReceiveAct1 unmarshals a pb.HandshakeEnvelope from an initiator,
 // verifies that the signed messages matches the expected peer.ID, and returns
-// the handshake.Act1Message for processing by the responder. It also makes
-// sure that the initiator is running the same protocol as the responder.
+// the handshake.Act1Message for processing by the responder.
 func (ac *authenticatedConnection) responderReceiveAct1(
 	responderConnectionReader protoio.ReadCloser,
 ) (*handshake.Act1Message, error) {

--- a/pkg/net/libp2p/authenticated_connection_test.go
+++ b/pkg/net/libp2p/authenticated_connection_test.go
@@ -53,6 +53,7 @@ func TestPinnedAndMessageKeyMismatch(t *testing.T) {
 		responder.peerID,
 		responder.privKey,
 		firewall,
+		ProtocolBeacon,
 	)
 	if err == nil {
 		t.Fatal("should not have successfully completed handshake")
@@ -67,7 +68,7 @@ func maliciousInitiatorHijacksHonestRun(t *testing.T, ac *authenticatedConnectio
 	initiatorConnectionReader := protoio.NewDelimitedReader(ac.Conn, maxFrameSize)
 	initiatorConnectionWriter := protoio.NewDelimitedWriter(ac.Conn)
 
-	initiatorAct1, err := handshake.InitiateHandshake()
+	initiatorAct1, err := handshake.InitiateHandshake(ProtocolBeacon)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,6 +238,7 @@ func connectInitiatorAndResponder(
 			initiatorPrivKey,
 			responderPeerID,
 			firewall,
+			ProtocolBeacon,
 		)
 		done <- struct{}{}
 	}(initiatorConn, initiator.peerID, initiator.privKey, responder.peerID)
@@ -246,6 +248,7 @@ func connectInitiatorAndResponder(
 		responder.peerID,
 		responder.privKey,
 		firewall,
+		ProtocolBeacon,
 	)
 
 	<-done // handshake is done

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -58,6 +58,12 @@ const (
 	ConnectedPeersCheckTick = time.Minute * 1
 )
 
+// Keep Network protocol identifiers
+const (
+	ProtocolBeacon = "keep-beacon"
+	ProtocolECDSA  = "keep-ecdsa"
+)
+
 // MaximumDisseminationTime is the maximum dissemination time of messages in
 // topics we are not subscribed to. By default courteous dissemination is
 // disabled and it should be enabled only on selected fast bootstrap nodes.
@@ -267,6 +273,7 @@ func Connect(
 	ctx context.Context,
 	config Config,
 	staticKey *key.NetworkPrivate,
+	protocol string,
 	firewall net.Firewall,
 	ticker *retransmission.Ticker,
 	options ...ConnectOption,
@@ -290,6 +297,7 @@ func Connect(
 		ctx,
 		identity,
 		config.Port,
+		protocol,
 		config.AnnouncedAddresses,
 		firewall,
 	)
@@ -353,6 +361,7 @@ func discoverAndListen(
 	ctx context.Context,
 	identity *identity,
 	port int,
+	protocol string,
 	announcedAddresses []string,
 	firewall net.Firewall,
 ) (host.Host, error) {
@@ -366,6 +375,7 @@ func discoverAndListen(
 
 	transport, err := newEncryptedAuthenticatedTransport(
 		identity.privKey,
+		protocol,
 		firewall,
 	)
 	if err != nil {

--- a/pkg/net/libp2p/libp2p_test.go
+++ b/pkg/net/libp2p/libp2p_test.go
@@ -28,6 +28,7 @@ func TestProviderReturnsType(t *testing.T) {
 		ctx,
 		generateDeterministicNetworkConfig(),
 		privKey,
+		ProtocolBeacon,
 		firewall.Disabled,
 		idleTicker(),
 	)
@@ -58,6 +59,7 @@ func TestProviderReturnsChannel(t *testing.T) {
 		ctx,
 		generateDeterministicNetworkConfig(),
 		privKey,
+		ProtocolBeacon,
 		firewall.Disabled,
 		idleTicker(),
 	)
@@ -97,6 +99,7 @@ func TestSendReceive(t *testing.T) {
 		ctx,
 		config,
 		privKey,
+		ProtocolBeacon,
 		firewall.Disabled,
 		idleTicker(),
 	)
@@ -172,6 +175,7 @@ func TestProviderSetAnnouncedAddresses(t *testing.T) {
 		ctx,
 		config,
 		privateKey,
+		ProtocolBeacon,
 		firewall.Disabled,
 		idleTicker(),
 	)

--- a/pkg/net/libp2p/transport.go
+++ b/pkg/net/libp2p/transport.go
@@ -24,12 +24,14 @@ var _ sec.SecureConn = (*authenticatedConnection)(nil)
 type transport struct {
 	localPeerID     peer.ID
 	privateKey      libp2pcrypto.PrivKey
+	protocol        string
 	firewall        keepNet.Firewall
 	encryptionLayer sec.SecureTransport
 }
 
 func newEncryptedAuthenticatedTransport(
 	pk libp2pcrypto.PrivKey,
+	protocol string,
 	firewall keepNet.Firewall,
 ) (*transport, error) {
 	id, err := peer.IDFromPrivateKey(pk)
@@ -47,6 +49,7 @@ func newEncryptedAuthenticatedTransport(
 		privateKey:      pk,
 		firewall:        firewall,
 		encryptionLayer: encryptionLayer,
+		protocol:        protocol,
 	}, nil
 }
 
@@ -65,6 +68,7 @@ func (t *transport) SecureInbound(
 		t.localPeerID,
 		t.privateKey,
 		t.firewall,
+		t.protocol,
 	)
 }
 
@@ -89,5 +93,6 @@ func (t *transport) SecureOutbound(
 		t.privateKey,
 		remotePeerID,
 		t.firewall,
+		t.protocol,
 	)
 }

--- a/pkg/net/libp2p/unicast_channel_test.go
+++ b/pkg/net/libp2p/unicast_channel_test.go
@@ -207,6 +207,7 @@ func withNetwork(
 			Port: provider1Port,
 		},
 		privKey1,
+		ProtocolBeacon,
 		firewall.Disabled,
 		retransmission.NewTicker(make(chan uint64)),
 	)
@@ -226,6 +227,7 @@ func withNetwork(
 			Port: provider2Port,
 		},
 		privKey2,
+		ProtocolBeacon,
 		firewall.Disabled,
 		retransmission.NewTicker(make(chan uint64)),
 	)

--- a/pkg/net/security/handshake/connection_handshake.go
+++ b/pkg/net/security/handshake/connection_handshake.go
@@ -18,11 +18,11 @@
 //
 // [Act 1]
 // nonce1 = random_nonce()
-// act1Message{nonce1} ---->
+// act1Message{nonce1, protocol_id1} ---->
 //                                       [Act 2]
 //                                       nonce2 = random_nonce()
 //                                       challenge = sha256(nonce1 || nonce2)
-//                                       <---- act2Message{challenge, nonce2}
+//                                       <---- act2Message{challenge, nonce2, protocol_id2}
 // [Act 3]
 // challenge = sha256(nonce1 || nonce2)
 // act3Message{challenge} ---->
@@ -52,27 +52,29 @@ import (
 	"fmt"
 )
 
-// act1Message is sent in the first handshake act by the initiator to the
+// Act1Message is sent in the first handshake act by the initiator to the
 // responder. It contains randomly generated `nonce1`, an 8-byte (64-bit)
-// unsigned integer.
+// unsigned integer as well as the protocol identifier.
 //
 // act1Message should be signed with initiator's static private key.
 type Act1Message struct {
-	nonce1 uint64
+	nonce1    uint64
+	protocol1 string
 }
 
-// act2Message is sent in the second handshake act by the responder to the
+// Act2Message is sent in the second handshake act by the responder to the
 // initiator. It contains randomly generated `nonce2`, which is an 8-byte
-// unsigned integer, and `challenge`, which is the result of SHA256 on the
-// concatenated bytes of `nonce1` and `nonce2`.
+// unsigned integer, `challenge`, which is the result of SHA256 on the
+// concatenated bytes of `nonce1` and `nonce2`, and the protocol identifier.
 //
 // act2Message should be signed with responder's static private key.
 type Act2Message struct {
 	nonce2    uint64
 	challenge [sha256.Size]byte
+	protocol2 string
 }
 
-// act3Message is sent in the third handshake act by the initiator to the
+// Act3Message is sent in the third handshake act by the initiator to the
 // responder. It contains the challenge that has been recomputed by the
 // initiator as a SHA256 of the concatenated bytes of `nonce1` and `nonce2`.
 //
@@ -84,38 +86,44 @@ type Act3Message struct {
 // initiatorAct1 represents the state of the initiator in the first act of the
 // handshake protocol.
 type initiatorAct1 struct {
-	nonce1 uint64
+	nonce1    uint64
+	protocol1 string
 }
 
 // InitiateHandshake function allows to initiate a handshake by creating
 // and initializing a state machine representing initiator in the first round
 // of the handshake, ready to execute the protocol.
-func InitiateHandshake() (*initiatorAct1, error) {
+func InitiateHandshake(protocol string) (*initiatorAct1, error) {
 	nonce1, err := randomNonce()
 	if err != nil {
 		return nil, fmt.Errorf("could not initiate the handshake: [%v]", err)
 	}
 
-	return &initiatorAct1{nonce1}, nil
+	return &initiatorAct1{nonce1, protocol}, nil
 }
 
 // Message returns the message sent by initiator to the responder in the first
 // act of the handshake protocol.
 func (ia1 *initiatorAct1) Message() *Act1Message {
-	return &Act1Message{nonce1: ia1.nonce1}
+	return &Act1Message{nonce1: ia1.nonce1, protocol1: ia1.protocol1}
 }
 
 // Next performs a state transition and returns initiator in a state ready to
 // execute the second act of the handshake protocol.
 func (ia1 *initiatorAct1) Next() *initiatorAct2 {
-	return &initiatorAct2{nonce1: ia1.nonce1}
+	return &initiatorAct2{nonce1: ia1.nonce1, protocol1: ia1.protocol1}
 }
 
 // AnswerHandshake is used to initiate a responder as a result of receiving
 // message from initiator in the first act of the handshake protocol.
 // The returned responder is in a state ready to execute the second act of the
 // handshake protocol.
-func AnswerHandshake(message *Act1Message) (*responderAct2, error) {
+// The function also validates if both parties run the same protocol.
+func AnswerHandshake(message *Act1Message, protocol string) (*responderAct2, error) {
+	if message.protocol1 != protocol {
+		return nil, fmt.Errorf("unsupported protocol: [%v]", message.protocol1)
+	}
+
 	nonce1 := message.nonce1
 	nonce2, err := randomNonce()
 	if err != nil {
@@ -123,13 +131,14 @@ func AnswerHandshake(message *Act1Message) (*responderAct2, error) {
 	}
 	challenge := hashToChallenge(nonce1, nonce2)
 
-	return &responderAct2{nonce2, challenge}, nil
+	return &responderAct2{nonce2, challenge, protocol}, nil
 }
 
 // initiatorAct2 represents the state of the initiator in the second act of the
 // handshake protocol.
 type initiatorAct2 struct {
-	nonce1 uint64
+	nonce1    uint64
+	protocol1 string
 }
 
 // responderAct2 represents the state of the responder in the second act of the
@@ -137,12 +146,17 @@ type initiatorAct2 struct {
 type responderAct2 struct {
 	nonce2    uint64
 	challenge [sha256.Size]byte
+	protocol2 string
 }
 
 // Message returns the message sent by responder to the initiator in the second
 // act of the handshake protocol.
 func (ra2 *responderAct2) Message() *Act2Message {
-	return &Act2Message{nonce2: ra2.nonce2, challenge: ra2.challenge}
+	return &Act2Message{
+		nonce2:    ra2.nonce2,
+		challenge: ra2.challenge,
+		protocol2: ra2.protocol2,
+	}
 }
 
 // Next performs a state transition and returns responder in a state ready to
@@ -158,7 +172,13 @@ func (ra2 *responderAct2) Next() *responderAct3 {
 // the protocol. If the challenge is the same as expected one, new state of
 // initiator is returned. Otherwise, function reports an error and handshake
 // protocol should be immediately aborted.
+//
+// The function also validates if both parties run the same protocol.
 func (ia2 *initiatorAct2) Next(message *Act2Message) (*initiatorAct3, error) {
+	if message.protocol2 != ia2.protocol1 {
+		return nil, fmt.Errorf("unsupported protocol: [%v]", message.protocol2)
+	}
+
 	expectedChallenge := hashToChallenge(ia2.nonce1, message.nonce2)
 	if expectedChallenge != message.challenge {
 		return nil, fmt.Errorf("unexpected responder's challenge")

--- a/pkg/net/security/handshake/connection_handshake_test.go
+++ b/pkg/net/security/handshake/connection_handshake_test.go
@@ -7,12 +7,17 @@ import (
 	"testing"
 )
 
+const (
+	protocol  = "keep-beacon"
+	protocol2 = "keep-ecdsa"
+)
+
 func TestInitiateHanshakeWithUniqueNonce(t *testing.T) {
-	initiator1, err := InitiateHandshake()
+	initiator1, err := InitiateHandshake(protocol)
 	if err != nil {
 		t.Fatal(err)
 	}
-	initiator2, err := InitiateHandshake()
+	initiator2, err := InitiateHandshake(protocol)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,14 +38,14 @@ func TestAnswerHandshakeWithChallenge(t *testing.T) {
 	//
 
 	// initiator station
-	initiator, err := InitiateHandshake()
+	initiator, err := InitiateHandshake(protocol)
 	if err != nil {
 		t.Fatal(err)
 	}
 	act1Msg := initiator.Message()
 
 	// responder station
-	responder, err := AnswerHandshake(act1Msg)
+	responder, err := AnswerHandshake(act1Msg, protocol)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,10 +79,10 @@ func TestRepeatChallengeToFinalize(t *testing.T) {
 	//
 
 	// responder station
-	act2Msg := &Act2Message{nonce2, expectedChallenge}
+	act2Msg := &Act2Message{nonce2, expectedChallenge, protocol}
 
 	// initiator station
-	initiatorAct2 := &initiatorAct2{nonce1}
+	initiatorAct2 := &initiatorAct2{nonce1, protocol}
 	initiatorAct3, err := initiatorAct2.Next(act2Msg)
 	if err != nil {
 		t.Fatal(err)
@@ -101,6 +106,57 @@ func TestRepeatChallengeToFinalize(t *testing.T) {
 	}
 }
 
+func TestFailAct1ForUnexpectedProtocol(t *testing.T) {
+	//
+	// Act 1
+	//
+
+	// initiator station
+	initiator, err := InitiateHandshake(protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	act1Msg := initiator.Message()
+
+	// responder station
+	_, err = AnswerHandshake(act1Msg, protocol2)
+
+	expectedErr := "unsupported protocol: [keep-beacon]"
+	if err.Error() != expectedErr {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			expectedErr,
+			err.Error(),
+		)
+	}
+}
+
+func TestFailAct2ForUnexpectedProtocol(t *testing.T) {
+	nonce1 := rand.Uint64()
+	nonce2 := rand.Uint64()
+	expectedChallenge := hashToChallenge(nonce1, nonce2)
+
+	//
+	// Act 2
+	//
+
+	// responder station
+	act2Msg := &Act2Message{nonce2, expectedChallenge, protocol2}
+
+	// initiator station
+	initiatorAct2 := &initiatorAct2{nonce1, protocol}
+	_, err := initiatorAct2.Next(act2Msg)
+
+	expectedErr := "unsupported protocol: [keep-ecdsa]"
+	if err.Error() != expectedErr {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			expectedErr,
+			err.Error(),
+		)
+	}
+}
+
 func TestFailAct2ForInvalidChallenge(t *testing.T) {
 	nonce1 := rand.Uint64()
 	nonce2 := rand.Uint64()
@@ -111,10 +167,10 @@ func TestFailAct2ForInvalidChallenge(t *testing.T) {
 
 	// responder station
 	invalidChallenge := [32]byte{0xff, 0xfa}
-	act2Msg := &Act2Message{nonce2, invalidChallenge}
+	act2Msg := &Act2Message{nonce2, invalidChallenge, protocol}
 
 	// initiator station
-	initiatorAct2 := &initiatorAct2{nonce1}
+	initiatorAct2 := &initiatorAct2{nonce1, protocol}
 	_, err := initiatorAct2.Next(act2Msg)
 
 	// assert if initiator detects invalid challenge sent by responder
@@ -158,7 +214,7 @@ func TestFullHandshake(t *testing.T) {
 	//
 
 	// initiator station
-	initiatorAct1, err := InitiateHandshake()
+	initiatorAct1, err := InitiateHandshake(protocol)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +222,7 @@ func TestFullHandshake(t *testing.T) {
 	initiatorAct2 := initiatorAct1.Next()
 
 	// responder station
-	responderAct2, err := AnswerHandshake(act1Message)
+	responderAct2, err := AnswerHandshake(act1Message, protocol)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/net/security/handshake/marshaling.go
+++ b/pkg/net/security/handshake/marshaling.go
@@ -17,7 +17,7 @@ const (
 func (am *Act1Message) Marshal() ([]byte, error) {
 	nonceBytes := make([]byte, nonceByteLength)
 	binary.LittleEndian.PutUint64(nonceBytes, am.nonce1)
-	return (&pb.Act1Message{Nonce: nonceBytes}).Marshal()
+	return (&pb.Act1Message{Nonce: nonceBytes, Protocol: am.protocol1}).Marshal()
 }
 
 // Unmarshal converts a byte array produced by Marshal to a Act1Message.
@@ -34,6 +34,8 @@ func (am *Act1Message) Unmarshal(bytes []byte) error {
 
 	am.nonce1 = binary.LittleEndian.Uint64(pbAct1.Nonce)
 
+	am.protocol1 = pbAct1.Protocol
+
 	return nil
 }
 
@@ -42,7 +44,11 @@ func (am *Act1Message) Unmarshal(bytes []byte) error {
 func (am *Act2Message) Marshal() ([]byte, error) {
 	nonceBytes := make([]byte, nonceByteLength)
 	binary.LittleEndian.PutUint64(nonceBytes, am.nonce2)
-	return (&pb.Act2Message{Nonce: nonceBytes, Challenge: am.challenge[:]}).Marshal()
+	return (&pb.Act2Message{
+		Nonce:     nonceBytes,
+		Challenge: am.challenge[:],
+		Protocol:  am.protocol2,
+	}).Marshal()
 }
 
 // Unmarshal converts a byte array produced by Marshal to a Act2Message.
@@ -65,6 +71,8 @@ func (am *Act2Message) Unmarshal(bytes []byte) error {
 	}
 
 	copy(am.challenge[:], pbAct2.Challenge[:challengeByteLength])
+
+	am.protocol2 = pbAct2.Protocol
 
 	return nil
 }

--- a/pkg/net/security/handshake/marshaling_test.go
+++ b/pkg/net/security/handshake/marshaling_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestAct1MessageRoundTrip(t *testing.T) {
 	message := &Act1Message{
-		nonce1: 100,
+		nonce1:    100,
+		protocol1: "keep-beacon",
 	}
 
 	unmarshaler := &Act1Message{}
@@ -28,13 +29,18 @@ func TestAct1MessageRoundTrip(t *testing.T) {
 
 func TestFuzzAct1MessageRoundtrip(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		var nonce1 uint64
+		var (
+			nonce1   uint64
+			protocol string
+		)
 
 		f := fuzz.New().NilChance(0.1)
 		f.Fuzz(&nonce1)
+		f.Fuzz(&protocol)
 
 		message := &Act1Message{
-			nonce1: nonce1,
+			nonce1:    nonce1,
+			protocol1: protocol,
 		}
 
 		_ = pbutils.RoundTrip(message, &Act1Message{})
@@ -56,6 +62,7 @@ func TestAct2MessageRoundTrip(t *testing.T) {
 	message := &Act2Message{
 		nonce2:    100,
 		challenge: challenge,
+		protocol2: "keep-ecdsa",
 	}
 
 	unmarshaler := &Act2Message{}
@@ -75,15 +82,18 @@ func TestFuzzAct2MessageRoundtrip(t *testing.T) {
 		var (
 			nonce2    uint64
 			challenge [32]byte
+			protocol  string
 		)
 
 		f := fuzz.New().NilChance(0.1)
 		f.Fuzz(&nonce2)
 		f.Fuzz(&challenge)
+		f.Fuzz(&protocol)
 
 		message := &Act2Message{
 			nonce2:    nonce2,
 			challenge: challenge,
+			protocol2: protocol,
 		}
 
 		_ = pbutils.RoundTrip(message, &Act2Message{})


### PR DESCRIPTION
There are two protocols run by Keep network: `keep-beacon` and `keep-ecdsa`. Both initiator and responder are expected to pass the protocol identifier during the handshake. This change lets to eliminate an honest, misconfigured nodes from the subnetwork they do not support.

This is what we should expect when a node not sending protocol identifier tries to connect to node expecting the protocol identifier:

> 22:10:29.446  INFO     swarm2: got error on dial: failed to negotiate security protocol: connection handshake failed: [read tcp4 127.0.0.1:3922->127.0.0.1:3921: read: connection reset by peer] swarm_dial.go:420
>   [/ip4/127.0.0.1/tcp/3921] failed to negotiate security protocol: connection handshake failed: [read tcp4 127.0.0.1:3922->127.0.0.1:3921: read: connection reset by peer]] bootstrap.go:170

This is what we should expect when a node expecting protcol identifier receives connection request from a node not sending protocol identifier:
> 22:06:26.338  INFO     swarm2: got error on dial: failed to negotiate security protocol: connection handshake failed: [unsupported protocol: []] swarm_dial.go:420