### PR TITLE
Linty faucet: Improved linting pre-commits, linting config for faucet, and a fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,20 @@ repos:
       additional_dependencies:
       - ethlint@1.2.3
     - id: lint-js
-      name: 'lint js'
+      name: 'lint solidity js'
       entry: /usr/bin/env bash -c "cd solidity && npm run lint:js"
-      files: '\.js$'
+      files: 'solidity\/.*\/\.js$'
+      language: script
+      description: "Checks JS code according to the package's linter configuration"
+    - id: lint-dashboard-js
+      name: 'lint dashboard js'
+      entry: /usr/bin/env bash -c "cd solidity/dashboard && npm run js:lint"
+      files: 'solidity\/.*\/\.js$'
+      language: script
+      description: "Checks JS code according to the package's linter configuration"
+    - id: lint-faucet-js
+      name: 'lint faucet js'
+      entry: /usr/bin/env bash -c "cd infrastructure/gcp/keep-test/google-functions/keep-faucet && npm run lint:js"
+      files: 'infrastructure\/gcp\/keep-test\/google-functions\/keep-faucet\/.*\.js$'
       language: script
       description: "Checks JS code according to the package's linter configuration"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     - id: lint-dashboard-js
       name: 'lint dashboard js'
       entry: /usr/bin/env bash -c "cd solidity/dashboard && npm run js:lint"
-      files: 'solidity\/.*\/\.js$'
+      files: 'solidity\/dashboard\/.*\/\.js$'
       language: script
       description: "Checks JS code according to the package's linter configuration"
     - id: lint-faucet-js

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/.eslintrc
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "extends": ["eslint-config-keep"],
+  "parserOptions": {
+    "ecmaVersion": 2017,
+    "sourceType": "module"
+  },
+  "env": {
+    "es6": true,
+    "mocha": true
+  }
+}
+

--- a/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
+++ b/infrastructure/gcp/keep-test/google-functions/keep-faucet/issue-grant.js
@@ -249,9 +249,10 @@ async function issueGrant(granteeAccount, grantAmount, currentNonce, gasPrice) {
         .on("error", (error) => {
           if (
             // Confirmed transaction with this nonce, so bump it.
-            error == "Error: nonce too low" ||
+            (error.message && error.message == "nonce too low") ||
             // Pending transaction with this nonce, so bump it and queue up.
-            error == "Error: replacement transaction underpriced"
+            (error.message &&
+              error.message == "replacement transaction underpriced")
           ) {
             console.error(
               `Error with account grant transaction for ${granteeAccount}, ` +


### PR DESCRIPTION
Three bits here:
- The faucet now has a proper `eslintrc`, based on the common Keep config.
- The faucet (and as a bonus the dashboard) now have linting pre-commit configurations (/cc @r-czajkowski ).
- The faucet now handles the newer error structures we get from web3 (this was an oversight from a web3 version bump).

See #1551.