### PR TITLE
Reduce bytecode size of TokenStaking contract

### DIFF
--- a/solidity/contracts/Authorizations.sol
+++ b/solidity/contracts/Authorizations.sol
@@ -92,7 +92,7 @@ contract Authorizations is AuthorityVerifier {
         );
         require(
             getAuthoritySource(_operatorContract) == _operatorContract,
-            "Contract uses delegated authority"
+            "Delegated authority used"
         );
         authorizations[_operatorContract][_operator] = true;
     }

--- a/solidity/contracts/Authorizations.sol
+++ b/solidity/contracts/Authorizations.sol
@@ -68,14 +68,6 @@ contract Authorizations is AuthorityVerifier {
         _;
     }
 
-    modifier onlyOperatorAuthorizer(address _operator) {
-        require(
-            authorizerOf(_operator) == msg.sender,
-            "Not operator authorizer"
-        );
-        _;
-    }
-
     constructor(KeepRegistry _registry) public {
         registry = _registry;
     }
@@ -93,8 +85,11 @@ contract Authorizations is AuthorityVerifier {
     /// @param _operatorContract address of operator contract.
     function authorizeOperatorContract(address _operator, address _operatorContract)
         public
-        onlyOperatorAuthorizer(_operator)
         onlyApprovedOperatorContract(_operatorContract) {
+        require(
+            authorizerOf(_operator) == msg.sender,
+            "Not operator authorizer"
+        );
         require(
             getAuthoritySource(_operatorContract) == _operatorContract,
             "Contract uses delegated authority"

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -321,12 +321,11 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             "Timestamp in the past"
         );
         uint256 oldParams = operators[_operator].packedParams;
-        uint256 existingCreationTimestamp = oldParams.getCreationTimestamp();
-        uint256 existingUndelegationTimestamp = oldParams.getUndelegationTimestamp();
         require(
-            _undelegationTimestamp > existingCreationTimestamp.add(initializationPeriod),
+            _undelegationTimestamp > oldParams.getCreationTimestamp().add(initializationPeriod),
             "Timestamp in initialization period"
         );
+        uint256 existingUndelegationTimestamp = oldParams.getUndelegationTimestamp();
         require(
             // Undelegation not in progress OR
             existingUndelegationTimestamp == 0 ||

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -208,7 +208,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         );
         require(
             !_isUndelegating(operatorParams),
-            "Operator undelegated"
+            "Stake undelegated"
         );
 
         // Top-up comes from a grant if it's been initiated from TokenGrantStake

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -263,8 +263,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     ) internal returns (uint256) {
         uint256 oldParams = operators[_operator].packedParams;
         uint256 newAmount = oldParams.getAmount().add(_topUp);
-        uint256 newParams = oldParams.setAmount(newAmount);
-        operators[_operator].packedParams = newParams;
+        operators[_operator].packedParams = oldParams.setAmount(newAmount);
         return newAmount;
     }
 

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -52,7 +52,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     event TopUpInitiated(address indexed operator, uint256 topUp);
     event TopUpCommitted(address indexed operator, uint256 newAmount);
     event Undelegated(address indexed operator, uint256 undelegatedAt);
-    event RecoveredStake(address operator, uint256 recoveredAt);
+    event RecoveredStake(address operator);
     event TokensSlashed(address indexed operator, uint256 amount);
     event TokensSeized(address indexed operator, uint256 amount);
     event StakeLocked(address indexed operator, address lockCreator, uint256 until);
@@ -365,7 +365,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         operators[_operator].packedParams = operatorParams.setAmount(0);
         transferOrDeposit(operators[_operator].owner, _operator, amount);
 
-        emit RecoveredStake(_operator, block.timestamp);
+        emit RecoveredStake(_operator);
     }
 
     /// @notice Gets stake delegation info for the given operator.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -304,10 +304,9 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address _operator,
         uint256 _undelegationTimestamp
     ) public {
-        address owner = operators[_operator].owner;
         require(
-            msg.sender == owner ||
             msg.sender == _operator ||
+            msg.sender == operators[_operator].owner ||
             grantStaking.canUndelegate(_operator, tokenGrant),
             "Not authorized"
         );

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -37,7 +37,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     using BytesLib for bytes;
     using SafeMath for uint256;
     using PercentUtils for uint256;
-    using LockUtils for LockUtils.LockSet;
     using SafeERC20 for ERC20Burnable;
     using GrantStaking for GrantStaking.Storage;
     using Locks for Locks.Storage;

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -570,14 +570,17 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address _operatorContract
     ) public view returns (uint256 balance) {
         uint256 operatorParams = operators[_operator].packedParams;
+        // To be eligible for work selection, the operator must:
+        // - have the operator contract authorized
+        // - have the stake initialized
+        // - must not be undelegating; keep in mind the `undelegatedAt` may be
+        // set to a time in the future, to schedule undelegation in advance.
+        // In this case the operator is still eligible until the timestamp
+        // `undelegatedAt`.
         if (
             isAuthorizedForOperator(_operator, _operatorContract) &&
             _isInitialized(operatorParams) &&
             !_isUndelegating(operatorParams)
-            // `undelegatedAt` may be set to a time in the future,
-            // to schedule undelegation in advance.
-            // In this case the operator is still eligible
-            // until the timestamp `undelegatedAt`.
         ) {
             balance = operatorParams.getAmount();
         }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -66,6 +66,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     ERC20Burnable internal token;
     TokenGrant internal tokenGrant;
     TokenStakingEscrow internal escrow;
+
     GrantStaking.Storage internal grantStaking;
     Locks.Storage internal locks;
     TopUps.Storage internal topUps;
@@ -578,18 +579,16 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address _operator,
         address _operatorContract
     ) public view returns (uint256 balance) {
-        bool isAuthorized = isAuthorizedForOperator(_operator, _operatorContract);
-
         uint256 operatorParams = operators[_operator].packedParams;
-
-        bool isActive = _isInitialized(operatorParams);
-        // `undelegatedAt` may be set to a time in the future,
-        // to schedule undelegation in advance.
-        // In this case the operator is still eligible
-        // until the timestamp `undelegatedAt`.
-        bool isUndelegating = _isUndelegating(operatorParams);
-
-        if (isAuthorized && isActive && !isUndelegating) {
+        if (
+            isAuthorizedForOperator(_operator, _operatorContract) &&
+            _isInitialized(operatorParams) &&
+            !_isUndelegating(operatorParams)
+            // `undelegatedAt` may be set to a time in the future,
+            // to schedule undelegation in advance.
+            // In this case the operator is still eligible
+            // until the timestamp `undelegatedAt`.
+        ) {
             balance = operatorParams.getAmount();
         }
     }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -704,11 +704,10 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     ) internal {
         if (grantStaking.hasGrantDelegated(_operator)) {
             // For tokens staked from a grant, transfer them to the escrow.
-            uint256 grantId = grantStaking.getGrantForOperator(_operator);
             TokenSender(address(token)).approveAndCall(
                 address(escrow),
                 _amount,
-                abi.encode(_operator, grantId)
+                abi.encode(_operator, grantStaking.getGrantForOperator(_operator))
             );
         } else {
             // For liquid tokens staked, transfer them straight to the owner.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -356,7 +356,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             "Locked stake"
         );
 
-        address owner = operators[_operator].owner;
         uint256 amount = operatorParams.getAmount();
 
         // If there is a pending top-up, force-commit it before returning
@@ -367,7 +366,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         }
 
         operators[_operator].packedParams = operatorParams.setAmount(0);
-        transferOrDeposit(owner, _operator, amount);
+        transferOrDeposit(operators[_operator].owner, _operator, amount);
 
         emit RecoveredStake(_operator, block.timestamp);
     }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -66,7 +66,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     ERC20Burnable internal token;
     TokenGrant internal tokenGrant;
     TokenStakingEscrow internal escrow;
-
     GrantStaking.Storage internal grantStaking;
     Locks.Storage internal locks;
     TopUps.Storage internal topUps;
@@ -499,15 +498,13 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
             if (currentAmount < amountToSlash) {
                 totalAmountToBurn = totalAmountToBurn.add(currentAmount);
-
-                uint256 newAmount = 0;
-                operators[operator].packedParams = operatorParams.setAmount(newAmount);
+                operators[operator].packedParams = operatorParams.setAmount(0);
                 emit TokensSlashed(operator, currentAmount);
             } else {
                 totalAmountToBurn = totalAmountToBurn.add(amountToSlash);
-
-                uint256 newAmount = currentAmount.sub(amountToSlash);
-                operators[operator].packedParams = operatorParams.setAmount(newAmount);
+                operators[operator].packedParams = operatorParams.setAmount(
+                    currentAmount.sub(amountToSlash)
+                );
                 emit TokensSlashed(operator, amountToSlash);
             }
         }
@@ -549,15 +546,13 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
             if (currentAmount < amountToSeize) {
                 totalAmountToBurn = totalAmountToBurn.add(currentAmount);
-
-                uint256 newAmount = 0;
-                operators[operator].packedParams = operatorParams.setAmount(newAmount);
+                operators[operator].packedParams = operatorParams.setAmount(0);
                 emit TokensSeized(operator, currentAmount);
             } else {
                 totalAmountToBurn = totalAmountToBurn.add(amountToSeize);
-
-                uint256 newAmount = currentAmount.sub(amountToSeize);
-                operators[operator].packedParams = operatorParams.setAmount(newAmount);
+                operators[operator].packedParams = operatorParams.setAmount(
+                    currentAmount.sub(amountToSeize)
+                );
                 emit TokensSeized(operator, amountToSeize);
             }
         }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -651,8 +651,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// @notice Is the operator with the given params initialized
     function _isInitialized(uint256 _operatorParams)
         internal view returns (bool) {
-        uint256 createdAt = _operatorParams.getCreationTimestamp();
-        return block.timestamp > createdAt.add(initializationPeriod);
+        return block.timestamp > _operatorParams.getCreationTimestamp().add(initializationPeriod);
     }
 
     /// @notice Is the operator with the given params undelegating
@@ -666,8 +665,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     function _isUndelegatingFinished(uint256 _operatorParams)
         internal view returns (bool) {
         uint256 undelegatedAt = _operatorParams.getUndelegationTimestamp();
-        uint256 finishedAt = undelegatedAt.add(undelegationPeriod);
-        return (undelegatedAt != 0) && (block.timestamp > finishedAt);
+        return (undelegatedAt != 0) && (block.timestamp > undelegatedAt.add(undelegationPeriod));
     }
 
     /// @notice Get whether the operator's stake is released

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -615,19 +615,16 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address _operator,
         address _operatorContract
     ) public view returns (uint256 balance) {
-        bool isAuthorized = isAuthorizedForOperator(_operator, _operatorContract);
-
         uint256 operatorParams = operators[_operator].packedParams;
-
-        bool isActive = _isInitialized(operatorParams);
-
-        bool stakeReleased = _isStakeReleased(
-            _operator,
-            operatorParams,
-            _operatorContract
-        );
-
-        if (isAuthorized && isActive && !stakeReleased) {
+        if (
+            isAuthorizedForOperator(_operator, _operatorContract) &&
+            _isInitialized(operatorParams) &&
+            !_isStakeReleased(
+                _operator,
+                operatorParams,
+                _operatorContract
+            )
+        ) {
             balance = operatorParams.getAmount();
         }
     }

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -60,8 +60,8 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     event ExpiredLockReleased(address indexed operator, address lockCreator);
 
     uint256 public minimumStakeScheduleStart;
-    uint256 public initializationPeriod;
-    uint256 public undelegationPeriod;
+    uint256 public initializationPeriod; // varies between mainnet and testnet
+    uint256 public constant undelegationPeriod = 5184000; // ~60 days
 
     ERC20Burnable internal token;
     TokenGrant internal tokenGrant;
@@ -78,23 +78,18 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// @param _registry Keep contract registry contract.
     /// @param _initializationPeriod To avoid certain attacks on work selection, recently created
     /// operators must wait for a specific period of time before being eligible for work selection.
-    /// @param _undelegationPeriod The staking contract guarantees that an undelegated operator’s
-    /// stakes will stay locked for a period of time after undelegation, and thus available as
-    /// collateral for any work the operator is engaged in.
     constructor(
         ERC20Burnable _token,
         TokenGrant _tokenGrant,
         TokenStakingEscrow _escrow,
         KeepRegistry _registry,
-        uint256 _initializationPeriod,
-        uint256 _undelegationPeriod
+        uint256 _initializationPeriod
     ) Authorizations(_registry) public {
         token = _token;
         tokenGrant = _tokenGrant;
         escrow = _escrow;
         registry = _registry;
         initializationPeriod = _initializationPeriod;
-        undelegationPeriod = _undelegationPeriod;
         minimumStakeScheduleStart = block.timestamp;
     }
 

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -678,11 +678,8 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         uint256 _operatorParams,
         address _operatorContract
     ) internal view returns (bool) {
-        if (!_isUndelegatingFinished(_operatorParams)) {
-            return false;
-        }
-        // Undelegating finished, so check locks
-        return locks.isStakeReleased(_operator, _operatorContract);
+        return _isUndelegatingFinished(_operatorParams) &&
+            locks.isStakeReleased(_operator, _operatorContract);
     }
 
     function transferOrDeposit(

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -133,8 +133,8 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address _token,
         bytes memory _extraData
     ) public {
-        require(ERC20Burnable(_token) == token, "Unrecognized token contract");
-        require(_value >= minimumStake(), "Value must be greater than the minimum stake");
+        require(ERC20Burnable(_token) == token, "Unrecognized token");
+        require(_value >= minimumStake(), "Less than the minimum stake");
         require(_extraData.length >= 60, "Corrupted delegation data");
 
         // Transfer tokens to this contract.
@@ -210,7 +210,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         uint256 operatorParams = operators[_operator].packedParams;
         require(
             _isInitialized(operatorParams),
-            "Initialization period is not over"
+            "Stake is initializing"
         );
         require(
             !_isUndelegating(operatorParams),
@@ -285,7 +285,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
         require(
             !_isInitialized(operatorParams),
-            "Initialization period is over"
+            "Initialized stake"
         );
 
         uint256 amount = operatorParams.getAmount();
@@ -320,14 +320,14 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         );
         require(
             _undelegationTimestamp >= block.timestamp,
-            "Undelegation timestamp in the past"
+            "Timestamp in the past"
         );
         uint256 oldParams = operators[_operator].packedParams;
         uint256 existingCreationTimestamp = oldParams.getCreationTimestamp();
         uint256 existingUndelegationTimestamp = oldParams.getUndelegationTimestamp();
         require(
             _undelegationTimestamp > existingCreationTimestamp.add(initializationPeriod),
-            "Cannot undelegate in initialization period"
+            "Timestamp in initialization period"
         );
         require(
             // Undelegation not in progress OR
@@ -353,16 +353,15 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         uint256 operatorParams = operators[_operator].packedParams;
         require(
             operatorParams.getUndelegationTimestamp() != 0,
-            "Can not recover without first undelegating"
+            "Not undelegated"
         );
         require(
             _isUndelegatingFinished(operatorParams),
-            "Can not recover before undelegation period is over"
+            "Still undelegating"
         );
-
         require(
             !isStakeLocked(_operator),
-            "Can not recover locked stake"
+            "Locked stake"
         );
 
         address owner = operators[_operator].owner;
@@ -411,11 +410,11 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
         require(
             _isInitialized(operatorParams),
-            "Stake must be active"
+            "Inactive stake"
         );
         require(
             !_isUndelegating(operatorParams),
-            "Operator undelegating"
+            "Undelegating stake"
         );
 
         locks.lockStake(operator, duration);
@@ -490,7 +489,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             uint256 operatorParams = operators[operator].packedParams;
             require(
                 _isInitialized(operatorParams),
-                "Stake must be active"
+                "Inactive stake"
             );
 
             require(
@@ -540,7 +539,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             uint256 operatorParams = operators[operator].packedParams;
             require(
                 _isInitialized(operatorParams),
-                "Stake must be active"
+                "Inactive stake"
             );
 
             require(

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -332,8 +332,9 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             msg.sender != _operator,
             "Operator may not postpone undelegation"
         );
-        uint256 newParams = oldParams.setUndelegationTimestamp(_undelegationTimestamp);
-        operators[_operator].packedParams = newParams;
+        operators[_operator].packedParams = oldParams.setUndelegationTimestamp(
+            _undelegationTimestamp
+        );
         emit Undelegated(_operator, _undelegationTimestamp);
     }
 

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -310,14 +310,11 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             grantStaking.canUndelegate(_operator, tokenGrant),
             "Not authorized"
         );
-        require(
-            _undelegationTimestamp >= block.timestamp,
-            "Timestamp in the past"
-        );
         uint256 oldParams = operators[_operator].packedParams;
         require(
+            _undelegationTimestamp >= block.timestamp &&
             _undelegationTimestamp > oldParams.getCreationTimestamp().add(initializationPeriod),
-            "Timestamp in initialization period"
+            "Invalid timestamp"
         );
         uint256 existingUndelegationTimestamp = oldParams.getUndelegationTimestamp();
         require(

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -473,7 +473,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         public
         onlyApprovedOperatorContract(msg.sender) {
 
-        uint256 totalAmountToBurn = 0;
+        uint256 totalAmountToBurn;
         address authoritySource = getAuthoritySource(msg.sender);
         for (uint i = 0; i < misbehavedOperators.length; i++) {
             address operator = misbehavedOperators[i];
@@ -521,7 +521,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address tattletale,
         address[] memory misbehavedOperators
     ) public onlyApprovedOperatorContract(msg.sender) {
-        uint256 totalAmountToBurn = 0;
+        uint256 totalAmountToBurn;
         address authoritySource = getAuthoritySource(msg.sender);
         for (uint i = 0; i < misbehavedOperators.length; i++) {
             address operator = misbehavedOperators[i];

--- a/solidity/contracts/libraries/staking/TopUps.sol
+++ b/solidity/contracts/libraries/staking/TopUps.sol
@@ -49,7 +49,7 @@ library TopUps {
         require(topUp.amount > 0, "No top up to commit");
         require(
             now > topUp.createdAt.add(initializationPeriod),
-            "Initialization period is not over"
+            "Stake is initializing"
         );
 
         delete self.topUps[operator];

--- a/solidity/contracts/stubs/TokenStakingSlashingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingSlashingStub.sol
@@ -11,9 +11,8 @@ contract TokenStakingSlashingStub is TokenStaking {
         TokenGrant _tokenGrant,
         TokenStakingEscrow _escrow,
         KeepRegistry _registry,
-        uint256 _initializationPeriod,
-        uint256 _undelegationPeriod
-    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
+        uint256 _initializationPeriod
+    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod) public {
     }
 
     function slash(uint256 amountToSlash, address[] memory misbehavedOperators) public {

--- a/solidity/contracts/stubs/TokenStakingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingStub.sol
@@ -11,9 +11,8 @@ contract TokenStakingStub is TokenStaking {
         TokenGrant _tokenGrant,
         TokenStakingEscrow _escrow,
         KeepRegistry _registry,
-        uint256 _initializationPeriod,
-        uint256 _undelegationPeriod
-    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod, _undelegationPeriod) public {
+        uint256 _initializationPeriod
+    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod) public {
     }
 
     function setInitializationPeriod(uint256 _initializationPeriod) public {

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -24,7 +24,6 @@ const DelayFactor = artifacts.require("./libraries/operator/DelayFactor.sol");
 const KeepRegistry = artifacts.require("./KeepRegistry.sol");
 
 let initializationPeriod = 43200; // ~12 hours
-let undelegationPeriod = 7776000; // ~3 months
 const dkgContributionMargin = 1; // 1%
 
 module.exports = async function(deployer, network) {
@@ -57,8 +56,7 @@ module.exports = async function(deployer, network) {
     TokenGrant.address,
     TokenStakingEscrow.address,
     KeepRegistry.address,
-    initializationPeriod,
-    undelegationPeriod
+    initializationPeriod
   );
   await deployer.deploy(PermissiveStakingPolicy);
   await deployer.deploy(GuaranteedMinimumStakingPolicy, TokenStaking.address);

--- a/solidity/test/RolesLookupTest.js
+++ b/solidity/test/RolesLookupTest.js
@@ -35,7 +35,6 @@ describe('RolesLookup', () => {
     nonGrantee = accounts[12]
 
   const initializationPeriod = time.duration.seconds(0),
-    undelegationPeriod = time.duration.seconds(0),
     grantUnlockingDuration = time.duration.seconds(0),
     grantStart = time.duration.seconds(0),
     grantCliff = time.duration.seconds(0),
@@ -57,7 +56,6 @@ describe('RolesLookup', () => {
       tokenGrant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -1,4 +1,5 @@
 const {contract, accounts} = require("@openzeppelin/test-environment")
+const {time} = require('@openzeppelin/test-helpers')
 
 const BLS = contract.fromArtifact('BLS');
 const GroupSelection = contract.fromArtifact('GroupSelection');
@@ -19,7 +20,6 @@ async function initTokenStaking(
   tokenGrantAddress,
   keepRegistryAddress,
   stakeInitializationPeriod,
-  stakeUndelegationPeriod,
   TokenStakingEscrow,
   TokenStaking
 ) {
@@ -53,7 +53,6 @@ async function initTokenStaking(
     tokenStakingEscrow.address,
     keepRegistryAddress,
     stakeInitializationPeriod,
-    stakeUndelegationPeriod,
     {from: accounts[0]}
   );
   await tokenStakingEscrow.transferOwnership(
@@ -75,8 +74,7 @@ async function initContracts(TokenStaking, KeepRandomBeaconService,
     operatorContract;
 
   let dkgContributionMargin = 5, // 5% Represents DKG frequency of 1/20 (Every 20 entries trigger group selection)
-    stakeInitializationPeriod = 30, // In seconds
-    stakeUndelegationPeriod = 300; // In seconds
+    stakeInitializationPeriod = time.duration.hours(6)
 
   token = await KeepToken.new({from: accounts[0]});
   tokenGrant = await TokenGrant.new(token.address, {from: accounts[0]});
@@ -88,7 +86,6 @@ async function initContracts(TokenStaking, KeepRandomBeaconService,
     tokenGrant.address,
     registry.address,
     stakeInitializationPeriod,
-    stakeUndelegationPeriod,
     contract.fromArtifact('TokenStakingEscrow'),
     TokenStaking
   )

--- a/solidity/test/token_grant/TestManagedGrant.js
+++ b/solidity/test/token_grant/TestManagedGrant.js
@@ -38,8 +38,8 @@ describe('TokenGrant/ManagedGrant', () => {
   const grantUnlockingDuration = time.duration.days(60);
   const grantCliff = time.duration.days(10);
 
-  const initializationPeriod = time.duration.minutes(10);
-  const undelegationPeriod = time.duration.minutes(30);
+  const initializationPeriod = time.duration.hours(12);
+  let undelegationPeriod
 
   let managedGrant;
 
@@ -54,7 +54,6 @@ describe('TokenGrant/ManagedGrant', () => {
       tokenGrant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     );
@@ -63,6 +62,7 @@ describe('TokenGrant/ManagedGrant', () => {
 
     await tokenGrant.authorizeStakingContract(staking.address, {from: grantCreator});
 
+    undelegationPeriod = await staking.undelegationPeriod()
     minimumStake = await staking.minimumStake()
 
     permissivePolicy = await PermissiveStakingPolicy.new()

--- a/solidity/test/token_grant/TestManagedGrantFactory.js
+++ b/solidity/test/token_grant/TestManagedGrantFactory.js
@@ -32,7 +32,6 @@ describe('TokenGrant/ManagedGrantFactory', () => {
   const grantCliff = time.duration.days(10);
 
   const initializationPeriod = time.duration.minutes(10);
-  const undelegationPeriod = time.duration.minutes(30);
 
   let factory;
 
@@ -45,7 +44,6 @@ describe('TokenGrant/ManagedGrantFactory', () => {
       tokenGrant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     );

--- a/solidity/test/token_grant/TestStakingPolicy.js
+++ b/solidity/test/token_grant/TestStakingPolicy.js
@@ -79,7 +79,6 @@ describe('GuaranteedMinimumStakingPolicy', async () => {
       accounts[9],
       accounts[9],
       accounts[9],
-      0, 
       0,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
@@ -243,7 +242,6 @@ describe('AdaptiveStakingPolicy', async () => {
       accounts[9],
       accounts[9],
       0, 
-      0,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     );

--- a/solidity/test/token_grant/TestTokenGrant.js
+++ b/solidity/test/token_grant/TestTokenGrant.js
@@ -27,7 +27,6 @@ describe('TokenGrant', function() {
       grantContract.address,
       registry.address,
       time.duration.days(1),
-      time.duration.days(30),
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     );

--- a/solidity/test/token_grant/TestTokenGrantRevoke.js
+++ b/solidity/test/token_grant/TestTokenGrantRevoke.js
@@ -34,7 +34,7 @@ describe('TokenGrant/Revoke', function() {
   const grantCliff = time.duration.minutes(1);
 
   const initializationPeriod = time.duration.minutes(10);
-  const undelegationPeriod = time.duration.minutes(30);
+  let undelegationPeriod;
 
   let minimumStake;
 
@@ -47,12 +47,12 @@ describe('TokenGrant/Revoke', function() {
       grantContract.address,
       registryContract.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )
     stakingContract = stakingContracts.tokenStaking
     stakingEscrowContract = stakingContracts.tokenStakingEscrow
+    undelegationPeriod = await stakingContract.undelegationPeriod()
     minimumStake = await stakingContract.minimumStake();
     grantAmount = minimumStake.muln(10);
 

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -42,11 +42,11 @@ describe('TokenGrant/Stake', function() {
   let evilGrantId;
   let grantStart;
 
-  const grantUnlockingDuration = time.duration.days(60);
+  const grantUnlockingDuration = time.duration.days(180);
   const grantCliff = time.duration.days(10);
 
-  const initializationPeriod = time.duration.minutes(10);
-  const undelegationPeriod = time.duration.minutes(30);
+  const initializationPeriod = time.duration.days(10);
+  let undelegationPeriod;
 
   before(async () => {
     tokenContract = await KeepToken.new({from: accounts[0]});
@@ -57,7 +57,6 @@ describe('TokenGrant/Stake', function() {
       grantContract.address,
       registryContract.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     );
@@ -65,6 +64,8 @@ describe('TokenGrant/Stake', function() {
     stakingEscrowContract = stakingContracts.tokenStakingEscrow;
 
     await grantContract.authorizeStakingContract(stakingContract.address, {from: accounts[0]});
+
+    undelegationPeriod = await stakingContract.undelegationPeriod()
 
     grantStart = await time.latest();
     minimumStake = await stakingContract.minimumStake()

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -266,7 +266,7 @@ describe('TokenGrant/Stake', function() {
 
     await expectRevert(
       grantContract.cancelStake(operatorOne, {from: grantee}),
-      "Initialization period is over"
+      "Initialized stake"
     );
   })
 
@@ -281,7 +281,7 @@ describe('TokenGrant/Stake', function() {
 
     await expectRevert(
       stakingContract.recoverStake(operatorOne),
-      "Can not recover before undelegation period is over"
+      "Still undelegating"
     )
   })
 

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -297,7 +297,7 @@ describe('TokenGrant/Stake', function() {
 
     await expectRevert(
       delegateLiquid(grantee, operatorOne, minimumStake),
-      "Operator undelegated"
+      "Stake undelegated"
     )
   })
 

--- a/solidity/test/token_grant/TestTokenGrantWithdraw.js
+++ b/solidity/test/token_grant/TestTokenGrantWithdraw.js
@@ -32,7 +32,6 @@ describe('TokenGrant/Withdraw', function() {
   const grantCliff = time.duration.seconds(1);
     
   const initializationPeriod = time.duration.seconds(10);
-  const undelegationPeriod = time.duration.seconds(30);
 
   before(async () => {
     tokenContract = await KeepToken.new({from: accounts[0]});
@@ -43,7 +42,6 @@ describe('TokenGrant/Withdraw', function() {
       grantContract.address,
       registryContract.address, 
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -205,7 +205,7 @@ describe("TokenStaking/DelegatedAuthority", async () => {
             recognizedContract,
             {from: authorizer}
           ),
-          "Contract uses delegated authority"
+          "Delegated authority used"
         );
       })
     })

--- a/solidity/test/token_stake/TestDelegatedAuthority.js
+++ b/solidity/test/token_stake/TestDelegatedAuthority.js
@@ -14,7 +14,6 @@ const KeepRegistry = contract.fromArtifact("KeepRegistry");
 const DelegatedAuthorityStub = contract.fromArtifact("DelegatedAuthorityStub");
 
 const initializationPeriod = time.duration.seconds(10);
-const undelegationPeriod = time.duration.seconds(30);
 
 let token, registry, stakingContract;
 let authorityDelegator, badAuthorityDelegator;
@@ -40,7 +39,6 @@ describe("TokenStaking/DelegatedAuthority", async () => {
       grant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )

--- a/solidity/test/token_stake/TestMinimumStake.js
+++ b/solidity/test/token_stake/TestMinimumStake.js
@@ -16,7 +16,6 @@ const KeepRegistry = contract.fromArtifact("KeepRegistry");
 describe('TokenStaking/MinimumStake', function() {
   let token, registry, stakingContract, keepDecimals;
   const initializationPeriod = time.duration.seconds(10);
-  const undelegationPeriod = time.duration.seconds(30);
 
   const schedule = web3.utils.toBN(86400 * 365 * 2)
   const steps = web3.utils.toBN(10)
@@ -31,7 +30,6 @@ describe('TokenStaking/MinimumStake', function() {
       grant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )

--- a/solidity/test/token_stake/TestPunishment.js
+++ b/solidity/test/token_stake/TestPunishment.js
@@ -114,7 +114,7 @@ describe('TokenStaking/Punishment', () => {
             let amountToSlash = web3.utils.toBN(1000)
             await expectRevert(
                 stakingContract.slash(amountToSlash, [operator], { from: operatorContract }),
-                "Stake must be active"
+                "Inactive stake"
             )
         })
 
@@ -219,7 +219,7 @@ describe('TokenStaking/Punishment', () => {
                     amountToSeize, rewardMultiplier, tattletale,
                     [operator], { from: operatorContract }
                 ),
-                "Stake must be active"
+                "Inactive stake"
             )
         })
 

--- a/solidity/test/token_stake/TestPunishment.js
+++ b/solidity/test/token_stake/TestPunishment.js
@@ -26,7 +26,7 @@ describe('TokenStaking/Punishment', () => {
     let largeStake, minimumStake;
 
     const initializationPeriod = time.duration.seconds(10)
-    const undelegationPeriod = time.duration.seconds(30)
+    let undelegationPeriod
 
     before(async () => {
         token = await KeepToken.new({ from: owner })
@@ -37,11 +37,12 @@ describe('TokenStaking/Punishment', () => {
             tokenGrant.address,
             registry.address,
             initializationPeriod,
-            undelegationPeriod,
             contract.fromArtifact('TokenStakingEscrow'),
             contract.fromArtifact('TokenStaking')
         )
         stakingContract = stakingContracts.tokenStaking;
+
+        undelegationPeriod = await stakingContract.undelegationPeriod()
 
         await registry.setRegistryKeeper(registryKeeper, { from: owner })
 

--- a/solidity/test/token_stake/TestStakingGrant.js
+++ b/solidity/test/token_stake/TestStakingGrant.js
@@ -35,11 +35,12 @@ describe('TokenStaking/StakingGrant', () => {
     authorizer = accounts[9],
     thirdParty = accounts[10]
 
-    const initializationPeriod = time.duration.seconds(10),
-      undelegationPeriod = time.duration.seconds(10),
+    const initializationPeriod = time.duration.hours(6),
       grantUnlockingDuration = time.duration.years(2),
       grantCliff = time.duration.seconds(0),
       grantRevocable = true
+
+    let undelegationPeriod
 
     let token, tokenGrant, tokenStakingEscrow, tokenStaking
 
@@ -67,7 +68,6 @@ describe('TokenStaking/StakingGrant', () => {
         tokenGrant.address,
         registry.address,
         initializationPeriod,
-        undelegationPeriod,
         contract.fromArtifact('TokenStakingEscrow'),
         contract.fromArtifact('TokenStaking')
       )
@@ -77,6 +77,8 @@ describe('TokenStaking/StakingGrant', () => {
       await tokenGrant.authorizeStakingContract(tokenStaking.address, {
         from: grantManager,
       })
+
+      undelegationPeriod = await tokenStaking.undelegationPeriod()
       
       const minimumStake = await tokenStaking.minimumStake();
       grantedAmount = minimumStake.muln(40);

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -111,7 +111,7 @@ describe('TokenStaking', function() {
     it("should not allow to delegate less than the minimum stake", async () => {    
       await expectRevert(
         delegate(operatorOne, minimumStake.subn(1)),
-        "Value must be greater than the minimum stake"
+        "Less than the minimum stake"
       )
     })
   
@@ -187,7 +187,7 @@ describe('TokenStaking', function() {
   
       await expectRevert(
         stakingContract.cancelStake(operatorOne, {from: owner}),
-        "Initialization period is over"
+        "Initialized stake"
       );
     })
 
@@ -273,7 +273,7 @@ describe('TokenStaking', function() {
       await time.increaseTo(createdAt.add(initializationPeriod).sub(timeRoundMargin))
       await expectRevert(
         stakingContract.undelegate(operatorOne, {from: operatorOne}),
-        "Cannot undelegate in initialization period"
+        "Timestamp in initialization period"
       )
     })
 
@@ -394,7 +394,7 @@ describe('TokenStaking', function() {
           operatorOne, currentTime.add(initializationPeriod).sub(timeRoundMargin),
           {from: operatorOne}
         ),
-        "Cannot undelegate in initialization period"
+        "Timestamp in initialization period"
       )
     })
 
@@ -411,7 +411,7 @@ describe('TokenStaking', function() {
           operatorOne, currentTime - 1,
           {from: operatorOne}
         ),
-        "Undelegation timestamp in the past"
+        "Timestamp in the past"
       )
     })
 
@@ -481,7 +481,7 @@ describe('TokenStaking', function() {
   
       await expectRevert(
         stakingContract.recoverStake(operatorOne),
-        "Can not recover without first undelegating"
+        "Not undelegated"
       )
     })
 
@@ -496,7 +496,7 @@ describe('TokenStaking', function() {
   
       await expectRevert(
         stakingContract.recoverStake(operatorOne),
-        "Can not recover before undelegation period is over"
+        "Still undelegating"
       )
     })
 

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -29,7 +29,7 @@ describe('TokenStaking', function() {
     operatorContract = accounts[6];
 
   const initializationPeriod = time.duration.minutes(10);
-  const undelegationPeriod = time.duration.minutes(30);
+  let undelegationPeriod;
 
   before(async () => {
     token = await KeepToken.new({from: accounts[0]});
@@ -40,11 +40,12 @@ describe('TokenStaking', function() {
       tokenGrant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )
     stakingContract = stakingContracts.tokenStaking;
+
+    undelegationPeriod = await stakingContract.undelegationPeriod()
 
     await registry.approveOperatorContract(operatorContract, {from: accounts[0]});
 

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -274,7 +274,7 @@ describe('TokenStaking', function() {
       await time.increaseTo(createdAt.add(initializationPeriod).sub(timeRoundMargin))
       await expectRevert(
         stakingContract.undelegate(operatorOne, {from: operatorOne}),
-        "Timestamp in initialization period"
+        "Invalid timestamp"
       )
     })
 
@@ -395,7 +395,7 @@ describe('TokenStaking', function() {
           operatorOne, currentTime.add(initializationPeriod).sub(timeRoundMargin),
           {from: operatorOne}
         ),
-        "Timestamp in initialization period"
+        "Invalid timestamp"
       )
     })
 
@@ -412,7 +412,7 @@ describe('TokenStaking', function() {
           operatorOne, currentTime - 1,
           {from: operatorOne}
         ),
-        "Timestamp in the past"
+        "Invalid timestamp"
       )
     })
 

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -105,7 +105,7 @@ describe('TokenStaking', function() {
           
       await expectRevert(
         delegate(operatorOne, stakingAmount),
-        "Operator undelegated"
+        "Stake undelegated"
       )
     })
 

--- a/solidity/test/token_stake/TestTokenStakeLock.js
+++ b/solidity/test/token_stake/TestTokenStakeLock.js
@@ -18,8 +18,8 @@ describe('TokenStaking/Lock', () => {
     operatorContract = accounts[6],
     operatorContract2 = accounts[7];
 
-  const initializationPeriod = time.duration.minutes(10);
-  const undelegationPeriod = time.duration.minutes(10);
+  const initializationPeriod = time.duration.days(10);
+  let undelegationPeriod;
   const lockPeriod = time.duration.weeks(12);
 
   let createdAt;
@@ -34,11 +34,12 @@ describe('TokenStaking/Lock', () => {
       grant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )
     stakingContract = stakingContracts.tokenStaking;
+
+    undelegationPeriod = await stakingContract.undelegationPeriod()
 
     await registry.approveOperatorContract(operatorContract, {from: owner});
     await registry.approveOperatorContract(operatorContract2, {from: owner});

--- a/solidity/test/token_stake/TestTokenStakeLock.js
+++ b/solidity/test/token_stake/TestTokenStakeLock.js
@@ -95,7 +95,7 @@ describe('TokenStaking/Lock', () => {
     it("should not permit locks on non-initialized operators", async () => {
       await expectRevert(
         stakingContract.lockStake(operator, lockPeriod, {from: operatorContract}),
-        "Stake must be active"
+        "Inactive stake"
       )
     })
 
@@ -106,7 +106,7 @@ describe('TokenStaking/Lock', () => {
       await time.increaseTo(undelegatedAt.addn(1))
       await expectRevert(
         stakingContract.lockStake(operator, lockPeriod, {from: operatorContract}),
-        "Operator undelegating"
+        "Undelegating stake"
       )
     })
 
@@ -165,7 +165,7 @@ describe('TokenStaking/Lock', () => {
       await undelegate(operator)
       await expectRevert(
         stakingContract.recoverStake(operator),
-        "Can not recover locked stake"
+        "Locked stake"
       )
 
       await stakingContract.unlockStake(operator, {from: operatorContract})
@@ -177,7 +177,7 @@ describe('TokenStaking/Lock', () => {
       await undelegate(operator)
       await expectRevert(
         stakingContract.recoverStake(operator),
-        "Can not recover locked stake"
+        "Locked stake"
       )
 
       await time.increase(lockPeriod)
@@ -189,7 +189,7 @@ describe('TokenStaking/Lock', () => {
       await undelegate(operator)
       await expectRevert(
         stakingContract.recoverStake(operator),
-        "Can not recover locked stake"
+        "Locked stake"
       )
 
       // disable operator contract with panic button
@@ -210,7 +210,7 @@ describe('TokenStaking/Lock', () => {
       // 5 minutes left in lock
       await expectRevert(
         stakingContract.recoverStake(operator),
-        "Can not recover locked stake"
+        "Locked stake"
       )
 
       await time.increase(time.duration.minutes(5))
@@ -328,7 +328,7 @@ describe('TokenStaking/Lock', () => {
 
       await expectRevert(
         stakingContract.recoverStake(operator),
-        "Can not recover locked stake"
+        "Locked stake"
       )
 
       await stakingContract.unlockStake(operator, {from: operatorContract2})
@@ -343,7 +343,7 @@ describe('TokenStaking/Lock', () => {
 
       await expectRevert(
         stakingContract.recoverStake(operator),
-        "Can not recover locked stake"
+        "Locked stake"
       )
 
       await registry.disableOperatorContract(operatorContract2, {from: owner});

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -38,12 +38,13 @@ describe('TokenStaking/TopUps', () => {
     thirdParty = accounts[11]
     operatorContract = accounts[12]
 
-  const initializationPeriod = time.duration.seconds(10),
-    undelegationPeriod = time.duration.seconds(10),
+  const initializationPeriod = time.duration.days(10),
     grantStart = time.duration.seconds(0),
     grantUnlockingDuration = time.duration.years(100),
     grantCliff = time.duration.seconds(0),
     grantRevocable = true
+
+  let undelegationPeriod;
 
   let token, tokenGrant, tokenStakingEscrow, tokenStaking
 
@@ -78,7 +79,6 @@ describe('TokenStaking/TopUps', () => {
       tokenGrant.address,
       registry.address,
       initializationPeriod,
-      undelegationPeriod,
       contract.fromArtifact('TokenStakingEscrow'),
       contract.fromArtifact('TokenStaking')
     )
@@ -87,6 +87,8 @@ describe('TokenStaking/TopUps', () => {
     await tokenGrant.authorizeStakingContract(tokenStaking.address, {
       from: grantManager,
     })
+
+    undelegationPeriod = await tokenStaking.undelegationPeriod()
 
     //
     // Create three grants:

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -215,7 +215,7 @@ describe('TokenStaking/TopUps', () => {
     it("can not be done during initialization period", async () => {
       await expectRevert(
         initiateTopUp(),
-        "Initialization period is not over"
+        "Stake is initializing"
       )
     })
 
@@ -300,7 +300,7 @@ describe('TokenStaking/TopUps', () => {
       await initiateTopUp()
       await expectRevert(
         tokenStaking.commitTopUp(operatorOne),
-        "Initialization period is not over"
+        "Stake is initializing"
       )
     })
 
@@ -350,7 +350,7 @@ describe('TokenStaking/TopUps', () => {
     it("can not be done during initialization period", async () => {
       await expectRevert(
         initiateTopUp(),
-        "Initialization period is not over"
+        "Stake is initializing"
       )
     })
 
@@ -431,7 +431,7 @@ describe('TokenStaking/TopUps', () => {
       await initiateTopUp()
       await expectRevert(
         tokenStaking.commitTopUp(operatorTwo),
-        "Initialization period is not over"
+        "Stake is initializing"
       )
     })
 
@@ -480,7 +480,7 @@ describe('TokenStaking/TopUps', () => {
     it("can not be done during initialization period", async () => {
       await expectRevert(
         initiateTopUp(),
-        "Initialization period is not over"
+        "Stake is initializing"
       )
     })
 
@@ -561,7 +561,7 @@ describe('TokenStaking/TopUps', () => {
       await initiateTopUp()
       await expectRevert(
         tokenStaking.commitTopUp(operatorThree),
-        "Initialization period is not over"
+        "Stake is initializing"
       )
     })
 

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -227,7 +227,7 @@ describe('TokenStaking/TopUps', () => {
       time.increase(1) // we need the block timestamp to increase
       await expectRevert(
         initiateTopUp(),
-        "Operator undelegated"
+        "Stake undelegated"
       ) 
     })
 
@@ -239,7 +239,7 @@ describe('TokenStaking/TopUps', () => {
       time.increase(1) // we need the block timestamp to increase
       await expectRevert(
         initiateTopUp(),
-        "Operator undelegated"
+        "Stake undelegated"
       )
     })
 
@@ -362,7 +362,7 @@ describe('TokenStaking/TopUps', () => {
       time.increase(1) // we need the block timestamp to increase
       await expectRevert(
         initiateTopUp(),
-        "Operator undelegated"
+        "Stake undelegated"
       )
     })
 
@@ -374,7 +374,7 @@ describe('TokenStaking/TopUps', () => {
       time.increase(1) // we need the block timestamp to increase
       await expectRevert(
         initiateTopUp(),
-        "Operator undelegated"
+        "Stake undelegated"
       )
     })
 
@@ -492,7 +492,7 @@ describe('TokenStaking/TopUps', () => {
       time.increase(1) // we need the block timestamp to increase
       await expectRevert(
         initiateTopUp(),
-        "Operator undelegated"
+        "Stake undelegated"
       )
     })
 
@@ -504,7 +504,7 @@ describe('TokenStaking/TopUps', () => {
       time.increase(1) // we need the block timestamp to increase
       await expectRevert(
         initiateTopUp(),
-        "Operator undelegated"
+        "Stake undelegated"
       )
     })
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1883
~~Depends on https://github.com/keep-network/keep-core/pull/1893~~

Extracting stake locks to a separate library (https://github.com/keep-network/keep-core/pull/1888) provided some space in `TokenStaking` bytecode but we quickly used all of that space for the implementation of top-ups (https://github.com/keep-network/keep-core/pull/1893). In this PR, we are doing small changes, one by one, to reduce the bytecode size to allow for stake bridge implementation (https://github.com/keep-network/keep-core/issues/1883). This PR reduces the bytecode from `24596` to `24270` (`-326` bytes) and will let us add just a few lines of code, an absolute minimum needed for the stake bridge implementation.

I recommend reviewing this PR commit-by-commit, it's easier to understand changes this way.
