### PR TITLE
Added TokenGrant as a constructor parameter of TokenStaking

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -57,6 +57,9 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
     TokenStakingEscrow public escrow;
 
+    // KEEP token grant contract.
+    TokenGrant public tokenGrant;
+
     // Locks placed on the operator.
     // `operatorLocks[operator]` returns all locks placed on the operator.
     // Each authorized operator contract can place one lock on an operator.
@@ -64,6 +67,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
     /// @notice Creates a token staking contract for a provided Standard ERC20Burnable token.
     /// @param _token KEEP token contract.
+    /// @param _tokenGrant KEEP token grant contract.
     /// @param _escrow Escrow dedicated for this staking contract.
     /// @param _registry Keep contract registry contract.
     /// @param _initializationPeriod To avoid certain attacks on work selection, recently created
@@ -73,12 +77,14 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// collateral for any work the operator is engaged in.
     constructor(
         ERC20Burnable _token,
+        TokenGrant _tokenGrant,
         TokenStakingEscrow _escrow,
         KeepRegistry _registry,
         uint256 _initializationPeriod,
         uint256 _undelegationPeriod
     ) Authorizations(_registry) public {
         token = _token;
+        tokenGrant = _tokenGrant;
         escrow = _escrow;
         registry = _registry;
         initializationPeriod = _initializationPeriod;

--- a/solidity/contracts/stubs/TokenStakingSlashingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingSlashingStub.sol
@@ -2,16 +2,18 @@ pragma solidity 0.5.17;
 
 import "../TokenStaking.sol";
 import "../TokenStakingEscrow.sol";
+import "../TokenGrant.sol";
 import "../KeepRegistry.sol";
 
 contract TokenStakingSlashingStub is TokenStaking {
     constructor(
         ERC20Burnable _token,
+        TokenGrant _tokenGrant,
         TokenStakingEscrow _escrow,
         KeepRegistry _registry,
         uint256 _initializationPeriod,
         uint256 _undelegationPeriod
-    ) TokenStaking(_token, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
+    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
     }
 
     function slash(uint256 amountToSlash, address[] memory misbehavedOperators) public {

--- a/solidity/contracts/stubs/TokenStakingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingStub.sol
@@ -2,16 +2,18 @@ pragma solidity 0.5.17;
 
 import "../TokenStaking.sol";
 import "../TokenStakingEscrow.sol";
+import "../TokenGrant.sol";
 import "../KeepRegistry.sol";
 
 contract TokenStakingStub is TokenStaking {
     constructor(
         ERC20Burnable _token,
+        TokenGrant _tokenGrant,
         TokenStakingEscrow _escrow,
         KeepRegistry _registry,
         uint256 _initializationPeriod,
         uint256 _undelegationPeriod
-    ) TokenStaking(_token, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
+    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
     }
 
     function setInitializationPeriod(uint256 _initializationPeriod) public {

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -45,6 +45,7 @@ module.exports = async function(deployer, network) {
   await deployer.deploy(
     TokenStaking,
     KeepToken.address,
+    TokenGrant.address,
     TokenStakingEscrow.address,
     KeepRegistry.address,
     initializationPeriod,

--- a/solidity/test/RolesLookupTest.js
+++ b/solidity/test/RolesLookupTest.js
@@ -67,6 +67,7 @@ describe('RolesLookup', () => {
     )
     tokenStaking = await TokenStaking.new(
       token.address,
+      tokenGrant.address,
       tokenStakingEscrow.address,
       registry.address,
       initializationPeriod,

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -40,6 +40,7 @@ async function initContracts(TokenStaking, KeepRandomBeaconService,
   )
   stakingContract = await TokenStaking.new(
     token.address,
+    tokenGrant.address,
     stakingEscrow.address,
     registry.address,
     stakeInitializationPeriod,

--- a/solidity/test/token_grant/TestManagedGrant.js
+++ b/solidity/test/token_grant/TestManagedGrant.js
@@ -63,6 +63,7 @@ describe('TokenGrant/ManagedGrant', () => {
     )
     staking = await TokenStaking.new(
       token.address,
+      tokenGrant.address,
       stakingEscrow.address,
       registry.address,
       initializationPeriod,

--- a/solidity/test/token_grant/TestManagedGrantFactory.js
+++ b/solidity/test/token_grant/TestManagedGrantFactory.js
@@ -54,6 +54,7 @@ describe('TokenGrant/ManagedGrantFactory', () => {
     );
     staking = await TokenStaking.new(
       token.address,
+      tokenGrant.address,
       stakingEscrow.address,
       registry.address,
       initializationPeriod,

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -83,6 +83,7 @@ describe('GuaranteedMinimumStakingPolicy', async () => {
       accounts[9],
       accounts[9],
       accounts[9],
+      accounts[9],
       0, 0
     );
     policy = await GuaranteedMinimumStakingPolicy.new(stakingContract.address);
@@ -244,6 +245,7 @@ describe('AdaptiveStakingPolicy', async () => {
       (await MinimumStakeSchedule.new()).address
     )
     stakingContract = await TokenStaking.new(
+      accounts[9],
       accounts[9],
       accounts[9],
       accounts[9],

--- a/solidity/test/token_grant/TestTokenGrant.js
+++ b/solidity/test/token_grant/TestTokenGrant.js
@@ -34,6 +34,7 @@ describe('TokenGrant', function() {
     );
     stakingContract = await TokenStaking.new(
       token.address,
+      grantContract.address,
       stakingEscrow.address,
       registry.address,
       time.duration.days(1),

--- a/solidity/test/token_grant/TestTokenGrantRevoke.js
+++ b/solidity/test/token_grant/TestTokenGrantRevoke.js
@@ -55,6 +55,7 @@ describe('TokenGrant/Revoke', function() {
     );
     stakingContract = await TokenStaking.new(
       tokenContract.address,
+      grantContract.address,
       stakingEscrow.address,
       registryContract.address, 
       initializationPeriod, 

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -66,6 +66,7 @@ describe('TokenGrant/Stake', function() {
     );
     stakingContract = await TokenStaking.new(
       tokenContract.address,
+      grantContract.address,
       stakingEscrow.address,
       registryContract.address,
       initializationPeriod,

--- a/solidity/test/token_grant/TestTokenGrantWithdraw.js
+++ b/solidity/test/token_grant/TestTokenGrantWithdraw.js
@@ -52,6 +52,7 @@ describe('TokenGrant/Withdraw', function() {
     );
     stakingContract = await TokenStaking.new(
       tokenContract.address,
+      grantContract.address,
       stakingEscrow.address, 
       registryContract.address, 
       initializationPeriod, 

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -49,6 +49,7 @@ describe("TokenStaking/DelegatedAuthority", async () => {
     );
     stakingContract = await TokenStaking.new(
       token.address,
+      grant.address,
       escrow.address,
       registry.address,
       initializationPeriod,

--- a/solidity/test/token_stake/TestMinimumStake.js
+++ b/solidity/test/token_stake/TestMinimumStake.js
@@ -36,6 +36,7 @@ describe('TokenStaking/MinimumStake', function() {
     );
     stakingContract = await TokenStaking.new(
       token.address,
+      grant.address,
       escrow.address,
       registry.address,
       initializationPeriod,

--- a/solidity/test/token_stake/TestPunishment.js
+++ b/solidity/test/token_stake/TestPunishment.js
@@ -46,6 +46,7 @@ describe('TokenStaking/Punishment', () => {
         )
         stakingContract = await TokenStaking.new(
             token.address,
+            tokenGrant.address,
             stakingEscrow.address,
             registry.address,
             initializationPeriod,

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -50,6 +50,7 @@ describe('TokenStaking', function() {
     );
     stakingContract = await TokenStaking.new(
       token.address,
+      tokenGrant.address,
       stakingEscrow.address,
       registry.address,
       initializationPeriod,

--- a/solidity/test/token_stake/TestTokenStakeLock.js
+++ b/solidity/test/token_stake/TestTokenStakeLock.js
@@ -43,6 +43,7 @@ describe('TokenStaking/Lock', () => {
     );
     stakingContract = await TokenStaking.new(
       token.address,
+      grant.address,
       escrow.address,
       registry.address,
       initializationPeriod,


### PR DESCRIPTION
`TokenStaking` needs to resolve grant ID when stake is delegated from a grant so that it can later deposit undelegated tokens in `TokenStakingEscrow` with the original grant's unlocking parameters. This is needed to implement stake top-ups properly.

![image](https://user-images.githubusercontent.com/4712360/85143706-5f097200-b24a-11ea-8799-b9705286fd57.png)
