### PR TITLE
Add peers multiaddresses to the diagnostics endpoint response

### DIFF
--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -43,9 +43,16 @@ func RegisterConnectedPeersSource(
 				continue
 			}
 
+			multiaddresses, err := connectionManager.GetPeerMultiaddresses(peer)
+			if err != nil {
+				logger.Error("error on getting peer multiaddresses: [%v]", err)
+				continue
+			}
+
 			peersList[i] = map[string]interface{}{
 				"network_id":       peer,
 				"ethereum_address": key.NetworkPubKeyToEthAddress(peerPublicKey),
+				"multiaddresses":   multiaddresses,
 			}
 		}
 

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -189,6 +189,27 @@ func (cm *connectionManager) GetPeerPublicKey(connectedPeer string) (*key.Networ
 	return key.Libp2pKeyToNetworkKey(peerPublicKey), nil
 }
 
+func (cm *connectionManager) GetPeerMultiaddresses(
+	peerHash string,
+) ([]string, error) {
+	peerID, err := peer.IDB58Decode(peerHash)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to decode peer hash [%v]: [%v]",
+			peerHash,
+			err,
+		)
+	}
+
+	multiaddresses := make([]string, 0)
+
+	for _, multiaddress := range cm.Network().Peerstore().Addrs(peerID) {
+		multiaddresses = append(multiaddresses, multiaddress.String())
+	}
+
+	return multiaddresses, nil
+}
+
 func (cm *connectionManager) DisconnectPeer(peerHash string) {
 	peerID, err := peer.IDB58Decode(peerHash)
 	if err != nil {

--- a/pkg/net/local/local.go
+++ b/pkg/net/local/local.go
@@ -139,3 +139,9 @@ func (lcm *localConnectionManager) AddrStrings() []string {
 func (lcm *localConnectionManager) IsConnected(address string) bool {
 	panic("not implemented")
 }
+
+func (lcm *localConnectionManager) GetPeerMultiaddresses(
+	peerHash string,
+) ([]string, error) {
+	panic("not implemented")
+}

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -73,6 +73,7 @@ type Provider interface {
 type ConnectionManager interface {
 	ConnectedPeers() []string
 	GetPeerPublicKey(connectedPeer string) (*key.NetworkPublic, error)
+	GetPeerMultiaddresses(peerHash string) ([]string, error)
 	DisconnectPeer(connectedPeer string)
 
 	// AddrStrings returns all listen addresses of the provider.


### PR DESCRIPTION
Here we add a new field with known multiaddresses of the connected peers to the diagnostics endpoint response. That enables the possibility of diagnosing issues related to the public availability of network members.