### PR TITLE
Phased Escrow: Escrow contract that allows phased release

### DIFF
--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -4,6 +4,10 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 
+interface IBeneficiaryContract {
+    function __escrowSentTokens(uint256 amount) external;
+}
+
 // @title PhasedEscrow
 // @notice A token holder contract allowing contract owner to set beneficiary of
 //         tokens held by the contract and allowing the owner to withdraw the
@@ -15,7 +19,7 @@ contract PhasedEscrow is Ownable {
     event TokensWithdrawn(address beneficiary, uint256 amount);
 
     IERC20 public token;
-    address public beneficiary;
+    IBeneficiaryContract public beneficiary;
 
     constructor(IERC20 _token) public {
         token = _token;
@@ -24,21 +28,23 @@ contract PhasedEscrow is Ownable {
     // @notice Sets the provided address as a beneficiary allowing it to
     //         withdraw all tokens from escrow. This function can be called only
     //         by escrow owner.
-    function setBeneficiary(address _beneficiary) public onlyOwner {
+    function setBeneficiary(IBeneficiaryContract _beneficiary) external onlyOwner {
         beneficiary = _beneficiary;
-        emit BeneficiaryUpdated(beneficiary);
+        emit BeneficiaryUpdated(address(beneficiary));
     }
 
     // @notice Withdraws the specified number of tokens from escrow to the
     //         beneficiary. If the beneficiary is not set, or there are
     //         insufficient tokens in escrow, the function fails.
-    function withdraw(uint256 amount) public onlyOwner {
-        require(beneficiary != address(0), "Beneficiary not assigned");
+    function withdraw(uint256 amount) external onlyOwner {
+        require(address(beneficiary) != address(0), "Beneficiary not assigned");
 
         uint256 balance = token.balanceOf(address(this));
         require(amount <= balance, "Not enough tokens for withdrawal");
 
-        token.safeTransfer(beneficiary, amount);
-        emit TokensWithdrawn(beneficiary, amount);
+        token.safeTransfer(address(beneficiary), amount);
+        emit TokensWithdrawn(address(beneficiary), amount);
+
+        beneficiary.__escrowSentTokens(amount);
     }
 }

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -8,10 +8,10 @@ interface IBeneficiaryContract {
     function __escrowSentTokens(uint256 amount) external;
 }
 
-// @title PhasedEscrow
-// @notice A token holder contract allowing contract owner to set beneficiary of
-//         tokens held by the contract and allowing the owner to withdraw the
-//         tokens to that beneficiary in phases.
+/// @title PhasedEscrow
+/// @notice A token holder contract allowing contract owner to set beneficiary of
+///         tokens held by the contract and allowing the owner to withdraw the
+///         tokens to that beneficiary in phases.
 contract PhasedEscrow is Ownable {
     using SafeERC20 for IERC20;
 
@@ -25,17 +25,17 @@ contract PhasedEscrow is Ownable {
         token = _token;
     }
 
-    // @notice Sets the provided address as a beneficiary allowing it to
-    //         withdraw all tokens from escrow. This function can be called only
-    //         by escrow owner.
+    /// @notice Sets the provided address as a beneficiary allowing it to
+    ///         withdraw all tokens from escrow. This function can be called only
+    ///         by escrow owner.
     function setBeneficiary(IBeneficiaryContract _beneficiary) external onlyOwner {
         beneficiary = _beneficiary;
         emit BeneficiaryUpdated(address(beneficiary));
     }
 
-    // @notice Withdraws the specified number of tokens from escrow to the
-    //         beneficiary. If the beneficiary is not set, or there are
-    //         insufficient tokens in escrow, the function fails.
+    /// @notice Withdraws the specified number of tokens from escrow to the
+    ///         beneficiary. If the beneficiary is not set, or there are
+    ///         insufficient tokens in escrow, the function fails.
     function withdraw(uint256 amount) external onlyOwner {
         require(address(beneficiary) != address(0), "Beneficiary not assigned");
 
@@ -53,10 +53,10 @@ interface ICurveRewards {
     function notifyRewardAmount(uint256 amount) external;
 }
 
-// @title CurveRewardsEscrowBeneficiary
-// @notice A beneficiary contract that can receive a withdrawal phase from a
-//         PhasedEscrow contract. Immediately stakes the received tokens on a
-//         designated CurveRewards contract.
+/// @title CurveRewardsEscrowBeneficiary
+/// @notice A beneficiary contract that can receive a withdrawal phase from a
+///         PhasedEscrow contract. Immediately stakes the received tokens on a
+///         designated CurveRewards contract.
 contract CurveRewardsEscrowBeneficiary is Ownable {
     IERC20 public token;
     ICurveRewards public curveRewards;

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+
+// @title PhasedEscrow
+// @notice A token holder contract allowing contract owner to set beneficiary of
+//         tokens held by the contract and allowing the owner to withdraw the
+//         tokens to that beneficiary in phases.
+contract PhasedEscrow is Ownable {
+    using SafeERC20 for IERC20;
+
+    event BeneficiaryUpdated(address beneficiary);
+    event TokensWithdrawn(address beneficiary, uint256 amount);
+
+    IERC20 public token;
+    address public beneficiary;
+
+    constructor(IERC20 _token) public {
+        token = _token;
+    }
+
+    // @notice Sets the provided address as a beneficiary allowing it to
+    //         withdraw all tokens from escrow. This function can be called only
+    //         by escrow owner.
+    function setBeneficiary(address _beneficiary) public onlyOwner {
+        beneficiary = _beneficiary;
+        emit BeneficiaryUpdated(beneficiary);
+    }
+
+    // @notice Withdraws the specified number of tokens from escrow to the
+    //         beneficiary. If the beneficiary is not set, or there are
+    //         insufficient tokens in escrow, the function fails.
+    function withdraw(uint256 amount) public onlyOwner {
+        require(beneficiary != address(0), "Beneficiary not assigned");
+
+        uint256 balance = token.balanceOf(address(this));
+        require(amount <= balance, "Not enough tokens for withdrawal");
+
+        token.safeTransfer(beneficiary, amount);
+        emit TokensWithdrawn(beneficiary, amount);
+    }
+}

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -50,7 +50,7 @@ contract PhasedEscrow is Ownable {
 }
 
 interface ICurveRewards {
-    function stake(uint256 amount) external;
+    function notifyRewardAmount(uint256 amount) external;
 }
 
 // @title CurveRewardsEscrowBeneficiary
@@ -68,6 +68,6 @@ contract CurveRewardsEscrowBeneficiary is Ownable {
 
     function __escrowSentTokens(uint256 amount) external {
         token.approve(address(curveRewards), amount);
-        curveRewards.stake(amount);
+        curveRewards.notifyRewardAmount(amount);
     }
 }

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -48,3 +48,26 @@ contract PhasedEscrow is Ownable {
         beneficiary.__escrowSentTokens(amount);
     }
 }
+
+interface ICurveRewards {
+    function stake(uint256 amount) external;
+}
+
+// @title CurveRewardsEscrowBeneficiary
+// @notice A beneficiary contract that can receive a withdrawal phase from a
+//         PhasedEscrow contract. Immediately stakes the received tokens on a
+//         designated CurveRewards contract.
+contract CurveRewardsEscrowBeneficiary is Ownable {
+    IERC20 public token;
+    ICurveRewards public curveRewards;
+
+    constructor(IERC20 _token, ICurveRewards _curveRewards) public {
+        token = _token;
+        curveRewards = _curveRewards;
+    }
+
+    function __escrowSentTokens(uint256 amount) external {
+        token.approve(address(curveRewards), amount);
+        curveRewards.stake(amount);
+    }
+}

--- a/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
+++ b/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
@@ -1,0 +1,52 @@
+pragma solidity 0.5.17;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+
+// Simple beneficiary that does nothing when notified that it has received
+// tokens.
+contract TestSimpleBeneficiary {
+    function __escrowSentTokens(uint256 amount) external {}
+}
+
+contract TestLPTokenWrapper {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    IERC20 public token;
+
+    constructor(IERC20 _token) public {
+        token = _token;
+    }
+
+    uint256 private _totalSupply;
+    mapping(address => uint256) private _balances;
+
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
+    }
+
+    function stake(uint256 amount) public {
+        _totalSupply = _totalSupply.add(amount);
+        _balances[msg.sender] = _balances[msg.sender].add(amount);
+        token.safeTransferFrom(msg.sender, address(this), amount);
+    }
+}
+
+contract TestCurveRewards is TestLPTokenWrapper {
+    event Staked(address indexed user, uint256 amount);
+
+    constructor(IERC20 _token) public TestLPTokenWrapper(_token) {}
+
+    // stake visibility is public as overriding LPTokenWrapper's stake() function
+    function stake(uint256 amount) public {
+        require(amount > 0, "Cannot stake 0");
+        super.stake(amount);
+        emit Staked(msg.sender, amount);
+    }
+}

--- a/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
+++ b/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
@@ -10,43 +10,20 @@ contract TestSimpleBeneficiary {
     function __escrowSentTokens(uint256 amount) external {}
 }
 
-contract TestLPTokenWrapper {
-    using SafeMath for uint256;
+// CurveRewards contract mock for curvefi.
+contract TestCurveRewards {
     using SafeERC20 for IERC20;
 
     IERC20 public token;
+
+    event RewardAdded(uint256 reward);
 
     constructor(IERC20 _token) public {
         token = _token;
     }
 
-    uint256 private _totalSupply;
-    mapping(address => uint256) private _balances;
-
-    function totalSupply() public view returns (uint256) {
-        return _totalSupply;
-    }
-
-    function balanceOf(address account) public view returns (uint256) {
-        return _balances[account];
-    }
-
-    function stake(uint256 amount) public {
-        _totalSupply = _totalSupply.add(amount);
-        _balances[msg.sender] = _balances[msg.sender].add(amount);
-        token.safeTransferFrom(msg.sender, address(this), amount);
-    }
-}
-
-contract TestCurveRewards is TestLPTokenWrapper {
-    event Staked(address indexed user, uint256 amount);
-
-    constructor(IERC20 _token) public TestLPTokenWrapper(_token) {}
-
-    // stake visibility is public as overriding LPTokenWrapper's stake() function
-    function stake(uint256 amount) public {
-        require(amount > 0, "Cannot stake 0");
-        super.stake(amount);
-        emit Staked(msg.sender, amount);
+    function notifyRewardAmount(uint256 reward) external {
+        token.safeTransferFrom(msg.sender, address(this), reward);
+        emit RewardAdded(reward);
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -16,6 +16,7 @@
     "compile": "npm run clean && truffle compile --contracts_build_directory=./build/truffle",
     "test": "truffle compile && mocha --exit --recursive --timeout 75000",
     "test:quick": "mocha --exit --recursive --timeout 45000",
+    "test:quick:watch": "mocha --watch --exit --recursive --timeout 45000",
     "demo": "truffle migrate --reset && truffle exec ./scripts/delegate-tokens.js",
     "lint": "solium --dir ./contracts",
     "lint:js": "eslint ${npm_package_config_eslintPaths}",

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -238,15 +238,14 @@ describe("PhasedEscrow", () => {
         })
       })
 
-      it("emits a Staked event from the rewards beneficiary", async () => {
+      it("emits a RewardAdded event from the rewards beneficiary", async () => {
         const receipt = resolveAllLogs(
           (await phasedEscrow.withdraw(transferAmount, {from: owner})).receipt,
           {curveRewards}
         )
 
-        expectEvent(receipt, "Staked", {
-          user: rewardsBeneficiary.address,
-          amount: web3.utils.toBN(transferAmount),
+        expectEvent(receipt, "RewardAdded", {
+          reward: web3.utils.toBN(transferAmount),
         })
       })
     })

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -4,17 +4,23 @@ const {expectRevert, expectEvent} = require("@openzeppelin/test-helpers")
 
 const KeepToken = contract.fromArtifact("KeepToken")
 const PhasedEscrow = contract.fromArtifact("PhasedEscrow")
+const CurveRewardsEscrowBeneficiary = contract.fromArtifact(
+  "CurveRewardsEscrowBeneficiary"
+)
+
+const TestSimpleBeneficiary = contract.fromArtifact("TestSimpleBeneficiary")
+const TestCurveRewards = contract.fromArtifact("TestCurveRewards")
 
 const chai = require("chai")
 chai.use(require("bn-chai")(web3.utils.BN))
 const expect = chai.expect
 
-describe.only("PhasedEscrow", () => {
+describe("PhasedEscrow", () => {
   const owner = accounts[0]
   const updatedOwner = accounts[1]
 
-  const beneficiary = accounts[2]
-  const updatedBeneficiary = accounts[3]
+  let beneficiary
+  let updatedBeneficiary
 
   let token
   let phasedEscrow
@@ -22,6 +28,8 @@ describe.only("PhasedEscrow", () => {
   before(async () => {
     token = await KeepToken.new({from: owner})
     phasedEscrow = await PhasedEscrow.new(token.address, {from: owner})
+    beneficiary = await TestSimpleBeneficiary.new()
+    updatedBeneficiary = await TestSimpleBeneficiary.new()
   })
 
   beforeEach(async () => {
@@ -34,7 +42,7 @@ describe.only("PhasedEscrow", () => {
 
   describe("setBeneficiary", async () => {
     it("can be called by owner", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
       // ok, no revert
     })
 
@@ -42,36 +50,38 @@ describe.only("PhasedEscrow", () => {
       await phasedEscrow.transferOwnership(updatedOwner, {from: owner})
 
       await expectRevert(
-        phasedEscrow.setBeneficiary(beneficiary, {from: owner}),
+        phasedEscrow.setBeneficiary(beneficiary.address, {from: owner}),
         "Ownable: caller is not the owner"
       )
-      await phasedEscrow.setBeneficiary(beneficiary, {from: updatedOwner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {
+        from: updatedOwner,
+      })
       // ok, no revert
     })
 
     it("can not be called by non-owner", async () => {
       await expectRevert(
-        phasedEscrow.setBeneficiary(beneficiary, {from: beneficiary}),
+        phasedEscrow.setBeneficiary(beneficiary.address, {from: updatedOwner}),
         "Ownable: caller is not the owner"
       )
     })
 
     it("sets beneficiary", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
 
       expect(await phasedEscrow.beneficiary()).to.equal(
-        beneficiary,
+        beneficiary.address,
         "Unexpected beneficiary"
       )
     })
 
     it("emits an event", async () => {
-      const receipt = await phasedEscrow.setBeneficiary(beneficiary, {
+      const receipt = await phasedEscrow.setBeneficiary(beneficiary.address, {
         from: owner,
       })
 
       expectEvent(receipt, "BeneficiaryUpdated", {
-        beneficiary: beneficiary,
+        beneficiary: beneficiary.address,
       })
     })
   })
@@ -87,61 +97,45 @@ describe.only("PhasedEscrow", () => {
 
     it("can not be called by non-owner", async () => {
       await token.transfer(phasedEscrow.address, 100, {from: owner})
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
       await expectRevert(
-        phasedEscrow.withdraw(100, {from: beneficiary}),
+        phasedEscrow.withdraw(100, {from: beneficiary.address}),
         "Ownable: caller is not the owner"
       )
     })
 
     it("can be called by owner", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
       await token.transfer(phasedEscrow.address, 100, {from: owner})
       await phasedEscrow.withdraw(100, {from: owner})
       // ok, no reverts
     })
 
     it("fails when escrow is empty", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
       await expectRevert(
         phasedEscrow.withdraw(100, {from: owner}),
         "Not enough tokens for withdrawal"
       )
     })
 
-    it("withdraws specified tokens to beneficiary", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
-      const amount = web3.utils.toBN(123456789)
-      await token.transfer(phasedEscrow.address, amount, {from: owner})
-
-      await phasedEscrow.withdraw(100, {from: owner})
-
-      expect(await token.balanceOf(beneficiary)).to.eq.BN(
-        100,
-        "Unexpected amount withdrawn"
-      )
-      expect(await token.balanceOf(phasedEscrow.address)).to.eq.BN(
-        123456789 - 100,
-        "Unexpected amount withdrawn"
-      )
-    })
-
     it("withdraws specified tokens to updated beneficiary", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
-
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
       const amount = web3.utils.toBN(987654321)
       await token.transfer(phasedEscrow.address, amount, {from: owner})
 
       await phasedEscrow.withdraw(100, {from: owner})
 
-      await phasedEscrow.setBeneficiary(updatedBeneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(updatedBeneficiary.address, {
+        from: owner,
+      })
       await phasedEscrow.withdraw(100, {from: owner})
 
-      expect(await token.balanceOf(beneficiary)).to.eq.BN(
+      expect(await token.balanceOf(beneficiary.address)).to.eq.BN(
         100,
         "Unexpected amount withdrawn"
       )
-      expect(await token.balanceOf(updatedBeneficiary)).to.eq.BN(
+      expect(await token.balanceOf(updatedBeneficiary.address)).to.eq.BN(
         100,
         "Unexpected amount withdrawn"
       )
@@ -151,17 +145,166 @@ describe.only("PhasedEscrow", () => {
       )
     })
 
+    it("withdraws specified tokens to beneficiary", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
+      const amount = web3.utils.toBN(123456789)
+      await token.transfer(phasedEscrow.address, amount, {from: owner})
+
+      await phasedEscrow.withdraw(100, {from: owner})
+
+      expect(await token.balanceOf(beneficiary.address)).to.eq.BN(
+        100,
+        "Unexpected amount withdrawn"
+      )
+      expect(await token.balanceOf(phasedEscrow.address)).to.eq.BN(
+        123456789 - 100,
+        "Unexpected amount withdrawn"
+      )
+    })
+
     it("emits an event", async () => {
-      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary.address, {from: owner})
       const amount = web3.utils.toBN(100)
       await token.transfer(phasedEscrow.address, amount.muln(2), {from: owner})
 
       const receipt = await phasedEscrow.withdraw(amount, {from: owner})
 
       await expectEvent(receipt, "TokensWithdrawn", {
-        beneficiary: beneficiary,
+        beneficiary: beneficiary.address,
         amount: amount,
+      })
+    })
+
+    describe("when withdrawing to a CurveRewardsEscrowBeneficiary", () => {
+      let curveRewards
+      let rewardsBeneficiary
+
+      const baseBalance = 123456789
+      const transferAmount = 100
+
+      before(async () => {
+        curveRewards = await TestCurveRewards.new(token.address)
+        rewardsBeneficiary = await CurveRewardsEscrowBeneficiary.new(
+          token.address,
+          curveRewards.address
+        )
+
+        const amount = web3.utils.toBN(baseBalance)
+        await token.transfer(phasedEscrow.address, amount, {from: owner})
+
+        await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
+          from: owner,
+        })
+      })
+
+      beforeEach(createSnapshot)
+      afterEach(restoreSnapshot)
+
+      it("withdraws specified tokens from escrow", async () => {
+        await phasedEscrow.withdraw(transferAmount, {from: owner})
+
+        expect(await token.balanceOf(phasedEscrow.address)).to.eq.BN(
+          baseBalance - transferAmount,
+          "Unexpected amount withdrawn"
+        )
+      })
+
+      it("transfers specified tokens to curve rewards contract", async () => {
+        await phasedEscrow.withdraw(transferAmount, {from: owner})
+
+        expect(await token.balanceOf(curveRewards.address)).to.eq.BN(
+          transferAmount,
+          "Unexpected amount deposited"
+        )
+      })
+
+      it("leaves no tokens in the rewards beneficiary", async () => {
+        await phasedEscrow.withdraw(100, {from: owner})
+
+        expect(await token.balanceOf(rewardsBeneficiary.address)).to.eq.BN(
+          0,
+          "Unexpected amount left in rewards beneficiary"
+        )
+      })
+
+      it("emits a TokensWithdrawn event to the rewards beneficiary", async () => {
+        const receipt = await phasedEscrow.withdraw(transferAmount, {
+          from: owner,
+        })
+
+        expectEvent(receipt, "TokensWithdrawn", {
+          beneficiary: rewardsBeneficiary.address,
+          amount: web3.utils.toBN(transferAmount),
+        })
+      })
+
+      it("emits a Staked event from the rewards beneficiary", async () => {
+        const receipt = resolveAllLogs(
+          (await phasedEscrow.withdraw(transferAmount, {from: owner})).receipt,
+          {curveRewards}
+        )
+
+        expectEvent(receipt, "Staked", {
+          user: rewardsBeneficiary.address,
+          amount: web3.utils.toBN(transferAmount),
+        })
       })
     })
   })
 })
+
+// FIXME Move to a shared test utils library for all Keep projects.
+/**
+ * Uses the ABIs of all contracts in the `contractContainer` to resolve any
+ * events they may have emitted into the given `receipt`'s logs. Typically
+ * Truffle only resolves the events on the calling contract; this function
+ * resolves all of the ones that can be resolved.
+ *
+ * @param {TruffleReceipt} receipt The receipt of a contract function call
+ *        submission.
+ * @param {ContractContainer} contractContainer An object that contains
+ *        properties that are TruffleContracts. Not all properties in the
+ *        container need be contracts, nor do all contracts need to have events
+ *        in the receipt.
+ *
+ * @return {TruffleReceipt} The receipt, with its `logs` property updated to
+ *         include all resolved logs.
+ */
+function resolveAllLogs(receipt, contractContainer) {
+  const contracts = Object.entries(contractContainer)
+    .map(([, value]) => value)
+    .filter((_) => _.contract && _.address)
+
+  const {resolved: resolvedLogs} = contracts.reduce(
+    ({raw, resolved}, contract) => {
+      const events = contract.contract._jsonInterface.filter(
+        (_) => _.type === "event"
+      )
+      const contractLogs = raw.filter((_) => _.address == contract.address)
+
+      const decoded = contractLogs.map((log) => {
+        const event = events.find((_) => log.topics.includes(_.signature))
+        const decoded = web3.eth.abi.decodeLog(
+          event.inputs,
+          log.data,
+          log.topics.slice(1)
+        )
+
+        return Object.assign({}, log, {
+          event: event.name,
+          args: decoded,
+        })
+      })
+
+      return {
+        raw: raw.filter((_) => _.address != contract.address),
+        resolved: resolved.concat(decoded),
+      }
+    },
+    {raw: receipt.rawLogs, resolved: []}
+  )
+
+  return Object.assign({}, receipt, {
+    logs: resolvedLogs,
+  })
+}

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -1,0 +1,167 @@
+const {accounts, contract, web3} = require("@openzeppelin/test-environment")
+const {createSnapshot, restoreSnapshot} = require("./helpers/snapshot.js")
+const {expectRevert, expectEvent} = require("@openzeppelin/test-helpers")
+
+const KeepToken = contract.fromArtifact("KeepToken")
+const PhasedEscrow = contract.fromArtifact("PhasedEscrow")
+
+const chai = require("chai")
+chai.use(require("bn-chai")(web3.utils.BN))
+const expect = chai.expect
+
+describe.only("PhasedEscrow", () => {
+  const owner = accounts[0]
+  const updatedOwner = accounts[1]
+
+  const beneficiary = accounts[2]
+  const updatedBeneficiary = accounts[3]
+
+  let token
+  let phasedEscrow
+
+  before(async () => {
+    token = await KeepToken.new({from: owner})
+    phasedEscrow = await PhasedEscrow.new(token.address, {from: owner})
+  })
+
+  beforeEach(async () => {
+    await createSnapshot()
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot()
+  })
+
+  describe("setBeneficiary", async () => {
+    it("can be called by owner", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      // ok, no revert
+    })
+
+    it("can be called by updated owner", async () => {
+      await phasedEscrow.transferOwnership(updatedOwner, {from: owner})
+
+      await expectRevert(
+        phasedEscrow.setBeneficiary(beneficiary, {from: owner}),
+        "Ownable: caller is not the owner"
+      )
+      await phasedEscrow.setBeneficiary(beneficiary, {from: updatedOwner})
+      // ok, no revert
+    })
+
+    it("can not be called by non-owner", async () => {
+      await expectRevert(
+        phasedEscrow.setBeneficiary(beneficiary, {from: beneficiary}),
+        "Ownable: caller is not the owner"
+      )
+    })
+
+    it("sets beneficiary", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+
+      expect(await phasedEscrow.beneficiary()).to.equal(
+        beneficiary,
+        "Unexpected beneficiary"
+      )
+    })
+
+    it("emits an event", async () => {
+      const receipt = await phasedEscrow.setBeneficiary(beneficiary, {
+        from: owner,
+      })
+
+      expectEvent(receipt, "BeneficiaryUpdated", {
+        beneficiary: beneficiary,
+      })
+    })
+  })
+
+  describe("withdraw", async () => {
+    it("can not be called if beneficiary wasn't set", async () => {
+      await token.transfer(phasedEscrow.address, 100, {from: owner})
+      await expectRevert(
+        phasedEscrow.withdraw(100, {from: owner}),
+        "Beneficiary not assigned"
+      )
+    })
+
+    it("can not be called by non-owner", async () => {
+      await token.transfer(phasedEscrow.address, 100, {from: owner})
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await expectRevert(
+        phasedEscrow.withdraw(100, {from: beneficiary}),
+        "Ownable: caller is not the owner"
+      )
+    })
+
+    it("can be called by owner", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await token.transfer(phasedEscrow.address, 100, {from: owner})
+      await phasedEscrow.withdraw(100, {from: owner})
+      // ok, no reverts
+    })
+
+    it("fails when escrow is empty", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      await expectRevert(
+        phasedEscrow.withdraw(100, {from: owner}),
+        "Not enough tokens for withdrawal"
+      )
+    })
+
+    it("withdraws specified tokens to beneficiary", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      const amount = web3.utils.toBN(123456789)
+      await token.transfer(phasedEscrow.address, amount, {from: owner})
+
+      await phasedEscrow.withdraw(100, {from: owner})
+
+      expect(await token.balanceOf(beneficiary)).to.eq.BN(
+        100,
+        "Unexpected amount withdrawn"
+      )
+      expect(await token.balanceOf(phasedEscrow.address)).to.eq.BN(
+        123456789 - 100,
+        "Unexpected amount withdrawn"
+      )
+    })
+
+    it("withdraws specified tokens to updated beneficiary", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+
+      const amount = web3.utils.toBN(987654321)
+      await token.transfer(phasedEscrow.address, amount, {from: owner})
+
+      await phasedEscrow.withdraw(100, {from: owner})
+
+      await phasedEscrow.setBeneficiary(updatedBeneficiary, {from: owner})
+      await phasedEscrow.withdraw(100, {from: owner})
+
+      expect(await token.balanceOf(beneficiary)).to.eq.BN(
+        100,
+        "Unexpected amount withdrawn"
+      )
+      expect(await token.balanceOf(updatedBeneficiary)).to.eq.BN(
+        100,
+        "Unexpected amount withdrawn"
+      )
+      expect(await token.balanceOf(phasedEscrow.address)).to.eq.BN(
+        987654321 - 200,
+        "Unexpected amount withdrawn"
+      )
+    })
+
+    it("emits an event", async () => {
+      await phasedEscrow.setBeneficiary(beneficiary, {from: owner})
+      const amount = web3.utils.toBN(100)
+      await token.transfer(phasedEscrow.address, amount.muln(2), {from: owner})
+
+      const receipt = await phasedEscrow.withdraw(amount, {from: owner})
+
+      await expectEvent(receipt, "TokensWithdrawn", {
+        beneficiary: beneficiary,
+        amount: amount,
+      })
+    })
+  })
+})


### PR DESCRIPTION
Two contracts implemented here:

`PhasedEscrow` - a token holder contract allowing contract owner to set beneficiary of tokens held by the contract and allowing the owner to withdraw the tokens to that beneficiary in phases.

`CurveRewardsEscrowBeneficiary` A beneficiary contract that can receive a withdrawal phase from a `PhasedEscrow` contract. Immediately stakes the received tokens on a designated `CurveRewards` contract.

This allows us to adjust rewards strategies over time if strictly necessary.