### PR TITLE
DefaultMaxGasPrice used by client set to 500 Gwei

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -19,7 +19,7 @@
 	# allowed gas price is reached, no further resubmission attempts are
 	# performed.
 	#
-	# MaxGasPrice = 70000000000 # 70 gwei (default value)
+	# MaxGasPrice = 500000000000 # 500 Gwei (default value)
 	#
 	# Uncomment to enable Ethereum node rate limiting. Both properties can be
 	# used together or separately.

--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -32,7 +32,7 @@ var (
 	// gas price can not be higher than the max gas price value. If the maximum
 	// allowed gas price is reached, no further resubmission attempts are
 	// performed. This value can be overwritten in the configuration file.
-	DefaultMaxGasPrice = big.NewInt(70000000000) // 70 Gwei
+	DefaultMaxGasPrice = big.NewInt(500000000000) // 500 Gwei
 )
 
 type ethereumChain struct {


### PR DESCRIPTION

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/4712360/92462841-4d8d9180-f1cb-11ea-9834-bd45149730ae.png">

Source: https://etherscan.io/chart/gasprice


The last weeks brought an extreme gas price increase on mainnet, even to 500 Gwei average price. The default value of 70 Gwei could not be enough.

The `MaxGasPrice` can be still configured in the config file, here we just update the default value to keep it aligned with the reality.