### PR TITLE
Removed unused internal constant from BeaconBackportRewards

### DIFF
--- a/solidity/contracts/BeaconBackportRewards.sol
+++ b/solidity/contracts/BeaconBackportRewards.sol
@@ -36,7 +36,6 @@ contract BeaconBackportRewards is Rewards {
 
     // We are going to have one interval, with a weight of 100%.
     uint256[] internal beaconIntervalWeight = [100];
-    uint256 internal constant lastInterval = 0;
 
     // 136 days between the genesis of the old and the new random beacon
     // contract versions:


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1783

`lastInterval` was not used anywhere.