### PR TITLE
Skip data updates if its a copied delegation

### DIFF
--- a/solidity/dashboard/src/pages/TokensPageContainer.jsx
+++ b/solidity/dashboard/src/pages/TokensPageContainer.jsx
@@ -202,14 +202,16 @@ const useSubscribeToStakedEvent = () => {
       return
     }
 
-    if (!delegation.isFromGrant) {
-      refreshKeepTokenBalance()
-      dispatch({
-        type: UPDATE_OWNED_DELEGATED_TOKENS_BALANCE,
-        payload: { operation: add, value },
-      })
-    } else {
-      grantStaked(delegation.grantId, value)
+    if (!delegation.isCopiedStake) {
+      if (!delegation.isFromGrant) {
+        refreshKeepTokenBalance()
+        dispatch({
+          type: UPDATE_OWNED_DELEGATED_TOKENS_BALANCE,
+          payload: { operation: add, value },
+        })
+      } else {
+        grantStaked(delegation.grantId, value)
+      }
     }
 
     dispatch({ type: ADD_DELEGATION, payload: delegation })


### PR DESCRIPTION
The dapp subscribes to the `StakeDelegated` event and updates data based on that event. If the `StakeCopied` event was emitted with a `StakedDelegated` event, we do not want to update grant data or KEEP token balance, since a copied delegations are from already staked tokens.