### PR TITLE
Disabling ADD KEEP button when no KEEP is available

### DIFF
--- a/solidity/dashboard/src/components/DelegatedTokensTable.jsx
+++ b/solidity/dashboard/src/components/DelegatedTokensTable.jsx
@@ -11,6 +11,7 @@ import { SubmitButton } from "./Button"
 import { useModal } from "../hooks/useModal"
 import AddTopUpModal from "./AddTopUpModal"
 import { connect } from "react-redux"
+import web3Utils from "web3-utils"
 
 const DelegatedTokensTable = ({
   delegatedTokens,
@@ -30,6 +31,14 @@ const DelegatedTokensTable = ({
     },
     [grants]
   )
+
+  const isAddKeepBtnDisabled = (delegationData) => {
+    const availableAmount = delegationData.isFromGrant
+      ? getAvailableToStakeFromGrant(delegationData.grantId)
+      : keepTokenBalance
+
+    return web3Utils.toBN(availableAmount).lten(0)
+  }
 
   const onTopUpBtn = async (delegationData, awaitingPromise) => {
     const availableAmount = delegationData.isFromGrant
@@ -153,6 +162,7 @@ const DelegatedTokensTable = ({
                     onSubmitAction={(awaitingPromise) =>
                       onTopUpBtn(delegation, awaitingPromise)
                     }
+                    disabled={isAddKeepBtnDisabled(delegation)}
                   >
                     add keep
                   </SubmitButton>


### PR DESCRIPTION
It is confusing clicking at the ADD KEEP button when a user won't be able to add KEEP anyway.

![Screenshot 2020-09-08 at 11 51 31](https://user-images.githubusercontent.com/3156420/92461678-d60b3280-f1c9-11ea-9b0a-3395e5d24265.png)
