### PR TITLE
Fix for not presenting slashes

### DIFF
--- a/solidity/dashboard/src/services/slashed-tokens.service.js
+++ b/solidity/dashboard/src/services/slashed-tokens.service.js
@@ -112,7 +112,10 @@ const groupByTransactionHash = (events) => {
         amount: add(returnValues.amount, prevData.amount),
       }
     } else {
-      groupedByTransactionHash[transactionHash] = { ...returnValues }
+      groupedByTransactionHash[transactionHash] = {
+        ...returnValues,
+        amount: returnValues.amount,
+      }
     }
   })
 

--- a/solidity/dashboard/src/services/slashed-tokens.service.js
+++ b/solidity/dashboard/src/services/slashed-tokens.service.js
@@ -78,6 +78,7 @@ const fetchSlashedTokens = async (web3Context) => {
       punishmentData = { amount, type: "SEIZED", event }
     }
 
+    if (!punishmentData.hasOwnProperty("amount")) continue
     if (lte(punishmentData.amount, 0)) continue
 
     punishmentData.date = moment.unix(

--- a/solidity/dashboard/src/services/slashed-tokens.service.js
+++ b/solidity/dashboard/src/services/slashed-tokens.service.js
@@ -69,7 +69,7 @@ const fetchSlashedTokens = async (web3Context) => {
       blockNumber,
       returnValues: { groupIndex },
     } = punishmentEvents[i]
-    let punishmentData = {}
+    let punishmentData
     if (slashedTokensGroupedByTxtHash.hasOwnProperty(transactionHash)) {
       const { amount } = slashedTokensGroupedByTxtHash[transactionHash]
       punishmentData = { amount, type: "SLASHED", event }
@@ -78,8 +78,7 @@ const fetchSlashedTokens = async (web3Context) => {
       punishmentData = { amount, type: "SEIZED", event }
     }
 
-    if (!punishmentData.hasOwnProperty("amount")) continue
-    if (lte(punishmentData.amount, 0)) continue
+    if (!punishmentData || lte(punishmentData.amount, 0)) continue
 
     punishmentData.date = moment.unix(
       (await eth.getBlock(blockNumber)).timestamp


### PR DESCRIPTION
The issue could result in not presenting information about slashing / seizing in a dashboard under some specific conditions (when transaction hash is neither in slashedTokensGroupedByTxtHash nor in seizedTokensGroupedByTxtHash). As the result user would observe correct total number of staked tokens with no explanation why it is lesser than used to be. 

Actual fix consists of two parts: 
- skipping uninitialized punishmentData-s 
- properly filling 'amount' (unrelated to my original issue but might result in similar behaviour if not fixed too)

@pdyraga @sthompson22 - it resolved my issue with 'missing 1k & no slashes' 