### PR TITLE
Operator balance monitoring

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -42,6 +42,17 @@ const (
 const startDescription = `Starts the Keep client in the foreground. Currently this only consists of the
    threshold relay client for the Keep random beacon.`
 
+// Constants related with balance monitoring.
+const (
+	// defaultBalanceAlertThreshold determines the alert threshold below which
+	// the alert should be triggered.
+	defaultBalanceAlertThreshold = 500000000000000000 // 0.5 ETH
+
+	// defaultBalanceMonitoringTick determines how often the monitoring
+	// check should be triggered.
+	defaultBalanceMonitoringTick = 10 * time.Minute
+)
+
 func init() {
 	StartCommand =
 		cli.Command{
@@ -264,23 +275,24 @@ func initializeBalanceMonitoring(
 	balanceMonitor, err := chainProvider.BalanceMonitor()
 	if err != nil {
 		logger.Errorf("error obtaining balance monitor handle [%v]", err)
+		return
 	}
 
 	alertThreshold := config.Ethereum.BalanceAlertThreshold
 	if alertThreshold == 0 {
-		alertThreshold = 500000000000000000 // 0.5 ETH by default.
+		alertThreshold = defaultBalanceAlertThreshold
 	}
 
 	balanceMonitor.Observe(
 		ctx,
 		ethereumAddress,
 		new(big.Int).SetUint64(alertThreshold),
-		10*time.Minute,
+		defaultBalanceMonitoringTick,
 	)
 
 	logger.Infof(
 		"started balance monitoring for address [%v] "+
-			"with alerting below [%v] wei",
+			"with the alert threshold set to [%v] wei",
 		ethereumAddress,
 		alertThreshold,
 	)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -275,7 +275,7 @@ func initializeBalanceMonitoring(
 		ctx,
 		ethereumAddress,
 		new(big.Int).SetUint64(alertThreshold),
-		10*time.Second,
+		10*time.Minute,
 	)
 
 	logger.Infof(

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -39,9 +39,9 @@
 	# ConcurrencyLimit = 30
 	#
 	# BalanceAlertThreshold defines a minimum value of the operator's account
-        # balance below which an alert will be triggered.
-        #
-        # BalanceAlertThreshold = 500000000000000000 # 0.5 ETH (default value)
+	# balance below which an alert will be triggered.
+	#
+	# BalanceAlertThreshold = 500000000000000000 # 0.5 ETH (default value)
 
 [ethereum.account]
 	KeyFile            = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -37,6 +37,11 @@
 	# including view function calls.
 	#
 	# ConcurrencyLimit = 30
+	#
+	# BalanceAlertThreshold defines a minimum value of the operator's account
+    # balance below which an alert will be triggered.
+    #
+    # BalanceAlertThreshold = 500000000000000000 # 0.5 ETH (default value)
 
 [ethereum.account]
 	KeyFile            = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -39,7 +39,8 @@
 	# ConcurrencyLimit = 30
 	#
 	# BalanceAlertThreshold defines a minimum value of the operator's account
-	# balance below which an alert will be triggered.
+	# balance below which the client will start reporting errors in logs.
+	# The value should be passed in [wei].
 	#
 	# BalanceAlertThreshold = 500000000000000000 # 0.5 ETH (default value)
 

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -39,9 +39,9 @@
 	# ConcurrencyLimit = 30
 	#
 	# BalanceAlertThreshold defines a minimum value of the operator's account
-    # balance below which an alert will be triggered.
-    #
-    # BalanceAlertThreshold = 500000000000000000 # 0.5 ETH (default value)
+        # balance below which an alert will be triggered.
+        #
+        # BalanceAlertThreshold = 500000000000000000 # 0.5 ETH (default value)
 
 [ethereum.account]
 	KeyFile            = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.2.0
+	github.com/keep-network/keep-common v1.2.1-0.20201006102729-2dbe02bd3d5b
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.2.1-0.20201006102729-2dbe02bd3d5b
+	github.com/keep-network/keep-common v1.2.1-0.20201029113201-c0dd6371b13d
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.2.1-0.20201029113201-c0dd6371b13d
+	github.com/keep-network/keep-common v1.2.1-0.20201117163745-878626866ba7
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.2.1-0.20201006102729-2dbe02bd3d5b h1:QdqEEwIeAFVpzGnc6ZHoEmygaefO2cc7/iA1/is/IdI=
-github.com/keep-network/keep-common v1.2.1-0.20201006102729-2dbe02bd3d5b/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.2.1-0.20201029113201-c0dd6371b13d h1:YD6NeVLBKYaCEmToskF9Sc14CUNnv7GvzF3Ozwfsdv4=
+github.com/keep-network/keep-common v1.2.1-0.20201029113201-c0dd6371b13d/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.2.1-0.20201029113201-c0dd6371b13d h1:YD6NeVLBKYaCEmToskF9Sc14CUNnv7GvzF3Ozwfsdv4=
-github.com/keep-network/keep-common v1.2.1-0.20201029113201-c0dd6371b13d/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.2.1-0.20201117163745-878626866ba7 h1:bmyyWcrg7dZ2TcgEIPV3d5uUrpoOncz9gEGBNg9eMHA=
+github.com/keep-network/keep-common v1.2.1-0.20201117163745-878626866ba7/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,7 @@ github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvK
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277 h1:E0whKxgp2ojts0FDgUA8dl62bmH0LxKanMoBr6MDTDM=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
@@ -338,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.2.0 h1:hVd2tTd7vL+9CQP5Ntk5kjs+GYvkgrRNBcNvTuhHhVk=
-github.com/keep-network/keep-common v1.2.0/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.2.1-0.20201006102729-2dbe02bd3d5b h1:QdqEEwIeAFVpzGnc6ZHoEmygaefO2cc7/iA1/is/IdI=
+github.com/keep-network/keep-common v1.2.1-0.20201006102729-2dbe02bd3d5b/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/beacon/relay/registry/groups_test.go
+++ b/pkg/beacon/relay/registry/groups_test.go
@@ -190,6 +190,11 @@ func (phm *persistenceHandleMock) Save(data []byte, directory string, name strin
 	return nil
 }
 
+func (phm *persistenceHandleMock) Snapshot(data []byte, directory string, name string) error {
+	// noop
+	return nil
+}
+
 func (phm *persistenceHandleMock) ReadAll() (<-chan persistence.DataDescriptor, <-chan error) {
 	membershipBytes1, _ := (&Membership{
 		Signer:      signer1,

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -3,6 +3,8 @@ package chain
 import (
 	"context"
 	"crypto/ecdsa"
+	"math/big"
+	"time"
 
 	relaychain "github.com/keep-network/keep-core/pkg/beacon/relay/chain"
 	"github.com/keep-network/keep-core/pkg/gen/async"
@@ -51,6 +53,20 @@ type StakeMonitor interface {
 	StakerFor(address string) (Staker, error)
 }
 
+// StakeMonitor is an interface that provides the ability to monitor
+// the balance for the provided address.
+type BalanceMonitor interface {
+	// Observe starts a process which checks the address balance with the given
+	// tick and triggers an alert in case the balance falls below the
+	// alert threshold value.
+	Observe(
+		ctx context.Context,
+		address string,
+		alertThreshold *big.Int,
+		tick time.Duration,
+	)
+}
+
 // Signing is an interface that provides ability to sign and verify
 // signatures using operator's key associated with the chain.
 type Signing interface {
@@ -92,6 +108,7 @@ type Signing interface {
 type Handle interface {
 	BlockCounter() (BlockCounter, error)
 	StakeMonitor() (StakeMonitor, error)
+	BalanceMonitor() (BalanceMonitor, error)
 	ThresholdRelay() relaychain.Interface
 	Signing() Signing
 }

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -53,7 +53,7 @@ type StakeMonitor interface {
 	StakerFor(address string) (Staker, error)
 }
 
-// StakeMonitor is an interface that provides the ability to monitor
+// BalanceMonitor is an interface that provides the ability to monitor
 // the balance for the provided address.
 type BalanceMonitor interface {
 	// Observe starts a process which checks the address balance with the given

--- a/pkg/chain/ethereum/balance_monitor.go
+++ b/pkg/chain/ethereum/balance_monitor.go
@@ -10,12 +10,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// BalanceSource provides a balance info for the given address.
 type BalanceSource func(address common.Address) (*big.Int, error)
 
+// BalanceMonitor provides the possibility to monitor balances for given
+// accounts.
 type BalanceMonitor struct {
 	balanceSource BalanceSource
 }
 
+// Observe starts a process which checks the address balance with the given
+// tick and triggers an alert in case the balance falls below the
+// alert threshold value.
 func (bm *BalanceMonitor) Observe(
 	ctx context.Context,
 	address string,
@@ -31,8 +37,9 @@ func (bm *BalanceMonitor) Observe(
 
 		if balance.Cmp(alertThreshold) == -1 {
 			logger.Errorf(
-				"ethereum balance is below [%v] wei; "+
-					"please fund your operator account",
+				"ethereum balance for account [%v] is below [%v] wei; "+
+					"account should be funded",
+				address,
 				alertThreshold.Text(10),
 			)
 		}

--- a/pkg/chain/ethereum/balance_monitor.go
+++ b/pkg/chain/ethereum/balance_monitor.go
@@ -1,0 +1,52 @@
+package ethereum
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type BalanceSource func(address common.Address) (*big.Int, error)
+
+type BalanceMonitor struct {
+	balanceSource BalanceSource
+}
+
+func (bm *BalanceMonitor) Observe(
+	ctx context.Context,
+	address common.Address,
+	alertThreshold *big.Int,
+	tick time.Duration,
+) {
+	check := func() {
+		balance, err := bm.balanceSource(address)
+		if err != nil {
+			logger.Errorf("ethereum balance monitor error: [%v]", err)
+			return
+		}
+
+		if balance.Cmp(alertThreshold) < -1 {
+			logger.Errorf(
+				"ethereum balance is below [%v] wei; "+
+					"please fund your operator account",
+				alertThreshold.Text(10),
+			)
+		}
+	}
+
+	go func() {
+		ticker := time.NewTicker(tick)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				check()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/pkg/chain/ethereum/balance_monitor.go
+++ b/pkg/chain/ethereum/balance_monitor.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/keep-network/keep-core/pkg/chain"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -16,18 +18,18 @@ type BalanceMonitor struct {
 
 func (bm *BalanceMonitor) Observe(
 	ctx context.Context,
-	address common.Address,
+	address string,
 	alertThreshold *big.Int,
 	tick time.Duration,
 ) {
 	check := func() {
-		balance, err := bm.balanceSource(address)
+		balance, err := bm.balanceSource(common.HexToAddress(address))
 		if err != nil {
 			logger.Errorf("ethereum balance monitor error: [%v]", err)
 			return
 		}
 
-		if balance.Cmp(alertThreshold) < -1 {
+		if balance.Cmp(alertThreshold) == -1 {
 			logger.Errorf(
 				"ethereum balance is below [%v] wei; "+
 					"please fund your operator account",
@@ -49,4 +51,8 @@ func (bm *BalanceMonitor) Observe(
 			}
 		}
 	}()
+}
+
+func (ec *ethereumChain) BalanceMonitor() (chain.BalanceMonitor, error) {
+	return &BalanceMonitor{ec.WeiBalanceOf}, nil
 }

--- a/pkg/chain/ethereum/balance_monitor.go
+++ b/pkg/chain/ethereum/balance_monitor.go
@@ -19,6 +19,11 @@ type BalanceMonitor struct {
 	balanceSource BalanceSource
 }
 
+// NewBalanceMonitor creates a new instance of the balance monitor.
+func NewBalanceMonitor(balanceSource BalanceSource) *BalanceMonitor {
+	return &BalanceMonitor{balanceSource}
+}
+
 // Observe starts a process which checks the address balance with the given
 // tick and triggers an alert in case the balance falls below the
 // alert threshold value.
@@ -61,5 +66,5 @@ func (bm *BalanceMonitor) Observe(
 }
 
 func (ec *ethereumChain) BalanceMonitor() (chain.BalanceMonitor, error) {
-	return &BalanceMonitor{ec.WeiBalanceOf}, nil
+	return NewBalanceMonitor(ec.WeiBalanceOf), nil
 }

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/ipfs/go-log"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -516,4 +518,16 @@ func (ec *ethereumChain) CalculateDKGResultHash(
 	hash := crypto.Keccak256(dkgResult.GroupPublicKey, dkgResult.Misbehaved)
 
 	return relaychain.DKGResultHashFromBytes(hash)
+}
+
+func (ec *ethereumChain) Address() common.Address {
+	return ec.accountKey.Address
+}
+
+func (ec *ethereumChain) WeiBalanceOf(address common.Address) (*big.Int, error) {
+	var result hexutil.Big
+
+	err := ec.clientRPC.Call(&result, "eth_getBalance", address)
+
+	return (*big.Int)(&result), err
 }

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -527,7 +527,7 @@ func (ec *ethereumChain) Address() common.Address {
 func (ec *ethereumChain) WeiBalanceOf(address common.Address) (*big.Int, error) {
 	var result hexutil.Big
 
-	err := ec.clientRPC.Call(&result, "eth_getBalance", address)
+	err := ec.clientRPC.Call(&result, "eth_getBalance", address, "latest")
 
 	return (*big.Int)(&result), err
 }

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -1,11 +1,10 @@
 package ethereum
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"time"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ipfs/go-log"
 
@@ -525,9 +524,8 @@ func (ec *ethereumChain) Address() common.Address {
 }
 
 func (ec *ethereumChain) WeiBalanceOf(address common.Address) (*big.Int, error) {
-	var result hexutil.Big
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancelCtx()
 
-	err := ec.clientRPC.Call(&result, "eth_getBalance", address, "latest")
-
-	return (*big.Int)(&result), err
+	return ec.client.BalanceAt(ctx, address, nil)
 }

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -92,6 +92,10 @@ func (c *localChain) StakeMonitor() (chain.StakeMonitor, error) {
 	return c.stakeMonitor, nil
 }
 
+func (c *localChain) BalanceMonitor() (chain.BalanceMonitor, error) {
+	return nil, nil // not implemented.
+}
+
 func (c *localChain) Signing() chain.Signing {
 	return &localSigning{c.operatorKey}
 }

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -93,7 +93,7 @@ func (c *localChain) StakeMonitor() (chain.StakeMonitor, error) {
 }
 
 func (c *localChain) BalanceMonitor() (chain.BalanceMonitor, error) {
-	return nil, nil // not implemented.
+	panic("not implemented")
 }
 
 func (c *localChain) Signing() chain.Signing {

--- a/solidity/scripts/lcl-client-config.js
+++ b/solidity/scripts/lcl-client-config.js
@@ -51,9 +51,10 @@ module.exports = async function () {
                         // so we can run the following match check.
                         typeof key === "string" &&
                         // Find keys that match exactly `Port`, `MiningCheckInterval`,
-                        // `MaxGasPrice` or end with `MetricsTick` or `Limit`.
+                        // `MaxGasPrice`, `BalanceAlertThreshold` or end with
+                        // `MetricsTick` or `Limit`.
                         key.match(
-                          /(^Port|^MiningCheckInterval|^MaxGasPrice|MetricsTick|Limit)$/
+                          /(^Port|^MiningCheckInterval|^MaxGasPrice|^BalanceAlertThreshold|MetricsTick|Limit)$/
                         )
                           ? value.toFixed(0) // convert float to integer
                           : false // do nothing


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/2163
Closes #2171
Refs: https://github.com/keep-network/keep-ecdsa/issues/551
Depends on: https://github.com/keep-network/keep-common/pull/51
Depends on: https://github.com/keep-network/keep-common/pull/59

Here we implement a simple balance monitor and enable it for the operator account balance. The monitoring routine checks the balance every 10 minutes and display a log error in case the balance falls below a threshold value passed from the config file.