### PR TITLE
Improved modsqrt documentation

### DIFF
--- a/pkg/altbn128/altbn128.go
+++ b/pkg/altbn128/altbn128.go
@@ -60,8 +60,11 @@ func mod(i, m *big.Int) *big.Int {
 	return new(big.Int).Mod(i, m)
 }
 
-func modSqrt(i, m *big.Int) *big.Int {
-	return new(big.Int).ModSqrt(i, m)
+// modSqrt returns square root of x mod p if such a square root exists. The
+// modulus p must be an odd prime. If x is not a square mod p, function returns
+// nil.
+func modSqrt(x, p *big.Int) *big.Int {
+	return new(big.Int).ModSqrt(x, p)
 }
 
 // yFromX calculates and returns only one of the two possible Ys, by

--- a/solidity/contracts/utils/ModUtils.sol
+++ b/solidity/contracts/utils/ModUtils.sol
@@ -50,10 +50,6 @@ library ModUtils {
             return 0;
         }
 
-        if (p == 2) {
-            return p;
-        }
-
         if (p % 4 == 3) {
             return modExp(a, (p + 1) / 4, p);
         }

--- a/solidity/contracts/utils/ModUtils.sol
+++ b/solidity/contracts/utils/ModUtils.sol
@@ -33,8 +33,9 @@ library ModUtils {
     }
 
     /**
-     * @dev Calculates and returns the square root of a mod p,
-     * or 0 if there is no such root.
+     * @dev Calculates and returns the square root of a mod p if such a square
+     * root exists. The modulus p must be an odd prime. If a square root does
+     * not exist, function returns 0.
      */
     function modSqrt(uint256 a, uint256 p)
         internal


### PR DESCRIPTION
Tonelli-shanks algorithm only works when p is a prime, and the Legendre symbol is only defined for odd primes. Since both functions are internal, we should be fine with just making the expectations about p clear in the documentation.

Also, removed incorrect `p == 2` condition in `modSqrt` implementation. This value of `p` is not a valid input.