### PR TITLE
Temporarily removed GCP bootstrap peers

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -386,8 +386,6 @@ Once you've got your KEEP token grant you can manage it with our https://dashboa
 
 [.small]
 ```
-"/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH",
-"/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY",
 "/dns4/bootstrap-1.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAkuTUKNh6HkfvWBEkftZbqZHPHi3Kak5ZUygAxvsdQ2UgG",
 "/dns4/bootstrap-2.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAmQirGruZBvtbLHr5SDebsYGcq6Djw7ijF3gnkqsdQs3wK"
 ```


### PR DESCRIPTION
We are having problems with GCP bootstrap peers so we are temporarily
removing them from testnet bootstrap peers list. We still have two boar.network
bootstraps there so we should be good with the redundancy we have.