### PR TITLE
Fix subscription to a `Undelegated` event on the Operator page

### DIFF
--- a/solidity/dashboard/src/components/PendingUndelegation.jsx
+++ b/solidity/dashboard/src/components/PendingUndelegation.jsx
@@ -39,7 +39,7 @@ const PendingUndelegation = ({ latestUnstakeEvent, data, setData }) => {
     setData({
       ...data,
       undelegationCompletedAt,
-      delegatedStatus: "UNDELEGATED",
+      delegationStatus: "UNDELEGATED",
     })
   })
 


### PR DESCRIPTION
Closes: #1901 

We should update `delegationStatus` field instead of `delegatedStatus` when subscribing to the `Undelegated` event on the `Operations` page.