### PR TITLE
Pass minimum stake schedule start as a parameter to the library

### DIFF
--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -77,6 +77,10 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     uint256 internal constant twoWeeks = 1209600; // [sec]
     uint256 internal constant twoMonths = 5184000; // [sec]
 
+    // 2020-04-28; the date of deploying KEEP token.
+    // TX:  0xea22d72bc7de4c82798df7194734024a1f2fd57b173d0e065864ff4e9d3dc014
+    uint256 internal constant minimumStakeScheduleStart = 1588042366;
+
     /// @notice Creates a token staking contract for a provided Standard ERC20Burnable token.
     /// @param _token KEEP token contract.
     /// @param _tokenGrant KEEP token grant contract.
@@ -104,7 +108,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     /// Initial minimum stake is higher than the final and lowered periodically based
     /// on the amount of steps and the length of the minimum stake schedule in seconds.
     function minimumStake() public view returns (uint256) {
-        return MinimumStakeSchedule.current();
+        return MinimumStakeSchedule.current(minimumStakeScheduleStart);
     }
 
     /// @notice Returns the current value of the undelegation period.

--- a/solidity/contracts/libraries/staking/MinimumStakeSchedule.sol
+++ b/solidity/contracts/libraries/staking/MinimumStakeSchedule.sol
@@ -4,16 +4,11 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 /// @notice MinimumStakeSchedule defines the minimum stake parametrization and
 /// schedule. It starts with a minimum stake of 100k KEEP. Over the following
-/// 2 years, starting from the moment KEEP token has been deployed, the minimum
-/// stake is lowered periodically using a uniform stepwise function, eventually
-/// ending at 10k.
+/// 2 years, the minimum stake is lowered periodically using a uniform stepwise
+/// function, eventually ending at 10k.
 library MinimumStakeSchedule {
     using SafeMath for uint256;
 
-    // Apr-28-2020 02:52:46 AM UTC when KEEP token has been deployed
-    // TX:  0xea22d72bc7de4c82798df7194734024a1f2fd57b173d0e065864ff4e9d3dc014
-    uint256 public constant scheduleStart = 1588042366;
-    
     // 2 years in seconds (seconds per day * days in a year * years)
     uint256 public constant schedule = 86400 * 365 * 2;
     uint256 public constant steps = 10;
@@ -21,11 +16,7 @@ library MinimumStakeSchedule {
 
     /// @notice Returns the current value of the minimum stake. The minimum
     /// stake is lowered periodically over the course of 2 years since the time
-    /// KEEP token has been deployed and eventually ends at 10k KEEP.
-    function current() public view returns (uint256) {
-        return current(scheduleStart);
-    }
-
+    /// of the shedule start and eventually ends at 10k KEEP.
     function current(uint256 scheduleStart) internal view returns (uint256) {
         if (now < scheduleStart.add(schedule)) {
             uint256 currentStep = steps.mul(now.sub(scheduleStart)).div(schedule);


### PR DESCRIPTION
During the review of https://github.com/keep-network/keep-core/pull/1977 @nkuba and @Shadowfiend commented about not hardcoding the schedule start in the library. This is addressed in this PR. 

Instead of hardcoding schedule start in `MinimumStakeSchedule` library, we can pass it as a parameter. It's a little cleaner given that we don't have an alternative function for unit tests. It's a little more expensive gas-wise but we can live with it.

Having this value passed in the constructor is not possible given the contract size constraints. 

We also use ISO8601 format for schedule start date now.