### PR TITLE
Replace icons on the Overview page

### DIFF
--- a/solidity/dashboard/src/components/TokenOverview.jsx
+++ b/solidity/dashboard/src/components/TokenOverview.jsx
@@ -49,7 +49,7 @@ const TokenOverview = ({
         style={boxWrapperStyle}
         className="flex column center space-between mt-1"
       >
-        <Icons.MoneyWalletOpen />
+        <Icons.GrantContextIcon />
         <h4 className="text-grey-70">Granted Tokens</h4>
         <TokenAmount
           currencyIconProps={{ width: 18, heigh: 18 }}
@@ -70,7 +70,7 @@ const TokenOverview = ({
         style={boxWrapperStyle}
         className="flex column center space-between mt-1"
       >
-        <Icons.GrantContextIcon />
+        <Icons.MoneyWalletOpen />
         <h4 className="text-grey-70">Owned Tokens</h4>
         <TokenAmount
           currencyIconProps={{ width: 18, heigh: 18 }}


### PR DESCRIPTION
The `open wallet` icon should be in `owned` card instead of `granted`, since this icon refsto tokens in the user's wallet. And `grant` icon should be in `granted` card insted of `owned.`

Fix:
![obraz](https://user-images.githubusercontent.com/57687279/91983383-e041b280-ed2b-11ea-805b-a31e5ec4c5ef.png)

bug:
![obraz](https://user-images.githubusercontent.com/57687279/91983524-1848f580-ed2c-11ea-9d4b-f9c8984ac634.png)

