### PR TITLE
Flattening the rewards curve

### DIFF
--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -391,10 +391,10 @@ contract Rewards {
     /// @param interval The interval.
     /// @return The percentage weight of the interval.
     function getIntervalWeight(uint256 interval) public view returns (uint256) {
-        if (interval < getIntervalCount()) {
+        if (interval < intervalWeights.length) {
             return intervalWeights[interval];
         } else {
-            return 100;
+            return intervalWeights[intervalWeights.length - 1];
         }
     }
 

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -294,10 +294,10 @@ describe('Rewards', () => {
             expect(weight3.toNumber()).to.equal(50)
         })
 
-        it("returns 100% after the defined intervals", async () => {
+        it("returns the last defined interval weight after the defined intervals", async () => {
             await createKeeps([])
             let weight4 = await rewards.getIntervalWeight(4)
-            expect(weight4.toNumber()).to.equal(100)
+            expect(weight4.toNumber()).to.equal(50)
         })
     })
 

--- a/solidity/test/rewards/rewardsData.js
+++ b/solidity/test/rewards/rewardsData.js
@@ -26,22 +26,22 @@ const testValues = {
         50, // 15:15
     ],
     inVacuumBaseRewards: [
-        200000, 500000, 250000, 500000, 1000000, 1000000, 1000000,
+        200000, 500000, 250000, 500000, 500000, 500000, 500000,
     ],
     inVacuumAdjustedRewards: [
-        200000, 500000, 125000, 500000, 0, 500000, 1000000,
+        200000, 500000, 125000, 500000, 0, 250000, 500000,
     ],
     inVacuumPerKeepRewards: [
-        66666, 125000, 125000, 250000, 0, 500000, 500000,
+        66666, 125000, 125000, 250000, 0, 250000, 250000,
     ],
     actualAllocations: [
         200000, // 800000 remaining
         400000, // 400000 remaining
         50000,  // 350000 remaining
         175000, // 175000 remaining
-        0,
-        87500, // 87500 remaining
-        87500, // 0 remaining
+        0,      // 175000 remaining
+        43750,  // 131250 remaining
+        65625,  // 65625 remaining
     ]
 }
 module.exports = { testValues }


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1783

Instead of allocating yet unallocated rewards in the last interval with 100% interval weight, we are going to use the last defined interval's weight which should flatten the rewards curve.

Instead of:
![image](https://user-images.githubusercontent.com/4712360/94716632-6f53e180-034f-11eb-9ab9-c56306692a22.png)

We would have:
![image](https://user-images.githubusercontent.com/4712360/94716668-7b3fa380-034f-11eb-8bdd-03df91cf9d93.png)

