### PR TITLE
Gas price ceiling updates

### DIFF
--- a/solidity/contracts/GasPriceOracle.sol
+++ b/solidity/contracts/GasPriceOracle.sol
@@ -34,7 +34,7 @@ contract GasPriceOracle is Ownable {
 
     event GasPriceUpdated(uint256 newValue);
 
-    uint256 public constant governanceDelay = 6 hours; 
+    uint256 public constant governanceDelay = 1 hours; 
 
     uint256 public gasPrice;
 

--- a/solidity/contracts/GasPriceOracle.sol
+++ b/solidity/contracts/GasPriceOracle.sol
@@ -1,0 +1,99 @@
+/**
+▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+  ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+  ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+  ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓▌        ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+  ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+  ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+
+                           Trust math, not hardware.
+*/
+
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+/// @dev Interface expected to be implemented by contracts added as a gas price
+/// oracle consumers. Consumers are notified by GasPriceOracle every time gas
+/// price change is finalized by calling their refreshGasPrice function. Each
+/// consumer may decide to pull the new value from the oracle immediatelly or
+/// at the moment right for the consumer.
+interface GasPriceOracleConsumer {
+    function refreshGasPrice() external;
+}
+
+/// @notice Oracle presenting the current gas price. The oracle is manually
+/// updated by its owner.
+contract GasPriceOracle is Ownable {
+    using SafeMath for uint256;
+
+    event GasPriceUpdated(uint256 newValue);
+
+    uint256 public constant governanceDelay = 6 hours; 
+
+    uint256 public gasPrice;
+
+    uint256 public newGasPrice;
+    uint256 public gasPriceChangeInitiated;
+
+    address[] public consumerContracts;
+
+    modifier onlyAfterGovernanceDelay {
+        require(gasPriceChangeInitiated > 0, "Change not initiated");
+        require(
+            block.timestamp.sub(gasPriceChangeInitiated) >= governanceDelay,
+            "Governance delay has not elapsed"
+        );
+        _;
+    }
+
+    /// @notice Initialize the gas price update. Change is finalized after
+    /// the governance delay elapses.
+    /// @param _newGasPrice New gas price in wei.
+    function beginGasPriceUpdate(uint256 _newGasPrice) public onlyOwner {
+        newGasPrice = _newGasPrice;
+        gasPriceChangeInitiated = block.timestamp;
+    }
+
+    /// @notice Finalizes the gas price update. Finalization may happen only
+    /// after the governance delay elapses.
+    function finalizeGasPriceUpdate() public onlyAfterGovernanceDelay {
+        gasPrice = newGasPrice;
+
+        newGasPrice = 0;
+        gasPriceChangeInitiated = 0;
+
+        emit GasPriceUpdated(gasPrice);
+        
+        for (uint256 i = 0; i < consumerContracts.length; i++) {
+            GasPriceOracleConsumer(consumerContracts[i]).refreshGasPrice();
+        }
+    }
+
+    /// @notice Adds a new consumer contract to the oracle. Consumer contract is
+    /// expected to implement GasPriceOracleConsumer interface and receives
+    /// a notifcation every time gas price update is finalized.
+    /// @param consumerContract The new consumer contract to add to the oracle.
+    function addConsumerContract(address consumerContract) public onlyOwner {
+        consumerContracts.push(consumerContract);
+    }
+
+    /// @notice Removes consumer contract from the oracle by its index.
+    /// @param index Index of the consumer contract to be removed.
+    function removeConsumerContract(uint256 index) public onlyOwner {
+        require(index < consumerContracts.length, "Invalid index");
+        consumerContracts[index] = consumerContracts[consumerContracts.length - 1];
+        consumerContracts.length--;
+    }
+
+    /// @notice Returns all consumer contracts currently registered in the
+    /// oracle.
+    function getConsumerContracts() public view returns (address[] memory) {
+        return consumerContracts;
+    }
+}

--- a/solidity/contracts/GasPriceOracle.sol
+++ b/solidity/contracts/GasPriceOracle.sol
@@ -23,6 +23,8 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 /// price change is finalized by calling their refreshGasPrice function. Each
 /// consumer may decide to pull the new value from the oracle immediatelly or
 /// at the moment right for the consumer.
+/// Consumers must be trusted contracts whose refreshGasPrice must always
+/// succeed and never consume excessive gas.
 interface GasPriceOracleConsumer {
     function refreshGasPrice() external;
 }

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -154,14 +154,6 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
         startGroupSelection(_genesisGroupSeed, msg.value);
     }
 
-    modifier onlyServiceContractUpgrader() {
-        require(
-            registry.serviceContractUpgraderFor(address(this)) == msg.sender,
-            "Not authorized"
-        );
-        _;
-    }
-
     modifier onlyServiceContract() {
         require(
             serviceContracts.contains(msg.sender),
@@ -218,14 +210,13 @@ contract KeepRandomBeaconOperator is ReentrancyGuard {
 
     /// @notice Adds service contract
     /// @param serviceContract Address of the service contract.
-    function addServiceContract(address serviceContract) public onlyServiceContractUpgrader {
-        serviceContracts.push(serviceContract);
-    }
+    function addServiceContract(address serviceContract) public {
+        require(
+            registry.serviceContractUpgraderFor(address(this)) == msg.sender,
+            "Not authorized"
+        );
 
-    /// @notice Removes service contract
-    /// @param serviceContract Address of the service contract.
-    function removeServiceContract(address serviceContract) public onlyServiceContractUpgrader {
-        serviceContracts.removeAddress(serviceContract);
+        serviceContracts.push(serviceContract);
     }
 
     /// @notice Triggers the selection process of a new candidate group.

--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -171,11 +171,10 @@ contract KeepRandomBeaconOperator is ReentrancyGuard, GasPriceOracleConsumer {
         address _keepRegistry,
         address _gasPriceOracle
     ) public {
-        registry = KeepRegistry(_keepRegistry);
-
         serviceContracts.push(_serviceContract);
-        stakingContract = TokenStaking(_tokenStaking);
 
+        stakingContract = TokenStaking(_tokenStaking);
+        registry = KeepRegistry(_keepRegistry);
         gasPriceOracle = GasPriceOracle(_gasPriceOracle);
 
         groups.stakingContract = stakingContract;

--- a/solidity/contracts/stubs/GasPriceOracleConsumerStub.sol
+++ b/solidity/contracts/stubs/GasPriceOracleConsumerStub.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.5.17;
+
+import "../GasPriceOracle.sol";
+
+contract GasPriceOracleConsumerStub is GasPriceOracleConsumer {
+    GasPriceOracle gasPriceOracle;
+
+    uint256 public gasPrice;
+
+    constructor(GasPriceOracle _gasPriceOracle) public {
+        gasPriceOracle = _gasPriceOracle;
+    }
+
+    function refreshGasPrice() public {
+        gasPrice = gasPriceOracle.gasPrice();
+    }
+}

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorCallbackStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorCallbackStub.sol
@@ -7,11 +7,13 @@ contract KeepRandomBeaconOperatorCallbackStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorDKGResultStub.sol
@@ -7,11 +7,13 @@ contract KeepRandomBeaconOperatorDKGResultStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         groupSelection.ticketSubmissionTimeout = 100;
     }

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorGroupSelectionStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorGroupSelectionStub.sol
@@ -6,11 +6,13 @@ contract KeepRandomBeaconOperatorGroupSelectionStub is KeepRandomBeaconOperator 
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         groupSelection.ticketSubmissionTimeout = 65;
 

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorInitializationStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorInitializationStub.sol
@@ -11,11 +11,13 @@ contract KeepRandomBeaconOperatorInitializationStub is KeepRandomBeaconOperator 
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
     }
 

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorMisbehaviorStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorMisbehaviorStub.sol
@@ -7,11 +7,13 @@ contract KeepRandomBeaconOperatorMisbehaviorStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingDKGStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingDKGStub.sol
@@ -11,11 +11,13 @@ contract KeepRandomBeaconOperatorPricingDKGStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingRewardsWithdrawStub.sol
@@ -10,11 +10,13 @@ contract KeepRandomBeaconOperatorPricingRewardsWithdrawStub is KeepRandomBeaconO
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         groupSize = 3;
         groups.groupActiveTime = 3;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorPricingStub.sol
@@ -7,11 +7,13 @@ contract KeepRandomBeaconOperatorPricingStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
     }
 

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorRewardsStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorRewardsStub.sol
@@ -7,11 +7,13 @@ contract KeepRandomBeaconOperatorRewardsStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         groups.groupActiveTime = 5;
         groups.relayEntryTimeout = 10;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorServicePricingStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorServicePricingStub.sol
@@ -11,11 +11,13 @@ contract KeepRandomBeaconOperatorServicePricingStub is KeepRandomBeaconOperator 
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorSlashingStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorSlashingStub.sol
@@ -7,11 +7,13 @@ contract KeepRandomBeaconOperatorSlashingStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;

--- a/solidity/contracts/stubs/KeepRandomBeaconOperatorStub.sol
+++ b/solidity/contracts/stubs/KeepRandomBeaconOperatorStub.sol
@@ -11,11 +11,13 @@ contract KeepRandomBeaconOperatorStub is KeepRandomBeaconOperator {
     constructor(
         address _serviceContract,
         address _stakingContract,
-        address _registryContract
+        address _registryContract,
+        address _gasPriceOracle
     ) KeepRandomBeaconOperator(
         _serviceContract,
         _stakingContract,
-        _registryContract
+        _registryContract,
+        _gasPriceOracle
     ) public {
         relayEntryTimeout = 10;
         groupSelection.ticketSubmissionTimeout = 69;

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -22,6 +22,7 @@ const DKGResultVerification = artifacts.require("./libraries/operator/DKGResultV
 const Reimbursements = artifacts.require("./libraries/operator/Reimbursements.sol");
 const DelayFactor = artifacts.require("./libraries/operator/DelayFactor.sol");
 const KeepRegistry = artifacts.require("./KeepRegistry.sol");
+const GasPriceOracle = artifacts.require("./GasPriceOracle.sol");
 
 let initializationPeriod = 43200; // ~12 hours
 const dkgContributionMargin = 1; // 1%
@@ -65,6 +66,7 @@ module.exports = async function(deployer, network) {
     KeepToken.address,
     TokenGrant.address
   );
+  await deployer.deploy(GasPriceOracle);
   await deployer.deploy(GroupSelection);
   await deployer.link(GroupSelection, KeepRandomBeaconOperator);
   await deployer.link(BLS, Groups);
@@ -96,7 +98,8 @@ module.exports = async function(deployer, network) {
     KeepRandomBeaconOperator, 
     KeepRandomBeaconService.address, 
     TokenStaking.address,
-    KeepRegistry.address
+    KeepRegistry.address,
+    GasPriceOracle.address
   );
 
   await deployer.deploy(

--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -5,6 +5,7 @@ const KeepRegistry = artifacts.require("./KeepRegistry.sol");
 const TokenStaking = artifacts.require("./TokenStaking.sol");
 const TokenStakingEscrow = artifacts.require("./TokenStakingEscrow.sol");
 const TokenGrant = artifacts.require("./TokenGrant.sol");
+const GasPriceOracle = artifacts.require("./GasPriceOracle.sol");
 
 module.exports = async function(deployer, network) {
     const keepRandomBeaconService = await KeepRandomBeaconService.deployed();
@@ -14,6 +15,7 @@ module.exports = async function(deployer, network) {
     const tokenStaking = await TokenStaking.deployed();
     const tokenStakingEscrow = await TokenStakingEscrow.deployed();
     const tokenGrant = await TokenGrant.deployed();
+    const gasPriceOracle = await GasPriceOracle.deployed();
 
     if (!(await keepRandomBeaconServiceImplV1.initialized())) {
         throw Error("keep random beacon service not initialized")
@@ -32,4 +34,6 @@ module.exports = async function(deployer, network) {
         keepRandomBeaconOperator.address,
         {from: operatorContractUpgrader}
     );
+
+    await gasPriceOracle.addConsumerContract(keepRandomBeaconOperator.address);
 };

--- a/solidity/test/TestGasPriceOracle.js
+++ b/solidity/test/TestGasPriceOracle.js
@@ -1,0 +1,175 @@
+const { accounts, contract, web3 } = require("@openzeppelin/test-environment")
+const { expectRevert, expectEvent } = require("@openzeppelin/test-helpers")
+const { time } = require("@openzeppelin/test-helpers")
+const { createSnapshot, restoreSnapshot } = require("./helpers/snapshot.js")
+
+const GasPriceOracle = contract.fromArtifact("GasPriceOracle");
+const GasPriceOracleConsumerStub = contract.fromArtifact("GasPriceOracleConsumerStub");
+
+const BN = web3.utils.BN
+const chai = require('chai');
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+const assert = chai.assert
+
+describe("GasPriceOracle", () => {
+
+    const owner = accounts[0]
+    const thirdParty = accounts[2]
+
+    let oracle
+
+    before(async () => {
+        oracle = await GasPriceOracle.new({from: owner})
+    })
+
+    beforeEach(async () => {
+        await createSnapshot()
+    })
+
+    afterEach(async () => {
+        await restoreSnapshot()
+    })
+
+    describe("when updating gas price", async () => {
+        it("does not let third party to begin the process", async () => {
+            await expectRevert(
+                oracle.beginGasPriceUpdate(123, {from: thirdParty}),
+                "caller is not the owner"
+            )
+        })
+
+        it("lets the owner to begin the process", async () => {
+            await oracle.beginGasPriceUpdate(123, {from: owner})
+            // ok, no revert
+        })
+
+        it("does not allow to finalize change without initiating it first", async () => {
+            await expectRevert(
+                oracle.finalizeGasPriceUpdate(),
+                "Change not initiated"
+            )
+        })
+
+        it("does not allow to finalize change before governance delay", async () => {
+            await oracle.beginGasPriceUpdate(123, {from: owner})
+            await time.increase(time.duration.minutes(359)) // 5 hours and 59 minutes
+            await expectRevert(
+                oracle.finalizeGasPriceUpdate(),
+                "Governance delay has not elapsed"
+            )
+        })
+
+        it("updates value when finalizing the change", async () => {
+            const newValue = 9129111
+            await oracle.beginGasPriceUpdate(newValue, {from: owner})
+            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await oracle.finalizeGasPriceUpdate()
+
+            expect(await oracle.gasPrice()).to.eq.BN(newValue)
+        })
+
+        it("does not allow to finalize the change twice", async () => {
+            const newValue = 1111
+            await oracle.beginGasPriceUpdate(newValue, {from: owner})
+            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await oracle.finalizeGasPriceUpdate()   
+            await expectRevert(
+                oracle.finalizeGasPriceUpdate(),
+                "Change not initiated"
+            )
+        })
+
+        it("emits an event when finalizing the change", async () => {
+            const newValue = web3.utils.toBN(55555)
+            await oracle.beginGasPriceUpdate(newValue, {from: owner})
+            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            const receipt = await oracle.finalizeGasPriceUpdate()
+            await expectEvent(receipt, "GasPriceUpdated", {
+                newValue: newValue
+            })
+        })
+    
+        it("notifies consumer contracts when finalizing the change", async () => {
+            const consumer = await GasPriceOracleConsumerStub.new(oracle.address)
+            await oracle.addConsumerContract(consumer.address, {from: owner});
+
+            const newValue = 545666
+            await oracle.beginGasPriceUpdate(newValue, {from: owner})
+            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await oracle.finalizeGasPriceUpdate()   
+
+            expect(await consumer.gasPrice()).to.eq.BN(newValue)
+        })
+
+        it("does not notify removed consumer contracts when finalizing the change", async () => {
+            const consumer1 = await GasPriceOracleConsumerStub.new(oracle.address)
+            const consumer2 = await GasPriceOracleConsumerStub.new(oracle.address)
+            const consumer3 = await GasPriceOracleConsumerStub.new(oracle.address)
+
+            await oracle.addConsumerContract(consumer1.address, {from: owner})
+            await oracle.addConsumerContract(consumer2.address, {from: owner})
+            await oracle.addConsumerContract(consumer3.address, {from: owner})
+
+            await oracle.removeConsumerContract(1, {from: owner})
+
+            const newValue = 156444
+            await oracle.beginGasPriceUpdate(newValue, {from: owner})
+            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await oracle.finalizeGasPriceUpdate()   
+
+            expect(await consumer1.gasPrice()).to.eq.BN(newValue)
+            expect(await consumer2.gasPrice()).to.eq.BN(0)
+            expect(await consumer3.gasPrice()).to.eq.BN(newValue)
+        })
+    })
+
+    describe("when managing consumer contracts", async () => {
+        it("does not allow third party to add new consumer contract", async () => {
+            const consumer = await GasPriceOracleConsumerStub.new(oracle.address)
+            await expectRevert(
+                oracle.addConsumerContract(consumer.address, {from: thirdParty}),
+                "Ownable: caller is not the owner."
+            )
+        })
+
+        it("allows the owner to add new consumer contract", async () => {
+            const consumer = await GasPriceOracleConsumerStub.new(oracle.address)
+            await oracle.addConsumerContract(consumer.address, {from: owner});
+            // ok, no revert
+        })
+
+        it("does not allow third party to remove consumer contract", async () => {
+            const consumer = await GasPriceOracleConsumerStub.new(oracle.address)
+            await oracle.addConsumerContract(consumer.address, {from: owner});
+            await expectRevert(
+                oracle.removeConsumerContract(0, {from: thirdParty}),
+                "Ownable: caller is not the owner."
+            ) 
+        })
+
+        it("allows the owner to remove consumer contract", async () => {
+            const consumer = await GasPriceOracleConsumerStub.new(oracle.address)
+            await oracle.addConsumerContract(consumer.address, {from: owner});
+            await oracle.removeConsumerContract(0, {from: owner})
+            // ok, no revert
+        })
+
+        it("allows to selectively remove consumer contracts", async () => {
+            const consumer1 = await GasPriceOracleConsumerStub.new(oracle.address)
+            const consumer2 = await GasPriceOracleConsumerStub.new(oracle.address)
+            const consumer3 = await GasPriceOracleConsumerStub.new(oracle.address)
+
+            await oracle.addConsumerContract(consumer1.address, {from: owner})
+            await oracle.addConsumerContract(consumer2.address, {from: owner})
+            await oracle.addConsumerContract(consumer3.address, {from: owner})
+
+            await oracle.removeConsumerContract(1, {from: owner})
+
+            const consumers = await oracle.getConsumerContracts()
+            assert.equal(consumers.length, 2)
+            assert.equal(consumers[0], consumer1.address)
+            assert.equal(consumers[1], consumer3.address)
+        })
+    })
+})

--- a/solidity/test/TestGasPriceOracle.js
+++ b/solidity/test/TestGasPriceOracle.js
@@ -53,7 +53,7 @@ describe("GasPriceOracle", () => {
 
         it("does not allow to finalize change before governance delay", async () => {
             await oracle.beginGasPriceUpdate(123, {from: owner})
-            await time.increase(time.duration.minutes(359)) // 5 hours and 59 minutes
+            await time.increase(time.duration.minutes(59))
             await expectRevert(
                 oracle.finalizeGasPriceUpdate(),
                 "Governance delay has not elapsed"
@@ -63,7 +63,7 @@ describe("GasPriceOracle", () => {
         it("updates value when finalizing the change", async () => {
             const newValue = 9129111
             await oracle.beginGasPriceUpdate(newValue, {from: owner})
-            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await time.increase(time.duration.minutes(61))
             await oracle.finalizeGasPriceUpdate()
 
             expect(await oracle.gasPrice()).to.eq.BN(newValue)
@@ -72,7 +72,7 @@ describe("GasPriceOracle", () => {
         it("does not allow to finalize the change twice", async () => {
             const newValue = 1111
             await oracle.beginGasPriceUpdate(newValue, {from: owner})
-            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await time.increase(time.duration.minutes(61))
             await oracle.finalizeGasPriceUpdate()   
             await expectRevert(
                 oracle.finalizeGasPriceUpdate(),
@@ -83,7 +83,7 @@ describe("GasPriceOracle", () => {
         it("emits an event when finalizing the change", async () => {
             const newValue = web3.utils.toBN(55555)
             await oracle.beginGasPriceUpdate(newValue, {from: owner})
-            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await time.increase(time.duration.minutes(61))
             const receipt = await oracle.finalizeGasPriceUpdate()
             await expectEvent(receipt, "GasPriceUpdated", {
                 newValue: newValue
@@ -96,7 +96,7 @@ describe("GasPriceOracle", () => {
 
             const newValue = 545666
             await oracle.beginGasPriceUpdate(newValue, {from: owner})
-            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await time.increase(time.duration.minutes(61))
             await oracle.finalizeGasPriceUpdate()   
 
             expect(await consumer.gasPrice()).to.eq.BN(newValue)
@@ -115,7 +115,7 @@ describe("GasPriceOracle", () => {
 
             const newValue = 156444
             await oracle.beginGasPriceUpdate(newValue, {from: owner})
-            await time.increase(time.duration.minutes(361)) // 6 hours and 1 minute
+            await time.increase(time.duration.minutes(61))
             await oracle.finalizeGasPriceUpdate()   
 
             expect(await consumer1.gasPrice()).to.eq.BN(newValue)

--- a/solidity/test/TestGasPriceOracle.js
+++ b/solidity/test/TestGasPriceOracle.js
@@ -122,6 +122,22 @@ describe("GasPriceOracle", () => {
             expect(await consumer2.gasPrice()).to.eq.BN(0)
             expect(await consumer3.gasPrice()).to.eq.BN(newValue)
         })
+
+        it("lets to overwrite the pending update", async () => {
+            await oracle.beginGasPriceUpdate(55555, {from: owner})
+            await time.increase(time.duration.minutes(59))
+
+            const overwritten = 66666
+            await oracle.beginGasPriceUpdate(overwritten, {from: owner})
+            
+            expect(await oracle.newGasPrice()).to.eq.BN(overwritten)
+            expect(await oracle.gasPriceChangeInitiated()).to.eq.BN(await time.latest())     
+            
+            await time.increase(time.duration.minutes(61))
+            await oracle.finalizeGasPriceUpdate()   
+
+            expect(await oracle.gasPrice()).to.eq.BN(overwritten)
+        })
     })
 
     describe("when managing consumer contracts", async () => {

--- a/solidity/test/TestGasPriceOracle.js
+++ b/solidity/test/TestGasPriceOracle.js
@@ -14,7 +14,7 @@ const assert = chai.assert
 
 describe("GasPriceOracle", () => {
 
-    const owner = accounts[0]
+    const owner = accounts[1]
     const thirdParty = accounts[2]
 
     let oracle

--- a/solidity/test/helpers/initContracts.js
+++ b/solidity/test/helpers/initContracts.js
@@ -7,6 +7,7 @@ const Groups = contract.fromArtifact('Groups');
 const DKGResultVerification = contract.fromArtifact("DKGResultVerification");
 const DelayFactor = contract.fromArtifact("DelayFactor");
 const Reimbursements = contract.fromArtifact("Reimbursements");
+const GasPriceOracle = contract.fromArtifact("GasPriceOracle");
 const KeepRegistry = contract.fromArtifact("KeepRegistry");
 const KeepToken = contract.fromArtifact('KeepToken');
 const TokenGrant = contract.fromArtifact('TokenGrant');
@@ -100,8 +101,9 @@ async function initContracts(TokenStaking, KeepRandomBeaconService,
           registry.address,
       ).encodeABI();
 
-  serviceContractProxy = await KeepRandomBeaconService.new(serviceContractImplV1.address, initialize, {from: accounts[0]});
+  const gasPriceOracle = await GasPriceOracle.new({from: accounts[0]})
 
+  serviceContractProxy = await KeepRandomBeaconService.new(serviceContractImplV1.address, initialize, {from: accounts[0]});
   serviceContract = await KeepRandomBeaconServiceImplV1.at(serviceContractProxy.address);
   // Initialize Keep Random Beacon operator contract
   const bls = await BLS.new({from: accounts[0]});
@@ -113,7 +115,6 @@ async function initContracts(TokenStaking, KeepRandomBeaconService,
   const groups = await Groups.new({from: accounts[0]});
   const delayFactor = await DelayFactor.new({from: accounts[0]});
   const dkgResultVerification = await DKGResultVerification.new({from: accounts[0]});
-
   const reimbursements = await Reimbursements.new({from: accounts[0]});
 
   await KeepRandomBeaconOperator.link("DelayFactor", delayFactor.address);
@@ -125,8 +126,10 @@ async function initContracts(TokenStaking, KeepRandomBeaconService,
     serviceContractProxy.address,
     stakingContract.address,
     registry.address,
+    gasPriceOracle.address,
     {from: accounts[0]}
   );
+  await gasPriceOracle.addConsumerContract(operatorContract.address, {from: accounts[0]});
 
   await registry.approveOperatorContract(operatorContract.address, {from: accounts[0]});
 

--- a/solidity/test/random_beacon_operator/TestManageServiceContracts.js
+++ b/solidity/test/random_beacon_operator/TestManageServiceContracts.js
@@ -9,9 +9,8 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
   let operatorContract
   let registry
   let serviceContract2 = accounts[1]
-  let serviceContract3 = accounts[2]
-  let serviceContractUpgrader = accounts[3]
-  let someoneElse = accounts[4]
+  let serviceContractUpgrader = accounts[2]
+  let someoneElse = accounts[3]
 
   let groupProfitAndEntryVerificationFee;
 
@@ -85,64 +84,6 @@ describe('KeepRandomBeaconOperator/ManageServiceContracts', () => {
         }
       )
       // ok, no revert
-    })
-  })
-
-  describe("removeServiceContract", async () => {
-    it("can be called by service contract upgrader", async () => {
-      await operatorContract.removeServiceContract(
-        serviceContract.address, 
-        {from: serviceContractUpgrader}
-      )
-      // ok, no revert
-    })
-
-    it("cannot be called by non-upgrader", async () => {
-      await expectRevert(
-        operatorContract.removeServiceContract(
-          serviceContract.address,
-          {from: someoneElse}
-        ),
-        "Not authorized"
-      )
-    })
-
-    it("removes service contract from the list", async () => {
-      await operatorContract.addServiceContract(
-        serviceContract2,
-        {from: serviceContractUpgrader}
-      )
-      await operatorContract.addServiceContract(
-        serviceContract3,
-        {from: serviceContractUpgrader}
-      )
-
-      await operatorContract.removeServiceContract(
-        serviceContract2,
-        {from: serviceContractUpgrader}
-      )
-
-      await expectRevert(
-        operatorContract.sign(
-          1, 
-          blsData.previousEntry, 
-          {
-            value: groupProfitAndEntryVerificationFee, 
-            from: serviceContract2
-          }
-        ),
-        "Caller is not a service contract"
-      )
-
-      await operatorContract.sign(
-        1, 
-        blsData.previousEntry, 
-        {
-          value: groupProfitAndEntryVerificationFee, 
-          from: serviceContract3
-        }
-      )
-      // ok, no revert - the second service contract is still there
     })
   })
 })

--- a/solidity/test/random_beacon_service/TestSelectOperator.js
+++ b/solidity/test/random_beacon_service/TestSelectOperator.js
@@ -4,14 +4,15 @@ const {initContracts} = require('../helpers/initContracts')
 const assert = require('chai').assert
 const {contract, accounts} = require("@openzeppelin/test-environment")
 const OperatorContract = contract.fromArtifact('KeepRandomBeaconOperatorStub')
-
+const GasPriceOracle = contract.fromArtifact("GasPriceOracle")
 
 describe('TestKeepRandomBeaconService/SelectOperator', function() {
 
   let registry, stakingContract, serviceContract, operatorContract, operatorContract2, operatorContract3;
 
   before(async () => {
-    let contracts = await initContracts(
+    const gasPriceOracle = await GasPriceOracle.new({from: accounts[0]})
+    const contracts = await initContracts(
       contract.fromArtifact('TokenStaking'),
       contract.fromArtifact('KeepRandomBeaconService'),
       contract.fromArtifact('KeepRandomBeaconServiceImplV1'),
@@ -28,12 +29,14 @@ describe('TestKeepRandomBeaconService/SelectOperator', function() {
       serviceContract.address, 
       stakingContract.address, 
       registry.address,
+      gasPriceOracle.address,
       {from: accounts[0]}
     );
     operatorContract3 = await OperatorContract.new(
       serviceContract.address, 
       stakingContract.address, 
       registry.address,
+      gasPriceOracle.address,
       {from: accounts[0]}
     );
 


### PR DESCRIPTION
Our 60Gwei gas price ceiling set in https://github.com/keep-network/keep-core/pull/1914 is not enough given the current gas price trends. 👨‍🌾 👩‍🌾 . 60Gwei ceiling we considered a bold move one month ago is not even 50% of today's current average gas price of 200Gwei, not even speaking about average 367Gwei price yesterday.

Until we come up with a pricing model taking gas price fluctuations into account we need to have a way to update gas price ceiling. That's what's implemented here.

`GasPriceOracle` is an ownable contract allowing the owner to modify the current gas price value with respect to 6 hours governance delay. The oracle notifies all subscribed contracts when the change is finalized and lets them pull the most recent gas price.

When working on this change I had to drop `removeServiceContract` function from `KeepRandomBeaconOperator` to save some bytecode and not exceed the maximum allowed contract size. There was little to no benefit of having this function. There are two places we guard by `onlyServiceContract` modifier: function triggering group selection and function requesting for a new entry signature. Both functions are designed and implemented in a way that is secure for staker and operator contract state even if the service contract gets compromised. It is quite unlikely we'll have to upgrade service contract at all but even if we do, we don't need to remove it from the allowed service contracts list.

