### PR TITLE
Fix reward pool per week for saddle pool

### DIFF
--- a/solidity/dashboard/src/services/liquidity-rewards.js
+++ b/solidity/dashboard/src/services/liquidity-rewards.js
@@ -155,7 +155,7 @@ class SaddleLPRewards extends LiquidityRewards {
 
     const keepTokenInUSD = await getKeepTokenPriceInUSD()
 
-    const rewardPoolPerWeek = 125000 // await this.rewardPoolPerWeek()
+    const rewardPoolPerWeek = await this.rewardPoolPerWeek()
 
     const lpRewardsPoolInUSD = totalSupplyOfLPRewards
       .multipliedBy(wrappedTokenPoolInUSD)


### PR DESCRIPTION
Get reward pool per week value based on rewardRate() method from the
LPRewardsContract instead of hardcoding the value.