### PR TITLE
Get operator contract ready for rewards, for real this time

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -703,8 +703,8 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         return groups.groups.length;
     }
 
-    function getGroupRegistrationBlockHeight(uint256 groupIndex) public view returns (uint256) {
-        return groups.getGroupRegistrationBlockHeight(groupIndex);
+    function getGroupRegistrationTime(uint256 groupIndex) public view returns (uint256) {
+        return groups.getGroupRegistrationTime(groupIndex);
     }
 
     function isGroupTerminated(uint256 groupIndex) public view returns (bool) {

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -67,7 +67,7 @@ library Groups {
     function addGroup(
         Storage storage self,
         bytes memory groupPubKey
-    ) internal {
+    ) public {
         self.groupIndices[groupPubKey] = (self.groups.length ^ GROUP_INDEX_FLAG);
         self.groups.push(Group(groupPubKey, uint64(block.number), uint64(block.timestamp), false));
     }
@@ -141,7 +141,7 @@ library Groups {
     function terminateGroup(
         Storage storage self,
         uint256 groupIndex
-    ) internal {
+    ) public {
         require(
             !isGroupTerminated(self, groupIndex),
             "Group has been already terminated"

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -27,9 +27,9 @@ library Groups {
 
     struct Group {
         bytes groupPubKey;
-        uint64 registrationBlockHeight;
-        uint64 registrationTime;
+        uint256 registrationBlockHeight;
         bool terminated;
+        uint248 registrationTime;
     }
 
     struct Storage {
@@ -69,7 +69,7 @@ library Groups {
         bytes memory groupPubKey
     ) public {
         self.groupIndices[groupPubKey] = (self.groups.length ^ GROUP_INDEX_FLAG);
-        self.groups.push(Group(groupPubKey, uint64(block.number), uint64(block.timestamp), false));
+        self.groups.push(Group(groupPubKey, block.number, false, uint248(block.timestamp)));
     }
 
     /// @notice Sets addresses of members for the group with the given public key

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -28,6 +28,7 @@ library Groups {
     struct Group {
         bytes groupPubKey;
         uint64 registrationBlockHeight;
+        uint64 registrationTime;
         bool terminated;
     }
 
@@ -68,7 +69,7 @@ library Groups {
         bytes memory groupPubKey
     ) internal {
         self.groupIndices[groupPubKey] = (self.groups.length ^ GROUP_INDEX_FLAG);
-        self.groups.push(Group(groupPubKey, uint64(block.number), false));
+        self.groups.push(Group(groupPubKey, uint64(block.number), uint64(block.timestamp), false));
     }
 
     /// @notice Sets addresses of members for the group with the given public key
@@ -357,11 +358,11 @@ library Groups {
         return self.groupMembers[groupPubKey];
     }
 
-    function getGroupRegistrationBlockHeight(
+    function getGroupRegistrationTime(
         Storage storage self,
         uint256 groupIndex
     ) public view returns (uint256) {
-        return uint256(self.groups[groupIndex].registrationBlockHeight);
+        return uint256(self.groups[groupIndex].registrationTime);
     }
 
     /// @notice Reports unauthorized signing for the provided group. Must provide


### PR DESCRIPTION
Rewards don't play particularly nice with blockheights, so we need to use timestamps. To avoid out-of-gas issues with deployments, a couple of library functions need to be made public instead of internal. Group registration times are packed in a separate storage slot to avoid creating additional instructions for registration block accesses.