### PR TITLE
Voluminous Containers: Fix initcontainers that require keyfile

### DIFF
--- a/infrastructure/kube/keep-dev/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-0-statefulset.yaml
@@ -39,6 +39,19 @@ spec:
         type: beacon
         id: '0'
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-0-keyfile
+              path: account-0-keyfile
       containers:
       - name: keep-client-0
         image: gcr.io/keep-dev-fe24/keep-client
@@ -63,19 +76,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-0-keyfile
-              path: account-0-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
@@ -119,4 +119,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-dev/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-1-statefulset.yaml
@@ -39,6 +39,19 @@ spec:
         type: beacon
         id: '1'
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-1-keyfile
+              path: account-1-keyfile
       containers:
       - name: keep-client-1
         image: gcr.io/keep-dev-fe24/keep-client
@@ -63,19 +76,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-1-keyfile
-              path: account-1-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
@@ -119,4 +119,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-dev/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-2-statefulset.yaml
@@ -39,6 +39,19 @@ spec:
         type: beacon
         id: '2'
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-2-keyfile
+              path: account-2-keyfile
       containers:
       - name: keep-client-0
         image: gcr.io/keep-dev-fe24/keep-client
@@ -63,19 +76,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-2-keyfile
-              path: account-2-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
@@ -119,4 +119,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-dev/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-3-statefulset.yaml
@@ -39,6 +39,19 @@ spec:
         type: beacon
         id: '3'
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-3-keyfile
+              path: account-3-keyfile
       containers:
       - name: keep-client-0
         image: gcr.io/keep-dev-fe24/keep-client
@@ -63,19 +76,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-3-keyfile
-              path: account-3-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
@@ -119,4 +119,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-dev/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-4-statefulset.yaml
@@ -39,6 +39,19 @@ spec:
         type: beacon
         id: '4'
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-4-keyfile
+              path: account-4-keyfile
       containers:
       - name: keep-client-0
         image: gcr.io/keep-dev-fe24/keep-client
@@ -63,19 +76,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-4-keyfile
-              path: account-4-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
@@ -119,4 +119,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
@@ -41,6 +41,19 @@ spec:
         network: ropsten
     spec:
       containers:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-0-keyfile
+              path: account-0-keyfile
       - name: keep-client-0
         image: gcr.io/keep-test-f3e0/keep-client
         imagePullPolicy: Always
@@ -64,19 +77,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-0-keyfile
-              path: account-0-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
@@ -120,4 +120,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
@@ -40,6 +40,19 @@ spec:
         id: '1'
         network: ropsten
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-1-keyfile
+              path: account-1-keyfile
       containers:
       - name: keep-client-1
         image: gcr.io/keep-test-f3e0/keep-client
@@ -64,19 +77,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-1-keyfile
-              path: account-1-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
@@ -120,4 +120,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -40,6 +40,19 @@ spec:
         id: '2'
         network: ropsten
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-2-keyfile
+              path: account-2-keyfile
       containers:
       - name: keep-client-2
         image: gcr.io/keep-test-f3e0/keep-client
@@ -64,19 +77,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-2-keyfile
-              path: account-2-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
@@ -125,4 +125,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
@@ -40,6 +40,19 @@ spec:
         id: '3'
         network: ropsten
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-3-keyfile
+              path: account-3-keyfile
       containers:
       - name: keep-client-3
         image: gcr.io/keep-test-f3e0/keep-client
@@ -64,19 +77,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-3-keyfile
-              path: account-3-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
@@ -120,4 +120,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
@@ -40,6 +40,19 @@ spec:
         id: '4'
         network: ropsten
     spec:
+      volumes:
+      - name: keep-client-config
+        persistentVolumeClaim:
+          claimName: keep-client-config
+      - name: keep-client-data
+        persistentVolumeClaim:
+          claimName: keep-client-data
+      - name: eth-account-keyfile
+        configMap:
+          name: eth-account-info
+          items:
+            - key: account-4-keyfile
+              path: account-4-keyfile
       containers:
       - name: keep-client-4
         image: gcr.io/keep-test-f3e0/keep-client
@@ -64,19 +77,6 @@ spec:
           - name: eth-account-keyfile
             mountPath: /mnt/keep-client/keyfile
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
-      volumes:
-      - name: keep-client-config
-        persistentVolumeClaim:
-          claimName: keep-client-config
-      - name: keep-client-data
-        persistentVolumeClaim:
-          claimName: keep-client-data
-      - name: eth-account-keyfile
-        configMap:
-          name: eth-account-info
-          items:
-            - key: account-4-keyfile
-              path: account-4-keyfile
       initContainers:
       - name: initcontainer-provision-keep-client
         image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
@@ -120,4 +120,6 @@ spec:
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config
+          - name: eth-account-keyfile
+            mountPath: /mnt/keep-client/keyfile
         command: ["node", "/tmp/provision-keep-client.js"]

--- a/infrastructure/kube/keep-test/keep-network-ropsten-relay-request-cronjob.yaml
+++ b/infrastructure/kube/keep-test/keep-network-ropsten-relay-request-cronjob.yaml
@@ -18,6 +18,18 @@ spec:
       activeDeadlineSeconds: 600
       template:
         spec:
+          volumes:
+          - name: relay-requester-config
+            persistentVolumeClaim:
+              claimName: relay-requester-config
+          - name: eth-account-keyfile
+            configMap:
+              name: eth-account-info
+              items:
+                - key: relay-requester-keyfile
+                  path: relay-requester-keyfile
+          restartPolicy: OnFailure
+
           containers:
           - name: keep-network-relay-request-submitter
             image: gcr.io/keep-test-f3e0/keep-client
@@ -37,18 +49,6 @@ spec:
               - name: eth-account-keyfile
                 mountPath: /mnt/keep-client/keyfile
             command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "relay", "request"]
-          volumes:
-          - name: relay-requester-config
-            persistentVolumeClaim:
-              claimName: relay-requester-config
-          - name: eth-account-keyfile
-            configMap:
-              name: eth-account-info
-              items:
-                - key: relay-requester-keyfile
-                  path: relay-requester-keyfile
-          restartPolicy: OnFailure
-
           initContainers:
           - name: initcontainer-provision-keep-client
             image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
@@ -90,6 +90,8 @@ spec:
             volumeMounts:
               - name: relay-requester-config
                 mountPath: /mnt/keep-client/config
+              - name: eth-account-keyfile
+                mountPath: /mnt/keep-client/keyfile
             command: ["node", "/tmp/provision-keep-client.js"]
 ---
 apiVersion: v1


### PR DESCRIPTION
The provisioning script used in init containers recently moved to
reading Ethereum key and account information from a keyfile rather than
from the environment; however, the corresponding Kubernetes stateful set
and cron job configurations were not updated to mount the keyfile for
the initcontainer (it was already being mounted for the container
proper).

The initcontainer now has the keyfile mounted properly. In the process,
moved volumes to the top of the spec, since they are now used in both of
the subsequent sections.

This state is currently deployed on keep-test for client-2 and client-3,
as well as the relay requester.