### PR TITLE
Validating for 0 ETH account balance

### DIFF
--- a/solidity/dashboard/src/components/AddETHModal.jsx
+++ b/solidity/dashboard/src/components/AddETHModal.jsx
@@ -66,6 +66,8 @@ const AddETHFormik = withFormik({
 
       if (!ethAmount) {
         errors.ethAmount = "Required"
+      } else if (ethBalance.isZero()) {
+        errors.ethAmount = "Account ETH balance should be greater than 0"
       } else if (valueInWei.gt(ethBalance)) {
         errors.ethAmount = `The value should be less than ${web3Utils.fromWei(
           ethBalance.toString(),


### PR DESCRIPTION
Added validation for 0 ETH account balance when bonding ETH. When a user has no EHT on its balance, we will notify him about it.

Incorrect message will be replaced with: "Account ETH balance should be greater than 0"

![Screenshot 2020-09-11 at 17 51 09](https://user-images.githubusercontent.com/3156420/92951476-b17bb880-f45e-11ea-902f-c238fe8bbaeb.png)
