### PR TITLE
Fix golangci-lint test(gofmt)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,7 @@ func TestReadConfig(t *testing.T) {
 		"Ethereum.ContractAddresses": {
 			readValueFunc: func(c *Config) interface{} { return c.Ethereum.ContractAddresses },
 			expectedValue: map[string]string{
-				"KeepRandomBeaconOperator":  "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb",
+				"KeepRandomBeaconOperator": "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb",
 			},
 		},
 		"Storage.DataDir": {

--- a/pkg/beacon/relay/dkg/result/signing_test.go
+++ b/pkg/beacon/relay/dkg/result/signing_test.go
@@ -106,13 +106,13 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 	}{
 		"received valid messages with signatures for the preferred result": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member2.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature21,
 					publicKey:   signing2.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature311,
@@ -127,19 +127,19 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		},
 		"received messages from other member with duplicated different signatures for the preferred result": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature311,
 					publicKey:   signing3.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature312,
 					publicKey:   signing3.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature311,
@@ -152,13 +152,13 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		},
 		"received messages from other member with the same signatures for the preferred result": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature311,
 					publicKey:   signing3.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature311,
@@ -171,13 +171,13 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		},
 		"received messages from other member with signatures for two different results": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member4.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature411,
 					publicKey:   signing4.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member4.index,
 					resultHash:  dkgResultHash2,
 					signature:   signature421,
@@ -190,7 +190,7 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		},
 		"received a message from other member with signature for result different than preferred": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member5.index,
 					resultHash:  dkgResultHash2,
 					signature:   signature52,
@@ -203,7 +203,7 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		},
 		"received a message from other member with invalid signature": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member2.index,
 					resultHash:  dkgResultHash1,
 					signature:   []byte{99},
@@ -216,7 +216,7 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		},
 		"received a message from other member with invalid public key": {
 			messages: []*DKGResultHashSignatureMessage{
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member2.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature21,
@@ -230,40 +230,40 @@ func TestVerifyDKGResultSignatures(t *testing.T) {
 		"mixed cases with received valid signatures and duplicated signatures": {
 			messages: []*DKGResultHashSignatureMessage{
 				// Valid signature supporting the same result as preferred.
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member2.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature21,
 					publicKey:   signing2.PublicKey(),
 				},
 				// Multiple signatures from the same member supporting the same result as preferred.
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature311,
 					publicKey:   signing3.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member3.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature312,
 					publicKey:   signing3.PublicKey(),
 				},
 				// Multiple signatures from the same member supporting two different results.
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member4.index,
 					resultHash:  dkgResultHash1,
 					signature:   signature411,
 					publicKey:   signing4.PublicKey(),
 				},
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member4.index,
 					resultHash:  dkgResultHash2,
 					signature:   signature421,
 					publicKey:   signing4.PublicKey(),
 				},
 				// Member supporting different result than preferred.
-				&DKGResultHashSignatureMessage{
+				{
 					senderIndex: member5.index,
 					resultHash:  dkgResultHash2,
 					signature:   signature52,

--- a/pkg/beacon/relay/dkg/result/submission_test.go
+++ b/pkg/beacon/relay/dkg/result/submission_test.go
@@ -29,10 +29,10 @@ func TestSubmitDKGResult(t *testing.T) {
 		GroupPublicKey: []byte{123, 45},
 	}
 	signatures := map[group.MemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	tStep := config.ResultPublicationBlockStep
@@ -128,10 +128,10 @@ func TestConcurrentPublishResult(t *testing.T) {
 	}
 
 	signatures := map[group.MemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	var tests = map[string]struct {

--- a/pkg/beacon/relay/gjkr/message_filter_test.go
+++ b/pkg/beacon/relay/gjkr/message_filter_test.go
@@ -16,8 +16,8 @@ func TestFilterSymmetricKeyGeneratingMembers(t *testing.T) {
 		InitializeSymmetricKeyGeneration()
 
 	messages := []*EphemeralPublicKeyMessage{
-		&EphemeralPublicKeyMessage{senderID: 11},
-		&EphemeralPublicKeyMessage{senderID: 14},
+		{senderID: 11},
+		{senderID: 14},
 	}
 
 	member.MarkInactiveMembers(messages)
@@ -41,15 +41,15 @@ func TestFilterCommitmentsVefiryingMembers(t *testing.T) {
 		InitializeCommitmentsVerification()
 
 	sharesMessages := []*PeerSharesMessage{
-		&PeerSharesMessage{senderID: 91},
-		&PeerSharesMessage{senderID: 92},
-		&PeerSharesMessage{senderID: 94},
+		{senderID: 91},
+		{senderID: 92},
+		{senderID: 94},
 	}
 
 	commitmentsMessages := []*MemberCommitmentsMessage{
-		&MemberCommitmentsMessage{senderID: 92},
-		&MemberCommitmentsMessage{senderID: 94},
-		&MemberCommitmentsMessage{senderID: 95},
+		{senderID: 92},
+		{senderID: 94},
+		{senderID: 95},
 	}
 
 	member.MarkInactiveMembers(sharesMessages, commitmentsMessages)
@@ -86,8 +86,8 @@ func TestFilterSharingMembers(t *testing.T) {
 		InitializeSharing()
 
 	messages := []*MemberPublicKeySharePointsMessage{
-		&MemberPublicKeySharePointsMessage{senderID: 21},
-		&MemberPublicKeySharePointsMessage{senderID: 23},
+		{senderID: 21},
+		{senderID: 23},
 	}
 
 	member.MarkInactiveMembers(messages)

--- a/pkg/beacon/relay/state/machine_test.go
+++ b/pkg/beacon/relay/state/machine_test.go
@@ -70,20 +70,20 @@ func TestExecute(t *testing.T) {
 	}
 
 	expectedTestLog := map[uint64][]string{
-		1: []string{
+		1: {
 			"1-state.testState1-initiate",
 			"1-state.testState1-receive-message_1",
 		},
-		3: []string{"1-state.testState2-initiate"},
-		4: []string{"1-state.testState2-receive-message_2"},
-		6: []string{
+		3: {"1-state.testState2-initiate"},
+		4: {"1-state.testState2-receive-message_2"},
+		6: {
 			"1-state.testState3-initiate",
 			"1-state.testState4-initiate",
 		},
-		7: []string{
+		7: {
 			"1-state.testState4-receive-message_3",
 		},
-		8: []string{
+		8: {
 			"1-state.testState5-initiate",
 		},
 	}

--- a/pkg/chain/local/local_test.go
+++ b/pkg/chain/local/local_test.go
@@ -215,10 +215,10 @@ func TestLocalOnGroupRegistered(t *testing.T) {
 	memberIndex := relaychain.GroupMemberIndex(1)
 	dkgResult := &relaychain.DKGResult{GroupPublicKey: groupPublicKey}
 	signatures := map[relaychain.GroupMemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	chainHandle.SubmitDKGResult(memberIndex, dkgResult, signatures)
@@ -264,10 +264,10 @@ func TestLocalOnGroupRegisteredUnsubscribed(t *testing.T) {
 	memberIndex := relaychain.GroupMemberIndex(1)
 	dkgResult := &relaychain.DKGResult{GroupPublicKey: groupPublicKey}
 	signatures := map[relaychain.GroupMemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	chainHandle.SubmitDKGResult(memberIndex, dkgResult, signatures)
@@ -303,10 +303,10 @@ func TestLocalOnDKGResultSubmitted(t *testing.T) {
 	memberIndex := relaychain.GroupMemberIndex(1)
 	dkgResult := &relaychain.DKGResult{GroupPublicKey: groupPublicKey}
 	signatures := map[relaychain.GroupMemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	chainHandle.SubmitDKGResult(memberIndex, dkgResult, signatures)
@@ -353,10 +353,10 @@ func TestLocalOnDKGResultSubmittedUnsubscribed(t *testing.T) {
 	memberIndex := relaychain.GroupMemberIndex(1)
 	dkgResult := &relaychain.DKGResult{GroupPublicKey: groupPublicKey}
 	signatures := map[relaychain.GroupMemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	chainHandle.SubmitDKGResult(memberIndex, dkgResult, signatures)
@@ -601,10 +601,10 @@ func TestLocalSubmitDKGResult(t *testing.T) {
 	}
 
 	signatures := map[relaychain.GroupMemberIndex][]byte{
-		1: []byte{101},
-		2: []byte{102},
-		3: []byte{103},
-		4: []byte{104},
+		1: {101},
+		2: {102},
+		3: {103},
+		4: {104},
 	}
 
 	chainHandle.SubmitDKGResult(memberIndex, result, signatures)
@@ -635,41 +635,41 @@ func TestLocalSubmitDKGResultWithSignatures(t *testing.T) {
 		},
 		"one signature": {
 			signatures: map[relaychain.GroupMemberIndex][]byte{
-				1: []byte{101},
+				1: {101},
 			},
 			expectedError: fmt.Errorf("failed to submit result with [1] signatures for honest threshold [%v]", honestThreshold),
 		},
 		"one less signature than threshold": {
 			signatures: map[relaychain.GroupMemberIndex][]byte{
-				1: []byte{101},
-				2: []byte{102},
+				1: {101},
+				2: {102},
 			},
 			expectedError: fmt.Errorf("failed to submit result with [2] signatures for honest threshold [%v]", honestThreshold),
 		},
 		"threshold signatures": {
 			signatures: map[relaychain.GroupMemberIndex][]byte{
-				1: []byte{101},
-				2: []byte{102},
-				3: []byte{103},
+				1: {101},
+				2: {102},
+				3: {103},
 			},
 			expectedError: nil,
 		},
 		"one more signature than threshold": {
 			signatures: map[relaychain.GroupMemberIndex][]byte{
-				1: []byte{101},
-				2: []byte{102},
-				3: []byte{103},
-				4: []byte{104},
+				1: {101},
+				2: {102},
+				3: {103},
+				4: {104},
 			},
 			expectedError: nil,
 		},
 		"signatures from all group members": {
 			signatures: map[relaychain.GroupMemberIndex][]byte{
-				1: []byte{101},
-				2: []byte{102},
-				3: []byte{103},
-				4: []byte{104},
-				5: []byte{105},
+				1: {101},
+				2: {102},
+				3: {103},
+				4: {104},
+				5: {105},
 			},
 			expectedError: nil,
 		},


### PR DESCRIPTION
```
$golangci-lint --version
golangci-lint has version 1.27.0 built from fb74c2e on 2020-05-13T18:48:26Z

$golangci-lint run --deadline=10m --disable-all --enable=gofmt
```

I fixed so that warning does not appear.

I'm doing a separate commit now.
https://github.com/wakiyamap/keep-core/commits/Fix_lint