### PR TITLE
Fix subscription to TopUpCompleted event

### DIFF
--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -532,7 +532,7 @@ function* observeTopUpCompletedEvent() {
   const contractEventCahnnel = yield call(
     createSubcribeToContractEventChannel,
     stakingContract,
-    "TopUpCompleeted"
+    "TopUpCompleted"
   )
 
   while (true) {


### PR DESCRIPTION
There was a typo in the event name. `TopUpCompleeted` -> `TopUpCompleted`.