### PR TITLE
Separated dashboard build for keep-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,9 +229,10 @@ jobs:
           name: Resolve latest contracts
           working_directory: ~/project/solidity/dashboard
           command: |
-            npm update @keep-network/keep-core
-            npm update @keep-network/keep-ecdsa
-            npm update @keep-network/tbtc
+            npm update \
+              @keep-network/keep-core \
+              @keep-network/keep-ecdsa \
+              @keep-network/tbtc
       - run:
           name: Run Docker build
           working_directory: ~/project/solidity/dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
     executor: docker-node
     steps:
       - run:
-          name: "Rebuild downstream same-branch build(s)"
+          name: 'Rebuild downstream same-branch build(s)'
           command: |
             # CIRCLE_BRANCH || CIRCLE_TAG?
             # curl CIRCLE_API_BUILD/keep-tecdsa?branch=${CIRCLE_BRANCH}
@@ -229,7 +229,9 @@ jobs:
           name: Resolve latest contracts
           working_directory: ~/project/solidity/dashboard
           command: |
-            npm upgrade @keep-network/keep-core
+            npm update @keep-network/keep-core
+            npm update @keep-network/keep-ecdsa
+            npm update @keep-network/tbtc
       - run:
           name: Run Docker build
           working_directory: ~/project/solidity/dashboard
@@ -365,109 +367,118 @@ workflows:
           requires:
             - build_token_dashboard_dapp
   build-test-migrate-publish-keep-test:
-      jobs:
-        - keep_test_approval:
-            type: approval
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-        - build_client_and_test_go:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - keep_test_approval
-        - build_initcontainer:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - migrate_contracts
-              - build_client_and_test_go
-        - migrate_contracts:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - build_client_and_test_go
-        - publish_keep_client:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - build_client_and_test_go
-              - build_initcontainer
-              - migrate_contracts
-        - publish_initcontainer_provision_keep_client:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - build_client_and_test_go
-              - build_initcontainer
-              - migrate_contracts
-        - publish_contract_data:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - build_client_and_test_go
-              - migrate_contracts
-        - publish_npm_package:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - migrate_contracts
-        - trigger_downstream_builds:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - publish_npm_package
-        - build_token_dashboard_dapp:
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - publish_npm_package
-        - publish_token_dashboard_dapp:
-            context: keep-test
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                only: /releases\/.*/
-            requires:
-              - build_token_dashboard_dapp
+    jobs:
+      - keep_test_approval:
+          type: approval
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+      - build_client_and_test_go:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - keep_test_approval
+      - build_initcontainer:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - migrate_contracts
+            - build_client_and_test_go
+      - migrate_contracts:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - build_client_and_test_go
+      - publish_keep_client:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - build_client_and_test_go
+            - build_initcontainer
+            - migrate_contracts
+      - publish_initcontainer_provision_keep_client:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - build_client_and_test_go
+            - build_initcontainer
+            - migrate_contracts
+      - publish_contract_data:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - build_client_and_test_go
+            - migrate_contracts
+      - publish_npm_package:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - migrate_contracts
+      - trigger_downstream_builds:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - publish_npm_package
+  build-publish-dashboard-keep-test:
+    jobs:
+      - keep_test_approval:
+          type: approval
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+      - build_token_dashboard_dapp:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - keep_test_approval
+      - publish_token_dashboard_dapp:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /releases\/.*/
+          requires:
+            - build_token_dashboard_dapp
   docs:
     jobs:
       - generate_docs_tex


### PR DESCRIPTION
We can't build dashboard right after keep-core migration as we also have dependencies for keep-ecdsa and tbtc. So we first need to migrate all three projects and only after that can execute dashboard building.

The flow would look like:
- approve `build-test-migrate-publish-keep-test` execution
- kick off migrations and package publication for dependencies: `keep-ecdsa` and `tbtc` projects
- approve `build-publish-dashboard-keep-test`.