### PR TITLE
Replacing error with a warning when there is no entry in progress

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -251,14 +251,24 @@ func confirmCurrentRelayRequest(
 			)
 			return
 		} else if i == maxRetries {
-			logger.Errorf(
-				"could not confirm the expected relay request starting block; "+
-					"the most recent one obtained from chain is [%v] and the "+
-					"expected one is [%v]; giving up after [%v] retries",
-				currentRequestStartBlock,
-				expectedRequestStartBlock,
-				maxRetries,
-			)
+			if currentRequestStartBlock == 0 {
+				logger.Warningf(
+					"there is no entry in progress; "+
+						"current request start block is 0 "+
+						"giving up after [%v] retries",
+					currentRequestStartBlock,
+					maxRetries,
+				)
+			} else {
+				logger.Errorf(
+					"could not confirm the expected relay request starting block; "+
+						"the most recent one obtained from chain is [%v] and the "+
+						"expected one is [%v]; giving up after [%v] retries",
+					currentRequestStartBlock,
+					expectedRequestStartBlock,
+					maxRetries,
+				)
+			}
 			return
 		} else {
 			logger.Infof(

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -251,6 +251,9 @@ func confirmCurrentRelayRequest(
 			)
 			return
 		} else if i == maxRetries {
+			// This scenario usually happens when an entry was submitted very
+			// fast before this node receives an event and is able to confirm a
+			// request ID.
 			if currentRequestStartBlock == 0 {
 				logger.Warningf(
 					"there is no entry in progress; "+


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/2122

If the relay entry has been already submitted to the chain and there is no other entry in progress (current request start block is 0), then we should log a Warning instead of an Error.