### PR TITLE
Stake top-ups

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -108,16 +108,16 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     }
 
     /// @notice Receives approval of token transfer and stakes the approved
-    /// amount or top-ups an existing delegation with the approved amount.
-    /// In case of a top-up, it is expected that the operator stake passed
-    /// initialization period, it is not undelegated and that the top-up is
+    /// amount or adds the approved amount to an existing delegation (a “top-up”).
+    /// In case of an existing delegation, it is required that the operator stake
+    /// passed initialization period, it is not undelegated and that the top-up is
     /// performed from the same source of tokens as the initial delegation.
     /// That is, if the tokens were delegated from a grant, top-up
     /// has to be performed from the same grant. If the delegation was done
     /// using liquid tokens, only liquid tokens from the same owner can be used
     /// to top-up the stake.
-    /// @dev Makes sure provided token contract is the same one linked to this
-    /// contract.
+    /// @dev Requires that the provided token contract be the same one linked to
+    /// this contract.
     /// @param _from The owner of the tokens who approved them to transfer.
     /// @param _value Approved amount for the transfer and stake.
     /// @param _token Token contract address.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -21,6 +21,7 @@ import "./StakeDelegatable.sol";
 import "./libraries/staking/MinimumStakeSchedule.sol";
 import "./libraries/staking/GrantStaking.sol";
 import "./libraries/staking/Locks.sol";
+import "./libraries/staking/TopUps.sol";
 import "./utils/PercentUtils.sol";
 import "./utils/BytesLib.sol";
 import "./Authorizations.sol";
@@ -40,6 +41,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     using SafeERC20 for ERC20Burnable;
     using GrantStaking for GrantStaking.Storage;
     using Locks for Locks.Storage;
+    using TopUps for TopUps.Storage;
 
     event Staked(
         address owner,
@@ -48,6 +50,8 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address indexed authorizer,
         uint256 value
     );
+    event TopUpInitiated(address indexed operator, uint256 topUp);
+    event TopUpCommitted(address indexed operator, uint256 newAmount);
     event Undelegated(address indexed operator, uint256 undelegatedAt);
     event RecoveredStake(address operator, uint256 recoveredAt);
     event TokensSlashed(address indexed operator, uint256 amount);
@@ -56,21 +60,17 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     event LockReleased(address indexed operator, address lockCreator);
     event ExpiredLockReleased(address indexed operator, address lockCreator);
 
+    uint256 public minimumStakeScheduleStart;
     uint256 public initializationPeriod;
     uint256 public undelegationPeriod;
 
-    uint256 public minimumStakeScheduleStart;
-
     ERC20Burnable internal token;
-
+    TokenGrant internal tokenGrant;
     TokenStakingEscrow internal escrow;
 
     GrantStaking.Storage internal grantStaking;
-
     Locks.Storage internal locks;
-
-    // KEEP token grant contract.
-    TokenGrant internal tokenGrant;
+    TopUps.Storage internal topUps;
 
     /// @notice Creates a token staking contract for a provided Standard ERC20Burnable token.
     /// @param _token KEEP token contract.
@@ -107,44 +107,164 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         return MinimumStakeSchedule.current(minimumStakeScheduleStart);
     }
 
-    /// @notice Receives approval of token transfer and stakes the approved amount.
-    /// @dev Makes sure provided token contract is the same one linked to this contract.
+    /// @notice Receives approval of token transfer and stakes the approved
+    /// amount or top-ups an existing delegation with the approved amount.
+    /// In case of a top-up, it is expected that the operator stake passed
+    /// initialization period, it is not undelegated and that the top-up is
+    /// performed from the same source of tokens as the initial delegation.
+    /// That is, if the tokens were delegated from a grant, top-up
+    /// has to be performed from the same grant. If the delegation was done
+    /// using liquid tokens, only liquid tokens from the same owner can be used
+    /// to top-up the stake.
+    /// @dev Makes sure provided token contract is the same one linked to this
+    /// contract.
     /// @param _from The owner of the tokens who approved them to transfer.
     /// @param _value Approved amount for the transfer and stake.
     /// @param _token Token contract address.
     /// @param _extraData Data for stake delegation. This byte array must have
     /// the following values concatenated:
-    /// - Beneficiary address (20 bytes)
+    /// - Beneficiary address (20 bytes), ignored for a top-up
     /// - Operator address (20 bytes)
-    /// - Authorizer address (20 bytes)
-    function receiveApproval(address _from, uint256 _value, address _token, bytes memory _extraData) public {
+    /// - Authorizer address (20 bytes), ignored for a top-up
+    /// - Grant ID (32 bytes) - required only when called by TokenStakingEscrow
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes memory _extraData
+    ) public {
         require(ERC20Burnable(_token) == token, "Unrecognized token contract");
         require(_value >= minimumStake(), "Value must be greater than the minimum stake");
         require(_extraData.length >= 60, "Corrupted delegation data");
 
-        address payable beneficiary = address(uint160(_extraData.toAddress(0)));
-        address operator = _extraData.toAddress(20);
-        require(operators[operator].owner == address(0), "Operator already in use");
-        address authorizer = _extraData.toAddress(40);
-
         // Transfer tokens to this contract.
         token.safeTransferFrom(_from, address(this), _value);
 
-        operators[operator] = Operator(
+        address operator = _extraData.toAddress(20);
+        // See if there is an existing delegation for this operator...
+        if (operators[operator].packedParams.getCreationTimestamp() == 0) {
+            // If there is no existing delegation, tokens are delegated using
+            // beneficiary and authorizer passed in _extraData.
+            delegate(_from, _value, operator, _extraData);
+        } else {
+            // If there is an existing delegation, top-up of the stake is
+            // initiated.
+            initiateTopUp(_from, _value, operator);
+        }
+    }
+
+    /// @notice Delegates tokens to a new operator using beneficiary and
+    /// authorizer passed in _extraData parameter.
+    /// @param _from The owner of the tokens who approved them to transfer.
+    /// @param _value Approved amount for the transfer and stake.
+    /// @param _operator The new operator address.
+    /// @param _extraData Data for stake delegation. This byte array must have
+    /// the following values concatenated:
+    /// - Beneficiary address (20 bytes)
+    /// - Operator address (20 bytes)
+    /// - Authorizer address (20 bytes)
+    /// - Grant ID (32 bytes) - required only when called by TokenStakingEscrow
+    function delegate(
+        address _from,
+        uint256 _value,
+        address _operator,
+        bytes memory _extraData
+    ) internal {
+        address payable beneficiary = address(uint160(_extraData.toAddress(0)));
+        address authorizer = _extraData.toAddress(40);
+
+        operators[_operator] = Operator(
             OperatorParams.pack(_value, block.timestamp, 0),
             _from,
             beneficiary,
             authorizer
         );
-        ownerOperators[_from].push(operator);
+        ownerOperators[_from].push(_operator);
 
-        if (_from == address(escrow)) {
-            grantStaking.setGrantForOperator(operator, _extraData.toUint(60));
+        grantStaking.tryCapturingDelegationData(
+            tokenGrant,
+            address(escrow),
+            _from,
+            _operator,
+            _extraData
+        );
+
+        emit Staked(_from, _operator, beneficiary, authorizer, _value);
+    }
+
+    /// @notice Initializes top-up to an existing operator. Tokens added in
+    /// a top-up are not included in the operator stake until the initialization
+    /// period for a top-up passes and top-up is committed. Operator must not
+    /// have the stake undelegated and it has to be initialized. It is expected
+    /// that the top-up is done from the same source of tokens as the initial
+    /// delegation. That is, if the tokens were delegated from a grant, top-up
+    /// has to be performed from the same grant. If the delegation was done
+    /// using liquid tokens, only liquid tokens from the same owner can be used
+    /// to top-up the stake.
+    /// @param _from The owner of the tokens who approved them to transfer.
+    /// @param _value Approved amount for the transfer and top-up to
+    /// an existing stake.
+    /// @param _operator The new operator address.
+    function initiateTopUp(
+        address _from,
+        uint256 _value,
+        address _operator
+    ) internal {
+        uint256 operatorParams = operators[_operator].packedParams;
+        require(
+            _isInitialized(operatorParams),
+            "Initialization period is not over"
+        );
+        require(
+            !_isUndelegating(operatorParams),
+            "Operator undelegated"
+        );
+
+        bool isFromGrant = address(tokenGrant.grantStakes(_operator)) == _from;
+        if (grantStaking.hasGrantDelegated(_operator)) {
+            // Operator has grant delegated. We need to see if the top-up
+            // is performed also from a grant.
+            require(isFromGrant, "Must be from a grant");
+            // If it is from a grant, we need to make sure it's from the same
+            // grant as the original delegation. We do not want to mix unlocking
+            // schedules.
+            uint256 previousGrantId = grantStaking.getGrantForOperator(_operator);
+            (, uint256 grantId) = grantStaking.tryCapturingGrantId(
+                tokenGrant, _operator
+            );
+            require(grantId == previousGrantId, "Not the same grant");
         } else {
-            grantStaking.tryCapturingGrantId(tokenGrant, operator);
+            // Operator has no grant delegated. We need to see if the top-up
+            // is performed from liquid tokens of the same owner.
+            require(!isFromGrant, "Must not be from a grant");
+            require(operators[_operator].owner == _from, "Not the same owner");
         }
 
-        emit Staked(_from, operator, beneficiary, authorizer, _value);
+        topUps.initiate(_value, _operator);
+        emit TopUpInitiated(_operator, _value);
+    }
+
+    /// @notice Commits pending top-up for the provided operator. If the top-up
+    /// did not pass the initialization period, the function fails.
+    /// @param _operator The operator with a pending top-up that is getting
+    /// committed.
+    function commitTopUp(address _operator) public {
+        uint256 newAmount = addStakeAmount(
+            topUps.commit(_operator, initializationPeriod),
+            _operator
+        );
+        emit TopUpCommitted(_operator, newAmount);
+    }
+
+    function addStakeAmount(
+        uint256 _topUp,
+        address _operator
+    ) internal returns (uint256) {
+        uint256 oldParams = operators[_operator].packedParams;
+        uint256 newAmount = oldParams.getAmount().add(_topUp);
+        uint256 newParams = oldParams.setAmount(newAmount);
+        operators[_operator].packedParams = newParams;
+        return newAmount;
     }
 
     /// @notice Cancels stake of tokens within the operator initialization period
@@ -211,7 +331,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             // Undelegation not in progress OR
             existingUndelegationTimestamp == 0 ||
             // Undelegating sooner than previously set time OR
-            existingUndelegationTimestamp > _undelegationTimestamp ||            
+            existingUndelegationTimestamp > _undelegationTimestamp ||
             // We have already checked above that msg.sender is owner, grantee,
             // or operator. Only owner and grantee are eligible to postpone the
             // delegation so it is enough if we exclude operator here.
@@ -245,6 +365,13 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
         address owner = operators[_operator].owner;
         uint256 amount = operatorParams.getAmount();
+
+        // If there is a pending top-up, force-commit it before returning
+        // tokens.
+        uint256 topUp = topUps.forceCommit(_operator);
+        if (topUp > 0) {
+            amount = addStakeAmount(topUp, _operator);
+        }
 
         operators[_operator].packedParams = operatorParams.setAmount(0);
         transferOrDeposit(owner, _operator, amount);

--- a/solidity/contracts/libraries/staking/GrantStaking.sol
+++ b/solidity/contracts/libraries/staking/GrantStaking.sol
@@ -30,7 +30,7 @@ library GrantStaking {
     /// @notice Tries to capture delegation data if the pending delegation has
     /// been created from a grant. There are only two possibilities and they
     /// need to be handled differently: delegation comes from the TokenGrant
-    /// contract or delegation comes from TokenStakincEscrow. In those two cases
+    /// contract or delegation comes from TokenStakingEscrow. In those two cases
     /// grant ID has to be captured in a different way.
     /// @dev In case of a delegation from the escrow, it is expected that grant
     /// ID is passed in extraData bytes array. When the delegation comes from

--- a/solidity/contracts/libraries/staking/GrantStaking.sol
+++ b/solidity/contracts/libraries/staking/GrantStaking.sol
@@ -1,13 +1,15 @@
 pragma solidity 0.5.17;
 
 import "../../TokenGrant.sol";
+import "../../TokenStakingEscrow.sol";
+import "../..//utils/BytesLib.sol";
 import "../RolesLookup.sol";
 
 /// @notice TokenStaking contract library allowing to capture the details of
 /// delegated grants and offering functions allowing to check grantee
 /// authentication for stake delegation management.
 library GrantStaking {
-
+    using BytesLib for bytes;
     using RolesLookup for address payable;
 
     /// @dev Grant ID is flagged with the most significant bit set, to
@@ -25,6 +27,37 @@ library GrantStaking {
         mapping (address => uint256) _operatorToGrant;
     }
 
+    /// @notice Tries to capture delegation data if the pending delegation has
+    /// been created from a grant. There are only two possibilities and they
+    /// need to be handled differently: delegation comes from the TokenGrant
+    /// contract or delegation comes from TokenStakincEscrow. In those two cases
+    /// grant ID has to be captured in a different way.
+    /// @dev In case of a delegation from the escrow, it is expected that grant
+    /// ID is passed in extraData bytes array. When the delegation comes from
+    /// the TokenGrant contract, delegation data are obtained directly from that
+    /// contract using `tryCapturingGrantId` function.
+    /// @param tokenGrant KEEP token grant contract reference.
+    /// @param escrow TokenStakingEscrow contract address.
+    /// @param from The owner of the tokens who approved them to transfer.
+    /// @param operator The operator tokens are delegated to.
+    /// @param extraData Data for stake delegation, as passed to
+    /// `receiveApproval` of `TokenStaking`.
+    function tryCapturingDelegationData(
+        Storage storage self,
+        TokenGrant tokenGrant,
+        address escrow,
+        address from,
+        address operator,
+        bytes memory extraData
+    ) public {
+        if (from == address(escrow)) {
+            require(extraData.length == 92, "Corrupted delegation data from escrow");
+            setGrantForOperator(self, operator, extraData.toUint(60));
+        } else {
+            tryCapturingGrantId(self, tokenGrant, operator);
+        }
+    }
+
     /// @notice Checks if the delegation for the given operator has been created
     /// from a grant defined in the passed token grant contract and if so,
     /// captures the grant ID for that delegation.
@@ -37,14 +70,17 @@ library GrantStaking {
         Storage storage self,
         TokenGrant tokenGrant,
         address operator
-    ) public {
+    ) public returns (bool, uint256) {
         (bool success, bytes memory data) = address(tokenGrant).call(
             abi.encodeWithSignature("getGrantStakeDetails(address)", operator)
         );
         if (success) {
             uint256 grantId = abi.decode(data, (uint256));
             setGrantForOperator(self, operator, grantId);
+            return (true, grantId);
         }
+
+        return (false, 0);
     }
 
     /// @notice Returns true if the given operator operates on stake delegated

--- a/solidity/contracts/libraries/staking/GrantStaking.sol
+++ b/solidity/contracts/libraries/staking/GrantStaking.sol
@@ -49,12 +49,14 @@ library GrantStaking {
         address from,
         address operator,
         bytes memory extraData
-    ) public {
+    ) public returns (bool, uint256) {
         if (from == address(escrow)) {
             require(extraData.length == 92, "Corrupted delegation data from escrow");
-            setGrantForOperator(self, operator, extraData.toUint(60));
+            uint256 grantId = extraData.toUint(60);
+            setGrantForOperator(self, operator, grantId);
+            return (true, grantId);
         } else {
-            tryCapturingGrantId(self, tokenGrant, operator);
+            return tryCapturingGrantId(self, tokenGrant, operator);
         }
     }
 
@@ -70,7 +72,7 @@ library GrantStaking {
         Storage storage self,
         TokenGrant tokenGrant,
         address operator
-    ) public returns (bool, uint256) {
+    ) internal returns (bool, uint256) {
         (bool success, bytes memory data) = address(tokenGrant).call(
             abi.encodeWithSignature("getGrantStakeDetails(address)", operator)
         );

--- a/solidity/contracts/libraries/staking/TopUps.sol
+++ b/solidity/contracts/libraries/staking/TopUps.sol
@@ -1,0 +1,76 @@
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+/// @notice TokenStaking contract library allowing to perform two-step stake
+/// top-ups for existing delegations.
+/// Top-up is a two-step process: it is initiated with a declared top-up value
+/// and after waiting for at least the initialization period it can be
+/// committed.
+library TopUps {
+    using SafeMath for uint256;
+
+    struct TopUp {
+        uint256 amount;
+        uint256 createdAt;
+    }
+
+    struct Storage {
+        // operator -> TopUp
+        mapping(address => TopUp) topUps;
+    }
+
+    /// @notice Initiates top-up of the given value for tokens delegated to
+    /// the provided operator. If there is an existing top-up still
+    /// initializing, top-up values are summed up and initialization period
+    /// is set to the current block timestamp.
+    /// @param value Top-up value, the number of tokens added to the stake.
+    /// @param operator Operator The operator with existing delegation to which
+    /// the tokens should be added to.
+    function initiate(
+        Storage storage self,
+        uint256 value,
+        address operator
+    ) public {
+        TopUp memory awaiting = self.topUps[operator];
+        self.topUps[operator] = TopUp(awaiting.amount.add(value), now);
+    }
+
+    /// @notice Commits the top-up if it passed the initialization period.
+    /// Tokens are added to the stake once the top-up is committed.
+    /// @param operator Operator The operator with a pending stake top-up.
+    /// @param initializationPeriod Stake initialization period.
+    function commit(
+        Storage storage self,
+        address operator,
+        uint256 initializationPeriod
+    ) public returns (uint256) {
+        TopUp memory topUp = self.topUps[operator];
+        require(topUp.amount > 0, "No top up to commit");
+        require(
+            now > topUp.createdAt.add(initializationPeriod),
+            "Initialization period is not over"
+        );
+
+        delete self.topUps[operator];
+        return topUp.amount;
+    }
+
+    /// @notice Force-commits existing top-up without taking into account
+    /// stake initialization period. If there is no pending top-up for the
+    /// operator, function does nothing. This function should be used when
+    /// the stake is recovered to return tokens from a pending top-up.
+    /// @param operator Operator The operator from which the stake is recovered.
+    function forceCommit(
+        Storage storage self,
+        address operator
+    ) public returns (uint256) {
+        TopUp memory topUp = self.topUps[operator];
+        if (topUp.amount == 0) {
+            return 0;
+        }
+
+        delete self.topUps[operator];
+        return topUp.amount;
+    }
+}

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -2,9 +2,10 @@ const KeepToken = artifacts.require("./KeepToken.sol");
 const ModUtils = artifacts.require("./utils/ModUtils.sol");
 const AltBn128 = artifacts.require("./cryptography/AltBn128.sol");
 const BLS = artifacts.require("./cryptography/BLS.sol");
-const MinimumStakeSchedule = artifacts.require("./MinimumStakeSchedule.sol");
-const GrantStaking = artifacts.require("./GrantStaking.sol");
-const Locks = artifacts.require("./Locks.sol");
+const MinimumStakeSchedule = artifacts.require("./libraries/staking/MinimumStakeSchedule.sol");
+const GrantStaking = artifacts.require("./libraries/staking/GrantStaking.sol");
+const Locks = artifacts.require("./libraries/staking/Locks.sol");
+const TopUps = artifacts.require("./libraries/staking/TopUps.sol");
 const TokenStaking = artifacts.require("./TokenStaking.sol");
 const TokenStakingEscrow = artifacts.require("./TokenStakingEscrow.sol");
 const PermissiveStakingPolicy = artifacts.require('./PermissiveStakingPolicy.sol');
@@ -45,9 +46,11 @@ module.exports = async function(deployer, network) {
   await deployer.deploy(MinimumStakeSchedule);
   await deployer.deploy(GrantStaking);
   await deployer.deploy(Locks);
+  await deployer.deploy(TopUps);
   await deployer.link(MinimumStakeSchedule, TokenStaking);
   await deployer.link(GrantStaking, TokenStaking);
   await deployer.link(Locks, TokenStaking);
+  await deployer.link(TopUps, TokenStaking);
   await deployer.deploy(
     TokenStaking,
     KeepToken.address,

--- a/solidity/test/helpers/delegateStake.js
+++ b/solidity/test/helpers/delegateStake.js
@@ -13,7 +13,7 @@ async function delegateStake(
     Buffer.from(authorizer.substr(2), 'hex')
   ]);
     
-  await tokenContract.approveAndCall(
+  return tokenContract.approveAndCall(
     stakingContract.address, amount, 
     '0x' + data.toString('hex'), 
     {from: tokenOwner}

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -12,6 +12,7 @@ const TokenGrant = contract.fromArtifact('TokenGrant');
 const MinimumStakeSchedule = contract.fromArtifact('MinimumStakeSchedule');
 const GrantStaking = contract.fromArtifact('GrantStaking');
 const Locks = contract.fromArtifact('Locks');
+const TopUps = contract.fromArtifact('TopUps');
 
 async function initTokenStaking(
   tokenAddress,
@@ -40,6 +41,10 @@ async function initTokenStaking(
   await TokenStaking.link(
     'Locks',
     (await Locks.new({from: accounts[0]})).address
+  )
+  await TokenStaking.link(
+    'TopUps',
+    (await TopUps.new({from: accounts[0]})).address
   )
 
   let tokenStaking = await TokenStaking.new(

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -285,17 +285,7 @@ describe('TokenGrant/Stake', function() {
     )
   })
 
-  it("should not allow to delegate to the same operator twice", async () => {
-    let amountToDelegate = minimumStake.muln(5);
-    await delegate(grantee, operatorOne, amountToDelegate);
-
-    await expectRevert(
-      delegate(grantee, operatorOne, amountToDelegate, grantId),
-      "Operator already in use"
-    )
-  })
-
-  it("should not allow to delegate to the same operator even after recovering stake", async () => {
+  it("should not allow to delegate to the same operator after recovering stake", async () => {
     let tx = await delegate(grantee, operatorOne, grantAmount)
     let createdAt = web3.utils.toBN((await web3.eth.getBlock(tx.receipt.blockNumber)).timestamp)
     await time.increaseTo(createdAt.add(initializationPeriod).addn(1))
@@ -306,7 +296,7 @@ describe('TokenGrant/Stake', function() {
 
     await expectRevert(
       delegateLiquid(grantee, operatorOne, minimumStake),
-      "Operator already in use"
+      "Operator undelegated"
     )
   })
 

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -93,16 +93,7 @@ describe('TokenStaking', function() {
       ); 
     })
 
-    it("should not allow to delegate to the same operator twice", async () => {
-      await delegate(operatorOne, stakingAmount)
-  
-      await expectRevert(
-        delegate(operatorOne, stakingAmount),
-        "Operator already in use"
-      )
-    })
-  
-    it("should not allow to delegate to the same operator even after recovering stake", async () => {
+    it("should not allow to delegate to the same operator after recovering stake", async () => {
       let tx = await delegate(operatorOne, stakingAmount)
       let createdAt = web3.utils.toBN((await web3.eth.getBlock(tx.receipt.blockNumber)).timestamp)
   
@@ -113,10 +104,10 @@ describe('TokenStaking', function() {
           
       await expectRevert(
         delegate(operatorOne, stakingAmount),
-        "Operator already in use"
+        "Operator undelegated"
       )
     })
-  
+
     it("should not allow to delegate less than the minimum stake", async () => {    
       await expectRevert(
         delegate(operatorOne, minimumStake.subn(1)),

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -331,6 +331,14 @@ describe('TokenStaking/TopUps', () => {
 
       expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))
     })
+
+    it("fails to commit if not first initialized", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorOne),
+        "No top up to commit"
+      )
+    })
   })
 
   describe("delegated grant top-ups", async () => {
@@ -462,6 +470,14 @@ describe('TokenStaking/TopUps', () => {
 
       expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))  
     })
+
+    it("fails to commit if not first initialized", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorTwo),
+        "No top up to commit"
+      )
+    })
   })
 
   describe("delegated managed grant top-ups", async () => {
@@ -591,6 +607,14 @@ describe('TokenStaking/TopUps', () => {
       const after = await tokenStakingEscrow.depositedAmount(operatorThree)
 
       expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))
+    })
+
+    it("fails to commit if not first initialized", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorThree),
+        "No top up to commit"
+      )
     })
   })
 

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -1,0 +1,595 @@
+const {contract, accounts, web3} = require("@openzeppelin/test-environment")
+const {expectRevert, time} = require("@openzeppelin/test-helpers")
+const {initTokenStaking} = require('../helpers/initContracts')
+const {createSnapshot, restoreSnapshot} = require('../helpers/snapshot');
+
+const {grantTokens, grantTokensToManagedGrant} = require('../helpers/grantTokens');
+const {
+    delegateStake,
+    delegateStakeFromGrant,
+    delegateStakeFromManagedGrant,
+  } = require('../helpers/delegateStake')
+
+const KeepToken = contract.fromArtifact('KeepToken')
+const KeepRegistry = contract.fromArtifact('KeepRegistry')
+const TokenGrant = contract.fromArtifact('TokenGrant')
+const PermissiveStakingPolicy = contract.fromArtifact('PermissiveStakingPolicy')
+const ManagedGrantFactory = contract.fromArtifact('ManagedGrantFactory')
+const ManagedGrant = contract.fromArtifact('ManagedGrant')
+
+const BN = web3.utils.BN
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
+describe('TokenStaking/TopUps', () => {
+
+  const deployer = accounts[0],
+    grantManager = accounts[1],
+    grantee = accounts[2],
+    managedGrantee = accounts[3],
+    tokenOwner = accounts[4],
+    operatorOne = accounts[5],
+    operatorTwo = accounts[6],
+    operatorThree = accounts[7],
+    beneficiary = accounts[8],
+    authorizer = accounts[9],
+    thirdParty = accounts[10]
+    operatorContract = accounts[11]
+
+  const initializationPeriod = time.duration.seconds(10),
+    undelegationPeriod = time.duration.seconds(10),
+    grantStart = time.duration.seconds(0),
+    grantUnlockingDuration = time.duration.years(100),
+    grantCliff = time.duration.seconds(0),
+    grantRevocable = true
+
+  let token, tokenGrant, tokenStakingEscrow, tokenStaking
+
+  let grantId, grant2Id, managedGrant, grantedAmount, delegatedAmount
+
+  before(async () => {
+    //
+    // Deploy KEEP token contract.
+    // Transfer 50% of all tokens to grant manager and 50% of tokens
+    // to token owner (account delegating liquid tokens in tests).
+    //
+    token = await KeepToken.new({from: deployer})
+    const allTokens = await token.balanceOf(deployer)
+    await token.transfer(grantManager, allTokens.divn(2), {from: deployer})
+    await token.transfer(tokenOwner, allTokens.divn(2), {from: deployer})
+
+    //
+    // Deploy TokenGrant, ManagedGrantFactory, KeepRegistry, TokenStaking,
+    // and TokenStakingEscrow. 
+    // Authorize TokenStaking contract in TokenGrant contract.
+    //
+    tokenGrant = await TokenGrant.new(token.address, {from: deployer})
+    const permissivePolicy = await PermissiveStakingPolicy.new()
+    const managedGrantFactory = await ManagedGrantFactory.new(
+      token.address,
+      tokenGrant.address,
+      {from: deployer}
+    ) 
+    const registry = await KeepRegistry.new({from: deployer})
+    const stakingContracts = await initTokenStaking(
+      token.address,
+      tokenGrant.address,
+      registry.address,
+      initializationPeriod,
+      undelegationPeriod,
+      contract.fromArtifact('TokenStakingEscrow'),
+      contract.fromArtifact('TokenStaking')
+    )
+    tokenStaking = stakingContracts.tokenStaking
+    tokenStakingEscrow = stakingContracts.tokenStakingEscrow
+    await tokenGrant.authorizeStakingContract(tokenStaking.address, {
+      from: grantManager,
+    })
+
+    //
+    // Create three grants:
+    // - two separate grants goes to grantee,
+    // - one grant goes to managed grantee. 
+    // 
+    const minimumStake = await tokenStaking.minimumStake();
+    grantedAmount = minimumStake.muln(40);
+    delegatedAmount = minimumStake.muln(20);
+
+    grantId = await grantTokens(
+      tokenGrant, 
+      token, 
+      grantedAmount, 
+      grantManager, 
+      grantee, 
+      grantUnlockingDuration,
+      grantStart,
+      grantCliff,
+      grantRevocable,
+      permissivePolicy.address
+    )
+    grant2Id = await grantTokens(
+      tokenGrant, 
+      token, 
+      grantedAmount, 
+      grantManager, 
+      grantee, 
+      grantUnlockingDuration,
+      grantStart,
+      grantCliff,
+      grantRevocable,
+      permissivePolicy.address
+    )
+    const managedGrantAddress = await grantTokensToManagedGrant(
+      managedGrantFactory,
+      token,
+      grantedAmount,
+      grantManager,
+      managedGrantee,
+      grantUnlockingDuration,
+      grantStart,
+      grantCliff,
+      false,
+      permissivePolicy.address,
+    )
+    managedGrant = await ManagedGrant.at(managedGrantAddress)
+
+    //
+    // Delegate stakes:
+    // - operatorOne receives delegation from liquid tokens of tokenOwner
+    // - operatorTwo receives delegation from granted tokens of grantee
+    //   from the first grant
+    // - operatorThree receives delegation from granted tokens of managed grantee.
+    //
+    await delegateStake(
+      token, 
+      tokenStaking, 
+      tokenOwner,
+      operatorOne,
+      beneficiary,
+      authorizer,
+      delegatedAmount
+    )
+    await delegateStakeFromGrant(
+      tokenGrant,
+      tokenStaking.address,
+      grantee,
+      operatorTwo,
+      beneficiary,
+      authorizer,
+      delegatedAmount,
+      grantId
+    )
+    await delegateStakeFromManagedGrant(
+      managedGrant,
+      tokenStaking.address,
+      managedGrantee,
+      operatorThree,
+      beneficiary,
+      authorizer,
+      delegatedAmount
+    ) 
+
+    //
+    // Approve operator contract in the registry, authorize operator contract
+    // for all three operators.
+    //
+    await registry.approveOperatorContract(
+      operatorContract,
+      {from: deployer}
+    )
+    await tokenStaking.authorizeOperatorContract(
+      operatorOne,
+      operatorContract,
+      {from: authorizer}
+    )
+    await tokenStaking.authorizeOperatorContract(
+      operatorTwo,
+      operatorContract,
+      {from: authorizer}
+    )
+    await tokenStaking.authorizeOperatorContract(
+      operatorThree,
+      operatorContract,
+      {from: authorizer}
+    )
+  })
+
+  beforeEach(async () => {
+    await createSnapshot()
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot()
+  })
+
+  describe("delegated liquid tokens top ups", async () => {
+    async function initiateTopUp() {
+      return delegateStake(
+        token, tokenStaking, tokenOwner, operatorOne,
+        beneficiary, authorizer, delegatedAmount
+      )
+    }
+
+    it("can not be done during initialization period", async () => {
+      await expectRevert(
+        initiateTopUp(),
+        "Initialization period is not over"
+      )
+    })
+
+    it("can not be done when stake is undelegating", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.undelegate(operatorOne, {from: tokenOwner})
+      time.increase(1) // we need the block timestamp to increase
+      await expectRevert(
+        initiateTopUp(),
+        "Operator undelegated"
+      ) 
+    })
+
+    it("can not be done when stake is recovered", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.undelegate(operatorOne, {from: tokenOwner})
+      await time.increase(undelegationPeriod.addn(1))
+      await tokenStaking.recoverStake(operatorOne)
+      time.increase(1) // we need the block timestamp to increase
+      await expectRevert(
+        initiateTopUp(),
+        "Operator undelegated"
+      )
+    })
+
+    it("can not be done by another token owner", async () => {
+      await token.transfer(thirdParty, delegatedAmount, {from: tokenOwner})
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        delegateStake(
+          token, tokenStaking, thirdParty, operatorOne,
+          beneficiary, authorizer, delegatedAmount
+        ),
+        "Not the same owner"
+      )
+    })
+
+    it("can not be done from a token grant", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        delegateStakeFromGrant(
+          tokenGrant,
+          tokenStaking.address,
+          grantee,
+          operatorOne,
+          beneficiary,
+          authorizer,
+          delegatedAmount,
+          grantId
+        ),
+        "Must not be from a grant"
+      )   
+    })
+
+    it("does not increase stake before committed", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod)
+
+      let currentStake = await tokenStaking.activeStake(
+        operatorOne,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount)
+    })
+
+    it("increases stake once committed", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorOne)
+
+      const currentStake = await tokenStaking.activeStake(
+        operatorOne,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(2))
+    })
+
+    it("can not be committed before initialization period is over", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorOne),
+        "Initialization period is not over"
+      )
+    })
+
+    it("returns full amount with committed top-ups to owner after recovering stake", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorOne)
+      await tokenStaking.undelegate(operatorOne, {from: tokenOwner})
+      await time.increase(undelegationPeriod.addn(1))
+
+      const before = await token.balanceOf(tokenOwner) 
+      await tokenStaking.recoverStake(operatorOne, {from: tokenOwner})
+      const after = await token.balanceOf(tokenOwner)
+
+      expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))
+    })
+
+    it("returns uncommitted top-ups to owner after recovering stake", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await tokenStaking.undelegate(operatorOne, {from: tokenOwner})
+      await time.increase(undelegationPeriod.addn(1))
+
+      const before = await token.balanceOf(tokenOwner) 
+      await tokenStaking.recoverStake(operatorOne, {from: tokenOwner})
+      const after = await token.balanceOf(tokenOwner)
+
+      expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))
+    })
+  })
+
+  describe("delegated grant top ups", async () => {
+    async function initiateTopUp() {
+      await delegateStakeFromGrant(
+        tokenGrant,
+        tokenStaking.address,
+        grantee,
+        operatorTwo,
+        beneficiary,
+        authorizer,
+        delegatedAmount,
+        grantId
+      ) 
+    }
+
+    it("can not be done during initialization period", async () => {
+      await expectRevert(
+        initiateTopUp(),
+        "Initialization period is not over"
+      )
+    })
+
+    it("can not be done when stake is undelegated", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.undelegate(operatorTwo, {from: grantee})
+      time.increase(1) // we need the block timestamp to increase
+      await expectRevert(
+        initiateTopUp(),
+        "Operator undelegated"
+      )
+    })
+
+    it("can not be done when stake is recovered", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.undelegate(operatorTwo, {from: grantee})
+      await time.increase(undelegationPeriod.addn(1))
+      await tokenStaking.recoverStake(operatorTwo)
+      time.increase(1) // we need the block timestamp to increase
+      await expectRevert(
+        initiateTopUp(),
+        "Operator undelegated"
+      )
+    })
+
+    it("can not be done from another grant", async () => {
+      await time.increase(initializationPeriod.addn(1))
+
+      await expectRevert(
+        delegateStakeFromGrant(
+          tokenGrant, tokenStaking.address, grantee, operatorTwo,
+          beneficiary, authorizer, delegatedAmount, grant2Id
+        ),
+        "Not the same grant"
+      ) 
+    })
+
+    it("can not be done from liquid tokens", async () => {
+      await time.increase(initializationPeriod.addn(1))
+
+      await token.transfer(grantee, grantedAmount, {from: grantManager})
+      await expectRevert(
+        delegateStake(
+          token, tokenStaking, grantee, operatorTwo,
+          beneficiary, authorizer, delegatedAmount
+        ),
+        "Must be from a grant"
+      );
+    })
+
+    it("does not increase stake before committed", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod)
+
+      let currentStake = await tokenStaking.activeStake(
+        operatorTwo,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount)
+    })
+
+    it("increases stake once committed", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorTwo)
+
+      const currentStake = await tokenStaking.activeStake(
+        operatorTwo,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(2))
+    })
+
+    it("can not be committed before initialization period is over", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorTwo),
+        "Initialization period is not over"
+      )
+    })
+
+    it("returns full amount with committed top-ups to escrow after recovering stake", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorTwo)
+      await tokenStaking.undelegate(operatorTwo, {from: grantee})
+      await time.increase(undelegationPeriod.addn(1))
+
+      const before = await tokenStakingEscrow.depositedAmount(operatorTwo)
+      await tokenStaking.recoverStake(operatorTwo, {from: grantee})
+      const after = await tokenStakingEscrow.depositedAmount(operatorTwo)
+
+      expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))  
+    })
+
+    it("returns uncommitted top-ups to escrow after recovering stake", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await tokenStaking.undelegate(operatorTwo, {from: grantee})
+      await time.increase(undelegationPeriod.addn(1))
+
+      const before = await tokenStakingEscrow.depositedAmount(operatorTwo)
+      await tokenStaking.recoverStake(operatorTwo, {from: grantee})
+      const after = await tokenStakingEscrow.depositedAmount(operatorTwo)
+
+      expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))  
+    })
+  })
+
+  describe("delegated managed grant top ups", async () => {
+    async function initiateTopUp() {
+      await delegateStakeFromManagedGrant(
+        managedGrant,
+        tokenStaking.address,
+        managedGrantee,
+        operatorThree,
+        beneficiary,
+        authorizer,
+        delegatedAmount
+      ) 
+    }
+
+    it("can not be done during initialization period", async () => {
+      await expectRevert(
+        initiateTopUp(),
+        "Initialization period is not over"
+      )
+    })
+
+    it("can not be done when stake is undelegating", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.undelegate(operatorThree, {from: managedGrantee})
+      time.increase(1) // we need the block timestamp to increase
+      await expectRevert(
+        initiateTopUp(),
+        "Operator undelegated"
+      )
+    })
+
+    it("can not be done when stake is recovered", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.undelegate(operatorThree, {from: managedGrantee})
+      await time.increase(undelegationPeriod.addn(1))
+      await tokenStaking.recoverStake(operatorThree)
+      time.increase(1) // we need the block timestamp to increase
+      await expectRevert(
+        initiateTopUp(),
+        "Operator undelegated"
+      )
+    })
+
+    it("can not be done from another grant", async () => {
+      await time.increase(initializationPeriod.addn(1))
+
+      await expectRevert(
+        delegateStakeFromGrant(
+          tokenGrant, tokenStaking.address, grantee, operatorThree,
+          beneficiary, authorizer, delegatedAmount, grantId
+        ),
+        "Not the same grant"
+      )   
+    })
+
+    it("can not be done from liquid tokens", async () => {
+      await time.increase(initializationPeriod.addn(1))
+
+      await token.transfer(managedGrantee, grantedAmount, {from: grantManager})
+      await expectRevert(
+        delegateStake(
+          token, tokenStaking, managedGrantee, operatorTwo,
+          beneficiary, authorizer, delegatedAmount
+        ),
+        "Must be from a grant"
+      );
+    })
+
+    it("does not increase stake before committed", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod)
+
+      let currentStake = await tokenStaking.activeStake(
+        operatorThree,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount)
+    })
+
+    it("increases stake once committed", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorThree)
+
+      const currentStake = await tokenStaking.activeStake(
+        operatorThree,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(2))
+    })
+
+    it("can not be committed before initialization period is over", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorThree),
+        "Initialization period is not over"
+      )
+    })
+
+    it("returns full amount with committed top-ups to escrow after recovering stake", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorThree)
+      await tokenStaking.undelegate(operatorThree, {from: managedGrantee})
+      await time.increase(undelegationPeriod.addn(1))
+
+      const before = await tokenStakingEscrow.depositedAmount(operatorThree)
+      await tokenStaking.recoverStake(operatorThree, {from: managedGrantee})
+      const after = await tokenStakingEscrow.depositedAmount(operatorThree)
+
+      expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))  
+    })
+
+    it("returns uncommitted top-ups to escrow after recovering stake", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await initiateTopUp()
+      await tokenStaking.undelegate(operatorThree, {from: managedGrantee})
+      await time.increase(undelegationPeriod.addn(1))
+
+      const before = await tokenStakingEscrow.depositedAmount(operatorThree)
+      await tokenStaking.recoverStake(operatorThree, {from: managedGrantee})
+      const after = await tokenStakingEscrow.depositedAmount(operatorThree)
+
+      expect(after.sub(before)).to.eq.BN(delegatedAmount.muln(2))
+    })
+  })
+}) 


### PR DESCRIPTION
The idea behind a top-up is to let the staker add KEEP tokens to existing delegations. This is a two-step process: first, staker
initiates a top-up, locking new KEEPs in the staking contract. Once the initialization period is over, staker (or anyone else)
can commit the top-up, increasing operator's stake.

From the smart contract's perspective, top-ups are performed using the same interface as delegations: `receiveApproval` on `TokenStaking` contract. If the given operator is active, tokens are treated as a top-up. If the given operator is not known, tokens are used to create a new delegation.

Operators who have their stake undelegated cannot have their stake topped-up. It means that we still enforce operator's uniqueness - operator address cannot be reused after delegating and recovering the stake. This is important because token staking escrow assumes operator's uniqueness when accepting a token deposit. Without operator's uniqueness, bookkeeping in the escrow would become a nightmare. 

For the same reason, staking contract enforces the same source of token for a top-up as used for the initial delegation. If the initial delegation was done from a grant, the same grant has to be used for a top-up to the operator. If the initial delegation was done using owner's liquid tokens, liquid tokens from the same owner are required for a top-up.

Top-up is a two-step process for gas efficiency reasons. For the random beacon group selection I see no risk - staker is always free to send any number of tickets they want, so postponing commitment of a top-up gives no advantage. I see a little risk of manipulation for a sortition pool, when waiting with committing a top-up may allow for some degree of manipulation when the seed is known. However, given that anyone can commit the top-up, I don't think we add any new issues to the existing threat model given that operator undelegation could pose a similar thread in the pool.

The following use-cases are supported:
- stake topped-up from liquid tokens
- stake topped-up from a grant
- stake topped-up from the escrow
