### PR TITLE
Allow PhasedEscrow to receive tokens via approveAndCall

### DIFF
--- a/solidity/contracts/PhasedEscrow.sol
+++ b/solidity/contracts/PhasedEscrow.sol
@@ -27,6 +27,18 @@ contract PhasedEscrow is Ownable {
         token = _token;
     }
 
+    /// @notice Funds the escrow by transferring all of the approved tokens
+    ///         to the escrow.
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes memory
+    ) public {
+        require(IERC20(_token) == token, "Unsupported token");
+        token.safeTransferFrom(_from, address(this), _value);
+    }
+
     /// @notice Sets the provided address as a beneficiary allowing it to
     ///         withdraw all tokens from escrow. This function can be called only
     ///         by escrow owner.

--- a/solidity/test/TestPhasedEscrow.js
+++ b/solidity/test/TestPhasedEscrow.js
@@ -517,6 +517,11 @@ describe("BeaconRewards to PhasedEscrow transfer", async () => {
   const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
   const totalRewards = web3.utils.toBN(19800000).mul(tokenDecimalMultiplier)
 
+  let token
+  let operatorContract
+  let phasedEscrow
+  let rewardsContract
+
   before(async() => {
     let contracts = await initContracts(
       contract.fromArtifact('TokenStaking'),
@@ -526,8 +531,8 @@ describe("BeaconRewards to PhasedEscrow transfer", async () => {
     )
 
     token = contracts.token
-    stakingContract = contracts.stakingContract
     operatorContract = contracts.operatorContract
+    const stakingContract = contracts.stakingContract
 
     phasedEscrow = await PhasedEscrow.new(token.address, {from: owner})
     rewardsContract = await BeaconRewards.new(

--- a/solidity/test/token_stake/TestTopUps.js
+++ b/solidity/test/token_stake/TestTopUps.js
@@ -35,7 +35,7 @@ describe('TokenStaking/TopUps', () => {
     operatorFour = accounts[8],
     beneficiary = accounts[9],
     authorizer = accounts[10],
-    thirdParty = accounts[11]
+    thirdParty = accounts[11],
     operatorContract = accounts[12]
 
   const initializationPeriod = time.duration.days(10),


### PR DESCRIPTION
Added receiveApproval function to token escrow pulling all of the
approved tokens. We will use this functionality to update staker rewards
for the interval 3.