### PR TITLE
Removed ethereum account address from config

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -97,13 +97,13 @@ func Start(c *cli.Context) error {
 		return fmt.Errorf("error obtaining stake monitor handle [%v]", err)
 	}
 	if c.Int(waitForStakeFlag) != 0 {
-		err = waitForStake(stakeMonitor, config.Ethereum.Account.Address, c.Int(waitForStakeFlag))
+		err = waitForStake(stakeMonitor, ethereumKey.Address.Hex(), c.Int(waitForStakeFlag))
 		if err != nil {
 			return err
 		}
 	}
 	hasMinimumStake, err := stakeMonitor.HasMinimumStake(
-		config.Ethereum.Account.Address,
+		ethereumKey.Address.Hex(),
 	)
 	if err != nil {
 		return fmt.Errorf("could not check the stake [%v]", err)
@@ -147,7 +147,7 @@ func Start(c *cli.Context) error {
 
 	err = beacon.Initialize(
 		ctx,
-		config.Ethereum.Account.Address,
+		ethereumKey.Address.Hex(),
 		chainProvider,
 		netProvider,
 		persistence,
@@ -156,7 +156,7 @@ func Start(c *cli.Context) error {
 		return fmt.Errorf("error initializing beacon: [%v]", err)
 	}
 
-	initializeMetrics(ctx, config, netProvider, stakeMonitor)
+	initializeMetrics(ctx, config, ethereumKey.Address.Hex(), netProvider, stakeMonitor)
 
 	select {
 	case <-ctx.Done():
@@ -188,6 +188,7 @@ func waitForStake(stakeMonitor chain.StakeMonitor, address string, timeout int) 
 func initializeMetrics(
 	ctx context.Context,
 	config *config.Config,
+	ethereumAddress string,
 	netProvider net.Provider,
 	stakeMonitor chain.StakeMonitor,
 ) {
@@ -223,7 +224,7 @@ func initializeMetrics(
 		ctx,
 		registry,
 		stakeMonitor,
-		config.Ethereum.Account.Address,
+		ethereumAddress,
 		time.Duration(config.Metrics.EthereumMetricsTick)*time.Second,
 	)
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -156,7 +156,7 @@ func Start(c *cli.Context) error {
 		return fmt.Errorf("error initializing beacon: [%v]", err)
 	}
 
-	initializeMetrics(ctx, config, ethereumKey.Address.Hex(), netProvider, stakeMonitor)
+	initializeMetrics(ctx, config, netProvider, stakeMonitor, ethereumKey.Address.Hex())
 
 	select {
 	case <-ctx.Done():
@@ -188,9 +188,9 @@ func waitForStake(stakeMonitor chain.StakeMonitor, address string, timeout int) 
 func initializeMetrics(
 	ctx context.Context,
 	config *config.Config,
-	ethereumAddress string,
 	netProvider net.Provider,
 	stakeMonitor chain.StakeMonitor,
+	ethereumAddress string,
 ) {
 	registry, isConfigured := metrics.Initialize(
 		config.Metrics.Port,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -70,14 +70,16 @@ func Start(c *cli.Context) error {
 		config.LibP2P.Port = c.Int(portFlag)
 	}
 
-	// FIXME This needs to happen inside the `pkg/chain/ethereum` scope,
-	// FIXME probably.
-	operatorPrivateKey, operatorPublicKey, err := loadStaticKey(
+	ethereumKey, err := ethutil.DecryptKeyFile(
 		config.Ethereum.Account.KeyFile,
 		config.Ethereum.Account.KeyFilePassword,
 	)
 	if err != nil {
-		return fmt.Errorf("error loading static peer's key [%v]", err)
+		return fmt.Errorf(
+			"failed to read key file [%s]: [%v]",
+			config.Ethereum.Account.KeyFile,
+			err,
+		)
 	}
 
 	chainProvider, err := ethereum.Connect(config.Ethereum)
@@ -116,8 +118,9 @@ func Start(c *cli.Context) error {
 	}
 
 	ctx := context.Background()
+
 	networkPrivateKey, _ := key.OperatorKeyToNetworkKey(
-		operatorPrivateKey, operatorPublicKey,
+		operator.EthereumKeyToOperatorKey(ethereumKey),
 	)
 	netProvider, err := libp2p.Connect(
 		ctx,
@@ -163,25 +166,6 @@ func Start(c *cli.Context) error {
 
 		return fmt.Errorf("uh-oh, we went boom boom for no reason")
 	}
-}
-
-func loadStaticKey(
-	keyFile string,
-	keyFilePassword string,
-) (*operator.PrivateKey, *operator.PublicKey, error) {
-	ethereumKey, err := ethutil.DecryptKeyFile(
-		keyFile,
-		keyFilePassword,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"failed to read KeyFile: %s [%v]", keyFile, err,
-		)
-	}
-
-	privateKey, publicKey := operator.EthereumKeyToOperatorKey(ethereumKey)
-
-	return privateKey, publicKey, nil
 }
 
 func waitForStake(stakeMonitor chain.StakeMonitor, address string, timeout int) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,16 +34,10 @@ func TestReadConfig(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Ethereum.URLRPC },
 			expectedValue: "http://192.168.0.158:8545",
 		},
-		"Ethereum.Account.Address": {
-			readValueFunc: func(c *Config) interface{} {
-				return c.Ethereum.Account.Address
-			},
-			expectedValue: "0xc2a56884538778bacd91aa5bf343bf882c5fb18b",
-		},
 		"Ethereum.ContractAddresses": {
 			readValueFunc: func(c *Config) interface{} { return c.Ethereum.ContractAddresses },
 			expectedValue: map[string]string{
-				"KeepRandomBeaconOperator":  "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb",
+				"KeepRandomBeaconOperator": "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb",
 			},
 		},
 		"Storage.DataDir": {

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -22,7 +22,6 @@
 	# MaxGasPrice = 50000000000 # 50 gwei (default value)
 
 [ethereum.account]
-	Address            = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"
 	KeyFile            = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"
 
 [ethereum.ContractAddresses]

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1
+	github.com/keep-network/keep-common v1.1.1-0.20200805115808-67d9cb633ddb
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,7 @@ github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883 h1:FSeK4fZCo8u40n2JMnyAsd6x7+SbvoOMHvQOU/n10P4=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -337,8 +338,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1 h1:SCjStilprtxkLaY6+pw/xqvCJFPEm71n3GJyC+cbLU0=
-github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.1.1-0.20200805115808-67d9cb633ddb h1:crl+zcYj2adhb9qRGgq7PfYXNusZFGxxvw7g5aLsE/I=
+github.com/keep-network/keep-common v1.1.1-0.20200805115808-67d9cb633ddb/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -383,8 +384,6 @@ github.com/libp2p/go-libp2p v0.7.0/go.mod h1:hZJf8txWeCduQRDC/WSqBGMxaTHCOYHt2xS
 github.com/libp2p/go-libp2p v0.7.4/go.mod h1:oXsBlTLF1q7pxr+9w6lqzS1ILpyHsaBPniVO7zIHGMw=
 github.com/libp2p/go-libp2p v0.8.3/go.mod h1:EsH1A+8yoWK+L4iKcbPYu6MPluZ+CHWI9El8cTaefiM=
 github.com/libp2p/go-libp2p v0.10.0/go.mod h1:yBJNpb+mGJdgrwbKAKrhPU0u3ogyNFTfjJ6bdM+Q/G8=
-github.com/libp2p/go-libp2p v0.10.2 h1:VQOo/Pbj9Ijco9jiMYN5ImAg236IjTXfnUPJ2OvbpLM=
-github.com/libp2p/go-libp2p v0.10.2/go.mod h1:BYckt6lmS/oA1SlRETSPWSUulCQKiZuTVsymVMc//HQ=
 github.com/libp2p/go-libp2p v0.10.3 h1:Bc8/VjmC+pICtK6xG8YgVutZvCdK0MsroWCHP+6AdFQ=
 github.com/libp2p/go-libp2p v0.10.3/go.mod h1:0ER6iPSaPeQjryNgOnm9bLNpMJCYmuw54xJXsVR17eE=
 github.com/libp2p/go-libp2p-autonat v0.1.1 h1:WLBZcIRsjZlWdAZj9CiBSvU2wQXoUOiS1Zk1tM7DTJI=
@@ -393,8 +392,6 @@ github.com/libp2p/go-libp2p-autonat v0.2.0/go.mod h1:DX+9teU4pEEoZUqR1PiMlqliONQ
 github.com/libp2p/go-libp2p-autonat v0.2.1/go.mod h1:MWtAhV5Ko1l6QBsHQNSuM6b1sRkXrpk0/LqCr+vCVxI=
 github.com/libp2p/go-libp2p-autonat v0.2.2/go.mod h1:HsM62HkqZmHR2k1xgX34WuWDzk/nBwNHoeyyT4IWV6A=
 github.com/libp2p/go-libp2p-autonat v0.2.3/go.mod h1:2U6bNWCNsAG9LEbwccBDQbjzQ8Krdjge1jLTE9rdoMM=
-github.com/libp2p/go-libp2p-autonat v0.3.1 h1:60sc3NuQz+RxEb4ZVCRp/7uPtD7gnlLcOIKYNulzSIo=
-github.com/libp2p/go-libp2p-autonat v0.3.1/go.mod h1:0OzOi1/cVc7UcxfOddemYD5vzEqi4fwRbnZcJGLi68U=
 github.com/libp2p/go-libp2p-autonat v0.3.2 h1:OhDSwVVaq7liTaRIsFFYvsaPp0pn2yi0WazejZ4DUmo=
 github.com/libp2p/go-libp2p-autonat v0.3.2/go.mod h1:0OzOi1/cVc7UcxfOddemYD5vzEqi4fwRbnZcJGLi68U=
 github.com/libp2p/go-libp2p-blankhost v0.1.1/go.mod h1:pf2fvdLJPsC1FsVrNP3DUUvMzUts2dsLLBEpo1vW1ro=
@@ -953,6 +950,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
In https://github.com/keep-network/keep-common/pull/44 we removed ethereum address from the config file. In this PR we handle this change in keep-core client. After loading the ethereum key we are able to get the address from it.

Depends on: https://github.com/keep-network/keep-common/pull/44
Closes: keep-network/keep-core#1968