### PR TITLE
Releases/mainnet/solidity/v1.5.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.5.0",
+  "version": "1.6.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.5.0-pre.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.5.0",
+  "version": "1.6.0-pre.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.5.0-pre.0",
+  "version": "1.5.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating version to tag `PhasedEscrow` changes. Please see https://github.com/keep-network/keep-core/milestone/35?closed=1

2fb40a350 is tagged as `solidity/v1.5.0`