### PR TITLE
Liquidity rewards empty pool

### DIFF
--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -67,7 +67,11 @@ const LiquidityRewardCard = ({
           View pool
         </a>
       </h4>
-      <div className={"liquidity__info text-grey-60 mt-2"}>
+      <div
+        className={`${
+          gt(lpBalance, 0) ? "liquidity__info" : "liquidity__info-locked"
+        } mt-2`}
+      >
         <div className={"liquidity__info-tile bg-mint-10"}>
           <h2 className={"liquidity__info-tile__title text-mint-100"}>
             {formattedApy}*
@@ -115,7 +119,7 @@ const LiquidityRewardCard = ({
           )
         }
       >
-        add more lp tokens
+        {gt(lpBalance, 0) ? "add more lp tokens" : "deposit lp tokens"}
       </SubmitButton>
 
       <SubmitButton

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -68,9 +68,7 @@ const LiquidityRewardCard = ({
         </a>
       </h4>
       <div
-        className={`${
-          gt(lpBalance, 0) ? "liquidity__info" : "liquidity__info-locked"
-        } mt-2`}
+        className={`liquidity__info${gt(lpBalance, 0) ? "" : "--locked"} mt-2`}
       >
         <div className={"liquidity__info-tile bg-mint-10"}>
           <h2 className={"liquidity__info-tile__title text-mint-100"}>

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -78,7 +78,7 @@ const LiquidityRewardCard = ({
         </div>
         <div className={"liquidity__info-tile bg-mint-10"}>
           {isFetching ? (
-            <Skeleton tag="h2" shining color="mint-20" />
+            <Skeleton tag="h2" shining color="color-grey-60" />
           ) : (
             <h2
               className={"liquidity__info-tile__title text-mint-100"}

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -124,14 +124,14 @@ const LiquidityRewardCard = ({
 
       <SubmitButton
         className={"liquidity__withdraw btn btn-secondary btn-lg w-100"}
-        disabled={!gt(rewardBalance, 0)}
+        disabled={!gt(rewardBalance, 0) && !gt(lpBalance, 0)}
         onSubmitAction={(awaitingPromise) =>
           withdrawLiquidityRewards(liquidityPairContractName, awaitingPromise)
         }
       >
         withdraw all
       </SubmitButton>
-      {gt(rewardBalance, 0) && (
+      {(gt(rewardBalance, 0) || gt(lpBalance, 0)) && (
         <div className={"text-validation text-center"}>
           Withdraw includes rewards and principal
         </div>

--- a/solidity/dashboard/src/css/liquidity-page.less
+++ b/solidity/dashboard/src/css/liquidity-page.less
@@ -29,7 +29,7 @@
     margin: 0.3rem 0;
   }
 
-  .liquidity__info, .liquidity__info-locked {
+  .liquidity__info, .liquidity__info--locked {
     display: flex;
     justify-content: center;
 
@@ -46,11 +46,11 @@
     }
   }
 
-  .liquidity__info-locked {
+  .liquidity__info--locked {
     .liquidity__info-tile {
       &:extend(.bg-grey-20);
       .liquidity__info-tile__title {
-        color: #6D6D6D !important;
+        color: @color-grey-60!important;
       }
     }
   }

--- a/solidity/dashboard/src/css/liquidity-page.less
+++ b/solidity/dashboard/src/css/liquidity-page.less
@@ -29,7 +29,7 @@
     margin: 0.3rem 0;
   }
 
-  .liquidity__info {
+  .liquidity__info, .liquidity__info-locked {
     display: flex;
     justify-content: center;
 
@@ -43,6 +43,15 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
+    }
+  }
+
+  .liquidity__info-locked {
+    .liquidity__info-tile {
+      &:extend(.bg-grey-20);
+      .liquidity__info-tile__title {
+        color: #6D6D6D !important;
+      }
     }
   }
 

--- a/solidity/dashboard/src/css/liquidity-page.less
+++ b/solidity/dashboard/src/css/liquidity-page.less
@@ -34,6 +34,7 @@
     justify-content: center;
 
     .liquidity__info-tile {
+      transition: background-color 0.5s ease;
       text-align: center;
       border-radius: 8px;
       padding: 1rem;


### PR DESCRIPTION
Liquidity rewards empty pool ui changes

Issues changed/fixed by this PR:
- gray out liquidity info when the % of the pool is equal to 0
- change text of the button "add more lp tokens" to "deposit lp tokens" when the % of the pool is equal to 0
- enable 'withdraw all' button to allow the user to withdraw the lp tokens when there are no rewards yet

![image](https://user-images.githubusercontent.com/40306834/103226471-809b9280-492c-11eb-9cd2-a5081cf6f563.png)
