### PR TITLE
Hiding a copy stake banner when no old delegations available

### DIFF
--- a/solidity/dashboard/src/components/copy-stake-steps/Step1.jsx
+++ b/solidity/dashboard/src/components/copy-stake-steps/Step1.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React from "react"
 import TokenAmount from "../TokenAmount"
 import Button from "../Button"
 import { KeepLoadingIndicator } from "../Loadable"
@@ -26,7 +26,6 @@ const styles = {
 }
 
 const CopyStakeStep1 = ({
-  fetchDelegations,
   isFetching,
   delegations,
   decrementStep,
@@ -34,10 +33,6 @@ const CopyStakeStep1 = ({
   onSelectDelegation,
   selectedDelegation,
 }) => {
-  useEffect(() => {
-    fetchDelegations()
-  }, [fetchDelegations])
-
   return (
     <>
       <h2 style={styles.title}>Stake balances to be upgraded.</h2>

--- a/solidity/dashboard/src/pages/CopyStakePage.jsx
+++ b/solidity/dashboard/src/pages/CopyStakePage.jsx
@@ -12,7 +12,6 @@ import {
   DECREMENT_STEP,
   SET_STRATEGY,
   SET_DELEGATION,
-  FETCH_DELEGATIONS_FROM_OLD_STAKING_CONTRACT_REQUEST,
   RESET_COPY_STAKE_FLOW,
 } from "../actions"
 import { connect } from "react-redux"
@@ -72,7 +71,6 @@ const CopyStakePage = ({
             isFetching={oldDelegationsFetching}
             selectedDelegation={selectedDelegation}
             onSelectDelegation={setDelegation}
-            fetchDelegations={fetchOldDelegations}
           />
         )
       case 2:
@@ -135,8 +133,6 @@ const mapDispatchToProps = (dispatch) => {
       dispatch({ type: SET_STRATEGY, payload: strategy }),
     setDelegation: (delegation) =>
       dispatch({ type: SET_DELEGATION, payload: delegation }),
-    fetchOldDelegations: () =>
-      dispatch({ type: FETCH_DELEGATIONS_FROM_OLD_STAKING_CONTRACT_REQUEST }),
     undelegateOldStake: (delegation) =>
       dispatch({ type: "copy-stake/undelegate_request", payload: delegation }),
     recoverOldStake: (delegation) =>

--- a/solidity/dashboard/src/pages/TokensPageContainer.jsx
+++ b/solidity/dashboard/src/pages/TokensPageContainer.jsx
@@ -27,6 +27,7 @@ import {
 } from "../constants/constants"
 import { isSameEthAddress } from "../utils/general.utils"
 import { sub, add } from "../utils/arithmetics.utils"
+import { isEmptyArray } from "../utils/array.utils"
 import moment from "moment"
 import {
   createManagedGrantContractInstance,
@@ -65,7 +66,7 @@ const TokensPageContainer = ({ oldDelegations, fetchOldDelegations }) => {
 
   return (
     <>
-      {oldDelegations.length > 0 && (
+      {!isEmptyArray(oldDelegations) && (
         <Banner
           type={BANNER_TYPE.NOTIFICATION}
           withIcon

--- a/solidity/dashboard/src/reducers/copy-stake.js
+++ b/solidity/dashboard/src/reducers/copy-stake.js
@@ -8,6 +8,7 @@ import {
   FETCH_DELEGATIONS_FROM_OLD_STAKING_CONTRACT_REQUEST,
   RESET_COPY_STAKE_FLOW,
 } from "../actions"
+import { isSameEthAddress } from "../utils/general.utils"
 
 export const copyStakeInitialData = {
   oldDelegations: [],
@@ -90,6 +91,15 @@ const copyStakeReducer = (state = copyStakeInitialData, action) => {
         isProcessing: false,
         error: action.payload,
       }
+    case "copy-stake/remove_old_delegation": {
+      return {
+        ...state,
+        oldDelegations: state.oldDelegations.filter(
+          (delegation) =>
+            !isSameEthAddress(delegation.operatorAddress, action.payload)
+        ),
+      }
+    }
     default:
       return state
   }

--- a/solidity/dashboard/src/sagas/copy-stake.js
+++ b/solidity/dashboard/src/sagas/copy-stake.js
@@ -1,4 +1,4 @@
-import { takeLatest, call, put, delay } from "redux-saga/effects"
+import { takeLatest, take, call, put, delay, fork } from "redux-saga/effects"
 import {
   FETCH_DELEGATIONS_FROM_OLD_STAKING_CONTRACT_REQUEST,
   FETCH_DELEGATIONS_FROM_OLD_STAKING_CONTRACT_SUCCESS,
@@ -7,7 +7,7 @@ import {
 } from "../actions"
 import { fetchOldDelegations } from "../services/staking-port-backer.service"
 import { getContractsContext } from "./utils"
-import { sendTransaction } from "./web3"
+import { sendTransaction, createSubcribeToContractEventCahnnel } from "./web3"
 import { CONTRACT_DEPLOY_BLOCK_NUMBER } from "../contracts"
 import { showMessage, showCreatedMessage } from "../actions/messages"
 import { isEmptyArray } from "../utils/array.utils"
@@ -29,6 +29,8 @@ function* fetchOldStakingDelegations() {
       payload: error,
     })
   }
+
+  yield fork(observeEvents)
 }
 
 export function* watchFetchOldStakingContract() {
@@ -185,4 +187,40 @@ export function* watchUndelegateOldStakeRequest() {
 
 export function* watchRecovereOldStakeRequest() {
   yield takeLatest("copy-stake/recover_request", recoverFromOldStakingContract)
+}
+
+function* observeEvents() {
+  const { oldTokenStakingContract, stakingPortBackerContract } = yield call(
+    getContractsContext
+  )
+
+  yield fork(removeOldDelegationWatcher, oldTokenStakingContract, "Undelegated")
+  yield fork(
+    removeOldDelegationWatcher,
+    stakingPortBackerContract,
+    "StakeCopied"
+  )
+  yield fork(removeOldDelegationWatcher, oldTokenStakingContract, "Recovered")
+}
+
+function* removeOldDelegationWatcher(contract, eventName) {
+  // Create subscription channel.
+  const contractEventCahnnel = yield call(
+    createSubcribeToContractEventCahnnel,
+    contract,
+    eventName
+  )
+
+  // Observe and dispatch an action that updates copy-stake reducer.
+  while (true) {
+    try {
+      const {
+        returnValues: { operator },
+      } = yield take(contractEventCahnnel)
+      yield put({ type: "copy-stake/remove_old_delegation", payload: operator })
+    } catch (error) {
+      console.error(`Failed subscribing to ${eventName} event`, error)
+      contractEventCahnnel.close()
+    }
+  }
 }

--- a/solidity/dashboard/src/sagas/copy-stake.js
+++ b/solidity/dashboard/src/sagas/copy-stake.js
@@ -7,7 +7,7 @@ import {
 } from "../actions"
 import { fetchOldDelegations } from "../services/staking-port-backer.service"
 import { getContractsContext } from "./utils"
-import { sendTransaction, createSubcribeToContractEventCahnnel } from "./web3"
+import { sendTransaction, createSubcribeToContractEventChannel } from "./web3"
 import { CONTRACT_DEPLOY_BLOCK_NUMBER } from "../contracts"
 import { showMessage, showCreatedMessage } from "../actions/messages"
 import { isEmptyArray } from "../utils/array.utils"
@@ -206,7 +206,7 @@ function* observeEvents() {
 function* removeOldDelegationWatcher(contract, eventName) {
   // Create subscription channel.
   const contractEventCahnnel = yield call(
-    createSubcribeToContractEventCahnnel,
+    createSubcribeToContractEventChannel,
     contract,
     eventName
   )

--- a/solidity/dashboard/src/sagas/web3.js
+++ b/solidity/dashboard/src/sagas/web3.js
@@ -74,7 +74,7 @@ function createTransactionEventChannel(contract, method, args, options) {
   }, buffers.expanding())
 }
 
-export function createSubcribeToContractEventCahnnel(contract, eventName) {
+export function createSubcribeToContractEventChannel(contract, eventName) {
   const contractHasEvent = contract.options.jsonInterface.find(
     (entry) => entry.type === "event" && entry.name === eventName
   )


### PR DESCRIPTION
Hide the copy stake banner when no delegations are available on the old token stake contracts. We do not want to confuse users with displaying them a banner when they don't have any old delegations in the first place.