### PR TITLE
Rewards deallocation tests

### DIFF
--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -603,6 +603,7 @@ contract Rewards is Ownable {
             bytes("")
         );
         require(success, "Upgrade finalization failed");
+        
 
         upgradeInitiatedTimestamp = 0;
         upgradeFinalizedTimestamp = block.timestamp;
@@ -611,8 +612,6 @@ contract Rewards is Ownable {
     /// @notice Return the given amount to the unallocated pool.
     /// If the contract has been upgraded,
     /// the deallocated amount will be sent to the new contract.
-    /// @param amount Amount to be transferred to a new contract or added to 
-    /// unallocated pool.
     function deallocate(uint256 amount) internal {
         if (upgradeFinalizedTimestamp != 0) {
             bool success = token.approveAndCall(

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -603,7 +603,6 @@ contract Rewards is Ownable {
             bytes("")
         );
         require(success, "Upgrade finalization failed");
-        
 
         upgradeInitiatedTimestamp = 0;
         upgradeFinalizedTimestamp = block.timestamp;
@@ -612,6 +611,8 @@ contract Rewards is Ownable {
     /// @notice Return the given amount to the unallocated pool.
     /// If the contract has been upgraded,
     /// the deallocated amount will be sent to the new contract.
+    /// @param amount Amount to be transferred to a new contract or added to 
+    /// unallocated pool.
     function deallocate(uint256 amount) internal {
         if (upgradeFinalizedTimestamp != 0) {
             bool success = token.approveAndCall(

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -583,8 +583,10 @@ contract Rewards is Ownable {
             "Interval at which the upgrade was initiated hasn't ended yet"
         );
 
-        // allocate all past intervals    
-        allocateRewards(currentInterval.sub(1));
+        // ensure all past intervals are allocated
+        if (!isAllocated(currentInterval.sub(1))) {
+            allocateRewards(currentInterval.sub(1));
+        }
 
         // transfer the unallocated KEEP to the new rewards contract and update
         // this contract's balances

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -168,7 +168,7 @@ describe("Rewards/Upgrades", () => {
             )
         })
 
-        it("allocates interval before finalize rewards upgrade", async () => {
+        it("can be finalized with all previous intervals already allocated", async () => {
             await time.increase(termLength + 1) // interval 0 ends
 
             await rewards.initiateRewardsUpgrade(

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -182,6 +182,27 @@ describe("Rewards/Upgrades", () => {
             await rewards.allocateRewards(1)
             await rewards.finalizeRewardsUpgrade({from: owner})
 
+            const allocation0 = await rewards.getAllocatedRewards(0)
+            const allocation1 = await rewards.getAllocatedRewards(1)
+            
+            expect(allocation0).to.eq.BN(50000) // 5% of 1000000
+            expect(allocation1).to.eq.BN(95000) // 10% of (1000000 - 50000)
+        })
+
+        it("should correctly update timestamps", async () => {
+            await time.increase(termLength + 1) // interval 0 ends
+
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(termLength + 1) // interval 1 ends
+            await rewards.setCloseTime(timestamps[2])
+
+            await rewards.allocateRewards(1)
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
             const upgradeInitiatedTimestamp = await rewards.upgradeInitiatedTimestamp()
             const upgradeFinalizedTimestamp = await rewards.upgradeFinalizedTimestamp()
 

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -168,6 +168,27 @@ describe("Rewards/Upgrades", () => {
             )
         })
 
+        it("allocates interval before finalize rewards upgrade", async () => {
+            await time.increase(termLength + 1) // interval 0 ends
+
+            await rewards.initiateRewardsUpgrade(
+                newRewards.address,
+                {from: owner}
+            )
+
+            await time.increase(termLength + 1) // interval 1 ends
+            await rewards.setCloseTime(timestamps[2])
+
+            await rewards.allocateRewards(1)
+            await rewards.finalizeRewardsUpgrade({from: owner})
+
+            const upgradeInitiatedTimestamp = await rewards.upgradeInitiatedTimestamp()
+            const upgradeFinalizedTimestamp = await rewards.upgradeFinalizedTimestamp()
+
+            expect(upgradeInitiatedTimestamp).to.eq.BN(0)
+            expect(upgradeFinalizedTimestamp).not.to.eq.BN(0)
+        })
+
         it("moves all unallocated rewards to new contract", async () => {
             await rewards.initiateRewardsUpgrade(
                 newRewards.address,

--- a/solidity/test/rewards/TestRewardUpgrades.js
+++ b/solidity/test/rewards/TestRewardUpgrades.js
@@ -210,7 +210,7 @@ describe("Rewards/Upgrades", () => {
             expect(upgradeFinalizedTimestamp).not.to.eq.BN(0)
         })
 
-        it("transfers amount to a new contract upon rewards upgrade", async () => {
+        it("transfers any topped-up amount to a new contract after finalizing the upgrade", async () => {
             await time.increase(termLength + 1) // interval 0 ends
 
             await rewards.initiateRewardsUpgrade(


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-core/pull/2136

Adding tests around:
- deallocation of rewards
- rewards allocation just before finalizing rewards contract upgrade.