### PR TITLE
Fix dapp build process via docker

### DIFF
--- a/solidity/dashboard/Dockerfile
+++ b/solidity/dashboard/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --update --no-cache \
 
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
+COPY .env* /app/
 
 # Install from lockfile.
 RUN npm ci


### PR DESCRIPTION
Closes: #2188 

To get the current app version we added the `.env` file that contains `REACT_APP_VERSION` env variable. This env variable is provided by `create-react-app` under the hood and used in `Footer` component. For the `create-react-app` be able to inject env variable the .env file is needed during the build process and we missed the `COPY .env* /app/` in Dockerfile. This missed snippet of code should have been added in https://github.com/keep-network/keep-core/commit/e014af0bb2a1affff857a0ce037947bbdf6a85f4.

### Bug:
![obraz](https://user-images.githubusercontent.com/57687279/101144432-9c0aca80-3618-11eb-8d2b-832040c6abf9.png)

### Fix:
![obraz](https://user-images.githubusercontent.com/57687279/101144457-a5943280-3618-11eb-9533-898bd0de63c3.png)
