### PR TITLE
DefaultMaxGasPrice updated to 70Gwei

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -19,7 +19,7 @@
 	# allowed gas price is reached, no further resubmission attempts are
 	# performed.
 	#
-	# MaxGasPrice = 50000000000 # 50 gwei (default value)
+	# MaxGasPrice = 70000000000 # 70 gwei (default value)
 
 [ethereum.account]
 	KeyFile            = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"

--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -30,7 +30,7 @@ var (
 	// gas price can not be higher than the max gas price value. If the maximum
 	// allowed gas price is reached, no further resubmission attempts are
 	// performed. This value can be overwritten in the configuration file.
-	DefaultMaxGasPrice = big.NewInt(50000000000) // 50 Gwei
+	DefaultMaxGasPrice = big.NewInt(70000000000) // 70 Gwei
 )
 
 type ethereumChain struct {


### PR DESCRIPTION
Given the current trends of gas prices, it makes sense to increase the `DefaultMaxGasPrice` to `70Gwei`. As for today, Etherscan indicates `60Gwei` is the safe price and `75Gwei` is the proposed price, both with ~20 seconds expected mining time of a TX.