### PR TITLE
Fix fetching slashed tokens

### DIFF
--- a/solidity/dashboard/src/services/slashed-tokens.service.js
+++ b/solidity/dashboard/src/services/slashed-tokens.service.js
@@ -32,7 +32,6 @@ const fetchSlashedTokens = async (web3Context) => {
     "TokensSeized",
     eventsSearchFilters
   )
-  console.log("seizedTokensEvents", seizedTokensEvents)
 
   if (isEmptyArray(slashedTokensEvents) && isEmptyArray(seizedTokensEvents)) {
     return data
@@ -80,6 +79,8 @@ const fetchSlashedTokens = async (web3Context) => {
     } else {
       continue
     }
+
+    if (punishmentData && lte(punishmentData.amount, 0)) continue
 
     punishmentData.date = moment.unix(
       (await eth.getBlock(blockNumber)).timestamp

--- a/solidity/dashboard/src/services/slashed-tokens.service.js
+++ b/solidity/dashboard/src/services/slashed-tokens.service.js
@@ -32,6 +32,7 @@ const fetchSlashedTokens = async (web3Context) => {
     "TokensSeized",
     eventsSearchFilters
   )
+  console.log("seizedTokensEvents", seizedTokensEvents)
 
   if (isEmptyArray(slashedTokensEvents) && isEmptyArray(seizedTokensEvents)) {
     return data
@@ -76,9 +77,9 @@ const fetchSlashedTokens = async (web3Context) => {
     } else if (seizedTokensGroupedByTxtHash.hasOwnProperty(transactionHash)) {
       const { amount } = seizedTokensGroupedByTxtHash[transactionHash]
       punishmentData = { amount, type: "SEIZED", event }
+    } else {
+      continue
     }
-
-    if (!punishmentData || lte(punishmentData.amount, 0)) continue
 
     punishmentData.date = moment.unix(
       (await eth.getBlock(blockNumber)).timestamp

--- a/solidity/dashboard/src/services/tokens-page.service.js
+++ b/solidity/dashboard/src/services/tokens-page.service.js
@@ -129,7 +129,7 @@ const getDelegations = async (
       amount,
     } = await stakingContract.methods.getDelegationInfo(operatorAddress).call()
 
-    let managedGrantContractInstance
+    let managedGrantContractInstance = null
     if (isFromGrant && !grantId) {
       try {
         const grantStakeDetails = await grantContract.methods


### PR DESCRIPTION
Closes: #1992

We should skip `UnauthorizedSigningReported\RelayEntryTimeoutReported` events if they were not emitted in the same transaction as the `TokenSlashed / TokenSeized` events because it means that these punishment events are not related to the provided operator.
