### PR TITLE
Make sure only KEEP token can call escrow's receiveApproval

### DIFF
--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -103,6 +103,7 @@ contract TokenStakingEscrow is Ownable {
         bytes memory extraData
     ) public {
         require(IERC20(token) == keepToken, "Not a KEEP token");
+        require(msg.sender == token, "KEEP token is not the sender");
         require(extraData.length == 64, "Unexpected data length");
 
         (address operator, uint256 grantId) = abi.decode(

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -110,6 +110,20 @@ describe('TokenStakingEscrow', () => {
       )
     })
 
+    it('reverts when it is not KEEP token calling', async () => {
+      const data = web3.eth.abi.encodeParameters(
+        ['address', 'uint256'], [operator, grantId]
+      )
+
+      await expectRevert(
+        escrow.receiveApproval(
+          tokenStaking, grantedAmount, 
+          token.address, data, {from: thirdParty}
+        ),
+        "KEEP token is not the sender"
+      )
+    })
+
     it('reverts for corrupted extraData', async () => {
       const corruptedData = web3.eth.abi.encodeParameters(
         ['address'], [operator]


### PR DESCRIPTION
We do have a `require` making sure tokens come from the `TokenStaking` contract (at least they are declared as such) but a malicious third party could still call `receiveApproval` directly passing `TokenStaking` (`owner()`) in `from` parameter.

We now ensure that no one but KEEP token can call `receiveApproval` of `TokenStakingEscrow`.