### PR TITLE
KEEP Token Dashboard release v1.8.0

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.7.2
+        image: keepnetwork/token-dashboard:v1.8.0
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
c97a6fd68b562d7c7016a8b600849e53b68615a4 is the commit hash for `token-dashboard/v1.8.0`.

This bundles work from https://github.com/keep-network/keep-core/milestone/41?closed=1