### PR TITLE
Minimum stake schedule starts at the moment of deploying KEEP token

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -63,7 +63,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     event LockReleased(address indexed operator, address lockCreator);
     event ExpiredLockReleased(address indexed operator, address lockCreator);
 
-    uint256 public minimumStakeScheduleStart;
+    uint256 public deployedAt;
     uint256 public initializationPeriod; // varies between mainnet and testnet
 
     ERC20Burnable internal token;
@@ -96,7 +96,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         escrow = _escrow;
         registry = _registry;
         initializationPeriod = _initializationPeriod;
-        minimumStakeScheduleStart = block.timestamp;
+        deployedAt = block.timestamp;
     }
 
     /// @notice Returns minimum amount of KEEP that allows sMPC cluster client to
@@ -104,7 +104,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// Initial minimum stake is higher than the final and lowered periodically based
     /// on the amount of steps and the length of the minimum stake schedule in seconds.
     function minimumStake() public view returns (uint256) {
-        return MinimumStakeSchedule.current(minimumStakeScheduleStart);
+        return MinimumStakeSchedule.current();
     }
 
     /// @notice Returns the current value of the undelegation period.
@@ -114,7 +114,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// The undelegation period is two weeks for the first two months and
     /// two months after that.
     function undelegationPeriod() public view returns(uint256) {
-        return block.timestamp < minimumStakeScheduleStart.add(twoMonths) ? twoWeeks : twoMonths;
+        return block.timestamp < deployedAt.add(twoMonths) ? twoWeeks : twoMonths;
     }
 
     /// @notice Receives approval of token transfer and stakes the approved

--- a/solidity/contracts/libraries/operator/Groups.sol
+++ b/solidity/contracts/libraries/operator/Groups.sol
@@ -419,12 +419,12 @@ library Groups {
     ) public view returns (uint256) {
         uint256 minimumStake = self.stakingContract.minimumStake();
 
-        uint256 minimumStakeScheduleStart = self.stakingContract.minimumStakeScheduleStart();
+        uint256 stakingContractDeployedAt = self.stakingContract.deployedAt();
         /* solium-disable-next-line security/no-block-members */
-        if (now < minimumStakeScheduleStart + THREE_MONTHS) {
+        if (now < stakingContractDeployedAt + THREE_MONTHS) {
             return minimumStake.percent(1);
         /* solium-disable-next-line security/no-block-members */
-        } else if (now < minimumStakeScheduleStart + SIX_MONTHS) {
+        } else if (now < stakingContractDeployedAt + SIX_MONTHS) {
             return minimumStake.percent(50);
         } else {
             return minimumStake;

--- a/solidity/contracts/libraries/staking/MinimumStakeSchedule.sol
+++ b/solidity/contracts/libraries/staking/MinimumStakeSchedule.sol
@@ -9,12 +9,20 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 library MinimumStakeSchedule {
     using SafeMath for uint256;
 
+    // Apr-28-2020 02:52:46 AM UTC when KEEP token has been deployed
+    // TX:  0xea22d72bc7de4c82798df7194734024a1f2fd57b173d0e065864ff4e9d3dc014
+    uint256 public constant scheduleStart = 1588042366;
+    
     // 2 years in seconds (seconds per day * days in a year * years)
     uint256 public constant schedule = 86400 * 365 * 2;
     uint256 public constant steps = 10;
     uint256 public constant base = 10000 * 1e18;
 
-    function current(uint256 scheduleStart) public view returns (uint256) {
+    function current() public view returns (uint256) {
+        return current(scheduleStart);
+    }
+
+    function current(uint256 scheduleStart) internal view returns (uint256) {
         if (now < scheduleStart.add(schedule)) {
             uint256 currentStep = steps.mul(now.sub(scheduleStart)).div(schedule);
             return base.mul(steps.sub(currentStep));

--- a/solidity/contracts/libraries/staking/MinimumStakeSchedule.sol
+++ b/solidity/contracts/libraries/staking/MinimumStakeSchedule.sol
@@ -4,8 +4,9 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 /// @notice MinimumStakeSchedule defines the minimum stake parametrization and
 /// schedule. It starts with a minimum stake of 100k KEEP. Over the following
-/// 2 years, the minimum stake is lowered periodically using a uniform stepwise
-/// function, eventually ending at 10k.
+/// 2 years, starting from the moment KEEP token has been deployed, the minimum
+/// stake is lowered periodically using a uniform stepwise function, eventually
+/// ending at 10k.
 library MinimumStakeSchedule {
     using SafeMath for uint256;
 
@@ -18,6 +19,9 @@ library MinimumStakeSchedule {
     uint256 public constant steps = 10;
     uint256 public constant base = 10000 * 1e18;
 
+    /// @notice Returns the current value of the minimum stake. The minimum
+    /// stake is lowered periodically over the course of 2 years since the time
+    /// KEEP token has been deployed and eventually ends at 10k KEEP.
     function current() public view returns (uint256) {
         return current(scheduleStart);
     }

--- a/solidity/contracts/stubs/MinimumStakeScheduleStub.sol
+++ b/solidity/contracts/stubs/MinimumStakeScheduleStub.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.5.17;
+
+import "../libraries/staking/MinimumStakeSchedule.sol";
+
+contract MinimumStakeScheduleStub {
+
+    uint256 scheduleStart = now;
+
+    function current() public view returns (uint256) {
+        return MinimumStakeSchedule.current(scheduleStart);
+    }
+}

--- a/solidity/contracts/stubs/TokenStakingStub.sol
+++ b/solidity/contracts/stubs/TokenStakingStub.sol
@@ -1,0 +1,27 @@
+pragma solidity 0.5.17;
+
+import "../TokenStaking.sol";
+import "../TokenStakingEscrow.sol";
+import "../TokenGrant.sol";
+import "../KeepRegistry.sol";
+
+/// @dev TokenStakingStub keeps the same minimum stake value of 100k KEEP for
+/// all the time. This stub is used by tests for which we want to maintain the
+/// same minimum stake value. MinimumStakeSchedule uses the time of deploying KEEP
+/// token as the starting point of the minimum stake schedule.
+/// Use this stub to keep it at the same, predictable level. Going back in time
+/// in tests is not possible.
+contract TokenStakingStub is TokenStaking {
+    constructor(
+        ERC20Burnable _token,
+        TokenGrant _tokenGrant,
+        TokenStakingEscrow _escrow,
+        KeepRegistry _registry,
+        uint256 _initializationPeriod
+    ) TokenStaking(_token, _tokenGrant, _escrow, _registry, _initializationPeriod) public {
+    }
+
+    function minimumStake() public view returns (uint256) {
+        return 100000 * 1e18;
+    }
+}

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -33,7 +33,7 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
   before(async () => {
 
     let contracts = await initContracts(
-      contract.fromArtifact('TokenStaking'),
+      contract.fromArtifact('TokenStakingStub'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),
       contract.fromArtifact('KeepRandomBeaconOperatorSlashingStub')
@@ -56,7 +56,7 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
     await stakingContract.authorizeOperatorContract(operator2, operatorContract.address, { from: authorizer })
     await stakingContract.authorizeOperatorContract(operator3, operatorContract.address, { from: authorizer })
 
-    scheduleStart = await stakingContract.minimumStakeScheduleStart()
+    scheduleStart = await stakingContract.deployedAt()
 
     time.increase((await stakingContract.initializationPeriod()).addn(1))
 
@@ -84,7 +84,7 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
         tattletaleSignature,
         { from: tattletale }
       )
-  
+
       expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
         "49900000000000000000000000" // 50000000000000000000000000 - 100000000000000000000000
       )
@@ -209,15 +209,14 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       await time.increaseTo(scheduleStart.addn(86400 * 89))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
 
-      // minimum stake = 90000000000000000000000
       expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
-        "49999100000000000000000000" // 50000000000000000000000000 - 1% * 90000000000000000000000 
+        "49999000000000000000000000" // 50000000000000000000000000 - 1% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
-        "499100000000000000000000"  // 500000000000000000000000 - 1% * 90000000000000000000000 
+        "499000000000000000000000"  // 500000000000000000000000 - 1% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
-        "99100000000000000000000"  // 100000000000000000000000 - 1% * 90000000000000000000000
+        "99000000000000000000000"  // 100000000000000000000000 - 1% * 100000000000000000000000
       )
     })
 
@@ -230,9 +229,9 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
       // for the first three months:
       //
-      // minimum stake = 90000000000000000000000
-      // 3 * 90000000000000000000000 * 1% * 5% * 31% = 41850000000000000000
-      expect(await token.balanceOf(tattletale)).to.eq.BN("41850000000000000000")
+      // minimum stake = 100000000000000000000000
+      // 3 * 100000000000000000000000 * 1% * 5% * 31% = 46500000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("46500000000000000000")
     })
 
     it("seizes 50% of minimum stake from operators after the first 3 months", async () => {
@@ -240,15 +239,14 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       await time.increaseTo(scheduleStart.addn(86400 * 90))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
 
-      // minimum stake = 90000000000000000000000
       expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
-        "49955000000000000000000000" // 50000000000000000000000000 - 50% * 90000000000000000000000 
+        "49950000000000000000000000" // 50000000000000000000000000 - 50% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
-        "455000000000000000000000"  // 500000000000000000000000 - 50% * 90000000000000000000000 
+        "450000000000000000000000"  // 500000000000000000000000 - 50% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
-        "55000000000000000000000"  // 100000000000000000000000 - 50% * 90000000000000000000000
+        "50000000000000000000000"  // 100000000000000000000000 - 50% * 100000000000000000000000
       )
     })
 
@@ -261,9 +259,9 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       // And "all of the seized tokens" are 3 * minimum stake with 50% adjustment
       // after the first 3 months end
       //
-      // minimum stake = 90000000000000000000000
-      // 3 * 90000000000000000000000 * 50% * 5% * 31% = 2092500000000000000000
-      expect(await token.balanceOf(tattletale)).to.eq.BN("2092500000000000000000")
+      // minimum stake = 100000000000000000000000
+      // 3 * 100000000000000000000000 * 50% * 5% * 31% = 2325000000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("2325000000000000000000")
     })
     
     it("seizes 50% of minimum stake from operators before the first 6 months end", async () => {
@@ -271,15 +269,15 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       await time.increaseTo(scheduleStart.addn(86400 * 179))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
 
-      // minimum stake = 80000000000000000000000
+      // minimum stake = 100000000000000000000000
       expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
-        "49960000000000000000000000" // 50000000000000000000000000 - 50% * 80000000000000000000000 
+        "49950000000000000000000000" // 50000000000000000000000000 - 50% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
-        "460000000000000000000000"  // 500000000000000000000000 - 50% * 80000000000000000000000 
+        "450000000000000000000000"  // 500000000000000000000000 - 50% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
-        "60000000000000000000000"  // 100000000000000000000000 - 50% * 80000000000000000000000
+        "50000000000000000000000"  // 100000000000000000000000 - 50% * 100000000000000000000000
       )
     })
 
@@ -292,9 +290,9 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
       // for the first three months:
       //
-      // minimum stake = 80000000000000000000000
-      // 3 * 80000000000000000000000 * 50% * 5% * 31% = 1860000000000000000000
-      expect(await token.balanceOf(tattletale)).to.eq.BN("1860000000000000000000")
+      // minimum stake = 100000000000000000000000
+      // 3 * 100000000000000000000000 * 50% * 5% * 31% = 2325000000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("2325000000000000000000")
     })
 
     it("seizes 100% of minimum stake from operators after the first 6 months end", async () => {
@@ -302,15 +300,15 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       await time.increaseTo(scheduleStart.addn(86400 * 180))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
 
-      // minimum stake = 80000000000000000000000
+      // minimum stake = 100000000000000000000000
       expect(await stakingContract.balanceOf(operator1)).to.eq.BN(
-        "49920000000000000000000000" // 50000000000000000000000000 - 100% * 80000000000000000000000 
+        "49900000000000000000000000" // 50000000000000000000000000 - 100% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator2)).to.eq.BN(
-        "420000000000000000000000"  // 500000000000000000000000 - 100% * 80000000000000000000000 
+        "400000000000000000000000"  // 500000000000000000000000 - 100% * 100000000000000000000000 
       )
       expect(await stakingContract.balanceOf(operator3)).to.eq.BN(
-        "20000000000000000000000"  // 100000000000000000000000 - 100% * 80000000000000000000000
+        "0"  // 100000000000000000000000 - 100% * 100000000000000000000000
       )
     })
 
@@ -323,9 +321,9 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       // And "all of the seized tokens" are 3 * minimum stake with 1% adjustment
       // for the first three months:
       //
-      // minimum stake = 80000000000000000000000
-      // 3 * 80000000000000000000000 * 100% * 5% * 31% = 3720000000000000000000
-      expect(await token.balanceOf(tattletale)).to.eq.BN("3720000000000000000000")
+      // minimum stake = 100000000000000000000000
+      // 3 * 100000000000000000000000 * 100% * 5% * 31% = 4650000000000000000000
+      expect(await token.balanceOf(tattletale)).to.eq.BN("4650000000000000000000")
     })
   })
 })

--- a/solidity/test/token_stake/TestMinimumStake.js
+++ b/solidity/test/token_stake/TestMinimumStake.js
@@ -2,40 +2,26 @@
 const {contract, web3} = require("@openzeppelin/test-environment")
 const {time} = require("@openzeppelin/test-helpers")
 const {createSnapshot, restoreSnapshot} = require('../helpers/snapshot');
-const {initTokenStaking} = require('../helpers/initContracts')
 
 const BN = web3.utils.BN
 const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-const KeepToken = contract.fromArtifact('KeepToken');
-const TokenGrant = contract.fromArtifact('TokenGrant');
-const KeepRegistry = contract.fromArtifact("KeepRegistry");
+const MinimumStakeScheduleStub = contract.fromArtifact('MinimumStakeScheduleStub');
 
 describe('TokenStaking/MinimumStake', function() {
-  let token, registry, stakingContract, keepDecimals;
-  const initializationPeriod = time.duration.seconds(10);
+  let scheduleLib, scheduleStart
 
   const schedule = web3.utils.toBN(86400 * 365 * 2)
   const steps = web3.utils.toBN(10)
   const stepDuration = schedule.div(steps) // 2 years / 10 intervals
 
-  before(async () => {
-    token = await KeepToken.new();
-    grant = await TokenGrant.new(token.address);
-    registry = await KeepRegistry.new();
-    const stakingContracts = await initTokenStaking(
-      token.address,
-      grant.address,
-      registry.address,
-      initializationPeriod,
-      contract.fromArtifact('TokenStakingEscrow'),
-      contract.fromArtifact('TokenStaking')
-    )
-    stakingContract = stakingContracts.tokenStaking;
+  const keepDecimals = web3.utils.toBN(10).pow(web3.utils.toBN(18));
 
-    keepDecimals = web3.utils.toBN(10).pow(web3.utils.toBN(18));
+  before(async () => {
+    scheduleLib = await MinimumStakeScheduleStub.new();
+    scheduleStart = await time.latest()
   });
 
   beforeEach(async () => {
@@ -48,28 +34,26 @@ describe('TokenStaking/MinimumStake', function() {
 
   describe("minimumStake", async () => {
     it("returns max value when the schedule starts", async () => {
-      expect(await stakingContract.minimumStake()).to.eq.BN(
+      expect(await scheduleLib.current()).to.eq.BN(
         web3.utils.toBN(100000).mul(keepDecimals),
         "Unexpected minimum stake amount"
       );
     })
 
     it("returns max value right before the next schedule step", async () => {
-      let minimumStakeScheduleStart = await stakingContract.minimumStakeScheduleStart();
-      let timeForStepOne = minimumStakeScheduleStart.add(stepDuration)
+      let timeForStepOne = scheduleStart.add(stepDuration)
       // Rounding timestamp jump to 1 minute less (looks like increaseTime() can occasionally add extra seconds)
       await time.increase(timeForStepOne.sub(await time.latest()).sub(time.duration.minutes(1)))
-      expect(await stakingContract.minimumStake()).to.eq.BN(
+      expect(await scheduleLib.current()).to.eq.BN(
         web3.utils.toBN(100000).mul(keepDecimals),
         "Unexpected minimum stake amount"
       );
     })
 
     it("returns correct value right after the first schedule step", async () => {
-      let minimumStakeScheduleStart = await stakingContract.minimumStakeScheduleStart();
-      let timeForStepOne = minimumStakeScheduleStart.add(stepDuration)
+      let timeForStepOne = scheduleStart.add(stepDuration)
       await time.increase(timeForStepOne.sub(await time.latest()))
-      expect(await stakingContract.minimumStake()).to.eq.BN(
+      expect(await scheduleLib.current()).to.eq.BN(
         web3.utils.toBN(90000).mul(keepDecimals),
         "Unexpected minimum stake amount"
       );
@@ -77,7 +61,7 @@ describe('TokenStaking/MinimumStake', function() {
 
     it("returns half value in the middle of the schedule", async () => {
       await time.increase(schedule.divn(2).toNumber());
-      expect(await stakingContract.minimumStake()).to.eq.BN(
+      expect(await scheduleLib.current()).to.eq.BN(
         web3.utils.toBN(50000).mul(keepDecimals),
         "Unexpected minimum stake amount"
       );
@@ -85,7 +69,7 @@ describe('TokenStaking/MinimumStake', function() {
 
     it("returns min value when the schedule ends", async () => {
       await time.increase(schedule.toNumber());
-      expect(await stakingContract.minimumStake()).to.eq.BN(
+      expect(await scheduleLib.current()).to.eq.BN(
         web3.utils.toBN(10000).mul(keepDecimals),
         "Unexpected minimum stake amount"
       );

--- a/solidity/test/token_stake/TestPunishment.js
+++ b/solidity/test/token_stake/TestPunishment.js
@@ -38,7 +38,7 @@ describe('TokenStaking/Punishment', () => {
             registry.address,
             initializationPeriod,
             contract.fromArtifact('TokenStakingEscrow'),
-            contract.fromArtifact('TokenStaking')
+            contract.fromArtifact('TokenStakingStub')
         )
         stakingContract = stakingContracts.tokenStaking;
 

--- a/solidity/test/token_stake/TestStakingGrant.js
+++ b/solidity/test/token_stake/TestStakingGrant.js
@@ -69,7 +69,7 @@ describe('TokenStaking/StakingGrant', () => {
         registry.address,
         initializationPeriod,
         contract.fromArtifact('TokenStakingEscrow'),
-        contract.fromArtifact('TokenStaking')
+        contract.fromArtifact('TokenStakingStub')
       )
       tokenStaking = stakingContracts.tokenStaking;
       tokenStakingEscrow = stakingContracts.tokenStakingEscrow;


### PR DESCRIPTION
We are deploying a new staking contract version but we want to maintain the same minimum KEEP stake schedule. To make it happen, instead of using staking contract deployment time as a schedule start, we now define a constant in `MinimumStakeSchedule` with a value equal to the time of deploying KEEP token. On the other hand, we want the slashing schedule (1% for the first 3 month and 50% for the next 3 months) start with the time of deploying the new `TokenStaking` contract. I renamed `TokenStaking.minimumStakeScheduleStart` to `TokenStaking.deployedAt` and updated `Groups.sol` to use the new name.

The most problematic part were unit tests. Since we now use a fixed point in the past as a minimum stake schedule start, I had to introduce `TokenStakingStub` for some tests with a fixed minimum stake of 100k KEEP.