### PR TITLE
Removed redundant casting operation

### DIFF
--- a/solidity/contracts/libraries/staking/GrantStaking.sol
+++ b/solidity/contracts/libraries/staking/GrantStaking.sol
@@ -50,7 +50,7 @@ library GrantStaking {
         address operator,
         bytes memory extraData
     ) public returns (bool, uint256) {
-        if (from == address(escrow)) {
+        if (from == escrow) {
             require(extraData.length == 92, "Corrupted delegation data from escrow");
             uint256 grantId = extraData.toUint(60);
             setGrantForOperator(self, operator, grantId);


### PR DESCRIPTION
`escrow` is already an address and we get nothing from casting `address` to `address`.