### PR TITLE
[Backport] Fix subscription to TopUpCompleted event

### DIFF
--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -532,7 +532,7 @@ function* observeTopUpCompletedEvent() {
   const contractEventCahnnel = yield call(
     createSubcribeToContractEventChannel,
     stakingContract,
-    "TopUpCompleeted"
+    "TopUpCompleted"
   )
 
   while (true) {


### PR DESCRIPTION
This PR is a backport of v1.4.1 fix done on releases/mainnet/token-dashboard/v1.4 release branch in PR #2198.

There was a typo in the event name. `TopUpCompleeted` -> `TopUpCompleted`.