### PR TITLE
Fix total balance of grants- KEEP token dashboard overview page

### DIFF
--- a/solidity/dashboard/src/components/ChooseWallet.jsx
+++ b/solidity/dashboard/src/components/ChooseWallet.jsx
@@ -130,7 +130,7 @@ const Wallet = ({
         {renderModalContent()}
       </ModalComponent>
       <li
-        title={providerName === "COINBASE" && "Coinbase not yet supported"}
+        title={providerName === "COINBASE" ? "Coinbase not yet supported" : ""}
         className={`wallet${providerName === "COINBASE" ? " disabled" : ""}`}
         onClick={async () => {
           if (providerName === "COINBASE") {

--- a/solidity/dashboard/src/pages/TokenGrantsPage.jsx
+++ b/solidity/dashboard/src/pages/TokenGrantsPage.jsx
@@ -38,7 +38,7 @@ const TokenGrantsPage = () => {
 }
 
 const renderTokenGrantOverview = (tokenGrant) => (
-  <TokenGrantOverview tokenGrant={tokenGrant} />
+  <TokenGrantOverview key={tokenGrant.id} tokenGrant={tokenGrant} />
 )
 
 const TokenGrantOverview = React.memo(({ tokenGrant }) => {

--- a/solidity/dashboard/src/pages/TokenOverviewPage.jsx
+++ b/solidity/dashboard/src/pages/TokenOverviewPage.jsx
@@ -5,7 +5,7 @@ import Undelegations from "../components/Undelegations"
 import TokenOverview from "../components/TokenOverview"
 import { LoadingOverlay } from "../components/Loadable"
 import { useTokensPageContext } from "../contexts/TokensPageContext"
-import { add } from "../utils/arithmetics.utils"
+import { add, sub } from "../utils/arithmetics.utils"
 import { isEmptyArray } from "../utils/array.utils"
 import DataTableSkeleton from "../components/skeletons/DataTableSkeleton"
 
@@ -42,9 +42,11 @@ const TokenOverviewPage = () => {
   }, [delegations, undelegations])
 
   const totalGrantedTokenBalance = useMemo(() => {
-    const grantedBalance = grants.map(({ amount }) => amount).reduce(add, "0")
-    return add(grantedBalance, totalGrantedStakedBalance)
-  }, [grants, totalGrantedStakedBalance])
+    const grantedBalance = grants
+      .map(({ amount, withdrawn }) => sub(amount, withdrawn))
+      .reduce(add, "0")
+    return grantedBalance
+  }, [grants])
 
   return (
     <PageWrapper title="Token Overview">

--- a/solidity/dashboard/src/reducers/tokens-page.reducer.js
+++ b/solidity/dashboard/src/reducers/tokens-page.reducer.js
@@ -149,6 +149,7 @@ const grantWithdrawn = (grants, { grantId, amount, availableToStake }) => {
   grantToUpdate.released = add(grantToUpdate.released, amount)
   grantToUpdate.unlocked = add(grantToUpdate.released, grantToUpdate.staked)
   grantToUpdate.availableToStake = availableToStake
+  grantToUpdate.withdrawn = add(grantToUpdate.withdrawn, amount)
   grants[indexInArray] = grantToUpdate
 
   return grants

--- a/solidity/dashboard/src/services/tokens-page.service.js
+++ b/solidity/dashboard/src/services/tokens-page.service.js
@@ -173,7 +173,7 @@ const getDelegations = async (
       } catch (error) {
         grantId = null
       }
-      if (isManagedGrant) {
+      if (isManagedGrant && grantId !== null) {
         const { grantee } = await contractService.makeCall(
           web3Context,
           TOKEN_GRANT_CONTRACT_NAME,

--- a/solidity/dashboard/src/services/tokens-page.service.js
+++ b/solidity/dashboard/src/services/tokens-page.service.js
@@ -173,7 +173,7 @@ const getDelegations = async (
       } catch (error) {
         grantId = null
       }
-      if (isManagedGrant && grantId !== null) {
+      if (isManagedGrant && grantId) {
         const { grantee } = await contractService.makeCall(
           web3Context,
           TOKEN_GRANT_CONTRACT_NAME,


### PR DESCRIPTION
Closes: #1911 

This PR fixes a bug with a total balance of grants on the overview page.

Before:
* total balance of grants- `1 000 000` KEEP,
* delegate `100 000` KEEP,
* total balance of grants on the overview page- `1 100 000` KEEP- which was not correct.

Currently: 
* total balance of grants- `1 000 000` KEEP,
* delegate `100 000` KEEP,
* we are able to observe `1 000 000` KEEP and `10%` Staked in `Granted Tokens` card.