### PR TITLE
Information on the gas cost of operating the client

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -55,19 +55,23 @@ to submit more transactions as a result.
 
 Below is the average gas cost of the most important transactions the client is submitting:
 
-[%header,cols=2*]
+[%header,cols=3*]
 |===
 |TX
 |Gas Cost
+|Reimbursed
 
 |Submit group selection ticket
 |140 000
+|No
 
 |Submit DKG result
 |1 740 000
+|Yes
 
 |Submit relay entry
 |280 000
+|Yes
 |===
 
 For example, if the operator has 10 x minimum stake, it can submit 10 tickets. If the operator has

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -43,6 +43,35 @@ Keep Random Beacon client.
 |2 vCPU / 4 GiB RAM / 1 GiB Persistent Storage
 |===
 
+== Gas Costs
+
+Random Beacon smart contracts reimburse the operator for successfully submitting relay entry and DKG result but they do not reimburse for submitting a group selection ticket. Reimbursements are sent to the beneficiary account and can be claimed along with rewards once the group expires. It is expected that the operators have enough ETH on the accounts used by clients to submit the required transactions and that the operator account balance is monitored and refilled as needed. Bear in mind that the higher stake is, the operator is selected more frequently and is expected to submit more transactions as a result.
+
+Below is the average gas cost of the most important transactions the client is submitting:
+
+[%header,cols=2*]
+|===
+|TX
+|Gas Cost
+
+|Submit group selection ticket
+|140 000
+
+|Submit DKG result
+|1 740 000
+
+|Submit relay entry
+|280 000
+|===
+
+For example, if the operator has 10 x minimum stake, it can submit 10 tickets. If the operator has been selected to the group with index 1, it is expected to submit DKG result and every relay entry the group will produce. Assuming the group produces 100 entries, the cost for the operator is `(10 * 140 000 + 1 740 000 + 100 * 280 000) * gas_price` ETH. It means that the operator needs to have on their account:
+
+- For the gas price of 20 Gwei, at least 0.6228 ETH. 
+- For the gas price of 100 Gwei, at least 3.114 ETH. 
+- For the gas price of 800 Gwei, at least 24.912 ETH. 
+
+It is paramount that the operator accounts have some safety margin and consider the current gas price and stake when funding their accounts.
+
 == Configuration
 
 === Network

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -45,7 +45,13 @@ Keep Random Beacon client.
 
 == Gas Costs
 
-Random Beacon smart contracts reimburse the operator for successfully submitting relay entry and DKG result but they do not reimburse for submitting a group selection ticket. Reimbursements are sent to the beneficiary account and can be claimed along with rewards once the group expires. It is expected that the operators have enough ETH on the accounts used by clients to submit the required transactions and that the operator account balance is monitored and refilled as needed. Bear in mind that the higher stake is, the operator is selected more frequently and is expected to submit more transactions as a result.
+Random Beacon smart contracts reimburse the operator for successfully submitting relay entry
+and DKG result but they do not reimburse for submitting a group selection ticket. Reimbursements
+are sent to the beneficiary account and can be claimed along with rewards once the group expires.
+It is expected that the operators have enough ETH on the accounts used by clients to submit the
+required transactions and that the operator account balance is monitored and refilled as needed.
+Bear in mind that the higher stake is, the operator is selected more frequently and is expected
+to submit more transactions as a result.
 
 Below is the average gas cost of the most important transactions the client is submitting:
 
@@ -64,13 +70,18 @@ Below is the average gas cost of the most important transactions the client is s
 |280 000
 |===
 
-For example, if the operator has 10 x minimum stake, it can submit 10 tickets. If the operator has been selected to the group with index 1, it is expected to submit DKG result and every relay entry the group will produce. Assuming the group produces 100 entries, the cost for the operator is `(10 * 140 000 + 1 740 000 + 100 * 280 000) * gas_price` ETH. It means that the operator needs to have on their account:
+For example, if the operator has 10 x minimum stake, it can submit 10 tickets. If the operator has
+been selected to the group with index 1, it is expected to submit DKG result and every relay entry
+the group will produce. Assuming the group produces 100 entries, the cost for the operator is
+`(10 * 140 000 + 1 740 000 + 100 * 280 000) * gas_price` ETH. It means that the operator needs to
+have on their account:
 
 - For the gas price of 20 Gwei, at least 0.6228 ETH. 
 - For the gas price of 100 Gwei, at least 3.114 ETH. 
 - For the gas price of 800 Gwei, at least 24.912 ETH. 
 
-It is paramount that the operator accounts have some safety margin and consider the current gas price and stake when funding their accounts.
+It is paramount that the operator accounts have some safety margin and consider the current gas price
+and stake when funding their accounts.
 
 == Configuration
 


### PR DESCRIPTION
Added information about gas costs of operations the beacon client is performing. It is important that the operators understand the cost of running the client and can estimate the required ETH based on their stake, current gas price, and the expected traffic in the network.