### PR TITLE
Cache negative minimum stake check results

### DIFF
--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -31,7 +31,7 @@ const (
 	// NegativeMinimumStakeCachePeriod is the time period the cache maintains
 	// the negative result of the last HasMinimumStake check.
 	// We use the cache to minimize calls to Ethereum client.
-	NegativeMinimumStakeCachePeriod = 6 * time.Hour
+	NegativeMinimumStakeCachePeriod = 1 * time.Hour
 )
 
 var errNoMinimumStake = fmt.Errorf("remote peer has no minimum stake")

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -60,7 +60,7 @@ func TestHasNoMinimumStake(t *testing.T) {
 	}
 }
 
-func TestCachesActiveKeepMembers(t *testing.T) {
+func TestCachesHasMinimumStake(t *testing.T) {
 	stakeMonitor := local.NewStakeMonitor(minimumStake)
 	policy := &minimumStakePolicy{
 		stakeMonitor:        stakeMonitor,
@@ -104,7 +104,7 @@ func TestCachesActiveKeepMembers(t *testing.T) {
 	}
 }
 
-func TestCachesInactiveKeepMembers(t *testing.T) {
+func TestCachesHasNoMinimumStake(t *testing.T) {
 	stakeMonitor := local.NewStakeMonitor(minimumStake)
 	policy := &minimumStakePolicy{
 		stakeMonitor:        stakeMonitor,

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -16,8 +16,9 @@ var cachingPeriod = time.Second
 func TestHasMinimumStake(t *testing.T) {
 	stakeMonitor := local.NewStakeMonitor(minimumStake)
 	policy := &minimumStakePolicy{
-		stakeMonitor: stakeMonitor,
-		cache:        cache.NewTimeCache(cachingPeriod),
+		stakeMonitor:        stakeMonitor,
+		positiveResultCache: cache.NewTimeCache(cachingPeriod),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
 	}
 
 	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
@@ -38,8 +39,9 @@ func TestHasMinimumStake(t *testing.T) {
 func TestHasNoMinimumStake(t *testing.T) {
 	stakeMonitor := local.NewStakeMonitor(minimumStake)
 	policy := &minimumStakePolicy{
-		stakeMonitor: stakeMonitor,
-		cache:        cache.NewTimeCache(cachingPeriod),
+		stakeMonitor:        stakeMonitor,
+		positiveResultCache: cache.NewTimeCache(cachingPeriod),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
 	}
 
 	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
@@ -61,8 +63,9 @@ func TestHasNoMinimumStake(t *testing.T) {
 func TestCachesActiveKeepMembers(t *testing.T) {
 	stakeMonitor := local.NewStakeMonitor(minimumStake)
 	policy := &minimumStakePolicy{
-		stakeMonitor: stakeMonitor,
-		cache:        cache.NewTimeCache(cachingPeriod),
+		stakeMonitor:        stakeMonitor,
+		positiveResultCache: cache.NewTimeCache(cachingPeriod),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
 	}
 
 	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
@@ -98,5 +101,52 @@ func TestCachesActiveKeepMembers(t *testing.T) {
 			err,
 			errNoMinimumStake,
 		)
+	}
+}
+
+func TestCachesInactiveKeepMembers(t *testing.T) {
+	stakeMonitor := local.NewStakeMonitor(minimumStake)
+	policy := &minimumStakePolicy{
+		stakeMonitor:        stakeMonitor,
+		positiveResultCache: cache.NewTimeCache(cachingPeriod),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	remotePeerAddress := key.NetworkPubKeyToEthAddress(remotePeerPublicKey)
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinimumStake {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinimumStake,
+		)
+	}
+
+	stakeMonitor.StakeTokens(remotePeerAddress)
+
+	// still caching the old result
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinimumStake {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinimumStake,
+		)
+	}
+
+	time.Sleep(time.Second)
+
+	// no longer caches the previous result
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
 	}
 }


### PR DESCRIPTION
Closes  #1895

Introduced cache for negative minimum stake check results in the same way as for positive results.