### PR TITLE
Updated locked keep-core dependency for faucet

### DIFF
--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/package-lock.json
@@ -284,9 +284,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.2.4-rc.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.4-rc.1.tgz",
-      "integrity": "sha512-Pda3oitEIcNC9diiNfFOi5SPiK8TNtl/JW8ucOwYMSCHbQJmrxITeJ6PGS5hwMdhf81lToBMYvhwpf3Slv+D7w==",
+      "version": "1.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0-rc.1.tgz",
+      "integrity": "sha512-u12pMnmTRbwx7OYeZOzM3+7U4eE7tRco/FZwv/0kKVdwVFfsETVJD9s4SLOdwUrzzG13YNQHfYpD0blC2EYA3Q==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -4369,26 +4369,6 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
-    "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
-      "from": "github:web3-js/scrypt-shim",
-      "requires": {
-        "scryptsy": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "scryptsy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
-    },
     "secp256k1": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
@@ -5691,7 +5671,6 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
-        "scrypt-shim": "github:web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",


### PR DESCRIPTION
Faucet's `package.json` depends on `>1.3.0-rc <1.3.0` but the lock file
was on `1.2.4-rc.1`. Updated that dependency to the most common version
of `1.3.0-rc.1`.