### PR TITLE
Bump web3 dependency to v1.3.3

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -33425,23 +33425,23 @@
       }
     },
     "web3": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.1.tgz",
-      "integrity": "sha512-lDJwOLSRWHYwhPy4h5TNgBRJ/lED7lWXyVOXHCHcEC8ai3coBNdgEXWBu/GGYbZMsS89EoUOJ14j3Ufi4dUkog==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.3.tgz",
+      "integrity": "sha512-fI/g0yC1FC0m4envv8FsPh7tbBoe/eXbEho+iY/hahs7YGgGt3nYNrAFTkR9pLhQaVMpOilhwgFxXEp+O7My/g==",
       "requires": {
-        "web3-bzz": "1.3.1",
-        "web3-core": "1.3.1",
-        "web3-eth": "1.3.1",
-        "web3-eth-personal": "1.3.1",
-        "web3-net": "1.3.1",
-        "web3-shh": "1.3.1",
-        "web3-utils": "1.3.1"
+        "web3-bzz": "1.3.3",
+        "web3-core": "1.3.3",
+        "web3-eth": "1.3.3",
+        "web3-eth-personal": "1.3.3",
+        "web3-net": "1.3.3",
+        "web3-shh": "1.3.3",
+        "web3-utils": "1.3.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.14.tgz",
-          "integrity": "sha512-2U9uLN46+7dv9PiS8VQJcHhuoOjiDPZOLAt0WuA1EanEknIMae+2QbMhayF7cgGqjvRVIfNpt+6jLPczJZFiRw=="
+          "version": "12.19.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
+          "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
         },
         "decompress-response": {
           "version": "3.3.0",
@@ -33562,9 +33562,9 @@
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "web3-bzz": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.1.tgz",
-          "integrity": "sha512-MN726zFpFpwhs3NMC35diJGkwTVUj+8LM/VWqooGX/MOjgYzNrJ7Wr8EzxoaTCy87edYNBprtxBkd0HzzLmung==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.3.tgz",
+          "integrity": "sha512-lFERlqnr/upJhADT6US7BGUkM5cy6idw86/GvWKo9h/uyrbV14gk+bUqcQdBBSopa1Mvvy5ZaO6rKtRe8PTsQw==",
           "requires": {
             "@types/node": "^12.12.6",
             "got": "9.6.0",
@@ -33573,107 +33573,107 @@
           }
         },
         "web3-core": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.1.tgz",
-          "integrity": "sha512-QlBwSyjl2pqYUBE7lH9PfLxa8j6AzzAtvLUqkgoaaFJYLP/+XavW1n6dhVCTq+U3L3eNc+bMp9GLjGDJNXMnGg==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.3.tgz",
+          "integrity": "sha512-hCDWj/3PBHhSJSSBi+nV7MiW9Djf/pRuUXcVO2jWroAXqAbTSXLHpju0AWTzXnlsqs1QHK0Yk8nF9jojGUQVYg==",
           "requires": {
             "@types/bn.js": "^4.11.5",
             "@types/node": "^12.12.6",
             "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-core-requestmanager": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core-helpers": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-core-requestmanager": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-core-helpers": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.1.tgz",
-          "integrity": "sha512-tMVU0ScyQUJd/HFWfZrvGf+QmPCodPyKQw1gQ+n9We/H3vPPbUxDjNeYnd4BbYy5O9ox+0XG6i3+JlwiSkgDkA==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.3.tgz",
+          "integrity": "sha512-rUTC9sgn1Wvw2KGBtc9/bsQKUd+yjzIm14mlaqqiO0vpFueTmmagwiGRE2CWzEfYg+r2jnYIIgh9qnsCykgVkQ==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-eth-iban": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-eth-iban": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-core-method": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.1.tgz",
-          "integrity": "sha512-dA38tNVZWTxBFMlLFunLD5Az1AWRi5HqM+AtQrTIhxWCzg7rJSHuaYOZ6A5MHKGPWpdykLhzlna0SsNv5AVs8w==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.3.tgz",
+          "integrity": "sha512-d3AA1lyw0dvLs53X17pHpD5QpxJdkfolbN31UQymRF5Y+swFweqRiCuJoNTplE95ZX2uUtsLhEIbaszj7dQgFg==",
           "requires": {
             "@ethersproject/transactions": "^5.0.0-beta.135",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-promievent": "1.3.1",
-            "web3-core-subscriptions": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core-helpers": "1.3.3",
+            "web3-core-promievent": "1.3.3",
+            "web3-core-subscriptions": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-core-promievent": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.1.tgz",
-          "integrity": "sha512-jGu7TkwUqIHlvWd72AlIRpsJqdHBQnHMeMktrows2148gg5PBPgpJ10cPFmCCzKT6lDOVh9B7pZMf9eckMDmiA==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.3.tgz",
+          "integrity": "sha512-ARgO+BWUCxK8U/977SdJ8oyJo51mDYUzlZFoa2NFjUH+QYrFoKA7l9Hhw/vxhy13jE2LaVUM31JBLzVb+GM9dQ==",
           "requires": {
             "eventemitter3": "4.0.4"
           }
         },
         "web3-core-requestmanager": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.1.tgz",
-          "integrity": "sha512-9WTaN2SoyJX1amRyTzX2FtbVXsyWBI2Wef2Q3gPiWaEo/VRVm3e4Bq8MwxNTUMIJMO8RLGHjtdgsoDKPwfL73Q==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.3.tgz",
+          "integrity": "sha512-4/J23wK5IXRw/1kqda7FXtvySKjX7Phcevqjx0EkcBtrxAfLedcqf8k2PlDh5LtCXfPW66u4V3fDgHdLZMrVgQ==",
           "requires": {
             "underscore": "1.9.1",
             "util": "^0.12.0",
-            "web3-core-helpers": "1.3.1",
-            "web3-providers-http": "1.3.1",
-            "web3-providers-ipc": "1.3.1",
-            "web3-providers-ws": "1.3.1"
+            "web3-core-helpers": "1.3.3",
+            "web3-providers-http": "1.3.3",
+            "web3-providers-ipc": "1.3.3",
+            "web3-providers-ws": "1.3.3"
           }
         },
         "web3-core-subscriptions": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.1.tgz",
-          "integrity": "sha512-eX3N5diKmrxshc6ZBZ8EJxxAhCxdYPbYXuF2EfgdIyHmxwmYqIVvKepzO8388Bx8JD3D0Id/pKE0dC/FnDIHTQ==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.3.tgz",
+          "integrity": "sha512-VvcPuNYcGLb6HfgMrNN6Q/1CwSk2uIqUjhrVTQ67JIxIddsEdV1f6SsQH9MX1cmwi39ffGsYtssOT1pht4Zc8g==",
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.1"
+            "web3-core-helpers": "1.3.3"
           }
         },
         "web3-eth": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.1.tgz",
-          "integrity": "sha512-e4iL8ovj0zNxzbv4LTHEv9VS03FxKlAZD+95MolwAqtVoUnKC2H9X6dli0w6eyXP0aKw+mwY0g0CWQHzqZvtXw==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.3.tgz",
+          "integrity": "sha512-NvbkCaN26o7f9EogsRsA/lbwF+8dXimJWsaGpZK3ANa+AZrYkWj3NuaxfPO/S/RLsC9ptJdt7id72qxT40r5QQ==",
           "requires": {
             "underscore": "1.9.1",
-            "web3-core": "1.3.1",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-core-subscriptions": "1.3.1",
-            "web3-eth-abi": "1.3.1",
-            "web3-eth-accounts": "1.3.1",
-            "web3-eth-contract": "1.3.1",
-            "web3-eth-ens": "1.3.1",
-            "web3-eth-iban": "1.3.1",
-            "web3-eth-personal": "1.3.1",
-            "web3-net": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-helpers": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-core-subscriptions": "1.3.3",
+            "web3-eth-abi": "1.3.3",
+            "web3-eth-accounts": "1.3.3",
+            "web3-eth-contract": "1.3.3",
+            "web3-eth-ens": "1.3.3",
+            "web3-eth-iban": "1.3.3",
+            "web3-eth-personal": "1.3.3",
+            "web3-net": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-eth-abi": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.1.tgz",
-          "integrity": "sha512-ds4aTeKDUEqTXgncAtxvcfMpPiei9ey7+s2ZZ+OazK2CK5jWhFiJuuj9Q68kOT+hID7E1oSDVsNmJWFD/7lbMw==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.3.tgz",
+          "integrity": "sha512-9GQ7YTALt1uxGwdMBpBHlagCj4yn0fPUT2wDDAGoyJFVJMsUt3arF855zsVpJL3zfhHmUgRNoVrAkobRR2YYLw==",
           "requires": {
             "@ethersproject/abi": "5.0.7",
             "underscore": "1.9.1",
-            "web3-utils": "1.3.1"
+            "web3-utils": "1.3.3"
           }
         },
         "web3-eth-accounts": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.1.tgz",
-          "integrity": "sha512-wsV3/0Pbn5+pI8PiCD1CYw7I1dkQujcP//aJ+ZH8PoaHQoG6HnJ7nTp7foqa0r/X5lizImz/g5S8D76t3Z9tHA==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.3.tgz",
+          "integrity": "sha512-Jn9nguNsCLnY7Po6lv7Mg5JDaYuKdvL0Ezv1V2LTLy+EhcVt5i19h+/3M92Xynpe5Tx+WY/ELfeA2jLTeP5jRg==",
           "requires": {
             "crypto-browserify": "3.12.0",
             "eth-lib": "0.2.8",
@@ -33682,10 +33682,10 @@
             "scrypt-js": "^3.0.1",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
-            "web3-core": "1.3.1",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-helpers": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-utils": "1.3.3"
           },
           "dependencies": {
             "eth-lib": {
@@ -33701,114 +33701,114 @@
           }
         },
         "web3-eth-contract": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.1.tgz",
-          "integrity": "sha512-cHu9X1iGrK+Zbrj4wYKwHI1BtVGn/9O0JRsZqd9qcFGLwwAmaCJYy0sDn7PKCKDSL3qB+MDILoyI7FaDTWWTHg==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.3.tgz",
+          "integrity": "sha512-TKGs1qvc/v7TriyGKtnTqVrB3J/mWSeqLkWtLY60lGqY8KopZ9k7dZ/g5Cvfiox57VHWkpOk0xDwUQjlIe4Ikg==",
           "requires": {
             "@types/bn.js": "^4.11.5",
             "underscore": "1.9.1",
-            "web3-core": "1.3.1",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-core-promievent": "1.3.1",
-            "web3-core-subscriptions": "1.3.1",
-            "web3-eth-abi": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-helpers": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-core-promievent": "1.3.3",
+            "web3-core-subscriptions": "1.3.3",
+            "web3-eth-abi": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-eth-ens": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.1.tgz",
-          "integrity": "sha512-MUQvYgUYQ5gAwbZyHwI7y+NTT6j98qG3MVhGCUf58inF5Gxmn9OlLJRw8Tofgf0K87Tk9Kqw1/2QxUE4PEZMMA==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.3.tgz",
+          "integrity": "sha512-tresrI1CM6RbxsUCM6kfG1W10LDMqWJnU+lNhfaD5mt5IzJ4GcfDAHO9WzoYl8Esh+Epj/jD+vI30clI4j90Vg==",
           "requires": {
             "content-hash": "^2.5.2",
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
-            "web3-core": "1.3.1",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-promievent": "1.3.1",
-            "web3-eth-abi": "1.3.1",
-            "web3-eth-contract": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-helpers": "1.3.3",
+            "web3-core-promievent": "1.3.3",
+            "web3-eth-abi": "1.3.3",
+            "web3-eth-contract": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-eth-iban": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.1.tgz",
-          "integrity": "sha512-RCQLfR9Z+DNfpw7oUauYHg1HcVoEljzhwxKn3vi15gK0ssWnTwRGqUiIyVTeSb836G6oakOd5zh7XYqy7pn+nw==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.3.tgz",
+          "integrity": "sha512-+9a+bZHAKQ4oBcRxiGbC1MC8S2cOgDlXo8qcw0XpMhLJZ3c/brZM7ZbPdiuU8Z7AMYf3PknaGFQyVmedZhrauA==",
           "requires": {
             "bn.js": "^4.11.9",
-            "web3-utils": "1.3.1"
+            "web3-utils": "1.3.3"
           }
         },
         "web3-eth-personal": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.1.tgz",
-          "integrity": "sha512-/vZEQpXJfBfYoy9KT911ItfoscEfF0Q2j8tsXzC2xmmasSZ6YvAUuPhflVmAo0IHQSX9rmxq0q1p3sbnE3x2pQ==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.3.tgz",
+          "integrity": "sha512-S/TSGTm7x9oHRXUHXi8f+y187RKpn5aqYJRlSoyTmB3B4EMrv9NcZZQmHaiXwM48wkFdRhTMECW1Ar8E5zZLFw==",
           "requires": {
             "@types/node": "^12.12.6",
-            "web3-core": "1.3.1",
-            "web3-core-helpers": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-net": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-helpers": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-net": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-net": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.1.tgz",
-          "integrity": "sha512-vuMMWMk+NWHlrNfszGp3qRjH/64eFLiNIwUi0kO8JXQ896SP3Ma0su5sBfSPxNCig047E9GQimrL9wvYAJSO5A==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.3.tgz",
+          "integrity": "sha512-GcPj2lyAC5CP6FOCwoURCRMFsh0khWBi6sGqiKtUPMa7dKnLw8CLCAFcwX//d3ucnn1E7I78Va6k8liKjj87sA==",
           "requires": {
-            "web3-core": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-utils": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-utils": "1.3.3"
           }
         },
         "web3-providers-http": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.1.tgz",
-          "integrity": "sha512-DOujG6Ts7/hAMj0PW5p9/1vwxAIr+1CJ6ZWHshtfOq1v1KnMphVTGOrjcTTUvPT33/DA/so2pgGoPMrgaEIIvQ==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.3.tgz",
+          "integrity": "sha512-V2x27IFXQqsaZrAbA4GJurKuyrNXapmmpSJ7jxPDOxewOy9dEURlKIg5W1bb4QXGh2YSCksuH9fKquvTfPfc/A==",
           "requires": {
-            "web3-core-helpers": "1.3.1",
+            "web3-core-helpers": "1.3.3",
             "xhr2-cookies": "1.1.0"
           }
         },
         "web3-providers-ipc": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.1.tgz",
-          "integrity": "sha512-BNPscLbvwo+u/tYJrLvPnl/g/SQVSnqP/TjEsB033n4IXqTC4iZ9Of8EDmI0U6ds/9nwNqOBx3KsxbinL46UZA==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.3.tgz",
+          "integrity": "sha512-XMQo/YsH/2lBaRlkYa5d/Q+2EJ2RTzVjio1i2G9TESESfHCj0l2AWLb3zet+f/QRVxfvXGmGlZuf99diof2a1g==",
           "requires": {
             "oboe": "2.1.5",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.1"
+            "web3-core-helpers": "1.3.3"
           }
         },
         "web3-providers-ws": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.1.tgz",
-          "integrity": "sha512-DAbVbiizv0Hr/bLKjyyKMHc/66ccVkudan3eRsf+R/PXWCqfXb7q6Lwodj4llvC047pEuLKR521ZKr5wbfk1KQ==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.3.tgz",
+          "integrity": "sha512-yuzqB3jST9JS19oOR1FRaARM7JBeP6cbKffM8HoWp4Y98/OowjW1mbDQVS47YTSHBP2QiLzSrwBxjIEPm8f48Q==",
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.3.1",
+            "web3-core-helpers": "1.3.3",
             "websocket": "^1.0.32"
           }
         },
         "web3-shh": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.1.tgz",
-          "integrity": "sha512-57FTQvOW1Zm3wqfZpIEqL4apEQIR5JAxjqA4RM4eL0jbdr+Zj5Y4J93xisaEVl6/jMtZNlsqYKTVswx8mHu1xw==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.3.tgz",
+          "integrity": "sha512-byp2+sHnc8UAj6sNcVFacF3pmRzIaMATsI4ARfU+0S8EpaQ3trojww2QBYPnZ4r0QOMH+I6+bVl8qTu0Zz4eoA==",
           "requires": {
-            "web3-core": "1.3.1",
-            "web3-core-method": "1.3.1",
-            "web3-core-subscriptions": "1.3.1",
-            "web3-net": "1.3.1"
+            "web3-core": "1.3.3",
+            "web3-core-method": "1.3.3",
+            "web3-core-subscriptions": "1.3.3",
+            "web3-net": "1.3.3"
           }
         },
         "web3-utils": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.1.tgz",
-          "integrity": "sha512-9gPwFm8SXtIJuzdrZ37PRlalu40fufXxo+H2PiCwaO6RpKGAvlUlWU0qQbyToFNXg7W2H8djEgoAVac8NLMCKQ==",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
           "requires": {
             "bn.js": "^4.11.9",
             "eth-lib": "0.2.8",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -31,7 +31,7 @@
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
     "trezor-connect": "^8.0.13",
-    "web3": "1.3.1",
+    "web3": "1.3.3",
     "web3-provider-engine": "15.0.6"
   },
   "scripts": {


### PR DESCRIPTION
Closes: #2300 

This v1.3.3 version is a hot fix to address breaking changes in the
MetaMask API provided in v.9.
Details:
https://github.com/ChainSafe/web3.js/pull/3864
https://github.com/MetaMask/metamask-extension/issues/8077#issuecomment-765004856