### PR TITLE
Moved ECDSA rewards related beneficiaries contracts

### DIFF
--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -127,23 +127,3 @@ contract BeaconRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
         StakerRewardsBeneficiary(_token, _stakerRewards)
     {}
 }
-
-/// @title ECDSABackportRewardsEscrowBeneficiary
-/// @notice Trasfer the received tokens to a designated
-///         ECDSABackportRewardsEscrowBeneficiary contract.
-contract ECDSABackportRewardsEscrowBeneficiary is StakerRewardsBeneficiary {
-    constructor(IERC20 _token, IStakerRewards _stakerRewards)
-        public
-        StakerRewardsBeneficiary(_token, _stakerRewards)
-    {}
-}
-
-/// @title ECDSARewardsEscrowBeneficiary
-/// @notice Transfer the received tokens to a designated
-///         ECDSARewardsEscrowBeneficiary contract.
-contract ECDSARewardsEscrowBeneficiary is StakerRewardsBeneficiary {
-    constructor(IERC20 _token, IStakerRewards _stakerRewards)
-        public
-        StakerRewardsBeneficiary(_token, _stakerRewards)
-    {}
-}

--- a/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
+++ b/solidity/contracts/stubs/TestPhasedEscrowBeneficiaries.sol
@@ -28,8 +28,8 @@ contract TestCurveRewards {
     }
 }
 
-// ECDSA Reward contract mock for ecdsa staker rewards.
-contract TestECDSARewards {
+// Simple reward contract mock for testing purposes.
+contract TestSimpleStakerRewards {
     using SafeERC20 for IERC20;
 
     IERC20 public token;

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -24,14 +24,7 @@ const BeaconRewardsEscrowBeneficiary = contract.fromArtifact(
   "BeaconRewardsEscrowBeneficiary"
 )
 const BeaconRewards = contract.fromArtifact("BeaconRewards")
-
-const TestECDSARewards = contract.fromArtifact("TestECDSARewards")
-const ECDSABackportRewardsEscrowBeneficiary = contract.fromArtifact(
-  "ECDSABackportRewardsEscrowBeneficiary"
-)
-const ECDSARewardsEscrowBeneficiary = contract.fromArtifact(
-  "ECDSARewardsEscrowBeneficiary"
-)
+const TestSimpleStakerRewards = contract.fromArtifact("TestSimpleStakerRewards")
 
 const chai = require("chai")
 chai.use(require("bn-chai")(web3.utils.BN))
@@ -324,54 +317,6 @@ describe("PhasedEscrow", () => {
     assertRewards(baseBalance, transferAmount)
   })
 
-  describe("when withdrawing to a ECDSABackportRewardsEscrowBeneficiary", () => {
-    const baseBalance = 200000000
-    const transferAmount = 1800000
-
-    before(async () => {
-      rewardsContract = await TestECDSARewards.new(token.address)
-
-      rewardsBeneficiary = await ECDSABackportRewardsEscrowBeneficiary.new(
-        token.address,
-        rewardsContract.address,
-        {from: owner}
-      )
-      await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {
-        from: owner,
-      })
-
-      await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
-        from: owner,
-      })
-    })
-
-    assertRewards(baseBalance, transferAmount)
-  })
-
-  describe("when withdrawing to a ECDSARewardsEscrowBeneficiary", () => {
-    const baseBalance = 200000000
-    const transferAmount = 178200000
-
-    before(async () => {
-      rewardsContract = await TestECDSARewards.new(token.address)
-
-      rewardsBeneficiary = await ECDSARewardsEscrowBeneficiary.new(
-        token.address,
-        rewardsContract.address,
-        {from: owner}
-      )
-      await rewardsBeneficiary.transferOwnership(phasedEscrow.address, {
-        from: owner,
-      })
-
-      await phasedEscrow.setBeneficiary(rewardsBeneficiary.address, {
-        from: owner,
-      })
-    })
-
-    assertRewards(baseBalance, transferAmount)
-  })
-
   async function assertRewards(baseBalance, transferAmount) {
     it("withdraws specified tokens from escrow", async () => {
       await phasedEscrow.withdraw(transferAmount, {from: owner})
@@ -467,7 +412,7 @@ describe("StakerRewardsBeneficiary", () => {
 
   before(async () => {
     token = await KeepToken.new({from: owner})
-    rewardsContract = await TestECDSARewards.new(token.address)
+    rewardsContract = await TestSimpleStakerRewards.new(token.address)
     rewardsBeneficiary = await StakerRewardsBeneficiary.new(
       token.address,
       rewardsContract.address,


### PR DESCRIPTION
We removed ECDSA rewards related beneficiaries contracts and moved them
to keep-ecdsa repository. The contracts require references to ECDSA
rewards contracts that are defined and dpeloyed in keep-ecdsa
repository. We should define beneficiaries there as well.

Refs https://github.com/keep-network/keep-core/pull/2149