### PR TITLE
Fix infinity APY

### DIFF
--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -158,7 +158,7 @@ const LiquidityRewardCard = ({
             &nbsp;to fetch the the total pool value and KEEP token in USD.
           </Tooltip>
           <h2 className={"liquidity__info-tile__title text-mint-100"}>
-            {formattedApy.value === Infinity ? (
+            {formattedApy === Infinity ? (
               <span>&#8734;</span>
             ) : (
               <CountUp


### PR DESCRIPTION
Remove `value` property from `formattedApy` in the condition that checks if `formattedApy` is infinite.

This bug in some scenarios caused apy to be printed as >Infinity% instead of ♾️ sign.

![image](https://user-images.githubusercontent.com/40306834/104319074-a4400a80-54e0-11eb-8c19-baf476d40e08.png)


![image](https://user-images.githubusercontent.com/40306834/104319032-912d3a80-54e0-11eb-9d81-303453f96177.png)
