### PR TITLE
`useEtherscanUrl` hook fix

### DIFF
--- a/solidity/dashboard/src/hooks/useEtherscanUrl.js
+++ b/solidity/dashboard/src/hooks/useEtherscanUrl.js
@@ -1,10 +1,8 @@
-import { useContext } from "react"
-import { Web3Context } from "../components/WithWeb3Context"
+import { getChainId } from "../connectors/utils"
 
+const chainID = getChainId()
 export const useEtherscanUrl = () => {
-  const { networkType } = useContext(Web3Context)
-
-  return networkType === "main"
+  return chainID === 1 // Mainnet network ID.
     ? "https://etherscan.io"
     : "https://ropsten.etherscan.io"
 }


### PR DESCRIPTION
This hook relied on the existence of the web3 provider, so it always returned a ropsten link during hardware wallet connection pop-up. Here we updated this custom hook and currently relies on the `@keep-network` package, since for a given build only support a single network ID.