### PR TITLE
releases/mainnet/solidity/v1.70

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.7.0",
+  "version": "1.8.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.7.0-pre.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.7.0-pre.0",
+  "version": "1.7.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.7.0",
+  "version": "1.8.0-pre.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
3a3e1ccbc6796f7ae73a49dc38ba30acd1858a2d is the commit hash for `solidity/v1.7.0`

This bundles the work from https://github.com/keep-network/keep-core/milestone/44?closed=1.