### PR TITLE
Failed to check if stale for group public key

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -186,6 +186,7 @@ func Initialize(
 			registration.GroupPublicKey,
 			registration.BlockNumber,
 		)
+		go groupRegistry.UnregisterStaleGroups(registration.GroupPublicKey)
 	})
 
 	return nil

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -186,7 +186,7 @@ func Initialize(
 			registration.GroupPublicKey,
 			registration.BlockNumber,
 		)
-		go groupRegistry.UnregisterStaleGroups()
+		go groupRegistry.UnregisterStaleGroups(registration.GroupPublicKey)
 	})
 
 	return nil

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -186,7 +186,6 @@ func Initialize(
 			registration.GroupPublicKey,
 			registration.BlockNumber,
 		)
-		go groupRegistry.UnregisterStaleGroups(registration.GroupPublicKey)
 	})
 
 	return nil

--- a/pkg/beacon/relay/registry/groups.go
+++ b/pkg/beacon/relay/registry/groups.go
@@ -53,8 +53,7 @@ func (g *Groups) RegisterGroup(
 	g.mutex.Lock()
 	defer g.mutex.Unlock()
 
-	groupPublicKeyBytes := signer.GroupPublicKeyBytes()
-	groupPublicKey := groupKeyToString(groupPublicKeyBytes)
+	groupPublicKey := groupKeyToString(signer.GroupPublicKeyBytes())
 
 	membership := &Membership{
 		Signer:      signer,
@@ -68,8 +67,6 @@ func (g *Groups) RegisterGroup(
 
 	g.myGroups[groupPublicKey] = append(g.myGroups[groupPublicKey], membership)
 
-	go g.unregisterStaleGroups(groupPublicKeyBytes)
-
 	return nil
 }
 
@@ -81,13 +78,13 @@ func (g *Groups) GetGroup(groupPublicKey []byte) []*Membership {
 	return g.myGroups[groupKeyToString(groupPublicKey)]
 }
 
-// unregisterStaleGroups lookup for groups that have been marked as stale
+// UnregisterStaleGroups lookup for groups that have been marked as stale
 // on-chain. A stale group is a group that has expired and a certain time passed
 // after the group expiration. This guarantees the group will not be selected to
 // a new operation and it cannot have an ongoing operation for which it could be
 // selected before it expired. Such a group can be safely removed from the registry
 // and archived in the underlying storage.
-func (g *Groups) unregisterStaleGroups(latestGroupPublicKey []byte) {
+func (g *Groups) UnregisterStaleGroups(latestGroupPublicKey []byte) {
 	g.mutex.Lock()
 	defer g.mutex.Unlock()
 

--- a/pkg/beacon/relay/registry/groups.go
+++ b/pkg/beacon/relay/registry/groups.go
@@ -81,7 +81,7 @@ func (g *Groups) GetGroup(groupPublicKey []byte) []*Membership {
 	return g.myGroups[groupKeyToString(groupPublicKey)]
 }
 
-// nregisterStaleGroups lookup for groups that have been marked as stale
+// unregisterStaleGroups lookup for groups that have been marked as stale
 // on-chain. A stale group is a group that has expired and a certain time passed
 // after the group expiration. This guarantees the group will not be selected to
 // a new operation and it cannot have an ongoing operation for which it could be

--- a/pkg/beacon/relay/registry/groups_test.go
+++ b/pkg/beacon/relay/registry/groups_test.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"bytes"
-	"encoding/hex"
 	"math/big"
 	"reflect"
 	"testing"
@@ -118,41 +117,72 @@ func TestLoadGroup(t *testing.T) {
 
 func TestUnregisterStaleGroups(t *testing.T) {
 	mockChain := &mockGroupRegistrationInterface{
-		groupsToRemove: [][]byte{},
+		groupsToRemove:       [][]byte{},
+		groupsCheckedIfStale: make(map[string]bool),
 	}
 
 	gr := NewGroupRegistry(mockChain, persistenceMock)
 
-	gr.RegisterGroup(signer1, channelName1)
-	gr.RegisterGroup(signer2, channelName1)
-	gr.RegisterGroup(signer3, channelName1)
+	groupPubKey1 := groupKeyToString(signer1.GroupPublicKeyBytes())
+	membership1 := &Membership{
+		Signer:      signer1,
+		ChannelName: channelName1,
+	}
+	gr.myGroups[groupPubKey1] = append(gr.myGroups[groupPubKey1], membership1)
+
+	groupPubKey2 := groupKeyToString(signer2.GroupPublicKeyBytes())
+	membership2 := &Membership{
+		Signer:      signer2,
+		ChannelName: channelName1,
+	}
+	gr.myGroups[groupPubKey2] = append(gr.myGroups[groupPubKey2], membership2)
+
+	groupPubKey3 := groupKeyToString(signer3.GroupPublicKeyBytes())
+	membership3 := &Membership{
+		Signer:      signer3,
+		ChannelName: channelName1,
+	}
+	gr.myGroups[groupPubKey3] = append(gr.myGroups[groupPubKey3], membership3)
 
 	mockChain.markAsStale(signer2.GroupPublicKeyBytes())
-
-	gr.UnregisterStaleGroups(signer3.GroupPublicKeyBytes())
+	gr.unregisterStaleGroups(signer3.GroupPublicKeyBytes())
 
 	group1 := gr.GetGroup(signer1.GroupPublicKeyBytes())
 	if group1 == nil {
 		t.Fatalf("Expecting a group, but nil was returned instead")
+	}
+	group1PublicKeyString := groupKeyToString(signer1.GroupPublicKeyBytes())
+	if mockChain.groupsCheckedIfStale[group1PublicKeyString] != true {
+		t.Fatalf("IsStaleGroup() was expected to be called for group %s", group1PublicKeyString)
 	}
 
 	group2 := gr.GetGroup(signer2.GroupPublicKeyBytes())
 	if group2 != nil {
 		t.Fatalf("Group2 was expected to be unregistered, but is still present")
 	}
+	group2PublicKeyStringCompressed := groupKeyToString(signer2.GroupPublicKeyBytesCompressed())
+	group2PublicKeyString := groupKeyToString(signer2.GroupPublicKeyBytes())
 	if len(persistenceMock.archivedGroups) != 1 ||
-		persistenceMock.archivedGroups[0] != hex.EncodeToString(signer2.GroupPublicKeyBytesCompressed()) {
+		persistenceMock.archivedGroups[0] != group2PublicKeyStringCompressed {
 		t.Fatalf("Group2 was expected to be archived")
+	}
+	if mockChain.groupsCheckedIfStale[group2PublicKeyString] != true {
+		t.Fatalf("IsStaleGroup() was expected to be called for group %s", group2PublicKeyString)
 	}
 
 	group3 := gr.GetGroup(signer3.GroupPublicKeyBytes())
 	if group3 == nil {
 		t.Fatalf("Expecting a group, but nil was returned instead")
 	}
+	group3PublicKeyString := groupKeyToString(signer3.GroupPublicKeyBytes())
+	if mockChain.groupsCheckedIfStale[group3PublicKeyString] == true {
+		t.Fatalf("IsStaleGroup() was not expected to be called for group %s", group3PublicKeyString)
+	}
 }
 
 type mockGroupRegistrationInterface struct {
-	groupsToRemove [][]byte
+	groupsToRemove       [][]byte
+	groupsCheckedIfStale map[string]bool
 }
 
 func (mgri *mockGroupRegistrationInterface) markAsStale(publicKey []byte) {
@@ -166,6 +196,7 @@ func (mgri *mockGroupRegistrationInterface) OnGroupRegistered(
 }
 
 func (mgri *mockGroupRegistrationInterface) IsStaleGroup(groupPublicKey []byte) (bool, error) {
+	mgri.groupsCheckedIfStale[groupKeyToString(groupPublicKey)] = true
 	for _, groupToRemove := range mgri.groupsToRemove {
 		if bytes.Compare(groupToRemove, groupPublicKey) == 0 {
 			return true, nil

--- a/pkg/beacon/relay/registry/groups_test.go
+++ b/pkg/beacon/relay/registry/groups_test.go
@@ -119,6 +119,7 @@ func TestLoadGroup(t *testing.T) {
 func TestUnregisterStaleGroups(t *testing.T) {
 	mockChain := &mockGroupRegistrationInterface{
 		groupsToRemove: [][]byte{},
+		groupsCheckedIfStale: make(map[string]bool),
 	}
 
 	gr := NewGroupRegistry(mockChain, persistenceMock)
@@ -151,8 +152,39 @@ func TestUnregisterStaleGroups(t *testing.T) {
 	}
 }
 
+func TestUnregisterStaleGroupsSkipLastGroupCheck(t *testing.T) {
+	mockChain := &mockGroupRegistrationInterface{
+		groupsToRemove:       [][]byte{},
+		groupsCheckedIfStale: make(map[string]bool),
+	}
+
+	gr := NewGroupRegistry(mockChain, persistenceMock)
+
+	gr.RegisterGroup(signer1, channelName1)
+	gr.RegisterGroup(signer2, channelName1)
+	gr.RegisterGroup(signer3, channelName1)
+
+	gr.UnregisterStaleGroups(signer3.GroupPublicKeyBytes())
+
+	group1PublicKeyString := groupKeyToString(signer1.GroupPublicKeyBytes())
+	if mockChain.groupsCheckedIfStale[group1PublicKeyString] != true {
+		t.Fatalf("IsStaleGroup() was expected to be called for the first group")
+	}
+
+	group2PublicKeyString := groupKeyToString(signer2.GroupPublicKeyBytes())
+	if mockChain.groupsCheckedIfStale[group2PublicKeyString] != true {
+		t.Fatalf("IsStaleGroup() was expected to be called for the second group")
+	}
+
+	group3PublicKeyString := groupKeyToString(signer3.GroupPublicKeyBytes())
+	if mockChain.groupsCheckedIfStale[group3PublicKeyString] != false {
+		t.Fatalf("IsStaleGroup() was expected to not be called for the third group")
+	}
+}
+
 type mockGroupRegistrationInterface struct {
-	groupsToRemove [][]byte
+	groupsToRemove       [][]byte
+	groupsCheckedIfStale map[string]bool
 }
 
 func (mgri *mockGroupRegistrationInterface) markAsStale(publicKey []byte) {
@@ -166,6 +198,7 @@ func (mgri *mockGroupRegistrationInterface) OnGroupRegistered(
 }
 
 func (mgri *mockGroupRegistrationInterface) IsStaleGroup(groupPublicKey []byte) (bool, error) {
+	mgri.groupsCheckedIfStale[groupKeyToString(groupPublicKey)] = true
 	for _, groupToRemove := range mgri.groupsToRemove {
 		if bytes.Compare(groupToRemove, groupPublicKey) == 0 {
 			return true, nil

--- a/pkg/beacon/relay/registry/groups_test.go
+++ b/pkg/beacon/relay/registry/groups_test.go
@@ -129,7 +129,7 @@ func TestUnregisterStaleGroups(t *testing.T) {
 
 	mockChain.markAsStale(signer2.GroupPublicKeyBytes())
 
-	gr.UnregisterStaleGroups()
+	gr.UnregisterStaleGroups(signer3.GroupPublicKeyBytes())
 
 	group1 := gr.GetGroup(signer1.GroupPublicKeyBytes())
 	if group1 == nil {
@@ -149,7 +149,6 @@ func TestUnregisterStaleGroups(t *testing.T) {
 	if group3 == nil {
 		t.Fatalf("Expecting a group, but nil was returned instead")
 	}
-
 }
 
 type mockGroupRegistrationInterface struct {


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/2120

A node might run into situation when there is a slight delay with syncing to the recent state of the chain. It might result in error loggin "Group does not exist", even though it was just added to the chain. In order to avoid described scenario, we can skip checking the latest added group if it is a "stale group".