### PR TITLE
Require to report timeout if it happened before requesting new entry

### DIFF
--- a/solidity/contracts/KeepRandomBeaconOperator.sol
+++ b/solidity/contracts/KeepRandomBeaconOperator.sol
@@ -416,7 +416,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard, GasPriceOracleConsumer {
         uint256 entryVerificationAndProfitFee,
         uint256 callbackFee
     ) internal {
-        require(!isEntryInProgress() || hasEntryTimedOut(), "Beacon is busy");
+        require(!isEntryInProgress(), "Beacon is busy");
 
         uint256 groupIndex = groups.selectGroup(uint256(keccak256(previousEntry)));
 
@@ -578,6 +578,7 @@ contract KeepRandomBeaconOperator is ReentrancyGuard, GasPriceOracleConsumer {
     function reportRelayEntryTimeout() public {
         require(hasEntryTimedOut(), "Entry did not time out");
         groups.reportRelayEntryTimeout(currentRequestGroupIndex, groupSize);
+        currentRequestStartBlock = 0;
 
         // We could terminate the last active group. If that's the case,
         // do not try to execute signing again because there is no group

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -94,11 +94,6 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
       await expectRevert(requestRelayEntry(), "Beacon is busy");
     })
 
-    it("should be rejected when another request is in progress", async () => {
-      await requestRelayEntry()
-      await expectRevert(requestRelayEntry(), "Beacon is busy");
-    })
-
     it("should be rejected when another request is in progress even if it timed out", async () => {
       const timeout = await operatorContract.relayEntryTimeout()      
       await requestRelayEntry()

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -114,6 +114,7 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
       
       expect(await operatorContract.isEntryInProgress()).to.be.true;
       await expectEvent(receipt, "RelayEntryRequested") 
+      await expectRevert(requestRelayEntry(), "Beacon is busy")
     })
 
     it("should not be retried when there are no more active groups", async () => {

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -85,7 +85,7 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
 
   describe("request for a new relay entry", async () => {
     it("should be accepted when no other request is in progress", async () => {
-      let receipt = await requestRelayEntry()
+      const receipt = await requestRelayEntry()
       await expectEvent(receipt, 'RelayEntryRequested') 
     })
 
@@ -110,7 +110,7 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
       const timeout = await operatorContract.relayEntryTimeout()      
       await requestRelayEntry()
       await time.advanceBlockTo((await time.latestBlock()).add(timeout))
-      let receipt = await operatorContract.reportRelayEntryTimeout({from: thirdParty})
+      const receipt = await operatorContract.reportRelayEntryTimeout({from: thirdParty})
       await expectEvent(receipt, 'RelayEntryRequested') 
     })
   })

--- a/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
+++ b/solidity/test/random_beacon_operator/TestRelayEntryTimeout.js
@@ -1,14 +1,21 @@
-const blsData = require("../helpers/data.js")
-const {expectRevert, time} = require("@openzeppelin/test-helpers")
-const {initContracts} = require('../helpers/initContracts')
-const assert = require('chai').assert
+
+const {expectRevert, expectEvent, time} = require("@openzeppelin/test-helpers")
 const {createSnapshot, restoreSnapshot} = require("../helpers/snapshot.js")
 const {contract, accounts, web3} = require("@openzeppelin/test-environment")
+const blsData = require("../helpers/data.js")
+const stakeDelegate = require('../helpers/stakeDelegate')
+const {initContracts} = require('../helpers/initContracts')
 
 describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
-  let operatorContract, serviceContract, fee;
-  const blocksForward = web3.utils.toBN(20);
-  const requestCounter = 0;
+  const deployer = accounts[0],
+    serviceContractUpgrader = accounts[1]
+    serviceContract = accounts[2],
+    operator1 = accounts[3],
+    operator2 = accounts[4],
+    operator3 = accounts[5],
+    thirdParty = accounts[6]
+
+  let operatorContract, entryFee;
 
   before(async() => {
     let contracts = await initContracts(
@@ -18,20 +25,55 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
       contract.fromArtifact('KeepRandomBeaconOperatorStub')
     ); 
 
-    registryContract = contracts.registry
     operatorContract = contracts.operatorContract;
-    serviceContract = contracts.serviceContract;
-
-    await registryContract.setServiceContractUpgrader(
-      operatorContract.address, accounts[0], {from: accounts[0]}
+  
+    //
+    // register 'serviceContract' account as a new service contract so that
+    // we can hit the operator contract from this account for tests' simplicity
+    //
+    await contracts.registry.setServiceContractUpgrader(
+      operatorContract.address,
+      serviceContractUpgrader,
+      {from: deployer}
     )
-    await operatorContract.addServiceContract(accounts[0], {from: accounts[0]})  
+    await operatorContract.addServiceContract(
+      serviceContract,
+      {from: serviceContractUpgrader}
+    )  
 
-    await operatorContract.registerNewGroup(blsData.groupPubKey);
-    await operatorContract.setGroupMembers(blsData.groupPubKey, [accounts[0]]);
+    //
+    // stake 3 operators, authorize operator contract for all of them,
+    // and wait for the stake initialization period to complete
+    //
+    let token = contracts.token
+    let tokenStaking = contracts.stakingContract
+    const stake = web3.utils.toBN("500000000000000000000000") // 500 000 KEEP
+    await stakeDelegate(tokenStaking, token, deployer, operator1, operator1, operator1, stake)
+    await stakeDelegate(tokenStaking, token, deployer, operator2, operator2, operator2, stake)
+    await stakeDelegate(tokenStaking, token, deployer, operator3, operator3, operator3, stake)
+    await tokenStaking.authorizeOperatorContract(operator1, operatorContract.address, { from: operator1 })
+    await tokenStaking.authorizeOperatorContract(operator2, operatorContract.address, { from: operator2 })
+    await tokenStaking.authorizeOperatorContract(operator3, operatorContract.address, { from: operator3 })
+    await time.increase((await tokenStaking.initializationPeriod()).addn(1))
+    
+    //
+    // register two groups with operators staked in the previous step
+    //
+    await operatorContract.registerNewGroup("0x111")
+    await operatorContract.setGroupMembers("0x111", [operator1, operator2, operator3])
+    await operatorContract.registerNewGroup(blsData.groupPubKey)
+    await operatorContract.setGroupMembers(blsData.groupPubKey, [operator3, operator2, operator1])
 
-    fee = await serviceContract.entryFeeEstimate(0);
+    entryFee = await contracts.serviceContract.entryFeeEstimate(0);
   });
+
+  async function requestRelayEntry() {
+    return operatorContract.sign(
+      0,
+      blsData.previousEntry,
+      {value: entryFee, from: serviceContract}
+    )
+  }
 
   beforeEach(async () => {
     await createSnapshot()
@@ -41,61 +83,59 @@ describe("KeepRandomBeaconOperator/RelayEntryTimeout", function() {
     await restoreSnapshot()
   });
 
-  it("should not throw an error when entry is in progress and " +
-     "block number > relay entry timeout", async () => {
-    await operatorContract.sign(
-      requestCounter, blsData.previousEntry, {value: fee, from: accounts[0]}
-    );
+  describe("request for a new relay entry", async () => {
+    it("should be accepted when no other request is in progress", async () => {
+      let receipt = await requestRelayEntry()
+      await expectEvent(receipt, 'RelayEntryRequested') 
+    })
 
-    await time.advanceBlockTo(blocksForward.addn(await web3.eth.getBlockNumber()))
+    it("should be rejected when another request is in progress", async () => {
+      await requestRelayEntry()
+      await expectRevert(requestRelayEntry(), "Beacon is busy");
+    })
 
-    await operatorContract.sign(
-      requestCounter, blsData.previousEntry, {value: fee, from: accounts[0]}
-    );
+    it("should be rejected when another request is in progress", async () => {
+      await requestRelayEntry()
+      await expectRevert(requestRelayEntry(), "Beacon is busy");
+    })
 
-    assert.equal(
-      (await operatorContract.getPastEvents())[0].event, 
-      "RelayEntryRequested", 
-      "RelayEntryRequested event should occur on operator contract"
-    );
-  });
+    it("should be rejected when another request is in progress even if it timed out", async () => {
+      const timeout = await operatorContract.relayEntryTimeout()      
+      await requestRelayEntry()
+      await time.advanceBlockTo((await time.latestBlock()).add(timeout))    
+      await expectRevert(requestRelayEntry(), "Beacon is busy");
+    })
 
-  it("should throw an error when entry is in progress and " + 
-     "block number <= relay entry timeout", async () => {
-    await operatorContract.sign(
-      requestCounter, blsData.previousEntry, {value: fee, from: accounts[0]}
-    );
+    it("should be retried when another request timed out and it's been reported", async () => {
+      const timeout = await operatorContract.relayEntryTimeout()      
+      await requestRelayEntry()
+      await time.advanceBlockTo((await time.latestBlock()).add(timeout))
+      let receipt = await operatorContract.reportRelayEntryTimeout({from: thirdParty})
+      await expectEvent(receipt, 'RelayEntryRequested') 
+    })
+  })
 
-    await expectRevert(
-      operatorContract.sign(requestCounter, blsData.previousEntry, {value: fee, from: accounts[0]}), 
-      "Beacon is busy"
-    );
-  });
-
-  it("should not throw an error when entry is not in progress and " + 
-     "block number > relay entry timeout", async () => {
-    await operatorContract.sign(
-      requestCounter, blsData.previousEntry, {value: fee, from: accounts[0]}
+  describe("relay entry submission", async () => {
+    it("should be rejected after timeout", async() => {
+      const timeout = await operatorContract.relayEntryTimeout()      
+      await requestRelayEntry()
+      await time.advanceBlockTo((await time.latestBlock()).add(timeout))
+      await expectRevert(
+        operatorContract.relayEntry(blsData.groupSignature), 
+        "Entry timed out"
       );
+    })
 
-    assert.equal(
-      (await operatorContract.getPastEvents())[0].event, 
-      "RelayEntryRequested", 
-      "RelayEntryRequested event should occur on operator contract."
-    );
-  });
+    it("should be accepted when the previous request timed out and it's been reported", async () => {
+      const timeout = await operatorContract.relayEntryTimeout()      
+      await requestRelayEntry()
+      await time.advanceBlockTo((await time.latestBlock()).add(timeout))
+      await operatorContract.reportRelayEntryTimeout({from: thirdParty})
+      // 0x111 group gets terminated and bls.groupPubKey group is now asked
+      // to provide the signature
 
-  it("should not allow to submit relay entry after timeout", async () => {
-    await operatorContract.sign(
-      requestCounter, blsData.previousEntry, {value: fee, from: accounts[0]}
-    );
-
-    const relayEntryTimeout = await operatorContract.relayEntryTimeout()
-    await time.advanceBlockTo(relayEntryTimeout.addn(await web3.eth.getBlockNumber()))
-
-    await expectRevert(
-      operatorContract.relayEntry(blsData.groupSignature), 
-      "Entry timed out"
-    );
-  });
+      await operatorContract.relayEntry(blsData.groupSignature)
+      // ok, no revert
+    })
+  })
 });

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -159,7 +159,7 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
     // there is no other group in the system, we do not retry with another
     // group. reportRelayEntryTimeout reverts so that the last group may not
     // be slashed more than one time.
-    it("reverts when reported for the last active group", async () => {
+    it("reverts when already reported for the last active group", async () => {
       await time.advanceBlockTo(relayRequestStartBlock.addn(10))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
       await expectRevert(

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -177,12 +177,12 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       await time.advanceBlockTo(relayRequestStartBlock.addn(10))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
 
-      let groupCount = await operatorContract.numberOfGroups()
+      const groupCount = await operatorContract.numberOfGroups()
       expect(groupCount).to.eq.BN(0)
       // no more groups
 
-      let dkgGasEstimate = await operatorContract.dkgGasEstimate();
-      let gasPriceCeiling = await operatorContract.gasPriceCeiling();
+      const dkgGasEstimate = await operatorContract.dkgGasEstimate();
+      const gasPriceCeiling = await operatorContract.gasPriceCeiling();
       await operatorContract.genesis({value: dkgGasEstimate.mul(gasPriceCeiling), from: tattletale});
       // ok, no revert
     })

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -168,24 +168,7 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
       )
     })
 
-    // There is only one active group in the system and that group did not
-    // produce relay entry on time. Relay entry timeout is reported but since
-    // there is no other group in the system, we do not retry with another
-    // group. Entry is not marked as timed out to not block the beacon.
-    // With no groups, anyone can genesis again.
-    it("allows to genesis if reported for the last active group", async () => {
-      await time.advanceBlockTo(relayRequestStartBlock.addn(10))
-      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
 
-      const groupCount = await operatorContract.numberOfGroups()
-      expect(groupCount).to.eq.BN(0)
-      // no more groups
-
-      const dkgGasEstimate = await operatorContract.dkgGasEstimate();
-      const gasPriceCeiling = await operatorContract.gasPriceCeiling();
-      await operatorContract.genesis({value: dkgGasEstimate.mul(gasPriceCeiling), from: tattletale});
-      // ok, no revert
-    })
 
     it("does not revert in the first block relay entry timed out", async () => {
       await time.advanceBlockTo(relayRequestStartBlock.addn(10))

--- a/solidity/test/random_beacon_operator/TestSlashing.js
+++ b/solidity/test/random_beacon_operator/TestSlashing.js
@@ -157,16 +157,34 @@ describe('KeepRandomBeaconOperator/Slashing', function () {
     // There is only one active group in the system and that group did not
     // produce relay entry on time. Relay entry timeout is reported but since
     // there is no other group in the system, we do not retry with another
-    // group. This way, relay entry is timed out until someone requests for
-    // another entry and we need to make sure the group cannot be slashed more
-    // than one time.
-    it("reverts when already reported for the last active group", async () => {
+    // group. reportRelayEntryTimeout reverts so that the last group may not
+    // be slashed more than one time.
+    it("reverts when reported for the last active group", async () => {
       await time.advanceBlockTo(relayRequestStartBlock.addn(10))
       await operatorContract.reportRelayEntryTimeout({ from: tattletale })
       await expectRevert(
         operatorContract.reportRelayEntryTimeout({ from: tattletale }),
-        "Group has been already terminated"
+        "Entry did not time out"
       )
+    })
+
+    // There is only one active group in the system and that group did not
+    // produce relay entry on time. Relay entry timeout is reported but since
+    // there is no other group in the system, we do not retry with another
+    // group. Entry is not marked as timed out to not block the beacon.
+    // With no groups, anyone can genesis again.
+    it("allows to genesis if reported for the last active group", async () => {
+      await time.advanceBlockTo(relayRequestStartBlock.addn(10))
+      await operatorContract.reportRelayEntryTimeout({ from: tattletale })
+
+      let groupCount = await operatorContract.numberOfGroups()
+      expect(groupCount).to.eq.BN(0)
+      // no more groups
+
+      let dkgGasEstimate = await operatorContract.dkgGasEstimate();
+      let gasPriceCeiling = await operatorContract.gasPriceCeiling();
+      await operatorContract.genesis({value: dkgGasEstimate.mul(gasPriceCeiling), from: tattletale});
+      // ok, no revert
     })
 
     it("does not revert in the first block relay entry timed out", async () => {


### PR DESCRIPTION
We were allowing to request a new entry if the previous timed out and this fact has not been reported. This could lead do group members avoiding slashing by submitting a new entry before someone can report the timeout (gas auction).

It is fixed now by requiring to report entry timeout before a new entry can be requested. All clients monitor the entry - those participating and not participating in the signing group - so entry timeout is reported as soon as possible and there is no risk for blocking the beacon.