### PR TITLE
Added nkuba as a code owner of OperatorParams.sol

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@
 /solidity/contracts/libraries/staking/MinimumStakeSchedule.sol @Shadowfiend @pdyraga @nkuba
 /solidity/contracts/utils/AddressArrayUtils.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/BytesLib.sol @Shadowfiend @pdyraga
-/solidity/contracts/utils/OperatorParams.sol @Shadowfiend @pdyraga
+/solidity/contracts/utils/OperatorParams.sol @Shadowfiend @pdyraga @nkuba
 /solidity/contracts/utils/PercentUtils.sol @Shadowfiend @pdyraga
 /solidity/contracts/utils/UIntArrayUtils.sol @Shadowfiend @pdyraga
 /solidity/package.json @Shadowfiend @pdyraga


### PR DESCRIPTION
@nkuba is already a code owner of token staking contract and related libraries.
`OperatorParams` seems to be the last one staking-related code file where  he is not yet an owner.

We found it when working on #1929 - although @nkuba approved the code, he could not merge it.