### PR TITLE
Fetch liquidity reward per week from contract

### DIFF
--- a/solidity/dashboard/src/constants/constants.js
+++ b/solidity/dashboard/src/constants/constants.js
@@ -46,7 +46,6 @@ export const LIQUIDITY_REWARD_PAIRS = {
     label: "KEEP + ETH",
     viewPoolLink:
       "https://info.uniswap.org/pair/0xe6f19dab7d43317344282f803f8e8d240708174a",
-    rewardPoolPerWeek: 150000,
     address: "0xe6f19dab7d43317344282f803f8e8d240708174a",
   },
   KEEP_TBTC: {
@@ -54,7 +53,6 @@ export const LIQUIDITY_REWARD_PAIRS = {
     label: "KEEP + TBTC",
     viewPoolLink:
       "https://info.uniswap.org/pair/0x38c8ffee49f286f25d25bad919ff7552e5daf081",
-    rewardPoolPerWeek: 200000,
     address: "0x38c8ffee49f286f25d25bad919ff7552e5daf081",
   },
   TBTC_ETH: {
@@ -62,7 +60,6 @@ export const LIQUIDITY_REWARD_PAIRS = {
     label: "TBTC + ETH",
     viewPoolLink:
       "https://info.uniswap.org/pair/0x854056fd40c1b52037166285b2e54fee774d33f6",
-    rewardPoolPerWeek: 50000,
     address: "0x854056fd40c1b52037166285b2e54fee774d33f6",
   },
 }

--- a/solidity/dashboard/src/sagas/liquidity-rewards.js
+++ b/solidity/dashboard/src/sagas/liquidity-rewards.js
@@ -45,7 +45,12 @@ function* fetchLiquidityRewardsData(liquidityRewardPair, address) {
     // Fetching total deposited liqidity tokens in the `LPRewards` contract.
     const totalSupply = yield call(fetchLPRewardsTotalSupply, LPRewardsContract)
     if (gt(totalSupply, 0)) {
-      apy = yield call(calculateAPY, totalSupply, liquidityRewardPair.name)
+      apy = yield call(
+        calculateAPY,
+        totalSupply,
+        liquidityRewardPair.name,
+        LPRewardsContract
+      )
     }
 
     let reward = 0
@@ -151,7 +156,12 @@ function* fetchLiquidityRewardsAPY(liquidityRewardPair) {
     let apy = Infinity
     const totalSupply = yield call(fetchLPRewardsTotalSupply, LPRewardsContract)
     if (gt(totalSupply, 0)) {
-      apy = yield call(calculateAPY, totalSupply, liquidityRewardPair.name)
+      apy = yield call(
+        calculateAPY,
+        totalSupply,
+        liquidityRewardPair.name,
+        LPRewardsContract
+      )
     }
 
     yield put({

--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -673,7 +673,12 @@ function* lpTokensStakedOrWithdrawn(
   const { user, amount } = eventValues
   const totalSupply = yield call(fetchLPRewardsTotalSupply, LPRewardsContract)
 
-  const apy = yield call(calculateAPY, totalSupply, liquidityRewardPairName)
+  const apy = yield call(
+    calculateAPY,
+    totalSupply,
+    liquidityRewardPairName,
+    LPRewardsContract
+  )
 
   const reward = yield call(
     fetchRewardBalance,


### PR DESCRIPTION
We can compute weekly rewards based on data in LPRewards contract
instead of hardcoded values -> `LPReward.rewardRate * 7 days in seconds`