### PR TITLE
Bumping up token dashboard version to 1.3.2

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.3.1
+        image: keepnetwork/token-dashboard:v1.3.2
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
1.3.2 release with the fix from https://github.com/keep-network/keep-core/pull/2051