### PR TITLE
Make sure upgrade initiated interval ends before finalizing the upgrade

### DIFF
--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -91,14 +91,27 @@ describe("Rewards/Upgrades", () => {
             ) 
         })
 
-        it("cannot be finalized before the current interval ends", async () => {
+        it("cannot be finalized before the initiation, zero interval ends", async () => {
             await rewards.initiateRewardsUpgrade(
                 newRewards.address,
                 {from: owner}
             )
             await expectRevert(
                 rewards.finalizeRewardsUpgrade({from: owner}),
-                "Interval hasn't ended yet"
+                "Interval at which the upgrade was initiated hasn't ended yet"
+            )
+        })
+
+        it("cannot be finalized before the initiation, non-zero interval ends", async () => {
+            await time.increase(termLength + 1) // interval 0 ends
+
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+            await expectRevert(
+                rewards.finalizeRewardsUpgrade({from: owner}),
+                "Interval at which the upgrade was initiated hasn't ended yet"
             )
         })
 
@@ -198,7 +211,7 @@ describe("Rewards/Upgrades", () => {
             expect(dispensedRewards).to.eq.BN(855000)
         })
 
-        it("let to withdraw outstanding rewards after migration", async () => {
+        it("lets to withdraw outstanding rewards after migration", async () => {
             await rewards.initiateRewardsUpgrade(
                 newRewards.address,
                 {from: owner}


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1783

We were not properly checking whether the interval in which the upgrade was initiated ended before the upgrade was finalized. There was a unit test checking it but it was giving a false-positive given that the interval we were initiating on was 0 and it was not allocating any previous intervals.

We now have a separate `require` making sure the allocation condition holds as well as we have another unit test for non-zero interval.

I have also improved a comment in the code saying that the intervals must receive their reward before tokens are transferred out of the contract on upgrade. The right word to use here is "allocated", not "receive".