### PR TITLE
Update to solidity@5 | macos-setup.sh

### DIFF
--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -7,7 +7,7 @@ brew list golang &> /dev/null || brew install golang
 echo "Installing ethereum requirements..."
 brew tap ethereum/ethereum
 brew list geth &>/dev/null || brew install geth
-brew list solidity &>/dev/null || brew install solidity
+brew list solidity &>/dev/null || brew install solidity@5
 
 echo "Installing protobuf requirements..."
 # Protobuf


### PR DESCRIPTION
Update "brew install solidity" to "brew install solidity@5". It installs the correct version of Solidity (0.5.17) to compile the SCs in keep-core code base.