### PR TITLE
Fix the positioning of the arrow icon in the link

### DIFF
--- a/solidity/dashboard/src/css/typography.less
+++ b/solidity/dashboard/src/css/typography.less
@@ -101,7 +101,7 @@ a {
       background-size: 1.25rem 1.25rem;
       top: 50%;
       margin-top: -0.625rem;
-      right: -calc(1.25rem + 2px);
+      right: calc(-1.25rem - 2px);
       background-image: url("../static/svg/link-arrow.svg");
     }
     


### PR DESCRIPTION
This PR fixes the positioning of the arrow icon in the link. This problem occurs on the production build only.

Bug:
![obraz](https://user-images.githubusercontent.com/57687279/82648661-45a7e280-9c18-11ea-9f87-f1fc9ad89886.png)

Fix:
![obraz](https://user-images.githubusercontent.com/57687279/82648829-9a4b5d80-9c18-11ea-887c-4432fec34511.png)

