### PR TITLE
Replace StakeDelegatable.ownerOperators mapping with an event 

### DIFF
--- a/solidity/contracts/StakeDelegatable.sol
+++ b/solidity/contracts/StakeDelegatable.sol
@@ -21,8 +21,6 @@ import "./utils/OperatorParams.sol";
 contract StakeDelegatable {
     using OperatorParams for uint256;
 
-    mapping(address => address[]) internal ownerOperators;
-
     mapping(address => Operator) internal operators;
 
     struct Operator {
@@ -30,12 +28,6 @@ contract StakeDelegatable {
         address owner;
         address payable beneficiary;
         address authorizer;
-    }
-
-    /// @notice Gets the list of operators of the specified address.
-    /// @return An array of addresses.
-    function operatorsOf(address _address) public view returns (address[] memory) {
-        return ownerOperators[_address];
     }
 
     /// @notice Gets the stake balance of the specified address.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -565,6 +565,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     function transferStakeOwnership(address operator, address newOwner) public {
         require(msg.sender == operators[operator].owner, "Not authorized");
         operators[operator].owner = newOwner;
+        ownerOperators[newOwner].push(operator);
         emit StakeOwnershipTransferred(operator, newOwner);
     }
 

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -51,7 +51,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     );
     event StakeOwnershipTransferred(
         address indexed operator,
-        address newOwner
+        address indexed newOwner
     );
     event TopUpInitiated(address indexed operator, uint256 topUp);
     event TopUpCompleted(address indexed operator, uint256 newAmount);

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -42,16 +42,15 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     using Locks for Locks.Storage;
     using TopUps for TopUps.Storage;
 
-    event Staked(
-        address owner,
+    event StakeDelegated(
+        address indexed owner,
+        address indexed operator
+    );
+    event OperatorStaked(
         address indexed operator,
         address indexed beneficiary,
         address indexed authorizer,
         uint256 value
-    );
-    event StakeOwnershipTransferred(
-        address indexed operator,
-        address indexed newOwner
     );
     event TopUpInitiated(address indexed operator, uint256 topUp);
     event TopUpCompleted(address indexed operator, uint256 newAmount);
@@ -183,7 +182,6 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             beneficiary,
             authorizer
         );
-        ownerOperators[_from].push(_operator);
 
         grantStaking.tryCapturingDelegationData(
             tokenGrant,
@@ -193,7 +191,8 @@ contract TokenStaking is Authorizations, StakeDelegatable {
             _extraData
         );
 
-        emit Staked(_from, _operator, beneficiary, authorizer, _value);
+        emit StakeDelegated(_from, _operator);
+        emit OperatorStaked(_operator, beneficiary, authorizer, _value);
     }
 
     /// @notice Performs top-up to an existing operator. Tokens added during
@@ -565,8 +564,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     function transferStakeOwnership(address operator, address newOwner) public {
         require(msg.sender == operators[operator].owner, "Not authorized");
         operators[operator].owner = newOwner;
-        ownerOperators[newOwner].push(operator);
-        emit StakeOwnershipTransferred(operator, newOwner);
+        emit StakeDelegated(newOwner, operator);
     }
 
     /// @notice Gets the eligible stake balance of the specified address.

--- a/solidity/contracts/TokenStaking.sol
+++ b/solidity/contracts/TokenStaking.sol
@@ -52,6 +52,10 @@ contract TokenStaking is Authorizations, StakeDelegatable {
         address indexed authorizer,
         uint256 value
     );
+    event StakeOwnershipTransferred(
+        address indexed operator,
+        address indexed newOwner
+    );
     event TopUpInitiated(address indexed operator, uint256 topUp);
     event TopUpCompleted(address indexed operator, uint256 newAmount);
     event Undelegated(address indexed operator, uint256 undelegatedAt);
@@ -564,7 +568,7 @@ contract TokenStaking is Authorizations, StakeDelegatable {
     function transferStakeOwnership(address operator, address newOwner) public {
         require(msg.sender == operators[operator].owner, "Not authorized");
         operators[operator].owner = newOwner;
-        emit StakeDelegated(newOwner, operator);
+        emit StakeOwnershipTransferred(operator, newOwner);
     }
 
     /// @notice Gets the eligible stake balance of the specified address.

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -177,6 +177,27 @@ describe('TokenStaking', function() {
         "Staking amount should be added to the operator balance"
       );
     })
+
+    it("should emit OperatorStaked event", async () => {
+      await delegate(operatorOne, stakingAmount)
+      
+      const operatorStakedEvents = await stakingContract.getPastEvents("OperatorStaked")
+      expect(operatorStakedEvents.length).to.equal(1)
+      const operatorStakedEvent = operatorStakedEvents[0]
+      expect(operatorStakedEvent.args['operator']).to.equal(operatorOne)
+      expect(operatorStakedEvent.args['beneficiary']).to.equal(beneficiary)
+      expect(operatorStakedEvent.args['authorizer']).to.equal(authorizer)
+    })
+
+    it("should emit StakeDelegated event", async () => {
+      await delegate(operatorOne, stakingAmount)
+
+      const stakeDelegatedEvents = await stakingContract.getPastEvents("StakeDelegated")
+      expect(stakeDelegatedEvents.length).to.equal(1)
+      const stakeDelegatedEvent = stakeDelegatedEvents[0]
+      expect(stakeDelegatedEvent.args['owner']).to.equal(owner)
+      expect(stakeDelegatedEvent.args['operator']).to.equal(operatorOne)
+    })
   })
 
   describe("cancelStake", async () => {

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -870,9 +870,7 @@ describe('TokenStaking', function() {
         {from: owner}
       )
       const newOwner = await stakingContract.ownerOf(operatorOne)
-      const operatorsOf = await stakingContract.operatorsOf(newOwner)
       expect(newOwner).to.equal(thirdParty)
-      expect(operatorsOf).contains(operatorOne)
     })
 
     it("emits an event", async () => {
@@ -883,9 +881,9 @@ describe('TokenStaking', function() {
         {from: owner}
       )
 
-      await expectEvent(receipt, "StakeOwnershipTransferred", {
-        operator: operatorOne,
-        newOwner: thirdParty
+      await expectEvent(receipt, "StakeDelegated", {
+        owner: thirdParty,
+        operator: operatorOne
       })
     })
   })

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -870,7 +870,9 @@ describe('TokenStaking', function() {
         {from: owner}
       )
       const newOwner = await stakingContract.ownerOf(operatorOne)
+      const operatorsOf = await stakingContract.operatorsOf(newOwner)
       expect(newOwner).to.equal(thirdParty)
+      expect(operatorsOf).contains(operatorOne)
     })
 
     it("emits an event", async () => {

--- a/solidity/test/token_stake/TestTokenStake.js
+++ b/solidity/test/token_stake/TestTokenStake.js
@@ -881,9 +881,9 @@ describe('TokenStaking', function() {
         {from: owner}
       )
 
-      await expectEvent(receipt, "StakeDelegated", {
-        owner: thirdParty,
-        operator: operatorOne
+      await expectEvent(receipt, "StakeOwnershipTransferred", {
+        operator: operatorOne,
+        newOwner: thirdParty
       })
     })
   })


### PR DESCRIPTION
`ownerOperators` mapping in `StakeDelegatable` was quite a problematic append-only data structure.

The first issue was that this mapping was not cleared up when a stake was recovered. The reason for that was to maintain a historical mapping between owner and operator so that the owner may withdraw rewards after recovering the stake even if it lost the operator address (operator address is a parameter to withdraw function).

Another issue was that this mapping maintained no longer up-to-date information in case the stake ownership was transferred with `transferStakeOwnership` function in `TokenStaking`. Clearing up this mapping would involve writing a loop and compering operator address bytes. This is problematic because of the contract size constraints as well as there is a tiny possibility such a loop may cause gas limit problems in case an owner has a lot of delegations.

The solution proposed here assumes we drop `ownerOperators` altogether, introduce `StakeDelegated` event with indexed owner and operator, as well as rename `Stake` event to `OperatorStaked` and remove owner field from there.

The relationship between owner and operator can be now looked up using `StakeDelegatedEvent` having both owner and operator indexed. This event is emitted when the delegation to the operator is registerred for the first time as well as when the delegation is transferred to another owner.

`OperatorStaked` event contains information about operator-beneficiary-authorizer triplet and this triplet is never changing. Since those values are set only one time and never updated, we emit this event only one time - when the delegation is created.

From KEEP token dashboard perspective:
- To find authorizer for operator, it's enough to filter out `OperatorStaked` event by indexed fields
- To find beneficiary for operator, it's enough to filter out `OperatorStaked` event by indexed fields
- To find operator for beneficiary, it's enough to filter out `OperatorStaked` event by indexed fields
- To find operator for authorizer, it's enough to filter out `OperatorStaked` event by indexed fields
- To find operator for owner, we should:  
  - Filter out `StakeDelegated` events by owner field
  - Filter out `StakeDelegated` events by operator field, checking more recent events to make sure the delegation ownership has not been transferred.