### PR TITLE
Added PhasedEscrow.withdrawFromEscrow function

### DIFF
--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -4,6 +4,8 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 
+import "./Escrow.sol";
+
 interface IBeneficiaryContract {
     function __escrowSentTokens(uint256 amount) external;
 }
@@ -46,6 +48,13 @@ contract PhasedEscrow is Ownable {
         emit TokensWithdrawn(address(beneficiary), amount);
 
         beneficiary.__escrowSentTokens(amount);
+    }
+
+    /// @notice Withdraws all funds from a non-phased Escrow passed as
+    ///         a parameter. For this function to succeed, this PhasedEscrow
+    ///         has to be set as a beneficiary of the non-phased Escrow.
+    function withdrawFromEscrow(Escrow _escrow) public {
+        _escrow.withdraw();
     }
 }
 

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -125,7 +125,7 @@ describe("PhasedEscrow", () => {
 
     it("pulls all funds from a non-phased Escrow when having some tokens", async () => {
       const initialFunds = web3.utils.toBN(999)
-      await token.transfer(phasedEscrow.address, 999, {from: owner})
+      await token.transfer(phasedEscrow.address, initialFunds, {from: owner})
       const balanceBefore = await token.balanceOf(phasedEscrow.address)
       expect(balanceBefore).to.eq.BN(initialFunds)
 


### PR DESCRIPTION
`withdrawFromEscrow` pulls all funds from a non-phased `Escrow` passed as a parameter. For `withdrawFromEscrow` to succeed, the `PhasedEscrow` has to be set as a beneficiary of the non-phased `Escrow`.

This PR is targeted to `solidity/v1.4.0` release branch and will have to be later backported to `master`.