### PR TITLE
Funky fresh: Additional adjustments to repo setup for fresh machines

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,7 +43,7 @@ printf "${LOG_START}Updating keep-core client configs...${LOG_END}"
 for CONFIG_FILE in $KEEP_CORE_CONFIG_DIR_PATH/*.toml
 do
     KEEP_CORE_CONFIG_FILE_PATH=$CONFIG_FILE \
-        truffle exec scripts/lcl-client-config.js --network local
+        npx truffle exec scripts/lcl-client-config.js --network local
 done
 
 printf "${LOG_START}Building keep-core client...${LOG_END}"

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -26,9 +26,6 @@ echo "Installing solidity npm and requirements..."
 brew list npm &>/dev/null || brew install npm
 cd ../solidity && npm install && cd ../scripts
 
-echo "Installing truffle..."
-npm install -g truffle
-
 if ! [ -x "$(command -v protoc-gen-gogoslick)" ]; then
   echo 'WARNING: protoc-gen-gogoslick command is not available'
   echo 'WARNING: please check whether $GOPATH/bin is added to your $PATH'

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo "Installing coreutils requirement..."
+brew list coreutils &> /dev/null || brew install coreutils
+
 echo "Installing golang requirements..."
 brew list golang &> /dev/null || brew install golang
 

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -291,11 +291,6 @@
         }
       }
     },
-    "@openzeppelin/contracts-ethereum-package": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
-      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
-    },
     "@openzeppelin/test-environment": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@openzeppelin/test-environment/-/test-environment-0.1.4.tgz",
@@ -22979,9 +22974,9 @@
       "dev": true
     },
     "nofilter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
-      "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
     },
     "normalize-path": {
       "version": "1.0.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://github.com/keep-network/keep-core/contracts/solidity",
   "dependencies": {
-    "@openzeppelin/contracts-ethereum-package": "^2.4.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.4.0"
   },


### PR DESCRIPTION
I went through the `local-setup` installation process on a fresh machine, which found a few more gaps I'd missed in our scripts:
- A few stray references to `truffle` instead of `npx truffle`.
- Some unused dependencies.
- A reliance on `coreutils`.

Those changes are reflected here.