### PR TITLE
Improve rewards upgrade handling

### DIFF
--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -120,6 +120,7 @@ contract Rewards is Ownable {
     // but the pending and past intervals must have their rewards allocated
     // before any KEEP tokens are transferred out from this contract.
     uint256 public upgradeInitiatedTimestamp;
+    uint256 public upgradeFinalizedTimestamp;
     address public newRewardsContract;
 
     event RewardReceived(bytes32 keep, uint256 amount);
@@ -144,6 +145,8 @@ contract Rewards is Ownable {
     /// @dev Adds the received amount of tokens to `totalRewards` and
     /// `unallocatedRewards`. May be called at any time, even after allocating
     /// some intervals.
+    /// If the contract has been upgraded,
+    /// the funding will be transferred to the new contract instead.
     /// Changes to `unallocatedRewards` will take effect on subsequent interval
     /// allocations. Intended to be used with `approveAndCall`.
     /// If the reward contract has received tokens outside `approveAndCall`,
@@ -175,7 +178,7 @@ contract Rewards is Ownable {
         uint256 addedBalance = currentBalance.sub(beforeBalance);
 
         totalRewards = totalRewards.add(addedBalance);
-        unallocatedRewards = unallocatedRewards.add(addedBalance);
+        deallocate(addedBalance);
     }
 
     function markAsFunded() public onlyOwner {
@@ -550,7 +553,7 @@ contract Rewards is Ownable {
             emit RewardReceived(keepIdentifier, perKeepReward);
         } else {
             // Return the reward to the unallocated pool
-            unallocatedRewards = unallocatedRewards.add(perKeepReward);
+            deallocate(perKeepReward);
         }
     }
 
@@ -601,6 +604,25 @@ contract Rewards is Ownable {
         
 
         upgradeInitiatedTimestamp = 0;
+        upgradeFinalizedTimestamp = block.timestamp;
+    }
+
+    /// @notice Return the given amount to the unallocated pool.
+    /// If the contract has been upgraded,
+    /// the deallocated amount will be sent to the new contract.
+    function deallocate(uint256 amount) internal {
+        if (upgradeFinalizedTimestamp != 0) {
+            bool success = token.approveAndCall(
+                newRewardsContract,
+                amount,
+                bytes("")
+            );
+            if (!success) {
+                unallocatedRewards = unallocatedRewards.add(amount);
+            }
+        } else {
+            unallocatedRewards = unallocatedRewards.add(amount);
+        }
     }
 
     /// @notice Get the total number of keeps ever created by the factory,

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -612,6 +612,7 @@ contract Rewards is Ownable {
     /// @notice Return the given amount to the unallocated pool.
     /// If the contract has been upgraded,
     /// the deallocated amount will be sent to the new contract.
+    /// @param amount The amount to deallocate
     function deallocate(uint256 amount) internal {
         if (upgradeFinalizedTimestamp != 0) {
             bool success = token.approveAndCall(

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -583,8 +583,10 @@ contract Rewards is Ownable {
             "Interval at which the upgrade was initiated hasn't ended yet"
         );
 
-        // allocate all past intervals    
-        allocateRewards(currentInterval.sub(1));
+        // ensure all past intervals are allocated
+        if (!isAllocated(currentInterval.sub(1))) {
+            allocateRewards(currentInterval.sub(1));
+        }
 
         // transfer the unallocated KEEP to the new rewards contract and update
         // this contract's balances


### PR DESCRIPTION
Refs #1783

Finalizing a rewards upgrade can get blocked if the latest interval is allocated before the finalization. Fix this by only allocating intervals on finalization as required.

Send deallocated rewards or new funding to the new rewards contract if the upgrade has been finalized.