### PR TITLE
Fix fetching past events

### DIFF
--- a/solidity/dashboard/src/services/tbtc-rewards.service.js
+++ b/solidity/dashboard/src/services/tbtc-rewards.service.js
@@ -11,6 +11,7 @@ import {
 } from "../contracts"
 import web3Utils from "web3-utils"
 import { isSameEthAddress } from "../utils/general.utils"
+import { isEmptyArray } from "../utils/array.utils"
 
 const fetchTBTCRewards = async (web3Context, beneficiaryAddress) => {
   const transferEventSearchFilter = {
@@ -25,13 +26,16 @@ const fetchTBTCRewards = async (web3Context, beneficiaryAddress) => {
     transferEventSearchFilter
   )
 
+  const depositCreatedFilterParam = isEmptyArray(transferEventToBeneficiary)
+    ? {}
+    : {
+        _depositContractAddress: transferEventToBeneficiary.map(
+          (_) => _.returnValues.from
+        ),
+      }
   const depositCreatedSearchFilter = {
     fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER[TBTC_SYSTEM_CONTRACT_NAME],
-    filter: {
-      _depositContractAddress: transferEventToBeneficiary.map(
-        (_) => _.returnValues.from
-      ),
-    },
+    filter: depositCreatedFilterParam,
   }
 
   const depositCreatedEvents = await contractService.getPastEvents(

--- a/solidity/dashboard/src/services/token-staking.service.js
+++ b/solidity/dashboard/src/services/token-staking.service.js
@@ -11,6 +11,7 @@ import {
   ContractsLoaded,
 } from "../contracts"
 import { isSameEthAddress } from "../utils/general.utils"
+import { isEmptyArray } from "../utils/array.utils"
 
 const fetchDelegatedTokensData = async (web3Context) => {
   const { yourAddress, grantContract, eth, web3 } = web3Context
@@ -218,12 +219,15 @@ export const getOperatorsOfOwner = async (owner) => {
 
   // Fetch `StakeOwnershipTransferred` by operator field. We need to check more recent event
   // to make sure the delegation ownership has not been transferred.
-  const transferEventsByOperators = (
-    await stakingContract.getPastEvents("StakeOwnershipTransferred", {
-      fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingContract,
-      filter: { operator: operators },
-    })
-  ).reduce(reduceByOperator, {})
+  let transferEventsByOperators = {}
+  if (!isEmptyArray(operators)) {
+    transferEventsByOperators = (
+      await stakingContract.getPastEvents("StakeOwnershipTransferred", {
+        fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingContract,
+        filter: { operator: operators },
+      })
+    ).reduce(reduceByOperator, {})
+  }
 
   return operators.filter((operator) => {
     if (!transferEventsByOperators.hasOwnProperty(operator)) {

--- a/solidity/dashboard/src/services/tokens-page.service.js
+++ b/solidity/dashboard/src/services/tokens-page.service.js
@@ -210,12 +210,15 @@ const getOwnedDelegations = async (
   const operators = await getOperatorsOfOwner(yourAddress)
 
   // Scan `OperatorStaked` event by operator(indexed param) to get authorizer and beneeficiary.
-  const operatorToDetails = (
-    await stakingContract.getPastEvents("OperatorStaked", {
-      fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingContract,
-      filter: { operator: operators },
-    })
-  ).reduce(toOperator, {})
+  let operatorToDetails = {}
+  if (!isEmptyArray(operators)) {
+    operatorToDetails = (
+      await stakingContract.getPastEvents("OperatorStaked", {
+        fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingContract,
+        filter: { operator: operators },
+      })
+    ).reduce(toOperator, {})
+  }
 
   return await getDelegations(
     operatorToDetails,
@@ -231,15 +234,18 @@ const getAllGranteeOperators = async (
 ) => {
   const { stakingContract, tokenStakingEscrow } = await ContractsLoaded
 
-  const escrowRedelegation = await tokenStakingEscrow.getPastEvents(
-    "DepositRedelegated",
-    {
-      fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.tokenStakingEscrow,
-      filter: {
-        grantId: grantIds,
-      },
-    }
-  )
+  let escrowRedelegation = []
+  if (!isEmptyArray(grantIds)) {
+    escrowRedelegation = await tokenStakingEscrow.getPastEvents(
+      "DepositRedelegated",
+      {
+        fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.tokenStakingEscrow,
+        filter: {
+          grantId: grantIds,
+        },
+      }
+    )
+  }
 
   const newOperatorToGrantId = escrowRedelegation.reduce((reducer, event) => {
     const {
@@ -269,12 +275,16 @@ const getAllGranteeOperators = async (
     (operator) => !oldOperators.includes(operator)
   )
 
-  const operatorsDetailsMap = (
-    await stakingContract.getPastEvents("OperatorStaked", {
-      fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingContract,
-      filter: { operator: activeOperators },
-    })
-  ).reduce(toOperator, {})
+  let operatorsDetailsMap = {}
+  if (!isEmptyArray(activeOperators)) {
+    operatorsDetailsMap = (operatorsDetailsMap = await stakingContract.getPastEvents(
+      "OperatorStaked",
+      {
+        fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingContract,
+        filter: { operator: activeOperators },
+      }
+    )).reduce(toOperator, {})
+  }
 
   const allOperatorsDetails = {
     ...operatorsDetailsMap,


### PR DESCRIPTION
If we want to get past events eg. by all operators, and pass an empty array to indexed param eg. `{filter: { operator: [] }}` to the [`getPastEvent`](https://web3js.readthedocs.io/en/v1.2.0/web3-eth-contract.html#getpastevents), all emitted events will be returned. To avoid this, before calling `getPastEvent` with an empty array for the indexed param, we check that the filter param is not an empty array and then call ` getPastEvent` function.
