### PR TITLE
Release: 1.2.3-rc (Ropsten)

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -388,9 +388,6 @@ Once you've got your KEEP token grant you can manage it with our https://dashboa
 ```
 "/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH",
 "/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY",
-"/dns4/bootstrap-2.test.keep.network/tcp/3919/ipfs/16Uiu2HAmNNuCp45z5bgB8KiTHv1vHTNAVbBgxxtTFGAndageo9Dp",
-"/dns4/bootstrap-3.test.keep.network/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf",
-"/dns4/bootstrap-4.test.keep.network/tcp/3919/ipfs/16Uiu2HAkxRTeySEWZfW9C83GPFpQUXvrygmZryCN6DL4piZrbAv4",
 "/dns4/bootstrap-1.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAkuTUKNh6HkfvWBEkftZbqZHPHi3Kak5ZUygAxvsdQ2UgG",
 "/dns4/bootstrap-2.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAmQirGruZBvtbLHr5SDebsYGcq6Djw7ijF3gnkqsdQs3wK"
 ```
@@ -405,7 +402,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0xEb2bA3f065081B6459A6784ba8b34A1DfeCc183A`
+|`0xbcA9e1817c9a4258Ddff8E553F5C45192389380e`
 |===
 
 [%header,cols=2*]
@@ -414,10 +411,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0xF9AEdd99357514d9D1AE389A65a4bd270cBCb56c`
+|`0x0a556bf7cA341cC0cA4f38E6C96A9DBD04CC7fdF`
 
 |KeepRandomBeaconOperator
-|`0x440626169759ad6598cd53558F0982b84A28Ad7a`
+|`0xb858BC6f450FCAd8688199c498CDeD5827Cb1F07`
 |===
 
 == Staking

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -402,7 +402,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0xbcA9e1817c9a4258Ddff8E553F5C45192389380e`
+|`0xEb2bA3f065081B6459A6784ba8b34A1DfeCc183A`
 |===
 
 [%header,cols=2*]
@@ -411,10 +411,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0x0a556bf7cA341cC0cA4f38E6C96A9DBD04CC7fdF`
+|`0xF9AEdd99357514d9D1AE389A65a4bd270cBCb56c`
 
 |KeepRandomBeaconOperator
-|`0xb858BC6f450FCAd8688199c498CDeD5827Cb1F07`
+|`0x440626169759ad6598cd53558F0982b84A28Ad7a`
 |===
 
 == Staking

--- a/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
@@ -121,7 +121,7 @@ async function stakeOperator(operatorAddress, contractOwnerAddress, authorizer) 
     console.log('Operator account already staked, exiting!');
     return;
   } else {
-    console.log(`Staking 2000000 KEEP tokens on operator account ${operatorAddress}`);
+    console.log(`Staking 4000000 KEEP tokens on operator account ${operatorAddress}`);
   }
 
   let delegation = '0x' + Buffer.concat([
@@ -132,7 +132,7 @@ async function stakeOperator(operatorAddress, contractOwnerAddress, authorizer) 
 
   await keepTokenContract.methods.approveAndCall(
     tokenStakingContract.address,
-    formatAmount(2000000, 18),
+    formatAmount(4000000, 18),
     delegation).send({from: contractOwnerAddress})
 
   console.log(`Staked!`);

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.2.0-pre",
+  "version": "1.2.3-rc",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z $GOOGLE_PROJECT_NAME || -z $GOOGLE_PROJECT_ID || -z $BUILD_TAG || -z $GOOGLE_REGION || -z $GOOGLE_COMPUTE_ZONE_A || -z $TRUFFLE_NETWORK || -z $CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY || -z $TENDERLY_TOKEN || -z $ETH_NETWORK_ID ]]; then
+if [[ -z $GOOGLE_PROJECT_NAME || -z $GOOGLE_PROJECT_ID || -z $BUILD_TAG || -z $GOOGLE_REGION || -z $GOOGLE_COMPUTE_ZONE_A || -z $TRUFFLE_NETWORK || -z $CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY || -z $TENDERLY_TOKEN || -z $ETH_NETWORK_ID || -z $ETH_HOSTNAME ]]; then
   echo "one or more required variables are undefined"
   exit 1
 fi
@@ -58,6 +58,8 @@ ssh utilitybox << EOF
   # CWD to install dependencies
   npm ci
 
+  export ETH_HOSTNAME=$ETH_HOSTNAME
+  echo  $ETH_HOSTNAME
   ./node_modules/.bin/truffle migrate --reset --network $TRUFFLE_NETWORK
   echo ">>>>>>FINISH Contract Migration FINISH>>>>>>"
   echo "<<<<<<START Tenderly Push START<<<<<<"

--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -59,7 +59,7 @@ ssh utilitybox << EOF
   npm ci
 
   export ETH_HOSTNAME=$ETH_HOSTNAME
-  echo  $ETH_HOSTNAME
+  
   ./node_modules/.bin/truffle migrate --reset --network $TRUFFLE_NETWORK
   echo ">>>>>>FINISH Contract Migration FINISH>>>>>>"
   echo "<<<<<<START Tenderly Push START<<<<<<"

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -27,7 +27,7 @@ module.exports = {
 
     ropsten: {
       provider: function() {
-        return new HDWalletProvider(process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY, "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5")
+        return new HDWalletProvider(process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY, process.env.ETH_HOSTNAME)
       },
       gas: 6721975,
       network_id: 3


### PR DESCRIPTION
### Intro

It's been awhile since we've cut a Ropsten release, this PR includes a couple extra updates as a result.

### What We Did

- `truffle-config.json`: Move `ropsten` network ETH hostname to env var.  Now that we're open source we shouldn't expose Infura accounts to source control
- `circleci-migrate-contracts.js`:  Forklift `ETH_HOSTNAME` from Circle Context to utility box.   This is so the truffle config has a value for the env var set.
- `keep-test/keep-client-*-statefulset`:  Moving to a  config where we read the Infura host from a Secret, again to obfuscate from source control.