### PR TITLE
Releases/mainnet/token dashboard/v1.9.0

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.8.1
+        image: keepnetwork/token-dashboard:v1.9.0
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
fd41a60b76a4e87769907fac36199f96cfc6ee4d is the commit hash for `token-dashboard/v1.9.0`

This bundles work from https://github.com/keep-network/keep-core/milestone/43?closed=1.