### PR TITLE
Make rewards upgradeable

### DIFF
--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -593,9 +593,8 @@ contract Rewards is Ownable {
             amountToTransfer,
             bytes("")
         );
-        if (!success) {
-            revert("Upgrade finalization failed");
-        }
+        require(success, "Upgrade finalization failed");
+        
 
         upgradeInitiatedTimestamp = 0;
     }

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -118,8 +118,8 @@ contract Rewards is Ownable {
     // Owner of the contract may initiate an upgrade to a new rewards contract
     // but the pending and past intervals must receive their rewards before any
     // KEEP tokens are transferred out from this contract.
-    uint256 upgradeInitiatedTimestamp;
-    address newRewardsContract;
+    uint256 public upgradeInitiatedTimestamp;
+    address public newRewardsContract;
 
     event RewardReceived(bytes32 keep, uint256 amount);
     event UpgradeInitiated(address newRewardsContract);

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -87,11 +87,11 @@ contract Rewards is Ownable {
     uint256 public totalRewards;
     // Rewards that haven't been allocated to finished intervals
     uint256 public unallocatedRewards;
-    // Rewards that have been paid out from this contract - as a signer
+    // Rewards that have been dispensed from this contract - as a signer
     // rewards or transferred to a new rewards contract.
     // `token.balanceOf(address(this))` should always equal
-    // `totalRewards.sub(paidOutRewards)`
-    uint256 public paidOutRewards;
+    // `totalRewards.sub(dispensedRewards)`
+    uint256 public dispensedRewards;
 
     // Timestamp of first interval beginning.
     // Interval 0 covers everything before `firstIntervalStart`
@@ -163,7 +163,7 @@ contract Rewards is Ownable {
         token.safeTransferFrom(_from, address(this), _value);
 
         uint256 currentBalance = token.balanceOf(address(this));
-        uint256 beforeBalance = totalRewards.sub(paidOutRewards);
+        uint256 beforeBalance = totalRewards.sub(dispensedRewards);
         require(
             currentBalance >= beforeBalance,
             "Reward contract has lost tokens"
@@ -542,7 +542,7 @@ contract Rewards is Ownable {
         intervalKeepsProcessed[interval] = intervalKeepsProcessed[interval].add(1);
 
         if (eligible) {
-            paidOutRewards = paidOutRewards.add(perKeepReward);
+            dispensedRewards = dispensedRewards.add(perKeepReward);
             _distributeReward(keepIdentifier, perKeepReward);
             emit RewardReceived(keepIdentifier, perKeepReward);
         } else {
@@ -584,7 +584,7 @@ contract Rewards is Ownable {
 
         totalRewards = totalRewards.sub(amountToTransfer);
         unallocatedRewards = 0;
-        paidOutRewards = paidOutRewards.add(amountToTransfer);
+        dispensedRewards = dispensedRewards.add(amountToTransfer);
 
         emit UpgradeFinalized(amountToTransfer);
 

--- a/solidity/contracts/stubs/NewRewardsStub.sol
+++ b/solidity/contracts/stubs/NewRewardsStub.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.17;
+
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+
+contract NewRewardsStub {
+
+    using SafeERC20 for IERC20;
+
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes memory
+    ) public {
+        IERC20(_token).safeTransferFrom(_from, address(this), _value);
+    }
+}

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -1,0 +1,222 @@
+const { accounts, contract, web3 } = require("@openzeppelin/test-environment")
+const { createSnapshot, restoreSnapshot } = require("../helpers/snapshot.js")
+const { expectRevert, time } = require("@openzeppelin/test-helpers")
+
+const KeepToken = contract.fromArtifact('KeepToken')
+const RewardsStub = contract.fromArtifact("RewardsStub");
+const NewRewardsStub = contract.fromArtifact("NewRewardsStub");
+
+const BN = web3.utils.BN
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
+describe.only("Rewards/Upgrades", () => {
+    const owner = accounts[0]
+    const thirdParty = accounts[1]
+    const beneficiary = accounts[3]
+
+    const intervalWeights = [5, 10, 15, 20]
+    const totalRewards = 1000000
+    const minimumKeepsPerInterval = 1
+    const termLength = 1000
+    let timestamps
+    let firstIntervalStart
+
+    let token, rewards, newRewards
+
+    before(async () => {
+        token = await KeepToken.new({ from: owner })
+        newRewards = await NewRewardsStub.new()
+
+        firstIntervalStart = await time.latest()
+        timestamps = [
+            101, 150,    // 2 keep in interval 0
+            1100,        // 1 keep in interval 1
+            2200, 2201   // 2 keeps in interval 2
+        ].map((t) => firstIntervalStart.addn(t).toNumber())
+
+        rewards = await RewardsStub.new(
+            token.address,
+            minimumKeepsPerInterval,
+            firstIntervalStart,
+            intervalWeights,
+            timestamps,
+            termLength,
+            {from: owner}
+         )
+         await token.approveAndCall(
+            rewards.address,
+            totalRewards,
+            "0x0",
+            {from: owner}
+        )
+        await rewards.markAsFunded({from: owner})
+    })
+
+    beforeEach(async () => {
+        await createSnapshot()
+    })
+
+    afterEach(async () => {
+        await restoreSnapshot()
+    })
+
+    describe("upgrades", async () => {
+        it("can be initiated only by contract owner", async () => {            
+            await expectRevert(
+                rewards.initiateRewardsUpgrade(
+                    newRewards.address,
+                    {from: thirdParty}
+                ),
+                "Ownable: caller is not the owner"
+            )
+        })
+
+        it("can be finalized only by contract owner", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+            await expectRevert(
+                rewards.finalizeRewardsUpgrade({from: thirdParty}),
+                "Ownable: caller is not the owner."
+            )            
+        })
+
+        it("can not be finalized without initiating first", async () => {
+            await expectRevert(
+                rewards.finalizeRewardsUpgrade({from: owner}),
+                "Upgrade not initiated"
+            ) 
+        })
+
+        it("can not be finalized before the current interval ends", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+            await expectRevert(
+                rewards.finalizeRewardsUpgrade({from: owner}),
+                "Interval hasn't ended yet"
+            )
+        })
+
+        it("can not be finalized another time without initiating again", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(termLength + 1) // interval 0 ends
+            await rewards.finalizeRewardsUpgrade({from: owner})
+            await expectRevert(
+                rewards.finalizeRewardsUpgrade({from: owner}),
+                "Upgrade not initiated"
+            ) 
+        })
+
+        it("should not change the current interval allocation", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(termLength + 1) // interval 0 ends
+            await rewards.setCloseTime(timestamps[1])
+
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
+            const allocation = await rewards.getAllocatedRewards(0)
+            expect(allocation).to.eq.BN(50000) // 5% of 1 000 000
+        })
+
+        it("allocates all possible intervals", async () => {
+            await time.increase(termLength + 1) // interval 0 ends
+
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(termLength + 1) // interval 1 ends
+            await rewards.setCloseTime(timestamps[2])
+
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
+            const allocation0 = await rewards.getAllocatedRewards(0)
+            const allocation1 = await rewards.getAllocatedRewards(1)
+            
+            expect(allocation0).to.eq.BN(50000) // 5% of 1000000
+            expect(allocation1).to.eq.BN(95000) // 10% of (1000000 - 50000)
+            await expectRevert(
+                rewards.getAllocatedRewards(2),
+                "Interval not allocated yet"
+            )
+        })
+
+        it("moves all unallocated rewards to new contract", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(2 * termLength + 1)  
+            
+            await rewards.setCloseTime(timestamps[2])
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
+            const newContractBalance = await token.balanceOf(newRewards.address)
+            // interval 0 allocates 50000
+            // interval 1 allocates 95000
+            // 1000000 - 50000 - 95000 = 855000 should be transferred to the
+            // new contract
+            expect(newContractBalance).to.eq.BN(855000)
+        })
+
+        it("correctly updates reward balances", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(2 * termLength + 1)  
+            
+            await rewards.setCloseTime(timestamps[2])
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
+            const totalRewards = await rewards.totalRewards()
+            const unallocatedRewards = await rewards.unallocatedRewards()
+            const paidOutRewards = await rewards.paidOutRewards()
+
+            // interval 0 allocates 50000
+            // interval 1 allocates 95000
+            // 50000 + 95000 = 145000
+            expect(totalRewards).to.eq.BN(145000)
+            expect(unallocatedRewards).to.eq.BN(0)
+            // nothing yet withdrawn but 855000 transferred to the new contract
+            expect(paidOutRewards).to.eq.BN(855000)
+        })
+
+        it("let to withdraw outstanding rewards after migration", async () => {
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(2 * termLength + 1)  
+            
+            await rewards.setCloseTime(timestamps[2])
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
+            await rewards.receiveReward(0, { from: beneficiary })
+            await rewards.receiveReward(1, { from: beneficiary })
+            await rewards.receiveReward(2, { from: beneficiary })
+            const beneficiaryBalance = await token.balanceOf(beneficiary)
+            // interval 0 allocates 50000
+            // interval 1 allocates 95000
+            // 50000 + 95000 = 145000
+            expect(beneficiaryBalance).to.eq.BN(145000)
+        })
+    })
+})

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -11,7 +11,7 @@ const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-describe.only("Rewards/Upgrades", () => {
+describe("Rewards/Upgrades", () => {
     const owner = accounts[0]
     const thirdParty = accounts[1]
     const beneficiary = accounts[3]

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -84,14 +84,14 @@ describe("Rewards/Upgrades", () => {
             )            
         })
 
-        it("can not be finalized without initiating first", async () => {
+        it("cannot be finalized without initiating first", async () => {
             await expectRevert(
                 rewards.finalizeRewardsUpgrade({from: owner}),
                 "Upgrade not initiated"
             ) 
         })
 
-        it("can not be finalized before the current interval ends", async () => {
+        it("cannot be finalized before the current interval ends", async () => {
             await rewards.initiateRewardsUpgrade(
                 newRewards.address,
                 {from: owner}
@@ -102,7 +102,7 @@ describe("Rewards/Upgrades", () => {
             )
         })
 
-        it("can not be finalized another time without initiating again", async () => {
+        it("cannot be finalized another time without initiating again", async () => {
             await rewards.initiateRewardsUpgrade(
                 newRewards.address,
                 {from: owner}

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -187,7 +187,7 @@ describe("Rewards/Upgrades", () => {
 
             const totalRewards = await rewards.totalRewards()
             const unallocatedRewards = await rewards.unallocatedRewards()
-            const paidOutRewards = await rewards.paidOutRewards()
+            const dispensedRewards = await rewards.dispensedRewards()
 
             // interval 0 allocates 50000
             // interval 1 allocates 95000
@@ -195,7 +195,7 @@ describe("Rewards/Upgrades", () => {
             expect(totalRewards).to.eq.BN(145000)
             expect(unallocatedRewards).to.eq.BN(0)
             // nothing yet withdrawn but 855000 transferred to the new contract
-            expect(paidOutRewards).to.eq.BN(855000)
+            expect(dispensedRewards).to.eq.BN(855000)
         })
 
         it("let to withdraw outstanding rewards after migration", async () => {


### PR DESCRIPTION
This PR presents an alternative approach for Rewards upgrades. Compared to https://github.com/keep-network/keep-core/pull/2102, it's less graceful but allows reallocating tokens quicker.

# Background

`KeepRandomBeaconOperator` and `BondedECDSAKeepFactory` may get upgraded to the improved versions. When this happens, we want to incentivize stakers to move to the new contracts and do not lock the entire unallocated signer subsidy in rewards contract backing old operator contract versions.

# Competing approach

The approach presented in #2102 is more graceful. Rewards tokens that would normally be returned to the unallocated pool would instead be sent to the new rewards contract. This would gracefully bleed out the old rewards contract's reward tokens as the creation of new keeps (or beacon groups) dwindles over time as the stakers move to the new contract.

# Proposed approach

The approach presented here is less graceful than the one in #2102 but allows to relocate tokens quicker and lower the gas cost of allocating rewards.

Given that tokens are allocated at interval end, going with #2102 means that each interval of the new rewards contract needs to have 100% weight if we want to pay out the full amount of rewards from the interval defined on the old rewards contract. Additionally, it first requires allocating tokens on the old contract and has a risk that some malicious actor may race to allocate tokens on the new contract before we have a chance to move them there from the old contract for the given interval.

The approach presented here is a two-step process:
- upgrade is initiated,
- once the interval at which the upgrade was initiated ends, upgrade can be finalized.

When finalizing the upgrade, tokens are transferred to the new rewards contract but first, all past intervals are allocated. It means the upgrade mechanism may not change the amounts of tokens that would be distributed in any past or pending interval at the moment of initiating the upgrade.