### PR TITLE
Reduce instance type recommendations

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -29,10 +29,10 @@ these capabilities consider the following criteria:
 |n1-standard-2
 
 |AWS
-|m5.large
+|t3.medium
 
 |Azure
-|D2s v3
+|A2 v2
 
 |Self-hosted
 |2 vCPU / 4 GiB RAM / 1 GiB Persistent Storage

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -20,6 +20,11 @@ these capabilities consider the following criteria:
   application port running under the same IP.
 - Recommended machine types by provider:
 
+Your operating environment will ultimately dictate what machine type to go with.  This is
+particulary relevant if you're running a containerized solution where multiple applications
+are sharing VM resources.  The below types are sufficient for running at least one instance of the
+Keep Random Beacon client.
+
 [%header,cols=2*]
 |===
 |Cloud Provider


### PR DESCRIPTION
After spending some time doing targeted testing with single client deployments across providers it feels safe to lower the instance type recommendations here.  Worth noting that depending on how you deploy your keep-client, particularly if you're in a containerized environment sharing VM resources across multiple applications, be sure to take that into consideration when selecting a machine.