### PR TITLE
Dragons and invariants: Do not decrease dispensed rewards on finalizing upgrade

### DIFF
--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -91,9 +91,7 @@ contract Rewards is Ownable {
     // `token.balanceOf(address(this))` should always equal
     // `totalRewards.sub(dispensedRewards)`
     uint256 public dispensedRewards;
-    // The following invariants should always hold:
-    //
-    // totalRewards.sub(dispensedRewards) == unallocatedRewards,
+    // The following invariant should always hold:
     // token.balanceOf(address(this)) >= totalRewards.sub(dispensedRewards)
 
     // Timestamp of first interval beginning.

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -82,16 +82,19 @@ contract Rewards is Ownable {
     // for the full reward to be allocated to the interval.
     uint256 public minimumKeepsPerInterval;
 
-    // Total number of keep tokens to distribute.
-    // Includes those already paid out.
+    // Total number of KEEP tokens to distribute by this contract.
+    // Includes those already dispensed.
     uint256 public totalRewards;
-    // Rewards that haven't been allocated to finished intervals
+    // Rewards that haven't been allocated to finished intervals.
     uint256 public unallocatedRewards;
-    // Rewards that have been dispensed from this contract - as a signer
-    // rewards or transferred to a new rewards contract.
+    // Rewards that have been dispensed from this contract as signer rewards.
     // `token.balanceOf(address(this))` should always equal
     // `totalRewards.sub(dispensedRewards)`
     uint256 public dispensedRewards;
+    // The following invariants should always hold:
+    //
+    // totalRewards.sub(dispensedRewards) == unallocatedRewards,
+    // token.balanceOf(address(this)) >= totalRewards.sub(dispensedRewards)
 
     // Timestamp of first interval beginning.
     // Interval 0 covers everything before `firstIntervalStart`
@@ -147,6 +150,8 @@ contract Rewards is Ownable {
     /// allocations. Intended to be used with `approveAndCall`.
     /// If the reward contract has received tokens outside `approveAndCall`,
     /// this collects them as well.
+    /// The following invariant should hold right after calling this function:
+    /// token.balanceOf(address(this)) == totalRewards.sub(dispensedRewards).
     /// @param _from The original sender of the tokens.
     /// Must have approved at least `_value` tokens for the rewards contract.
     /// @param _value The amount of tokens to fund.
@@ -586,7 +591,6 @@ contract Rewards is Ownable {
 
         totalRewards = totalRewards.sub(amountToTransfer);
         unallocatedRewards = 0;
-        dispensedRewards = dispensedRewards.add(amountToTransfer);
 
         emit UpgradeFinalized(amountToTransfer);
 


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-core/pull/2114
Refs https://github.com/keep-network/keep-core/issues/1783

We do not decrease `dispensedRewards` value when `finalizeUpgrade` is called to make the contract semantics easier and more transparent.

Additionally, we improve invariants defined in this contract by adding two that should always hold and clarifying the one already existing that is guaranteed to hold only right after `receiveApproval` is called.
    
Starting with invariants, we have two:
- `token.balanceOf(address(this)) >= totalRewards.sub(dispensedRewards)` should always hold,
- `token.balanceOf(address(this)) == totalRewards.sub(dispensedRewards)` should hold right after `receiveApproval` is called.

In regards to `finalizeUpgrade`, two options were considered:

**Option 1.** We do not decrease `totalRewards`, everything else stay as-is. In this case:
- `totalRewards` represents all KEEPs that came into this contract and were processed by `receiveApproval`,
- `dispensedRewards` represents all KEEPs that have already left this contract, either by `receiveReward` or `finalizeUpgrade`.

**Option 2.** We do decrease `totalRewards`, we do not increase `dispensedRewards`. In this case:
- `totalRewards` represents those KEEPs that came into this contract and were processed by `receiveApproval` and did not leave this contract by `finalizeUpgrade`.
- `dispensedRewards` represents all KEEPs that have already left this contract by `receiveReward`. It does not include those migrated to a new contract by `finalizeUpgrade`.

In addition to the invariants defined above, one more requirement has been added: after calling `finalizeUpgrade`, anyone can still call `receiveApproval` on the old contract and this call should not fail a produce a valid end state.

After considering two scenarios, it's been concluded that both Option 1 and 2 produce consistent outcomes and all invariants holds however Option 2 offers better semantics and that's what was done here.

Scenarios considered:

**Scenario 1.**  `totalRewards = 100`, `unallocatedRewards = 10`, `dispensedRewards = 90` and we initiate the upgrade.

  - With **Option 1**:
    - calling `finalizeUpgrade` produces end state: `totalRewards = 100`, `unallocatedRewards = 0`, `dispensedRewards = 100`, invariants holds.
    - calling `receiveApproval(5 KEEP)` after the upgrade has been finalized produces end state of: `totalRewards = 105`, `unallocatedRewards = 5`, `dispensedRewards = 100` and invariants still holds.

  - With **Option 2**: 
    - calling `finalizeUpgrade` produces end state: `totalRewards = 90`, `unallocatedRewards = 0`, `dispensedRewards = 90`, invariants holds.
    - calling `receiveApproval(5 KEEP)` after the upgrade has been finalized produces end state of: `totalRewards = 95`, `unallocatedRewards = 5`, `dispensedRewards = 90` and invariants still holds.

**Scenario 2.** `totalRewards = 100`, `unallocatedRewards = 90`, `dispensedRewards = 10` and we initiate the upgrade.

  - With **Option 1**:
    - calling `finalizeUpgrade` produces end state: `totalRewards = 100`, `unallocatedRewards = 0`, `dispensedRewards = 100`, invariants holds.
    - calling `receiveApproval(5 KEEP)` after the upgrade has been finalized produces end state of: `totalRewards = 105`, `unallocatedRewards = 5`, `dispensedRewards = 100` and invariants still holds

  - With **Option 2**:
    - calling `finalizeUpgrade` produces end state: `totalRewards = 10`, `unallocatedRewards = 0`, `dispensedRewards = 10`, invariants holds.
    - calling `receiveApproval(5 KEEP)` after the upgrade has been finalized produces end state of: `totalRewards = 15`, `unallocatedRewards = 5`, `dispensedRewards = 10` and invariants still holds.