### PR TITLE
Check if the accused member ID is non-zero

### DIFF
--- a/pkg/beacon/relay/gjkr/protocol.go
+++ b/pkg/beacon/relay/gjkr/protocol.go
@@ -549,7 +549,8 @@ func (sjm *SharesJustifyingMember) ResolveSecretSharesAccusationsMessages(
 	for _, message := range messages {
 		accuserID := message.senderID
 		for accusedID, revealedAccuserPrivateKey := range message.accusedMembersKeys {
-			if sjm.ID == accusedID || int(accusedID) > sjm.group.GroupSize() {
+			isAccusedValid := accusedID > 0 && int(accusedID) <= sjm.group.GroupSize()
+			if sjm.ID == accusedID || !isAccusedValid {
 				// The member does not resolve the dispute as an accused
 				// or the accussed member ID is not valid.
 				// Mark the accuser as disqualified immediately,
@@ -985,7 +986,8 @@ func (pjm *PointsJustifyingMember) ResolvePublicKeySharePointsAccusationsMessage
 	for _, message := range messages {
 		accuserID := message.senderID
 		for accusedID, revealedAccuserPrivateKey := range message.accusedMembersKeys {
-			if pjm.ID == accusedID || int(accusedID) > pjm.group.GroupSize() {
+			isAccusedValid := accusedID > 0 && int(accusedID) <= pjm.group.GroupSize()
+			if pjm.ID == accusedID || !isAccusedValid {
 				// The member does not resolve the dispute as an accused
 				// or the accussed member ID is not valid.
 				// Mark the accuser as disqualified immediately,

--- a/pkg/beacon/relay/gjkr/protocol.go
+++ b/pkg/beacon/relay/gjkr/protocol.go
@@ -549,8 +549,8 @@ func (sjm *SharesJustifyingMember) ResolveSecretSharesAccusationsMessages(
 	for _, message := range messages {
 		accuserID := message.senderID
 		for accusedID, revealedAccuserPrivateKey := range message.accusedMembersKeys {
-			isAccusedValid := accusedID > 0 && int(accusedID) <= sjm.group.GroupSize()
-			if sjm.ID == accusedID || !isAccusedValid {
+			isAccusedIDValid := accusedID > 0 && int(accusedID) <= sjm.group.GroupSize()
+			if sjm.ID == accusedID || !isAccusedIDValid {
 				// The member does not resolve the dispute as an accused
 				// or the accussed member ID is not valid.
 				// Mark the accuser as disqualified immediately,
@@ -986,8 +986,8 @@ func (pjm *PointsJustifyingMember) ResolvePublicKeySharePointsAccusationsMessage
 	for _, message := range messages {
 		accuserID := message.senderID
 		for accusedID, revealedAccuserPrivateKey := range message.accusedMembersKeys {
-			isAccusedValid := accusedID > 0 && int(accusedID) <= pjm.group.GroupSize()
-			if pjm.ID == accusedID || !isAccusedValid {
+			isAccusedIDValid := accusedID > 0 && int(accusedID) <= pjm.group.GroupSize()
+			if pjm.ID == accusedID || !isAccusedIDValid {
 				// The member does not resolve the dispute as an accused
 				// or the accussed member ID is not valid.
 				// Mark the accuser as disqualified immediately,

--- a/pkg/beacon/relay/gjkr/protocol_accusations_test.go
+++ b/pkg/beacon/relay/gjkr/protocol_accusations_test.go
@@ -401,41 +401,59 @@ func TestResolveSecretSharesAccusationsIncorrectAccussedMemberId(t *testing.T) {
 	dishonestThreshold := 2
 	groupSize := 5
 
-	accuserMemberID := group.MemberIndex(1)
-	accussedMemberID := group.MemberIndex(6)
 	currentMemberID := group.MemberIndex(3)
 
-	members, err := initializeSharesJustifyingMemberGroup(
-		dishonestThreshold,
-		groupSize,
-	)
-	if err != nil {
-		t.Fatalf("group initialization failed [%s]", err)
-	}
-
-	messages := [1]*SecretSharesAccusationsMessage{
-		{
-			senderID: accuserMemberID,
-			accusedMembersKeys: map[group.MemberIndex]*ephemeral.PrivateKey{
-				accussedMemberID: {},
-			},
+	var tests = map[string]struct {
+		accuserID            group.MemberIndex
+		accusedID            group.MemberIndex
+		expectedDisqualified []group.MemberIndex
+	}{
+		"group member index greater than the group size": {
+			accuserID:            1,
+			accusedID:            6,
+			expectedDisqualified: []group.MemberIndex{1},
+		},
+		"group member index 0": {
+			accuserID:            2,
+			accusedID:            0,
+			expectedDisqualified: []group.MemberIndex{2},
 		},
 	}
 
-	justifyingMember := findSharesJustifyingMemberByID(members, currentMemberID)
-	err = justifyingMember.ResolveSecretSharesAccusationsMessages(messages[:])
-	if err != nil {
-		t.Fatalf("resolving of secret shares accustion messages failed [%s]", err)
-	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			members, err := initializeSharesJustifyingMemberGroup(
+				dishonestThreshold,
+				groupSize,
+			)
+			if err != nil {
+				t.Fatalf("group initialization failed [%s]", err)
+			}
 
-	actualDisqualified := justifyingMember.group.DisqualifiedMemberIDs()
-	expectedDisqualified := [1]group.MemberIndex{accuserMemberID}
-	if !reflect.DeepEqual(actualDisqualified, expectedDisqualified[:]) {
-		t.Fatalf(
-			"unexpected members disqualified\nexpected: %d\nactual:   %d\n",
-			expectedDisqualified,
-			actualDisqualified,
-		)
+			messages := [1]*SecretSharesAccusationsMessage{
+				{
+					senderID: test.accuserID,
+					accusedMembersKeys: map[group.MemberIndex]*ephemeral.PrivateKey{
+						test.accusedID: {},
+					},
+				},
+			}
+
+			justifyingMember := findSharesJustifyingMemberByID(members, currentMemberID)
+			err = justifyingMember.ResolveSecretSharesAccusationsMessages(messages[:])
+			if err != nil {
+				t.Fatalf("resolving of secret shares accusation messages failed [%s]", err)
+			}
+
+			actualDisqualified := justifyingMember.group.DisqualifiedMemberIDs()
+			if !reflect.DeepEqual(actualDisqualified, test.expectedDisqualified) {
+				t.Fatalf(
+					"unexpected members disqualified\nexpected: %d\nactual:   %d\n",
+					test.expectedDisqualified,
+					actualDisqualified,
+				)
+			}
+		})
 	}
 }
 
@@ -443,41 +461,59 @@ func TestResolvePublicKeySharePointsAccusationsIncorrectAccusedMemberId(t *testi
 	dishonestThreshold := 2
 	groupSize := 5
 
-	accuserMemberID := group.MemberIndex(1)
-	accussedMemberID := group.MemberIndex(6)
 	currentMemberID := group.MemberIndex(3)
 
-	members, err := initializePointsJustifyingMemberGroup(
-		dishonestThreshold,
-		groupSize,
-	)
-	if err != nil {
-		t.Fatalf("group initialization failed [%s]", err)
-	}
-
-	messages := [1]*PointsAccusationsMessage{
-		{
-			senderID: accuserMemberID,
-			accusedMembersKeys: map[group.MemberIndex]*ephemeral.PrivateKey{
-				accussedMemberID: {},
-			},
+	var tests = map[string]struct {
+		accuserID            group.MemberIndex
+		accusedID            group.MemberIndex
+		expectedDisqualified []group.MemberIndex
+	}{
+		"group member index greater than the group size": {
+			accuserID:            1,
+			accusedID:            6,
+			expectedDisqualified: []group.MemberIndex{1},
+		},
+		"group member index 0": {
+			accuserID:            2,
+			accusedID:            0,
+			expectedDisqualified: []group.MemberIndex{2},
 		},
 	}
 
-	justifyingMember := findCoefficientsJustifyingMemberByID(members, currentMemberID)
-	err = justifyingMember.ResolvePublicKeySharePointsAccusationsMessages(messages[:])
-	if err != nil {
-		t.Fatalf("resolving of public key share points accusation messages failed [%s]", err)
-	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			members, err := initializePointsJustifyingMemberGroup(
+				dishonestThreshold,
+				groupSize,
+			)
+			if err != nil {
+				t.Fatalf("group initialization failed [%s]", err)
+			}
 
-	actualDisqualified := justifyingMember.group.DisqualifiedMemberIDs()
-	expectedDisqualified := [1]group.MemberIndex{accuserMemberID}
-	if !reflect.DeepEqual(actualDisqualified, expectedDisqualified[:]) {
-		t.Fatalf(
-			"unexpected members disqualified\nexpected: %d\nactual:   %d\n",
-			expectedDisqualified,
-			actualDisqualified,
-		)
+			messages := [1]*PointsAccusationsMessage{
+				{
+					senderID: test.accuserID,
+					accusedMembersKeys: map[group.MemberIndex]*ephemeral.PrivateKey{
+						test.accusedID: {},
+					},
+				},
+			}
+
+			justifyingMember := findCoefficientsJustifyingMemberByID(members, currentMemberID)
+			err = justifyingMember.ResolvePublicKeySharePointsAccusationsMessages(messages[:])
+			if err != nil {
+				t.Fatalf("resolving of public key share points accusation messages failed [%s]", err)
+			}
+
+			actualDisqualified := justifyingMember.group.DisqualifiedMemberIDs()
+			if !reflect.DeepEqual(actualDisqualified, test.expectedDisqualified) {
+				t.Fatalf(
+					"unexpected members disqualified\nexpected: %d\nactual:   %d\n",
+					test.expectedDisqualified,
+					actualDisqualified,
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
In the resolve secret shares accusation phase and resolve public key share points accusations phase, we were checking whether the accused member ID does not exceed the group size. We were not, however, checking if it's non-zero which could result in returning an error from GJKR protocol.