### PR TITLE
keep-test: Move ETH host to Secret

### DIFF
--- a/infrastructure/kube/keep-test/eth-network-ropsten-configmap.yaml
+++ b/infrastructure/kube/keep-test/eth-network-ropsten-configmap.yaml
@@ -4,7 +4,5 @@ metadata:
   name: eth-network-ropsten
   namespace: default
 data:
-  rpc-url: https://ropsten.infura.io/v3/414a548bc7434bbfb7a135b694b15aa4
-  ws-url: wss://ropsten.infura.io/ws/v3/414a548bc7434bbfb7a135b694b15aa4
   network-id: '3'
   contract-owner-eth-account-address: '0x923c5dbf353e99394a21aa7b67f3327ca111c67d'

--- a/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
           - name: KEEP_CLIENT_ETH_KEYFILE_PATH
             value: /mnt/keep-client/keyfile/account-0-keyfile
           - name: KEEP_CLIENT_PEERS
-            value: /dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
+            value: /dns4/bootstrap-1.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAkuTUKNh6HkfvWBEkftZbqZHPHi3Kak5ZUygAxvsdQ2UgG
           - name: KEEP_CLIENT_ANNOUNCED_ADDRESSES
             value: /dns4/bootstrap-0.test.keep.network/tcp/3919
           - name: KEEP_CLIENT_PORT

--- a/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
@@ -84,12 +84,12 @@ spec:
         env:
           - name: ETH_RPC_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: rpc-url
           - name: ETH_WS_URL
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: eth-network-ropsten
                 key: ws-url
           - name: ETH_NETWORK_ID

--- a/infrastructure/kube/keep-test/keep-network-ropsten-relay-request-cronjob.yaml
+++ b/infrastructure/kube/keep-test/keep-network-ropsten-relay-request-cronjob.yaml
@@ -58,12 +58,12 @@ spec:
                 value: relay-requester
               - name: ETH_RPC_URL
                 valueFrom:
-                  configMapKeyRef:
+                  secretKeyRef:
                     name: eth-network-ropsten
                     key: rpc-url
               - name: ETH_WS_URL
                 valueFrom:
-                  configMapKeyRef:
+                  secretKeyRef:
                     name: eth-network-ropsten
                     key: ws-url
               - name: ETH_NETWORK_ID

--- a/solidity/dashboard/src/config/config.json
+++ b/solidity/dashboard/src/config/config.json
@@ -4,7 +4,7 @@
             "wsURL": "ws://eth-tx-node.default.svc.cluster.local:8546"
         },
         "3": {
-            "wsURL": "wss://ropsten.infura.io/ws/v3/59fb36a36fa4474b890c13dd30038be5"
+            "wsURL": "wss://eth-ropsten.ws.alchemyapi.io/v2/NrYQBWbd7MC8daJDd8sgdRj80vLxQqkq"
         },
         "1": {
             "wsURL": "wss://mainnet.infura.io/ws/v3/59fb36a36fa4474b890c13dd30038be5"


### PR DESCRIPTION
### Intro

We want a way to protect ETH hosts from source control.   We already support `eth-network-<network-name>` Secrets for envs, so we're moving the hosts there.

### What we did

- Switch to Alchemy for hosting (for now)
- Move `rpc-url` and `ws-url` from `ConfigMap` `eth-network-ropsten` to `Secret` `eth-network-ropsten`
- Change `KeyRef` for `ETH_RPC_URL` and `ETH_WS_URL` from `ConfigMap` to `Secret`
- Deploy `keep-client-0` and `keep-client-1` against the new setup.