### PR TITLE
Fix `withdraw tokens` btn

### DIFF
--- a/solidity/dashboard/src/components/ProgressBar.jsx
+++ b/solidity/dashboard/src/components/ProgressBar.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useContext } from "react"
 import BigNumber from "bignumber.js"
 import CircularProgressBar from "./CircularProgressBar"
-import { percentageOf, sub } from "../utils/arithmetics.utils"
+import { percentageOf, sub, lt } from "../utils/arithmetics.utils"
 
 const defaultValue = 0
 const totalDefaultValue = 1
@@ -80,7 +80,10 @@ const ProgressBarLegend = ({
   displayLegendValuFn = defaultDisplayLegendValuFn,
 }) => {
   const { value, total, color, bgColor } = useProgressBarContext()
-  const leftValue = useMemo(() => sub(total, value).toString(), [value, total])
+  const leftValue = useMemo(() => {
+    const left = sub(total, value).toString()
+    return lt(left, 0) ? 0 : left
+  }, [value, total])
 
   return (
     <ProgressBarLegendContext.Provider value={{ displayLegendValuFn }}>

--- a/solidity/dashboard/src/components/TokenGrantOverview.jsx
+++ b/solidity/dashboard/src/components/TokenGrantOverview.jsx
@@ -151,7 +151,7 @@ export const TokenGrantWithdrawnTokensDetails = ({
     <>
       <ProgressBar
         value={selectedGrant.released || 0}
-        total={withdrawable || 0}
+        total={withdrawable}
         color={colors.secondary}
         bgColor={colors.bgSecondary}
       >

--- a/solidity/dashboard/src/components/TokenGrantOverview.jsx
+++ b/solidity/dashboard/src/components/TokenGrantOverview.jsx
@@ -165,7 +165,7 @@ export const TokenGrantWithdrawnTokensDetails = ({
       <SubmitButton
         className="btn btn-secondary btn-sm mt-2"
         onSubmitAction={onWithdrawnBtn}
-        disabled={gt(withdrawable, 0)}
+        disabled={!gt(selectedGrant.readyToRelease || 0, 0)}
       >
         withdraw tokens
       </SubmitButton>


### PR DESCRIPTION
The button should be disabled when there are no tokens to withdraw.

<details>
  <summary>Available to Withdraw label  bug</summary>

### Bug:
![obraz](https://user-images.githubusercontent.com/57687279/101360353-d46f0a80-389d-11eb-9d2d-26333307f4cf.png)

### Fix:
![obraz](https://user-images.githubusercontent.com/57687279/101360467-f8cae700-389d-11eb-9414-bbbab8af965b.png)


</details>