### PR TITLE
Fix Etherscan link of successful transaction

### DIFF
--- a/solidity/dashboard/src/actions/messages.js
+++ b/solidity/dashboard/src/actions/messages.js
@@ -7,18 +7,12 @@ let messageId = 1
 
 export class Message {
   static create(options) {
-    const { title, content, type, sticky, withTransactionHash } = options
-
-    return new Message(title, content, type, sticky, withTransactionHash)
+    return new Message(options)
   }
 
-  constructor(title, content, type, sticky = false, withTransactionHash) {
+  constructor(options) {
+    Object.assign(this, options)
     this.id = messageId++
-    this.title = title
-    this.content = content
-    this.type = type
-    this.sticky = sticky
-    this.withTransactionHash = withTransactionHash
   }
 
   id


### PR DESCRIPTION
Closes: #2277 

Fixed Etherscan link of successful transaction. The link did not
include the transaction hash because to the constructor of `Message`
object did not assign the `txHash` property to the Message object. This
commit fixes this issue by assigning the `txHash` property to the
`Message` object in constructor.

**Fix**
![obraz](https://user-images.githubusercontent.com/57687279/104185416-3c70bd80-5415-11eb-99e4-777f3970a68c.png)
