### PR TITLE
TokenStakingEscrow reverts if it already has a deposit

### DIFF
--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -365,6 +365,11 @@ contract TokenStakingEscrow is Ownable {
             "Grant with this ID does not exist"
         );
 
+        require(
+            depositedAmount(operator) == 0,
+            "Stake for the operator already deposited in the escrow"
+        );
+
         keepToken.safeTransferFrom(from, address(this), value);
         deposits[operator] = Deposit(grantId, value, 0, 0);
 

--- a/solidity/test/token_stake/TestStakingGrant.js
+++ b/solidity/test/token_stake/TestStakingGrant.js
@@ -227,6 +227,20 @@ describe('TokenStaking/StakingGrant', () => {
         deposited = await tokenStakingEscrow.depositedAmount(operatorTwo)
         expect(deposited).to.eq.BN(delegatedAmount)
       })
+
+      it('fails if already cancelled', async () => {
+        await tokenStaking.cancelStake(operatorOne, {from: grantee})
+        await expectRevert(
+          tokenStaking.cancelStake(operatorOne, {from: grantee}),
+          "Stake for the operator already deposited in the escrow"
+        )
+
+        await tokenStaking.cancelStake(operatorTwo, {from: managedGrantee})
+        await expectRevert(
+          tokenStaking.cancelStake(operatorTwo, {from: managedGrantee}),
+          "Stake for the operator already deposited in the escrow"
+        )
+      })
     })
 
     describe('undelegate', async () => {
@@ -328,6 +342,27 @@ describe('TokenStaking/StakingGrant', () => {
 
         deposited = await tokenStakingEscrow.depositedAmount(operatorTwo)
         expect(deposited).to.eq.BN(delegatedAmount)
+      })
+
+      it('fails if already recovered', async () => {
+        await time.increase(initializationPeriod.addn(1))
+
+        await tokenStaking.undelegate(operatorOne, {from: operatorOne})
+        await tokenStaking.undelegate(operatorTwo, {from: operatorTwo})
+
+        await time.increase(undelegationPeriod.addn(1))
+
+        await tokenStaking.recoverStake(operatorOne, {from: thirdParty})
+        await expectRevert(
+          tokenStaking.recoverStake(operatorOne, {from: thirdParty}),
+          "Stake for the operator already deposited in the escrow"
+        )
+
+        await tokenStaking.recoverStake(operatorTwo, {from: thirdParty})
+        await expectRevert(
+          tokenStaking.recoverStake(operatorTwo, {from: thirdParty}),
+          "Stake for the operator already deposited in the escrow"
+        )
       })
     })
 


### PR DESCRIPTION
In case someone calls `cancelStake` twice they can have their information about the deposit lost and tokens locked in the escrow. We prevent it by reverting the transaction if the deposit for the given operator is already in the escrow. The same situation and the same fix is for calling `recoverStake` twice. This change affects only grant stakes since liquid token stakes are returned straight to the owner.