### PR TITLE
Flatten the `npm link` commands into one line

### DIFF
--- a/scripts/start_dashboard.sh
+++ b/scripts/start_dashboard.sh
@@ -88,9 +88,7 @@ ln -s build/contracts artifacts
 npm link
 
 cd $DASHBOARD_DIR_PATH
-npm link @keep-network/keep-core
-npm link @keep-network/keep-ecdsa
-npm link @keep-network/tbtc
+npm link @keep-network/keep-core @keep-network/keep-ecdsa @keep-network/tbtc
 
 # printf "${LOG_START}Starting dashboard...${LOG_END}"
 # npm start


### PR DESCRIPTION
Calling `npm link` multiple times in one directory, for whatever reason,
unlinks all links and then only links the executed command. So:

```
npm link foo
npm link bar
```

will link foo, unlink `foo`, and then link `bar`. This leaves you with only
`bar` linked. To link both, we flatten the command:

```
npm link foo bar
```

tagging @Shadowfiend for review since he also reviewed the nearly-identical https://github.com/keep-network/local-setup/pull/59