### PR TITLE
Allow to copy stake only one time even if it's been recovered

### DIFF
--- a/solidity/contracts/StakingPortBacker.sol
+++ b/solidity/contracts/StakingPortBacker.sol
@@ -251,7 +251,6 @@ contract StakingPortBacker is Ownable {
     /// @param operator The operator address.
     function recoverStake(address operator) public {
         newStakingContract.recoverStake(operator);
-        delete copiedStakes[operator];
     }
 
     /// @notice Allows the contract owner to withdraw tokens from the balance


### PR DESCRIPTION
Modified `StakingPortBacker` to allow for copying stake only one time even if the copied stake has been recovered. This behavior was expected based on the documentation on `copyStake` which says:

> "(...)  the relationship can only be copied once (...)".

This scenario would be the most problematic in the situation when `StakingPortBacker` owner force-undelegates the stake after 3 months of not paying the loan back and recovers the stake after the undelegation time and the malicious staker copies the stake immediately before `StakingPortBacker` owner has a chance to withdraw tokens (gas auction).