### PR TITLE
Bump web3 dependency to v1.3.1

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1983,6 +1983,204 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@ethersproject/abi": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+      "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+      "requires": {
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
+      "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/networks": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/web": "^5.0.12"
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
+      "integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7"
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
+      "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/rlp": "^5.0.7"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
+      "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9"
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
+      "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
+      "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.8"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
+      "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13"
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
+      "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
+      "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "js-sha3": "0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+      "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+    },
+    "@ethersproject/networks": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
+      "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.8"
+      }
+    },
+    "@ethersproject/properties": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
+      "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.8"
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
+      "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8"
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
+      "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "elliptic": "6.5.3"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
+      "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/logger": "^5.0.8"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
+      "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+      "requires": {
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/rlp": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8"
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
+      "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+      "requires": {
+        "@ethersproject/base64": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -3686,6 +3884,11 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -3850,6 +4053,14 @@
             "node-releases": "^1.1.58"
           }
         }
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
       }
     },
     "await-semaphore": {
@@ -5377,6 +5588,14 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
+    "bufferutil": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -5478,6 +5697,15 @@
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "call-me-maybe": {
@@ -5697,6 +5925,29 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
+    "cids": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "dependencies": {
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        }
+      }
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -5705,6 +5956,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -6092,6 +6348,16 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "content-hash": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
+      "requires": {
+        "cids": "^0.7.1",
+        "multicodec": "^0.5.5",
+        "multihashes": "^0.4.15"
       }
     },
     "content-type": {
@@ -9183,6 +9449,11 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -22187,7 +22458,7 @@
               "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.11.8",
@@ -23438,6 +23709,16 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -24494,6 +24775,11 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
     },
+    "is-generator-function": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
+      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -24511,6 +24797,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-number": {
       "version": "3.0.0",
@@ -24616,6 +24907,88 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
         "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
+      "integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+          "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+          "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "is-typedarray": {
@@ -27002,6 +27375,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -27015,6 +27397,35 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "multicodec": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -27127,6 +27538,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
       "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-hid": {
       "version": "0.7.9",
@@ -32718,6 +33134,14 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "utf-8-validate": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
@@ -32792,6 +33216,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+    },
+    "varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "vary": {
       "version": "1.1.2",
@@ -32996,28 +33425,23 @@
       }
     },
     "web3": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.7.tgz",
-      "integrity": "sha512-jAAJHMfUlTps+jH2li1ckDFEpPrEEriU/ubegSTGRl3KRdNhEqT93+3kd7FHJTn3NgjcyURo2+f7Da1YcZL8Mw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.1.tgz",
+      "integrity": "sha512-lDJwOLSRWHYwhPy4h5TNgBRJ/lED7lWXyVOXHCHcEC8ai3coBNdgEXWBu/GGYbZMsS89EoUOJ14j3Ufi4dUkog==",
       "requires": {
-        "web3-bzz": "1.2.7",
-        "web3-core": "1.2.7",
-        "web3-eth": "1.2.7",
-        "web3-eth-personal": "1.2.7",
-        "web3-net": "1.2.7",
-        "web3-shh": "1.2.7",
-        "web3-utils": "1.2.7"
+        "web3-bzz": "1.3.1",
+        "web3-core": "1.3.1",
+        "web3-eth": "1.3.1",
+        "web3-eth-personal": "1.3.1",
+        "web3-net": "1.3.1",
+        "web3-shh": "1.3.1",
+        "web3-utils": "1.3.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
-          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
-        },
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "version": "12.19.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.14.tgz",
+          "integrity": "sha512-2U9uLN46+7dv9PiS8VQJcHhuoOjiDPZOLAt0WuA1EanEknIMae+2QbMhayF7cgGqjvRVIfNpt+6jLPczJZFiRw=="
         },
         "decompress-response": {
           "version": "3.3.0",
@@ -33027,64 +33451,28 @@
             "mimic-response": "^1.0.0"
           }
         },
-        "ethers": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-          "requires": {
-            "@types/node": "^10.3.2",
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.3",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-            }
-          }
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
         },
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
         "mimic-response": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "oboe": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+          "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
         },
         "p-cancelable": {
           "version": "0.3.0",
@@ -33097,9 +33485,9 @@
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "scrypt-js": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
         },
         "setimmediate": {
           "version": "1.0.5",
@@ -33155,136 +33543,149 @@
             "prepend-http": "^1.0.1"
           }
         },
-        "web3-bzz": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.7.tgz",
-          "integrity": "sha512-iTIWBR+Z+Bn09WprtKm46LmyNOasg2lUn++AjXkBTB8UNxlUybxtza84yl2ETTZUs0zuFzdSSAEgbjhygG+9oA==",
+        "util": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
           "requires": {
-            "@types/node": "^10.12.18",
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-bzz": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.1.tgz",
+          "integrity": "sha512-MN726zFpFpwhs3NMC35diJGkwTVUj+8LM/VWqooGX/MOjgYzNrJ7Wr8EzxoaTCy87edYNBprtxBkd0HzzLmung==",
+          "requires": {
+            "@types/node": "^12.12.6",
             "got": "9.6.0",
             "swarm-js": "^0.1.40",
             "underscore": "1.9.1"
           }
         },
         "web3-core": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.7.tgz",
-          "integrity": "sha512-QA0MTae0gXcr3KHe3cQ4x56+Wh43ZKWfMwg1gfCc3NNxPRM1jJ8qudzyptCAUcxUGXWpDG8syLIn1APDz5J8BQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.1.tgz",
+          "integrity": "sha512-QlBwSyjl2pqYUBE7lH9PfLxa8j6AzzAtvLUqkgoaaFJYLP/+XavW1n6dhVCTq+U3L3eNc+bMp9GLjGDJNXMnGg==",
           "requires": {
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^12.6.1",
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
             "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-core-requestmanager": "1.2.7",
-            "web3-utils": "1.2.7"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "12.12.47",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
-              "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
-            }
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-core-requestmanager": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-core-helpers": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.7.tgz",
-          "integrity": "sha512-bdU++9QATGeCetVrMp8pV97aQtVkN5oLBf/TWu/qumC6jK/YqrvLlBJLdwbz0QveU8zOSap6GCvJbqKvmmbV2A==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.1.tgz",
+          "integrity": "sha512-tMVU0ScyQUJd/HFWfZrvGf+QmPCodPyKQw1gQ+n9We/H3vPPbUxDjNeYnd4BbYy5O9ox+0XG6i3+JlwiSkgDkA==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-eth-iban": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-eth-iban": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-core-method": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.7.tgz",
-          "integrity": "sha512-e1TI0QUnByDMbQ8QHwnjxfjKw0LIgVRY4TYrlPijET9ebqUJU1HCayn/BHIMpV6LKyR1fQj9EldWyT64wZQXkg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.1.tgz",
+          "integrity": "sha512-dA38tNVZWTxBFMlLFunLD5Az1AWRi5HqM+AtQrTIhxWCzg7rJSHuaYOZ6A5MHKGPWpdykLhzlna0SsNv5AVs8w==",
           "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-promievent": "1.2.7",
-            "web3-core-subscriptions": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-core-helpers": "1.3.1",
+            "web3-core-promievent": "1.3.1",
+            "web3-core-subscriptions": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-core-promievent": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.7.tgz",
-          "integrity": "sha512-jNmsM/czCeMGQqKKwM9/HZVTJVIF96hdMVNN/V9TGvp+EEE7vDhB4pUocDnc/QF9Z/5QFBCVmvNWttlRgZmU0A==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.1.tgz",
+          "integrity": "sha512-jGu7TkwUqIHlvWd72AlIRpsJqdHBQnHMeMktrows2148gg5PBPgpJ10cPFmCCzKT6lDOVh9B7pZMf9eckMDmiA==",
           "requires": {
-            "eventemitter3": "3.1.2"
+            "eventemitter3": "4.0.4"
           }
         },
         "web3-core-requestmanager": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.7.tgz",
-          "integrity": "sha512-HJb/txjHixu1dxIebiZQKBoJCaNu4gsh7mq/uj6Z/w6tIHbybL90s/7ADyMED353yyJ2tDWtYJqeMVAR+KtdaA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.1.tgz",
+          "integrity": "sha512-9WTaN2SoyJX1amRyTzX2FtbVXsyWBI2Wef2Q3gPiWaEo/VRVm3e4Bq8MwxNTUMIJMO8RLGHjtdgsoDKPwfL73Q==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.7",
-            "web3-providers-http": "1.2.7",
-            "web3-providers-ipc": "1.2.7",
-            "web3-providers-ws": "1.2.7"
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.3.1",
+            "web3-providers-http": "1.3.1",
+            "web3-providers-ipc": "1.3.1",
+            "web3-providers-ws": "1.3.1"
           }
         },
         "web3-core-subscriptions": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.7.tgz",
-          "integrity": "sha512-W/CzQYOUawdMDvkgA/fmLsnG5aMpbjrs78LZMbc0MFXLpH3ofqAgO2by4QZrrTShUUTeWS0ZuEkFFL/iFrSObw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.1.tgz",
+          "integrity": "sha512-eX3N5diKmrxshc6ZBZ8EJxxAhCxdYPbYXuF2EfgdIyHmxwmYqIVvKepzO8388Bx8JD3D0Id/pKE0dC/FnDIHTQ==",
           "requires": {
-            "eventemitter3": "3.1.2",
+            "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.7"
+            "web3-core-helpers": "1.3.1"
           }
         },
         "web3-eth": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.7.tgz",
-          "integrity": "sha512-ljLd0oB4IjWkzFGVan4HkYhJXhSXgn9iaSaxdJixKGntZPgWMJfxeA+uLwTrlxrWzhvy4f+39WnT7wCh5e9TGg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.1.tgz",
+          "integrity": "sha512-e4iL8ovj0zNxzbv4LTHEv9VS03FxKlAZD+95MolwAqtVoUnKC2H9X6dli0w6eyXP0aKw+mwY0g0CWQHzqZvtXw==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-core": "1.2.7",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-core-subscriptions": "1.2.7",
-            "web3-eth-abi": "1.2.7",
-            "web3-eth-accounts": "1.2.7",
-            "web3-eth-contract": "1.2.7",
-            "web3-eth-ens": "1.2.7",
-            "web3-eth-iban": "1.2.7",
-            "web3-eth-personal": "1.2.7",
-            "web3-net": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-core": "1.3.1",
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-core-subscriptions": "1.3.1",
+            "web3-eth-abi": "1.3.1",
+            "web3-eth-accounts": "1.3.1",
+            "web3-eth-contract": "1.3.1",
+            "web3-eth-ens": "1.3.1",
+            "web3-eth-iban": "1.3.1",
+            "web3-eth-personal": "1.3.1",
+            "web3-net": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-abi": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.7.tgz",
-          "integrity": "sha512-4FnlT1q+D0XBkxSMXlIb/eG337uQeMaUdtVQ4PZ3XzxqpcoDuMgXm4o+3NRxnWmr4AMm6QKjM+hcC7c0mBKcyg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.1.tgz",
+          "integrity": "sha512-ds4aTeKDUEqTXgncAtxvcfMpPiei9ey7+s2ZZ+OazK2CK5jWhFiJuuj9Q68kOT+hID7E1oSDVsNmJWFD/7lbMw==",
           "requires": {
-            "ethers": "4.0.0-beta.3",
+            "@ethersproject/abi": "5.0.7",
             "underscore": "1.9.1",
-            "web3-utils": "1.2.7"
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-accounts": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.7.tgz",
-          "integrity": "sha512-AE7QWi/iIQIjXwlAPtlMabm/OPFF0a1PhxT1EiTckpYNP8fYs6jW7lYxEtJPPJIKqfMjoi1xkEqTVR1YZQ88lg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.1.tgz",
+          "integrity": "sha512-wsV3/0Pbn5+pI8PiCD1CYw7I1dkQujcP//aJ+ZH8PoaHQoG6HnJ7nTp7foqa0r/X5lizImz/g5S8D76t3Z9tHA==",
           "requires": {
-            "@web3-js/scrypt-shim": "^0.1.0",
             "crypto-browserify": "3.12.0",
-            "eth-lib": "^0.2.8",
+            "eth-lib": "0.2.8",
             "ethereumjs-common": "^1.3.2",
             "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
-            "web3-core": "1.2.7",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-core": "1.3.1",
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-utils": "1.3.1"
           },
           "dependencies": {
             "eth-lib": {
@@ -33296,139 +33697,121 @@
                 "elliptic": "^6.4.0",
                 "xhr-request-promise": "^0.1.2"
               }
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
             }
           }
         },
         "web3-eth-contract": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.7.tgz",
-          "integrity": "sha512-uW23Y0iL7XroRNbf9fWZ1N6OYhEYTJX8gTuYASuRnpYrISN5QGiQML6pq/NCzqypR1bl5E0fuINZQSK/xefIVw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.1.tgz",
+          "integrity": "sha512-cHu9X1iGrK+Zbrj4wYKwHI1BtVGn/9O0JRsZqd9qcFGLwwAmaCJYy0sDn7PKCKDSL3qB+MDILoyI7FaDTWWTHg==",
           "requires": {
-            "@types/bn.js": "^4.11.4",
+            "@types/bn.js": "^4.11.5",
             "underscore": "1.9.1",
-            "web3-core": "1.2.7",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-core-promievent": "1.2.7",
-            "web3-core-subscriptions": "1.2.7",
-            "web3-eth-abi": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-core": "1.3.1",
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-core-promievent": "1.3.1",
+            "web3-core-subscriptions": "1.3.1",
+            "web3-eth-abi": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-ens": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.7.tgz",
-          "integrity": "sha512-SPRnvUNWQ0CnnTDBteGIJkvFWEizJcAHlVsrFLICwcwFZu+appjX1UOaoGu2h3GXWtc/XZlu7B451Gi+Os2cTg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.1.tgz",
+          "integrity": "sha512-MUQvYgUYQ5gAwbZyHwI7y+NTT6j98qG3MVhGCUf58inF5Gxmn9OlLJRw8Tofgf0K87Tk9Kqw1/2QxUE4PEZMMA==",
           "requires": {
+            "content-hash": "^2.5.2",
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
-            "web3-core": "1.2.7",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-promievent": "1.2.7",
-            "web3-eth-abi": "1.2.7",
-            "web3-eth-contract": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-core": "1.3.1",
+            "web3-core-helpers": "1.3.1",
+            "web3-core-promievent": "1.3.1",
+            "web3-eth-abi": "1.3.1",
+            "web3-eth-contract": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-iban": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.7.tgz",
-          "integrity": "sha512-2NrClz1PoQ3nSJBd+91ylCOVga9qbTxjRofq/oSCoHVAEvz3WZyttx9k5DC+0rWqwJF1h69ufFvdHAAlmN/4lg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.1.tgz",
+          "integrity": "sha512-RCQLfR9Z+DNfpw7oUauYHg1HcVoEljzhwxKn3vi15gK0ssWnTwRGqUiIyVTeSb836G6oakOd5zh7XYqy7pn+nw==",
           "requires": {
-            "bn.js": "4.11.8",
-            "web3-utils": "1.2.7"
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-eth-personal": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.7.tgz",
-          "integrity": "sha512-2OAa1Spz0uB29dwCM8+1y0So7E47A4gKznjBEwXIYEcUIsvwT5X7ofFhC2XxyRpqlIWZSQAxRSSJFyupRRXzyw==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.1.tgz",
+          "integrity": "sha512-/vZEQpXJfBfYoy9KT911ItfoscEfF0Q2j8tsXzC2xmmasSZ6YvAUuPhflVmAo0IHQSX9rmxq0q1p3sbnE3x2pQ==",
           "requires": {
-            "@types/node": "^12.6.1",
-            "web3-core": "1.2.7",
-            "web3-core-helpers": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-net": "1.2.7",
-            "web3-utils": "1.2.7"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "12.12.47",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
-              "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
-            }
+            "@types/node": "^12.12.6",
+            "web3-core": "1.3.1",
+            "web3-core-helpers": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-net": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-net": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.7.tgz",
-          "integrity": "sha512-j9qeZrS1FNyCeA0BfdLojkxOZQz3FKa1DJI+Dw9fEVhZS68vLOFANu2RB96gR9BoPHo5+k5D3NsKOoxt1gw3Gg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.1.tgz",
+          "integrity": "sha512-vuMMWMk+NWHlrNfszGp3qRjH/64eFLiNIwUi0kO8JXQ896SP3Ma0su5sBfSPxNCig047E9GQimrL9wvYAJSO5A==",
           "requires": {
-            "web3-core": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-utils": "1.2.7"
+            "web3-core": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-utils": "1.3.1"
           }
         },
         "web3-providers-http": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.7.tgz",
-          "integrity": "sha512-vazGx5onuH/zogrwkUaLFJwFcJ6CckP65VFSHoiV+GTQdkOqgoDIha7StKkslvDz4XJ2FuY/zOZHbtuOYeltXQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.1.tgz",
+          "integrity": "sha512-DOujG6Ts7/hAMj0PW5p9/1vwxAIr+1CJ6ZWHshtfOq1v1KnMphVTGOrjcTTUvPT33/DA/so2pgGoPMrgaEIIvQ==",
           "requires": {
-            "web3-core-helpers": "1.2.7",
+            "web3-core-helpers": "1.3.1",
             "xhr2-cookies": "1.1.0"
           }
         },
         "web3-providers-ipc": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.7.tgz",
-          "integrity": "sha512-/zc0y724H2zbkV4UbGGMhsEiLfafjagIzfrsWZnyTZUlSB0OGRmmFm2EkLJAgtXrLiodaHHyXKM0vB8S24bxdA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.1.tgz",
+          "integrity": "sha512-BNPscLbvwo+u/tYJrLvPnl/g/SQVSnqP/TjEsB033n4IXqTC4iZ9Of8EDmI0U6ds/9nwNqOBx3KsxbinL46UZA==",
           "requires": {
-            "oboe": "2.1.4",
+            "oboe": "2.1.5",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.7"
+            "web3-core-helpers": "1.3.1"
           }
         },
         "web3-providers-ws": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.7.tgz",
-          "integrity": "sha512-b5XzqDpRkNVe6MFs5K6iqOEyjQikHtg3KuU2/ClCDV37hm0WN4xCRVMC0LwegulbDXZej3zT9+1CYzGaGFREzA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.1.tgz",
+          "integrity": "sha512-DAbVbiizv0Hr/bLKjyyKMHc/66ccVkudan3eRsf+R/PXWCqfXb7q6Lwodj4llvC047pEuLKR521ZKr5wbfk1KQ==",
           "requires": {
-            "@web3-js/websocket": "^1.0.29",
-            "eventemitter3": "^4.0.0",
+            "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.7"
-          },
-          "dependencies": {
-            "eventemitter3": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-              "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-            }
+            "web3-core-helpers": "1.3.1",
+            "websocket": "^1.0.32"
           }
         },
         "web3-shh": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.7.tgz",
-          "integrity": "sha512-f6PAgcpG0ZAo98KqCmeHoDEx5qzm3d5plet18DkT4U6WIeYowKdec8vZaLPRR7c2XreXFJ2gQf45CB7oqR7U/w==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.1.tgz",
+          "integrity": "sha512-57FTQvOW1Zm3wqfZpIEqL4apEQIR5JAxjqA4RM4eL0jbdr+Zj5Y4J93xisaEVl6/jMtZNlsqYKTVswx8mHu1xw==",
           "requires": {
-            "web3-core": "1.2.7",
-            "web3-core-method": "1.2.7",
-            "web3-core-subscriptions": "1.2.7",
-            "web3-net": "1.2.7"
+            "web3-core": "1.3.1",
+            "web3-core-method": "1.3.1",
+            "web3-core-subscriptions": "1.3.1",
+            "web3-net": "1.3.1"
           }
         },
         "web3-utils": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7.tgz",
-          "integrity": "sha512-FBh/CPJND+eiPeUF9KVbTyTZtXNWxPWtByBaWS6e2x4ACazPX711EeNaZaChIOGSLGe6se2n7kg6wnawe/MjuQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.1.tgz",
+          "integrity": "sha512-9gPwFm8SXtIJuzdrZ37PRlalu40fufXxo+H2PiCwaO6RpKGAvlUlWU0qQbyToFNXg7W2H8djEgoAVac8NLMCKQ==",
           "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
             "ethereum-bloom-filters": "^1.0.6",
             "ethjs-unit": "0.1.6",
             "number-to-bn": "1.7.0",
@@ -33438,15 +33821,28 @@
           },
           "dependencies": {
             "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
                 "xhr-request-promise": "^0.1.2"
               }
             }
+          }
+        },
+        "websocket": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+          "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+          "requires": {
+            "bufferutil": "^4.0.1",
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "typedarray-to-buffer": "^3.1.5",
+            "utf-8-validate": "^5.0.2",
+            "yaeti": "^0.0.6"
           }
         }
       }
@@ -34572,6 +34968,90 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "optional": true
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+          "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+          "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        }
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -31,7 +31,7 @@
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
     "trezor-connect": "^8.0.13",
-    "web3": "1.2.7",
+    "web3": "1.3.1",
     "web3-provider-engine": "15.0.6"
   },
   "scripts": {

--- a/solidity/dashboard/src/connectors/index.js
+++ b/solidity/dashboard/src/connectors/index.js
@@ -5,6 +5,13 @@ const InjectedProvider = window.ethereum
 if (InjectedProvider) {
   // https://docs.metamask.io/guide/ethereum-provider.html#ethereum-autorefreshonnetworkchange
   InjectedProvider.autoRefreshOnNetworkChange = false
+
+  // Override `enable` function in the injected provider.
+  // MetaMask: 'ethereum.enable()' is deprecated and may be removed in the
+  // future. https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3
+  InjectedProvider.enable = async () => {
+    return await InjectedProvider.request({ method: "eth_requestAccounts" })
+  }
 }
 
 export {


### PR DESCRIPTION
The previous version of web3 (1.2.7) doesn't support the breaking changes of
version 9.0.0 of the MetaMask extension described in
MetaMask/metamask-extension#8077.