### PR TITLE
Set two decimal places for the value of the progress bar

### DIFF
--- a/solidity/dashboard/src/components/ProgressBar.jsx
+++ b/solidity/dashboard/src/components/ProgressBar.jsx
@@ -134,7 +134,10 @@ export const renderProgressBarLegendItem = (item, index) => (
 const PercentageLabel = ({ text, className = "" }) => {
   const { value, total } = useProgressBarContext()
   const percentageOfValue = useMemo(
-    () => percentageOf(value, total).toString(),
+    () =>
+      new BigNumber(percentageOf(value, total))
+        .decimalPlaces(2, BigNumber.ROUND_DOWN)
+        .toString(),
     [value, total]
   )
 


### PR DESCRIPTION
Closes: #2243

Set two decimal places for the percentage value of the circular progress bar

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/40306834/103280290-4d124400-49d0-11eb-8a04-fb4b64c8bb13.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/40306834/103280233-2bb15800-49d0-11eb-835e-ea21b7087dd1.png)

</details>