### PR TITLE
Adding staker rewards escrow beneficiary contracts

### DIFF
--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -66,20 +66,27 @@ contract CurveRewardsEscrowBeneficiary is Ownable {
         curveRewards = _curveRewards;
     }
 
-    function __escrowSentTokens(uint256 amount) external {
+    function __escrowSentTokens(uint256 amount) external onlyOwner {
         token.approve(address(curveRewards), amount);
         curveRewards.notifyRewardAmount(amount);
     }
 }
 
 /// @dev Interface of recipient contract for approveAndCall pattern.
-interface IStakerRewards { function receiveApproval(address _from, uint256 _value, address _token, bytes calldata _extraData) external; }
+interface IStakerRewards {
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes calldata _extraData
+    ) external;
+}
 
-/// @title BeaconBackportRewardsEscrowBeneficiary
-/// @notice A beneficiary contract that can receive a withdrawal phase from a
-///         PhasedEscrow contract. Immediately stakes the received tokens on a
-///         designated BeaconBackportRewardsEscrowBeneficiary contract.
-contract BeaconBackportRewardsEscrowBeneficiary is Ownable {
+/// @title StakerRewardsBeneficiary
+/// @notice An abstract beneficiary contract that can receive a withdrawal phase
+///         from a PhasedEscrow contract. Immediately stakes the received tokens
+///         on a designated rewards escrow beneficiary contract.
+contract StakerRewardsBeneficiary is Ownable {
     IERC20 public token;
     IStakerRewards public stakerRewards;
 
@@ -88,65 +95,67 @@ contract BeaconBackportRewardsEscrowBeneficiary is Ownable {
         stakerRewards = _stakerRewards;
     }
 
-    function __escrowSentTokens(uint256 amount) external {
-        token.approve(address(stakerRewards), amount);
-        stakerRewards.receiveApproval(address(this), amount, address(token), "");
+    function __escrowSentTokens(uint256 amount) external onlyOwner {
+        bool success = token.approve(address(stakerRewards), amount);
+        require(success, "Rewards token staking has failed");
+        
+        stakerRewards.receiveApproval(
+            address(this),
+            amount,
+            address(token),
+            ""
+        );
+    }
+}
+
+/// @title BeaconBackportRewardsEscrowBeneficiary
+/// @notice Stakes the received tokens on a designated
+///         BeaconBackportRewardsEscrowBeneficiary contract.
+contract BeaconBackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
+    constructor(IERC20 _token, IStakerRewards _stakerRewards)
+        public
+        StakerRewardsBeneficiary(_token, _stakerRewards)
+    {
+        token = _token;
+        stakerRewards = _stakerRewards;
     }
 }
 
 /// @title BeaconRewardsEscrowBeneficiary
-/// @notice A beneficiary contract that can receive a withdrawal phase from a
-///         PhasedEscrow contract. Immediately stakes the received tokens on a
-///         designated BeaconRewardsEscrowBeneficiary contract.
-contract BeaconRewardsEscrowBeneficiary is Ownable {
-    IERC20 public token;
-    IStakerRewards public stakerRewards;
-
-    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+/// @notice Stakes the received tokens on a designated
+///         BeaconRewardsEscrowBeneficiary contract.
+contract BeaconRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
+    constructor(IERC20 _token, IStakerRewards _stakerRewards)
+        public
+        StakerRewardsBeneficiary(_token, _stakerRewards)
+    {
         token = _token;
         stakerRewards = _stakerRewards;
-    }
-
-    function __escrowSentTokens(uint256 amount) external {
-        token.approve(address(stakerRewards), amount);
-        stakerRewards.receiveApproval(address(this), amount, address(token), "");
     }
 }
 
 /// @title ECDSABackportRewardsEscrowBeneficiary
-/// @notice A beneficiary contract that can receive a withdrawal phase from a
-///         PhasedEscrow contract. Immediately stakes the received tokens on a
-///         designated ECDSABackportRewardsEscrowBeneficiary contract.
-contract ECDSABackportRewardsEscrowBeneficiary is Ownable {
-    IERC20 public token;
-    IStakerRewards public stakerRewards;
-
-    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+/// @notice Stakes the received tokens on a designated
+///         ECDSABackportRewardsEscrowBeneficiary contract.
+contract ECDSABackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
+    constructor(IERC20 _token, IStakerRewards _stakerRewards)
+        public
+        StakerRewardsBeneficiary(_token, _stakerRewards)
+    {
         token = _token;
         stakerRewards = _stakerRewards;
-    }
-
-    function __escrowSentTokens(uint256 amount) external {
-        token.approve(address(stakerRewards), amount);
-        stakerRewards.receiveApproval(address(this), amount, address(token), "");
     }
 }
 
 /// @title ECDSARewardsEscrowBeneficiary
-/// @notice A beneficiary contract that can receive a withdrawal phase from a
-///         PhasedEscrow contract. Immediately stakes the received tokens on a
-///         designated ECDSARewardsEscrowBeneficiary contract.
-contract ECDSARewardsEscrowBeneficiary is Ownable {
-    IERC20 public token;
-    IStakerRewards public stakerRewards;
-
-    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+/// @notice Stakes the received tokens on a designated
+///         ECDSARewardsEscrowBeneficiary contract.
+contract ECDSARewardsEscrowBeneficiary is StakerRewardsBeneficiary {
+    constructor(IERC20 _token, IStakerRewards _stakerRewards)
+        public
+        StakerRewardsBeneficiary(_token, _stakerRewards)
+    {
         token = _token;
         stakerRewards = _stakerRewards;
-    }
-
-    function __escrowSentTokens(uint256 amount) external {
-        token.approve(address(stakerRewards), amount);
-        stakerRewards.receiveApproval(address(this), amount, address(token), "");
     }
 }

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -75,6 +75,10 @@ contract CurveRewardsEscrowBeneficiary is Ownable {
 /// @dev Interface of recipient contract for approveAndCall pattern.
 interface IStakerRewards { function receiveApproval(address _from, uint256 _value, address _token, bytes calldata _extraData) external; }
 
+/// @title BeaconBackportRewardsEscrowBeneficiary
+/// @notice A beneficiary contract that can receive a withdrawal phase from a
+///         PhasedEscrow contract. Immediately stakes the received tokens on a
+///         designated BeaconBackportRewardsEscrowBeneficiary contract.
 contract BeaconBackportRewardsEscrowBeneficiary is Ownable {
     IERC20 public token;
     IStakerRewards public stakerRewards;
@@ -86,18 +90,63 @@ contract BeaconBackportRewardsEscrowBeneficiary is Ownable {
 
     function __escrowSentTokens(uint256 amount) external {
         token.approve(address(stakerRewards), amount);
-        stakerRewards.receiveApproval(msg.sender, amount, address(token), "");
+        stakerRewards.receiveApproval(address(this), amount, address(token), "");
     }
 }
 
+/// @title BeaconRewardsEscrowBeneficiary
+/// @notice A beneficiary contract that can receive a withdrawal phase from a
+///         PhasedEscrow contract. Immediately stakes the received tokens on a
+///         designated BeaconRewardsEscrowBeneficiary contract.
 contract BeaconRewardsEscrowBeneficiary is Ownable {
-    // TODO: implement similar to BeaconBackportRewardsEscrowBeneficiary
+    IERC20 public token;
+    IStakerRewards public stakerRewards;
+
+    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+        token = _token;
+        stakerRewards = _stakerRewards;
+    }
+
+    function __escrowSentTokens(uint256 amount) external {
+        token.approve(address(stakerRewards), amount);
+        stakerRewards.receiveApproval(address(this), amount, address(token), "");
+    }
 }
 
+/// @title ECDSABackportRewardsEscrowBeneficiary
+/// @notice A beneficiary contract that can receive a withdrawal phase from a
+///         PhasedEscrow contract. Immediately stakes the received tokens on a
+///         designated ECDSABackportRewardsEscrowBeneficiary contract.
 contract ECDSABackportRewardsEscrowBeneficiary is Ownable {
-    // TODO: implement similar to BeaconBackportRewardsEscrowBeneficiary
+    IERC20 public token;
+    IStakerRewards public stakerRewards;
+
+    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+        token = _token;
+        stakerRewards = _stakerRewards;
+    }
+
+    function __escrowSentTokens(uint256 amount) external {
+        token.approve(address(stakerRewards), amount);
+        stakerRewards.receiveApproval(address(this), amount, address(token), "");
+    }
 }
 
+/// @title ECDSARewardsEscrowBeneficiary
+/// @notice A beneficiary contract that can receive a withdrawal phase from a
+///         PhasedEscrow contract. Immediately stakes the received tokens on a
+///         designated ECDSARewardsEscrowBeneficiary contract.
 contract ECDSARewardsEscrowBeneficiary is Ownable {
-    // TODO: implement similar to BeaconBackportRewardsEscrowBeneficiary
+    IERC20 public token;
+    IStakerRewards public stakerRewards;
+
+    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+        token = _token;
+        stakerRewards = _stakerRewards;
+    }
+
+    function __escrowSentTokens(uint256 amount) external {
+        token.approve(address(stakerRewards), amount);
+        stakerRewards.receiveApproval(address(this), amount, address(token), "");
+    }
 }

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -115,10 +115,7 @@ contract BeaconBackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
         public
         StakerRewardsBeneficiary(_token, _stakerRewards)
-    {
-        token = _token;
-        stakerRewards = _stakerRewards;
-    }
+    {}
 }
 
 /// @title BeaconRewardsEscrowBeneficiary
@@ -128,10 +125,7 @@ contract BeaconRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
         public
         StakerRewardsBeneficiary(_token, _stakerRewards)
-    {
-        token = _token;
-        stakerRewards = _stakerRewards;
-    }
+    {}
 }
 
 /// @title ECDSABackportRewardsEscrowBeneficiary
@@ -141,10 +135,7 @@ contract ECDSABackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
         public
         StakerRewardsBeneficiary(_token, _stakerRewards)
-    {
-        token = _token;
-        stakerRewards = _stakerRewards;
-    }
+    {}
 }
 
 /// @title ECDSARewardsEscrowBeneficiary
@@ -154,8 +145,5 @@ contract ECDSARewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
         public
         StakerRewardsBeneficiary(_token, _stakerRewards)
-    {
-        token = _token;
-        stakerRewards = _stakerRewards;
-    }
+    {}
 }

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -84,8 +84,8 @@ interface IStakerRewards {
 
 /// @title StakerRewardsBeneficiary
 /// @notice An abstract beneficiary contract that can receive a withdrawal phase
-///         from a PhasedEscrow contract. Immediately stakes the received tokens
-///         on a designated rewards escrow beneficiary contract.
+///         from a PhasedEscrow contract. The received tokens are immediately 
+///         funded for a designated rewards escrow beneficiary contract.
 contract StakerRewardsBeneficiary is Ownable {
     IERC20 public token;
     IStakerRewards public stakerRewards;
@@ -97,7 +97,7 @@ contract StakerRewardsBeneficiary is Ownable {
 
     function __escrowSentTokens(uint256 amount) external onlyOwner {
         bool success = token.approve(address(stakerRewards), amount);
-        require(success, "Rewards token staking has failed");
+        require(success, "Token transfer approval failed");
         
         stakerRewards.receiveApproval(
             address(this),
@@ -109,7 +109,7 @@ contract StakerRewardsBeneficiary is Ownable {
 }
 
 /// @title BeaconBackportRewardsEscrowBeneficiary
-/// @notice Stakes the received tokens on a designated
+/// @notice Transfer the received tokens to a designated
 ///         BeaconBackportRewardsEscrowBeneficiary contract.
 contract BeaconBackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
@@ -122,7 +122,7 @@ contract BeaconBackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
 }
 
 /// @title BeaconRewardsEscrowBeneficiary
-/// @notice Stakes the received tokens on a designated
+/// @notice Transfer the received tokens to a designated
 ///         BeaconRewardsEscrowBeneficiary contract.
 contract BeaconRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
@@ -135,7 +135,7 @@ contract BeaconRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
 }
 
 /// @title ECDSABackportRewardsEscrowBeneficiary
-/// @notice Stakes the received tokens on a designated
+/// @notice Trasfer the received tokens to a designated
 ///         ECDSABackportRewardsEscrowBeneficiary contract.
 contract ECDSABackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)
@@ -148,7 +148,7 @@ contract ECDSABackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
 }
 
 /// @title ECDSARewardsEscrowBeneficiary
-/// @notice Stakes the received tokens on a designated
+/// @notice Transfer the received tokens to a designated
 ///         ECDSARewardsEscrowBeneficiary contract.
 contract ECDSARewardsEscrowBeneficiary is StakerRewardsBeneficiary {
     constructor(IERC20 _token, IStakerRewards _stakerRewards)

--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -71,3 +71,33 @@ contract CurveRewardsEscrowBeneficiary is Ownable {
         curveRewards.notifyRewardAmount(amount);
     }
 }
+
+/// @dev Interface of recipient contract for approveAndCall pattern.
+interface IStakerRewards { function receiveApproval(address _from, uint256 _value, address _token, bytes calldata _extraData) external; }
+
+contract BeaconBackportRewardsEscrowBeneficiary is Ownable {
+    IERC20 public token;
+    IStakerRewards public stakerRewards;
+
+    constructor(IERC20 _token, IStakerRewards _stakerRewards) public {
+        token = _token;
+        stakerRewards = _stakerRewards;
+    }
+
+    function __escrowSentTokens(uint256 amount) external {
+        token.approve(address(stakerRewards), amount);
+        stakerRewards.receiveApproval(msg.sender, amount, address(token), "");
+    }
+}
+
+contract BeaconRewardsEscrowBeneficiary is Ownable {
+    // TODO: implement similar to BeaconBackportRewardsEscrowBeneficiary
+}
+
+contract ECDSABackportRewardsEscrowBeneficiary is Ownable {
+    // TODO: implement similar to BeaconBackportRewardsEscrowBeneficiary
+}
+
+contract ECDSARewardsEscrowBeneficiary is Ownable {
+    // TODO: implement similar to BeaconBackportRewardsEscrowBeneficiary
+}

--- a/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
+++ b/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
@@ -27,3 +27,23 @@ contract TestCurveRewards {
         emit RewardAdded(reward);
     }
 }
+
+// ECDSA Reward contract mock for ecdsa staker rewards.
+contract TestECDSARewards {
+    using SafeERC20 for IERC20;
+
+    IERC20 public token;
+
+    constructor(IERC20 _token) public {
+        token = _token;
+    }
+
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes memory
+    ) public {
+        token.safeTransferFrom(_from, address(this), _value);
+    }
+}

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -205,9 +205,11 @@ describe("PhasedEscrow", () => {
         curveRewards = await TestCurveRewards.new(token.address)
         rewardsBeneficiary = await CurveRewardsEscrowBeneficiary.new(
           token.address,
-          curveRewards.address
+          curveRewards.address,
+          {from: owner}
         )
 
+        await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {from: owner})
         const amount = web3.utils.toBN(baseBalance)
         await token.transfer(phasedEscrow.address, amount, {from: owner})
 
@@ -269,7 +271,7 @@ describe("PhasedEscrow", () => {
       })
     })
 
-    describe("when withdrawing to a staker rewards escrow beneficiary", () => {
+    describe("when withdrawing to a StakerRewardsBeneficiary", () => {
       const baseBalance = 200000000
       let stakingContract
       let operatorContract
@@ -307,8 +309,10 @@ describe("PhasedEscrow", () => {
 
           rewardsBeneficiary = await BeaconBackportRewardsEscrowBeneficiary.new(
             token.address,
-            rewardsContract.address
+            rewardsContract.address,
+            {from: owner}
           )
+          await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {from: owner})
 
           await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
             from: owner,
@@ -330,8 +334,10 @@ describe("PhasedEscrow", () => {
 
           rewardsBeneficiary = await BeaconRewardsEscrowBeneficiary.new(
             token.address,
-            rewardsContract.address
+            rewardsContract.address,
+            {from: owner}
           )
+          await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {from: owner})
 
           await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
             from: owner,
@@ -349,8 +355,10 @@ describe("PhasedEscrow", () => {
 
           rewardsBeneficiary = await ECDSABackportRewardsEscrowBeneficiary.new(
             token.address,
-            rewardsContract.address
+            rewardsContract.address,
+            {from: owner}
           )
+          await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {from: owner})
 
           await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
             from: owner,
@@ -368,8 +376,10 @@ describe("PhasedEscrow", () => {
 
           rewardsBeneficiary = await ECDSARewardsEscrowBeneficiary.new(
             token.address,
-            rewardsContract.address
+            rewardsContract.address,
+            {from: owner}
           )
+          await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {from: owner})
 
           await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
             from: owner,

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -379,7 +379,7 @@ describe("PhasedEscrow", () => {
       )
     })
 
-    it("transfers specified tokens to beacon backport rewards contract", async () => {
+    it("transfers specified tokens to rewards contract", async () => {
       await phasedEscrow.withdraw(transferAmount, {from: owner})
 
       expect(await token.balanceOf(rewardsContract.address)).to.eq.BN(

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -22,6 +22,14 @@ const BeaconRewardsEscrowBeneficiary = contract.fromArtifact(
 )
 const BeaconRewards = contract.fromArtifact("BeaconRewards")
 
+const TestECDSARewards = contract.fromArtifact("TestECDSARewards")
+const ECDSABackportRewardsEscrowBeneficiary = contract.fromArtifact(
+  "ECDSABackportRewardsEscrowBeneficiary"
+)
+const ECDSARewardsEscrowBeneficiary = contract.fromArtifact(
+  "ECDSARewardsEscrowBeneficiary"
+)
+
 const chai = require("chai")
 chai.use(require("bn-chai")(web3.utils.BN))
 const expect = chai.expect
@@ -311,7 +319,7 @@ describe("PhasedEscrow", () => {
       })
 
       describe("BeaconRewardsEscrowBeneficiary", () => {
-        const transferAmount = 1800000
+        const transferAmount = 19800000
 
         before(async () => {
           rewardsContract = await BeaconRewards.new(
@@ -321,6 +329,44 @@ describe("PhasedEscrow", () => {
           )
 
           rewardsBeneficiary = await BeaconRewardsEscrowBeneficiary.new(
+            token.address,
+            rewardsContract.address
+          )
+
+          await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
+            from: owner,
+          })
+        })
+
+        assertStakerRewards(baseBalance, transferAmount)
+      })
+
+      describe("ECDSABackportRewardsEscrowBeneficiary", () => {
+        const transferAmount = 1800000
+
+        before(async () => {
+          rewardsContract = await TestECDSARewards.new(token.address)
+
+          rewardsBeneficiary = await ECDSABackportRewardsEscrowBeneficiary.new(
+            token.address,
+            rewardsContract.address
+          )
+
+          await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
+            from: owner,
+          })
+        })
+
+        assertStakerRewards(baseBalance, transferAmount)
+      })
+
+      describe("ECDSARewardsEscrowBeneficiary", () => {
+        const transferAmount = 178200000
+
+        before(async () => {
+          rewardsContract = await TestECDSARewards.new(token.address)
+
+          rewardsBeneficiary = await ECDSARewardsEscrowBeneficiary.new(
             token.address,
             rewardsContract.address
           )


### PR DESCRIPTION
In this PR we are adding 4 staker rewards beneficiary contracts. Each beneficiary contract can receive a withdrawal phase from a `PhasedEscrow` contract. Immediately transfers the received tokens to a designated `*RewardsEscrowBeneficiary` contract.
- `BeaconBackportRewardsEscrowBeneficiary`
- `BeaconRewardsEscrowBeneficiary`
-  `ECDSABackportRewardsEscrowBeneficiary`
- `ECDSARewardsEscrowBeneficiary`