### PR TITLE
Use alpine as the runtime container since Go binaries are self-contained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM golang:1.13.6-alpine3.10 AS runtime
-
-ENV APP_NAME=keep-client \
-	BIN_PATH=/usr/local/bin
-
-FROM runtime AS gobuild
+FROM golang:1.13.6-alpine3.10 AS gobuild
 
 ENV GOPATH=/go \
 	GOBIN=/go/bin \
@@ -68,7 +63,10 @@ RUN go generate ./pkg/gen
 RUN GOOS=linux go build -a -o $APP_NAME ./ && \
 	mv $APP_NAME $BIN_PATH
 
-FROM runtime
+FROM alpine:3.10
+
+ENV APP_NAME=keep-client \
+	BIN_PATH=/usr/local/bin
 
 COPY --from=gobuild $BIN_PATH/$APP_NAME $BIN_PATH
 


### PR DESCRIPTION
This cuts the final Docker image size down by 90% from 391MB (v1.2.0) to 36.9MB.