### PR TITLE
Create GH Actions workflow for build&test of Go client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
           root: /tmp/docs
           paths:
             - solidity/*
+  # GitHub Actions equivalent of this job (.github/workflows/client.yml) has been created as part of work on RFC-18
   build_client_and_test_go:
     executor: docker-git
     steps:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -24,43 +24,19 @@ jobs:
             --tag keep-client . 
       - name: Create and enter test results directory
         run: |
-          mkdir -p /tmp/test-results/keep-core-go
-          cd /tmp/test-results/keep-core-go/
-      - name: DEBUG
-        run: |
-          pwd
-      - name: DEBUG
-        run: |
-          ls
-      - name: DEBUG
-        run: |
-          ls /tmp/test-results/keep-core-go/
-      - name: DEBUG
-        run: |
-          ls /home/runner/work/keep-core/keep-core
+          mkdir -p $GITHUB_WORKSPACE/test-results/
       - name: Run Go tests
         run: |
           docker run \
-            --volume /tmp/test-results/keep-core-go:/mnt/test-results \
+            --volume $GITHUB_WORKSPACE/test-results:/mnt/test-results \
             --workdir /go/src/github.com/keep-network/keep-core \
             go-build-env \
             gotestsum --junitfile /mnt/test-results/unit-tests.xml
-      - name: DEBUG
-        run: |
-          pwd
-      - name: DEBUG
-        run: |
-          ls
-      - name: DEBUG
-        run: |
-          ls /tmp/test-results/keep-core-go/
-      - name: DEBUG
-        run: |
-          ls /home/runner/work/keep-core/keep-core
       - name: Publish Unit Test results
         uses: EnricoMi/publish-unit-test-result-action@v1.7
         if: always() # guarantees that this action always runs, even if earlier steps fail
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          files:  unit-tests.xml
+          files:  ./test-results/unit-tests.xml
           check_name: Go Test Results # name under which test results will be presented in GitHub (optional)
+          comment_on_pr: false # turns off commenting on Pull Requests

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -40,3 +40,4 @@ jobs:
           files:  ./test-results/unit-tests.xml
           check_name: Go Test Results # name under which test results will be presented in GitHub (optional)
           comment_on_pr: false # turns off commenting on Pull Requests
+          # temporary comment

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,0 +1,30 @@
+name: Go
+
+#TODO: extend the conditions once workflow gets tested together with other workflows 
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true # ignore the failure of a step and avoid terminating the job
+      - name: Create test results directory
+        run: |
+          mkdir -p /tmp/test-results/keep-core-go
+      - name: Run Docker build
+        run: |
+          docker build --target gobuild --tag go-build-env .
+          docker build --tag keep-client . 
+      - name: Run Go tests
+        run: |
+          docker run --volume /tmp/test-results/keep-core-go:/mnt/test-results --workdir /go/src/github.com/keep-network/keep-core go-build-env gotestsum --junitfile /mnt/test-results/unit-tests.xml
+          docker run --volume /tmp/test-results/keep-core-go:/mnt/test-results --workdir /go/src/github.com/keep-network/keep-core go-build-env cat /mnt/test-results/unit-tests.xml > ./unit-tests.xml
+      - name: Publish Unit Test results
+        uses: EnricoMi/publish-unit-test-result-action@v1.7
+        if: always() # guarantees that this action always runs, even if earlier steps fail
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files:  unit-tests.xml
+          check_name: Go Test Results # name under which test results will be presented in GitHub (optional)

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,7 +1,11 @@
 name: Go
 
 #TODO: extend the conditions once workflow gets tested together with other workflows 
-on: [push, pull_request]
+on:  
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build-and-test:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -10,17 +10,24 @@ jobs:
       - uses: actions/checkout@v1
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true # ignore the failure of a step and avoid terminating the job
-      - name: Create test results directory
-        run: |
-          mkdir -p /tmp/test-results/keep-core-go
       - name: Run Docker build
         run: |
-          docker build --target gobuild --tag go-build-env .
-          docker build --tag keep-client . 
+          docker build \
+            --target gobuild \
+            --tag go-build-env .
+          docker build \
+            --tag keep-client . 
+      - name: Create and enter test results directory
+        run: |
+          mkdir -p /tmp/test-results/keep-core-go
+          cd /tmp/test-results/keep-core-go/
       - name: Run Go tests
         run: |
-          docker run --volume /tmp/test-results/keep-core-go:/mnt/test-results --workdir /go/src/github.com/keep-network/keep-core go-build-env gotestsum --junitfile /mnt/test-results/unit-tests.xml
-          docker run --volume /tmp/test-results/keep-core-go:/mnt/test-results --workdir /go/src/github.com/keep-network/keep-core go-build-env cat /mnt/test-results/unit-tests.xml > ./unit-tests.xml
+          docker run \
+            --volume /tmp/test-results/keep-core-go:/mnt/test-results \
+            --workdir /go/src/github.com/keep-network/keep-core \
+            go-build-env \
+            gotestsum --junitfile /mnt/test-results/unit-tests.xml
       - name: Publish Unit Test results
         uses: EnricoMi/publish-unit-test-result-action@v1.7
         if: always() # guarantees that this action always runs, even if earlier steps fail

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -25,6 +26,18 @@ jobs:
         run: |
           mkdir -p /tmp/test-results/keep-core-go
           cd /tmp/test-results/keep-core-go/
+      - name: DEBUG
+        run: |
+          pwd
+      - name: DEBUG
+        run: |
+          ls
+      - name: DEBUG
+        run: |
+          ls /tmp/test-results/keep-core-go/
+      - name: DEBUG
+        run: |
+          ls /home/runner/work/keep-core/keep-core
       - name: Run Go tests
         run: |
           docker run \
@@ -32,6 +45,18 @@ jobs:
             --workdir /go/src/github.com/keep-network/keep-core \
             go-build-env \
             gotestsum --junitfile /mnt/test-results/unit-tests.xml
+      - name: DEBUG
+        run: |
+          pwd
+      - name: DEBUG
+        run: |
+          ls
+      - name: DEBUG
+        run: |
+          ls /tmp/test-results/keep-core-go/
+      - name: DEBUG
+        run: |
+          ls /home/runner/work/keep-core/keep-core
       - name: Publish Unit Test results
         uses: EnricoMi/publish-unit-test-result-action@v1.7
         if: always() # guarantees that this action always runs, even if earlier steps fail

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -22,7 +22,7 @@ jobs:
             --tag go-build-env .
           docker build \
             --tag keep-client . 
-      - name: Create and enter test results directory
+      - name: Create test results directory
         run: |
           mkdir -p $GITHUB_WORKSPACE/test-results/
       - name: Run Go tests

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -24,7 +24,7 @@ jobs:
             --tag keep-client . 
       - name: Create test results directory
         run: |
-          mkdir -p $GITHUB_WORKSPACE/test-results/
+          mkdir test-results
       - name: Run Go tests
         run: |
           docker run \
@@ -32,7 +32,7 @@ jobs:
             --workdir /go/src/github.com/keep-network/keep-core \
             go-build-env \
             gotestsum --junitfile /mnt/test-results/unit-tests.xml
-      - name: Publish Unit Test results
+      - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v1.7
         if: always() # guarantees that this action always runs, even if earlier steps fail
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -40,4 +40,3 @@ jobs:
           files:  ./test-results/unit-tests.xml
           check_name: Go Test Results # name under which test results will be presented in GitHub (optional)
           comment_on_pr: false # turns off commenting on Pull Requests
-          # temporary comment

--- a/pkg/beacon/beacon_test.go
+++ b/pkg/beacon/beacon_test.go
@@ -17,6 +17,7 @@ const (
 )
 
 func TestConfirmRelayRequestOnFirstAttempt(t *testing.T) {
+	t.Fatalf("TEST ERROR")
 	expectedRequestStartBlock := 1888
 	onConfirmedExecuted := false
 	onConfirmed := func() {

--- a/pkg/beacon/beacon_test.go
+++ b/pkg/beacon/beacon_test.go
@@ -17,7 +17,6 @@ const (
 )
 
 func TestConfirmRelayRequestOnFirstAttempt(t *testing.T) {
-	t.Fatalf("TEST ERROR")
 	expectedRequestStartBlock := 1888
 	onConfirmedExecuted := false
 	onConfirmed := func() {


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvment and make
the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions. This commit creates a
GitHub Action workfow for building and testing Go client.