### PR TITLE
Allow to top-up a stake during initialization period

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -152,13 +152,12 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address operator = _extraData.toAddress(20);
         // See if there is an existing delegation for this operator...
         if (operators[operator].packedParams.getCreationTimestamp() == 0) {
-            // If there is no existing delegation, tokens are delegated using
+            // If there is no existing delegation, delegate tokens using
             // beneficiary and authorizer passed in _extraData.
             delegate(_from, _value, operator, _extraData);
         } else {
-            // If there is an existing delegation, top-up of the stake is
-            // initiated.
-            initiateTopUp(_from, _value, operator, _extraData);
+            // If there is an existing delegation, top-up the stake.
+            topUp(_from, _value, operator, _extraData);
         }
     }
 
@@ -196,7 +195,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         emit Staked(_from, _operator, beneficiary, authorizer, _value);
     }
 
-    /// @notice Initializes top-up to an existing operator. Tokens added during
+    /// @notice Performs top-up to an existing operator. Tokens added during
     /// stake initialization period are immediatelly added to the stake and
     /// stake initialization timer is reset to the current block. Tokens added
     /// in a top-up after the stake initialization period is over are not
@@ -212,7 +211,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// an existing stake.
     /// @param _operator The new operator address.
     /// @param _extraData Data for stake delegation as passed to receiveApproval
-    function initiateTopUp(
+    function topUp(
         address _from,
         uint256 _value,
         address _operator,

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -250,7 +250,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         }
 
         if (!_isInitialized(operatorParams)) {
-            // If the stake is not yet initialized, we add tokens immediatelly
+            // If the stake is not yet initialized, we add tokens immediately
             // but we also reset stake initialization time counter.
             uint256 newAmount = operatorParams.getAmount().add(_value);
             operators[_operator].packedParams = operatorParams.setAmountAndCreationTimestamp(
@@ -259,7 +259,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             );
             emit TopUpCommitted(_operator, newAmount);
         } else {
-            // If the stake is not initialized, we do NOT add tokens immediatelly.
+            // If the stake is initialized, we do NOT add tokens immediately.
             // We initiate the top-up and will add tokens to the stake only
             // after the initialization period for a top-up passes.
             topUps.initiate(_value, _operator);

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -51,7 +51,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     );
     event StakeOwnershipTransferred(
         address indexed operator,
-        address oldOwner,
         address newOwner
     );
     event TopUpInitiated(address indexed operator, uint256 topUp);
@@ -120,13 +119,12 @@ contract TokenStaking is Authorizations, StakeDelegatable {
 
     /// @notice Receives approval of token transfer and stakes the approved
     /// amount or adds the approved amount to an existing delegation (a “top-up”).
-    /// In case of an existing delegation, it is required that the operator stake
-    /// passed initialization period, it is not undelegated and that the top-up is
-    /// performed from the same source of tokens as the initial delegation.
-    /// That is, if the tokens were delegated from a grant, top-up
-    /// has to be performed from the same grant. If the delegation was done
-    /// using liquid tokens, only liquid tokens from the same owner can be used
-    /// to top-up the stake.
+    /// In case of a top-up, it is expected that the operator stake is not
+    /// undelegated and that the top-up is performed from the same source of
+    /// tokens as the initial delegation. That is, if the tokens were delegated
+    /// from a grant, top-up has to be performed from the same grant. If the
+    /// delegation was done using liquid tokens, only liquid tokens from the
+    /// same owner can be used to top-up the stake.
     /// @dev Requires that the provided token contract be the same one linked to
     /// this contract.
     /// @param _from The owner of the tokens who approved them to transfer.
@@ -198,15 +196,17 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         emit Staked(_from, _operator, beneficiary, authorizer, _value);
     }
 
-    /// @notice Initializes top-up to an existing operator. Tokens added in
-    /// a top-up are not included in the operator stake until the initialization
-    /// period for a top-up passes and top-up is committed. Operator must not
-    /// have the stake undelegated and it has to be initialized. It is expected
-    /// that the top-up is done from the same source of tokens as the initial
-    /// delegation. That is, if the tokens were delegated from a grant, top-up
-    /// has to be performed from the same grant. If the delegation was done
-    /// using liquid tokens, only liquid tokens from the same owner can be used
-    /// to top-up the stake.
+    /// @notice Initializes top-up to an existing operator. Tokens added during
+    /// stake initialization period are immediatelly added to the stake and
+    /// stake initialization timer is reset to the current block. Tokens added
+    /// in a top-up after the stake initialization period is over are not
+    /// included in the operator stake until the initialization period for
+    /// a top-up passes and top-up is committed. Operator must not have the stake
+    /// undelegated. It is expected that the top-up is done from the same source
+    /// of tokens as the initial delegation. That is, if the tokens were
+    /// delegated from a grant, top-up has to be performed from the same grant.
+    /// If the delegation was done using liquid tokens, only liquid tokens from
+    /// the same owner can be used to top-up the stake.
     /// @param _from The owner of the tokens who approved them to transfer.
     /// @param _value Approved amount for the transfer and top-up to
     /// an existing stake.
@@ -219,10 +219,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         bytes memory _extraData
     ) internal {
         uint256 operatorParams = operators[_operator].packedParams;
-        require(
-            _isInitialized(operatorParams),
-            "Stake is initializing"
-        );
         require(
             !_isUndelegating(operatorParams),
             "Stake undelegated"
@@ -253,8 +249,22 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             require(operators[_operator].owner == _from, "Not the same owner");
         }
 
-        topUps.initiate(_value, _operator);
-        emit TopUpInitiated(_operator, _value);
+        if (!_isInitialized(operatorParams)) {
+            // If the stake is not yet initialized, we add tokens immediatelly
+            // but we also reset stake initialization time counter.
+            uint256 newAmount = operatorParams.getAmount().add(_value);
+            operators[_operator].packedParams = operatorParams.setAmountAndCreationTimestamp(
+                newAmount,
+                block.timestamp
+            );
+            emit TopUpCommitted(_operator, newAmount);
+        } else {
+            // If the stake is not initialized, we do NOT add tokens immediatelly.
+            // We initiate the top-up and will add tokens to the stake only
+            // after the initialization period for a top-up passes.
+            topUps.initiate(_value, _operator);
+            emit TopUpInitiated(_operator, _value);
+        }
     }
 
     /// @notice Commits pending top-up for the provided operator. If the top-up
@@ -343,7 +353,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             // or operator. Only owner and grantee are eligible to postpone the
             // delegation so it is enough if we exclude operator here.
             msg.sender != _operator,
-            "Operator may not postpone undelegation"
+            "Operator may not postpone"
         );
         operators[_operator].packedParams = oldParams.setUndelegationTimestamp(
             _undelegationTimestamp
@@ -576,10 +586,9 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// @param operator Address of the stake operator.
     /// @param newOwner Address of the new staking relationship owner.
     function transferStakeOwnership(address operator, address newOwner) public {
-        address oldOwner = operators[operator].owner;
-        require(msg.sender == oldOwner, "Not authorized");
+        require(msg.sender == operators[operator].owner, "Not authorized");
         operators[operator].owner = newOwner;
-        emit StakeOwnershipTransferred(operator, oldOwner, newOwner);
+        emit StakeOwnershipTransferred(operator, newOwner);
     }
 
     /// @notice Gets the eligible stake balance of the specified address.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -54,7 +54,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address newOwner
     );
     event TopUpInitiated(address indexed operator, uint256 topUp);
-    event TopUpCommitted(address indexed operator, uint256 newAmount);
+    event TopUpCompleted(address indexed operator, uint256 newAmount);
     event Undelegated(address indexed operator, uint256 undelegatedAt);
     event RecoveredStake(address operator);
     event TokensSlashed(address indexed operator, uint256 amount);
@@ -257,7 +257,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
                 newAmount,
                 block.timestamp
             );
-            emit TopUpCommitted(_operator, newAmount);
+            emit TopUpCompleted(_operator, newAmount);
         } else {
             // If the stake is initialized, we do NOT add tokens immediately.
             // We initiate the top-up and will add tokens to the stake only
@@ -276,7 +276,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             topUps.commit(_operator, initializationPeriod),
             _operator
         );
-        emit TopUpCommitted(_operator, newAmount);
+        emit TopUpCompleted(_operator, newAmount);
     }
 
     function addStakeAmount(

--- a/solidity/contracts/stubs/OperatorParamsStub.sol
+++ b/solidity/contracts/stubs/OperatorParamsStub.sol
@@ -35,4 +35,12 @@ contract OperatorParamsStub {
     function publicSetUndelegationTimestamp(uint256 packed, uint256 undelegationTimestamp) public pure returns (uint256) {
         return packed.setUndelegationTimestamp(undelegationTimestamp);
     }
+
+    function publicSetAmountAndCreationTimestamp(
+        uint256 packed,
+        uint256 amount,
+        uint256 creationTimestamp
+    ) public pure returns (uint256) {
+        return packed.setAmountAndCreationTimestamp(amount, creationTimestamp);
+    }
 }

--- a/solidity/contracts/utils/OperatorParams.sol
+++ b/solidity/contracts/utils/OperatorParams.sol
@@ -36,19 +36,17 @@ library OperatorParams {
         // We shouldn't actually ever need this.
         require(
             amount <= AMOUNT_MAX,
-            "amount uint128 overflow"
+            "uint128 overflow"
         );
         // Bitwise OR the timestamps together.
         // The resulting number is equal or greater than either,
         // and tells if we have a bit set outside the 64 available bits.
         require(
             (createdAt | undelegatedAt) <= TIMESTAMP_MAX,
-            "timestamp uint64 overflow"
+            "uint64 overflow"
         );
-        uint256 a = amount << AMOUNT_SHIFT;
-        uint256 c = createdAt << CREATION_SHIFT;
-        uint256 u = undelegatedAt;
-        return (a | c | u);
+
+        return (amount << AMOUNT_SHIFT | createdAt << CREATION_SHIFT | undelegatedAt);
     }
 
     function unpack(uint256 packedParams) internal pure returns (
@@ -106,6 +104,18 @@ library OperatorParams {
             getAmount(packedParams),
             getCreationTimestamp(packedParams),
             undelegationTimestamp
+        );
+    }
+
+    function setAmountAndCreationTimestamp(
+        uint256 packedParams,
+        uint256 amount,
+        uint256 creationTimestamp
+    ) internal pure returns (uint256) {
+        return pack(
+            amount,
+            creationTimestamp,
+            getUndelegationTimestamp(packedParams)
         );
     }
 }

--- a/solidity/test/TestOperatorParams.js
+++ b/solidity/test/TestOperatorParams.js
@@ -82,4 +82,36 @@ describe('OperatorParams', () => {
         "The undelegationTimestamp should be the same");
     })
   })
+
+  describe("setAmountAndCreationTimestamp", async () => {
+    it("should set the creation timestamp", async () => {
+      const params = await opUtils.publicPack(allKeepEver, recently, 0)
+      const newParams = await opUtils.publicSetAmountAndCreationTimestamp(
+        params,
+        billion,
+        billionYearsFromNow        
+      )
+      const creationBlock = await opUtils.publicGetCreationTimestamp(newParams)
+      assert.equal(
+        creationBlock.toJSON(),
+        billionYearsFromNow.toJSON(),
+        "The creation timestamp should be the same"
+      )
+    })
+
+    it("should set the amount", async () => {
+      const params = await opUtils.publicPack(allKeepEver, recently, 0);
+      const newParams = await opUtils.publicSetAmountAndCreationTimestamp(
+        params,
+        billion,
+        billionYearsFromNow
+      )
+      const amount = await opUtils.publicGetAmount(newParams);
+      assert.equal(
+        amount.toJSON(),
+        billion.toJSON(),
+        "The amount should be the same"
+      )
+    })
+  })
 })

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -351,7 +351,7 @@ describe('TokenStaking', function() {
 
       await expectRevert(
         stakingContract.undelegate(operatorOne, {from: operatorOne}),
-        "Operator may not postpone undelegation"
+        "Operator may not postpone"
       )
     })
   })
@@ -501,7 +501,7 @@ describe('TokenStaking', function() {
           operatorOne, currentTime.addn(1),
           {from: operatorOne}
         ),
-        "Operator may not postpone undelegation"
+        "Operator may not postpone"
       )
     })
   })
@@ -850,7 +850,6 @@ describe('TokenStaking', function() {
 
       await expectEvent(receipt, "StakeOwnershipTransferred", {
         operator: operatorOne,
-        oldOwner: owner,
         newOwner: thirdParty
       })
     })

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -277,6 +277,19 @@ describe('TokenStaking/TopUps', () => {
       expect(delegationInfo.undelegatedAt).to.eq.BN(0)
     })
 
+    it("fails to commit when done in one step during initialization period", async () => {
+      // half of the initialization period passed
+      await time.increase(initializationPeriod.divn(2))
+
+      // We are still in the initialization period, top-up is done in one step
+      // and there is nothing to commit.
+      await initiateTopUp() 
+      await expectRevert(
+        tokenStaking.commitTopUp(operatorOne),
+        "No top up to commit"
+      )
+    })
+
     it("does not increase stake before committed", async () => {
       await time.increase(initializationPeriod.addn(1))
       await initiateTopUp()

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -214,13 +214,6 @@ describe('TokenStaking/TopUps', () => {
       )
     }
 
-    it("can not be done during initialization period", async () => {
-      await expectRevert(
-        initiateTopUp(),
-        "Stake is initializing"
-      )
-    })
-
     it("can not be done when stake is undelegating", async () => {
       await time.increase(initializationPeriod.addn(1))
       await tokenStaking.undelegate(operatorOne, {from: tokenOwner})
@@ -270,6 +263,18 @@ describe('TokenStaking/TopUps', () => {
         ),
         "Must not be from a grant"
       )   
+    })
+
+    it("can be done in one step during initialization period", async () => {
+      // helf of the initialization period passed
+      await time.increase(initializationPeriod.divn(2))
+
+      await initiateTopUp()
+
+      const delegationInfo = await tokenStaking.getDelegationInfo(operatorOne)
+      expect(delegationInfo.amount).to.eq.BN(delegatedAmount.muln(2))
+      expect(delegationInfo.createdAt).to.eq.BN(await time.latest())
+      expect(delegationInfo.undelegatedAt).to.eq.BN(0)
     })
 
     it("does not increase stake before committed", async () => {
@@ -357,13 +362,6 @@ describe('TokenStaking/TopUps', () => {
       ) 
     }
 
-    it("can not be done during initialization period", async () => {
-      await expectRevert(
-        initiateTopUp(),
-        "Stake is initializing"
-      )
-    })
-
     it("can not be done when stake is undelegated", async () => {
       await time.increase(initializationPeriod.addn(1))
       await tokenStaking.undelegate(operatorTwo, {from: grantee})
@@ -409,6 +407,18 @@ describe('TokenStaking/TopUps', () => {
         ),
         "Must be from a grant"
       );
+    })
+
+    it("can be done in one step during initialization period", async () => {
+      // helf of the initialization period passed
+      await time.increase(initializationPeriod.divn(2))
+
+      await initiateTopUp()
+
+      const delegationInfo = await tokenStaking.getDelegationInfo(operatorTwo)
+      expect(delegationInfo.amount).to.eq.BN(delegatedAmount.muln(2))
+      expect(delegationInfo.createdAt).to.eq.BN(await time.latest())
+      expect(delegationInfo.undelegatedAt).to.eq.BN(0)
     })
 
     it("does not increase stake before committed", async () => {
@@ -495,13 +505,6 @@ describe('TokenStaking/TopUps', () => {
       ) 
     }
 
-    it("can not be done during initialization period", async () => {
-      await expectRevert(
-        initiateTopUp(),
-        "Stake is initializing"
-      )
-    })
-
     it("can not be done when stake is undelegating", async () => {
       await time.increase(initializationPeriod.addn(1))
       await tokenStaking.undelegate(operatorThree, {from: managedGrantee})
@@ -547,6 +550,18 @@ describe('TokenStaking/TopUps', () => {
         ),
         "Must be from a grant"
       );
+    })
+
+    it("can be done in one step during initialization period", async () => {
+      // helf of the initialization period passed
+      await time.increase(initializationPeriod.divn(2))
+
+      await initiateTopUp()
+
+      const delegationInfo = await tokenStaking.getDelegationInfo(operatorThree)
+      expect(delegationInfo.amount).to.eq.BN(delegatedAmount.muln(2))
+      expect(delegationInfo.createdAt).to.eq.BN(await time.latest())
+      expect(delegationInfo.undelegatedAt).to.eq.BN(0)
     })
 
     it("does not increase stake before committed", async () => {

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -97,7 +97,7 @@ describe('TokenStaking/TopUps', () => {
     // 
     const minimumStake = await tokenStaking.minimumStake();
     grantedAmount = minimumStake.muln(40);
-    delegatedAmount = minimumStake.muln(20);
+    delegatedAmount = minimumStake.muln(10);
 
     grantId = await grantTokens(
       tokenGrant, 
@@ -359,6 +359,45 @@ describe('TokenStaking/TopUps', () => {
         "No top up to commit"
       )
     })
+    
+    it("can be done multiple times", async () => {
+      // The first top-up.
+      // Half of the initialization period passed, top-up should  be processed
+      // immediately but also reset the initialization period.
+      await time.increase(initializationPeriod.divn(2))
+      await initiateTopUp()
+    
+      await time.increase(initializationPeriod.addn(1))
+      let currentStake = await tokenStaking.activeStake(
+        operatorOne,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(2))
+
+      // The second top-up.
+      // Initialization period passed so it has to be done in two steps.
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorOne)
+
+      currentStake = await tokenStaking.activeStake(
+        operatorOne,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(3))
+
+
+      // And yet one top-up...
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorOne)
+
+      currentStake = await tokenStaking.activeStake(
+        operatorOne,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(4))
+    })
   })
 
   describe("delegated grant top-ups", async () => {
@@ -503,6 +542,45 @@ describe('TokenStaking/TopUps', () => {
         "No top up to commit"
       )
     })
+    
+    it("can be done multiple times", async () => {
+      // The first top-up.
+      // Half of the initialization period passed, top-up should  be processed
+      // immediately but also reset the initialization period.
+      await time.increase(initializationPeriod.divn(2))
+      await initiateTopUp()
+    
+      await time.increase(initializationPeriod.addn(1))
+      let currentStake = await tokenStaking.activeStake(
+        operatorTwo,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(2))
+
+      // The second top-up.
+      // Initialization period passed so it has to be done in two steps.
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorTwo)
+
+      currentStake = await tokenStaking.activeStake(
+        operatorTwo,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(3))
+
+
+      // And yet one top-up...
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorTwo)
+
+      currentStake = await tokenStaking.activeStake(
+        operatorTwo,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(4))
+    })
   })
 
   describe("delegated managed grant top-ups", async () => {
@@ -645,6 +723,45 @@ describe('TokenStaking/TopUps', () => {
         tokenStaking.commitTopUp(operatorThree),
         "No top up to commit"
       )
+    })
+    
+    it("can be done multiple times", async () => {
+      // The first top-up.
+      // Half of the initialization period passed, top-up should  be processed
+      // immediately but also reset the initialization period.
+      await time.increase(initializationPeriod.divn(2))
+      await initiateTopUp()
+    
+      await time.increase(initializationPeriod.addn(1))
+      let currentStake = await tokenStaking.activeStake(
+        operatorThree,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(2))
+
+      // The second top-up.
+      // Initialization period passed so it has to be done in two steps.
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorThree)
+
+      currentStake = await tokenStaking.activeStake(
+        operatorThree,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(3))
+
+
+      // And yet one top-up...
+      await initiateTopUp()
+      await time.increase(initializationPeriod.addn(1))
+      await tokenStaking.commitTopUp(operatorThree)
+
+      currentStake = await tokenStaking.activeStake(
+        operatorThree,
+        operatorContract
+      )
+      expect(currentStake).to.eq.BN(delegatedAmount.muln(4))
     })
   })
 

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -266,7 +266,7 @@ describe('TokenStaking/TopUps', () => {
     })
 
     it("can be done in one step during initialization period", async () => {
-      // helf of the initialization period passed
+      // half of the initialization period passed
       await time.increase(initializationPeriod.divn(2))
 
       await initiateTopUp()
@@ -410,7 +410,7 @@ describe('TokenStaking/TopUps', () => {
     })
 
     it("can be done in one step during initialization period", async () => {
-      // helf of the initialization period passed
+      // half of the initialization period passed
       await time.increase(initializationPeriod.divn(2))
 
       await initiateTopUp()
@@ -553,7 +553,7 @@ describe('TokenStaking/TopUps', () => {
     })
 
     it("can be done in one step during initialization period", async () => {
-      // helf of the initialization period passed
+      // half of the initialization period passed
       await time.increase(initializationPeriod.divn(2))
 
       await initiateTopUp()


### PR DESCRIPTION
Closes: #1931 
~~Depends on #1915 (it is not really a dependency on functionality; I want to keep an eye on out-of-gas issues this way to avoid post-merge surprises)~~

In case the stake is still in the initialization period, we add tokens immediately but we also reset the stake initialization time counter.

This change allows for two things:
- Staker no longer has to pay for two transactions to achieve the same result (cancel + stake) and operator address uniqueness is no longer a problem.
- If the stake has been undelegated from multiple operators and is scattered in the escrow, staker may perform a delegation and top-up as many times as needed, right after the delegation. Multiple transactions have to be sent to the chain but staker does no longer needs to suffer from the initialization period between the delegation and the first top-up.

Because of out-of-gas problems during `TokenStaking` deployment I had to sacrifice something. I decided to shorten some revert strings and to remove `oldOwner` from `StakeOwnershipTransferred` event. This value can be deducted from the previous `StakeOwnershipTransferred` event for the given operator or from the `Staked` event.