### PR TITLE
Log connection close failures on debug level

### DIFF
--- a/pkg/net/libp2p/authenticated_connection.go
+++ b/pkg/net/libp2p/authenticated_connection.go
@@ -60,7 +60,7 @@ func newAuthenticatedInboundConnection(
 		// close the conn before returning (if it hasn't already)
 		// otherwise we leak.
 		if closeErr := ac.Close(); closeErr != nil {
-			logger.Errorf("could not close the connection: [%v]", closeErr)
+			logger.Debugf("could not close the connection: [%v]", closeErr)
 		}
 
 		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
@@ -68,7 +68,7 @@ func newAuthenticatedInboundConnection(
 
 	if err := ac.checkFirewallRules(); err != nil {
 		if closeErr := ac.Close(); closeErr != nil {
-			logger.Errorf("could not close the connection: [%v]", closeErr)
+			logger.Debugf("could not close the connection: [%v]", closeErr)
 		}
 
 		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
@@ -110,7 +110,7 @@ func newAuthenticatedOutboundConnection(
 
 	if err := ac.runHandshakeAsInitiator(); err != nil {
 		if closeErr := ac.Close(); closeErr != nil {
-			logger.Errorf("could not close the connection: [%v]", closeErr)
+			logger.Debugf("could not close the connection: [%v]", closeErr)
 		}
 
 		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
@@ -118,7 +118,7 @@ func newAuthenticatedOutboundConnection(
 
 	if err := ac.checkFirewallRules(); err != nil {
 		if closeErr := ac.Close(); closeErr != nil {
-			logger.Errorf("could not close the connection: [%v]", closeErr)
+			logger.Debugf("could not close the connection: [%v]", closeErr)
 		}
 
 		return nil, fmt.Errorf("connection handshake failed: [%v]", err)


### PR DESCRIPTION
When working on Gosec integration (https://github.com/keep-network/keep-core/pull/1996) we updated the authenticated connection handshake code to log connection close errors on ERROR level. This is not perfect, since when there is a lot of nodes trying to connect we observe a bunch of errors:
```
2020-09-01T16:30:44.976Z	ERROR	keep-net-libp2p	could not close the connection:
[Multiple errors: close tcp4 10.0.3.9:3001->78.141.221.231:1024: use of closed network connection]
```

A quick investigation shows that those nodes decided to drop the connection on their side so we are trying to close a connection that is already closed. Logging it on ERROR level is not a perfect solution but we also shouldn't ignore it. We decided to log this problem on DEBUG level for now and open an issue (#2029) to further investigate and decide what's the best solution for that.