### PR TITLE
Add jq to the macos Setup Script

### DIFF
--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -22,6 +22,9 @@ brew list pre-commit &>/dev/null || brew install pre-commit
 go get -u golang.org/x/tools/cmd/goimports
 go get -u golang.org/x/lint/golint
 
+echo "Installing jq..."
+brew list jq &>/dev/null || brew install jq
+
 echo "Installing pre-commit and specified hooks..."
 pre-commit install --install-hooks
 


### PR DESCRIPTION
The [manual setup doc](https://github.com/keep-network/local-setup/blob/master/docs/manual-setup.adoc#title) details that "If you are not on macOS or you don’t have Homebrew, you need to install:", and then lists `jq`, but the `macos-setup.sh` script doesn't install `jq` for you.

I also confirmed that `jq` is indeed necessary for the project via bricking by not having it XD

This PR adds a brew line to install it similar to how the rest of the dependencies are installed!
