### PR TITLE
Fix share of the total pool when withdrawing

### DIFF
--- a/solidity/dashboard/src/reducers/liquidity-rewards.js
+++ b/solidity/dashboard/src/reducers/liquidity-rewards.js
@@ -93,7 +93,7 @@ const liquidityRewardsReducer = (state = initialState, action) => {
           lpBalance,
           shareOfPoolInPercent: percentageOf(
             lpBalance,
-            restPayload.reward
+            restPayload.totalSupply
           ).toString(),
           reward: restPayload.reward,
           apy: restPayload.apy,


### PR DESCRIPTION
When someone withdraw the tokens from the pool, then the share of the total pool shows wrong value and it is needed to refresh the page.

How to reproduce the bug:
1. Log in in Chrome as a user who have some tokens in the pool (for example KEEP + ETH)
2. Log in in Firefox as a user who have some tokens int he pool (for example KKEP + ETH)
3. Withdraw all tokens as Firefox user
4. After 5-10 secs the Chrome user % of the total pool will update and will show the wrong value. After refresh it shows correct value.

This PR fixes the bug above, so the user doesn't have to refresh the page.