### PR TITLE
Calculate APY w/o connected wallet

### DIFF
--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -31,6 +31,7 @@ const LiquidityRewardCard = ({
   wrapperClassName = "",
   addLpTokens,
   withdrawLiquidityRewards,
+  isAPYFetching,
 }) => {
   const formattedApy = useMemo(() => {
     const bn = new BigNumber(apy).multipliedBy(100)
@@ -157,20 +158,24 @@ const LiquidityRewardCard = ({
             </a>
             &nbsp;to fetch the the total pool value and KEEP token in USD.
           </Tooltip>
-          <h2 className={"liquidity__info-tile__title text-mint-100"}>
-            {formattedApy === Infinity ? (
-              <span>&#8734;</span>
-            ) : (
-              <CountUp
-                end={formattedApy}
-                // Save previously ended number to start every new animation from it.
-                preserveValue
-                decimals={2}
-                duration={1}
-                formattingFn={formattingFn}
-              />
-            )}
-          </h2>
+          {isAPYFetching ? (
+            <Skeleton tag="h2" shining color="grey-10" />
+          ) : (
+            <h2 className={"liquidity__info-tile__title text-mint-100"}>
+              {formattedApy === Infinity ? (
+                <span>&#8734;</span>
+              ) : (
+                <CountUp
+                  end={formattedApy}
+                  // Save previously ended number to start every new animation from it.
+                  preserveValue
+                  decimals={2}
+                  duration={1}
+                  formattingFn={formattingFn}
+                />
+              )}
+            </h2>
+          )}
           <h6>Estimate of pool apy</h6>
         </div>
         <div className={"liquidity__info-tile bg-mint-10"}>

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -21,6 +21,7 @@ import LPRewardsKEEPETH from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPET
 import LPRewardsTBTCETH from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCETH.json"
 import LPRewardsKEEPTBTC from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPTBTC.json"
 import IERC20 from "@keep-network/keep-core/artifacts/IERC20.json"
+import Web3 from "web3"
 
 import {
   KEEP_TOKEN_CONTRACT_NAME,
@@ -306,4 +307,13 @@ const getOldTokenStakingArtifact = async () => {
 
 export const createERC20Contract = (web3, address) => {
   return createWeb3ContractInstance(web3, IERC20.abi, address)
+}
+
+export const initializeWeb3 = (provider) => {
+  return new Web3(provider)
+}
+
+export const createLPRewardsContract = async (web3, contractName) => {
+  const { artifact } = contracts[contractName]
+  return await getContract(web3, artifact, {})
 }

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -57,72 +57,67 @@ export const CONTRACT_DEPLOY_BLOCK_NUMBER = {
   [STAKING_PORT_BACKER_CONTRACT_NAME]: 0,
 }
 
-const contracts = [
-  [{ contractName: KEEP_TOKEN_CONTRACT_NAME }, KeepToken],
-  [{ contractName: TOKEN_GRANT_CONTRACT_NAME }, TokenGrant],
-  [
-    { contractName: OPERATOR_CONTRACT_NAME, withDeployBlock: true },
-    KeepRandomBeaconOperator,
-  ],
-  [
-    { contractName: TOKEN_STAKING_CONTRACT_NAME, withDeployBlock: true },
-    TokenStaking,
-  ],
-  [
-    {
-      contractName: KEEP_OPERATOR_STATISTICS_CONTRACT_NAME,
-    },
-    KeepRandomBeaconOperatorStatistics,
-  ],
-  [
-    {
-      contractName: MANAGED_GRANT_FACTORY_CONTRACT_NAME,
-      withDeployBlock: true,
-    },
-    ManagedGrantFactory,
-  ],
-  [
-    { contractName: KEEP_BONDING_CONTRACT_NAME, withDeployBlock: true },
-    KeepBonding,
-  ],
-  [
-    { contractName: TBTC_TOKEN_CONTRACT_NAME, withDeployBlock: true },
-    TBTCToken,
-  ],
-  [
-    { contractName: TBTC_SYSTEM_CONTRACT_NAME, withDeployBlock: true },
-    TBTCSystem,
-  ],
-  [
-    { contractName: TOKEN_STAKING_ESCROW_CONTRACT_NAME, withDeployBlock: true },
-    TokenStakingEscrow,
-  ],
-  [
-    { contractName: BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME },
-    BondedECDSAKeepFactory,
-  ],
-  [
-    { contractName: STAKING_PORT_BACKER_CONTRACT_NAME, withDeployBlock: true },
-    StakingPortBacker,
-  ],
-  [{ contractName: "beaconRewardsContract" }, BeaconRewards],
-  [
-    { contractName: "ECDSARewardsDistributorContract", withDeployBlock: true },
-    ECDSARewardsDistributor,
-  ],
-  [
-    { contractName: LP_REWARDS_KEEP_ETH_CONTRACT_NAME, withDeployBlock: true },
-    LPRewardsKEEPETH,
-  ],
-  [
-    { contractName: LP_REWARDS_TBTC_ETH_CONTRACT_NAME, withDeployBlock: true },
-    LPRewardsTBTCETH,
-  ],
-  [
-    { contractName: LP_REWARDS_KEEP_TBTC_CONTRACT_NAME, withDeployBlock: true },
-    LPRewardsKEEPTBTC,
-  ],
-]
+const contracts = {
+  [KEEP_TOKEN_CONTRACT_NAME]: { artifact: KeepToken },
+  [TOKEN_GRANT_CONTRACT_NAME]: { artifact: TokenGrant },
+  [OPERATOR_CONTRACT_NAME]: {
+    artifact: KeepRandomBeaconOperator,
+    withDeployBlock: true,
+  },
+  [TOKEN_STAKING_CONTRACT_NAME]: {
+    artifact: TokenStaking,
+    withDeployBlock: true,
+  },
+  [KEEP_OPERATOR_STATISTICS_CONTRACT_NAME]: {
+    artifact: KeepRandomBeaconOperatorStatistics,
+  },
+  [MANAGED_GRANT_FACTORY_CONTRACT_NAME]: {
+    artifact: ManagedGrantFactory,
+    withDeployBlock: true,
+  },
+  [KEEP_BONDING_CONTRACT_NAME]: {
+    artifact: KeepBonding,
+    withDeployBlock: true,
+  },
+  [TBTC_TOKEN_CONTRACT_NAME]: {
+    artifact: TBTCToken,
+    withDeployBlock: true,
+  },
+  [TBTC_SYSTEM_CONTRACT_NAME]: {
+    artifact: TBTCSystem,
+    withDeployBlock: true,
+  },
+  [TOKEN_STAKING_ESCROW_CONTRACT_NAME]: {
+    artifact: TokenStakingEscrow,
+    withDeployBlock: true,
+  },
+  [BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME]: {
+    artifact: BondedECDSAKeepFactory,
+  },
+  [STAKING_PORT_BACKER_CONTRACT_NAME]: {
+    artifact: StakingPortBacker,
+    withDeployBlock: true,
+  },
+  beaconRewardsContract: {
+    artifact: BeaconRewards,
+  },
+  ECDSARewardsDistributorContract: {
+    artifact: ECDSARewardsDistributor,
+    withDeployBlock: true,
+  },
+  [LP_REWARDS_KEEP_ETH_CONTRACT_NAME]: {
+    artifact: LPRewardsKEEPETH,
+    withDeployBlock: true,
+  },
+  [LP_REWARDS_TBTC_ETH_CONTRACT_NAME]: {
+    artifact: LPRewardsTBTCETH,
+    withDeployBlock: true,
+  },
+  [LP_REWARDS_KEEP_TBTC_CONTRACT_NAME]: {
+    artifact: LPRewardsKEEPTBTC,
+    withDeployBlock: true,
+  },
+}
 
 export async function getKeepTokenContractDeployerAddress(web3) {
   const deployTransactionHash = getTransactionHashOfContractDeploy(KeepToken)
@@ -204,12 +199,11 @@ export async function getContracts(web3) {
   }
 
   const web3Contracts = {}
-  for (const contractData of contracts) {
-    const [options, jsonArtifact] = contractData
-
-    web3Contracts[options.contractName] = await getContract(
+  for (const [contractName, options] of Object.entries(contracts)) {
+    options.contractName = contractName
+    web3Contracts[contractName] = await getContract(
       web3,
-      jsonArtifact,
+      options.artifact,
       options
     )
   }

--- a/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -36,7 +36,13 @@ const LiquidityPage = ({ headerTitle }) => {
   }, [dispatch, address])
 
   useEffect(() => {
-    if (isBannerVisible && isConnected && gt(keepTokenBalance.value, 0)) {
+    dispatch({
+      type: "liquidity_rewards/fetch_apy_request",
+    })
+  }, [dispatch])
+
+  useEffect(() => {
+    if (isBannerVisible && isConnected && gt(keepTokenBalance.value || 0, 0)) {
       hideBanner()
     }
   }, [isConnected, keepTokenBalance.value, hideBanner, isBannerVisible])
@@ -121,6 +127,7 @@ const LiquidityPage = ({ headerTitle }) => {
           wrapperClassName="keep-eth"
           addLpTokens={addLpTokens}
           withdrawLiquidityRewards={withdrawLiquidityRewards}
+          isAPYFetching={KEEP_ETH.isAPYFetching}
         />
         <LiquidityRewardCard
           title={LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.label}
@@ -139,6 +146,7 @@ const LiquidityPage = ({ headerTitle }) => {
           wrapperClassName="keep-tbtc"
           addLpTokens={addLpTokens}
           withdrawLiquidityRewards={withdrawLiquidityRewards}
+          isAPYFetching={KEEP_TBTC.isAPYFetching}
         />
         <LiquidityRewardCard
           title={LIQUIDITY_REWARD_PAIRS.TBTC_ETH.label}
@@ -157,6 +165,7 @@ const LiquidityPage = ({ headerTitle }) => {
           wrapperClassName="tbtc-eth"
           addLpTokens={addLpTokens}
           withdrawLiquidityRewards={withdrawLiquidityRewards}
+          isAPYFetching={TBTC_ETH.isAPYFetching}
         />
       </CardContainer>
     </PageWrapper>

--- a/solidity/dashboard/src/reducers/liquidity-rewards.js
+++ b/solidity/dashboard/src/reducers/liquidity-rewards.js
@@ -2,6 +2,7 @@ import { sub, add, percentageOf } from "../utils/arithmetics.utils"
 
 const liquidityPairInitialData = {
   apy: 0,
+  isAPYFetching: false,
   shareOfPoolInPercent: 0,
   reward: 0,
   wrappedTokenBalance: 0,
@@ -114,6 +115,31 @@ const liquidityRewardsReducer = (state = initialState, action) => {
         [liquidityRewardPairName]: {
           ...state[liquidityRewardPairName],
           apy: restPayload.apy,
+        },
+      }
+    case `liquidity_rewards/${liquidityRewardPairName}_fetch_apy_start`:
+      return {
+        ...state,
+        [liquidityRewardPairName]: {
+          ...state[liquidityRewardPairName],
+          isAPYFetching: true,
+        },
+      }
+    case `liquidity_rewards/${liquidityRewardPairName}_fetch_apy_success`:
+      return {
+        ...state,
+        [liquidityRewardPairName]: {
+          ...state[liquidityRewardPairName],
+          isAPYFetching: false,
+          apy: restPayload.apy,
+        },
+      }
+    case `liquidity_rewards/${liquidityRewardPairName}_fetch_apy_failure`:
+      return {
+        ...state,
+        [liquidityRewardPairName]: {
+          ...state[liquidityRewardPairName],
+          isAPYFetching: false,
         },
       }
     default:


### PR DESCRIPTION
This PR adds support for calculating the APY value for each `LPRewards` contract without a connected wallet.