### PR TITLE
Batch processing rewards and terminations

### DIFF
--- a/solidity/contracts/BeaconRewards.sol
+++ b/solidity/contracts/BeaconRewards.sol
@@ -97,6 +97,20 @@ contract BeaconRewards is Rewards {
         receiveReward(bytes32(groupIndex));
     }
 
+    /// @notice Stakers can receive KEEP rewards from multiple groups of their choice
+    /// in one transaction to reduce total cost comparing to single calls for rewards.
+    /// It is a caller responsibility to determine the cost and consumed gas when
+    /// receiving rewards from multiple groups.
+    /// @param groupIndices An array of group indices.
+    function receiveRewards(uint256[] memory groupIndices) public {
+        uint256 len = groupIndices.length;
+        bytes32[] memory bytes32identifiers = new bytes32[](len);
+        for (uint256 i = 0; i < groupIndices.length; i++) {
+            bytes32identifiers[i] = bytes32(groupIndices[i]);
+        }
+        receiveRewards(bytes32identifiers);
+    }
+
     /// @notice Checks if the group is eligible to receive a reward.
     /// Group is eligible to receive a reward if it has been marked as stale
     /// and rewards has not been claimed yet.
@@ -110,6 +124,18 @@ contract BeaconRewards is Rewards {
     /// @param groupIndex Index of the terminated group.
     function reportTermination(uint256 groupIndex) public {
         reportTermination(bytes32(groupIndex));
+    }
+
+    /// @notice Report about the terminated groups in batch. All the allocated
+    /// rewards in these groups will be returned to the unallocated pool.
+    /// @param groupIndices An array of group indices.
+    function reportTerminations(uint256[] memory groupIndices) public {
+        uint256 len = groupIndices.length;
+        bytes32[] memory bytes32identifiers = new bytes32[](len);
+        for (uint256 i = 0; i < groupIndices.length; i++) {
+            bytes32identifiers[i] = bytes32(groupIndices[i]);
+        }
+        reportTerminations(bytes32identifiers);
     }
 
     /// @notice Checks if the group is terminated and thus its rewards can be

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -185,6 +185,17 @@ contract Rewards is Ownable {
         funded = true;
     }
 
+    /// @notice Stakers can receive KEEP rewards from multiple keeps of their choice
+    /// in one transaction to reduce total cost comparing to single calls for rewards.
+    /// It is a caller responsibility to determine the cost and consumed gas when
+    /// receiving rewards from multiple keeps.
+    /// @param keepIdentifiers An array of keep addresses.
+    function receiveRewards(bytes32[] memory keepIdentifiers) public {
+        for (uint256 i = 0; i < keepIdentifiers.length; i++) {
+            receiveReward(keepIdentifiers[i]);
+        }
+    }
+
     /// @notice Sends the reward for a keep to the keep members.
     /// @param keepIdentifier A unique identifier for the keep,
     /// e.g. address or number converted to a `bytes32`.
@@ -195,6 +206,15 @@ contract Rewards is Ownable {
         public
     {
         _processKeep(true, keepIdentifier);
+    }
+
+    /// @notice Report about the terminated keeps in batch. All the allocated
+    /// rewards in these keeps will be returned to the unallocated pool.
+    /// @param keepIdentifiers An array of keep addresses.
+    function reportTerminations(bytes32[] memory keepIdentifiers) public {
+        for (uint256 i = 0; i < keepIdentifiers.length; i++) {
+            reportTermination(keepIdentifiers[i]);
+        }
     }
 
     /// @notice Report that the keep was terminated, and return its allocated

--- a/solidity/contracts/Rewards.sol
+++ b/solidity/contracts/Rewards.sol
@@ -189,7 +189,7 @@ contract Rewards is Ownable {
     /// in one transaction to reduce total cost comparing to single calls for rewards.
     /// It is a caller responsibility to determine the cost and consumed gas when
     /// receiving rewards from multiple keeps.
-    /// @param keepIdentifiers An array of keep addresses.
+    /// @param keepIdentifiers An array of keep identifiers.
     function receiveRewards(bytes32[] memory keepIdentifiers) public {
         for (uint256 i = 0; i < keepIdentifiers.length; i++) {
             receiveReward(keepIdentifiers[i]);
@@ -210,7 +210,7 @@ contract Rewards is Ownable {
 
     /// @notice Report about the terminated keeps in batch. All the allocated
     /// rewards in these keeps will be returned to the unallocated pool.
-    /// @param keepIdentifiers An array of keep addresses.
+    /// @param keepIdentifiers An array of keep identifiers.
     function reportTerminations(bytes32[] memory keepIdentifiers) public {
         for (uint256 i = 0; i < keepIdentifiers.length; i++) {
             reportTermination(keepIdentifiers[i]);

--- a/solidity/contracts/stubs/RewardsStub.sol
+++ b/solidity/contracts/stubs/RewardsStub.sol
@@ -28,11 +28,11 @@ contract RewardsStub is Rewards {
         receiveReward(bytes32(i));
     }
 
-    function receiveRewards(uint256[] memory identifieres) public {
-        uint256 len = identifieres.length;
+    function receiveRewards(uint256[] memory identifiers) public {
+        uint256 len = identifiers.length;
         bytes32[] memory bytes32identifiers = new bytes32[](len);
-        for (uint256 i = 0; i < identifieres.length; i++) {
-            bytes32identifiers[i] = bytes32(identifieres[i]);
+        for (uint256 i = 0; i < identifiers.length; i++) {
+            bytes32identifiers[i] = bytes32(identifiers[i]);
         }
         receiveRewards(bytes32identifiers);
     }

--- a/solidity/contracts/stubs/RewardsStub.sol
+++ b/solidity/contracts/stubs/RewardsStub.sol
@@ -41,7 +41,7 @@ contract RewardsStub is Rewards {
         reportTermination(bytes32(i));
     }
 
-    function reportMultipleTerminations(uint256[] memory identifieres) public {
+    function reportTerminations(uint256[] memory identifieres) public {
         uint256 len = identifieres.length;
         bytes32[] memory bytes32identifiers = new bytes32[](len);
         for (uint256 i = 0; i < identifieres.length; i++) {

--- a/solidity/contracts/stubs/RewardsStub.sol
+++ b/solidity/contracts/stubs/RewardsStub.sol
@@ -41,11 +41,11 @@ contract RewardsStub is Rewards {
         reportTermination(bytes32(i));
     }
 
-    function reportTerminations(uint256[] memory identifieres) public {
-        uint256 len = identifieres.length;
+    function reportTerminations(uint256[] memory identifiers) public {
+        uint256 len = identifiers.length;
         bytes32[] memory bytes32identifiers = new bytes32[](len);
-        for (uint256 i = 0; i < identifieres.length; i++) {
-            bytes32identifiers[i] = bytes32(identifieres[i]);
+        for (uint256 i = 0; i < identifiers.length; i++) {
+            bytes32identifiers[i] = bytes32(identifiers[i]);
         }
         reportTerminations(bytes32identifiers);
     }

--- a/solidity/contracts/stubs/RewardsStub.sol
+++ b/solidity/contracts/stubs/RewardsStub.sol
@@ -28,8 +28,26 @@ contract RewardsStub is Rewards {
         receiveReward(bytes32(i));
     }
 
+    function receiveRewards(uint256[] memory identifieres) public {
+        uint256 len = identifieres.length;
+        bytes32[] memory bytes32identifiers = new bytes32[](len);
+        for (uint256 i = 0; i < identifieres.length; i++) {
+            bytes32identifiers[i] = bytes32(identifieres[i]);
+        }
+        receiveRewards(bytes32identifiers);
+    }
+
     function reportTermination(uint256 i) public {
         reportTermination(bytes32(i));
+    }
+
+    function reportMultipleTerminations(uint256[] memory identifieres) public {
+        uint256 len = identifieres.length;
+        bytes32[] memory bytes32identifiers = new bytes32[](len);
+        for (uint256 i = 0; i < identifieres.length; i++) {
+            bytes32identifiers[i] = bytes32(identifieres[i]);
+        }
+        reportTerminations(bytes32identifiers);
     }
 
     function eligibleForReward(uint256 i) public view returns (bool) {

--- a/solidity/test/rewards/TestBeaconRewards.js
+++ b/solidity/test/rewards/TestBeaconRewards.js
@@ -238,7 +238,7 @@ describe('BeaconRewards', () => {
             expect(unallocatedInKeep).to.eq.BN(19404000)
         })
 
-        it("should not count terminated groups in batch when distributing rewards", async () => {
+        it("should not count a batch of terminated groups when distributing rewards", async () => {
             const startOf = await rewardsContract.startOf(0)
             await registerNewGroup(startOf.addn(1))
             await registerNewGroup(startOf.addn(2))
@@ -259,8 +259,8 @@ describe('BeaconRewards', () => {
 
             // the remaining unallocated rewards pool has 19,008,000 KEEP
             // the remaining 528,000 stays in unallocated rewards but the fact
-            // it terminated needs to be reported to recalculate the unallocated
-            // amount
+            // two keeps were terminated needs to be reported to recalculate the 
+            // unallocated amount
             // unallocated amount: 19,008,000 + 528,000 = 19,536,000
             await rewardsContract.methods['reportTerminations(uint256[])'](
                 terminatedGroups

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -426,18 +426,6 @@ describe('Rewards', () => {
             expect(aliceBalance.toNumber()).to.equal(66666)
         })
 
-        it("lets closed keeps claim the rewards from multiple keeps correctly", async () => {
-            let timestamps = testValues.rewardTimestamps
-            await createKeeps(timestamps)
-            await rewards.setCloseTime(timestamps[2])
-            let rewardsReceivingKeeps = [0, 1]
-            await rewards.receiveRewards(rewardsReceivingKeeps, { from: aliceBeneficiary })
-            let aliceBalance = await token.balanceOf(aliceBeneficiary)
-            // Beneficiary will receive 200,000 / 3 = 66,666 per keep
-            // 66,666 * 2 = 133332 KEEP rewards total for being in 2 closed keeps
-            expect(aliceBalance.toNumber()).to.equal(133332)
-        })
-
         it("doesn't let keeps claim rewards again", async () => {
             let timestamps = testValues.rewardTimestamps
             await createKeeps(timestamps)
@@ -496,6 +484,20 @@ describe('Rewards', () => {
         })
     })
 
+    describe("receiveRewards", async () => {
+        it("lets closed keeps claim the rewards from multiple keeps correctly", async () => {
+            let timestamps = testValues.rewardTimestamps
+            await createKeeps(timestamps)
+            await rewards.setCloseTime(timestamps[2])
+            let rewardsReceivingKeeps = [0, 1]
+            await rewards.receiveRewards(rewardsReceivingKeeps, { from: aliceBeneficiary })
+            let aliceBalance = await token.balanceOf(aliceBeneficiary)
+            // Beneficiary will receive 200,000 / 3 = 66,666 per keep
+            // 66,666 * 2 = 133332 KEEP rewards total for being in 2 closed keeps
+            expect(aliceBalance.toNumber()).to.equal(133332)
+        })
+    })
+
     describe("reportTermination", async () => {
         it("unallocates rewards allocated to terminated keep", async () => {
             let timestamps = testValues.rewardTimestamps
@@ -510,31 +512,6 @@ describe('Rewards', () => {
             let postUnallocated = await rewards.unallocatedRewards()
             expect(postUnallocated.toNumber()).to.equal(
                 preUnallocated.toNumber() + 66666
-            )
-        })
-
-        it("unallocates rewards allocated to terminated keeps in batch", async () => {
-            let timestamps = testValues.rewardTimestamps
-            await createKeeps(timestamps)
-
-            await rewards.setCloseTime(testValues.rewardTimestamps[0])
-            await rewards.allocateRewards(0)
-
-            await rewards.terminate(1)
-            await rewards.terminate(2)
-
-            let preUnallocated = await rewards.unallocatedRewards()
-
-            let terminatedKeeps = [1, 2]
-            await rewards.reportMultipleTerminations(terminatedKeeps, { from: aliceBeneficiary })
-            let actual = await rewards.unallocatedRewards()
-            // 200,000 KEEP were allocated for the first interval
-            // 800,000 KEEP remaining in unallocated pool
-            // 2 out of 3 keeps were terminated
-            // 200,000 / 3 = 66,666 rewards per keep
-            // 66,666 * 2 = 133,332 returned back to unallocated pool
-            expect(actual.toNumber()).to.equal(
-                preUnallocated.toNumber() + 133332
             )
         })
 
@@ -584,7 +561,33 @@ describe('Rewards', () => {
                 "Interval hasn't ended yet"
             )
         })
-
-
     })
+
+    describe("reportTerminations", async () => {
+        it("unallocates rewards allocated to terminated keeps in batch", async () => {
+            let timestamps = testValues.rewardTimestamps
+            await createKeeps(timestamps)
+    
+            await rewards.setCloseTime(testValues.rewardTimestamps[0])
+            await rewards.allocateRewards(0)
+    
+            await rewards.terminate(1)
+            await rewards.terminate(2)
+    
+            let preUnallocated = await rewards.unallocatedRewards()
+    
+            let terminatedKeeps = [1, 2]
+            await rewards.reportMultipleTerminations(terminatedKeeps, { from: aliceBeneficiary })
+            let actual = await rewards.unallocatedRewards()
+            // 200,000 KEEP were allocated for the first interval
+            // 800,000 KEEP remaining in unallocated pool
+            // 2 out of 3 keeps were terminated
+            // 200,000 / 3 = 66,666 rewards per keep
+            // 66,666 * 2 = 133,332 returned back to unallocated pool
+            expect(actual.toNumber()).to.equal(
+                preUnallocated.toNumber() + 133332
+            )
+        })
+    })
+    
 })

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -13,7 +13,7 @@ chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 const assert = chai.assert
 
-describe.only('Rewards', () => {
+describe('Rewards', () => {
     const owner = accounts[0]
     const aliceBeneficiary = accounts[1]
     const funder = accounts[9]

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -576,8 +576,10 @@ describe('Rewards', () => {
     
             let preUnallocated = await rewards.unallocatedRewards()
     
-            let terminatedKeeps = [1, 2]
-            await rewards.reportMultipleTerminations(terminatedKeeps, { from: aliceBeneficiary })
+            const terminatedIdentifiers = [1, 2]
+            await rewards.methods['reportTerminations(uint256[])'](
+                terminatedIdentifiers
+            )
             let actual = await rewards.unallocatedRewards()
             // 200,000 KEEP were allocated for the first interval
             // 800,000 KEEP remaining in unallocated pool

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -490,7 +490,11 @@ describe('Rewards', () => {
             await createKeeps(timestamps)
             await rewards.setCloseTime(timestamps[2])
             let rewardsReceivingKeeps = [0, 1]
-            await rewards.receiveRewards(rewardsReceivingKeeps, { from: aliceBeneficiary })
+
+            await rewards.methods['receiveRewards(uint256[])'](
+                rewardsReceivingKeeps,
+                { from: aliceBeneficiary }
+            )
             let aliceBalance = await token.balanceOf(aliceBeneficiary)
             // Beneficiary will receive 200,000 / 3 = 66,666 per keep
             // 66,666 * 2 = 133332 KEEP rewards total for being in 2 closed keeps

--- a/solidity/test/rewards/TestRewards.js
+++ b/solidity/test/rewards/TestRewards.js
@@ -497,7 +497,7 @@ describe('Rewards', () => {
             )
             let aliceBalance = await token.balanceOf(aliceBeneficiary)
             // Beneficiary will receive 200,000 / 3 = 66,666 per keep
-            // 66,666 * 2 = 133332 KEEP rewards total for being in 2 closed keeps
+            // 66,666 * 2 = 133,332 KEEP rewards total for being in 2 closed keeps
             expect(aliceBalance.toNumber()).to.equal(133332)
         })
     })


### PR DESCRIPTION
This PR is a continuation of https://github.com/keep-network/keep-ecdsa/pull/588

Adding the functionality to report termination of multiple keeps with one call. This should save transactions cost.
We decided to move batch processing of rewards receiving and terminations to the main `Rewards.sol` contract.