### PR TITLE
KEEP Token Dashboard release v1.7.0

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.6.0
+        image: keepnetwork/token-dashboard:v1.7.0
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
78d158f is a commit for token-dashboard/v1.7.0 tag.

This bundles work in https://github.com/keep-network/keep-core/milestone/33?closed=1.

Release notes to come on the release notes page.