### PR TITLE
Fund properly before allocating rewards

### DIFF
--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -14,6 +14,7 @@
 
 pragma solidity ^0.5.17;
 
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -64,7 +65,7 @@ import "openzeppelin-solidity/contracts/math/Math.sol";
 /// functions for accessing information about keeps and paying out rewards.
 /// For the purpose of rewards, Random Beacon signing groups count as "keeps"
 /// and the beacon operator contract acts as the "factory".
-contract Rewards {
+contract Rewards is Ownable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
@@ -92,9 +93,6 @@ contract Rewards {
     // Timestamp of first interval beginning.
     // Interval 0 covers everything before `firstIntervalStart`
     // and the first `termLength` after `firstIntervalStart`.
-    // This value should be set
-    // so that `firstIntervalStart + termLength` is in the future
-    // so the contract can be funded before intervals can be allocated.
     uint256 public firstIntervalStart;
     // Mapping of interval number to tokens allocated for the interval.
     uint256[] internal intervalAllocations;
@@ -107,6 +105,12 @@ contract Rewards {
     // Mapping of interval to number of keeps whose rewards have been paid out,
     // or reallocated because the keep closed unhappily
     mapping(uint256 => uint256) public intervalKeepsProcessed;
+
+    // Indicates whether the contract has been properly funded. Rewards can not
+    // be allocated before the first funding and the owner of the
+    // contract is responsible for marking it as already funded. Further funding
+    // of the contract is possible with no owner's intervention.
+    bool public funded = false;
 
     event RewardReceived(bytes32 keep, uint256 amount);
 
@@ -158,6 +162,10 @@ contract Rewards {
 
         totalRewards = totalRewards.add(addedBalance);
         unallocatedRewards = unallocatedRewards.add(addedBalance);
+    }
+
+    function markAsFunded() public onlyOwner {
+        funded = true;
     }
 
     /// @notice Sends the reward for a keep to the keep members.
@@ -458,6 +466,7 @@ contract Rewards {
     /// @param interval The interval to allocate.
     function allocateRewards(uint256 interval)
         mustBeFinished(interval)
+        mustBeFunded
         public
     {
         uint256 allocatedIntervals = intervalAllocations.length;
@@ -605,6 +614,11 @@ contract Rewards {
         require(
             _recognizedByFactory(_keep),
             "Keep not recognized by factory");
+        _;
+    }
+
+    modifier mustBeFunded() {
+        require(funded, "Contract not yet funded");
         _;
     }
 }

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -618,7 +618,7 @@ contract Rewards is Ownable {
     }
 
     modifier mustBeFunded() {
-        require(funded, "Contract not yet funded");
+        require(funded, "Contract has not been funded yet");
         _;
     }
 }

--- a/solidity/test/rewards/TestBeaconBackportRewards.js
+++ b/solidity/test/rewards/TestBeaconBackportRewards.js
@@ -44,7 +44,8 @@ describe('BeaconBackportRewards', () => {
         rewardsContract = await contract.fromArtifact('BeaconBackportRewards').new(
             token.address,
             operatorContract.address,
-            stakingContract.address
+            stakingContract.address,
+            { from: owner }
         )
 
         await token.approveAndCall(
@@ -53,6 +54,7 @@ describe('BeaconBackportRewards', () => {
             "0x0",
             { from: owner }
         )
+        await rewardsContract.markAsFunded({from: owner})
 
         // create 64 operators and beneficiaries, delegate stake for them
         const minimumStake = await stakingContract.minimumStake()

--- a/solidity/test/rewards/TestBeaconRewards.js
+++ b/solidity/test/rewards/TestBeaconRewards.js
@@ -47,7 +47,8 @@ describe('BeaconRewards', () => {
         rewardsContract = await contract.fromArtifact('BeaconRewards').new(
             token.address,
             operatorContract.address,
-            stakingContract.address
+            stakingContract.address,
+            { from: owner }
         )
 
         await token.approveAndCall(
@@ -56,6 +57,7 @@ describe('BeaconRewards', () => {
             "0x0",
             { from: owner }
         )
+        await rewardsContract.markAsFunded({from: owner})
 
         // create 64 operators and beneficiaries, delegate stake for them
         const minimumStake = await stakingContract.minimumStake()

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -107,7 +107,7 @@ describe('Rewards', () => {
         it("prevents from allocating rewards if not previously called", async () => {
             await expectRevert(
                 newRewards.allocateRewards(0),
-                "Contract not yet funded"
+                "Contract has not been funded yet"
             )
         })
     })

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -14,6 +14,7 @@ const expect = chai.expect
 const assert = chai.assert
 
 describe('Rewards', () => {
+    const owner = accounts[0]
     const aliceBeneficiary = accounts[1]
     const funder = accounts[9]
 
@@ -29,9 +30,11 @@ describe('Rewards', () => {
             testValues.initiationTime,
             testValues.intervalWeights,
             timestamps,
-            termLength
+            termLength,
+            {from: owner}
         )
         await fund(testValues.totalRewards)
+        await rewards.markAsFunded({from: owner})
     }
 
     async function fund(amount) {
@@ -76,6 +79,36 @@ describe('Rewards', () => {
             await fund(0)
             let postRewards = await rewards.totalRewards()
             expect(postRewards.toNumber()).to.equal(testValues.totalRewards * 2)
+        })
+    })
+
+    describe("markAsFunded", async () => {
+        let newRewards
+        
+        beforeEach(async() => {
+            newRewards = await RewardsStub.new(
+               token.address,
+               testValues.minimumIntervalKeeps,
+               testValues.initiationTime,
+               testValues.intervalWeights,
+               [],
+              termLength,
+              {from: owner}
+            )
+        })
+
+        it("can not be called by non-owner", async () => {
+            await expectRevert(
+                newRewards.markAsFunded({from: funder}),
+                "Ownable: caller is not the owner"
+            )
+        })
+
+        it("prevents from allocating rewards if not previously called", async () => {
+            await expectRevert(
+                newRewards.allocateRewards(0),
+                "Contract not yet funded"
+            )
         })
     })
 


### PR DESCRIPTION
Depends on #2103
Refs https://github.com/keep-network/keep-core/issues/1783

We had a problem with `firstIntervalStart` property - it had to be set in a way that `firstIntervalStart + termLength` would be in the future. Otherwise, someone could call `allocateRewards(0)` before we fund the contract properly and the allocation for the first interval would not be the same as we'd want it to be.

Here we are making `Rewards` contract `Ownable` for only one purpose - the owner has to mark the contract as properly funded calling `markAsFunded` function. Only from then, rewards can be allocated.

Setting the contract as funded does not stop it from being funded even more in the future.

The expected order of operations is as follows:
- contract is deployed,
- contract is funded with the expected amount of KEEP,
- contract is marked as funded and ready to be used by stakers.