### PR TITLE
Improve log messages around the chain config and channel filter

### DIFF
--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -279,6 +279,8 @@ func (ec *ethereumChain) BlockCounter() (chain.BlockCounter, error) {
 }
 
 func fetchChainConfig(ec *ethereumChain) (*relaychain.Config, error) {
+	logger.Infof("fetching relay chain config")
+
 	groupSize, err := ec.keepRandomBeaconOperatorContract.GroupSize()
 	if err != nil {
 		return nil, fmt.Errorf("error calling GroupSize: [%v]", err)

--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -327,7 +327,9 @@ func (c *channel) SetFilter(filter net.BroadcastChannelFilter) error {
 
 	err := c.pubsub.UnregisterTopicValidator(c.name)
 	if err != nil {
-		logger.Errorf(
+		// That error can occur when the filter is set for the first time
+		// and no prior filter exists.
+		logger.Debugf(
 			"could not unregister topic validator for channel [%v]: [%v]",
 			c.name,
 			err,


### PR DESCRIPTION
Here we improve some logging:
- We add log info when starting to fetch the relay chain config
- We log the `UnregisterTopicValidator` error on the debug level because actually it doesn't indicate anything wrong