### PR TITLE
Logging "relay entry requested event with previous entry.." as warning

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -251,24 +251,14 @@ func confirmCurrentRelayRequest(
 			)
 			return
 		} else if i == maxRetries {
-			if currentRequestStartBlock == 0 {
-				logger.Warningf(
-					"there is no entry in progress; "+
-						"current request start block is 0 "+
-						"giving up after [%v] retries",
-					currentRequestStartBlock,
-					maxRetries,
-				)
-			} else {
-				logger.Errorf(
-					"could not confirm the expected relay request starting block; "+
-						"the most recent one obtained from chain is [%v] and the "+
-						"expected one is [%v]; giving up after [%v] retries",
-					currentRequestStartBlock,
-					expectedRequestStartBlock,
-					maxRetries,
-				)
-			}
+			logger.Errorf(
+				"could not confirm the expected relay request starting block; "+
+					"the most recent one obtained from chain is [%v] and the "+
+					"expected one is [%v]; giving up after [%v] retries",
+				currentRequestStartBlock,
+				expectedRequestStartBlock,
+				maxRetries,
+			)
 			return
 		} else {
 			logger.Infof(

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -81,7 +81,7 @@ func Initialize(
 					previousEntry := hex.EncodeToString(request.PreviousEntry[:])
 
 					if ok := pendingRelayRequests.Add(previousEntry); !ok {
-						logger.Errorf(
+						logger.Warningf(
 							"relay entry requested event with previous entry "+
 								"[0x%x] has been registered already",
 							request.PreviousEntry,

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -251,14 +251,24 @@ func confirmCurrentRelayRequest(
 			)
 			return
 		} else if i == maxRetries {
-			logger.Errorf(
-				"could not confirm the expected relay request starting block; "+
-					"the most recent one obtained from chain is [%v] and the "+
-					"expected one is [%v]; giving up after [%v] retries",
-				currentRequestStartBlock,
-				expectedRequestStartBlock,
-				maxRetries,
-			)
+			if currentRequestStartBlock == 0 {
+				logger.Warningf(
+					"there is no entry in progress; "+
+						"current request start block is 0 "+
+						"giving up after [%v] retries",
+					currentRequestStartBlock,
+					maxRetries,
+				)
+			} else {
+				logger.Errorf(
+					"could not confirm the expected relay request starting block; "+
+						"the most recent one obtained from chain is [%v] and the "+
+						"expected one is [%v]; giving up after [%v] retries",
+					currentRequestStartBlock,
+					expectedRequestStartBlock,
+					maxRetries,
+				)
+			}
 			return
 		} else {
 			logger.Infof(


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/2121

In this PR we are changing logging level from Error to Warning. Event already registered is not an error and this scenario might happen in certain Ethereum client deployments where nodes are behind a load-balancer.