### PR TITLE
Kube: Download Secrets

### DIFF
--- a/infrastructure/scripts/download-gke-secrets.sh
+++ b/infrastructure/scripts/download-gke-secrets.sh
@@ -17,3 +17,4 @@ kubectl get secret --no-headers
 
 kubectl get secret --no-headers | awk '{print $1}' | \
   xargs -I{} sh -c 'kubectl get secret -o yaml "$1" > "$1.yaml"' - {}
+  

--- a/infrastructure/scripts/download-gke-secrets.sh
+++ b/infrastructure/scripts/download-gke-secrets.sh
@@ -1,0 +1,19 @@
+# Bare script to download each secret from a cluster.
+# This assumes you're using the intended Kube context.
+# This assumes you're on the correct VPN for that context.
+
+# Downloaded secrets will have key values base64 encoded.  
+# The last applied actuals should be in metadata.
+
+# If you want decoded values in one swoop, third party
+# tooling is required.  e.g. https://github.com/ashleyschuett/kubernetes-secret-decode
+
+CURRENT_CONTEXT=$(kubectl config current-context)
+
+printf "current kube context: [${CURRENT_CONTEXT}]\n\n"
+printf "SECRETS TO BE DOWNLOADED:\n"
+
+kubectl get secret --no-headers
+
+kubectl get secret --no-headers | awk '{print $1}' | \
+  xargs -I{} sh -c 'kubectl get secret -o yaml "$1" > "$1.yaml"' - {}


### PR DESCRIPTION
Letting my commit message stand for the PR description here, not much more to say.

----

This is about as rudimentary as it gets but here's a thing to download
each secret from a cluster.

It expects you to be on the correct kube context and VPN for the
environment you want to download the secrets from. Key values are base64
encoded but the secret metadata should have the actuals.

Frankly, this is a messy way to work with secrets, but if you don't want
to maintain a clean / plaintext representation of the configurations in
a secure location, this is the way.