### PR TITLE
Added Log rotation to docker run command

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -246,6 +246,8 @@ docker run -d \
 --volume $KEEP_CLIENT_CONFIG_DIR:/mnt/keep-client/config \
 --env KEEP_ETHEREUM_PASSWORD=$KEEP_CLIENT_ETHEREUM_PASSWORD \
 --env LOG_LEVEL=debug \
+--log-opt max-size=100m \
+--log-opt max-file=3 \
 -p 3919:3919 \
 keepnetwork/keep-client:<version> --config /mnt/keep-client/config/keep-client-config.toml start
 ----


### PR DESCRIPTION
Added in log rotation to the docker run command so that only 300mb of logs are stored at a time.  Logs over time, especially when run with `debug` will create GB of log files.