### PR TITLE
Bump token dashboard release to v1.4.0

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.3.4
+        image: keepnetwork/token-dashboard:v1.4.0
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Release notes to come in the release notes page.

This bundles the work in https://github.com/keep-network/keep-core/milestone/26?closed=1.

We should merge after things are deployed. Leaving as a draft in the meantime.