### PR TITLE
Use package-specific version of abigen

### DIFF
--- a/pkg/chain/gen/Makefile
+++ b/pkg/chain/gen/Makefile
@@ -39,7 +39,7 @@ abi/%.abi: ${solidity_dir}/contracts/%.sol
 		 -o abi $<
 
 abi/%.go: abi/%.abi
-	abigen --abi $< --pkg abi --type $* --out $@
+	go run github.com/ethereum/go-ethereum/cmd/abigen --abi $< --pkg abi --type $* --out $@
 
 contract/%.go cmd/%.go: abi/%ImplV1.abi abi/%ImplV1.go abi/%.go *.go
 	go run github.com/keep-network/keep-common/tools/generators/ethereum $< contract/$*.go cmd/$*.go


### PR DESCRIPTION
Fixes: #1854

Running `go run github.com/ethereum/go-ethereum/cmd/abigen` should run the package-specific version of abigen and we can avoid problems with incompatible `abigen` versions this way.

My initial fix was based on extracting right version of abigen into keep-common, but after re-checking  on a clean environment seems like much simpler approach works too. Not sure what was wrong previously... 