### PR TITLE
[Backport] Fix fetching ecdsa available rewards

### DIFF
--- a/solidity/dashboard/src/services/rewards.js
+++ b/solidity/dashboard/src/services/rewards.js
@@ -2,6 +2,7 @@ import { ContractsLoaded, CONTRACT_DEPLOY_BLOCK_NUMBER } from "../contracts"
 import { getOperatorsOfBeneficiary } from "./token-staking.service"
 import { ECDSARewardsHelper } from "../utils/rewardsHelper"
 import { add, gt } from "../utils/arithmetics.utils"
+import { isEmptyArray } from "../utils/array.utils"
 
 export const fetchtTotalDistributedRewards = async (
   beneficiary,
@@ -31,7 +32,11 @@ export const fetchECDSAAvailableRewards = async (beneficiary) => {
 
   let sum = 0
   const toWithdrawn = []
-  for (const operator of operators) {
+  if (!isEmptyArray(operators)) {
+    // If beneficiary has multiple operators, call `getWithdrawableRewards`
+    // function one time since `ECDSARewards` contract stores rewards per
+    // beneficiary not per operator.
+    const operator = operators[0]
     for (
       let interval = 0;
       interval <= ECDSARewardsHelper.currentInterval;


### PR DESCRIPTION
This PR is a backport of v1.4.1 fix done on releases/mainnet/token-dashboard/v1.4 release branch in PR #2193.

If the beneficiary has multiple operators, we should call `getWithdrawableRewards` one time in the given interval since `ECDSARewards` contract stores rewards per beneficiary not per operator.

https://github.com/keep-network/keep-ecdsa/blob/4fcb922ecaf319c0c4c14c2a9c5ee96b56756c31/solidity/contracts/ECDSARewards.sol#L155-L164.