### PR TITLE
Fix releasing tokens from a managed grant

### DIFF
--- a/solidity/dashboard/src/sagas/token-grant.js
+++ b/solidity/dashboard/src/sagas/token-grant.js
@@ -23,6 +23,7 @@ function* releaseTokens(action) {
         payload: {
           contract: managedGrantContractInstance,
           methodName: "withdraw",
+          args: [],
         },
       })
     } else {

--- a/solidity/dashboard/src/sagas/web3.js
+++ b/solidity/dashboard/src/sagas/web3.js
@@ -9,7 +9,7 @@ import {
 } from "../actions/messages"
 import { messageType } from "../components/Message"
 
-function createTransactionEventChannel(contract, method, args, options) {
+function createTransactionEventChannel(contract, method, args = [], options) {
   const infoMessage = Message.create({
     title: "Waiting for the transaction confirmation...",
     type: messageType.INFO,


### PR DESCRIPTION
Set `args` param to an empty array when calling `withdraw` function from a `ManagedGrant` contract  via [`sendTransaction`](https://github.com/keep-network/keep-core/blob/master/solidity/dashboard/src/sagas/web3.js#L111) helper.

