### PR TITLE
Fix a ledger bug

### DIFF
--- a/solidity/dashboard/src/connectors/ledger.js
+++ b/solidity/dashboard/src/connectors/ledger.js
@@ -85,6 +85,7 @@ class CustomLedgerSubprovider extends LedgerSubprovider {
         throw new Error("Invalid chainID")
       }
 
+      await this._destroyLedgerClientAsync()
       return `0x${tx.serialize().toString("hex")}`
     } catch (error) {
       await this._destroyLedgerClientAsync()


### PR DESCRIPTION
This commit fixes the `MULTIPLE_OPEN_CONNECTIONS_DISALLOWED` error. The problem was that the user could only send one transaction after connected to wallet.