### PR TITLE
Added nkuba as a code owner of LockUtils library

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 /solidity/contracts/libraries/operator/Reimbursements.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/AddressArrayUtils.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/BytesLib.sol @Shadowfiend @pdyraga
-/solidity/contracts/utils/LockUtils.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/LockUtils.sol @Shadowfiend @pdyraga @nkuba
 /solidity/contracts/utils/OperatorParams.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/PercentUtils.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/UIntArrayUtils.sol @Shadowfiend @pdyraga


### PR DESCRIPTION
@nkuba owns staking contracts and `LockUtils` is a part of staking contracts.