### PR TITLE
Updated dashboard lockfile with the newest keep-* and tbtc

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1443,34 +1443,34 @@
       },
       "dependencies": {
         "@ledgerhq/devices": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.21.0.tgz",
-          "integrity": "sha512-65XZgD2ykK7AJkcJuNEP8WD43HDkudA7NfB34U1T6pmPC6AgWoRYDNpJ23XQ8eiAImETlxv7FaDGUXSEpIQMGQ==",
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.22.0.tgz",
+          "integrity": "sha512-oJxhee/zlHmIx66zvQQTSpIsHOiiLjALemTX9oUtB4xQwFvoiptPnBCeTDTM9teode7wzk7oE9qdUAZuat+nCg==",
           "requires": {
-            "@ledgerhq/errors": "^5.21.0",
-            "@ledgerhq/logs": "^5.21.0",
-            "rxjs": "^6.6.0"
+            "@ledgerhq/errors": "^5.22.0",
+            "@ledgerhq/logs": "^5.22.0",
+            "rxjs": "^6.6.2"
           }
         },
         "@ledgerhq/errors": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.21.0.tgz",
-          "integrity": "sha512-sGfXoaVGfzrhnexu2TEdgL2FAjM7PUeobWdDBx3DJKE+ARje1y+i5+qg7gyvQL+9k4FV7mW2xMOcnUI3T2Zw0Q=="
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.22.0.tgz",
+          "integrity": "sha512-XDT0meBn39+q+JWzUFXmiFbVYLTy+uHRFMb9napcxyZ0Q/MdKkle9/vkgtvRHjPIkGobklXpyefsgH3BZQHukA=="
         },
         "@ledgerhq/hw-transport": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.21.0.tgz",
-          "integrity": "sha512-emVoy+ZEA19z+g6CsDcliVRRYDn4RzdH+zW9F37Z22uoMWslx2VNa+KdcKijmS3V3mkSLjle1cjwprPh61G8hQ==",
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.22.0.tgz",
+          "integrity": "sha512-MFfkVGYMYnr6fI4XGnJQNLd36JIrRpvd5WBmVSDhCO3UKUER2fJ9koVBGc97o7yXtE5IAlJKF+nR9HZJIa0lRQ==",
           "requires": {
-            "@ledgerhq/devices": "^5.21.0",
-            "@ledgerhq/errors": "^5.21.0",
+            "@ledgerhq/devices": "^5.22.0",
+            "@ledgerhq/errors": "^5.22.0",
             "events": "^3.2.0"
           }
         },
         "@ledgerhq/logs": {
-          "version": "5.21.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.21.0.tgz",
-          "integrity": "sha512-eyPXrKfQ+HSLcITB5MdSWhXlImE2qKWTLT2u6l+a9wiCZl5yimSqn0uC5evxaP0McKOW0wSntgfj+gOoKv+Paw=="
+          "version": "5.22.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.22.0.tgz",
+          "integrity": "sha512-jV4mJxD1aieORm+sK9bYakQd9GMLd7KAxgt2IaxhrTU+QD5Ne47mxQOTys9p7f5w25ujs3R+Px2t3KiMRASHtg=="
         },
         "@types/node": {
           "version": "12.12.54",
@@ -2244,9 +2244,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.3.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0-rc.0.tgz",
-      "integrity": "sha512-+IxDsKYn8zC8Sut5UM5Mb7pIyySJmbpT6yQXZ2fnEk95QuFEK6IguSE2qKF9n4KNPCyxXkeD5qRTwGu9xNsKiw==",
+      "version": "1.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0-rc.1.tgz",
+      "integrity": "sha512-u12pMnmTRbwx7OYeZOzM3+7U4eE7tRco/FZwv/0kKVdwVFfsETVJD9s4SLOdwUrzzG13YNQHfYpD0blC2EYA3Q==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -2254,12 +2254,12 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.2.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-rc.1.tgz",
-      "integrity": "sha512-16++cWpAun6G6rUu1aQl+5YePgBEIEWWaLiwaOTjWpwHd9DE7h3a1jo7S+geEqH7l+zWCW9t3+HmY7cp65K+oQ==",
+      "version": "1.2.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-rc.3.tgz",
+      "integrity": "sha512-jcMXyZR/eZKNpgrVrD8WBAuq97y11OFFvWsLVNyssZdSRpM8D2GW4m1c2yjEE1gTePDYr4POR0wGCxkgBJ96KQ==",
       "requires": {
         "@keep-network/keep-core": ">1.3.0-rc <1.3.0",
-        "@keep-network/sortition-pools": "1.1.0",
+        "@keep-network/sortition-pools": "1.1.1",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
         "solidity-bytes-utils": "0.0.7"
@@ -2273,17 +2273,17 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.0.tgz",
-      "integrity": "sha512-4mPp6f6HpfEdjfFM/PHwqabfnWc91gldbcIQEoS6bSfrqfrgFgmmOT6r9WO+Sqw9bR6Ve1tPWp3jpu6ufkPDww==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.1.tgz",
+      "integrity": "sha512-zdaVTew4xfDe65ZfO7B0TibpYVtm6iFB8ixvSqyzT+l6CPSZpj0IH/X0NIKPFTztL1yiibEsAUj3IaeppS3UmA==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@keep-network/tbtc": {
-      "version": "1.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0-rc.0.tgz",
-      "integrity": "sha512-IpeijbystYJFfr/OHwnSkCUBGm+cZOkvnEFr9FvP9TemX0xhQBbB+647eeasukuneflgNn9QrZJZXJHDzKVcCg==",
+      "version": "1.1.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0-rc.1.tgz",
+      "integrity": "sha512-v407R7Gj/R8rpk+cOuB9O6izn/rrYSL2HPDqQ4oPFdghYmkRjidoy4qOrzxIhQIvbG9hg4CJJongABrqNlyMhA==",
       "requires": {
         "@keep-network/keep-ecdsa": ">1.2.0-rc <1.2.0",
         "@summa-tx/bitcoin-spv-sol": "^3.1.0",
@@ -2730,9 +2730,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
         }
       }
     },
@@ -23503,9 +23503,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
-      "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw=="
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.13.tgz",
+      "integrity": "sha512-USnpjJkD8St+wyshy154lF74JeauNCd8vrcusSlWjSFWitXzl7ZSuCunA/XxeVLqBv6DShrSfFMYdwGZ7x4hOw=="
     },
     "got": {
       "version": "9.6.0",


### PR DESCRIPTION
The most recent versions are:
- `@keep-network/keep-core`: 1.3.0-rc.1
- `@keep-network/keep-ecdsa`: 1.2.0-rc.3
- `@keep-network/tbtc`: 1.1.0-rc.1