### PR TITLE
KEEP Token Dashboard release v1.7.1

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.7.0
+        image: keepnetwork/token-dashboard:v1.7.1
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
bdee794 is the commit hash for `token-dashboard/v1.7.1`

This bundles a fix from https://github.com/keep-network/keep-core/pull/2289.

