### PR TITLE
Release: v1.2.4-rc (Ropsten)

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -384,10 +384,15 @@ Once you've got your KEEP token grant you can manage it with our https://dashboa
 
 ==== Bootstrap Peers
 
+Bootstrap peers will come and go on testnet.  As long as at least one of your configured peers is
+up, there is no need to worry.
+
 [.small]
 ```
 "/dns4/bootstrap-1.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAkuTUKNh6HkfvWBEkftZbqZHPHi3Kak5ZUygAxvsdQ2UgG",
-"/dns4/bootstrap-2.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAmQirGruZBvtbLHr5SDebsYGcq6Djw7ijF3gnkqsdQs3wK"
+"/dns4/bootstrap-2.core.keep.test.boar.network/tcp/3001/ipfs/16Uiu2HAmQirGruZBvtbLHr5SDebsYGcq6Djw7ijF3gnkqsdQs3wK",
+"/dns4/bootstrap-3.test.keep.network/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf",
+"/dns4/bootstrap-2.test.keep.network/tcp/3919/ipfs/16Uiu2HAmNNuCp45z5bgB8KiTHv1vHTNAVbBgxxtTFGAndageo9Dp"
 ```
 
 ==== Contracts
@@ -400,7 +405,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0xEb2bA3f065081B6459A6784ba8b34A1DfeCc183A`
+|`0x88B3D0Bfb8F207292Dc4Cee7C923d0E7C3078a18`
 |===
 
 [%header,cols=2*]
@@ -409,10 +414,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0xF9AEdd99357514d9D1AE389A65a4bd270cBCb56c`
+|`0xa5018dbeB6920A04e0CFd3D8F0F45BC851838b0D`
 
 |KeepRandomBeaconOperator
-|`0x440626169759ad6598cd53558F0982b84A28Ad7a`
+|`0x9233Fd6C58e37dab223EF1dFD5e33eD69FD1f93b`
 |===
 
 == Staking

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.2.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.0-rc.0.tgz",
-      "integrity": "sha512-x4Lv5OhY7/qLwjRYLufls6Fpd/DcExH+HHkL/FvKOa4caqLDikcdnMH7xzXtrDitwqepn57Qvhjboo1MO7A/Sw==",
+      "version": "1.2.4-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.4-rc.1.tgz",
+      "integrity": "sha512-Pda3oitEIcNC9diiNfFOi5SPiK8TNtl/JW8ucOwYMSCHbQJmrxITeJ6PGS5hwMdhf81lToBMYvhwpf3Slv+D7w==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -52,9 +52,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.38",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.38.tgz",
-          "integrity": "sha512-75eLjX0pFuTcUXnnWmALMzzkYorjND0ezNEycaKesbUBg9eGZp4GHPuDmkRc4mQQvIpe29zrzATNRA6hkYqwmA=="
+          "version": "12.12.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+          "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         },
         "aes-js": {
           "version": "3.0.0",
@@ -178,9 +178,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.21",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+              "version": "10.17.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+              "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
             }
           }
         },
@@ -281,9 +281,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.21",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-              "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+              "version": "10.17.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+              "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
             },
             "elliptic": {
               "version": "6.3.3",
@@ -570,9 +570,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@solidity-parser/parser": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.1.tgz",
-      "integrity": "sha512-MUA5kP9LdeTILeOsaz/k/qA4MdTNUxrn6q6HMYsMzQN5crU9bWKND2DaoWZhzofQM0VaTOaD8GFkCw1BYbNj5w=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.2.tgz",
+      "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -4502,7 +4502,7 @@
       "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
     },
     "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
       "from": "github:web3-js/scrypt-shim",
       "requires": {
         "scryptsy": "^2.1.0",
@@ -5810,7 +5810,7 @@
       }
     },
     "websocket": {
-      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
       "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
       "requires": {
         "debug": "^2.2.0",

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package.json
@@ -1,7 +1,7 @@
 {
   "main": "issue-grant.js",
   "dependencies": {
-    "@keep-network/keep-core": ">1.2.0-rc <1.2.0",
+    "@keep-network/keep-core": ">1.2.4-rc <1.2.4",
     "@truffle/hdwallet-provider": "^1.0.25",
     "web3": "1.2.6"
   },

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
           - name: KEEP_CLIENT_ETH_KEYFILE_PATH
             value: /mnt/keep-client/keyfile/account-2-keyfile
           - name: KEEP_CLIENT_PEERS
-            value: /dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
+            value: /dns4/bootstrap-3.test.keep.network/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf
           - name: KEEP_CLIENT_ANNOUNCED_ADDRESSES
             value: /dns4/bootstrap-2.test.keep.network/tcp/3919
           - name: KEEP_CLIENT_PORT

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "1.2.4-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1659,9 +1659,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-pre.5.tgz",
-      "integrity": "sha512-JF0EM+iFf2fDiaqr0LKLeiBpkHqXVQixhZ/v68AiqpAxqBlWfdng5KWFZX03PMiVQ+1iaO2JXr0H8nOGpGgPZg==",
+      "version": "1.2.4-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.4-rc.1.tgz",
+      "integrity": "sha512-Pda3oitEIcNC9diiNfFOi5SPiK8TNtl/JW8ucOwYMSCHbQJmrxITeJ6PGS5hwMdhf81lToBMYvhwpf3Slv+D7w==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -1669,21 +1669,21 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.16.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.16.0-rc.0.tgz",
-      "integrity": "sha512-pgixJ4AKR9/4jwOSmBTAKmNEstMt76Tyi9vucDG5qspHjweGpozGltdIWRghotV0+x12nEXTY8k2AuSSN3GQRw==",
+      "version": "1.1.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.1.2-rc.0.tgz",
+      "integrity": "sha512-poPEYr4cf/6AmY3A73BNoHIs0crz/bCmF6+4konrnH3qiLegX+fPU7Kc4KIpa34bNfF0GjG04o06HTT/mFvmjw==",
       "requires": {
-        "@keep-network/keep-core": ">1.2.0-rc <1.2.0",
-        "@keep-network/sortition-pools": "0.3.0",
+        "@keep-network/keep-core": ">1.2.4-rc <1.2.4",
+        "@keep-network/sortition-pools": "1.0.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
         "solidity-bytes-utils": "0.0.7"
       },
       "dependencies": {
         "@keep-network/keep-core": {
-          "version": "1.2.0-rc.0",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.0-rc.0.tgz",
-          "integrity": "sha512-x4Lv5OhY7/qLwjRYLufls6Fpd/DcExH+HHkL/FvKOa4caqLDikcdnMH7xzXtrDitwqepn57Qvhjboo1MO7A/Sw==",
+          "version": "1.2.4-rc.1",
+          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.4-rc.1.tgz",
+          "integrity": "sha512-Pda3oitEIcNC9diiNfFOi5SPiK8TNtl/JW8ucOwYMSCHbQJmrxITeJ6PGS5hwMdhf81lToBMYvhwpf3Slv+D7w==",
           "requires": {
             "@openzeppelin/contracts-ethereum-package": "^2.4.0",
             "@openzeppelin/upgrades": "^2.7.2",
@@ -1705,19 +1705,19 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.3.0.tgz",
-      "integrity": "sha512-1nr1Wq3wmKYxtkWynB/xMHEYpVAOSCL5XBcHMlsUBGuG9rw+JhbDUNYbbxHNYUZ7sMRq0S0pOrzQVWb5M+ZUig==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.0.0.tgz",
+      "integrity": "sha512-wPOjqQphGtIBTGpGmw8gwBDbvMeq/9wf+HCsD6Vhvd7bcY5lPT/oWFFqhiExhuaLyISwr1fl6Jgm4RkN6Cispg==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@keep-network/tbtc": {
-      "version": "0.15.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-0.15.0-rc.0.tgz",
-      "integrity": "sha512-gpvccLpXW2HV9fDZSzvyG6B1+sCtiITrnySz3BUr8iSqazA+LfgofY0WY+bs562oBYidQePeJip1tLJ0AEqK4A==",
+      "version": "1.0.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.0.2-rc.0.tgz",
+      "integrity": "sha512-a1zcj7gxVb/l4FonZC6ZFXAbQcQXkVmWIMIcq4zDX3P0cxbXczTzRd9QVrw4Y6xBvjjJS5IEVHMLwuu60zrGVQ==",
       "requires": {
-        "@keep-network/keep-ecdsa": ">0.16.0-rc <0.16.0",
+        "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
         "@summa-tx/bitcoin-spv-sol": "^3.0.0",
         "@summa-tx/relay-sol": "^2.0.1",
         "openzeppelin-solidity": "2.3.0"
@@ -1921,9 +1921,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
-          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
+          "version": "12.12.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+          "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -2051,14 +2051,14 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@solidity-parser/parser": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.1.tgz",
-      "integrity": "sha512-MUA5kP9LdeTILeOsaz/k/qA4MdTNUxrn6q6HMYsMzQN5crU9bWKND2DaoWZhzofQM0VaTOaD8GFkCw1BYbNj5w=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.2.tgz",
+      "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA=="
     },
     "@summa-tx/bitcoin-spv-sol": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.0.0.tgz",
-      "integrity": "sha512-zyY0o1i5wGdaM8yK6JYlaUzNmZSdsGipXeEQpM7bNDW5d9/CzVOvbP1pOT97wOok2QYJG6f4oU8vf18OWzxkgQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.1.0.tgz",
+      "integrity": "sha512-YIwxTNCTIsL+qgzcMhzQk9f0A7yQ6dimlLj4i3gGhWrnqBIg3ljBxJ/aj9JRQyIdNDoCPmqS2s8ZZIdyM+vaGQ=="
     },
     "@summa-tx/relay-sol": {
       "version": "2.0.1",
@@ -2076,9 +2076,9 @@
           "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
         },
         "bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
         }
       }
     },
@@ -7488,17 +7488,17 @@
       }
     },
     "ethereumjs-wallet": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",
-      "integrity": "sha512-qiXPiZOsStem+Dj/CQHbn5qex+FVkuPmGH7SvSnA9F3tdRDt8dLMyvIj3+U05QzVZNPYh4HXEdnzoYI4dZkr9w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.4.tgz",
+      "integrity": "sha512-xAYLWVH/MA9Ds1+BiDTfdRrCBQIz7r70EJSjuBnvw/x40qJ1jBoBBAp8/l+I9VPGAsUXvHTfcnp2OZ9LbcTs/g==",
       "requires": {
         "aes-js": "^3.1.1",
         "bs58check": "^2.1.2",
         "ethereumjs-util": "^6.0.0",
-        "hdkey": "^1.1.0",
+        "hdkey": "^1.1.1",
         "randombytes": "^2.0.6",
         "safe-buffer": "^5.1.2",
-        "scrypt.js": "^0.3.0",
+        "scryptsy": "^1.2.1",
         "utf8": "^3.0.0",
         "uuid": "^3.3.2"
       },
@@ -7541,6 +7541,14 @@
             "inherits": "^2.0.4",
             "nan": "^2.14.0",
             "safe-buffer": "^5.2.0"
+          }
+        },
+        "scryptsy": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+          "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+          "requires": {
+            "pbkdf2": "^3.0.3"
           }
         },
         "uuid": {
@@ -29329,22 +29337,13 @@
         "ajv-keywords": "^3.4.1"
       }
     },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.0.8"
-      }
-    },
     "scrypt-js": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
       "from": "github:web3-js/scrypt-shim",
       "requires": {
         "scryptsy": "^2.1.0",
@@ -29355,25 +29354,6 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "scrypt.js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
-      "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
-      "requires": {
-        "scrypt": "^6.0.2",
-        "scryptsy": "^1.2.1"
-      },
-      "dependencies": {
-        "scryptsy": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-          "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
-          "requires": {
-            "pbkdf2": "^3.0.3"
-          }
         }
       }
     },
@@ -31356,9 +31336,9 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unbzip2-stream": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
-      "integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -32300,9 +32280,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
         }
       }
     },
@@ -32320,9 +32300,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
-          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
+          "version": "12.12.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+          "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         }
       }
     },
@@ -32410,9 +32390,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -32553,9 +32533,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
-          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
+          "version": "12.12.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+          "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         }
       }
     },
@@ -33318,7 +33298,7 @@
       }
     },
     "websocket": {
-      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
       "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
       "requires": {
         "debug": "^2.2.0",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
     "@keep-network/keep-core": ">1.2.4-rc <1.2.4",
-    "@keep-network/keep-ecdsa": "0.16.0-rc.0",
-    "@keep-network/tbtc": "0.15.0-rc.0",
+    "@keep-network/keep-ecdsa": ">1.1.2-rc <1.1.2",
+    "@keep-network/tbtc": ">1.0.2-rc <1.0.2",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "bignumber.js": "9.0.0",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,11 +1,11 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "1.2.4-rc",
   "private": true,
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
-    "@keep-network/keep-core": ">1.1.0-pre <1.1.0-rc",
+    "@keep-network/keep-core": ">1.2.4-rc <1.2.4",
     "@keep-network/keep-ecdsa": "0.16.0-rc.0",
     "@keep-network/tbtc": "0.15.0-rc.0",
     "@ledgerhq/hw-app-eth": "^5.13.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.2.3-rc",
+  "version": "1.2.4-rc",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Intro 

Here's a collection of changes to facilitate migration and deploying the keep-test environment against keep-core v1.2.4-rc.  We did this one slightly different in that we've left keep-client-0 and keep-client-1 running against the previous deployment, to not disturb operation while we roll the new release out.

Please do not merge this PR until all checkboxes in `Tasks` are checked.

### Migration Job

https://app.circleci.com/pipelines/github/keep-network/keep-core/7186/workflows/294eb7ae-b2c9-431d-a2cd-4cce96ec52d7

### Tasks

- [X]  Bump keep-core to v1.2.4-rc
- [X] Bump faucet keep-core dependency to v1.2.4-rc
- [X] Deploy keep-client-2 and keep-client-3 against new contracts, peered with each other
- [X] Run relay genesis via terminal on keep-client-2
- [X] Update docu to reflect new contract addresses and updated peers list
- [X] Deploy faucet against version v.1.2.4-rc
- [X] Deploy token-dashboard against updated keep-core 1.2.4-rc keep-ecdsa 1.1.2-rc tbtc 1.0.2 -rc contracts
- [X] Observe relay relay entry generation by the beacon
~~- [ ] Enable relay request submitter~~  I'm going to scratch this for now, continuing to test relay requests manually.