### PR TITLE
Set the default value for a  `options` param in the `createTransactionEventChannel`

### DIFF
--- a/solidity/dashboard/src/sagas/web3.js
+++ b/solidity/dashboard/src/sagas/web3.js
@@ -9,7 +9,12 @@ import {
 } from "../actions/messages"
 import { messageType } from "../components/Message"
 
-function createTransactionEventChannel(contract, method, args = [], options) {
+function createTransactionEventChannel(
+  contract,
+  method,
+  args = [],
+  options = {}
+) {
   const infoMessage = Message.create({
     title: "Waiting for the transaction confirmation...",
     type: messageType.INFO,


### PR DESCRIPTION
Ref: https://github.com/keep-network/keep-core/pull/2058#discussion_r490433685 
Set the default value to `{}` for the `options` param in the `createTransactionEventChannel` function.