### PR TITLE
Added DepositRedelegated event to TokenStakingEscrow

### DIFF
--- a/solidity/test/token_stake/TestStakingGrant.js
+++ b/solidity/test/token_stake/TestStakingGrant.js
@@ -1,5 +1,5 @@
 const {contract, accounts, web3} = require("@openzeppelin/test-environment")
-const {expectRevert, time} = require("@openzeppelin/test-helpers")
+const {expectRevert, expectEvent, time} = require("@openzeppelin/test-helpers")
 const {createSnapshot, restoreSnapshot} = require('../helpers/snapshot')
 const {initTokenStaking} = require('../helpers/initContracts')
 
@@ -655,6 +655,20 @@ describe('TokenStaking/StakingGrant', () => {
           tokenStaking.undelegate(operatorThree, {from: operatorOne}),
           "Not authorized"
         )
+      })
+
+      it('emits an event', async () => {
+        const redelegatedAmount = delegatedAmount
+        const receipt = await tokenStakingEscrow.redelegate(
+          operatorOne, redelegatedAmount, data3, {from: grantee}
+        )
+        
+        await expectEvent(receipt, 'DepositRedelegated', {
+          previousOperator: operatorOne,
+          newOperator: operatorThree,
+          grantId: grantId.toString(),
+          amount: redelegatedAmount.toString()
+        })
       })
     })
 })


### PR DESCRIPTION
This event will help to locate staking relationships created by escrow redelegations. The flow to locate all stakes could be as follows:

At the same time:
- Fetch `TokenGrant.TokenGrantStaked` events by `grantID`, read `operator`,
- Fetch `TokenStakingEscrow.DepositRedelegated` events by `grantID`, read `operator`,

then:
- Fetch `TokenStaking.Staked` event by the `operator`.