### PR TITLE
Do not allow to redelegate to an operator from which a delegation has been cancelled

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -253,7 +253,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             // If the stake is initialized, we do NOT add tokens immediately.
             // We initiate the top-up and will add tokens to the stake only
             // after the initialization period for a top-up passes.
-            topUps.initiate(_value, _operator, operatorParams);
+            topUps.initiate(_value, _operator, operatorParams, escrow);
         }
     }
 

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -246,7 +246,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         if (!_isInitialized(operatorParams)) {
             // If the stake is not yet initialized, we add tokens immediately
             // but we also reset stake initialization time counter.
-            operators[_operator].packedParams = topUps.executeInOneStep(
+            operators[_operator].packedParams = topUps.instantComplete(
                 _value, _operator, operatorParams, escrow
             );
         } else {

--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -19,6 +19,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 import "./libraries/grant/UnlockingSchedule.sol";
+import "./utils/BytesLib.sol";
 import "./KeepToken.sol";
 import "./utils/BytesLib.sol";
 import "./TokenGrant.sol";
@@ -148,6 +149,12 @@ contract TokenStakingEscrow is Ownable {
         require(
             availableAmount(previousOperator) >= amount,
             "Insufficient balance"
+        );
+
+        address newOperator = extraData.toAddress(20);
+        require(
+            previousOperator != newOperator,
+            "Redelegating to previously used operator is not allowed"
         );
 
         deposits[previousOperator].redelegated = deposit.redelegated.add(amount);

--- a/solidity/contracts/TokenStakingEscrow.sol
+++ b/solidity/contracts/TokenStakingEscrow.sol
@@ -123,8 +123,8 @@ contract TokenStakingEscrow is Ownable {
 
     /// @notice Redelegates deposit or part of the deposit to another operator.
     /// Uses the same staking contract as the original delegation.
-    /// @param previousOperator Operator from which tokens were undelegated
-    /// and deposited in the escrow.
+    /// @param previousOperator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     /// @dev Only grantee is allowed to call this function. For managed grant,
     /// caller has to be the managed grantee.
     /// @param amount Amount of tokens to delegate.
@@ -150,10 +150,8 @@ contract TokenStakingEscrow is Ownable {
             availableAmount(previousOperator) >= amount,
             "Insufficient balance"
         );
-
-        address newOperator = extraData.toAddress(20);
         require(
-            previousOperator != newOperator,
+            !hasDeposit(newOperator),
             "Redelegating to previously used operator is not allowed"
         );
 
@@ -173,12 +171,20 @@ contract TokenStakingEscrow is Ownable {
         );
     }
 
+    /// @notice Returns true if there is a deposit for the given operator in
+    /// the escrow. Otherwise, returns false.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
+    function hasDeposit(address operator) public view returns (bool) {
+        return depositedAmount(operator) > 0;
+    }
+
     /// @notice Returns the currently available amount deposited in the escrow
     /// that may or may not be currently withdrawable. The available amount
     /// is the amount initially deposited minus the amount withdrawn and
     /// redelegated so far from that deposit.
-    /// @param operator Address of the operator from which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function availableAmount(address operator) public view returns (uint256) {
         Deposit memory deposit = deposits[operator];
         return deposit.amount.sub(deposit.withdrawn).sub(deposit.redelegated);
@@ -186,24 +192,24 @@ contract TokenStakingEscrow is Ownable {
 
     /// @notice Returns the total amount deposited in the escrow after
     /// undelegating it from the provided operator.
-    /// @param operator Address of the operator from which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function depositedAmount(address operator) public view returns (uint256) {
         return deposits[operator].amount;
     }
 
     /// @notice Returns grant ID for the amount deposited in the escrow after
     /// undelegating it from the provided operator.
-    /// @param operator Address of the operator from which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function depositGrantId(address operator) public view returns (uint256) {
         return deposits[operator].grantId;
     }
 
     /// @notice Returns the amount withdrawn so far from the value deposited
     /// in the escrow contract after undelegating it from the provided operator.
-    /// @param operator Address of the operator from which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function depositWithdrawnAmount(address operator) public view returns (uint256) {
         return deposits[operator].withdrawn;
     }
@@ -211,8 +217,8 @@ contract TokenStakingEscrow is Ownable {
     /// @notice Returns the total amount redelegated so far from the value
     /// deposited in the escrow contract after undelegating it from the provided
     /// operator.
-    /// @param operator Address of the operator from which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function depositRedelegatedAmount(address operator) public view returns (uint256) {
         return deposits[operator].redelegated;
     }
@@ -222,8 +228,8 @@ contract TokenStakingEscrow is Ownable {
     /// Tokens are unlocked based on their grant unlocking schedule.
     /// Function returns 0 for non-existing deposits and revoked grants if they
     /// have been revoked before they fully unlocked.
-    /// @param operator Address of the operator for which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function withdrawable(address operator) public view returns (uint256) {
         Deposit memory deposit = deposits[operator];
 
@@ -264,8 +270,8 @@ contract TokenStakingEscrow is Ownable {
     /// operator can call this function. Important: this function can not be
     /// called for a `ManagedGrant` grantee. This may lead to locking tokens.
     /// For `ManagedGrant`, please use `withdrawToManagedGrantee` instead.
-    /// @param operator Address of the operator for which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function withdraw(address operator) public {
         Deposit memory deposit = deposits[operator];
         address grantee = getGrantee(deposit.grantId);
@@ -291,8 +297,8 @@ contract TokenStakingEscrow is Ownable {
     /// operator can call this function. This function works only for
     /// `ManagedGrant` grantees. For a standard grant, please use `withdraw`
     /// instead.
-    /// @param operator Address of the operator for which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function withdrawToManagedGrantee(address operator) public {
         Deposit memory deposit = deposits[operator];
         address managedGrant = getGrantee(deposit.grantId);
@@ -308,8 +314,8 @@ contract TokenStakingEscrow is Ownable {
 
     /// @notice Migrates all available tokens to another authorized escrow.
     /// Can be requested only by grantee.
-    /// @param operator Address of the operator for which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     /// @param receivingEscrow Escrow to which tokens should be migrated.
     /// @dev The receiving escrow needs to accept deposits from this escrow, at
     /// least for the period of migration.
@@ -338,8 +344,8 @@ contract TokenStakingEscrow is Ownable {
     /// @notice Withdraws the entire amount that is still deposited in the
     /// escrow in case the grant has been revoked. Anyone can call this function
     /// and the entire amount is transferred back to the grant manager.
-    /// @param operator Address of the operator for which undelegated tokens
-    /// were deposited.
+    /// @param operator Address of the operator from the undelegated/canceled
+    /// delegation from which tokens were deposited.
     function withdrawRevoked(address operator) public {
         Deposit memory deposit = deposits[operator];
 
@@ -389,7 +395,7 @@ contract TokenStakingEscrow is Ownable {
         );
 
         require(
-            depositedAmount(operator) == 0,
+            !hasDeposit(operator),
             "Stake for the operator already deposited in the escrow"
         );
 

--- a/solidity/contracts/libraries/staking/TopUps.sol
+++ b/solidity/contracts/libraries/staking/TopUps.sol
@@ -37,6 +37,7 @@ library TopUps {
     /// the tokens should be added to.
     /// @param operatorParams Parameters of that operator, as stored in the
     /// staking contract.
+    /// @param escrow Reference to TokenStakingEscrow contract.
     /// @return New value of parameters. It should be updated for the operator
     /// in the staking contract.
     function executeInOneStep(
@@ -72,15 +73,22 @@ library TopUps {
     /// @param value Top-up value, the number of tokens added to the stake.
     /// @param operator Operator The operator with existing delegation to which
     /// the tokens should be added to.
+    /// @param operatorParams Parameters of that operator, as stored in the
+    /// staking contract.
+    /// @param escrow Reference to TokenStakingEscrow contract.
     function initiate(
         Storage storage self,
         uint256 value,
         address operator,
-        uint256 operatorParams
+        uint256 operatorParams,
+        TokenStakingEscrow escrow
     ) public {
-        // Stake is initialized, the operator is still active so we just need
+        // Stake is initialized, the operator is still active so we need
         // to check if it's not undelegating.
         require(!isUndelegating(operatorParams), "Stake undelegated");
+        // We also need to check if the stake for the operator is not already
+        // in the escrow because it's been previously cancelled.
+        require(!escrow.hasDeposit(operator), "Stake canceled");
 
         TopUp memory awaiting = self.topUps[operator];
         self.topUps[operator] = TopUp(awaiting.amount.add(value), now);

--- a/solidity/contracts/libraries/staking/TopUps.sol
+++ b/solidity/contracts/libraries/staking/TopUps.sol
@@ -40,7 +40,7 @@ library TopUps {
     /// @param escrow Reference to TokenStakingEscrow contract.
     /// @return New value of parameters. It should be updated for the operator
     /// in the staking contract.
-    function executeInOneStep(
+    function instantComplete(
         Storage storage self,
         uint256 value,
         address operator,

--- a/solidity/contracts/libraries/staking/TopUps.sol
+++ b/solidity/contracts/libraries/staking/TopUps.sol
@@ -53,7 +53,10 @@ library TopUps {
         // operator has not canceled its previous stake for that operator,
         // depositing the stake it in the escrow. We do not want to allow
         // resurrecting operators with cancelled stake by top-ups.
-        require(!escrow.hasDeposit(operator), "Stake canceled");
+        require(
+            !escrow.hasDeposit(operator),
+            "Stake for the operator already deposited in the escrow"
+        );
 
         uint256 newAmount = operatorParams.getAmount().add(value);
         newParams = operatorParams.setAmountAndCreationTimestamp(
@@ -88,7 +91,10 @@ library TopUps {
         require(!isUndelegating(operatorParams), "Stake undelegated");
         // We also need to check if the stake for the operator is not already
         // in the escrow because it's been previously cancelled.
-        require(!escrow.hasDeposit(operator), "Stake canceled");
+        require(
+            !escrow.hasDeposit(operator),
+            "Stake for the operator already deposited in the escrow"
+        );
 
         TopUp memory awaiting = self.topUps[operator];
         self.topUps[operator] = TopUp(awaiting.amount.add(value), now);

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -287,7 +287,7 @@ describe('TokenGrant/Stake', function() {
   })
 
   it("should not allow to delegate to the same operator after recovering stake", async () => {
-    let tx = await delegate(grantee, operatorOne, grantAmount)
+    let tx = await delegate(grantee, operatorOne, minimumStake)
     let createdAt = web3.utils.toBN((await web3.eth.getBlock(tx.receipt.blockNumber)).timestamp)
     await time.increaseTo(createdAt.add(initializationPeriod).addn(1))
     tx = await grantContract.undelegate(operatorOne, {from: grantee})
@@ -296,7 +296,7 @@ describe('TokenGrant/Stake', function() {
     await stakingEscrowContract.withdraw(operatorOne, {from: grantee});
 
     await expectRevert(
-      delegateLiquid(grantee, operatorOne, minimumStake),
+      delegate(grantee, operatorOne, minimumStake),
       "Stake undelegated"
     )
   })

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -293,11 +293,27 @@ describe('TokenGrant/Stake', function() {
     tx = await grantContract.undelegate(operatorOne, {from: grantee})
     await time.increaseTo(createdAt.add(grantUnlockingDuration))
     await grantContract.recoverStake(operatorOne, {from: grantee});
-    await stakingEscrowContract.withdraw(operatorOne, {from: grantee});
 
     await expectRevert(
       delegate(grantee, operatorOne, minimumStake),
       "Stake undelegated"
+    )
+  })
+
+  it("should not allow to delegate to the same operator after cancelling stake", async () => {
+    await delegate(grantee, operatorOne, minimumStake)
+    await grantContract.cancelStake(operatorOne, {from: grantee});
+
+    await expectRevert(
+      delegate(grantee, operatorOne, minimumStake),
+      "Stake canceled"
+    )
+
+    await time.increase(initializationPeriod.addn(1))
+
+    await expectRevert(
+      delegate(grantee, operatorOne, minimumStake),
+      "Stake canceled"
     )
   })
 

--- a/solidity/test/token_grant/TestTokenGrantStake.js
+++ b/solidity/test/token_grant/TestTokenGrantStake.js
@@ -140,18 +140,6 @@ describe('TokenGrant/Stake', function() {
     )
   }
 
-  async function delegateLiquid(owner, operator, amount) {
-    return await delegateStake(
-      tokenContract,
-      stakingContract,
-      owner,
-      operator,
-      beneficiary,
-      authorizer,
-      amount
-    )
-  }
-
   async function delegateRevocable(grantee, operator, amount) {
     return await delegateStakeFromGrant(
       grantContract,
@@ -306,14 +294,14 @@ describe('TokenGrant/Stake', function() {
 
     await expectRevert(
       delegate(grantee, operatorOne, minimumStake),
-      "Stake canceled"
+      "Stake for the operator already deposited in the escrow"
     )
 
     await time.increase(initializationPeriod.addn(1))
 
     await expectRevert(
       delegate(grantee, operatorOne, minimumStake),
-      "Stake canceled"
+      "Stake for the operator already deposited in the escrow"
     )
   })
 

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -26,10 +26,11 @@ describe('TokenStakingEscrow', () => {
     grantee = accounts[2],
     operator = accounts[3],
     operator2 = accounts[4],
-    authorizer = accounts[5],
-    beneficiary = accounts[6],
-    thirdParty = accounts[7],
-    tokenStaking = accounts[8]
+    operator3 = accounts[5],
+    authorizer = accounts[6],
+    beneficiary = accounts[7],
+    thirdParty = accounts[8],
+    tokenStaking = accounts[9]
 
   let grantedAmount, grantStart, grantUnlockingDuration,
   grantId, managedGrantId, managedGrant
@@ -753,7 +754,7 @@ describe('TokenStakingEscrow', () => {
 
       const data = Buffer.concat([
         Buffer.from(beneficiary.substr(2), 'hex'),
-        Buffer.from(operator2.substr(2), 'hex'),
+        Buffer.from(operator3.substr(2), 'hex'),
         Buffer.from(authorizer.substr(2), 'hex')
       ])
       const expectedLeft = web3.utils.toBN('123114')


### PR DESCRIPTION
After we added a feature allowing to top-up in the initialization period (https://github.com/keep-network/keep-core/pull/1929) we unconsciously introduced a path allowing to redelegate to the operator from which the delegation has been canceled. It should not be allowed as it leads to rejecting the deposit by the escrow when undelegating/canceling that second delegation.

There are two scenarios when top-up can be performed on a canceled delegation:

Scenario 1: Someone tries to re-delegate from the escrow to operator that already has a deposit in the escrow:
```
delegate operator A -> escrow ->
redelegate operator B -> escrow ->
redelegate operator A -> escrow (TX reverted!)
 ```
 This scenario is now prohibited from happening by `TokenStakingEscrow.hasDeposit` check in redelegate function.

Scenario 2: Someone tries to top-up a stake to an operator that has been previously used and from which delegation was canceled.

This scenario is now prohibited from happening because of `TokenStakingEscrow.hasDeposit` check in the `TopUps.executeInOneStep`function.

The problem described here is not a vulnerability when a 3rd party can hurt a staker but rather an interesting edge case when the staker can hurt themselves.

When working on the fix, I had to move some code out of `TokenStaking` to `TopUps` library to avoid out-of-gas issues. The good part about it is that we now have the entire logic but grant rules validation in `TopUps` library.