### PR TITLE
Undelegation period set to two weeks for the first two months after TokenStaking deployment

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -66,7 +66,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
     uint256 public minimumStakeScheduleStart;
     uint256 public initializationPeriod; // varies between mainnet and testnet
-    uint256 public constant undelegationPeriod = 5184000; // ~60 days
 
     ERC20Burnable internal token;
     TokenGrant internal tokenGrant;
@@ -75,6 +74,9 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     GrantStaking.Storage internal grantStaking;
     Locks.Storage internal locks;
     TopUps.Storage internal topUps;
+
+    uint256 internal constant twoWeeks = 1209600; // [sec]
+    uint256 internal constant twoMonths = 5184000; // [sec]
 
     /// @notice Creates a token staking contract for a provided Standard ERC20Burnable token.
     /// @param _token KEEP token contract.
@@ -104,6 +106,16 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// on the amount of steps and the length of the minimum stake schedule in seconds.
     function minimumStake() public view returns (uint256) {
         return MinimumStakeSchedule.current(minimumStakeScheduleStart);
+    }
+
+    /// @notice Returns the current value of the undelegation period.
+    /// The staking contract guarantees that an undelegated operator’s stakes
+    /// will stay locked for a period of time after undelegation, and thus
+    /// available as collateral for any work the operator is engaged in.
+    /// The undelegation period is two weeks for the first two months and
+    /// two months after that.
+    function undelegationPeriod() public view returns(uint256) {
+        return block.timestamp < minimumStakeScheduleStart.add(twoMonths) ? twoWeeks : twoMonths;
     }
 
     /// @notice Receives approval of token transfer and stakes the approved
@@ -671,7 +683,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     function _isUndelegatingFinished(uint256 _operatorParams)
         internal view returns (bool) {
         uint256 undelegatedAt = _operatorParams.getUndelegationTimestamp();
-        return (undelegatedAt != 0) && (block.timestamp > undelegatedAt.add(undelegationPeriod));
+        return (undelegatedAt != 0) && (block.timestamp > undelegatedAt.add(undelegationPeriod()));
     }
 
     /// @notice Get whether the operator's stake is released

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -76,6 +76,38 @@ describe('TokenStaking', function() {
     );
   }
 
+  describe("undelegationPeriod", async () => {
+    const twoWeeks = web3.utils.toBN("1209600") // [sec]
+    const twoMonths = web3.utils.toBN("5184000") // [sec]
+    
+    it("is two weeks right after deploying the contract", async () => {
+      expect(await stakingContract.undelegationPeriod()).to.eq.BN(twoWeeks)
+    })
+
+    it("is two weeks one month after deploying the contract", async () => {
+      await time.increase(time.duration.days(30))
+      expect(await stakingContract.undelegationPeriod()).to.eq.BN(twoWeeks)
+    })
+
+    it("is two weeks before two months after the deployment passes", async () => {
+      await time.increase(time.duration.days(59))
+      await time.increase(time.duration.hours(23))
+      expect(await stakingContract.undelegationPeriod()).to.eq.BN(twoWeeks)
+    })
+
+    it("is two months after two months after the deployment passes", async () => {
+      await time.increase(time.duration.days(60))
+      expect(await stakingContract.undelegationPeriod()).to.eq.BN(twoMonths)
+    })
+
+    it("remains as two months after two months after the deployment passes", async () => {
+      await time.increase(time.duration.days(180))
+      expect(await stakingContract.undelegationPeriod()).to.eq.BN(twoMonths) 
+      await time.increase(time.duration.days(360))
+      expect(await stakingContract.undelegationPeriod()).to.eq.BN(twoMonths) 
+    })
+  })
+
   describe("delegate", async () => {
     it("should update balances", async () => {
       let ownerStartBalance = await token.balanceOf.call(owner);


### PR DESCRIPTION
Closes: #1900 
~~Depends on #1906 (I had to make sure we are not running into out-of-gas problems again but it seems that #1902 saved us)~~

For the first two months after the deployment of `TokenStaking` contract, the undelegation period is two weeks and it goes back to two months once two months after the deployment passes.

The staking contract guarantees that an undelegated operator’s stakes will stay locked for a period of time after undelegation, and thus available as collateral for any work the operator is engaged in. Two weeks is the absolute minimum given that the beacon group's active time is also two weeks. Changing undelegation period does not affect `keep-ecdsa` deposits since the stake is locked by the sanctioned application until all deposits the given staker has are redeemed and keeps are closed.

Shorten undelegation period should allow less stressful onboarding of new stakers to the system as well as allow for faster migration in case a new staking contract is deployed.