### PR TITLE
Let the grant manager to withdraw from escrow deposit for revoked grant

### DIFF
--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -281,7 +281,7 @@ contract TokenStakingEscrow is Ownable {
         address operator,
         address grantManager
     ) internal {
-        uint256 amount = deposit.amount - deposit.withdrawn;
+        uint256 amount = deposit.amount.sub(deposit.withdrawn);
 
         deposits[operator].withdrawn = deposit.amount;
         keepToken.safeTransfer(grantManager, amount);

--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -48,6 +48,11 @@ contract TokenStakingEscrow is Ownable {
         address indexed grantee,
         uint256 amount
     );
+    event RevokedDepositWithdrawn(
+        address indexed operator,
+        address indexed grantManager,
+        uint256 amount
+    );
 
     IERC20 public keepToken;
     TokenGrant public tokenGrant;
@@ -203,6 +208,23 @@ contract TokenStakingEscrow is Ownable {
         withdraw(deposit, operator, grantee);
     }
 
+    /// @notice Withdraws the entire amount that is still deposited in the
+    /// escrow in case the grant has been revoked. Anyone can call this function
+    /// and the entire amount is transferred back to the grant manager.
+    /// @param operator Address of the operator for which undelegated tokens
+    /// were deposited.
+    function withdrawRevoked(address operator) public {
+        Deposit memory deposit = deposits[operator];
+
+        require(
+            getAmountRevoked(deposit.grantId) > 0,
+            "Grant not revoked"
+        );
+
+        address grantManager = getGrantManager(deposit.grantId);
+        withdrawRevoked(deposit, operator, grantManager);
+    }
+
     /// @notice Resolves the final grantee of ManagedGrant contract. If the
     /// provided address is not a ManagedGrant contract, function reverts.
     /// @param managedGrant Address of the managed grant contract.
@@ -247,6 +269,19 @@ contract TokenStakingEscrow is Ownable {
         emit DepositWithdrawn(operator, grantee, amount);
     }
 
+    function withdrawRevoked(
+        Deposit memory deposit,
+        address operator,
+        address grantManager
+    ) internal {
+        uint256 amount = deposit.amount - deposit.withdrawn;
+
+        deposits[operator].withdrawn = deposit.amount;
+        keepToken.safeTransfer(grantManager, amount);
+
+        emit RevokedDepositWithdrawn(operator, grantManager, amount);
+    }
+
     function getAmountGranted(uint256 grantId) internal view returns (
         uint256 amountGranted
     ) {
@@ -271,5 +306,11 @@ contract TokenStakingEscrow is Ownable {
         address grantee
     ) {
         (,,,,,grantee) = tokenGrant.getGrant(grantId);
+    }
+
+    function getGrantManager(uint256 grantId) internal view returns (
+        address grantManager
+    ) {
+        (grantManager,,,,) = tokenGrant.getGrantUnlockingSchedule(grantId);
     }
 }

--- a/solidity/test/random_beacon_operator/TestInitialization.js
+++ b/solidity/test/random_beacon_operator/TestInitialization.js
@@ -8,7 +8,6 @@ describe("KeepRandomBeaconOperator/Initialization", function() {
 
   before(async() => {
     let contracts = await initContracts(
-      contract.fromArtifact('KeepToken'),
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -324,6 +324,14 @@ describe('TokenStakingEscrow', () => {
       expect(balance).to.eq.BN(depositedAmount)
     })
 
+    it('withdraws nothing if already withdrawn', async () => {
+      await time.increaseTo(grantStart.add(grantUnlockingDuration))
+      await escrow.withdraw(operator, {from: grantee})
+      await escrow.withdraw(operator, {from: grantee})
+      const balance = await token.balanceOf(grantee);
+      expect(balance).to.eq.BN(depositedAmount)
+    })
+
     it('emits an event', async () => {
       await time.increaseTo(grantStart.add(time.duration.days(15)))
       const receipt = await escrow.withdraw(operator, {from: grantee})
@@ -413,6 +421,14 @@ describe('TokenStakingEscrow', () => {
       expect(balance).to.eq.BN(depositedAmount)
     })
 
+    it('withdraws nothing if already withdrawn', async () => {
+      await time.increaseTo(grantStart.add(grantUnlockingDuration))
+      await escrow.withdrawToManagedGrantee(operator2, {from: grantee})
+      await escrow.withdrawToManagedGrantee(operator2, {from: grantee})
+      const balance = await token.balanceOf(grantee);
+      expect(balance).to.eq.BN(depositedAmount) 
+    })
+
     it('emits an event', async () => {
       await time.increaseTo(grantStart.add(time.duration.days(15)))
       const receipt = await escrow.withdrawToManagedGrantee(operator2, {from: grantee})
@@ -490,6 +506,20 @@ describe('TokenStakingEscrow', () => {
 
       const diff = balanceAfter.sub(balanceBefore)
       expect(diff).to.eq.BN(depositedAmount)
+    })
+
+    it('withdraws nothing if already withdrawn', async () => {
+      await time.increaseTo(grantStart.add(time.duration.days(15)))
+      await tokenGrant.revoke(grantId, {from: grantManager})
+
+      await escrow.withdrawRevoked(operator, {from: grantManager})
+
+      const balanceBefore = await token.balanceOf(grantManager)
+      await escrow.withdrawRevoked(operator, {from: grantManager})
+      const balanceAfter = await token.balanceOf(grantManager)
+
+      const diff = balanceAfter.sub(balanceBefore)
+      expect(diff).to.eq.BN(0) 
     })
 
     it('reverts if the entire grant unlocked', async () => {

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -19,12 +19,12 @@ const expect = chai.expect
 describe('TokenStakingEscrow', () => {
   
   const deployer = accounts[0],
-    grantManager = accounts[0],
-    grantee = accounts[1],
-    operator = accounts[2],
-    operator2 = accounts[3],
-    thirdParty = accounts[4],
-    tokenStaking = accounts[5]
+    grantManager = accounts[1],
+    grantee = accounts[2],
+    operator = accounts[3],
+    operator2 = accounts[4],
+    thirdParty = accounts[5],
+    tokenStaking = accounts[6]
 
   let grantedAmount, grantStart, grantUnlockingDuration,
   grantId, managedGrantId, managedGrant
@@ -34,6 +34,7 @@ describe('TokenStakingEscrow', () => {
   before(async () => {
     token = await KeepToken.new({from: deployer})
     await token.transfer(tokenStaking, 100000, {from: deployer})
+    await token.transfer(grantManager, 100000, {from: deployer})
 
     tokenGrant = await TokenGrant.new(token.address, {from: deployer})
     permissivePolicy = await PermissiveStakingPolicy.new()
@@ -60,7 +61,7 @@ describe('TokenStakingEscrow', () => {
       tokenGrant, 
       token, 
       grantedAmount, 
-      deployer, 
+      grantManager, 
       grantee, 
       grantUnlockingDuration,
       grantStart,
@@ -73,7 +74,7 @@ describe('TokenStakingEscrow', () => {
       managedGrantFactory,
       token,
       grantedAmount,
-      deployer,
+      grantManager,
       grantee,
       grantUnlockingDuration,
       grantStart,
@@ -246,7 +247,7 @@ describe('TokenStakingEscrow', () => {
 
     it('returns 0 for revoked grant', async () => {
       await time.increaseTo(grantStart.add(grantCliff))
-      await tokenGrant.revoke(grantId, {from: deployer})
+      await tokenGrant.revoke(grantId, {from: grantManager})
       const withdrawable = await escrow.withdrawable(operator)
       expect(withdrawable).to.eq.BN(0)
     })

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -281,6 +281,13 @@ describe('TokenStakingEscrow', () => {
       )
     })
 
+    it('can not be called by deployer', async () => {
+      await expectRevert(
+        escrow.withdraw(operator, {from: deployer}),
+        "Only grantee or operator can withdraw" 
+      )
+    })
+
     it('withdraws entire unlocked amount just after the cliff', async () => {
       await time.increaseTo(grantStart.add(grantCliff))
       await escrow.withdraw(operator, {from: grantee})
@@ -382,6 +389,13 @@ describe('TokenStakingEscrow', () => {
     it('can not be called by third-party', async () => {
       await expectRevert(
         escrow.withdrawToManagedGrantee(operator2, {from: thirdParty}),
+        "Only grantee or operator can withdraw" 
+      )
+    })
+
+    it('can not be called by deployer', async () => {
+      await expectRevert(
+        escrow.withdrawToManagedGrantee(operator2, {from: deployer}),
         "Only grantee or operator can withdraw" 
       )
     })

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -16,7 +16,7 @@ const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-describe.only('TokenStakingEscrow', () => {
+describe('TokenStakingEscrow', () => {
   
   const deployer = accounts[0],
     grantManager = accounts[0],


### PR DESCRIPTION
Added `withdrawRevoked` function allowing to withdraw the entire amount that is still deposited in `TokenStakingEscrow` in case the grant has been revoked. Anyone can call this function and the entire amount is transferred back to the grant manager.

`TokenStakingEscrow` does not implement an unlocking scheme for revoked grants and always returns the entire, not-yet-withdrawn amount to the grant manager. The reason for that is that it's very hard (if possible at all) to calculate the amount that should belong to the grantee of a revoked grant and that still remains in the escrow. If really needed, we leave this to the grant manager.