### PR TITLE
Increased gas price ceiling to 60Gwei

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -82,7 +82,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     /// next to the actual gas price from the transaction. We use gas price
     /// ceiling to defend against malicious miner-submitters who can manipulate
     /// transaction gas price.
-    uint256 public gasPriceCeiling = 30*1e9; // (30 Gwei = 30 * 10^9 wei)
+    uint256 public gasPriceCeiling = 50*1e9; // (50 Gwei = 50 * 10^9 wei)
 
     /// @dev Size of a group in the threshold relay.
     uint256 public groupSize = 64;

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -82,7 +82,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
     /// next to the actual gas price from the transaction. We use gas price
     /// ceiling to defend against malicious miner-submitters who can manipulate
     /// transaction gas price.
-    uint256 public gasPriceCeiling = 50*1e9; // (50 Gwei = 50 * 10^9 wei)
+    uint256 public gasPriceCeiling = 60*1e9; // (60 Gwei = 60 * 10^9 wei)
 
     /// @dev Size of a group in the threshold relay.
     uint256 public groupSize = 64;

--- a/solidity/test/random_beacon_operator/TestPublishDkgResult.js
+++ b/solidity/test/random_beacon_operator/TestPublishDkgResult.js
@@ -124,7 +124,7 @@ describe('KeepRandomBeaconOperator/PublishDkgResult', function () {
 
     let beneficiaryBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
     let dkgGasEstimate = await operatorContract.dkgGasEstimate();
-    let submitterCustomGasPrice = web3.utils.toWei(web3.utils.toBN(35), 'gwei');
+    let submitterCustomGasPrice = web3.utils.toWei(web3.utils.toBN(55), 'gwei');
     let expectedSubmitterReward = dkgGasEstimate.mul(await operatorContract.gasPriceCeiling());
 
     await operatorContract.submitDkgResult(

--- a/solidity/test/random_beacon_operator/TestPublishDkgResult.js
+++ b/solidity/test/random_beacon_operator/TestPublishDkgResult.js
@@ -124,7 +124,7 @@ describe('KeepRandomBeaconOperator/PublishDkgResult', function () {
 
     let beneficiaryBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
     let dkgGasEstimate = await operatorContract.dkgGasEstimate();
-    let submitterCustomGasPrice = web3.utils.toWei(web3.utils.toBN(55), 'gwei');
+    let submitterCustomGasPrice = web3.utils.toWei(web3.utils.toBN(65), 'gwei');
     let expectedSubmitterReward = dkgGasEstimate.mul(await operatorContract.gasPriceCeiling());
 
     await operatorContract.submitDkgResult(

--- a/solidity/test/random_beacon_service/TestRelayRequestCallback.js
+++ b/solidity/test/random_beacon_service/TestRelayRequestCallback.js
@@ -128,7 +128,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
 
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
     await operatorContract.relayEntry(blsData.groupSignature, {
       from: operator, 
       gasPrice: relayEntryTxGasPrice
@@ -200,7 +200,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
 
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -232,10 +232,10 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
 
     // use higher price than the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('70', 'Gwei'));
     // higher tx.gasprice should not be used for reimbursement - maximum gas
     // price is the one from the gas price ceiling
-    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
+    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -302,7 +302,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
 
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -374,10 +374,10 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
   
     // use higher price than the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('70', 'Gwei'));
     // higher tx.gasprice should not be used for reimbursement - maximum gas
     // price is the one from the gas price ceiling
-    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
+    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -431,7 +431,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
   
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('20', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
   
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));

--- a/solidity/test/random_beacon_service/TestRelayRequestCallback.js
+++ b/solidity/test/random_beacon_service/TestRelayRequestCallback.js
@@ -128,7 +128,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
 
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('30', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
     await operatorContract.relayEntry(blsData.groupSignature, {
       from: operator, 
       gasPrice: relayEntryTxGasPrice
@@ -200,7 +200,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
 
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('30', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -235,7 +235,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
     // higher tx.gasprice should not be used for reimbursement - maximum gas
     // price is the one from the gas price ceiling
-    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('30', 'Gwei'));
+    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -302,7 +302,7 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
 
     // use the same gas price as the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('30', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));
@@ -374,10 +374,10 @@ describe('KeepRandomBeacon/RelayRequestCallback', function() {
     );
   
     // use higher price than the gas price ceiling
-    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('40', 'Gwei'));
+    let relayEntryTxGasPrice = web3.utils.toBN(web3.utils.toWei('60', 'Gwei'));
     // higher tx.gasprice should not be used for reimbursement - maximum gas
     // price is the one from the gas price ceiling
-    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('30', 'Gwei'));
+    let gasPriceForReimbursement = web3.utils.toBN(web3.utils.toWei('50', 'Gwei'));
 
     let customerStartBalance = web3.utils.toBN(await web3.eth.getBalance(customer));
     let beneficiaryStartBalance = web3.utils.toBN(await web3.eth.getBalance(beneficiary));


### PR DESCRIPTION
Closes: #1896 

Relay entry fee estimate with no callback price difference:

- For `60 Gwei` ceiling, entry fee is `81964000000000000 wei = 0.081964 ETH`
- For `50 Gwei` ceiling, entry fee is `78970000000000000 wei = 0.07897 ETH`
- For `40 Gwei` ceiling, entry fee is `75976000000000000 wei = 0.075976 ETH`
- For `30 Gwei` ceiling, entry fee is `72982000000000000 wei = 0.072982 ETH`

[Analyzing the historical data](https://docs.google.com/spreadsheets/d/18gXkpBe1Qfpn6vaZ5jIfiMo8zfjvzXJb3-3e42V9FWU/edit#gid=911342864) from https://etherscan.io/chart/gasprice, the gas price values are as follows:
- `13/7/2019 - 13/7/2020` median is `14364979897 wei`
- `13/7/2019 - 13/7/2020` average is `22031400877 wei`
- `1/1/2020 - 13/7/2020` median is `13439926391 wei`
- `1/1/2020 - 13/7/2020` average is `27560064651 wei`
- `1/7/2020 - 13/7/2020` median is `40907231924 wei`
- `1/7/2020 - 13/7/2020` average is `41228001120 wei`

Increasing the ceiling to `40 Gwei` is a must, increasing it to `50 Gwei` is reasonable, and increasing it even further to `60 Gwei` is even more reasonable given the current trends on Ethereum.

The impact on DKG with 1% contribution margin as it's now:
- `30 Gwei` ceiling, `20 Gwei` actual price: DKG triggered every `72` entries
- `30 Gwei` ceiling, `10 Gwei` actual price: DKG triggered every `42` entries
- `40 Gwei` ceiling, `20 Gwei` actual price: DKG triggered every `54` entries
- `40 Gwei` ceiling, `10 Gwei` actual price: DKG triggered every `34` entries
- `50 Gwei` ceiling, `20 Gwei` actual price: DKG triggered every `48` entries
- `50 Gwei` ceiling, `10 Gwei` actual price: DKG triggered every `30` entries
- `60 Gwei` ceiling, `20 Gwei` actual price: DKG triggered every `42` entries
- `60 Gwei` ceiling, `10 Gwei` actual price: DKG triggered every `27` entries
- `60 Gwei` ceiling, `1 Gwei` actual price: DKG triggered every `13` entries

Detailed breakdown for DKG available at https://github.com/keep-network/keep-core/issues/1896