### PR TITLE
GitHub action for NPM package publication

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -37,6 +37,14 @@ jobs:
           version=$(jq --raw-output .version package.json)
           preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
 
+          # Check resolved `preid`. Currently only `pre` value is supported,
+          # other types of releases are not handled by this job.
+          if [ "$preid" != pre ]; then
+            echo "Unsupported preid. Resolved info:"
+            echo "$name@$version ; preid $preid"
+            exit 1
+          fi
+
           # Find the latest published package version matching this preid.
           # Note that in jq, we wrap the result in an array and then flatten;
           # this is because npm show json contains a single string if there

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,6 +19,17 @@ jobs:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@keep-network'
+      - name: Cache node modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-solidity-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Bump up version
         working-directory: ./solidity
         run: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -66,9 +66,6 @@ jobs:
           # Consider including commit id? Would be +<commit id>.
           npm version prerelease --preid=$preid --no-git-tag-version
 
-          # Fix resolved dependency versions.
-          npm update
-
       - name: Publish package
         run: npm publish --access public
         working-directory: ./solidity

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Bump up version
         working-directory: ./solidity
         run: |
+          set -x
+
           name=$(jq --raw-output .name package.json)
           version=$(jq --raw-output .version package.json)
           preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,57 @@
+name: NPM
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'solidity/contracts/**'
+      - 'solidity/package.json'
+      - 'solidity/package-lock.json'
+
+jobs:
+  publish-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@keep-network'
+      - name: Bump up version
+        working-directory: ./solidity
+        run: |
+          name=$(jq --raw-output .name package.json)
+          version=$(jq --raw-output .version package.json)
+          preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+
+          # Find the latest published package version matching this preid.
+          # Note that in jq, we wrap the result in an array and then flatten;
+          # this is because npm show json contains a single string if there
+          # is only one matching version, or an array if there are multiple,
+          # and we want to look at an array always.
+          latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
+          latest_version=${latest_version:-$version}
+          if [ -z $latest_version ]; then
+            echo "Latest version calculation failed. Resolved info:"
+            echo "$name@$version ; preid $preid"
+            exit 1
+          fi
+
+          # Update package.json with the latest published package version matching this
+          # preid to prepare for bumping.
+          echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+
+          # Bump without doing any git work. Versioning is a build-time action for us.
+          # Consider including commit id? Would be +<commit id>.
+          npm version prerelease --preid=$preid --no-git-tag-version
+
+          # Fix resolved dependency versions.
+          npm update
+
+      - name: Publish package
+        run: npm publish --access public
+        working-directory: ./solidity
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The action will be used to publish prerelease packages to the NPM package registry. It will be executed on a push to master if there are any changes to solidity contracts or dependencies.

Refs: https://github.com/keep-network/keep-ecdsa/pull/659/