### PR TITLE
Fix the bonded eth amount

### DIFF
--- a/solidity/dashboard/src/services/tbtc-authorization.service.js
+++ b/solidity/dashboard/src/services/tbtc-authorization.service.js
@@ -200,12 +200,9 @@ const fetchBondingData = async (web3Context) => {
         createdBonds[i].referenceID
       )
 
-      if (operatorBondingDataMap.has(operatorAddress)) {
-        const updatedBondedEth = add(
-          operatorBondingDataMap.get(operatorAddress),
-          bondedEth
-        )
-        operatorBondingDataMap.set(operatorAddress, updatedBondedEth)
+      const currentBond = operatorBondingDataMap.get(operatorAddress)
+      if (currentBond) {
+        operatorBondingDataMap.set(operatorAddress, add(currentBond, bondedEth))
       } else {
         operatorBondingDataMap.set(operatorAddress, bondedEth)
       }


### PR DESCRIPTION
It is possible that the operator is in multiple bonds (see [KeepBonding contract](https://github.com/keep-network/keep-ecdsa/blob/master/solidity/contracts/KeepBonding.sol#L32)). In that case the `bondedEth` value should be the sum of all locked bonds for a given operator.