### PR TITLE
Allow to top-up less than the minimum stake

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -143,7 +143,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         bytes memory _extraData
     ) public {
         require(ERC20Burnable(_token) == token, "Unrecognized token");
-        require(_value >= minimumStake(), "Less than the minimum stake");
         require(_extraData.length >= 60, "Corrupted delegation data");
 
         // Transfer tokens to this contract.
@@ -173,6 +172,8 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address _operator,
         bytes memory _extraData
     ) internal {
+        require(_value >= minimumStake(), "Less than the minimum stake");
+        
         address payable beneficiary = address(uint160(_extraData.toAddress(0)));
         address authorizer = _extraData.toAddress(40);
 

--- a/solidity/contracts/libraries/staking/TopUps.sol
+++ b/solidity/contracts/libraries/staking/TopUps.sol
@@ -57,6 +57,7 @@ library TopUps {
             !escrow.hasDeposit(operator),
             "Stake for the operator already deposited in the escrow"
         );
+        require(value > 0, "Top-up value must be greater than zero");
 
         uint256 newAmount = operatorParams.getAmount().add(value);
         newParams = operatorParams.setAmountAndCreationTimestamp(
@@ -95,6 +96,7 @@ library TopUps {
             !escrow.hasDeposit(operator),
             "Stake for the operator already deposited in the escrow"
         );
+        require(value > 0, "Top-up value must be greater than zero");
 
         TopUp memory awaiting = self.topUps[operator];
         self.topUps[operator] = TopUp(awaiting.amount.add(value), now);

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -400,7 +400,7 @@ describe('TokenStaking/TopUps', () => {
     })
 
     it("can be done with less than the minimum stake", async () => {
-      const topUpAmount = 9
+      const topUpAmount = (await tokenStaking.minimumStake()).subn(1)
 
       await time.increase(initializationPeriod.addn(1))
       await initiateTopUp(topUpAmount)
@@ -411,7 +411,7 @@ describe('TokenStaking/TopUps', () => {
         operatorOne,
         operatorContract
       )
-      expect(currentStake).to.eq.BN(delegatedAmount.addn(topUpAmount))
+      expect(currentStake).to.eq.BN(delegatedAmount.add(topUpAmount))
     })
   })
 
@@ -598,7 +598,7 @@ describe('TokenStaking/TopUps', () => {
     })
 
     it("can be done with less than the minimum stake", async () => {
-      const topUpAmount = 7
+      const topUpAmount = (await tokenStaking.minimumStake()).subn(1)
 
       await time.increase(initializationPeriod.addn(1))
       await initiateTopUp(topUpAmount)
@@ -609,7 +609,7 @@ describe('TokenStaking/TopUps', () => {
         operatorTwo,
         operatorContract
       )
-      expect(currentStake).to.eq.BN(delegatedAmount.addn(topUpAmount))
+      expect(currentStake).to.eq.BN(delegatedAmount.add(topUpAmount))
     })
   })
 
@@ -795,7 +795,7 @@ describe('TokenStaking/TopUps', () => {
     })
 
     it("can be done with less than the minimum stake", async () => {
-      const topUpAmount = 11
+      const topUpAmount = (await tokenStaking.minimumStake()).subn(1)
 
       await time.increase(initializationPeriod.addn(1))
       await initiateTopUp(topUpAmount)
@@ -806,7 +806,7 @@ describe('TokenStaking/TopUps', () => {
         operatorThree,
         operatorContract
       )
-      expect(currentStake).to.eq.BN(delegatedAmount.addn(topUpAmount))
+      expect(currentStake).to.eq.BN(delegatedAmount.add(topUpAmount))
     })
   })
 
@@ -906,7 +906,7 @@ describe('TokenStaking/TopUps', () => {
       let delegationInfo = await tokenStaking.getDelegationInfo(operatorFour)
       expect(delegationInfo.amount).to.eq.BN(delegatedAmount)
 
-      const topUpAmount = 91
+      const topUpAmount = (await tokenStaking.minimumStake()).subn(1)
       const data = Buffer.concat([
         Buffer.from(beneficiary.substr(2), 'hex'),
         Buffer.from(operatorFour.substr(2), 'hex'),
@@ -920,7 +920,7 @@ describe('TokenStaking/TopUps', () => {
       await tokenStaking.commitTopUp(operatorFour, {from: grantee})
         
       delegationInfo = await tokenStaking.getDelegationInfo(operatorFour)
-      expect(delegationInfo.amount).to.eq.BN(delegatedAmount.addn(topUpAmount))
+      expect(delegationInfo.amount).to.eq.BN(delegatedAmount.add(topUpAmount))
     })
   })
 }) 

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -290,6 +290,21 @@ describe('TokenStaking/TopUps', () => {
       )
     })
 
+    it("fails for a zero-value top-up when doing in one step", async () => {
+      await expectRevert(
+        initiateTopUp(0),
+        "Top-up value must be greater than zero"
+      )
+    })
+
+    it("fails for a zero-value top-up when doing in two steps", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        initiateTopUp(0),
+        "Top-up value must be greater than zero"
+      )
+    })
+
     it("does not increase stake before committed", async () => {
       await time.increase(initializationPeriod.addn(1))
       await initiateTopUp(delegatedAmount)
@@ -488,6 +503,21 @@ describe('TokenStaking/TopUps', () => {
       expect(delegationInfo.undelegatedAt).to.eq.BN(0)
     })
 
+    it("fails for a zero-value top-up when doing in one step", async () => {
+      await expectRevert(
+        initiateTopUp(0),
+        "Top-up value must be greater than zero"
+      )
+    })
+
+    it("fails for a zero-value top-up when doing in two steps", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        initiateTopUp(0),
+        "Top-up value must be greater than zero"
+      )
+    })
+
     it("does not increase stake before committed", async () => {
       await time.increase(initializationPeriod.addn(1))
       await initiateTopUp(delegatedAmount)
@@ -683,6 +713,21 @@ describe('TokenStaking/TopUps', () => {
       expect(delegationInfo.amount).to.eq.BN(delegatedAmount.muln(2))
       expect(delegationInfo.createdAt).to.eq.BN(await time.latest())
       expect(delegationInfo.undelegatedAt).to.eq.BN(0)
+    })
+
+    it("fails for a zero-value top-up when doing in one step", async () => {
+      await expectRevert(
+        initiateTopUp(0),
+        "Top-up value must be greater than zero"
+      )
+    })
+
+    it("fails for a zero-value top-up when doing in two steps", async () => {
+      await time.increase(initializationPeriod.addn(1))
+      await expectRevert(
+        initiateTopUp(0),
+        "Top-up value must be greater than zero"
+      )
     })
 
     it("does not increase stake before committed", async () => {


### PR DESCRIPTION
Having the minimum stake restriction on delegation makes perfect sense but users may want to top-up less than the minimum stake. It makes sense in two cases:
- As long as we slash 1% or 50% of the minimum stake (first 3 months and the next 3 months), users may delegate e.g. 100k KEEP and then to-up 1k KEEP to have 1% safety margin in case of slashing.
- Sortition pool weights by stake and if the `poolWeightDivisor` is lower than the minimum stake, having 101K KEEP delegated gives better chances of being selected than having 100k KEEP delegated.

Props to @r-czajkowski for finding this.