### PR TITLE
Releases/mainnet/solidity/v1.6.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.6.0-pre.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.6.0",
+  "version": "1.7.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.6.0-pre.0",
+  "version": "1.6.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.6.0",
+  "version": "1.7.0-pre.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release for solidity contracts milestone https://github.com/keep-network/keep-core/milestone/37?closed=1

45179938bddad7fc0011cb1be81ce911313c1bcd was tagged with `solidity/v1.6.0`.