### PR TITLE
Improvements around state machine and broadcast channel buffers

### DIFF
--- a/pkg/beacon/relay/state/machine.go
+++ b/pkg/beacon/relay/state/machine.go
@@ -9,9 +9,12 @@ import (
 )
 
 // For the entire time of state transition (delay + initiate), messages
-// are not handled. We use a small buffer to unblock producers and let
+// are not handled. We use a buffer to unblock producers and let
 // them perform optional filtering/validation during that time.
-const receiveBuffer = 64
+// The size of that buffer should be equal to the biggest possible
+// message count which can be delivered by the broadcast channel
+// in the same moment.
+const receiveBuffer = 128
 
 // Machine is a state machine that executes over states implemented from State
 // interface.

--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -27,7 +27,7 @@ var (
 
 const (
 	incomingMessageThrottle = 4096
-	messageHandlerThrottle  = 256
+	messageHandlerThrottle  = 512
 )
 
 type channel struct {


### PR DESCRIPTION
Here we introduce some improvements for state machine and broadcast channel buffers. The main motivation behind those changes is to minimize the number of dropped messages and hence increase the delivery rate. Specifically, we are touching those buffers:

- `receiveBuffer` living in the state machine. We change its size because the current value of `64` elements may be not
sufficient due to the DKG commitment phase which sends two types of messages. Giving the fact the group size is currently `64` members, each group member's state machine could receive `128` messages during the commitment phase. If those messages are not processed quickly enough, the `64` elements buffer will overflow easily and subsequent messages will be dropped by the broadcast channel handler. Aligning the receiver buffer size with the message peak should prevent overflows and minimize the number of dropped messages.
- `messageHandlerThrottle` in the broadcast channel code. In terms of DKG, the current message handler throttle
size is prepared to handle `4` retransmissions of `64` messages in a given DKG state. A standard DKG messaging state lasts for `1` delay block and `5` active blocks when retransmission is made on each block. However, the point validation state is active for `10` blocks during which it performs `10` retransmissions. In this state, there is a big chance the handler throttle buffer overflows and messages will be dropped as result. As a response, we increase that buffer size to `8 * 64` which should be a satisfying value for all states.

For broader context about those buffers, please refer https://github.com/keep-network/keep-core/pull/1322