### PR TITLE
Improvements for DKG reconstruction phase

### DIFF
--- a/pkg/beacon/relay/gjkr/integration_test.go
+++ b/pkg/beacon/relay/gjkr/integration_test.go
@@ -904,16 +904,12 @@ func TestExecute_DQ_member2_notRevealsDisqualifiedQualMemberKey_phase11(t *testi
 	seed := dkgtest.RandomSeed(t)
 
 	interceptor := func(msg net.TaggedMarshaler) net.TaggedMarshaler {
-		// Member 1 misbehaves by sending an accusation with wrong private key.
+		// Member 1 misbehaves by sending an invalid public key share points message.
 		// As result, they should be disqualified by other members.
-		accusationsMessage, ok := msg.(*gjkr.PointsAccusationsMessage)
-		if ok && accusationsMessage.SenderID() == group.MemberIndex(1) {
-			randomKeyPair, _ := ephemeral.GenerateKeyPair()
-			accusationsMessage.SetAccusedMemberKey(
-				group.MemberIndex(2),
-				randomKeyPair.PrivateKey,
-			)
-			return accusationsMessage
+		publicKeyShareMessage, ok := msg.(*gjkr.MemberPublicKeySharePointsMessage)
+		if ok && publicKeyShareMessage.SenderID() == group.MemberIndex(1) {
+			publicKeyShareMessage.RemovePublicKeyShare(2)
+			return publicKeyShareMessage
 		}
 
 		// Member 2 does not reveal private key generated for the sake

--- a/pkg/beacon/relay/gjkr/protocol.go
+++ b/pkg/beacon/relay/gjkr/protocol.go
@@ -1186,8 +1186,8 @@ func (rm *RevealingMember) RevealMisbehavedMembersKeys() (
 func (rm *RevealingMember) membersForReconstruction() []group.MemberIndex {
 	members := make([]group.MemberIndex, 0)
 
-	// The given member needs reconstruction if two conditions are met:
-	// - member provided qualified shares in Phase 3
+	// Member shares needs reconstruction if two conditions are met:
+	// - member provided valid shares in Phase 3 and is in QUAL set
 	// - member DID NOT provide valid public key share in phase 7
 	needsReconstruction := func(member group.MemberIndex) bool {
 		_, providedQualifiedShares := rm.receivedQualifiedSharesS[member]
@@ -1196,14 +1196,16 @@ func (rm *RevealingMember) membersForReconstruction() []group.MemberIndex {
 		return providedQualifiedShares && !providedValidPublicKeyShare
 	}
 
-	// From disqualified members list filter those who need reconstruction.
+	// From disqualified members list filter those
+	// whose shares need to be reconstructed.
 	for _, disqualifiedMemberID := range rm.group.DisqualifiedMemberIDs() {
 		if needsReconstruction(disqualifiedMemberID) {
 			members = append(members, disqualifiedMemberID)
 		}
 	}
 
-	// From inactive members list filter those who need reconstruction.
+	// From inactive members list filter those
+	// whose shares need to be reconstructed.
 	for _, inactiveMemberID := range rm.group.InactiveMemberIDs() {
 		if needsReconstruction(inactiveMemberID) {
 			members = append(members, inactiveMemberID)

--- a/pkg/beacon/relay/gjkr/protocol_reconstructions_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_reconstructions_test.go
@@ -31,6 +31,10 @@ func TestRevealMisbehavedMembersKeys(t *testing.T) {
 	// Simulate a case where member is disqualified in Phase 5.
 	delete(firstMember.receivedQualifiedSharesS, disqualifiedNotSharingMember)
 
+	// Simulate a case where members are disqualified in Phase 8.
+	delete(firstMember.receivedValidPeerPublicKeySharePoints, disqualifiedSharingMember1)
+	delete(firstMember.receivedValidPeerPublicKeySharePoints, disqualifiedSharingMember2)
+
 	expectedDisqualifiedKeys := map[group.MemberIndex]*ephemeral.PrivateKey{
 		disqualifiedSharingMember1: firstMember.ephemeralKeyPairs[disqualifiedSharingMember1].PrivateKey,
 		disqualifiedSharingMember2: firstMember.ephemeralKeyPairs[disqualifiedSharingMember2].PrivateKey,
@@ -160,6 +164,7 @@ func generateMisbehavedEphemeralKeysMessages(
 	for _, otherMember := range otherMembers {
 		for _, disqualifiedMember := range disqualifiedMembers {
 			otherMember.group.MarkMemberAsDisqualified(disqualifiedMember.ID)
+			delete(otherMember.receivedValidPeerPublicKeySharePoints, disqualifiedMember.ID)
 		}
 		misbehavedEphemeralKeysMessage, err := otherMember.RevealMisbehavedMembersKeys()
 		if err != nil {

--- a/pkg/beacon/relay/integration_test.go
+++ b/pkg/beacon/relay/integration_test.go
@@ -168,6 +168,60 @@ func TestInactiveMemberPublicKeySharesReconstructionAndSigning(t *testing.T) {
 	}
 }
 
+// Success: honest threshold of the signing group members participate in
+// signing.
+//
+// In this scenario, one of the members doesn't send `PointsAccusationsMessage`
+// thus they become inactive at the beginning of phase 9 during DKG.
+// This is problematic because that member provided valid shares in phase 3
+// and all group members include that shares in their private key shares.
+// What is even more important, that member also provided valid public key share
+// points during the phase 8 of DKG so other members have to decide whether they
+// use those received public key share points or they qualify the inactive member
+// to the reconstruction phase and reconstruct them on their own.
+// Otherwise, we may end up with a situation when a signature does not match the
+// group public key.
+func TestInactivePointsAccusationsReconstructionAndSigning(t *testing.T) {
+	t.Parallel()
+
+	interceptor := func(msg net.TaggedMarshaler) net.TaggedMarshaler {
+		pointsAccusationsMessage, ok := msg.(*gjkr.PointsAccusationsMessage)
+		if ok && pointsAccusationsMessage.SenderID() == group.MemberIndex(3) {
+			return nil
+		}
+
+		return msg
+	}
+
+	signingMembersCount := honestThreshold
+	dkgResult, signingResult := runTestWithInterceptor(
+		t,
+		groupSize,
+		honestThreshold,
+		signingMembersCount,
+		interceptor,
+	)
+
+	dkgtest.AssertDkgResultPublished(t, dkgResult)
+	dkgtest.AssertSamePublicKey(t, dkgResult)
+	entrytest.AssertEntryPublished(t, signingResult)
+	entrytest.AssertNoSignerFailures(t, signingResult)
+
+	groupPublicKey, err := getFirstGroupPublicKey(dkgResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newEntry, err := signingResult.EntryValue()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bls.VerifyG1(groupPublicKey, previousEntryG1(), newEntry) {
+		t.Errorf("threshold signature failed BLS verification")
+	}
+}
+
 func TestSigningWithInvalidSignatureShare(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Until now, the reconstruction of the public key share of an inactive/disqualified member was performed only when such member was part of the QUAL set (i.e. their shares broadcasted in phase 3 were valid). Unfortunately, this approach had an uncovered edge case when a member becomes inactive/disqualified exactly in phase 9. In that case, an inactive/disqualified member belongs to the QUAL set, it is selected for reconstruction and its reconstructed public key share is added to the group public key. But, becoming inactive/disqualified in phase 9 means that the member also provided valid public key share during phase 7 which are also added to the group public key. As a result, the group public key becomes invalid and causes errors while signing. The proposed fix improves the `membersForReconstruction` method by checking also the received valid public key shares map.