### PR TITLE
Respect redelegated tokens when withdrawing revoked grant from escrow

### DIFF
--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -419,9 +419,8 @@ contract TokenStakingEscrow is Ownable {
         address operator,
         address grantManager
     ) internal {
-        uint256 amount = deposit.amount.sub(deposit.withdrawn);
-
-        deposits[operator].withdrawn = deposit.amount;
+        uint256 amount = availableAmount(operator);
+        deposits[operator].withdrawn = amount;
         keepToken.safeTransfer(grantManager, amount);
 
         emit RevokedDepositWithdrawn(operator, grantManager, amount);


### PR DESCRIPTION
`TokenStakingEscrow` was not respecting redelegated tokens in `withdrawRevoked` function. As a result, a grant manager could withdraw more tokens from the escrow than they should be allowed and even drain the escrow to zero in the most pessimistic case.

The solution is to call `availableAmount` function to evaluate the number of tokens available for withdrawal from a revoked grant, just like we do during the migration of tokens between escrows.