### PR TITLE
Fixing displaying 0 KEEP amount delegations in the copy-stake flow

### DIFF
--- a/solidity/dashboard/src/services/staking-port-backer.service.js
+++ b/solidity/dashboard/src/services/staking-port-backer.service.js
@@ -173,7 +173,7 @@ const getDelegations = async (
 
     const delegationAmount = web3Utils.toBN(amount)
     // StakingPortBacker contract requires the delegation amount to be greater than zero.
-    if (delegationAmount.gt(0)) {
+    if (delegationAmount.gt(web3Utils.toBN(0))) {
       // Check if the stake is currently undelegating.
       if (operatorData.undelegatedAt === "0") {
         operatorData.isUndelegating = false

--- a/solidity/dashboard/src/services/staking-port-backer.service.js
+++ b/solidity/dashboard/src/services/staking-port-backer.service.js
@@ -173,7 +173,7 @@ const getDelegations = async (
 
     const delegationAmount = web3Utils.toBN(amount)
     // StakingPortBacker contract requires the delegation amount to be greater than zero.
-    if (delegationAmount.gt(web3Utils.toBN(0))) {
+    if (delegationAmount.gtn(0)) {
       // Check if the stake is currently undelegating.
       if (operatorData.undelegatedAt === "0") {
         operatorData.isUndelegating = false


### PR DESCRIPTION
Delegation amount (BN) has to be compared with `BN(0)` and not just `0`. Otherwise, comparison will not be correct and we can see 0 amount delegations in the copy-stake flow. 
We used the operator address from a "new" delegation but fetched delegation details from the "old" staking contract, hence 0 KEEP.

Scenario: Create grant from 0xAAA to 0xBBB. From 0xBBB delegate KEEP to 0xCCC. From 0xBBB click on the banner "Upgrade my stake". You will see a screenshot below:

![Screenshot 2020-09-07 at 13 20 17](https://user-images.githubusercontent.com/3156420/92389651-c502e880-f119-11ea-8f32-74a2b9ae3074.png)
