### PR TITLE
Fix handling of Metric number fields in config script

### DIFF
--- a/solidity/scripts/lcl-client-config.js
+++ b/solidity/scripts/lcl-client-config.js
@@ -43,13 +43,28 @@ module.exports = async function () {
             let formattedConfigFile = tomlify.toToml(fileContent, {
                 space: 2,
                 replace: (key, value) => {
-                    // Find keys that match exactly `Port`, `MiningCheckInterval`
-                    // `MaxGasPrice` or ends with `MetricsTick`.
-                    return key.match(
-                        /(^Port|^MiningCheckInterval|^MaxGasPrice|MetricsTick)$/
+                    let result
+                    try {
+                      result =
+                        // We expect the config file to contain arrays, in such case key for
+                        // each entry is its' index number. We verify if the key is a string
+                        // so we can run the following match check.
+                        typeof key === "string" &&
+                        // Find keys that match exactly `Port`, `MiningCheckInterval`,
+                        // `MaxGasPrice` or end with `MetricsTick`.
+                        key.match(
+                          /(^Port|^MiningCheckInterval|^MaxGasPrice|MetricsTick)$/
+                        )
+                          ? value.toFixed(0) // convert float to integer
+                          : false // do nothing
+                    } catch (err) {
+                      console.error(
+                        `tomlify replace failed for key ${key} and value ${value} with error: [${err}]`
                       )
-                        ? value.toFixed(0)
-                        : false
+                      process.exit(1)
+                    }
+          
+                    return result
                     },
             });
 

--- a/solidity/scripts/lcl-client-config.js
+++ b/solidity/scripts/lcl-client-config.js
@@ -43,9 +43,14 @@ module.exports = async function () {
             let formattedConfigFile = tomlify.toToml(fileContent, {
                 space: 2,
                 replace: (key, value) => {
-                    // Find keys that match exactly `Port` or ends with `MetricsTick`.
-                    return key.match(/(^Port|MetricsTick)$/) ? value.toFixed(0) : false;
-                  },
+                    // Find keys that match exactly `Port`, `MiningCheckInterval`
+                    // `MaxGasPrice` or ends with `MetricsTick`.
+                    return key.match(
+                        /(^Port|^MiningCheckInterval|^MaxGasPrice|MetricsTick)$/
+                      )
+                        ? value.toFixed(0)
+                        : false
+                    },
             });
 
             fs.writeFileSync(configFilePath, formattedConfigFile, (err) => {

--- a/solidity/scripts/lcl-client-config.js
+++ b/solidity/scripts/lcl-client-config.js
@@ -42,7 +42,10 @@ module.exports = async function () {
             */
             let formattedConfigFile = tomlify.toToml(fileContent, {
                 space: 2,
-                replace: (key, value) => { return (key == 'Port') ? value.toFixed(0) : false }
+                replace: (key, value) => {
+                    // Find keys that match exactly `Port` or ends with `MetricsTick`.
+                    return key.match(/(^Port|MetricsTick)$/) ? value.toFixed(0) : false;
+                  },
             });
 
             fs.writeFileSync(configFilePath, formattedConfigFile, (err) => {


### PR DESCRIPTION
The config file contains now new properties stored as numbers: `NetworkMetricsTick` and `EthereumMetricsTick`.

The library `tomlify-j0.4` we use in config generation script requires special handling of number fields to convert them from float to integer.

We already support `Port` properties and in this PR we added support of ones which key ends with `MetricsTick`.

Closes: https://github.com/keep-network/keep-core/issues/1946