### PR TITLE
Deploy StakingPortBacker

### DIFF
--- a/solidity/contracts/stubs/OldTokenStaking.sol
+++ b/solidity/contracts/stubs/OldTokenStaking.sol
@@ -3,11 +3,13 @@ pragma solidity 0.5.17;
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Burnable.sol";
 import "../utils/OperatorParams.sol";
 
-// Staking contract stub for testing purposes that mimics the behavior of:
-// v1.0.1 TokenStaking (Mainnet)
-// 1.3.0-rc.0 TokenStaking (Ropsten)
+/// Staking contract stub for testing purposes that mimics the behavior of:
+/// - v1.0.1 TokenStaking (Mainnet)
+/// - 1.3.0-rc.0 TokenStaking (Ropsten)
 contract OldTokenStaking {
     using OperatorParams for uint256;
+
+    event Undelegated(address indexed operator, uint256 undelegatedAt);
 
     mapping(address => address[]) public ownerOperators;
     mapping(address => Operator) public operators;
@@ -37,6 +39,23 @@ contract OldTokenStaking {
 
     function authorizerOf(address _operator) public view returns (address) {
         return operators[_operator].authorizer;
+    }
+
+    function getDelegationInfo(address _operator)
+    public view returns (uint256 amount, uint256 createdAt, uint256 undelegatedAt) {
+        return operators[_operator].packedParams.unpack();
+    }
+
+    function undelegationPeriod() public view returns(uint256) {
+        return 5184000; // two months
+    }
+
+    function undelegate(address _operator) public {
+        uint256 oldParams = operators[_operator].packedParams;
+        operators[_operator].packedParams = oldParams.setUndelegationTimestamp(
+            block.timestamp
+        );
+        emit Undelegated(_operator, block.timestamp);
     }
 
     function setOperator(

--- a/solidity/contracts/stubs/OldTokenStaking.sol
+++ b/solidity/contracts/stubs/OldTokenStaking.sol
@@ -1,0 +1,57 @@
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Burnable.sol";
+import "../utils/OperatorParams.sol";
+
+// Staking contract stub for testing purposes that mimics the behavior of:
+// v1.0.1 TokenStaking (Mainnet)
+// 1.3.0-rc.0 TokenStaking (Ropsten)
+contract OldTokenStaking {
+    using OperatorParams for uint256;
+
+    mapping(address => address[]) public ownerOperators;
+    mapping(address => Operator) public operators;
+
+    struct Operator {
+        uint256 packedParams;
+        address owner;
+        address payable beneficiary;
+        address authorizer;
+    }
+
+    function operatorsOf(address _address) public view returns (address[] memory) {
+        return ownerOperators[_address];
+    }
+
+    function balanceOf(address _address) public view returns (uint256 balance) {
+        return operators[_address].packedParams.getAmount();
+    }
+
+    function ownerOf(address _operator) public view returns (address) {
+        return operators[_operator].owner;
+    }
+
+    function beneficiaryOf(address _operator) public view returns (address payable) {
+        return operators[_operator].beneficiary;
+    }
+
+    function authorizerOf(address _operator) public view returns (address) {
+        return operators[_operator].authorizer;
+    }
+
+    function setOperator(
+        address _owner,
+        address _operator,
+        address payable _beneficiary,
+        address _authorizer,
+        uint256 _value
+    ) public {
+        operators[_operator] = Operator(
+            OperatorParams.pack(_value, block.timestamp, 0),
+            _owner,
+            _beneficiary,
+            _authorizer
+        );
+        ownerOperators[_owner].push(_operator);
+    }
+}

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -62,12 +62,12 @@ module.exports = async function(deployer, network) {
   );
 
   let oldStakingContractAddress;
-  if (network === 'ropsten') {
-    // 1.3.0-rc.0 TokenStaking contract address
-    oldStakingContractAddress = '0x8117632eC1D514550b3880Bc68F9AC1A76c9C67B';
-  } else if (network === 'mainnet') {
+  if (network === 'mainnet') {
     // v1.0.1 TokenStaking contract address
     oldStakingContractAddress = '0x6D1140a8c8e6Fac242652F0a5A8171b898c67600';
+  } else if (network === 'ropsten') {
+    // 1.3.0-rc.0 TokenStaking contract address
+    oldStakingContractAddress = '0x8117632eC1D514550b3880Bc68F9AC1A76c9C67B';
   } else {
     const OldTokenStaking = artifacts.require("./stubs/OldTokenStaking.sol");
     await deployer.link(MinimumStakeSchedule, OldTokenStaking);

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -23,6 +23,7 @@ const Reimbursements = artifacts.require("./libraries/operator/Reimbursements.so
 const DelayFactor = artifacts.require("./libraries/operator/DelayFactor.sol");
 const KeepRegistry = artifacts.require("./KeepRegistry.sol");
 const GasPriceOracle = artifacts.require("./GasPriceOracle.sol");
+const StakingPortBacker = artifacts.require("./StakingPortBacker.sol");
 
 let initializationPeriod = 43200; // ~12 hours
 const dkgContributionMargin = 1; // 1%
@@ -59,6 +60,33 @@ module.exports = async function(deployer, network) {
     KeepRegistry.address,
     initializationPeriod
   );
+
+  let oldStakingContractAddress;
+  if (network === 'ropsten') {
+    // 1.3.0-rc.0 TokenStaking contract address
+    oldStakingContractAddress = '0x8117632eC1D514550b3880Bc68F9AC1A76c9C67B';
+  } else if (network === 'mainnet') {
+    // v1.0.1 TokenStaking contract address
+    oldStakingContractAddress = '0x6D1140a8c8e6Fac242652F0a5A8171b898c67600';
+  } else {
+    const OldTokenStaking = artifacts.require("./stubs/OldTokenStaking.sol");
+    await deployer.link(MinimumStakeSchedule, OldTokenStaking);
+    await deployer.link(GrantStaking, OldTokenStaking);
+    await deployer.link(Locks, OldTokenStaking);
+    await deployer.link(TopUps, OldTokenStaking);
+    await deployer.deploy(OldTokenStaking);
+    oldStakingContractAddress = OldTokenStaking.address;
+  }
+
+  console.log(`Deploying StakingPortBacker using old TokenStaking[${oldStakingContractAddress}]`);
+  await deployer.deploy(
+    StakingPortBacker,
+    KeepToken.address,
+    TokenGrant.address,
+    oldStakingContractAddress,
+    TokenStaking.address
+  );
+
   await deployer.deploy(PermissiveStakingPolicy);
   await deployer.deploy(GuaranteedMinimumStakingPolicy, TokenStaking.address);
   await deployer.deploy(


### PR DESCRIPTION
`StakingPortBacker` is deployed and linked to a proper version of old staking contract based on the network ID.

For 'ropsten', we link to contract `0x8117632eC1D514550b3880Bc68F9AC1A76c9C67B` 
https://ropsten.etherscan.io/address/0x8117632eC1D514550b3880Bc68F9AC1A76c9C67B

For 'mainnet', we link to contract `0x6D1140a8c8e6Fac242652F0a5A8171b898c67600` 
https://etherscan.io/address/0x6D1140a8c8e6Fac242652F0a5A8171b898c67600#code

For any other network, we deploy `OldTokenStakingStub` and link `StakingPortBacker` to it.