### PR TITLE
Expose peers list as JSON via Diagnostics package

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -255,4 +255,5 @@ func initializeDiagnostics(
 	)
 
 	diagnostics.RegisterConnectedPeersSource(registry, netProvider)
+	diagnostics.RegisterNodeInfoSource(registry, netProvider)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -255,5 +255,5 @@ func initializeDiagnostics(
 	)
 
 	diagnostics.RegisterConnectedPeersSource(registry, netProvider)
-	diagnostics.RegisterNodeInfoSource(registry, netProvider)
+	diagnostics.RegisterClientInfoSource(registry, netProvider)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -255,28 +254,5 @@ func initializeDiagnostics(
 		config.Diagnostics.Port,
 	)
 
-	registry.RegisterSource("connected_peers", func() string {
-		connectedPeers := netProvider.ConnectionManager().ConnectedPeers()
-
-		peersList := make([]map[string]interface{}, len(connectedPeers))
-		for i := 0; i < len(connectedPeers); i++ {
-			peerPublicKey, err := netProvider.ConnectionManager().GetPeerPublicKey(connectedPeers[i])
-			if err != nil {
-				logger.Error("Error on getting peer public key: [%v]", err)
-				continue
-			}
-
-			peersList[i] = map[string]interface{}{
-				"PeerId":        connectedPeers[i],
-				"PeerPublicKey": key.NetworkPubKeyToEthAddress(peerPublicKey),
-			}
-		}
-
-		bytes, err := json.Marshal(peersList)
-		if err != nil {
-			return ""
-		}
-
-		return string(bytes)
-	})
+	diagnostics.RegisterConnectedPeersSource(registry, netProvider)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -229,11 +229,6 @@ func initializeMetrics(
 		ethereumAddress,
 		time.Duration(config.Metrics.EthereumMetricsTick)*time.Second,
 	)
-
-	metrics.ExposeLibP2PInfo(
-		registry,
-		netProvider,
-	)
 }
 
 func initializeDiagnostics(

--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,11 @@ const passwordEnvVariable = "KEEP_ETHEREUM_PASSWORD"
 
 // Config is the top level config structure.
 type Config struct {
-	Ethereum ethereum.Config
-	LibP2P   libp2p.Config
-	Storage  Storage
-	Metrics  Metrics
+	Ethereum    ethereum.Config
+	LibP2P      libp2p.Config
+	Storage     Storage
+	Metrics     Metrics
+	Diagnostics Diagnostics
 }
 
 // Storage stores meta-info about keeping data on disk
@@ -32,6 +33,11 @@ type Metrics struct {
 	Port                int
 	NetworkMetricsTick  int
 	EthereumMetricsTick int
+}
+
+// Diagnostics stores diagnostics-related configuration.
+type Diagnostics struct {
+	Port int
 }
 
 var (

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -54,10 +54,17 @@
 [Storage]
   DataDir = "/my/secure/location"
 
+# Uncomment to enable the metrics module which collects and exposes information
+# useful for external monitoring tools. The port on which the `/metrics`
+# endpoint will be available and the frequency with which the metrics will be
+# collected can be customized using the below parameters.
 # [Metrics]
     # Port = 8080
     # NetworkMetricsTick = 60
     # EthereumMetricsTick = 600
 
+# Uncomment to enable the diagnostics module which exposes information
+# useful for debugging. The port on which the `/diagnostics` endpoint
+# will be available can be customized.
 # [Diagnostics]
     # Port = 8081

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -58,3 +58,6 @@
     # Port = 8080
     # NetworkMetricsTick = 60
     # EthereumMetricsTick = 600
+
+# [Diagnostics]
+    # Port = 8081

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -55,16 +55,30 @@
   DataDir = "/my/secure/location"
 
 # Uncomment to enable the metrics module which collects and exposes information
-# useful for external monitoring tools. The port on which the `/metrics`
-# endpoint will be available and the frequency with which the metrics will be
-# collected can be customized using the below parameters.
+# useful for external monitoring tools usually operating on time series data.
+# All values exposed by metrics module are quantifiable or countable.
+#
+# The following metrics are available:
+# - connected peers count
+# - connected bootstraps count
+# - eth client connectivity status
+#
+# The port on which the `/metrics` endpoint will be available and the frequency
+# with which the metrics will be collected can be customized using the
+# below parameters.
 # [Metrics]
     # Port = 8080
     # NetworkMetricsTick = 60
     # EthereumMetricsTick = 600
 
-# Uncomment to enable the diagnostics module which exposes information
-# useful for debugging. The port on which the `/diagnostics` endpoint
-# will be available can be customized.
+# Uncomment to enable the diagnostics module which exposes information useful
+# for debugging and diagnostic client's status.
+#
+# Diagnostics module exposes the following information:
+# - list of connected peers along with their network id and ethereum operator address
+# - information about the client's network id and ethereum operator address
+#
+# The port on which the `/diagnostics` endpoint will be available can be
+# customized below.
 # [Diagnostics]
     # Port = 8081

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.1.1-0.20200805115808-67d9cb633ddb
+	github.com/keep-network/keep-common v1.1.1-0.20200820132710-84538e87a2c7
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v1.1.1-0.20200805115808-67d9cb633ddb h1:crl+zcYj2adhb9qRGgq7PfYXNusZFGxxvw7g5aLsE/I=
 github.com/keep-network/keep-common v1.1.1-0.20200805115808-67d9cb633ddb/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.1.1-0.20200820132710-84538e87a2c7 h1:XIn7NDKrjaGt2QwmuHD8oZopWwISedQX7FcdfWQOnJs=
+github.com/keep-network/keep-common v1.1.1-0.20200820132710-84538e87a2c7/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -992,6 +994,7 @@ golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -12,9 +12,7 @@ import (
 var logger = log.Logger("keep-diagnostics")
 
 // Initialize set up the diagnostics registry and enables diagnostics server.
-func Initialize(
-	port int,
-) (*diagnostics.DiagnosticsRegistry, bool) {
+func Initialize(port int) (*diagnostics.DiagnosticsRegistry, bool) {
 	if port == 0 {
 		return nil, false
 	}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -42,8 +42,8 @@ func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, net
 			}
 
 			peersList[i] = map[string]interface{}{
-				"PeerId":        peer,
-				"PeerPublicKey": key.NetworkPubKeyToEthAddress(peerPublicKey),
+				"PeerId":      peer,
+				"PeerAddress": key.NetworkPubKeyToEthAddress(peerPublicKey),
 			}
 		}
 
@@ -70,8 +70,8 @@ func RegisterNodeInfoSource(registry *diagnostics.DiagnosticsRegistry, netProvid
 		}
 
 		nodeInfo := map[string]interface{}{
-			"NodeId":        nodeId,
-			"NodePublicKey": key.NetworkPubKeyToEthAddress(nodePublicKey),
+			"NodeId":      nodeId,
+			"NodeAddress": key.NetworkPubKeyToEthAddress(nodePublicKey),
 		}
 
 		bytes, err := json.Marshal(nodeInfo)

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -27,7 +27,10 @@ func Initialize(
 }
 
 // Registers diagnostics source providing information about connected peers
-func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, netProvider net.Provider) {
+func RegisterConnectedPeersSource(
+	registry *diagnostics.DiagnosticsRegistry,
+	netProvider net.Provider,
+) {
 	registry.RegisterSource("connected_peers", func() string {
 		connectionManager := netProvider.ConnectionManager()
 		connectedPeers := connectionManager.ConnectedPeers()
@@ -42,8 +45,8 @@ func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, net
 			}
 
 			peersList[i] = map[string]interface{}{
-				"PeerId":      peer,
-				"PeerAddress": key.NetworkPubKeyToEthAddress(peerPublicKey),
+				"network_id":       peer,
+				"ethereum_address": key.NetworkPubKeyToEthAddress(peerPublicKey),
 			}
 		}
 
@@ -57,26 +60,29 @@ func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, net
 	})
 }
 
-// Registers diagnostics source providing information about node
-func RegisterNodeInfoSource(registry *diagnostics.DiagnosticsRegistry, netProvider net.Provider) {
-	registry.RegisterSource("node_info", func() string {
+// Registers diagnostics source providing information about the client.
+func RegisterClientInfoSource(
+	registry *diagnostics.DiagnosticsRegistry,
+	netProvider net.Provider,
+) {
+	registry.RegisterSource("client_info", func() string {
 		connectionManager := netProvider.ConnectionManager()
 
-		nodeId := netProvider.ID().String()
-		nodePublicKey, err := connectionManager.GetPeerPublicKey(nodeId)
+		clientId := netProvider.ID().String()
+		clientPublicKey, err := connectionManager.GetPeerPublicKey(clientId)
 		if err != nil {
-			logger.Error("error on getting peer public key: [%v]", err)
+			logger.Error("error on getting client public key: [%v]", err)
 			return ""
 		}
 
-		nodeInfo := map[string]interface{}{
-			"NodeId":      nodeId,
-			"NodeAddress": key.NetworkPubKeyToEthAddress(nodePublicKey),
+		clientInfo := map[string]interface{}{
+			"network_id":       clientId,
+			"ethereum_address": key.NetworkPubKeyToEthAddress(clientPublicKey),
 		}
 
-		bytes, err := json.Marshal(nodeInfo)
+		bytes, err := json.Marshal(clientInfo)
 		if err != nil {
-			logger.Error("error on serializing node info to JSON: [%v]", err)
+			logger.Error("error on serializing client info to JSON: [%v]", err)
 			return ""
 		}
 

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -37,7 +37,7 @@ func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, net
 			peer := connectedPeers[i]
 			peerPublicKey, err := connectionManager.GetPeerPublicKey(peer)
 			if err != nil {
-				logger.Error("Error on getting peer public key: [%v]", err)
+				logger.Error("error on getting peer public key: [%v]", err)
 				continue
 			}
 
@@ -49,7 +49,7 @@ func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, net
 
 		bytes, err := json.Marshal(peersList)
 		if err != nil {
-			logger.Error("Error on serializing peers list to JSON: [%v]", err)
+			logger.Error("error on serializing peers list to JSON: [%v]", err)
 			return ""
 		}
 

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -56,3 +56,30 @@ func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, net
 		return string(bytes)
 	})
 }
+
+// Registers diagnostics source providing information about node
+func RegisterNodeInfoSource(registry *diagnostics.DiagnosticsRegistry, netProvider net.Provider) {
+	registry.RegisterSource("node_info", func() string {
+		connectionManager := netProvider.ConnectionManager()
+
+		nodeId := netProvider.ID().String()
+		nodePublicKey, err := connectionManager.GetPeerPublicKey(nodeId)
+		if err != nil {
+			logger.Error("error on getting peer public key: [%v]", err)
+			return ""
+		}
+
+		nodeInfo := map[string]interface{}{
+			"NodeId":        nodeId,
+			"NodePublicKey": key.NetworkPubKeyToEthAddress(nodePublicKey),
+		}
+
+		bytes, err := json.Marshal(nodeInfo)
+		if err != nil {
+			logger.Error("error on serializing node info to JSON: [%v]", err)
+			return ""
+		}
+
+		return string(bytes)
+	})
+}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -11,7 +11,7 @@ import (
 
 var logger = log.Logger("keep-diagnostics")
 
-// Initialize set up the diagnostics registry and enables diagnostics server.
+// Initialize sets up the diagnostics registry and enables diagnostics server.
 func Initialize(port int) (*diagnostics.DiagnosticsRegistry, bool) {
 	if port == 0 {
 		return nil, false

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,0 +1,23 @@
+package diagnostics
+
+import (
+	"github.com/ipfs/go-log"
+	"github.com/keep-network/keep-common/pkg/diagnostics"
+)
+
+var logger = log.Logger("keep-diagnostics")
+
+// Initialize set up the diagnostics registry and enables diagnostics server.
+func Initialize(
+	port int,
+) (*diagnostics.DiagnosticsRegistry, bool) {
+	if port == 0 {
+		return nil, false
+	}
+
+	registry := diagnostics.NewRegistry()
+
+	registry.EnableServer(port)
+
+	return registry, true
+}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,8 +1,12 @@
 package diagnostics
 
 import (
+	"encoding/json"
+
 	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-common/pkg/diagnostics"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/net/key"
 )
 
 var logger = log.Logger("keep-diagnostics")
@@ -20,4 +24,33 @@ func Initialize(
 	registry.EnableServer(port)
 
 	return registry, true
+}
+
+func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, netProvider net.Provider) {
+
+	registry.RegisterSource("connected_peers", func() string {
+		connectedPeers := netProvider.ConnectionManager().ConnectedPeers()
+
+		peersList := make([]map[string]interface{}, len(connectedPeers))
+		for i := 0; i < len(connectedPeers); i++ {
+			peerPublicKey, err := netProvider.ConnectionManager().GetPeerPublicKey(connectedPeers[i])
+			if err != nil {
+				logger.Error("Error on getting peer public key: [%v]", err)
+				continue
+			}
+
+			peersList[i] = map[string]interface{}{
+				"PeerId":        connectedPeers[i],
+				"PeerPublicKey": key.NetworkPubKeyToEthAddress(peerPublicKey),
+			}
+		}
+
+		bytes, err := json.Marshal(peersList)
+		if err != nil {
+			logger.Error("Error on serializing peers list to JSON: [%v]", err)
+			return ""
+		}
+
+		return string(bytes)
+	})
 }

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -26,21 +26,23 @@ func Initialize(
 	return registry, true
 }
 
+// Registers diagnostics source providing information about connected peers
 func RegisterConnectedPeersSource(registry *diagnostics.DiagnosticsRegistry, netProvider net.Provider) {
-
 	registry.RegisterSource("connected_peers", func() string {
-		connectedPeers := netProvider.ConnectionManager().ConnectedPeers()
+		connectionManager := netProvider.ConnectionManager()
+		connectedPeers := connectionManager.ConnectedPeers()
 
 		peersList := make([]map[string]interface{}, len(connectedPeers))
 		for i := 0; i < len(connectedPeers); i++ {
-			peerPublicKey, err := netProvider.ConnectionManager().GetPeerPublicKey(connectedPeers[i])
+			peer := connectedPeers[i]
+			peerPublicKey, err := connectionManager.GetPeerPublicKey(peer)
 			if err != nil {
 				logger.Error("Error on getting peer public key: [%v]", err)
 				continue
 			}
 
 			peersList[i] = map[string]interface{}{
-				"PeerId":        connectedPeers[i],
+				"PeerId":        peer,
 				"PeerPublicKey": key.NetworkPubKeyToEthAddress(peerPublicKey),
 			}
 		}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -24,7 +24,8 @@ func Initialize(port int) (*diagnostics.DiagnosticsRegistry, bool) {
 	return registry, true
 }
 
-// Registers diagnostics source providing information about connected peers
+// RegisterConnectedPeersSource registers the diagnostics source providing
+// information about connected peers.
 func RegisterConnectedPeersSource(
 	registry *diagnostics.DiagnosticsRegistry,
 	netProvider net.Provider,
@@ -58,7 +59,8 @@ func RegisterConnectedPeersSource(
 	})
 }
 
-// Registers diagnostics source providing information about the client.
+// RegisterClientInfoSource registers the diagnostics source providing
+// information about the client itself.
 func RegisterClientInfoSource(
 	registry *diagnostics.DiagnosticsRegistry,
 	netProvider net.Provider,
@@ -66,15 +68,15 @@ func RegisterClientInfoSource(
 	registry.RegisterSource("client_info", func() string {
 		connectionManager := netProvider.ConnectionManager()
 
-		clientId := netProvider.ID().String()
-		clientPublicKey, err := connectionManager.GetPeerPublicKey(clientId)
+		clientID := netProvider.ID().String()
+		clientPublicKey, err := connectionManager.GetPeerPublicKey(clientID)
 		if err != nil {
 			logger.Error("error on getting client public key: [%v]", err)
 			return ""
 		}
 
 		clientInfo := map[string]interface{}{
-			"network_id":       clientId,
+			"network_id":       clientID,
 			"ethereum_address": key.NetworkPubKeyToEthAddress(clientPublicKey),
 		}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -139,19 +139,3 @@ func validateTick(tick time.Duration, defaultTick time.Duration) time.Duration {
 
 	return defaultTick
 }
-
-// ExposeLibP2PInfo provides some basic information about libp2p config.
-func ExposeLibP2PInfo(
-	registry *metrics.Registry,
-	netProvider net.Provider,
-) {
-	name := "libp2p_info"
-
-	id := metrics.NewLabel("id", netProvider.ID().String())
-
-	_, err := registry.NewInfo(name, []metrics.Label{id})
-	if err != nil {
-		logger.Warningf("could not create info metric [%v]", name)
-		return
-	}
-}


### PR DESCRIPTION
~~Depends on https://github.com/keep-network/keep-common/pull/43~~
Refs https://github.com/keep-network/keep-core/issues/1930

Enables the diagnostics module which exposes information useful for debugging and diagnostic client's status. 

Diagnostics module exposes the following information:
- list of connected peers along with their network id and ethereum operator address
- information about the client's network id and ethereum operator address 

Diagnostics module can be enabled in the config TOML file:
```
[Diagnostics]
Port = 8002
```