### PR TITLE
Align master to mainnet release

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.0.4
+        image: keepnetwork/token-dashboard:v1.0.5
         ports:
           - containerPort: 80

--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.0.3
+        image: keepnetwork/token-dashboard:v1.0.4
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1659,9 +1659,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-pre.5.tgz",
-      "integrity": "sha512-JF0EM+iFf2fDiaqr0LKLeiBpkHqXVQixhZ/v68AiqpAxqBlWfdng5KWFZX03PMiVQ+1iaO2JXr0H8nOGpGgPZg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.2.tgz",
+      "integrity": "sha512-BEpq/hdqmPZeGc3/EMdbgGeQQgspf41UYsDaFJxOb86UxpKe59aAqOV8eJYFGNec28KFa5l7bl7ucMWqilrbww==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -1669,34 +1669,17 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.16.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.16.0-rc.0.tgz",
-      "integrity": "sha512-pgixJ4AKR9/4jwOSmBTAKmNEstMt76Tyi9vucDG5qspHjweGpozGltdIWRghotV0+x12nEXTY8k2AuSSN3GQRw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.0.0.tgz",
+      "integrity": "sha512-MdR9AUSR7wZfkDw8HWJcl6YwMXtF/QMwc1A3brdMKW7d05F64cuWralkvfPP60zkLjUJy/+KXNXU3HP5BHfKYQ==",
       "requires": {
-        "@keep-network/keep-core": ">1.2.0-rc <1.2.0",
-        "@keep-network/sortition-pools": "0.3.0",
+        "@keep-network/keep-core": "1.1.2",
+        "@keep-network/sortition-pools": "1.0.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
         "solidity-bytes-utils": "0.0.7"
       },
       "dependencies": {
-        "@keep-network/keep-core": {
-          "version": "1.2.0-rc.0",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.0-rc.0.tgz",
-          "integrity": "sha512-x4Lv5OhY7/qLwjRYLufls6Fpd/DcExH+HHkL/FvKOa4caqLDikcdnMH7xzXtrDitwqepn57Qvhjboo1MO7A/Sw==",
-          "requires": {
-            "@openzeppelin/contracts-ethereum-package": "^2.4.0",
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.4.0"
-          },
-          "dependencies": {
-            "openzeppelin-solidity": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
-              "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
-            }
-          }
-        },
         "openzeppelin-solidity": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
@@ -1705,19 +1688,19 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.3.0.tgz",
-      "integrity": "sha512-1nr1Wq3wmKYxtkWynB/xMHEYpVAOSCL5XBcHMlsUBGuG9rw+JhbDUNYbbxHNYUZ7sMRq0S0pOrzQVWb5M+ZUig==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.0.0.tgz",
+      "integrity": "sha512-wPOjqQphGtIBTGpGmw8gwBDbvMeq/9wf+HCsD6Vhvd7bcY5lPT/oWFFqhiExhuaLyISwr1fl6Jgm4RkN6Cispg==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@keep-network/tbtc": {
-      "version": "0.15.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-0.15.0-rc.0.tgz",
-      "integrity": "sha512-gpvccLpXW2HV9fDZSzvyG6B1+sCtiITrnySz3BUr8iSqazA+LfgofY0WY+bs562oBYidQePeJip1tLJ0AEqK4A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.0.tgz",
+      "integrity": "sha512-uCawbUsrqezlNlIlId+J70tJ2wFpK0on697DCDai7qcoMbMob3pOU0ri1c+k/mcqg4fVEAYpSuaOflHdidR08g==",
       "requires": {
-        "@keep-network/keep-ecdsa": ">0.16.0-rc <0.16.0",
+        "@keep-network/keep-ecdsa": "1.0.0",
         "@summa-tx/bitcoin-spv-sol": "^3.0.0",
         "@summa-tx/relay-sol": "^2.0.1",
         "openzeppelin-solidity": "2.3.0"
@@ -1921,9 +1904,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
-          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
+          "version": "12.12.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.41.tgz",
+          "integrity": "sha512-Q+eSkdYQJ2XK1AJnr4Ji8Gvk3sRDybEwfTvtL9CA25FFUSD2EgZQewN6VCyWYZCXg5MWZdwogdTNBhlWRcWS1w=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -2076,9 +2059,9 @@
           "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
         },
         "bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
         }
       }
     },
@@ -32286,9 +32269,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+          "version": "10.17.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
+          "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
         }
       }
     },
@@ -32306,9 +32289,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
-          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
+          "version": "12.12.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.41.tgz",
+          "integrity": "sha512-Q+eSkdYQJ2XK1AJnr4Ji8Gvk3sRDybEwfTvtL9CA25FFUSD2EgZQewN6VCyWYZCXg5MWZdwogdTNBhlWRcWS1w=="
         }
       }
     },
@@ -32396,9 +32379,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+          "version": "10.17.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
+          "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -32539,9 +32522,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
-          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
+          "version": "12.12.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.41.tgz",
+          "integrity": "sha512-Q+eSkdYQJ2XK1AJnr4Ji8Gvk3sRDybEwfTvtL9CA25FFUSD2EgZQewN6VCyWYZCXg5MWZdwogdTNBhlWRcWS1w=="
         }
       }
     },

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,13 +1,13 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "1.0.4",
   "private": true,
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
-    "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc",
-    "@keep-network/keep-ecdsa": "0.16.0-rc.0",
-    "@keep-network/tbtc": "0.15.0-rc.0",
+    "@keep-network/keep-core": "1.1.2",
+    "@keep-network/keep-ecdsa": "1.0.0",
+    "@keep-network/tbtc": "1.0.0",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "bignumber.js": "9.0.0",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.2.0-pre",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.2.0-pre",
+  "version": "1.1.2",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After some discussion about how to handle versions in master while we're not continuously migrating @pdyraga made the suggestion that we just land on the most recent mainnet release versions for now.

Here we update keep-core to reflect those versions.  Notably absent here is an explicit version for the keep-client.  It's on the list.

I consider this a temporary setting, while we have deeper discussion about improvements to release management.