### PR TITLE
Fix creating the wrapped token of the LPRewards

### DIFF
--- a/solidity/dashboard/src/services/liquidity-rewards.js
+++ b/solidity/dashboard/src/services/liquidity-rewards.js
@@ -12,7 +12,7 @@ import { add } from "../utils/arithmetics.utils"
 /** @typedef {import("web3").default} Web3 */
 /** @typedef {LiquidityRewards} LiquidityRewards */
 
-// lp contract address -> wrapped ERC20 token as web3 contract instance
+// lp contract address -> wrapped ERC20 token as address
 const LPRewardsToWrappedTokenCache = {}
 const WEEKS_IN_YEAR = 52
 
@@ -214,11 +214,14 @@ export class LiquidityRewardsFactory {
         .call()
       LPRewardsToWrappedTokenCache[
         lpRewardsContractAddress
-      ] = createERC20Contract(web3, wrappedTokenAddress)
+      ] = wrappedTokenAddress
     }
 
-    const wrappedTokenContract =
+    const wrappedTokenContract = createERC20Contract(
+      web3,
       LPRewardsToWrappedTokenCache[lpRewardsContractAddress]
+    )
+
     const PoolStrategy = LiquidityRewardsPoolStrategy[pool]
 
     return new PoolStrategy(wrappedTokenContract, LPRewardsContract, web3)


### PR DESCRIPTION
Store in the `LPRewardsToWrappedTokenCache` address of the wrapped token instead of the web3 contract instance. In case the web3 provider has changed. This PR also fixes the `No "from" address...` error on staking in `LPRewards`.