### PR TITLE
Docs stronger than ever: small fixes to Rewards contract documentation

### DIFF
--- a/solidity/contracts/BeaconBackportRewards.sol
+++ b/solidity/contracts/BeaconBackportRewards.sol
@@ -103,8 +103,6 @@ contract BeaconBackportRewards is Rewards {
         return false;
     }
 
-    // A group is recognized if its index is at most `lastEligibleGroup`
-    // and it isn't listed as excluded.
     function _recognizedByFactory(bytes32 groupIndexBytes) internal view returns (bool) {
         return numberOfCreatedGroups > uint256(groupIndexBytes);
     }

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -614,7 +614,7 @@ contract Rewards is Ownable {
     /// when all keeps created by the factory are ordered by creation time.
     /// @param index The index of the queried keep.
     /// @return The `bytes32` identifier of the keep at the given index.
-    /// @dev Implementation is not required to check if keep with the given
+    /// @dev Implementation is not required to check if a keep with the given
     /// index exists.
     function _getKeepAtIndex(uint256 index) internal view returns (bytes32);
 

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -613,15 +613,16 @@ contract Rewards is Ownable {
     /// @notice Get the identifier of the keep at the given index,
     /// when all keeps created by the factory are ordered by creation time.
     /// @param index The index of the queried keep.
-    /// @return The `bytes32` identifier of the keep at the given index
-    /// for any index lower than `_getKeepCount()`.
-    /// Revert if the given index is outside the range of created keeps.
+    /// @return The `bytes32` identifier of the keep at the given index.
+    /// @dev Implementation is not required to check if keep with the given
+    /// index exists.
     function _getKeepAtIndex(uint256 index) internal view returns (bytes32);
 
     /// @notice Get the creation time of the given keep.
     /// @param _keep The identifier of the keep.
     /// @return The creation timestamp of the keep.
-    /// Revert if the identifier is invalid.
+    /// @dev If the idenfifier is invalid or not recognized by factory, function
+    /// may revert or return 0.
     function _getCreationTime(bytes32 _keep) internal view returns (uint256);
 
     /// @notice Is the given keep closed.


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-core/pull/2115
Refs https://github.com/keep-network/keep-core/issues/1783

The most important update here is the fix to `@dev` docs for `_getKeepAtIndex` and `_getCreationTime`.

Docs on those abstract functions stated that the implementation is required to revert if the identifier is invalid or not in the expected range. The implementation in `BeaconBackportRewards` and `BeaconRewards` does not revert and after some investigation, it's been concluded that additional checks are not really needed and we may save some gas on not having them. 

`_getKeepAtIndex` is used in:
* `_findEndpoint`
* `_find`

`_findEndpoint` starts the search with lower bound set to 0 and upper bound set to `_getKeepCount() - 1`. It is guaranteed that values of `lb` and `ub` with which `_getKeepAtIndex(lb)`/`_getKeepAtIndex(ub)` are called must be in range `0 <= lb/ub < _getKeepCount()` so there is no chance `_getKeepAtIndex` is called for a non-existing keep.

`_find` is used only by `_findEndpoint` so there is also no risk here.

`_getCreationTime` is used in:
* `_findEndpoint`
* `_find`
* ` _processKeep`

`_findEndpoint` starts the search with lower bound set to 0 and upper bound set to `_getKeepCount() - 1`. It is guaranteed that values of `lb` and `ub` with which `_getKeepAtIndex(lb)`/`_getKeepAtIndex(ub)` are called must be in range `0 <= lb/ub < _getKeepCount()` so there is no chance `_getCreationTime` is called for a non-existing keep.

`_find` is used only by `_findEndpoint` so there is also no risk here.

`_processKeep` is called only from `receiveReward` and `reportTermination`. Those two functions are public but they have `factoryMustRecognize` modifier that ensures `keepIdentifier < _getKeepCount()` so there is no chance `_getCreationTime` is called for a non-existing keep.

Another change - much less complex - is that outdated docs from `_recognizedByFactory` were removed. Documentation on this function was no longer up to date. In the past, we had last eligible group property and excluded groups property - they no longer exist.