### PR TITLE
Remove the unused Ethereum address in the keep-client configuration

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -133,7 +133,6 @@ Application configurations are stored in a `.toml` file and passed to the applic
 
 # Keep operator Ethereum account.
 [ethereum.account]
-  Address = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"
   KeyFile = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"
 
 # Keep contract addresses configuration.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/bisontrails/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/bisontrails/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0x1833a1a046db585d9c405ad93bfce085d43b2b04"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/blockdaemon/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/blockdaemon/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0xb4f78caa0ad8c8c700eaac42b68e5db4f9efeddf"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/figment/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/figment/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0x9f778b5d9b6e598e5a9dfb789500f6cf20e3203e"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/maker/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/maker/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0xc2f4c01a446f199fce344df1167c92650651f9c0"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/raghav/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/raghav/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0x32ce883e94ea3a75063e47064c777839aa4a0c94"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/stake-capital/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/stake-capital/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0x5c769c2a379ebd630aa8ac9f125176209f170e6d"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/staked/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/staked/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0xca8754f7060a0648824f274e3a4d897fa497139d"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/eth-networks/keep-test/ropsten/participants/synapse/config/keep-client-config.toml
+++ b/infrastructure/eth-networks/keep-test/ropsten/participants/synapse/config/keep-client-config.toml
@@ -3,7 +3,6 @@
   URLRPC = "https://ropsten.infura.io/v3/59fb36a36fa4474b890c13dd30038be5"
 
   [ethereum.account]
-    Address = "0x8e258d2299bc1ee92ec9e70efb381d9b7c70c3d7"
     KeyFile = "/mnt/keep-client/config/eth-account-keyfile"
 
   # Contracts are already deployed to Ropsten.  They are subject to change on deployment.

--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-config-template.toml
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-config-template.toml
@@ -5,7 +5,6 @@
   URLRPC = ""
 
   [ethereum.account]
-    Address = ""
     KeyFile = ""
 
   [ethereum.ContractAddresses]


### PR DESCRIPTION
This Ethereum address is not used in the code. If the user fills in an address that does not match the keyfile, the error will be difficult to understand and mistakenly think that their address staking is incorrect.

In addition, there is no such field in keep-common and keep-ecdsa. Compared with adding this field and judgment logic in the code, it should be the simplest to delete directly.