### PR TITLE
keep-test: Separate ETH host

### DIFF
--- a/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
@@ -86,12 +86,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: rpc-url
+                key: keep-client-rpc-url
           - name: ETH_WS_URL
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: ws-url
+                key: keep-client-ws-url
           - name: ETH_NETWORK_ID
             valueFrom:
               configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
@@ -86,12 +86,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: rpc-url
+                key: keep-client-rpc-url
           - name: ETH_WS_URL
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: ws-url
+                key: keep-client-ws-url
           - name: ETH_NETWORK_ID
             valueFrom:
               configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -86,12 +86,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: rpc-url
+                key: keep-client-rpc-url
           - name: ETH_WS_URL
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: ws-url
+                key: keep-client-ws-url
           - name: ETH_NETWORK_ID
             valueFrom:
               configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
@@ -86,12 +86,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: rpc-url
+                key: keep-client-rpc-url
           - name: ETH_WS_URL
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: ws-url
+                key: keep-client-ws-url
           - name: ETH_NETWORK_ID
             valueFrom:
               configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
@@ -86,12 +86,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: rpc-url
+                key: keep-client-rpc-url
           - name: ETH_WS_URL
             valueFrom:
               secretKeyRef:
                 name: eth-network-ropsten
-                key: ws-url
+                key: keep-client-ws-url
           - name: ETH_NETWORK_ID
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This is a keep-test/keep-client dedicated Alchemy app so that we can track keep-client usage in isolation on testnet.