### PR TITLE
Pass TokenStakingEscrow reference to TokenStaking

### DIFF
--- a/solidity/contracts/Authorizations.sol
+++ b/solidity/contracts/Authorizations.sol
@@ -64,8 +64,8 @@ contract Authorizations {
         _;
     }
 
-    constructor(address _registry) public {
-        registry = KeepRegistry(_registry);
+    constructor(KeepRegistry _registry) public {
+        registry = _registry;
     }
 
     /// @notice Gets the authorizer for the specified operator address.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -23,6 +23,7 @@ import "./utils/PercentUtils.sol";
 import "./utils/LockUtils.sol";
 import "./utils/BytesLib.sol";
 import "./Authorizations.sol";
+import "./TokenStakingEscrow.sol";
 
 
 /// @title TokenStaking
@@ -54,28 +55,32 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
     ERC20Burnable internal token;
 
+    TokenStakingEscrow public escrow;
+
     // Locks placed on the operator.
     // `operatorLocks[operator]` returns all locks placed on the operator.
     // Each authorized operator contract can place one lock on an operator.
     mapping(address => LockUtils.LockSet) internal operatorLocks;
 
     /// @notice Creates a token staking contract for a provided Standard ERC20Burnable token.
-    /// @param _tokenAddress Address of a token that will be linked to this contract.
-    /// @param _registry Address of a keep registry that will be linked to this contract.
+    /// @param _token KEEP token contract.
+    /// @param _escrow Escrow dedicated for this staking contract.
+    /// @param _registry Keep contract registry contract.
     /// @param _initializationPeriod To avoid certain attacks on work selection, recently created
     /// operators must wait for a specific period of time before being eligible for work selection.
     /// @param _undelegationPeriod The staking contract guarantees that an undelegated operator’s
     /// stakes will stay locked for a period of time after undelegation, and thus available as
     /// collateral for any work the operator is engaged in.
     constructor(
-        address _tokenAddress,
-        address _registry,
+        ERC20Burnable _token,
+        TokenStakingEscrow _escrow,
+        KeepRegistry _registry,
         uint256 _initializationPeriod,
         uint256 _undelegationPeriod
     ) Authorizations(_registry) public {
-        require(_tokenAddress != address(0x0), "Token address can't be zero");
-        token = ERC20Burnable(_tokenAddress);
-        registry = KeepRegistry(_registry);
+        token = _token;
+        escrow = _escrow;
+        registry = _registry;
         initializationPeriod = _initializationPeriod;
         undelegationPeriod = _undelegationPeriod;
         minimumStakeScheduleStart = block.timestamp;

--- a/solidity/contracts/stubs/TokenStakingSlashingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingSlashingStub.sol
@@ -1,14 +1,17 @@
 pragma solidity 0.5.17;
 
 import "../TokenStaking.sol";
+import "../TokenStakingEscrow.sol";
+import "../KeepRegistry.sol";
 
 contract TokenStakingSlashingStub is TokenStaking {
     constructor(
-        address _tokenAddress,
-        address _registry,
+        ERC20Burnable _token,
+        TokenStakingEscrow _escrow,
+        KeepRegistry _registry,
         uint256 _initializationPeriod,
         uint256 _undelegationPeriod
-    ) TokenStaking(_tokenAddress, _registry, _initializationPeriod, _undelegationPeriod) public {
+    ) TokenStaking(_token, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
     }
 
     function slash(uint256 amountToSlash, address[] memory misbehavedOperators) public {

--- a/solidity/contracts/stubs/TokenStakingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingStub.sol
@@ -1,14 +1,17 @@
 pragma solidity 0.5.17;
 
 import "../TokenStaking.sol";
+import "../TokenStakingEscrow.sol";
+import "../KeepRegistry.sol";
 
 contract TokenStakingStub is TokenStaking {
     constructor(
-        address _tokenAddress,
-        address _registry,
+        ERC20Burnable _token,
+        TokenStakingEscrow _escrow,
+        KeepRegistry _registry,
         uint256 _initializationPeriod,
         uint256 _undelegationPeriod
-    ) TokenStaking(_tokenAddress, _registry, _initializationPeriod, _undelegationPeriod) public {
+    ) TokenStaking(_token, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
     }
 
     function setInitializationPeriod(uint256 _initializationPeriod) public {

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -4,6 +4,7 @@ const AltBn128 = artifacts.require("./cryptography/AltBn128.sol");
 const BLS = artifacts.require("./cryptography/BLS.sol");
 const MinimumStakeSchedule = artifacts.require("./MinimumStakeSchedule.sol");
 const TokenStaking = artifacts.require("./TokenStaking.sol");
+const TokenStakingEscrow = artifacts.require("./TokenStakingEscrow.sol");
 const PermissiveStakingPolicy = artifacts.require('./PermissiveStakingPolicy.sol');
 const GuaranteedMinimumStakingPolicy = artifacts.require('./GuaranteedMinimumStakingPolicy.sol');
 const TokenGrant = artifacts.require("./TokenGrant.sol");
@@ -36,13 +37,21 @@ module.exports = async function(deployer, network) {
   await deployer.link(AltBn128, BLS);
   await deployer.deploy(BLS);
   await deployer.deploy(KeepToken);
+  await deployer.deploy(TokenGrant, KeepToken.address);
   await deployer.deploy(KeepRegistry);
+  await deployer.deploy(TokenStakingEscrow, KeepToken.address, TokenGrant.address);
   await deployer.deploy(MinimumStakeSchedule);
   await deployer.link(MinimumStakeSchedule, TokenStaking);
-  await deployer.deploy(TokenStaking, KeepToken.address, KeepRegistry.address, initializationPeriod, undelegationPeriod);
+  await deployer.deploy(
+    TokenStaking,
+    KeepToken.address,
+    TokenStakingEscrow.address,
+    KeepRegistry.address,
+    initializationPeriod,
+    undelegationPeriod
+  );
   await deployer.deploy(PermissiveStakingPolicy);
   await deployer.deploy(GuaranteedMinimumStakingPolicy, TokenStaking.address);
-  await deployer.deploy(TokenGrant, KeepToken.address);
   await deployer.deploy(
     ManagedGrantFactory,
     KeepToken.address,

--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -3,6 +3,7 @@ const KeepRandomBeaconServiceImplV1 = artifacts.require("./KeepRandomBeaconServi
 const KeepRandomBeaconOperator = artifacts.require("./KeepRandomBeaconOperator.sol");
 const KeepRegistry = artifacts.require("./KeepRegistry.sol");
 const TokenStaking = artifacts.require("./TokenStaking.sol");
+const TokenStakingEscrow = artifacts.require("./TokenStakingEscrow.sol");
 const TokenGrant = artifacts.require("./TokenGrant.sol");
 
 module.exports = async function(deployer, network) {
@@ -11,11 +12,14 @@ module.exports = async function(deployer, network) {
     const keepRandomBeaconOperator = await KeepRandomBeaconOperator.deployed();
     const keepRegistry = await KeepRegistry.deployed();
     const tokenStaking = await TokenStaking.deployed();
+    const tokenStakingEscrow = await TokenStakingEscrow.deployed();
     const tokenGrant = await TokenGrant.deployed();
 
     if (!(await keepRandomBeaconServiceImplV1.initialized())) {
         throw Error("keep random beacon service not initialized")
     }
+
+    await tokenStakingEscrow.transferOwnership(tokenStaking.address);
 
     await tokenGrant.authorizeStakingContract(tokenStaking.address);
 

--- a/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
+++ b/solidity/test/random_beacon_operator/TestDkgMisbehavior.js
@@ -26,7 +26,6 @@ describe('KeepRandomBeaconOperator/DkgMisbehavior', function () {
   before(async () => {
 
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestGroupSelection.js
+++ b/solidity/test/random_beacon_operator/TestGroupSelection.js
@@ -22,7 +22,6 @@ describe('KeepRandomBeaconOperator/GroupSelection', function() {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestManageServiceContracts.js
+++ b/solidity/test/random_beacon_operator/TestManageServiceContracts.js
@@ -17,7 +17,6 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestPricingRewards.js
+++ b/solidity/test/random_beacon_operator/TestPricingRewards.js
@@ -16,7 +16,6 @@ describe('KeepRandomBeaconOperator/PricingRewards', function() {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestPricingRewardsWithdraw.js
+++ b/solidity/test/random_beacon_operator/TestPricingRewardsWithdraw.js
@@ -22,7 +22,6 @@ describe('KeepRandomBeaconOperator/PricingRewardsWithdraw', function() {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestPublishDkgResult.js
+++ b/solidity/test/random_beacon_operator/TestPublishDkgResult.js
@@ -32,7 +32,6 @@ describe('KeepRandomBeaconOperator/PublishDkgResult', function () {
   before(async () => {
 
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestRelayEntry.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntry.js
@@ -11,7 +11,6 @@ describe('KeepRandomBeaconOperator/RelayEntry', () => {
   before(async () => {
 
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -12,7 +12,6 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
 
   before(async() => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -33,7 +33,6 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
   before(async () => {
 
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStakingStub'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_service/TestPricing.js
+++ b/solidity/test/random_beacon_service/TestPricing.js
@@ -20,7 +20,6 @@ describe('TestKeepRandomBeaconService/Pricing', function() {
 
   beforeEach(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_service/TestPricingDkg.js
+++ b/solidity/test/random_beacon_service/TestPricingDkg.js
@@ -12,7 +12,6 @@ describe('KeepRandomBeaconService/PricingDkg', () => {
 
     before(async () => {
         let contracts = await initContracts(
-          contract.fromArtifact('KeepToken'),
           contract.fromArtifact('TokenStaking'),
           contract.fromArtifact('KeepRandomBeaconService'),
           contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_service/TestPricingFees.js
+++ b/solidity/test/random_beacon_service/TestPricingFees.js
@@ -10,12 +10,10 @@ describe('KeepRandomBeaconService/PricingFees', function() {
 
     before(async () => {
         let contracts = await initContracts(
-
-        contract.fromArtifact('KeepToken'),
-        contract.fromArtifact('TokenStaking'),
-        contract.fromArtifact('KeepRandomBeaconService'),
-        contract.fromArtifact('KeepRandomBeaconServiceImplV1'),
-        contract.fromArtifact('KeepRandomBeaconOperatorPricingStub')
+          contract.fromArtifact('TokenStaking'),
+          contract.fromArtifact('KeepRandomBeaconService'),
+          contract.fromArtifact('KeepRandomBeaconServiceImplV1'),
+          contract.fromArtifact('KeepRandomBeaconOperatorPricingStub')
         );
     
         serviceContract = contracts.serviceContract;

--- a/solidity/test/random_beacon_service/TestRelayRequestCallback.js
+++ b/solidity/test/random_beacon_service/TestRelayRequestCallback.js
@@ -27,7 +27,6 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_service/TestSelectOperator.js
+++ b/solidity/test/random_beacon_service/TestSelectOperator.js
@@ -12,7 +12,6 @@ describe('TestKeepRandomBeaconService/SelectOperator', function() {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/random_beacon_service/TestViaProxy.js
+++ b/solidity/test/random_beacon_service/TestViaProxy.js
@@ -17,7 +17,6 @@ describe('TestKeepRandomBeaconService/ViaProxy', function() {
 
   before(async () => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       ServiceContractProxy,
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -82,6 +82,7 @@ describe('GuaranteedMinimumStakingPolicy', async () => {
     stakingContract = await TokenStaking.new(
       accounts[9],
       accounts[9],
+      accounts[9],
       0, 0
     );
     policy = await GuaranteedMinimumStakingPolicy.new(stakingContract.address);
@@ -243,6 +244,7 @@ describe('AdaptiveStakingPolicy', async () => {
       (await MinimumStakeSchedule.new()).address
     )
     stakingContract = await TokenStaking.new(
+      accounts[9],
       accounts[9],
       accounts[9],
       0, 0

--- a/solidity/test/token_grant/TestTokenGrant.js
+++ b/solidity/test/token_grant/TestTokenGrant.js
@@ -4,6 +4,7 @@ const {grantTokens} = require('../helpers/grantTokens');
 const KeepToken = contract.fromArtifact('KeepToken');
 const MinimumStakeSchedule = contract.fromArtifact('MinimumStakeSchedule');
 const TokenStaking = contract.fromArtifact('TokenStaking');
+const TokenStakingEscrow = contract.fromArtifact('TokenStakingEscrow');
 const TokenGrant = contract.fromArtifact('TokenGrant');
 const KeepRegistry = contract.fromArtifact("KeepRegistry");
 const PermissiveStakingPolicy = contract.fromArtifact('PermissiveStakingPolicy');
@@ -20,19 +21,26 @@ describe('TokenGrant', function() {
   before(async () => {
     token = await KeepToken.new({from: accounts[0]});
     registry = await KeepRegistry.new({from: accounts[0]});
+    grantContract = await TokenGrant.new(token.address, {from: accounts[0]});
+    stakingEscrow = await TokenStakingEscrow.new(
+      token.address, 
+      grantContract.address, 
+      {from: accounts[0]}
+    );
     await TokenStaking.detectNetwork()
     await TokenStaking.link(
       'MinimumStakeSchedule', 
       (await MinimumStakeSchedule.new({from: accounts[0]})).address
-    )
+    );
     stakingContract = await TokenStaking.new(
       token.address,
+      stakingEscrow.address,
       registry.address,
       time.duration.days(1),
       time.duration.days(30),
       {from: accounts[0]}
     );
-    grantContract = await TokenGrant.new(token.address, {from: accounts[0]});
+    await stakingEscrow.transferOwnership(stakingContract.address, {from: accounts[0]});
     await grantContract.authorizeStakingContract(stakingContract.address, {from: accounts[0]});
     permissivePolicy = await PermissiveStakingPolicy.new()
     amount = web3.utils.toBN(100);

--- a/solidity/test/token_grant/TestTokenGrantRevoke.js
+++ b/solidity/test/token_grant/TestTokenGrantRevoke.js
@@ -12,6 +12,7 @@ const expect = chai.expect
 const KeepToken = contract.fromArtifact('KeepToken');
 const MinimumStakeSchedule = contract.fromArtifact('MinimumStakeSchedule');
 const TokenStaking = contract.fromArtifact('TokenStaking');
+const TokenStakingEscrow = contract.fromArtifact('TokenStakingEscrow');
 const TokenGrant = contract.fromArtifact('TokenGrant');
 const KeepRegistry = contract.fromArtifact("KeepRegistry");
 const GuaranteedMinimumStakingPolicy = contract.fromArtifact("GuaranteedMinimumStakingPolicy");
@@ -40,22 +41,29 @@ describe('TokenGrant/Revoke', function() {
 
   before(async () => {
     tokenContract = await KeepToken.new( {from: accounts[0]});
+    grantContract = await TokenGrant.new(tokenContract.address,  {from: accounts[0]});
     registryContract = await KeepRegistry.new( {from: accounts[0]});
+    stakingEscrow = await TokenStakingEscrow.new(
+      tokenContract.address, 
+      grantContract.address, 
+      {from: accounts[0]}
+    );
     await TokenStaking.detectNetwork()
     await TokenStaking.link(
       'MinimumStakeSchedule', 
       (await MinimumStakeSchedule.new({from: accounts[0]})).address
-    )
+    );
     stakingContract = await TokenStaking.new(
-      tokenContract.address, 
+      tokenContract.address,
+      stakingEscrow.address,
       registryContract.address, 
       initializationPeriod, 
       undelegationPeriod,
       {from: accounts[0]}
     );
+    await stakingEscrow.transferOwnership(stakingContract.address, {from: accounts[0]});
     minimumStake = await stakingContract.minimumStake();
     grantAmount = minimumStake.muln(10);
-    grantContract = await TokenGrant.new(tokenContract.address,  {from: accounts[0]});
 
     await grantContract.authorizeStakingContract(stakingContract.address, {from: accounts[0]});
 

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -8,8 +8,10 @@ chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
 const KeepToken = contract.fromArtifact('KeepToken');
+const TokenGrant = contract.fromArtifact('TokenGrant');
 const TokenStaking = contract.fromArtifact('TokenStaking');
 const MinimumStakeSchedule = contract.fromArtifact('MinimumStakeSchedule')
+const TokenStakingEscrow = contract.fromArtifact('TokenStakingEscrow');
 const KeepRegistry = contract.fromArtifact("KeepRegistry");
 const DelegatedAuthorityStub = contract.fromArtifact("DelegatedAuthorityStub");
 
@@ -33,16 +35,27 @@ describe("TokenStaking/DelegatedAuthority", async () => {
 
   before(async () => {
     token = await KeepToken.new({from: accounts[0]});
+    grant = await TokenGrant.new(token.address,  {from: accounts[0]});
     registry = await KeepRegistry.new();
-
-    await TokenStaking.detectNetwork()
+    escrow = await TokenStakingEscrow.new(
+      token.address, 
+      grant.address, 
+      {from: accounts[0]}
+    );
+    await TokenStaking.detectNetwork();
     await TokenStaking.link(
       'MinimumStakeSchedule', 
       (await MinimumStakeSchedule.new()).address
-    )
-    stakingContract = await TokenStaking.new(
-      token.address, registry.address, initializationPeriod, undelegationPeriod
     );
+    stakingContract = await TokenStaking.new(
+      token.address,
+      escrow.address,
+      registry.address,
+      initializationPeriod,
+      undelegationPeriod
+    );
+    await escrow.transferOwnership(stakingContract.address, {from: accounts[0]});
+
     minimumStake = await stakingContract.minimumStake();
     stakingAmount = minimumStake.muln(20);
     let tx = await delegate(operator, stakingAmount);

--- a/solidity/test/token_stake/TestPunishment.js
+++ b/solidity/test/token_stake/TestPunishment.js
@@ -4,8 +4,10 @@ const { createSnapshot, restoreSnapshot } = require('../helpers/snapshot');
 const stakeDelegate = require('../helpers/stakeDelegate')
 
 const KeepToken = contract.fromArtifact('KeepToken');
+const TokenGrant = contract.fromArtifact('TokenGrant');
 const TokenStaking = contract.fromArtifact('TokenStaking');
 const MinimumStakeSchedule = contract.fromArtifact('MinimumStakeSchedule');
+const TokenStakingEscrow = contract.fromArtifact('TokenStakingEscrow');
 const KeepRegistry = contract.fromArtifact("KeepRegistry");
 
 const BN = web3.utils.BN
@@ -30,7 +32,13 @@ describe('TokenStaking/Punishment', () => {
 
     before(async () => {
         token = await KeepToken.new({ from: owner })
+        tokenGrant = await TokenGrant.new(token.address,  {from: owner})
         registry = await KeepRegistry.new({ from: owner })
+        stakingEscrow = await TokenStakingEscrow.new(
+            token.address, 
+            tokenGrant.address, 
+            {from: owner}
+        )
         await TokenStaking.detectNetwork()
         await TokenStaking.link(
             'MinimumStakeSchedule', 
@@ -38,6 +46,7 @@ describe('TokenStaking/Punishment', () => {
         )
         stakingContract = await TokenStaking.new(
             token.address,
+            stakingEscrow.address,
             registry.address,
             initializationPeriod,
             undelegationPeriod,


### PR DESCRIPTION
`TokenStaking` will not work (after implementing top-ups) without `TokenStakingEscrow` so we are passing the reference to the constructor.

I have also removed `KeepToken` parameter from `initContracts` function. `KeepToken` is never mocked and we always use the real contract for tests.

![image](https://user-images.githubusercontent.com/4712360/85141786-9d516200-b247-11ea-97c7-d47ea087d920.png)
