### PR TITLE
Metamask pop up

### DIFF
--- a/solidity/dashboard/src/components/LedgerModal.jsx
+++ b/solidity/dashboard/src/components/LedgerModal.jsx
@@ -1,93 +1,63 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useCallback } from "react"
 import * as Icons from "./Icons"
 import Button from "./Button"
-import ChooseWalletAddress from "./ChooseWalletAddress"
-import { isEmptyArray } from "../utils/array.utils"
-import { useShowMessage, messageType } from "./Message"
-import { KeepLoadingIndicator } from "./Loadable"
+import SelectedWalletModal from "./SelectedWalletModal"
 
 const LedgerModal = ({ connector, connectAppWithWallet, closeModal }) => {
-  const [accounts, setAccounts] = useState([])
-
-  const [isFetching, setIsFetching] = useState(false)
-  const [accountsOffSet, setAccountsOffSet] = useState(0)
   const [ledgerVersion, setLedgerVersion] = useState("")
-  const showMessage = useShowMessage()
 
-  useEffect(() => {
-    let shoudlSetState = true
-    if (ledgerVersion === "LEDGER_LIVE" || ledgerVersion === "LEDGER_LEGACY") {
-      setIsFetching(true)
-      connector[ledgerVersion]
-        .getAccounts(5, accountsOffSet)
-        .then((accounts) => {
-          if (shoudlSetState) {
-            setAccounts(accounts)
-            setIsFetching(false)
-          }
-        })
-        .catch((error) => {
-          if (shoudlSetState) {
-            setIsFetching(false)
-          }
-          showMessage({ type: messageType.ERROR, title: error.message })
-        })
-    }
-
-    return () => {
-      shoudlSetState = false
-    }
-  }, [ledgerVersion, connector, showMessage, accountsOffSet])
-
-  const onSelectAccount = async (account) => {
-    connector[ledgerVersion].defaultAccount = account
-    await connectAppWithWallet(connector[ledgerVersion], "LEDGER")
-    closeModal()
-  }
+  const fetchAccounts = useCallback(
+    async (numberOfAccounts, accountsOffset) => {
+      try {
+        const accounts = await connector[ledgerVersion].getAccounts(
+          numberOfAccounts,
+          accountsOffset
+        )
+        return accounts
+      } catch (error) {
+        throw error
+      }
+    },
+    [connector, ledgerVersion]
+  )
 
   return (
-    <div className="flex column center">
-      <div className="flex full-center mb-3">
-        <Icons.Ledger />
-        <h3 className="ml-1">Ledger</h3>
-      </div>
-      <Icons.LedgerDevice className="mb3" />
-      <span className="text-center">Plug in Ledger device and unlock.</span>
-      <div
-        className="flex column mt-1"
-        style={{
-          alignSelf: "normal",
-          justifyContent: "space-around",
-        }}
-      >
-        <Button
-          onClick={() => setLedgerVersion("LEDGER_LIVE")}
-          className="btn btn-primary btn-md mb-1"
+    <SelectedWalletModal
+      icon={<Icons.Ledger />}
+      walletName="Ledger"
+      descriptionIcon={<Icons.LedgerDevice className="mb3" />}
+      description="Plug in Ledger device and unlock."
+      providerName="LEDGER"
+      connector={connector[ledgerVersion]}
+      connectAppWithWallet={connectAppWithWallet}
+      closeModal={closeModal}
+      fetchAvailableAccounts={fetchAccounts}
+      numberOfAccounts={5}
+      withAccountPagination={true}
+    >
+      <>
+        <div
+          className="flex column mt-1"
+          style={{
+            alignSelf: "normal",
+            justifyContent: "space-around",
+          }}
         >
-          ledger live
-        </Button>
-        <Button
-          onClick={() => setLedgerVersion("LEDGER_LEGACY")}
-          className="btn btn-primary btn-md"
-        >
-          ledger legacy
-        </Button>
-      </div>
-      {isFetching ? (
-        <KeepLoadingIndicator />
-      ) : (
-        !isEmptyArray(accounts) && (
-          <ChooseWalletAddress
-            onSelectAccount={onSelectAccount}
-            addresses={accounts}
-            withPagination
-            renderPrevBtn={accountsOffSet > 0}
-            onNext={() => setAccountsOffSet((prevOffset) => prevOffset + 5)}
-            onPrev={() => setAccountsOffSet((prevOffset) => prevOffset - 5)}
-          />
-        )
-      )}
-    </div>
+          <Button
+            onClick={() => setLedgerVersion("LEDGER_LIVE")}
+            className="btn btn-primary btn-md mb-1"
+          >
+            ledger live
+          </Button>
+          <Button
+            onClick={() => setLedgerVersion("LEDGER_LEGACY")}
+            className="btn btn-primary btn-md"
+          >
+            ledger legacy
+          </Button>
+        </div>
+      </>
+    </SelectedWalletModal>
   )
 }
 

--- a/solidity/dashboard/src/components/MetaMaskModal.jsx
+++ b/solidity/dashboard/src/components/MetaMaskModal.jsx
@@ -1,0 +1,36 @@
+import React from "react"
+import SelectedWalletModal from "./SelectedWalletModal"
+import * as Icons from "./Icons"
+
+const MetaMaskModal = ({ connector, connectAppWithWallet, closeModal }) => {
+  return (
+    <SelectedWalletModal
+      icon={<Icons.MetaMask />}
+      walletName="MetaMask"
+      iconDescription={null}
+      description={
+        connector
+          ? "The MetaMask login screen will open in an external window."
+          : "Please install the MetaMask extension"
+      }
+      providerName="METAMASK"
+      connector={connector}
+      connectAppWithWallet={connectAppWithWallet}
+      closeModal={closeModal}
+      connectWithWalletOnMount
+    >
+      {!connector && (
+        <a
+          href="https://metamask.io"
+          className="btn bt-lg btn-primary mt-3"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          install extension
+        </a>
+      )}
+    </SelectedWalletModal>
+  )
+}
+
+export default React.memo(MetaMaskModal)

--- a/solidity/dashboard/src/components/SelectedWalletModal.jsx
+++ b/solidity/dashboard/src/components/SelectedWalletModal.jsx
@@ -1,36 +1,145 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
+import { KeepLoadingIndicator } from "./Icons"
+import { useShowMessage, messageType } from "./Message"
+import ChooseWalletAddress from "./ChooseWalletAddress"
+import { isEmptyArray } from "../utils/array.utils"
+import { wait } from "../utils/general.utils"
 
 const SelectedWalletModal = ({
-  walletName,
   icon,
-  description,
+  walletName,
   iconDescription,
-  btnText,
-  btnLink,
-  coinbaseQR,
+  description,
+  providerName,
+  connector,
+  connectAppWithWallet,
+  closeModal,
+  fetchAvailableAccounts = null,
+  numberOfAccounts = 15,
+  connectWithWalletOnMount = false,
+  withAccountPagination = false,
+  children,
 }) => {
+  const showMessage = useShowMessage()
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [accountsOffSet, setAccountsOffSet] = useState(0)
+  const [accountsAreFetching, setAccountsAreFetching] = useState(false)
+  const [availableAccounts, setAvailableAccounts] = useState([])
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    let shouldSetState = true
+    // Fetching wallet addresses.
+    if (
+      fetchAvailableAccounts &&
+      typeof fetchAvailableAccounts === "function" &&
+      connector
+    ) {
+      setAccountsAreFetching(true)
+      fetchAvailableAccounts(numberOfAccounts, accountsOffSet)
+        .then((availableAccounts) => {
+          if (shouldSetState) {
+            setAvailableAccounts(availableAccounts)
+            setAccountsAreFetching(false)
+          }
+        })
+        .catch((error) => {
+          if (shouldSetState) {
+            handleError(error)
+            setAccountsAreFetching(false)
+          }
+        })
+    }
+    return () => {
+      shouldSetState = false
+    }
+  }, [connector, fetchAvailableAccounts, numberOfAccounts, accountsOffSet])
+
+  useEffect(() => {
+    let shouldSetState = true
+    // Connecting to a wallet when a component did mount.
+    if (connector && connectWithWalletOnMount) {
+      setIsConnecting(true)
+      wait(1000) // Delay request and show loading indicator.
+        .then(() => connectAppWithWallet(connector, providerName))
+        .then(() => {
+          if (shouldSetState) {
+            setIsConnecting(false)
+          }
+          closeModal()
+        })
+        .catch((error) => {
+          if (shouldSetState) {
+            handleError(error)
+          }
+          showMessage({
+            type: messageType.ERROR,
+            title: error.message,
+            sticky: true,
+          })
+        })
+    }
+
+    return () => {
+      shouldSetState = false
+    }
+  }, [
+    connector,
+    connectAppWithWallet,
+    providerName,
+    closeModal,
+    showMessage,
+    connectWithWalletOnMount,
+  ])
+
+  const handleError = (error) => {
+    setError(error.toString())
+    setIsConnecting(false)
+  }
+
+  const onSelectAccount = async (account) => {
+    try {
+      connector.defaultAccount = account
+      setIsConnecting(true)
+      await connectAppWithWallet(connector, providerName)
+      setIsConnecting(false)
+      closeModal()
+    } catch (error) {
+      handleError(error)
+      showMessage({ type: messageType.ERROR, title: error.message })
+    }
+  }
+
   return (
     <div className="flex column center">
       <div className="flex full-center mb-3">
         {icon}
         <h3 className="ml-1">{walletName}</h3>
       </div>
-      {iconDescription && (
-        <img src={iconDescription} className="mb-3" alt={walletName} />
-      )}
+      {iconDescription && iconDescription}
       <span className="text-center">{description}</span>
-      {walletName === "COINBASE" && coinbaseQR}
-
-      {btnLink && btnText && (
-        <a
-          href={btnLink}
-          className="btn bt-lg btn-primary mt-3"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {btnText}
-        </a>
-      )}
+      {children}
+      {isConnecting || accountsAreFetching ? (
+        <>
+          <KeepLoadingIndicator />
+          {accountsAreFetching
+            ? `Loading wallet addresses...`
+            : `Connecting...`}
+        </>
+      ) : null}
+      {error && error}
+      {!isEmptyArray(availableAccounts) &&
+        !accountsAreFetching &&
+        !isConnecting && (
+          <ChooseWalletAddress
+            onSelectAccount={onSelectAccount}
+            addresses={availableAccounts}
+            withPagination={withAccountPagination}
+            renderPrevBtn={accountsOffSet > 0}
+            onNext={() => setAccountsOffSet((prevOffset) => prevOffset + 5)}
+            onPrev={() => setAccountsOffSet((prevOffset) => prevOffset - 5)}
+          />
+        )}
     </div>
   )
 }

--- a/solidity/dashboard/src/components/TrezorModal.jsx
+++ b/solidity/dashboard/src/components/TrezorModal.jsx
@@ -1,39 +1,35 @@
-import React, { useState, useEffect } from "react"
+import React, { useCallback } from "react"
 import * as Icons from "./Icons"
-import ChooseWalletAddress from "./ChooseWalletAddress"
-import { useShowMessage, messageType } from "./Message"
-import { isEmptyArray } from "../utils/array.utils"
+import SelectedWalletModal from "./SelectedWalletModal"
 
 const TrezorModal = ({ connector, connectAppWithWallet, closeModal }) => {
-  const [accounts, setAccounts] = useState([])
-  const showMessage = useShowMessage()
-
-  useEffect(() => {
-    connector
-      .getAccounts()
-      .then(setAccounts)
-      .catch((error) => {
-        showMessage({ type: messageType.ERROR, title: error.message })
-      })
-  }, [showMessage, connector])
-
-  const onSelectAccount = async (account) => {
-    connector.defaultAccount = account
-    await connectAppWithWallet(connector, "TREZOR")
-    closeModal()
-  }
-
+  const fetchAccounts = useCallback(
+    async (numberOfAccounts, accountsOffset) => {
+      try {
+        const accounts = await connector.getAccounts(
+          numberOfAccounts,
+          accountsOffset
+        )
+        return accounts
+      } catch (error) {
+        throw error
+      }
+    },
+    [connector]
+  )
   return (
-    <div className="flex column center">
-      <div className="flex full-center mb-3">
-        <Icons.Ledger />
-        <h3 className="ml-1">Trezor</h3>
-      </div>
-      <Icons.TrezorDevice className="mb3" />
-      <span className="text-center">
-        Plug in your Trezor device and unlock. If the setup screen doesn’t load
-        right away, go to Trezor setup:
-      </span>
+    <SelectedWalletModal
+      icon={<Icons.Trezor />}
+      walletName="Trezor"
+      descriptionIcon={<Icons.TrezorDevice className="mb3" />}
+      description="Plug in your Trezor device and unlock. If the setup screen doesn’t
+        load right away, go to Trezor setup:"
+      providerName="TREZOR"
+      connector={connector}
+      connectAppWithWallet={connectAppWithWallet}
+      closeModal={closeModal}
+      fetchAvailableAccounts={fetchAccounts}
+    >
       <a
         href="https://trezor.io/start/</div>"
         className="btn bt-lg btn-primary mt-3 mb-2"
@@ -42,13 +38,7 @@ const TrezorModal = ({ connector, connectAppWithWallet, closeModal }) => {
       >
         go to trezor setup
       </a>
-      {!isEmptyArray(accounts) && (
-        <ChooseWalletAddress
-          onSelectAccount={onSelectAccount}
-          addresses={accounts}
-        />
-      )}
-    </div>
+    </SelectedWalletModal>
   )
 }
 

--- a/solidity/dashboard/src/components/Web3ContextProvider.jsx
+++ b/solidity/dashboard/src/components/Web3ContextProvider.jsx
@@ -52,7 +52,10 @@ export default class Web3ContextProvider extends React.Component {
       throw error
     }
 
-    web3.eth.currentProvider.on("accountsChanged", this.onAccountChanged)
+    if (providerName === "METAMASK") {
+      web3.eth.currentProvider.on("accountsChanged", this.refreshProvider)
+      web3.eth.currentProvider.on("chainChanged", this.refreshProvider)
+    }
 
     this.setState({
       web3,
@@ -88,7 +91,7 @@ export default class Web3ContextProvider extends React.Component {
     await this.connectAppWithWallet(connector, provider)
   }
 
-  onAccountChanged = async ([yourAddress]) => {
+  refreshProvider = async ([yourAddress]) => {
     if (!yourAddress) {
       this.setState({
         isFetching: false,

--- a/solidity/dashboard/src/components/Web3ContextProvider.jsx
+++ b/solidity/dashboard/src/components/Web3ContextProvider.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Web3 from "web3"
 import { Web3Context } from "./WithWeb3Context"
-import { MessagesContext, messageType } from "./Message"
+import { MessagesContext } from "./Message"
 import { getContracts, resolveWeb3Deferred } from "../contracts"
 
 export default class Web3ContextProvider extends React.Component {
@@ -39,11 +39,7 @@ export default class Web3ContextProvider extends React.Component {
       resolveWeb3Deferred(web3)
     } catch (error) {
       this.setState({ providerError: error.message, isFetching: false })
-      this.context.showMessage({
-        type: messageType.ERROR,
-        title: error.message,
-      })
-      return
+      throw error
     }
 
     try {
@@ -51,9 +47,9 @@ export default class Web3ContextProvider extends React.Component {
     } catch (error) {
       this.setState({
         isFetching: false,
-        error: "Please select correct network",
+        error: error.message,
       })
-      return
+      throw error
     }
 
     web3.eth.currentProvider.on("accountsChanged", this.onAccountChanged)

--- a/solidity/dashboard/src/connectors/index.js
+++ b/solidity/dashboard/src/connectors/index.js
@@ -1,0 +1,15 @@
+import { TrezorProvider } from "./trezor"
+import { LedgerProvider, LEDGER_DERIVATION_PATHS } from "./ledger"
+
+const InjectedProvider = window.ethereum
+if (InjectedProvider) {
+  // https://docs.metamask.io/guide/ethereum-provider.html#ethereum-autorefreshonnetworkchange
+  InjectedProvider.autoRefreshOnNetworkChange = false
+}
+
+export {
+  TrezorProvider,
+  LedgerProvider,
+  LEDGER_DERIVATION_PATHS,
+  InjectedProvider,
+}

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -147,6 +147,36 @@ export const resovleContractsDeferred = (contracts) => {
 }
 
 export async function getContracts(web3) {
+  // This is a workaround for `web3.eth.net.getId()`, since on local machine
+  // returns unexpected values(eg. 105) and after calling this method the web3
+  // cannot call any other function eq `getTransaction` and doesnt throw errors.
+  // This is probably problem with `WebocketProvider`, because if we replace it
+  // with `RpcSubprovider` the result will be as expected (eg. for Mainnet
+  // returns 1).
+  const netIdDeferred = new Deferred()
+  web3.currentProvider.sendAsync(
+    {
+      jsonrpc: "2.0",
+      method: "net_version",
+      params: [],
+      id: new Date().getTime(),
+    },
+    (error, response) => {
+      if (error) {
+        netIdDeferred.reject(error)
+      } else {
+        netIdDeferred.resolve(response.result)
+      }
+    }
+  )
+  const netId = await netIdDeferred.promise
+  if (netId.toString() !== getFirstNetworkIdFromArtifact()) {
+    console.error(
+      `network id: ${netId}; expected network id ${getFirstNetworkIdFromArtifact()}`
+    )
+    throw new Error("Please connect to the appropriate Ethereum network.")
+  }
+
   const web3Contracts = {}
   for (const contractData of contracts) {
     const [options, jsonArtifact] = contractData
@@ -172,9 +202,7 @@ export async function getContracts(web3) {
 const getContract = async (web3, jsonArtifact, options) => {
   const { contractName, withDeployBlock } = options
   const address = getContractAddress(jsonArtifact)
-  // const code = await web3.eth.getCode(address)
 
-  // if (!isCodeValid(code)) throw Error("No contract at address")
   if (withDeployBlock) {
     CONTRACT_DEPLOY_BLOCK_NUMBER[contractName] = await contractDeployedAtBlock(
       web3,


### PR DESCRIPTION
Closes: #1956

This PR improves UX while connecting with wallet. Here we added loading indicators when the dapp fetches the wallet addresses and connects with a wallet. We also display the `install metamask` button only in case the user does not have the extension installed.

<details>
  <summary>Screenshoots</summary>

no MetaMask ext:
![no-metamask-ext](https://user-images.githubusercontent.com/57687279/93849412-5e9ad000-fcac-11ea-9fef-699d1d69cef1.gif)

wrong netowork error:
![mm-wrong-net](https://user-images.githubusercontent.com/57687279/93849634-d79a2780-fcac-11ea-8911-5e0dc9afad05.gif)

mm connecting:
![mm-connecting](https://user-images.githubusercontent.com/57687279/93849753-116b2e00-fcad-11ea-9b85-4009fdcdf7c9.gif)

ledger loading wallet addresses:
![ledger-loading-addresses](https://user-images.githubusercontent.com/57687279/93849994-8179b400-fcad-11ea-9525-7313ade00e4d.gif)

ledger select address:
![ledger-select-address](https://user-images.githubusercontent.com/57687279/93850129-c3a2f580-fcad-11ea-9ca1-d80a9fbdbd34.gif)

trezor loading wallet addresses:
![obraz](https://user-images.githubusercontent.com/57687279/93850291-0ebd0880-fcae-11ea-9868-eb916c9a920b.png)

trezor select address:
![trezor-select-acc](https://user-images.githubusercontent.com/57687279/93850360-3613d580-fcae-11ea-9895-ffeaee0fd5fe.gif)

</details>
