### PR TITLE
Update KEEP token dashboard for subscribing to `Staked` event

### DIFF
--- a/solidity/dashboard/src/pages/TokensPageContainer.jsx
+++ b/solidity/dashboard/src/pages/TokensPageContainer.jsx
@@ -50,7 +50,7 @@ export default React.memo(TokensPageContainerWithContext)
 
 const useSubscribeToStakedEvent = async () => {
   const web3Context = useContext(Web3Context)
-  const { grantContract, stakingContract, eth, web3 } = web3Context
+  const { grantContract, eth, web3, yourAddress } = web3Context
 
   const {
     initializationPeriod,
@@ -61,9 +61,10 @@ const useSubscribeToStakedEvent = async () => {
   const subscribeToEventCallback = async (event) => {
     const {
       blockNumber,
-      returnValues: { from, value },
+      returnValues: { owner, operator, authorizer, beneficiary, value },
     } = event
-    const grantStakeDetails = await getGrantDetails(from, grantContract)
+
+    const grantStakeDetails = await getGrantDetails(operator, grantContract)
     const isFromGrant = grantStakeDetails !== null
     const { grantee } = isFromGrant
       ? await grantContract.methods.getGrant(grantStakeDetails.grantId).call()
@@ -76,7 +77,7 @@ const useSubscribeToStakedEvent = async () => {
         web3,
         grantee
       )
-    } else if (!isAddressedToCurrentAccount(from, web3Context, grantee)) {
+    } else if (!isAddressedToCurrentAccount(owner, yourAddress, grantee)) {
       return
     }
 
@@ -84,11 +85,9 @@ const useSubscribeToStakedEvent = async () => {
 
     const delegation = {
       createdAt,
-      operatorAddress: from,
-      authorizerAddress: await stakingContract.methods
-        .authorizerOf(from)
-        .call(),
-      beneficiary: await stakingContract.methods.beneficiaryOf(from).call(),
+      operatorAddress: operator,
+      authorizerAddress: authorizer,
+      beneficiary: beneficiary,
       amount: value,
       isInInitializationPeriod: true,
       initializationOverAt: moment
@@ -121,60 +120,74 @@ const useSubscribeToUndelegatedEvent = () => {
   const web3Context = useContext(Web3Context)
   const { grantContract, stakingContract, web3 } = web3Context
 
-  const { undelegationPeriod, dispatch } = useTokensPageContext()
+  const { undelegationPeriod, dispatch, delegations } = useTokensPageContext()
 
   const subscribeToEventCallback = async (event) => {
     const {
       returnValues: { operator, undelegatedAt },
     } = event
-    const grantStakeDetails = await getGrantDetails(operator, grantContract)
-    const isFromGrant = grantStakeDetails !== null
-    const { grantee } = isFromGrant
-      ? await grantContract.methods.getGrant(grantStakeDetails.grantId).call()
-      : {}
-    let isManagedGrant
-    let managedGrantContractInstance
-    if (isFromGrant && isGranteeInManagedGrant(web3Context, grantee)) {
-      isManagedGrant = true
-      managedGrantContractInstance = createManagedGrantContractInstance(
-        web3,
-        grantee
-      )
-    } else if (!isAddressedToCurrentAccount(operator, web3Context, grantee)) {
-      return
+    const delegation = delegations.find(({ operatorAddress }) =>
+      isSameEthAddress(operatorAddress, operator)
+    )
+    let undelegation = {}
+    if (delegation) {
+      undelegation = {
+        ...delegation,
+        undelegatedAt: moment.unix(undelegatedAt),
+        undelegationCompleteAt: moment
+          .unix(undelegatedAt)
+          .add(undelegationPeriod, "seconds"),
+        canRecoverStake: false,
+      }
+    } else {
+      const grantStakeDetails = await getGrantDetails(operator, grantContract)
+      const isFromGrant = grantStakeDetails !== null
+      const { grantee } = isFromGrant
+        ? await grantContract.methods.getGrant(grantStakeDetails.grantId).call()
+        : {}
+      let isManagedGrant
+      let managedGrantContractInstance
+      if (isFromGrant && isGranteeInManagedGrant(web3Context, grantee)) {
+        isManagedGrant = true
+        managedGrantContractInstance = createManagedGrantContractInstance(
+          web3,
+          grantee
+        )
+      } else if (!isAddressedToCurrentAccount(operator, web3Context, grantee)) {
+        return
+      }
+      const { amount } = await stakingContract.methods
+        .getDelegationInfo(operator)
+        .call()
+      undelegation = {
+        operatorAddress: operator,
+        authorizerAddress: await stakingContract.methods
+          .authorizerOf(operator)
+          .call(),
+        beneficiary: await stakingContract.methods
+          .beneficiaryOf(operator)
+          .call(),
+        amount,
+        undelegatedAt: moment.unix(undelegatedAt),
+        undelegationCompleteAt: moment
+          .unix(undelegatedAt)
+          .add(undelegationPeriod, "seconds"),
+        canRecoverStake: false,
+        isFromGrant,
+        grantId: isFromGrant ? grantStakeDetails.grantId : null,
+        isManagedGrant,
+        managedGrantContractInstance,
+      }
     }
 
-    const { amount } = await stakingContract.methods
-      .getDelegationInfo(operator)
-      .call()
-
-    const undelegation = {
-      operatorAddress: operator,
-      authorizerAddress: await stakingContract.methods
-        .authorizerOf(operator)
-        .call(),
-      beneficiary: await stakingContract.methods.beneficiaryOf(operator).call(),
-      amount,
-      undelegatedAt: moment.unix(undelegatedAt),
-      undelegationCompleteAt: moment
-        .unix(undelegatedAt)
-        .add(undelegationPeriod, "seconds"),
-      canRecoverStake: false,
-      isFromGrant,
-      grantId: isFromGrant ? grantStakeDetails.grantId : null,
-      isManagedGrant,
-      managedGrantContractInstance,
-    }
-    dispatch({ type: REMOVE_DELEGATION, payload: operator })
-
-    if (!isFromGrant) {
+    if (!undelegation.isFromGrant) {
       dispatch({
         type: UPDATE_OWNED_DELEGATED_TOKENS_BALANCE,
-        payload: { operation: sub, value: amount },
+        payload: { operation: sub, value: undelegation.amount },
       })
       dispatch({
         type: UPDATE_OWNED_UNDELEGATIONS_TOKEN_BALANCE,
-        payload: { operation: add, value: amount },
+        payload: { operation: add, value: undelegation.amount },
       })
     }
 
@@ -244,15 +257,13 @@ const getGrantDetails = async (operator, grantContract) => {
   return grantStakeDetails
 }
 
-const isAddressedToCurrentAccount = async (operator, web3Context, grantee) => {
-  const { yourAddress, stakingContract } = web3Context
+const isAddressedToCurrentAccount = async (owner, yourAddress, grantee) => {
   const isFromGrant = !!grantee
 
   if (isFromGrant) {
     return isSameEthAddress(grantee, yourAddress)
   }
 
-  const owner = await stakingContract.methods.ownerOf(operator).call()
   return isSameEthAddress(owner, yourAddress)
 }
 


### PR DESCRIPTION
This PR fixes:
* subscription to the `Staked` event. `Staked` event's params have changed. Currently, a `Staked` event emits: `owner, operator, beneficiary, value`, instead of `from, value`.