### PR TITLE
Incorporate the `ethlike` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85
+	github.com/keep-network/keep-common v1.3.1-0.20210217111137-6949bf58ebd8
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.3.1-0.20210208155836-46d5a83c9997
+	github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe
+	github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6
+	github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85 h1:lQAxWVvkB2tCDP7cl5xo7BDHFJJbU0wwgLuceiTjzKs=
-github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210217111137-6949bf58ebd8 h1:M+Y3v63yyVDef2CrZbCe4m1QbWg4N6XuI/qwnSTbdsc=
+github.com/keep-network/keep-common v1.3.1-0.20210217111137-6949bf58ebd8/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe h1:j5wD0t4SRdy23JxwssBVy7IKf2MGWENS02kkU33Z5dc=
-github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6 h1:dVAaGCTUVdKEwna+lh5rocAHENYLlcnOp/9NleMH2FQ=
+github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.3.1-0.20210208155836-46d5a83c9997 h1:f23+tZaz0vBwYkSoWo2SjxqF+UTROeOrtAMvNqeT/m4=
-github.com/keep-network/keep-common v1.3.1-0.20210208155836-46d5a83c9997/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe h1:j5wD0t4SRdy23JxwssBVy7IKf2MGWENS02kkU33Z5dc=
+github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6 h1:dVAaGCTUVdKEwna+lh5rocAHENYLlcnOp/9NleMH2FQ=
-github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85 h1:lQAxWVvkB2tCDP7cl5xo7BDHFJJbU0wwgLuceiTjzKs=
+github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/chain/gen/cmd/KeepRandomBeaconService.go
+++ b/pkg/chain/gen/cmd/KeepRandomBeaconService.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"github.com/keep-network/keep-common/pkg/cmd"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/gen/contract"
@@ -53,6 +53,27 @@ func init() {
 		Usage:       `Provides access to the KeepRandomBeaconService contract.`,
 		Description: keepRandomBeaconServiceDescription,
 		Subcommands: []cli.Command{{
+			Name:      "entry-fee-estimate",
+			Usage:     "Calls the constant method entryFeeEstimate on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[callbackGas] ",
+			Action:    krbsEntryFeeEstimate,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "select-operator-contract",
+			Usage:     "Calls the constant method selectOperatorContract on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[seed] ",
+			Action:    krbsSelectOperatorContract,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "dkg-fee-pool",
+			Usage:     "Calls the constant method dkgFeePool on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsDkgFeePool,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
+		}, {
 			Name:      "base-callback-gas",
 			Usage:     "Calls the constant method baseCallbackGas on the KeepRandomBeaconService contract.",
 			ArgsUsage: "",
@@ -60,11 +81,11 @@ func init() {
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "callback-surplus-recipient",
-			Usage:     "Calls the constant method callbackSurplusRecipient on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[requestId] ",
-			Action:    krbsCallbackSurplusRecipient,
-			Before:    cmd.ArgCountChecker(1),
+			Name:      "dkg-contribution-margin",
+			Usage:     "Calls the constant method dkgContributionMargin on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsDkgContributionMargin,
+			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "entry-fee-breakdown",
@@ -95,31 +116,10 @@ func init() {
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "dkg-contribution-margin",
-			Usage:     "Calls the constant method dkgContributionMargin on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsDkgContributionMargin,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "dkg-fee-pool",
-			Usage:     "Calls the constant method dkgFeePool on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsDkgFeePool,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "entry-fee-estimate",
-			Usage:     "Calls the constant method entryFeeEstimate on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[callbackGas] ",
-			Action:    krbsEntryFeeEstimate,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "select-operator-contract",
-			Usage:     "Calls the constant method selectOperatorContract on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[seed] ",
-			Action:    krbsSelectOperatorContract,
+			Name:      "callback-surplus-recipient",
+			Usage:     "Calls the constant method callbackSurplusRecipient on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[requestId] ",
+			Action:    krbsCallbackSurplusRecipient,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -130,12 +130,12 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "add-operator-contract",
-			Usage:     "Calls the method addOperatorContract on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[operatorContract] ",
-			Action:    krbsAddOperatorContract,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
+			Name:      "request-relay-entry0",
+			Usage:     "Calls the payable method requestRelayEntry0 on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[callbackContract] [callbackGas] ",
+			Action:    krbsRequestRelayEntry0,
+			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(2))),
+			Flags:     cmd.PayableFlags,
 		}, {
 			Name:      "entry-created",
 			Usage:     "Calls the method entryCreated on the KeepRandomBeaconService contract.",
@@ -151,17 +151,17 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "request-relay-entry0",
-			Usage:     "Calls the payable method requestRelayEntry0 on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[callbackContract] [callbackGas] ",
-			Action:    krbsRequestRelayEntry0,
-			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.PayableFlags,
-		}, {
 			Name:      "fund-dkg-fee-pool",
 			Usage:     "Calls the payable method fundDkgFeePool on the KeepRandomBeaconService contract.",
 			ArgsUsage: "",
 			Action:    krbsFundDkgFeePool,
+			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
+			Flags:     cmd.PayableFlags,
+		}, {
+			Name:      "fund-request-subsidy-fee-pool",
+			Usage:     "Calls the payable method fundRequestSubsidyFeePool on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsFundRequestSubsidyFeePool,
 			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.PayableFlags,
 		}, {
@@ -172,24 +172,100 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "fund-request-subsidy-fee-pool",
-			Usage:     "Calls the payable method fundRequestSubsidyFeePool on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsFundRequestSubsidyFeePool,
-			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
-			Flags:     cmd.PayableFlags,
-		}, {
 			Name:      "request-relay-entry",
 			Usage:     "Calls the payable method requestRelayEntry on the KeepRandomBeaconService contract.",
 			ArgsUsage: "",
 			Action:    krbsRequestRelayEntry,
 			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.PayableFlags,
+		}, {
+			Name:      "add-operator-contract",
+			Usage:     "Calls the method addOperatorContract on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[operatorContract] ",
+			Action:    krbsAddOperatorContract,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
 		}},
 	})
 }
 
 /// ------------------- Const methods -------------------
+
+func krbsEntryFeeEstimate(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+	callbackGas, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.EntryFeeEstimateAtBlock(
+		callbackGas,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func krbsSelectOperatorContract(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+	seed, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter seed, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.SelectOperatorContractAtBlock(
+		seed,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func krbsDkgFeePool(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.DkgFeePoolAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
 
 func krbsBaseCallbackGas(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
@@ -211,21 +287,13 @@ func krbsBaseCallbackGas(c *cli.Context) error {
 	return nil
 }
 
-func krbsCallbackSurplusRecipient(c *cli.Context) error {
+func krbsDkgContributionMargin(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
 		return err
 	}
-	requestId, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter requestId, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
 
-	result, err := contract.CallbackSurplusRecipientAtBlock(
-		requestId,
+	result, err := contract.DkgContributionMarginAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -319,89 +387,21 @@ func krbsVersion(c *cli.Context) error {
 	return nil
 }
 
-func krbsDkgContributionMargin(c *cli.Context) error {
+func krbsCallbackSurplusRecipient(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
 		return err
 	}
-
-	result, err := contract.DkgContributionMarginAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func krbsDkgFeePool(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.DkgFeePoolAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func krbsEntryFeeEstimate(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-	callbackGas, err := hexutil.DecodeBig(c.Args()[0])
+	requestId, err := hexutil.DecodeBig(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
+			"couldn't parse parameter requestId, a uint256, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.EntryFeeEstimateAtBlock(
-		callbackGas,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func krbsSelectOperatorContract(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-	seed, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter seed, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.SelectOperatorContractAtBlock(
-		seed,
+	result, err := contract.CallbackSurplusRecipientAtBlock(
+		requestId,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -471,29 +471,39 @@ func krbsInitialize(c *cli.Context) error {
 	return nil
 }
 
-func krbsAddOperatorContract(c *cli.Context) error {
+func krbsRequestRelayEntry0(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
 		return err
 	}
 
-	operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	callbackContract, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			"couldn't parse parameter callbackContract, a address, from passed value %v",
 			c.Args()[0],
+		)
+	}
+
+	callbackGas, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
+			c.Args()[1],
 		)
 	}
 
 	var (
 		transaction *types.Transaction
+		result      *big.Int
 	)
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.AddOperatorContract(
-			operatorContract,
-		)
+		transaction, err = contract.RequestRelayEntry0(
+			callbackContract,
+			callbackGas,
+			cmd.ValueFlagValue.Uint)
 		if err != nil {
 			return err
 		}
@@ -501,15 +511,16 @@ func krbsAddOperatorContract(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallAddOperatorContract(
-			operatorContract,
-			cmd.BlockFlagValue.Uint,
+		result, err = contract.CallRequestRelayEntry0(
+			callbackContract,
+			callbackGas,
+			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
 			return err
 		}
 
-		cmd.PrintOutput(nil)
+		cmd.PrintOutput(result)
 	}
 
 	return nil
@@ -633,61 +644,6 @@ func krbsExecuteCallback(c *cli.Context) error {
 	return nil
 }
 
-func krbsRequestRelayEntry0(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	callbackContract, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter callbackContract, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	callbackGas, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-		result      *big.Int
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RequestRelayEntry0(
-			callbackContract,
-			callbackGas,
-			cmd.ValueFlagValue.Uint)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		result, err = contract.CallRequestRelayEntry0(
-			callbackContract,
-			callbackGas,
-			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(result)
-	}
-
-	return nil
-}
-
 func krbsFundDkgFeePool(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
@@ -710,6 +666,40 @@ func krbsFundDkgFeePool(c *cli.Context) error {
 	} else {
 		// Do a call.
 		err = contract.CallFundDkgFeePool(
+			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func krbsFundRequestSubsidyFeePool(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.FundRequestSubsidyFeePool(
+			cmd.ValueFlagValue.Uint)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallFundRequestSubsidyFeePool(
 			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -766,40 +756,6 @@ func krbsRemoveOperatorContract(c *cli.Context) error {
 	return nil
 }
 
-func krbsFundRequestSubsidyFeePool(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.FundRequestSubsidyFeePool(
-			cmd.ValueFlagValue.Uint)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallFundRequestSubsidyFeePool(
-			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
 func krbsRequestRelayEntry(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
@@ -830,6 +786,50 @@ func krbsRequestRelayEntry(c *cli.Context) error {
 		}
 
 		cmd.PrintOutput(result)
+	}
+
+	return nil
+}
+
+func krbsAddOperatorContract(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.AddOperatorContract(
+			operatorContract,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallAddOperatorContract(
+			operatorContract,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
 	}
 
 	return nil
@@ -869,9 +869,15 @@ func initializeKeepRandomBeaconService(c *cli.Context) (*contract.KeepRandomBeac
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
-	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
+	miningWaiter := ethlike.NewMiningWaiter(
+		ethutil.NewTransactionSourceAdapter(client),
+		checkInterval,
+		maxGasPrice,
+	)
 
-	blockCounter, err := blockcounter.CreateBlockCounter(client)
+	blockCounter, err := ethlike.CreateBlockCounter(
+		ethutil.NewBlockSourceAdapter(client),
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create Ethereum blockcounter: [%v]",
@@ -885,7 +891,10 @@ func initializeKeepRandomBeaconService(c *cli.Context) (*contract.KeepRandomBeac
 		address,
 		key,
 		client,
-		ethutil.NewNonceManager(key.Address, client),
+		ethlike.NewNonceManager(
+			key.Address.Hex(),
+			ethutil.NewNonceSourceAdapter(client),
+		),
 		miningWaiter,
 		blockCounter,
 		&sync.Mutex{},

--- a/pkg/chain/gen/cmd/KeepRandomBeaconService.go
+++ b/pkg/chain/gen/cmd/KeepRandomBeaconService.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
-	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"github.com/keep-network/keep-common/pkg/cmd"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/gen/contract"
@@ -53,34 +52,6 @@ func init() {
 		Usage:       `Provides access to the KeepRandomBeaconService contract.`,
 		Description: keepRandomBeaconServiceDescription,
 		Subcommands: []cli.Command{{
-			Name:      "entry-fee-estimate",
-			Usage:     "Calls the constant method entryFeeEstimate on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[callbackGas] ",
-			Action:    krbsEntryFeeEstimate,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "select-operator-contract",
-			Usage:     "Calls the constant method selectOperatorContract on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[seed] ",
-			Action:    krbsSelectOperatorContract,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "dkg-fee-pool",
-			Usage:     "Calls the constant method dkgFeePool on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsDkgFeePool,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "base-callback-gas",
-			Usage:     "Calls the constant method baseCallbackGas on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsBaseCallbackGas,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
 			Name:      "dkg-contribution-margin",
 			Usage:     "Calls the constant method dkgContributionMargin on the KeepRandomBeaconService contract.",
 			ArgsUsage: "",
@@ -95,10 +66,31 @@ func init() {
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "initialized",
-			Usage:     "Calls the constant method initialized on the KeepRandomBeaconService contract.",
+			Name:      "select-operator-contract",
+			Usage:     "Calls the constant method selectOperatorContract on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[seed] ",
+			Action:    krbsSelectOperatorContract,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "callback-surplus-recipient",
+			Usage:     "Calls the constant method callbackSurplusRecipient on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[requestId] ",
+			Action:    krbsCallbackSurplusRecipient,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "base-callback-gas",
+			Usage:     "Calls the constant method baseCallbackGas on the KeepRandomBeaconService contract.",
 			ArgsUsage: "",
-			Action:    krbsInitialized,
+			Action:    krbsBaseCallbackGas,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "dkg-fee-pool",
+			Usage:     "Calls the constant method dkgFeePool on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsDkgFeePool,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -116,26 +108,19 @@ func init() {
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "callback-surplus-recipient",
-			Usage:     "Calls the constant method callbackSurplusRecipient on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[requestId] ",
-			Action:    krbsCallbackSurplusRecipient,
+			Name:      "entry-fee-estimate",
+			Usage:     "Calls the constant method entryFeeEstimate on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[callbackGas] ",
+			Action:    krbsEntryFeeEstimate,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "initialize",
-			Usage:     "Calls the method initialize on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[dkgContributionMargin] [registry] ",
-			Action:    krbsInitialize,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "request-relay-entry0",
-			Usage:     "Calls the payable method requestRelayEntry0 on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[callbackContract] [callbackGas] ",
-			Action:    krbsRequestRelayEntry0,
-			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.PayableFlags,
+			Name:      "initialized",
+			Usage:     "Calls the constant method initialized on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsInitialized,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "entry-created",
 			Usage:     "Calls the method entryCreated on the KeepRandomBeaconService contract.",
@@ -151,6 +136,13 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
+			Name:      "request-relay-entry",
+			Usage:     "Calls the payable method requestRelayEntry on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsRequestRelayEntry,
+			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
+			Flags:     cmd.PayableFlags,
+		}, {
 			Name:      "fund-dkg-fee-pool",
 			Usage:     "Calls the payable method fundDkgFeePool on the KeepRandomBeaconService contract.",
 			ArgsUsage: "",
@@ -158,25 +150,11 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.PayableFlags,
 		}, {
-			Name:      "fund-request-subsidy-fee-pool",
-			Usage:     "Calls the payable method fundRequestSubsidyFeePool on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsFundRequestSubsidyFeePool,
-			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
-			Flags:     cmd.PayableFlags,
-		}, {
-			Name:      "remove-operator-contract",
-			Usage:     "Calls the method removeOperatorContract on the KeepRandomBeaconService contract.",
-			ArgsUsage: "[operatorContract] ",
-			Action:    krbsRemoveOperatorContract,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "request-relay-entry",
-			Usage:     "Calls the payable method requestRelayEntry on the KeepRandomBeaconService contract.",
-			ArgsUsage: "",
-			Action:    krbsRequestRelayEntry,
-			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
+			Name:      "request-relay-entry0",
+			Usage:     "Calls the payable method requestRelayEntry0 on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[callbackContract] [callbackGas] ",
+			Action:    krbsRequestRelayEntry0,
+			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.PayableFlags,
 		}, {
 			Name:      "add-operator-contract",
@@ -185,107 +163,32 @@ func init() {
 			Action:    krbsAddOperatorContract,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "fund-request-subsidy-fee-pool",
+			Usage:     "Calls the payable method fundRequestSubsidyFeePool on the KeepRandomBeaconService contract.",
+			ArgsUsage: "",
+			Action:    krbsFundRequestSubsidyFeePool,
+			Before:    cli.BeforeFunc(cmd.PayableArgsChecker.AndThen(cmd.ArgCountChecker(0))),
+			Flags:     cmd.PayableFlags,
+		}, {
+			Name:      "initialize",
+			Usage:     "Calls the method initialize on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[dkgContributionMargin] [registry] ",
+			Action:    krbsInitialize,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "remove-operator-contract",
+			Usage:     "Calls the method removeOperatorContract on the KeepRandomBeaconService contract.",
+			ArgsUsage: "[operatorContract] ",
+			Action:    krbsRemoveOperatorContract,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
 		}},
 	})
 }
 
 /// ------------------- Const methods -------------------
-
-func krbsEntryFeeEstimate(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-	callbackGas, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.EntryFeeEstimateAtBlock(
-		callbackGas,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func krbsSelectOperatorContract(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-	seed, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter seed, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.SelectOperatorContractAtBlock(
-		seed,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func krbsDkgFeePool(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.DkgFeePoolAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func krbsBaseCallbackGas(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.BaseCallbackGasAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
 
 func krbsDkgContributionMargin(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
@@ -327,13 +230,89 @@ func krbsEntryFeeBreakdown(c *cli.Context) error {
 	return nil
 }
 
-func krbsInitialized(c *cli.Context) error {
+func krbsSelectOperatorContract(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+	seed, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter seed, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.SelectOperatorContractAtBlock(
+		seed,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func krbsCallbackSurplusRecipient(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+	requestId, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter requestId, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.CallbackSurplusRecipientAtBlock(
+		requestId,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func krbsBaseCallbackGas(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
 		return err
 	}
 
-	result, err := contract.InitializedAtBlock(
+	result, err := contract.BaseCallbackGasAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func krbsDkgFeePool(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.DkgFeePoolAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -387,21 +366,41 @@ func krbsVersion(c *cli.Context) error {
 	return nil
 }
 
-func krbsCallbackSurplusRecipient(c *cli.Context) error {
+func krbsEntryFeeEstimate(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
 		return err
 	}
-	requestId, err := hexutil.DecodeBig(c.Args()[0])
+	callbackGas, err := hexutil.DecodeBig(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter requestId, a uint256, from passed value %v",
+			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.CallbackSurplusRecipientAtBlock(
-		requestId,
+	result, err := contract.EntryFeeEstimateAtBlock(
+		callbackGas,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func krbsInitialized(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.InitializedAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -416,115 +415,6 @@ func krbsCallbackSurplusRecipient(c *cli.Context) error {
 }
 
 /// ------------------- Non-const methods -------------------
-
-func krbsInitialize(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	dkgContributionMargin, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter dkgContributionMargin, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	registry, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter registry, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Initialize(
-			dkgContributionMargin,
-			registry,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallInitialize(
-			dkgContributionMargin,
-			registry,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func krbsRequestRelayEntry0(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	callbackContract, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter callbackContract, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	callbackGas, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-		result      *big.Int
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RequestRelayEntry0(
-			callbackContract,
-			callbackGas,
-			cmd.ValueFlagValue.Uint)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		result, err = contract.CallRequestRelayEntry0(
-			callbackContract,
-			callbackGas,
-			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(result)
-	}
-
-	return nil
-}
 
 func krbsEntryCreated(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
@@ -644,6 +534,41 @@ func krbsExecuteCallback(c *cli.Context) error {
 	return nil
 }
 
+func krbsRequestRelayEntry(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		transaction *types.Transaction
+		result      *big.Int
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.RequestRelayEntry(
+			cmd.ValueFlagValue.Uint)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		result, err = contract.CallRequestRelayEntry(
+			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(result)
+	}
+
+	return nil
+}
+
 func krbsFundDkgFeePool(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
@@ -678,88 +603,26 @@ func krbsFundDkgFeePool(c *cli.Context) error {
 	return nil
 }
 
-func krbsFundRequestSubsidyFeePool(c *cli.Context) error {
+func krbsRequestRelayEntry0(c *cli.Context) error {
 	contract, err := initializeKeepRandomBeaconService(c)
 	if err != nil {
 		return err
 	}
 
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.FundRequestSubsidyFeePool(
-			cmd.ValueFlagValue.Uint)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallFundRequestSubsidyFeePool(
-			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func krbsRemoveOperatorContract(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
-	if err != nil {
-		return err
-	}
-
-	operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	callbackContract, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			"couldn't parse parameter callbackContract, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RemoveOperatorContract(
-			operatorContract,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallRemoveOperatorContract(
-			operatorContract,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func krbsRequestRelayEntry(c *cli.Context) error {
-	contract, err := initializeKeepRandomBeaconService(c)
+	callbackGas, err := hexutil.DecodeBig(c.Args()[1])
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"couldn't parse parameter callbackGas, a uint256, from passed value %v",
+			c.Args()[1],
+		)
 	}
 
 	var (
@@ -769,7 +632,9 @@ func krbsRequestRelayEntry(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RequestRelayEntry(
+		transaction, err = contract.RequestRelayEntry0(
+			callbackContract,
+			callbackGas,
 			cmd.ValueFlagValue.Uint)
 		if err != nil {
 			return err
@@ -778,7 +643,9 @@ func krbsRequestRelayEntry(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		result, err = contract.CallRequestRelayEntry(
+		result, err = contract.CallRequestRelayEntry0(
+			callbackContract,
+			callbackGas,
 			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -835,6 +702,138 @@ func krbsAddOperatorContract(c *cli.Context) error {
 	return nil
 }
 
+func krbsFundRequestSubsidyFeePool(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.FundRequestSubsidyFeePool(
+			cmd.ValueFlagValue.Uint)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallFundRequestSubsidyFeePool(
+			cmd.ValueFlagValue.Uint, cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func krbsInitialize(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	dkgContributionMargin, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter dkgContributionMargin, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	registry, err := ethutil.AddressFromHex(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter registry, a address, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.Initialize(
+			dkgContributionMargin,
+			registry,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallInitialize(
+			dkgContributionMargin,
+			registry,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func krbsRemoveOperatorContract(c *cli.Context) error {
+	contract, err := initializeKeepRandomBeaconService(c)
+	if err != nil {
+		return err
+	}
+
+	operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.RemoveOperatorContract(
+			operatorContract,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallRemoveOperatorContract(
+			operatorContract,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
 /// ------------------- Initialization -------------------
 
 func initializeKeepRandomBeaconService(c *cli.Context) (*contract.KeepRandomBeaconService, error) {
@@ -869,18 +868,16 @@ func initializeKeepRandomBeaconService(c *cli.Context) (*contract.KeepRandomBeac
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
-	miningWaiter := ethlike.NewMiningWaiter(
-		ethutil.NewTransactionSourceAdapter(client),
+	miningWaiter := ethutil.NewMiningWaiter(
+		client,
 		checkInterval,
 		maxGasPrice,
 	)
 
-	blockCounter, err := ethlike.CreateBlockCounter(
-		ethutil.NewBlockSourceAdapter(client),
-	)
+	blockCounter, err := ethutil.NewBlockCounter(client)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to create Ethereum blockcounter: [%v]",
+			"failed to create block counter: [%v]",
 			err,
 		)
 	}
@@ -891,10 +888,7 @@ func initializeKeepRandomBeaconService(c *cli.Context) (*contract.KeepRandomBeac
 		address,
 		key,
 		client,
-		ethlike.NewNonceManager(
-			key.Address.Hex(),
-			ethutil.NewNonceSourceAdapter(client),
-		),
+		ethutil.NewNonceManager(client, key.Address),
 		miningWaiter,
 		blockCounter,
 		&sync.Mutex{},

--- a/pkg/chain/gen/cmd/TokenGrant.go
+++ b/pkg/chain/gen/cmd/TokenGrant.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"github.com/keep-network/keep-common/pkg/cmd"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/gen/contract"
@@ -52,46 +52,11 @@ func init() {
 		Usage:       `Provides access to the TokenGrant contract.`,
 		Description: tokenGrantDescription,
 		Subcommands: []cli.Command{{
-			Name:      "token",
-			Usage:     "Calls the constant method token on the TokenGrant contract.",
-			ArgsUsage: "",
-			Action:    tgToken,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "grants",
-			Usage:     "Calls the constant method grants on the TokenGrant contract.",
-			ArgsUsage: "[arg0] ",
-			Action:    tgGrants,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "stake-balance-of",
-			Usage:     "Calls the constant method stakeBalanceOf on the TokenGrant contract.",
-			ArgsUsage: "[_address] ",
-			Action:    tgStakeBalanceOf,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "get-grants",
-			Usage:     "Calls the constant method getGrants on the TokenGrant contract.",
-			ArgsUsage: "[_granteeOrGrantManager] ",
-			Action:    tgGetGrants,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
 			Name:      "balances",
 			Usage:     "Calls the constant method balances on the TokenGrant contract.",
 			ArgsUsage: "[arg0] ",
 			Action:    tgBalances,
 			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "grantees-to-operators",
-			Usage:     "Calls the constant method granteesToOperators on the TokenGrant contract.",
-			ArgsUsage: "[arg0] [arg1] ",
-			Action:    tgGranteesToOperators,
-			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "withdrawable",
@@ -108,31 +73,10 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "grant-stakes",
-			Usage:     "Calls the constant method grantStakes on the TokenGrant contract.",
-			ArgsUsage: "[arg0] ",
-			Action:    tgGrantStakes,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "grant-indices",
-			Usage:     "Calls the constant method grantIndices on the TokenGrant contract.",
-			ArgsUsage: "[arg0] [arg1] ",
-			Action:    tgGrantIndices,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "balance-of",
-			Usage:     "Calls the constant method balanceOf on the TokenGrant contract.",
-			ArgsUsage: "[_owner] ",
-			Action:    tgBalanceOf,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "get-grant-unlocking-schedule",
-			Usage:     "Calls the constant method getGrantUnlockingSchedule on the TokenGrant contract.",
+			Name:      "unlocked-amount",
+			Usage:     "Calls the constant method unlockedAmount on the TokenGrant contract.",
 			ArgsUsage: "[_id] ",
-			Action:    tgGetGrantUnlockingSchedule,
+			Action:    tgUnlockedAmount,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -143,17 +87,17 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "num-grants",
-			Usage:     "Calls the constant method numGrants on the TokenGrant contract.",
+			Name:      "token",
+			Usage:     "Calls the constant method token on the TokenGrant contract.",
 			ArgsUsage: "",
-			Action:    tgNumGrants,
+			Action:    tgToken,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "unlocked-amount",
-			Usage:     "Calls the constant method unlockedAmount on the TokenGrant contract.",
-			ArgsUsage: "[_id] ",
-			Action:    tgUnlockedAmount,
+			Name:      "balance-of",
+			Usage:     "Calls the constant method balanceOf on the TokenGrant contract.",
+			ArgsUsage: "[_owner] ",
+			Action:    tgBalanceOf,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -164,6 +108,13 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
+			Name:      "stake-balance-of",
+			Usage:     "Calls the constant method stakeBalanceOf on the TokenGrant contract.",
+			ArgsUsage: "[_address] ",
+			Action:    tgStakeBalanceOf,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
 			Name:      "get-grantee-operators",
 			Usage:     "Calls the constant method getGranteeOperators on the TokenGrant contract.",
 			ArgsUsage: "[grantee] ",
@@ -171,10 +122,73 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "authorize-staking-contract",
-			Usage:     "Calls the method authorizeStakingContract on the TokenGrant contract.",
-			ArgsUsage: "[_stakingContract] ",
-			Action:    tgAuthorizeStakingContract,
+			Name:      "grant-indices",
+			Usage:     "Calls the constant method grantIndices on the TokenGrant contract.",
+			ArgsUsage: "[arg0] [arg1] ",
+			Action:    tgGrantIndices,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "num-grants",
+			Usage:     "Calls the constant method numGrants on the TokenGrant contract.",
+			ArgsUsage: "",
+			Action:    tgNumGrants,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "grantees-to-operators",
+			Usage:     "Calls the constant method granteesToOperators on the TokenGrant contract.",
+			ArgsUsage: "[arg0] [arg1] ",
+			Action:    tgGranteesToOperators,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "grants",
+			Usage:     "Calls the constant method grants on the TokenGrant contract.",
+			ArgsUsage: "[arg0] ",
+			Action:    tgGrants,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "get-grant-unlocking-schedule",
+			Usage:     "Calls the constant method getGrantUnlockingSchedule on the TokenGrant contract.",
+			ArgsUsage: "[_id] ",
+			Action:    tgGetGrantUnlockingSchedule,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "get-grants",
+			Usage:     "Calls the constant method getGrants on the TokenGrant contract.",
+			ArgsUsage: "[_granteeOrGrantManager] ",
+			Action:    tgGetGrants,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "grant-stakes",
+			Usage:     "Calls the constant method grantStakes on the TokenGrant contract.",
+			ArgsUsage: "[arg0] ",
+			Action:    tgGrantStakes,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "receive-approval",
+			Usage:     "Calls the method receiveApproval on the TokenGrant contract.",
+			ArgsUsage: "[_from] [_amount] [_token] [_extraData] ",
+			Action:    tgReceiveApproval,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "revoke",
+			Usage:     "Calls the method revoke on the TokenGrant contract.",
+			ArgsUsage: "[_id] ",
+			Action:    tgRevoke,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "undelegate",
+			Usage:     "Calls the method undelegate on the TokenGrant contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tgUndelegate,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -185,34 +199,6 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "stake",
-			Usage:     "Calls the method stake on the TokenGrant contract.",
-			ArgsUsage: "[_id] [_stakingContract] [_amount] [_extraData] ",
-			Action:    tgStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "cancel-stake",
-			Usage:     "Calls the method cancelStake on the TokenGrant contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tgCancelStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "receive-approval",
-			Usage:     "Calls the method receiveApproval on the TokenGrant contract.",
-			ArgsUsage: "[_from] [_amount] [_token] [_extraData] ",
-			Action:    tgReceiveApproval,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "undelegate",
-			Usage:     "Calls the method undelegate on the TokenGrant contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tgUndelegate,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
-		}, {
 			Name:      "recover-stake",
 			Usage:     "Calls the method recoverStake on the TokenGrant contract.",
 			ArgsUsage: "[_operator] ",
@@ -220,17 +206,31 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "withdraw",
-			Usage:     "Calls the method withdraw on the TokenGrant contract.",
-			ArgsUsage: "[_id] ",
-			Action:    tgWithdraw,
+			Name:      "authorize-staking-contract",
+			Usage:     "Calls the method authorizeStakingContract on the TokenGrant contract.",
+			ArgsUsage: "[_stakingContract] ",
+			Action:    tgAuthorizeStakingContract,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "revoke",
-			Usage:     "Calls the method revoke on the TokenGrant contract.",
+			Name:      "stake",
+			Usage:     "Calls the method stake on the TokenGrant contract.",
+			ArgsUsage: "[_id] [_stakingContract] [_amount] [_extraData] ",
+			Action:    tgStake,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "withdraw-revoked",
+			Usage:     "Calls the method withdrawRevoked on the TokenGrant contract.",
 			ArgsUsage: "[_id] ",
-			Action:    tgRevoke,
+			Action:    tgWithdrawRevoked,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "cancel-stake",
+			Usage:     "Calls the method cancelStake on the TokenGrant contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tgCancelStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -241,10 +241,10 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "withdraw-revoked",
-			Usage:     "Calls the method withdrawRevoked on the TokenGrant contract.",
+			Name:      "withdraw",
+			Usage:     "Calls the method withdraw on the TokenGrant contract.",
 			ArgsUsage: "[_id] ",
-			Action:    tgWithdrawRevoked,
+			Action:    tgWithdraw,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}},
@@ -252,110 +252,6 @@ func init() {
 }
 
 /// ------------------- Const methods -------------------
-
-func tgToken(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.TokenAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGrants(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	arg0, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg0, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GrantsAtBlock(
-		arg0,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgStakeBalanceOf(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	_address, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _address, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.StakeBalanceOfAtBlock(
-		_address,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGetGrants(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	_granteeOrGrantManager, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _granteeOrGrantManager, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetGrantsAtBlock(
-		_granteeOrGrantManager,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
 
 func tgBalances(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
@@ -372,43 +268,6 @@ func tgBalances(c *cli.Context) error {
 
 	result, err := contract.BalancesAtBlock(
 		arg0,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGranteesToOperators(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	arg0, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg0, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	arg1, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg1, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	result, err := contract.GranteesToOperatorsAtBlock(
-		arg0,
-		arg1,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -478,21 +337,181 @@ func tgAvailableToStake(c *cli.Context) error {
 	return nil
 }
 
-func tgGrantStakes(c *cli.Context) error {
+func tgUnlockedAmount(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
-	arg0, err := ethutil.AddressFromHex(c.Args()[0])
+	_id, err := hexutil.DecodeBig(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter arg0, a address, from passed value %v",
+			"couldn't parse parameter _id, a uint256, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.GrantStakesAtBlock(
-		arg0,
+	result, err := contract.UnlockedAmountAtBlock(
+		_id,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGetGrant(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GetGrantAtBlock(
+		_id,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgToken(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.TokenAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgBalanceOf(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_owner, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _owner, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.BalanceOfAtBlock(
+		_owner,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGetGrantStakeDetails(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GetGrantStakeDetailsAtBlock(
+		operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgStakeBalanceOf(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_address, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _address, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.StakeBalanceOfAtBlock(
+		_address,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGetGranteeOperators(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	grantee, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter grantee, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GetGranteeOperatorsAtBlock(
+		grantee,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -543,21 +562,78 @@ func tgGrantIndices(c *cli.Context) error {
 	return nil
 }
 
-func tgBalanceOf(c *cli.Context) error {
+func tgNumGrants(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
-	_owner, err := ethutil.AddressFromHex(c.Args()[0])
+
+	result, err := contract.NumGrantsAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGranteesToOperators(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	arg0, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _owner, a address, from passed value %v",
+			"couldn't parse parameter arg0, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.BalanceOfAtBlock(
-		_owner,
+	arg1, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg1, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	result, err := contract.GranteesToOperatorsAtBlock(
+		arg0,
+		arg1,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGrants(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	arg0, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg0, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GrantsAtBlock(
+		arg0,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -599,21 +675,21 @@ func tgGetGrantUnlockingSchedule(c *cli.Context) error {
 	return nil
 }
 
-func tgGetGrant(c *cli.Context) error {
+func tgGetGrants(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
-	_id, err := hexutil.DecodeBig(c.Args()[0])
+	_granteeOrGrantManager, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
+			"couldn't parse parameter _granteeOrGrantManager, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.GetGrantAtBlock(
-		_id,
+	result, err := contract.GetGrantsAtBlock(
+		_granteeOrGrantManager,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -627,97 +703,21 @@ func tgGetGrant(c *cli.Context) error {
 	return nil
 }
 
-func tgNumGrants(c *cli.Context) error {
+func tgGrantStakes(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
-
-	result, err := contract.NumGrantsAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgUnlockedAmount(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	_id, err := hexutil.DecodeBig(c.Args()[0])
+	arg0, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
+			"couldn't parse parameter arg0, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.UnlockedAmountAtBlock(
-		_id,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGetGrantStakeDetails(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetGrantStakeDetailsAtBlock(
-		operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGetGranteeOperators(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	grantee, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter grantee, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetGranteeOperatorsAtBlock(
-		grantee,
+	result, err := contract.GrantStakesAtBlock(
+		arg0,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -733,16 +733,90 @@ func tgGetGranteeOperators(c *cli.Context) error {
 
 /// ------------------- Non-const methods -------------------
 
-func tgAuthorizeStakingContract(c *cli.Context) error {
+func tgReceiveApproval(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
 
-	_stakingContract, err := ethutil.AddressFromHex(c.Args()[0])
+	_from, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _stakingContract, a address, from passed value %v",
+			"couldn't parse parameter _from, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	_amount, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _amount, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	_token, err := ethutil.AddressFromHex(c.Args()[2])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _token, a address, from passed value %v",
+			c.Args()[2],
+		)
+	}
+
+	_extraData, err := hexutil.Decode(c.Args()[3])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _extraData, a bytes, from passed value %v",
+			c.Args()[3],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.ReceiveApproval(
+			_from,
+			_amount,
+			_token,
+			_extraData,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallReceiveApproval(
+			_from,
+			_amount,
+			_token,
+			_extraData,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgRevoke(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
 			c.Args()[0],
 		)
 	}
@@ -753,8 +827,8 @@ func tgAuthorizeStakingContract(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.AuthorizeStakingContract(
-			_stakingContract,
+		transaction, err = contract.Revoke(
+			_id,
 		)
 		if err != nil {
 			return err
@@ -763,8 +837,52 @@ func tgAuthorizeStakingContract(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallAuthorizeStakingContract(
-			_stakingContract,
+		err = contract.CallRevoke(
+			_id,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgUndelegate(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.Undelegate(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallUndelegate(
+			_operator,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -809,6 +927,94 @@ func tgCancelRevokedStake(c *cli.Context) error {
 		// Do a call.
 		err = contract.CallCancelRevokedStake(
 			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgRecoverStake(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.RecoverStake(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallRecoverStake(
+			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgAuthorizeStakingContract(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_stakingContract, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _stakingContract, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.AuthorizeStakingContract(
+			_stakingContract,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallAuthorizeStakingContract(
+			_stakingContract,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -895,6 +1101,50 @@ func tgStake(c *cli.Context) error {
 	return nil
 }
 
+func tgWithdrawRevoked(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.WithdrawRevoked(
+			_id,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallWithdrawRevoked(
+			_id,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
 func tgCancelStake(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
@@ -939,81 +1189,7 @@ func tgCancelStake(c *cli.Context) error {
 	return nil
 }
 
-func tgReceiveApproval(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_from, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _from, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	_amount, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _amount, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	_token, err := ethutil.AddressFromHex(c.Args()[2])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _token, a address, from passed value %v",
-			c.Args()[2],
-		)
-	}
-
-	_extraData, err := hexutil.Decode(c.Args()[3])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _extraData, a bytes, from passed value %v",
-			c.Args()[3],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.ReceiveApproval(
-			_from,
-			_amount,
-			_token,
-			_extraData,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallReceiveApproval(
-			_from,
-			_amount,
-			_token,
-			_extraData,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgUndelegate(c *cli.Context) error {
+func tgUndelegateRevoked(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
@@ -1033,7 +1209,7 @@ func tgUndelegate(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Undelegate(
+		transaction, err = contract.UndelegateRevoked(
 			_operator,
 		)
 		if err != nil {
@@ -1043,51 +1219,7 @@ func tgUndelegate(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallUndelegate(
-			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgRecoverStake(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RecoverStake(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallRecoverStake(
+		err = contract.CallUndelegateRevoked(
 			_operator,
 			cmd.BlockFlagValue.Uint,
 		)
@@ -1145,138 +1277,6 @@ func tgWithdraw(c *cli.Context) error {
 	return nil
 }
 
-func tgRevoke(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_id, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Revoke(
-			_id,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallRevoke(
-			_id,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgUndelegateRevoked(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UndelegateRevoked(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUndelegateRevoked(
-			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgWithdrawRevoked(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_id, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.WithdrawRevoked(
-			_id,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallWithdrawRevoked(
-			_id,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
 /// ------------------- Initialization -------------------
 
 func initializeTokenGrant(c *cli.Context) (*contract.TokenGrant, error) {
@@ -1311,9 +1311,15 @@ func initializeTokenGrant(c *cli.Context) (*contract.TokenGrant, error) {
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
-	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
+	miningWaiter := ethlike.NewMiningWaiter(
+		ethutil.NewTransactionSourceAdapter(client),
+		checkInterval,
+		maxGasPrice,
+	)
 
-	blockCounter, err := blockcounter.CreateBlockCounter(client)
+	blockCounter, err := ethlike.CreateBlockCounter(
+		ethutil.NewBlockSourceAdapter(client),
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create Ethereum blockcounter: [%v]",
@@ -1327,7 +1333,10 @@ func initializeTokenGrant(c *cli.Context) (*contract.TokenGrant, error) {
 		address,
 		key,
 		client,
-		ethutil.NewNonceManager(key.Address, client),
+		ethlike.NewNonceManager(
+			key.Address.Hex(),
+			ethutil.NewNonceSourceAdapter(client),
+		),
 		miningWaiter,
 		blockCounter,
 		&sync.Mutex{},

--- a/pkg/chain/gen/cmd/TokenGrant.go
+++ b/pkg/chain/gen/cmd/TokenGrant.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
-	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"github.com/keep-network/keep-common/pkg/cmd"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/gen/contract"
@@ -52,6 +51,69 @@ func init() {
 		Usage:       `Provides access to the TokenGrant contract.`,
 		Description: tokenGrantDescription,
 		Subcommands: []cli.Command{{
+			Name:      "grant-stakes",
+			Usage:     "Calls the constant method grantStakes on the TokenGrant contract.",
+			ArgsUsage: "[arg0] ",
+			Action:    tgGrantStakes,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "unlocked-amount",
+			Usage:     "Calls the constant method unlockedAmount on the TokenGrant contract.",
+			ArgsUsage: "[_id] ",
+			Action:    tgUnlockedAmount,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "get-grant-stake-details",
+			Usage:     "Calls the constant method getGrantStakeDetails on the TokenGrant contract.",
+			ArgsUsage: "[operator] ",
+			Action:    tgGetGrantStakeDetails,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "grantees-to-operators",
+			Usage:     "Calls the constant method granteesToOperators on the TokenGrant contract.",
+			ArgsUsage: "[arg0] [arg1] ",
+			Action:    tgGranteesToOperators,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "get-grants",
+			Usage:     "Calls the constant method getGrants on the TokenGrant contract.",
+			ArgsUsage: "[_granteeOrGrantManager] ",
+			Action:    tgGetGrants,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "grant-indices",
+			Usage:     "Calls the constant method grantIndices on the TokenGrant contract.",
+			ArgsUsage: "[arg0] [arg1] ",
+			Action:    tgGrantIndices,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "grants",
+			Usage:     "Calls the constant method grants on the TokenGrant contract.",
+			ArgsUsage: "[arg0] ",
+			Action:    tgGrants,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "available-to-stake",
+			Usage:     "Calls the constant method availableToStake on the TokenGrant contract.",
+			ArgsUsage: "[_grantId] ",
+			Action:    tgAvailableToStake,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "balance-of",
+			Usage:     "Calls the constant method balanceOf on the TokenGrant contract.",
+			ArgsUsage: "[_owner] ",
+			Action:    tgBalanceOf,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
 			Name:      "balances",
 			Usage:     "Calls the constant method balances on the TokenGrant contract.",
 			ArgsUsage: "[arg0] ",
@@ -66,45 +128,10 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "available-to-stake",
-			Usage:     "Calls the constant method availableToStake on the TokenGrant contract.",
-			ArgsUsage: "[_grantId] ",
-			Action:    tgAvailableToStake,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "unlocked-amount",
-			Usage:     "Calls the constant method unlockedAmount on the TokenGrant contract.",
-			ArgsUsage: "[_id] ",
-			Action:    tgUnlockedAmount,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
 			Name:      "get-grant",
 			Usage:     "Calls the constant method getGrant on the TokenGrant contract.",
 			ArgsUsage: "[_id] ",
 			Action:    tgGetGrant,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "token",
-			Usage:     "Calls the constant method token on the TokenGrant contract.",
-			ArgsUsage: "",
-			Action:    tgToken,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "balance-of",
-			Usage:     "Calls the constant method balanceOf on the TokenGrant contract.",
-			ArgsUsage: "[_owner] ",
-			Action:    tgBalanceOf,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "get-grant-stake-details",
-			Usage:     "Calls the constant method getGrantStakeDetails on the TokenGrant contract.",
-			ArgsUsage: "[operator] ",
-			Action:    tgGetGrantStakeDetails,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -115,39 +142,11 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "get-grantee-operators",
-			Usage:     "Calls the constant method getGranteeOperators on the TokenGrant contract.",
-			ArgsUsage: "[grantee] ",
-			Action:    tgGetGranteeOperators,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "grant-indices",
-			Usage:     "Calls the constant method grantIndices on the TokenGrant contract.",
-			ArgsUsage: "[arg0] [arg1] ",
-			Action:    tgGrantIndices,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "num-grants",
-			Usage:     "Calls the constant method numGrants on the TokenGrant contract.",
+			Name:      "token",
+			Usage:     "Calls the constant method token on the TokenGrant contract.",
 			ArgsUsage: "",
-			Action:    tgNumGrants,
+			Action:    tgToken,
 			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "grantees-to-operators",
-			Usage:     "Calls the constant method granteesToOperators on the TokenGrant contract.",
-			ArgsUsage: "[arg0] [arg1] ",
-			Action:    tgGranteesToOperators,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "grants",
-			Usage:     "Calls the constant method grants on the TokenGrant contract.",
-			ArgsUsage: "[arg0] ",
-			Action:    tgGrants,
-			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "get-grant-unlocking-schedule",
@@ -157,25 +156,25 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "get-grants",
-			Usage:     "Calls the constant method getGrants on the TokenGrant contract.",
-			ArgsUsage: "[_granteeOrGrantManager] ",
-			Action:    tgGetGrants,
+			Name:      "get-grantee-operators",
+			Usage:     "Calls the constant method getGranteeOperators on the TokenGrant contract.",
+			ArgsUsage: "[grantee] ",
+			Action:    tgGetGranteeOperators,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "grant-stakes",
-			Usage:     "Calls the constant method grantStakes on the TokenGrant contract.",
-			ArgsUsage: "[arg0] ",
-			Action:    tgGrantStakes,
-			Before:    cmd.ArgCountChecker(1),
+			Name:      "num-grants",
+			Usage:     "Calls the constant method numGrants on the TokenGrant contract.",
+			ArgsUsage: "",
+			Action:    tgNumGrants,
+			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "receive-approval",
-			Usage:     "Calls the method receiveApproval on the TokenGrant contract.",
-			ArgsUsage: "[_from] [_amount] [_token] [_extraData] ",
-			Action:    tgReceiveApproval,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Name:      "undelegate",
+			Usage:     "Calls the method undelegate on the TokenGrant contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tgUndelegate,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "revoke",
@@ -185,24 +184,17 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "undelegate",
-			Usage:     "Calls the method undelegate on the TokenGrant contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tgUndelegate,
+			Name:      "withdraw",
+			Usage:     "Calls the method withdraw on the TokenGrant contract.",
+			ArgsUsage: "[_id] ",
+			Action:    tgWithdraw,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "cancel-revoked-stake",
-			Usage:     "Calls the method cancelRevokedStake on the TokenGrant contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tgCancelRevokedStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "recover-stake",
-			Usage:     "Calls the method recoverStake on the TokenGrant contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tgRecoverStake,
+			Name:      "withdraw-revoked",
+			Usage:     "Calls the method withdrawRevoked on the TokenGrant contract.",
+			ArgsUsage: "[_id] ",
+			Action:    tgWithdrawRevoked,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -213,24 +205,24 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "stake",
-			Usage:     "Calls the method stake on the TokenGrant contract.",
-			ArgsUsage: "[_id] [_stakingContract] [_amount] [_extraData] ",
-			Action:    tgStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "withdraw-revoked",
-			Usage:     "Calls the method withdrawRevoked on the TokenGrant contract.",
-			ArgsUsage: "[_id] ",
-			Action:    tgWithdrawRevoked,
+			Name:      "cancel-revoked-stake",
+			Usage:     "Calls the method cancelRevokedStake on the TokenGrant contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tgCancelRevokedStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "cancel-stake",
-			Usage:     "Calls the method cancelStake on the TokenGrant contract.",
+			Name:      "receive-approval",
+			Usage:     "Calls the method receiveApproval on the TokenGrant contract.",
+			ArgsUsage: "[_from] [_amount] [_token] [_extraData] ",
+			Action:    tgReceiveApproval,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "recover-stake",
+			Usage:     "Calls the method recoverStake on the TokenGrant contract.",
 			ArgsUsage: "[_operator] ",
-			Action:    tgCancelStake,
+			Action:    tgRecoverStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -241,10 +233,17 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "withdraw",
-			Usage:     "Calls the method withdraw on the TokenGrant contract.",
-			ArgsUsage: "[_id] ",
-			Action:    tgWithdraw,
+			Name:      "stake",
+			Usage:     "Calls the method stake on the TokenGrant contract.",
+			ArgsUsage: "[_id] [_stakingContract] [_amount] [_extraData] ",
+			Action:    tgStake,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "cancel-stake",
+			Usage:     "Calls the method cancelStake on the TokenGrant contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tgCancelStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}},
@@ -252,6 +251,276 @@ func init() {
 }
 
 /// ------------------- Const methods -------------------
+
+func tgGrantStakes(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	arg0, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg0, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GrantStakesAtBlock(
+		arg0,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgUnlockedAmount(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.UnlockedAmountAtBlock(
+		_id,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGetGrantStakeDetails(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GetGrantStakeDetailsAtBlock(
+		operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGranteesToOperators(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	arg0, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg0, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	arg1, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg1, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	result, err := contract.GranteesToOperatorsAtBlock(
+		arg0,
+		arg1,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGetGrants(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_granteeOrGrantManager, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _granteeOrGrantManager, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GetGrantsAtBlock(
+		_granteeOrGrantManager,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGrantIndices(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	arg0, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg0, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	arg1, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg1, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	result, err := contract.GrantIndicesAtBlock(
+		arg0,
+		arg1,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgGrants(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	arg0, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg0, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GrantsAtBlock(
+		arg0,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgAvailableToStake(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_grantId, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _grantId, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.AvailableToStakeAtBlock(
+		_grantId,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tgBalanceOf(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+	_owner, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _owner, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.BalanceOfAtBlock(
+		_owner,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
 
 func tgBalances(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
@@ -309,62 +578,6 @@ func tgWithdrawable(c *cli.Context) error {
 	return nil
 }
 
-func tgAvailableToStake(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	_grantId, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _grantId, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.AvailableToStakeAtBlock(
-		_grantId,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgUnlockedAmount(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	_id, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.UnlockedAmountAtBlock(
-		_id,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
 func tgGetGrant(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
@@ -380,82 +593,6 @@ func tgGetGrant(c *cli.Context) error {
 
 	result, err := contract.GetGrantAtBlock(
 		_id,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgToken(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.TokenAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgBalanceOf(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	_owner, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _owner, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.BalanceOfAtBlock(
-		_owner,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGetGrantStakeDetails(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetGrantStakeDetailsAtBlock(
-		operator,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -497,143 +634,13 @@ func tgStakeBalanceOf(c *cli.Context) error {
 	return nil
 }
 
-func tgGetGranteeOperators(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	grantee, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter grantee, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetGranteeOperatorsAtBlock(
-		grantee,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGrantIndices(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	arg0, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg0, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	arg1, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg1, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	result, err := contract.GrantIndicesAtBlock(
-		arg0,
-		arg1,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgNumGrants(c *cli.Context) error {
+func tgToken(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
 
-	result, err := contract.NumGrantsAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGranteesToOperators(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	arg0, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg0, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	arg1, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg1, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	result, err := contract.GranteesToOperatorsAtBlock(
-		arg0,
-		arg1,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tgGrants(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-	arg0, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg0, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GrantsAtBlock(
-		arg0,
+	result, err := contract.TokenAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -675,21 +682,21 @@ func tgGetGrantUnlockingSchedule(c *cli.Context) error {
 	return nil
 }
 
-func tgGetGrants(c *cli.Context) error {
+func tgGetGranteeOperators(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
-	_granteeOrGrantManager, err := ethutil.AddressFromHex(c.Args()[0])
+	grantee, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _granteeOrGrantManager, a address, from passed value %v",
+			"couldn't parse parameter grantee, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.GetGrantsAtBlock(
-		_granteeOrGrantManager,
+	result, err := contract.GetGranteeOperatorsAtBlock(
+		grantee,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -703,21 +710,13 @@ func tgGetGrants(c *cli.Context) error {
 	return nil
 }
 
-func tgGrantStakes(c *cli.Context) error {
+func tgNumGrants(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
-	arg0, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg0, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
 
-	result, err := contract.GrantStakesAtBlock(
-		arg0,
+	result, err := contract.NumGrantsAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -732,6 +731,270 @@ func tgGrantStakes(c *cli.Context) error {
 }
 
 /// ------------------- Non-const methods -------------------
+
+func tgUndelegate(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.Undelegate(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallUndelegate(
+			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgRevoke(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.Revoke(
+			_id,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallRevoke(
+			_id,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgWithdraw(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.Withdraw(
+			_id,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallWithdraw(
+			_id,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgWithdrawRevoked(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_id, err := hexutil.DecodeBig(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _id, a uint256, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.WithdrawRevoked(
+			_id,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallWithdrawRevoked(
+			_id,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgAuthorizeStakingContract(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_stakingContract, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _stakingContract, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.AuthorizeStakingContract(
+			_stakingContract,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallAuthorizeStakingContract(
+			_stakingContract,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tgCancelRevokedStake(c *cli.Context) error {
+	contract, err := initializeTokenGrant(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.CancelRevokedStake(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallCancelRevokedStake(
+			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
 
 func tgReceiveApproval(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
@@ -807,138 +1070,6 @@ func tgReceiveApproval(c *cli.Context) error {
 	return nil
 }
 
-func tgRevoke(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_id, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Revoke(
-			_id,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallRevoke(
-			_id,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgUndelegate(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Undelegate(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUndelegate(
-			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgCancelRevokedStake(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.CancelRevokedStake(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallCancelRevokedStake(
-			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
 func tgRecoverStake(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
@@ -983,16 +1114,16 @@ func tgRecoverStake(c *cli.Context) error {
 	return nil
 }
 
-func tgAuthorizeStakingContract(c *cli.Context) error {
+func tgUndelegateRevoked(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
 		return err
 	}
 
-	_stakingContract, err := ethutil.AddressFromHex(c.Args()[0])
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _stakingContract, a address, from passed value %v",
+			"couldn't parse parameter _operator, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
@@ -1003,8 +1134,8 @@ func tgAuthorizeStakingContract(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.AuthorizeStakingContract(
-			_stakingContract,
+		transaction, err = contract.UndelegateRevoked(
+			_operator,
 		)
 		if err != nil {
 			return err
@@ -1013,8 +1144,8 @@ func tgAuthorizeStakingContract(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallAuthorizeStakingContract(
-			_stakingContract,
+		err = contract.CallUndelegateRevoked(
+			_operator,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1101,50 +1232,6 @@ func tgStake(c *cli.Context) error {
 	return nil
 }
 
-func tgWithdrawRevoked(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_id, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.WithdrawRevoked(
-			_id,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallWithdrawRevoked(
-			_id,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
 func tgCancelStake(c *cli.Context) error {
 	contract, err := initializeTokenGrant(c)
 	if err != nil {
@@ -1177,94 +1264,6 @@ func tgCancelStake(c *cli.Context) error {
 		// Do a call.
 		err = contract.CallCancelStake(
 			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgUndelegateRevoked(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UndelegateRevoked(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUndelegateRevoked(
-			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tgWithdraw(c *cli.Context) error {
-	contract, err := initializeTokenGrant(c)
-	if err != nil {
-		return err
-	}
-
-	_id, err := hexutil.DecodeBig(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _id, a uint256, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Withdraw(
-			_id,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallWithdraw(
-			_id,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1311,18 +1310,16 @@ func initializeTokenGrant(c *cli.Context) (*contract.TokenGrant, error) {
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
-	miningWaiter := ethlike.NewMiningWaiter(
-		ethutil.NewTransactionSourceAdapter(client),
+	miningWaiter := ethutil.NewMiningWaiter(
+		client,
 		checkInterval,
 		maxGasPrice,
 	)
 
-	blockCounter, err := ethlike.CreateBlockCounter(
-		ethutil.NewBlockSourceAdapter(client),
-	)
+	blockCounter, err := ethutil.NewBlockCounter(client)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to create Ethereum blockcounter: [%v]",
+			"failed to create block counter: [%v]",
 			err,
 		)
 	}
@@ -1333,10 +1330,7 @@ func initializeTokenGrant(c *cli.Context) (*contract.TokenGrant, error) {
 		address,
 		key,
 		client,
-		ethlike.NewNonceManager(
-			key.Address.Hex(),
-			ethutil.NewNonceSourceAdapter(client),
-		),
+		ethutil.NewNonceManager(client, key.Address),
 		miningWaiter,
 		blockCounter,
 		&sync.Mutex{},

--- a/pkg/chain/gen/cmd/TokenStaking.go
+++ b/pkg/chain/gen/cmd/TokenStaking.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
+	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"github.com/keep-network/keep-common/pkg/cmd"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/gen/contract"
@@ -52,39 +52,11 @@ func init() {
 		Usage:       `Provides access to the TokenStaking contract.`,
 		Description: tokenStakingDescription,
 		Subcommands: []cli.Command{{
-			Name:      "deployed-at",
-			Usage:     "Calls the constant method deployedAt on the TokenStaking contract.",
+			Name:      "undelegation-period",
+			Usage:     "Calls the constant method undelegationPeriod on the TokenStaking contract.",
 			ArgsUsage: "",
-			Action:    tsDeployedAt,
+			Action:    tsUndelegationPeriod,
 			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "is-approved-operator-contract",
-			Usage:     "Calls the constant method isApprovedOperatorContract on the TokenStaking contract.",
-			ArgsUsage: "[_operatorContract] ",
-			Action:    tsIsApprovedOperatorContract,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "beneficiary-of",
-			Usage:     "Calls the constant method beneficiaryOf on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsBeneficiaryOf,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "is-authorized-for-operator",
-			Usage:     "Calls the constant method isAuthorizedForOperator on the TokenStaking contract.",
-			ArgsUsage: "[_operator] [_operatorContract] ",
-			Action:    tsIsAuthorizedForOperator,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "get-locks",
-			Usage:     "Calls the constant method getLocks on the TokenStaking contract.",
-			ArgsUsage: "[operator] ",
-			Action:    tsGetLocks,
-			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "has-minimum-stake",
@@ -101,39 +73,32 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "eligible-stake",
-			Usage:     "Calls the constant method eligibleStake on the TokenStaking contract.",
+			Name:      "deployed-at",
+			Usage:     "Calls the constant method deployedAt on the TokenStaking contract.",
+			ArgsUsage: "",
+			Action:    tsDeployedAt,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "is-authorized-for-operator",
+			Usage:     "Calls the constant method isAuthorizedForOperator on the TokenStaking contract.",
 			ArgsUsage: "[_operator] [_operatorContract] ",
-			Action:    tsEligibleStake,
+			Action:    tsIsAuthorizedForOperator,
 			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "undelegation-period",
-			Usage:     "Calls the constant method undelegationPeriod on the TokenStaking contract.",
-			ArgsUsage: "",
-			Action:    tsUndelegationPeriod,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "authorizer-of",
-			Usage:     "Calls the constant method authorizerOf on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsAuthorizerOf,
+			Name:      "is-stake-locked",
+			Usage:     "Calls the constant method isStakeLocked on the TokenStaking contract.",
+			ArgsUsage: "[operator] ",
+			Action:    tsIsStakeLocked,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "get-delegation-info",
-			Usage:     "Calls the constant method getDelegationInfo on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsGetDelegationInfo,
+			Name:      "balance-of",
+			Usage:     "Calls the constant method balanceOf on the TokenStaking contract.",
+			ArgsUsage: "[_address] ",
+			Action:    tsBalanceOf,
 			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "minimum-stake",
-			Usage:     "Calls the constant method minimumStake on the TokenStaking contract.",
-			ArgsUsage: "",
-			Action:    tsMinimumStake,
-			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "initialization-period",
@@ -143,10 +108,17 @@ func init() {
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "is-stake-locked",
-			Usage:     "Calls the constant method isStakeLocked on the TokenStaking contract.",
-			ArgsUsage: "[operator] ",
-			Action:    tsIsStakeLocked,
+			Name:      "get-authority-source",
+			Usage:     "Calls the constant method getAuthoritySource on the TokenStaking contract.",
+			ArgsUsage: "[operatorContract] ",
+			Action:    tsGetAuthoritySource,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "is-approved-operator-contract",
+			Usage:     "Calls the constant method isApprovedOperatorContract on the TokenStaking contract.",
+			ArgsUsage: "[_operatorContract] ",
+			Action:    tsIsApprovedOperatorContract,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -157,25 +129,67 @@ func init() {
 			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "balance-of",
-			Usage:     "Calls the constant method balanceOf on the TokenStaking contract.",
-			ArgsUsage: "[_address] ",
-			Action:    tsBalanceOf,
+			Name:      "beneficiary-of",
+			Usage:     "Calls the constant method beneficiaryOf on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsBeneficiaryOf,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "get-authority-source",
-			Usage:     "Calls the constant method getAuthoritySource on the TokenStaking contract.",
-			ArgsUsage: "[operatorContract] ",
-			Action:    tsGetAuthoritySource,
+			Name:      "authorizer-of",
+			Usage:     "Calls the constant method authorizerOf on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsAuthorizerOf,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "minimum-stake",
+			Usage:     "Calls the constant method minimumStake on the TokenStaking contract.",
+			ArgsUsage: "",
+			Action:    tsMinimumStake,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "eligible-stake",
+			Usage:     "Calls the constant method eligibleStake on the TokenStaking contract.",
+			ArgsUsage: "[_operator] [_operatorContract] ",
+			Action:    tsEligibleStake,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "get-delegation-info",
+			Usage:     "Calls the constant method getDelegationInfo on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsGetDelegationInfo,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "get-locks",
+			Usage:     "Calls the constant method getLocks on the TokenStaking contract.",
+			ArgsUsage: "[operator] ",
+			Action:    tsGetLocks,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "undelegate",
+			Usage:     "Calls the method undelegate on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsUndelegate,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "authorize-operator-contract",
 			Usage:     "Calls the method authorizeOperatorContract on the TokenStaking contract.",
 			ArgsUsage: "[_operator] [_operatorContract] ",
 			Action:    tsAuthorizeOperatorContract,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "receive-approval",
+			Usage:     "Calls the method receiveApproval on the TokenStaking contract.",
+			ArgsUsage: "[_from] [_value] [_token] [_extraData] ",
+			Action:    tsReceiveApproval,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "unlock-stake",
@@ -185,17 +199,10 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "lock-stake",
-			Usage:     "Calls the method lockStake on the TokenStaking contract.",
-			ArgsUsage: "[operator] [duration] ",
-			Action:    tsLockStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "release-expired-lock",
-			Usage:     "Calls the method releaseExpiredLock on the TokenStaking contract.",
-			ArgsUsage: "[operator] [operatorContract] ",
-			Action:    tsReleaseExpiredLock,
+			Name:      "transfer-stake-ownership",
+			Usage:     "Calls the method transferStakeOwnership on the TokenStaking contract.",
+			ArgsUsage: "[operator] [newOwner] ",
+			Action:    tsTransferStakeOwnership,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -206,17 +213,10 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "transfer-stake-ownership",
-			Usage:     "Calls the method transferStakeOwnership on the TokenStaking contract.",
-			ArgsUsage: "[operator] [newOwner] ",
-			Action:    tsTransferStakeOwnership,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "undelegate",
-			Usage:     "Calls the method undelegate on the TokenStaking contract.",
+			Name:      "cancel-stake",
+			Usage:     "Calls the method cancelStake on the TokenStaking contract.",
 			ArgsUsage: "[_operator] ",
-			Action:    tsUndelegate,
+			Action:    tsCancelStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -227,11 +227,11 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "receive-approval",
-			Usage:     "Calls the method receiveApproval on the TokenStaking contract.",
-			ArgsUsage: "[_from] [_value] [_token] [_extraData] ",
-			Action:    tsReceiveApproval,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Name:      "release-expired-lock",
+			Usage:     "Calls the method releaseExpiredLock on the TokenStaking contract.",
+			ArgsUsage: "[operator] [operatorContract] ",
+			Action:    tsReleaseExpiredLock,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "commit-top-up",
@@ -241,11 +241,11 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "cancel-stake",
-			Usage:     "Calls the method cancelStake on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsCancelStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Name:      "lock-stake",
+			Usage:     "Calls the method lockStake on the TokenStaking contract.",
+			ArgsUsage: "[operator] [duration] ",
+			Action:    tsLockStake,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "recover-stake",
@@ -260,134 +260,13 @@ func init() {
 
 /// ------------------- Const methods -------------------
 
-func tsDeployedAt(c *cli.Context) error {
+func tsUndelegationPeriod(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
 
-	result, err := contract.DeployedAtAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsIsApprovedOperatorContract(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operatorContract, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.IsApprovedOperatorContractAtBlock(
-		_operatorContract,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsBeneficiaryOf(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.BeneficiaryOfAtBlock(
-		_operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsIsAuthorizedForOperator(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	_operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operatorContract, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	result, err := contract.IsAuthorizedForOperatorAtBlock(
-		_operator,
-		_operatorContract,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsGetLocks(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetLocksAtBlock(
-		operator,
+	result, err := contract.UndelegationPeriodAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -466,7 +345,27 @@ func tsOwnerOf(c *cli.Context) error {
 	return nil
 }
 
-func tsEligibleStake(c *cli.Context) error {
+func tsDeployedAt(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.DeployedAtAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsIsAuthorizedForOperator(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
@@ -487,7 +386,7 @@ func tsEligibleStake(c *cli.Context) error {
 		)
 	}
 
-	result, err := contract.EligibleStakeAtBlock(
+	result, err := contract.IsAuthorizedForOperatorAtBlock(
 		_operator,
 		_operatorContract,
 
@@ -503,41 +402,21 @@ func tsEligibleStake(c *cli.Context) error {
 	return nil
 }
 
-func tsUndelegationPeriod(c *cli.Context) error {
+func tsIsStakeLocked(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-
-	result, err := contract.UndelegationPeriodAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsAuthorizerOf(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
+			"couldn't parse parameter operator, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.AuthorizerOfAtBlock(
-		_operator,
+	result, err := contract.IsStakeLockedAtBlock(
+		operator,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -551,41 +430,21 @@ func tsAuthorizerOf(c *cli.Context) error {
 	return nil
 }
 
-func tsGetDelegationInfo(c *cli.Context) error {
+func tsBalanceOf(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	_address, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
+			"couldn't parse parameter _address, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.GetDelegationInfoAtBlock(
-		_operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsMinimumStake(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.MinimumStakeAtBlock(
+	result, err := contract.BalanceOfAtBlock(
+		_address,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -619,21 +478,49 @@ func tsInitializationPeriod(c *cli.Context) error {
 	return nil
 }
 
-func tsIsStakeLocked(c *cli.Context) error {
+func tsGetAuthoritySource(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
+			"couldn't parse parameter operatorContract, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.IsStakeLockedAtBlock(
-		operator,
+	result, err := contract.GetAuthoritySourceAtBlock(
+		operatorContract,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsIsApprovedOperatorContract(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+	_operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operatorContract, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.IsApprovedOperatorContractAtBlock(
+		_operatorContract,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -684,21 +571,21 @@ func tsActiveStake(c *cli.Context) error {
 	return nil
 }
 
-func tsBalanceOf(c *cli.Context) error {
+func tsBeneficiaryOf(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-	_address, err := ethutil.AddressFromHex(c.Args()[0])
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _address, a address, from passed value %v",
+			"couldn't parse parameter _operator, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.BalanceOfAtBlock(
-		_address,
+	result, err := contract.BeneficiaryOfAtBlock(
+		_operator,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -712,21 +599,21 @@ func tsBalanceOf(c *cli.Context) error {
 	return nil
 }
 
-func tsGetAuthoritySource(c *cli.Context) error {
+func tsAuthorizerOf(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-	operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			"couldn't parse parameter _operator, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.GetAuthoritySourceAtBlock(
-		operatorContract,
+	result, err := contract.AuthorizerOfAtBlock(
+		_operator,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -740,14 +627,31 @@ func tsGetAuthoritySource(c *cli.Context) error {
 	return nil
 }
 
-/// ------------------- Non-const methods -------------------
-
-func tsAuthorizeOperatorContract(c *cli.Context) error {
+func tsMinimumStake(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
 
+	result, err := contract.MinimumStakeAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsEligibleStake(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
 	_operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
@@ -764,196 +668,27 @@ func tsAuthorizeOperatorContract(c *cli.Context) error {
 		)
 	}
 
-	var (
-		transaction *types.Transaction
+	result, err := contract.EligibleStakeAtBlock(
+		_operator,
+		_operatorContract,
+
+		cmd.BlockFlagValue.Uint,
 	)
 
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.AuthorizeOperatorContract(
-			_operator,
-			_operatorContract,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallAuthorizeOperatorContract(
-			_operator,
-			_operatorContract,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsUnlockStake(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
 
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UnlockStake(
-			operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUnlockStake(
-			operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
+	cmd.PrintOutput(result)
 
 	return nil
 }
 
-func tsLockStake(c *cli.Context) error {
+func tsGetDelegationInfo(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	duration, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter duration, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.LockStake(
-			operator,
-			duration,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallLockStake(
-			operator,
-			duration,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsReleaseExpiredLock(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operatorContract, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.ReleaseExpiredLock(
-			operator,
-			operatorContract,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallReleaseExpiredLock(
-			operator,
-			operatorContract,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsUndelegateAt(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
 	_operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
@@ -962,52 +697,26 @@ func tsUndelegateAt(c *cli.Context) error {
 		)
 	}
 
-	_undelegationTimestamp, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _undelegationTimestamp, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
+	result, err := contract.GetDelegationInfoAtBlock(
+		_operator,
 
-	var (
-		transaction *types.Transaction
+		cmd.BlockFlagValue.Uint,
 	)
 
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UndelegateAt(
-			_operator,
-			_undelegationTimestamp,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUndelegateAt(
-			_operator,
-			_undelegationTimestamp,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsTransferStakeOwnership(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
 
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsGetLocks(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
 	operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
@@ -1016,45 +725,22 @@ func tsTransferStakeOwnership(c *cli.Context) error {
 		)
 	}
 
-	newOwner, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter newOwner, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
+	result, err := contract.GetLocksAtBlock(
+		operator,
 
-	var (
-		transaction *types.Transaction
+		cmd.BlockFlagValue.Uint,
 	)
 
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.TransferStakeOwnership(
-			operator,
-			newOwner,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallTransferStakeOwnership(
-			operator,
-			newOwner,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
+	if err != nil {
+		return err
 	}
+
+	cmd.PrintOutput(result)
 
 	return nil
 }
+
+/// ------------------- Non-const methods -------------------
 
 func tsUndelegate(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
@@ -1100,17 +786,25 @@ func tsUndelegate(c *cli.Context) error {
 	return nil
 }
 
-func tsClaimDelegatedAuthority(c *cli.Context) error {
+func tsAuthorizeOperatorContract(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
 
-	delegatedAuthoritySource, err := ethutil.AddressFromHex(c.Args()[0])
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter delegatedAuthoritySource, a address, from passed value %v",
+			"couldn't parse parameter _operator, a address, from passed value %v",
 			c.Args()[0],
+		)
+	}
+
+	_operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operatorContract, a address, from passed value %v",
+			c.Args()[1],
 		)
 	}
 
@@ -1120,8 +814,9 @@ func tsClaimDelegatedAuthority(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.ClaimDelegatedAuthority(
-			delegatedAuthoritySource,
+		transaction, err = contract.AuthorizeOperatorContract(
+			_operator,
+			_operatorContract,
 		)
 		if err != nil {
 			return err
@@ -1130,8 +825,9 @@ func tsClaimDelegatedAuthority(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallClaimDelegatedAuthority(
-			delegatedAuthoritySource,
+		err = contract.CallAuthorizeOperatorContract(
+			_operator,
+			_operatorContract,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1218,7 +914,105 @@ func tsReceiveApproval(c *cli.Context) error {
 	return nil
 }
 
-func tsCommitTopUp(c *cli.Context) error {
+func tsUnlockStake(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.UnlockStake(
+			operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallUnlockStake(
+			operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsTransferStakeOwnership(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	newOwner, err := ethutil.AddressFromHex(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter newOwner, a address, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.TransferStakeOwnership(
+			operator,
+			newOwner,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallTransferStakeOwnership(
+			operator,
+			newOwner,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsUndelegateAt(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
@@ -1232,14 +1026,23 @@ func tsCommitTopUp(c *cli.Context) error {
 		)
 	}
 
+	_undelegationTimestamp, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _undelegationTimestamp, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
 	var (
 		transaction *types.Transaction
 	)
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.CommitTopUp(
+		transaction, err = contract.UndelegateAt(
 			_operator,
+			_undelegationTimestamp,
 		)
 		if err != nil {
 			return err
@@ -1248,8 +1051,9 @@ func tsCommitTopUp(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallCommitTopUp(
+		err = contract.CallUndelegateAt(
 			_operator,
+			_undelegationTimestamp,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1294,6 +1098,202 @@ func tsCancelStake(c *cli.Context) error {
 		// Do a call.
 		err = contract.CallCancelStake(
 			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsClaimDelegatedAuthority(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	delegatedAuthoritySource, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter delegatedAuthoritySource, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.ClaimDelegatedAuthority(
+			delegatedAuthoritySource,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallClaimDelegatedAuthority(
+			delegatedAuthoritySource,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsReleaseExpiredLock(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.ReleaseExpiredLock(
+			operator,
+			operatorContract,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallReleaseExpiredLock(
+			operator,
+			operatorContract,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsCommitTopUp(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.CommitTopUp(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallCommitTopUp(
+			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsLockStake(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	duration, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter duration, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.LockStake(
+			operator,
+			duration,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallLockStake(
+			operator,
+			duration,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1384,9 +1384,15 @@ func initializeTokenStaking(c *cli.Context) (*contract.TokenStaking, error) {
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
-	miningWaiter := ethutil.NewMiningWaiter(client, checkInterval, maxGasPrice)
+	miningWaiter := ethlike.NewMiningWaiter(
+		ethutil.NewTransactionSourceAdapter(client),
+		checkInterval,
+		maxGasPrice,
+	)
 
-	blockCounter, err := blockcounter.CreateBlockCounter(client)
+	blockCounter, err := ethlike.CreateBlockCounter(
+		ethutil.NewBlockSourceAdapter(client),
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create Ethereum blockcounter: [%v]",
@@ -1400,7 +1406,10 @@ func initializeTokenStaking(c *cli.Context) (*contract.TokenStaking, error) {
 		address,
 		key,
 		client,
-		ethutil.NewNonceManager(key.Address, client),
+		ethlike.NewNonceManager(
+			key.Address.Hex(),
+			ethutil.NewNonceSourceAdapter(client),
+		),
 		miningWaiter,
 		blockCounter,
 		&sync.Mutex{},

--- a/pkg/chain/gen/cmd/TokenStaking.go
+++ b/pkg/chain/gen/cmd/TokenStaking.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
-	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 	"github.com/keep-network/keep-common/pkg/cmd"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/gen/contract"
@@ -52,20 +51,6 @@ func init() {
 		Usage:       `Provides access to the TokenStaking contract.`,
 		Description: tokenStakingDescription,
 		Subcommands: []cli.Command{{
-			Name:      "undelegation-period",
-			Usage:     "Calls the constant method undelegationPeriod on the TokenStaking contract.",
-			ArgsUsage: "",
-			Action:    tsUndelegationPeriod,
-			Before:    cmd.ArgCountChecker(0),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "has-minimum-stake",
-			Usage:     "Calls the constant method hasMinimumStake on the TokenStaking contract.",
-			ArgsUsage: "[staker] [operatorContract] ",
-			Action:    tsHasMinimumStake,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
 			Name:      "owner-of",
 			Usage:     "Calls the constant method ownerOf on the TokenStaking contract.",
 			ArgsUsage: "[_operator] ",
@@ -73,11 +58,32 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "deployed-at",
-			Usage:     "Calls the constant method deployedAt on the TokenStaking contract.",
-			ArgsUsage: "",
-			Action:    tsDeployedAt,
-			Before:    cmd.ArgCountChecker(0),
+			Name:      "get-locks",
+			Usage:     "Calls the constant method getLocks on the TokenStaking contract.",
+			ArgsUsage: "[operator] ",
+			Action:    tsGetLocks,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "is-approved-operator-contract",
+			Usage:     "Calls the constant method isApprovedOperatorContract on the TokenStaking contract.",
+			ArgsUsage: "[_operatorContract] ",
+			Action:    tsIsApprovedOperatorContract,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "authorizer-of",
+			Usage:     "Calls the constant method authorizerOf on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsAuthorizerOf,
+			Before:    cmd.ArgCountChecker(1),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "balance-of",
+			Usage:     "Calls the constant method balanceOf on the TokenStaking contract.",
+			ArgsUsage: "[_address] ",
+			Action:    tsBalanceOf,
+			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-authorized-for-operator",
@@ -87,18 +93,11 @@ func init() {
 			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "is-stake-locked",
-			Usage:     "Calls the constant method isStakeLocked on the TokenStaking contract.",
-			ArgsUsage: "[operator] ",
-			Action:    tsIsStakeLocked,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "balance-of",
-			Usage:     "Calls the constant method balanceOf on the TokenStaking contract.",
-			ArgsUsage: "[_address] ",
-			Action:    tsBalanceOf,
-			Before:    cmd.ArgCountChecker(1),
+			Name:      "has-minimum-stake",
+			Usage:     "Calls the constant method hasMinimumStake on the TokenStaking contract.",
+			ArgsUsage: "[staker] [operatorContract] ",
+			Action:    tsHasMinimumStake,
+			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "initialization-period",
@@ -115,31 +114,10 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "is-approved-operator-contract",
-			Usage:     "Calls the constant method isApprovedOperatorContract on the TokenStaking contract.",
-			ArgsUsage: "[_operatorContract] ",
-			Action:    tsIsApprovedOperatorContract,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "active-stake",
-			Usage:     "Calls the constant method activeStake on the TokenStaking contract.",
-			ArgsUsage: "[_operator] [_operatorContract] ",
-			Action:    tsActiveStake,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "beneficiary-of",
-			Usage:     "Calls the constant method beneficiaryOf on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsBeneficiaryOf,
-			Before:    cmd.ArgCountChecker(1),
-			Flags:     cmd.ConstFlags,
-		}, {
-			Name:      "authorizer-of",
-			Usage:     "Calls the constant method authorizerOf on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsAuthorizerOf,
+			Name:      "is-stake-locked",
+			Usage:     "Calls the constant method isStakeLocked on the TokenStaking contract.",
+			ArgsUsage: "[operator] ",
+			Action:    tsIsStakeLocked,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
@@ -150,13 +128,6 @@ func init() {
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "eligible-stake",
-			Usage:     "Calls the constant method eligibleStake on the TokenStaking contract.",
-			ArgsUsage: "[_operator] [_operatorContract] ",
-			Action:    tsEligibleStake,
-			Before:    cmd.ArgCountChecker(2),
-			Flags:     cmd.ConstFlags,
-		}, {
 			Name:      "get-delegation-info",
 			Usage:     "Calls the constant method getDelegationInfo on the TokenStaking contract.",
 			ArgsUsage: "[_operator] ",
@@ -164,59 +135,45 @@ func init() {
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "get-locks",
-			Usage:     "Calls the constant method getLocks on the TokenStaking contract.",
-			ArgsUsage: "[operator] ",
-			Action:    tsGetLocks,
+			Name:      "beneficiary-of",
+			Usage:     "Calls the constant method beneficiaryOf on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsBeneficiaryOf,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "undelegate",
-			Usage:     "Calls the method undelegate on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsUndelegate,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
+			Name:      "deployed-at",
+			Usage:     "Calls the constant method deployedAt on the TokenStaking contract.",
+			ArgsUsage: "",
+			Action:    tsDeployedAt,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "authorize-operator-contract",
-			Usage:     "Calls the method authorizeOperatorContract on the TokenStaking contract.",
+			Name:      "active-stake",
+			Usage:     "Calls the constant method activeStake on the TokenStaking contract.",
 			ArgsUsage: "[_operator] [_operatorContract] ",
-			Action:    tsAuthorizeOperatorContract,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.NonConstFlags,
+			Action:    tsActiveStake,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
 		}, {
-			Name:      "receive-approval",
-			Usage:     "Calls the method receiveApproval on the TokenStaking contract.",
-			ArgsUsage: "[_from] [_value] [_token] [_extraData] ",
-			Action:    tsReceiveApproval,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
-			Flags:     cmd.NonConstFlags,
+			Name:      "undelegation-period",
+			Usage:     "Calls the constant method undelegationPeriod on the TokenStaking contract.",
+			ArgsUsage: "",
+			Action:    tsUndelegationPeriod,
+			Before:    cmd.ArgCountChecker(0),
+			Flags:     cmd.ConstFlags,
+		}, {
+			Name:      "eligible-stake",
+			Usage:     "Calls the constant method eligibleStake on the TokenStaking contract.",
+			ArgsUsage: "[_operator] [_operatorContract] ",
+			Action:    tsEligibleStake,
+			Before:    cmd.ArgCountChecker(2),
+			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "unlock-stake",
 			Usage:     "Calls the method unlockStake on the TokenStaking contract.",
 			ArgsUsage: "[operator] ",
 			Action:    tsUnlockStake,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "transfer-stake-ownership",
-			Usage:     "Calls the method transferStakeOwnership on the TokenStaking contract.",
-			ArgsUsage: "[operator] [newOwner] ",
-			Action:    tsTransferStakeOwnership,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "undelegate-at",
-			Usage:     "Calls the method undelegateAt on the TokenStaking contract.",
-			ArgsUsage: "[_operator] [_undelegationTimestamp] ",
-			Action:    tsUndelegateAt,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "cancel-stake",
-			Usage:     "Calls the method cancelStake on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsCancelStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -234,17 +191,10 @@ func init() {
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
-			Name:      "commit-top-up",
-			Usage:     "Calls the method commitTopUp on the TokenStaking contract.",
-			ArgsUsage: "[_operator] ",
-			Action:    tsCommitTopUp,
-			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
-			Flags:     cmd.NonConstFlags,
-		}, {
-			Name:      "lock-stake",
-			Usage:     "Calls the method lockStake on the TokenStaking contract.",
-			ArgsUsage: "[operator] [duration] ",
-			Action:    tsLockStake,
+			Name:      "undelegate-at",
+			Usage:     "Calls the method undelegateAt on the TokenStaking contract.",
+			ArgsUsage: "[_operator] [_undelegationTimestamp] ",
+			Action:    tsUndelegateAt,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
@@ -254,68 +204,60 @@ func init() {
 			Action:    tsRecoverStake,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "cancel-stake",
+			Usage:     "Calls the method cancelStake on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsCancelStake,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "transfer-stake-ownership",
+			Usage:     "Calls the method transferStakeOwnership on the TokenStaking contract.",
+			ArgsUsage: "[operator] [newOwner] ",
+			Action:    tsTransferStakeOwnership,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "receive-approval",
+			Usage:     "Calls the method receiveApproval on the TokenStaking contract.",
+			ArgsUsage: "[_from] [_value] [_token] [_extraData] ",
+			Action:    tsReceiveApproval,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "lock-stake",
+			Usage:     "Calls the method lockStake on the TokenStaking contract.",
+			ArgsUsage: "[operator] [duration] ",
+			Action:    tsLockStake,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "authorize-operator-contract",
+			Usage:     "Calls the method authorizeOperatorContract on the TokenStaking contract.",
+			ArgsUsage: "[_operator] [_operatorContract] ",
+			Action:    tsAuthorizeOperatorContract,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "undelegate",
+			Usage:     "Calls the method undelegate on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsUndelegate,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
+		}, {
+			Name:      "commit-top-up",
+			Usage:     "Calls the method commitTopUp on the TokenStaking contract.",
+			ArgsUsage: "[_operator] ",
+			Action:    tsCommitTopUp,
+			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
+			Flags:     cmd.NonConstFlags,
 		}},
 	})
 }
 
 /// ------------------- Const methods -------------------
-
-func tsUndelegationPeriod(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.UndelegationPeriodAtBlock(
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsHasMinimumStake(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	staker, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter staker, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operatorContract, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	result, err := contract.HasMinimumStakeAtBlock(
-		staker,
-		operatorContract,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
 
 func tsOwnerOf(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
@@ -345,13 +287,105 @@ func tsOwnerOf(c *cli.Context) error {
 	return nil
 }
 
-func tsDeployedAt(c *cli.Context) error {
+func tsGetLocks(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
 
-	result, err := contract.DeployedAtAtBlock(
+	result, err := contract.GetLocksAtBlock(
+		operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsIsApprovedOperatorContract(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+	_operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operatorContract, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.IsApprovedOperatorContractAtBlock(
+		_operatorContract,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsAuthorizerOf(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.AuthorizerOfAtBlock(
+		_operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsBalanceOf(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+	_address, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _address, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.BalanceOfAtBlock(
+		_address,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -402,49 +436,30 @@ func tsIsAuthorizedForOperator(c *cli.Context) error {
 	return nil
 }
 
-func tsIsStakeLocked(c *cli.Context) error {
+func tsHasMinimumStake(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	staker, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
+			"couldn't parse parameter staker, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.IsStakeLockedAtBlock(
-		operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsBalanceOf(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_address, err := ethutil.AddressFromHex(c.Args()[0])
+	operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _address, a address, from passed value %v",
-			c.Args()[0],
+			"couldn't parse parameter operatorContract, a address, from passed value %v",
+			c.Args()[1],
 		)
 	}
 
-	result, err := contract.BalanceOfAtBlock(
-		_address,
+	result, err := contract.HasMinimumStakeAtBlock(
+		staker,
+		operatorContract,
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -506,21 +521,117 @@ func tsGetAuthoritySource(c *cli.Context) error {
 	return nil
 }
 
-func tsIsApprovedOperatorContract(c *cli.Context) error {
+func tsIsStakeLocked(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
-	_operatorContract, err := ethutil.AddressFromHex(c.Args()[0])
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter _operatorContract, a address, from passed value %v",
+			"couldn't parse parameter operator, a address, from passed value %v",
 			c.Args()[0],
 		)
 	}
 
-	result, err := contract.IsApprovedOperatorContractAtBlock(
-		_operatorContract,
+	result, err := contract.IsStakeLockedAtBlock(
+		operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsMinimumStake(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.MinimumStakeAtBlock(
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsGetDelegationInfo(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.GetDelegationInfoAtBlock(
+		_operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsBeneficiaryOf(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	result, err := contract.BeneficiaryOfAtBlock(
+		_operator,
+
+		cmd.BlockFlagValue.Uint,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func tsDeployedAt(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.DeployedAtAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -571,69 +682,13 @@ func tsActiveStake(c *cli.Context) error {
 	return nil
 }
 
-func tsBeneficiaryOf(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.BeneficiaryOfAtBlock(
-		_operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsAuthorizerOf(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.AuthorizerOfAtBlock(
-		_operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsMinimumStake(c *cli.Context) error {
+func tsUndelegationPeriod(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
 	}
 
-	result, err := contract.MinimumStakeAtBlock(
+	result, err := contract.UndelegationPeriodAtBlock(
 
 		cmd.BlockFlagValue.Uint,
 	)
@@ -684,235 +739,7 @@ func tsEligibleStake(c *cli.Context) error {
 	return nil
 }
 
-func tsGetDelegationInfo(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetDelegationInfoAtBlock(
-		_operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
-func tsGetLocks(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	result, err := contract.GetLocksAtBlock(
-		operator,
-
-		cmd.BlockFlagValue.Uint,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
 /// ------------------- Non-const methods -------------------
-
-func tsUndelegate(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.Undelegate(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUndelegate(
-			_operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsAuthorizeOperatorContract(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	_operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operatorContract, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.AuthorizeOperatorContract(
-			_operator,
-			_operatorContract,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallAuthorizeOperatorContract(
-			_operator,
-			_operatorContract,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsReceiveApproval(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	_from, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _from, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	_value, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _value, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	_token, err := ethutil.AddressFromHex(c.Args()[2])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _token, a address, from passed value %v",
-			c.Args()[2],
-		)
-	}
-
-	_extraData, err := hexutil.Decode(c.Args()[3])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _extraData, a bytes, from passed value %v",
-			c.Args()[3],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.ReceiveApproval(
-			_from,
-			_value,
-			_token,
-			_extraData,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallReceiveApproval(
-			_from,
-			_value,
-			_token,
-			_extraData,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
 
 func tsUnlockStake(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
@@ -946,158 +773,6 @@ func tsUnlockStake(c *cli.Context) error {
 		// Do a call.
 		err = contract.CallUnlockStake(
 			operator,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsTransferStakeOwnership(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	newOwner, err := ethutil.AddressFromHex(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter newOwner, a address, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.TransferStakeOwnership(
-			operator,
-			newOwner,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallTransferStakeOwnership(
-			operator,
-			newOwner,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsUndelegateAt(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	_undelegationTimestamp, err := hexutil.DecodeBig(c.Args()[1])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _undelegationTimestamp, a uint256, from passed value %v",
-			c.Args()[1],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UndelegateAt(
-			_operator,
-			_undelegationTimestamp,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallUndelegateAt(
-			_operator,
-			_undelegationTimestamp,
-			cmd.BlockFlagValue.Uint,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(nil)
-	}
-
-	return nil
-}
-
-func tsCancelStake(c *cli.Context) error {
-	contract, err := initializeTokenStaking(c)
-	if err != nil {
-		return err
-	}
-
-	_operator, err := ethutil.AddressFromHex(c.Args()[0])
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter _operator, a address, from passed value %v",
-			c.Args()[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if c.Bool(cmd.SubmitFlag) {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.CancelStake(
-			_operator,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash)
-	} else {
-		// Do a call.
-		err = contract.CallCancelStake(
-			_operator,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1208,7 +883,61 @@ func tsReleaseExpiredLock(c *cli.Context) error {
 	return nil
 }
 
-func tsCommitTopUp(c *cli.Context) error {
+func tsUndelegateAt(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	_undelegationTimestamp, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _undelegationTimestamp, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.UndelegateAt(
+			_operator,
+			_undelegationTimestamp,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallUndelegateAt(
+			_operator,
+			_undelegationTimestamp,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsRecoverStake(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
@@ -1228,7 +957,7 @@ func tsCommitTopUp(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.CommitTopUp(
+		transaction, err = contract.RecoverStake(
 			_operator,
 		)
 		if err != nil {
@@ -1238,8 +967,180 @@ func tsCommitTopUp(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallCommitTopUp(
+		err = contract.CallRecoverStake(
 			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsCancelStake(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.CancelStake(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallCancelStake(
+			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsTransferStakeOwnership(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	newOwner, err := ethutil.AddressFromHex(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter newOwner, a address, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.TransferStakeOwnership(
+			operator,
+			newOwner,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallTransferStakeOwnership(
+			operator,
+			newOwner,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsReceiveApproval(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	_from, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _from, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	_value, err := hexutil.DecodeBig(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _value, a uint256, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	_token, err := ethutil.AddressFromHex(c.Args()[2])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _token, a address, from passed value %v",
+			c.Args()[2],
+		)
+	}
+
+	_extraData, err := hexutil.Decode(c.Args()[3])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _extraData, a bytes, from passed value %v",
+			c.Args()[3],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.ReceiveApproval(
+			_from,
+			_value,
+			_token,
+			_extraData,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallReceiveApproval(
+			_from,
+			_value,
+			_token,
+			_extraData,
 			cmd.BlockFlagValue.Uint,
 		)
 		if err != nil {
@@ -1306,7 +1207,61 @@ func tsLockStake(c *cli.Context) error {
 	return nil
 }
 
-func tsRecoverStake(c *cli.Context) error {
+func tsAuthorizeOperatorContract(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	_operatorContract, err := ethutil.AddressFromHex(c.Args()[1])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operatorContract, a address, from passed value %v",
+			c.Args()[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.AuthorizeOperatorContract(
+			_operator,
+			_operatorContract,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallAuthorizeOperatorContract(
+			_operator,
+			_operatorContract,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsUndelegate(c *cli.Context) error {
 	contract, err := initializeTokenStaking(c)
 	if err != nil {
 		return err
@@ -1326,7 +1281,7 @@ func tsRecoverStake(c *cli.Context) error {
 
 	if c.Bool(cmd.SubmitFlag) {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RecoverStake(
+		transaction, err = contract.Undelegate(
 			_operator,
 		)
 		if err != nil {
@@ -1336,7 +1291,51 @@ func tsRecoverStake(c *cli.Context) error {
 		cmd.PrintOutput(transaction.Hash)
 	} else {
 		// Do a call.
-		err = contract.CallRecoverStake(
+		err = contract.CallUndelegate(
+			_operator,
+			cmd.BlockFlagValue.Uint,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(nil)
+	}
+
+	return nil
+}
+
+func tsCommitTopUp(c *cli.Context) error {
+	contract, err := initializeTokenStaking(c)
+	if err != nil {
+		return err
+	}
+
+	_operator, err := ethutil.AddressFromHex(c.Args()[0])
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter _operator, a address, from passed value %v",
+			c.Args()[0],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if c.Bool(cmd.SubmitFlag) {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.CommitTopUp(
+			_operator,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash)
+	} else {
+		// Do a call.
+		err = contract.CallCommitTopUp(
 			_operator,
 			cmd.BlockFlagValue.Uint,
 		)
@@ -1384,18 +1383,16 @@ func initializeTokenStaking(c *cli.Context) (*contract.TokenStaking, error) {
 		maxGasPrice = config.MaxGasPrice.Int
 	}
 
-	miningWaiter := ethlike.NewMiningWaiter(
-		ethutil.NewTransactionSourceAdapter(client),
+	miningWaiter := ethutil.NewMiningWaiter(
+		client,
 		checkInterval,
 		maxGasPrice,
 	)
 
-	blockCounter, err := ethlike.CreateBlockCounter(
-		ethutil.NewBlockSourceAdapter(client),
-	)
+	blockCounter, err := ethutil.NewBlockCounter(client)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to create Ethereum blockcounter: [%v]",
+			"failed to create block counter: [%v]",
 			err,
 		)
 	}
@@ -1406,10 +1403,7 @@ func initializeTokenStaking(c *cli.Context) (*contract.TokenStaking, error) {
 		address,
 		key,
 		client,
-		ethlike.NewNonceManager(
-			key.Address.Hex(),
-			ethutil.NewNonceSourceAdapter(client),
-		),
+		ethutil.NewNonceManager(client, key.Address),
 		miningWaiter,
 		blockCounter,
 		&sync.Mutex{},

--- a/pkg/chain/gen/contract/TokenGrant.go
+++ b/pkg/chain/gen/contract/TokenGrant.go
@@ -100,6 +100,822 @@ func NewTokenGrant(
 // ----- Non-const Methods ------
 
 // Transaction submission.
+func (tg *TokenGrant) Undelegate(
+	_operator common.Address,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tgLogger.Debug(
+		"submitting transaction undelegate",
+		"params: ",
+		fmt.Sprint(
+			_operator,
+		),
+	)
+
+	tg.transactionMutex.Lock()
+	defer tg.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tg.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tg.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tg.contract.Undelegate(
+		transactorOptions,
+		_operator,
+	)
+	if err != nil {
+		return transaction, tg.errorResolver.ResolveError(
+			err,
+			tg.transactorOptions.From,
+			nil,
+			"undelegate",
+			_operator,
+		)
+	}
+
+	tgLogger.Infof(
+		"submitted transaction undelegate with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tg.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tg.contract.Undelegate(
+				transactorOptions,
+				_operator,
+			)
+			if err != nil {
+				return nil, tg.errorResolver.ResolveError(
+					err,
+					tg.transactorOptions.From,
+					nil,
+					"undelegate",
+					_operator,
+				)
+			}
+
+			tgLogger.Infof(
+				"submitted transaction undelegate with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tg.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tg *TokenGrant) CallUndelegate(
+	_operator common.Address,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tg.transactorOptions.From,
+		blockNumber, nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"undelegate",
+		&result,
+		_operator,
+	)
+
+	return err
+}
+
+func (tg *TokenGrant) UndelegateGasEstimate(
+	_operator common.Address,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tg.callerOptions.From,
+		tg.contractAddress,
+		"undelegate",
+		tg.contractABI,
+		tg.transactor,
+		_operator,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tg *TokenGrant) Revoke(
+	_id *big.Int,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tgLogger.Debug(
+		"submitting transaction revoke",
+		"params: ",
+		fmt.Sprint(
+			_id,
+		),
+	)
+
+	tg.transactionMutex.Lock()
+	defer tg.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tg.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tg.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tg.contract.Revoke(
+		transactorOptions,
+		_id,
+	)
+	if err != nil {
+		return transaction, tg.errorResolver.ResolveError(
+			err,
+			tg.transactorOptions.From,
+			nil,
+			"revoke",
+			_id,
+		)
+	}
+
+	tgLogger.Infof(
+		"submitted transaction revoke with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tg.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tg.contract.Revoke(
+				transactorOptions,
+				_id,
+			)
+			if err != nil {
+				return nil, tg.errorResolver.ResolveError(
+					err,
+					tg.transactorOptions.From,
+					nil,
+					"revoke",
+					_id,
+				)
+			}
+
+			tgLogger.Infof(
+				"submitted transaction revoke with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tg.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tg *TokenGrant) CallRevoke(
+	_id *big.Int,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tg.transactorOptions.From,
+		blockNumber, nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"revoke",
+		&result,
+		_id,
+	)
+
+	return err
+}
+
+func (tg *TokenGrant) RevokeGasEstimate(
+	_id *big.Int,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tg.callerOptions.From,
+		tg.contractAddress,
+		"revoke",
+		tg.contractABI,
+		tg.transactor,
+		_id,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tg *TokenGrant) Withdraw(
+	_id *big.Int,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tgLogger.Debug(
+		"submitting transaction withdraw",
+		"params: ",
+		fmt.Sprint(
+			_id,
+		),
+	)
+
+	tg.transactionMutex.Lock()
+	defer tg.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tg.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tg.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tg.contract.Withdraw(
+		transactorOptions,
+		_id,
+	)
+	if err != nil {
+		return transaction, tg.errorResolver.ResolveError(
+			err,
+			tg.transactorOptions.From,
+			nil,
+			"withdraw",
+			_id,
+		)
+	}
+
+	tgLogger.Infof(
+		"submitted transaction withdraw with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tg.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tg.contract.Withdraw(
+				transactorOptions,
+				_id,
+			)
+			if err != nil {
+				return nil, tg.errorResolver.ResolveError(
+					err,
+					tg.transactorOptions.From,
+					nil,
+					"withdraw",
+					_id,
+				)
+			}
+
+			tgLogger.Infof(
+				"submitted transaction withdraw with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tg.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tg *TokenGrant) CallWithdraw(
+	_id *big.Int,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tg.transactorOptions.From,
+		blockNumber, nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"withdraw",
+		&result,
+		_id,
+	)
+
+	return err
+}
+
+func (tg *TokenGrant) WithdrawGasEstimate(
+	_id *big.Int,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tg.callerOptions.From,
+		tg.contractAddress,
+		"withdraw",
+		tg.contractABI,
+		tg.transactor,
+		_id,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tg *TokenGrant) WithdrawRevoked(
+	_id *big.Int,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tgLogger.Debug(
+		"submitting transaction withdrawRevoked",
+		"params: ",
+		fmt.Sprint(
+			_id,
+		),
+	)
+
+	tg.transactionMutex.Lock()
+	defer tg.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tg.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tg.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tg.contract.WithdrawRevoked(
+		transactorOptions,
+		_id,
+	)
+	if err != nil {
+		return transaction, tg.errorResolver.ResolveError(
+			err,
+			tg.transactorOptions.From,
+			nil,
+			"withdrawRevoked",
+			_id,
+		)
+	}
+
+	tgLogger.Infof(
+		"submitted transaction withdrawRevoked with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tg.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tg.contract.WithdrawRevoked(
+				transactorOptions,
+				_id,
+			)
+			if err != nil {
+				return nil, tg.errorResolver.ResolveError(
+					err,
+					tg.transactorOptions.From,
+					nil,
+					"withdrawRevoked",
+					_id,
+				)
+			}
+
+			tgLogger.Infof(
+				"submitted transaction withdrawRevoked with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tg.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tg *TokenGrant) CallWithdrawRevoked(
+	_id *big.Int,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tg.transactorOptions.From,
+		blockNumber, nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"withdrawRevoked",
+		&result,
+		_id,
+	)
+
+	return err
+}
+
+func (tg *TokenGrant) WithdrawRevokedGasEstimate(
+	_id *big.Int,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tg.callerOptions.From,
+		tg.contractAddress,
+		"withdrawRevoked",
+		tg.contractABI,
+		tg.transactor,
+		_id,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tg *TokenGrant) AuthorizeStakingContract(
+	_stakingContract common.Address,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tgLogger.Debug(
+		"submitting transaction authorizeStakingContract",
+		"params: ",
+		fmt.Sprint(
+			_stakingContract,
+		),
+	)
+
+	tg.transactionMutex.Lock()
+	defer tg.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tg.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tg.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tg.contract.AuthorizeStakingContract(
+		transactorOptions,
+		_stakingContract,
+	)
+	if err != nil {
+		return transaction, tg.errorResolver.ResolveError(
+			err,
+			tg.transactorOptions.From,
+			nil,
+			"authorizeStakingContract",
+			_stakingContract,
+		)
+	}
+
+	tgLogger.Infof(
+		"submitted transaction authorizeStakingContract with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tg.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tg.contract.AuthorizeStakingContract(
+				transactorOptions,
+				_stakingContract,
+			)
+			if err != nil {
+				return nil, tg.errorResolver.ResolveError(
+					err,
+					tg.transactorOptions.From,
+					nil,
+					"authorizeStakingContract",
+					_stakingContract,
+				)
+			}
+
+			tgLogger.Infof(
+				"submitted transaction authorizeStakingContract with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tg.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tg *TokenGrant) CallAuthorizeStakingContract(
+	_stakingContract common.Address,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tg.transactorOptions.From,
+		blockNumber, nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"authorizeStakingContract",
+		&result,
+		_stakingContract,
+	)
+
+	return err
+}
+
+func (tg *TokenGrant) AuthorizeStakingContractGasEstimate(
+	_stakingContract common.Address,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tg.callerOptions.From,
+		tg.contractAddress,
+		"authorizeStakingContract",
+		tg.contractABI,
+		tg.transactor,
+		_stakingContract,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tg *TokenGrant) CancelRevokedStake(
+	_operator common.Address,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tgLogger.Debug(
+		"submitting transaction cancelRevokedStake",
+		"params: ",
+		fmt.Sprint(
+			_operator,
+		),
+	)
+
+	tg.transactionMutex.Lock()
+	defer tg.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tg.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tg.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tg.contract.CancelRevokedStake(
+		transactorOptions,
+		_operator,
+	)
+	if err != nil {
+		return transaction, tg.errorResolver.ResolveError(
+			err,
+			tg.transactorOptions.From,
+			nil,
+			"cancelRevokedStake",
+			_operator,
+		)
+	}
+
+	tgLogger.Infof(
+		"submitted transaction cancelRevokedStake with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tg.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tg.contract.CancelRevokedStake(
+				transactorOptions,
+				_operator,
+			)
+			if err != nil {
+				return nil, tg.errorResolver.ResolveError(
+					err,
+					tg.transactorOptions.From,
+					nil,
+					"cancelRevokedStake",
+					_operator,
+				)
+			}
+
+			tgLogger.Infof(
+				"submitted transaction cancelRevokedStake with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tg.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tg *TokenGrant) CallCancelRevokedStake(
+	_operator common.Address,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tg.transactorOptions.From,
+		blockNumber, nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"cancelRevokedStake",
+		&result,
+		_operator,
+	)
+
+	return err
+}
+
+func (tg *TokenGrant) CancelRevokedStakeGasEstimate(
+	_operator common.Address,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tg.callerOptions.From,
+		tg.contractAddress,
+		"cancelRevokedStake",
+		tg.contractABI,
+		tg.transactor,
+		_operator,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
 func (tg *TokenGrant) ReceiveApproval(
 	_from common.Address,
 	_amount *big.Int,
@@ -169,7 +985,7 @@ func (tg *TokenGrant) ReceiveApproval(
 
 	go tg.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -203,7 +1019,7 @@ func (tg *TokenGrant) ReceiveApproval(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -260,414 +1076,6 @@ func (tg *TokenGrant) ReceiveApprovalGasEstimate(
 		_amount,
 		_token,
 		_extraData,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tg *TokenGrant) Revoke(
-	_id *big.Int,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tgLogger.Debug(
-		"submitting transaction revoke",
-		"params: ",
-		fmt.Sprint(
-			_id,
-		),
-	)
-
-	tg.transactionMutex.Lock()
-	defer tg.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tg.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tg.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tg.contract.Revoke(
-		transactorOptions,
-		_id,
-	)
-	if err != nil {
-		return transaction, tg.errorResolver.ResolveError(
-			err,
-			tg.transactorOptions.From,
-			nil,
-			"revoke",
-			_id,
-		)
-	}
-
-	tgLogger.Infof(
-		"submitted transaction revoke with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tg.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tg.contract.Revoke(
-				transactorOptions,
-				_id,
-			)
-			if err != nil {
-				return nil, tg.errorResolver.ResolveError(
-					err,
-					tg.transactorOptions.From,
-					nil,
-					"revoke",
-					_id,
-				)
-			}
-
-			tgLogger.Infof(
-				"submitted transaction revoke with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tg.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallRevoke(
-	_id *big.Int,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tg.transactorOptions.From,
-		blockNumber, nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"revoke",
-		&result,
-		_id,
-	)
-
-	return err
-}
-
-func (tg *TokenGrant) RevokeGasEstimate(
-	_id *big.Int,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tg.callerOptions.From,
-		tg.contractAddress,
-		"revoke",
-		tg.contractABI,
-		tg.transactor,
-		_id,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tg *TokenGrant) Undelegate(
-	_operator common.Address,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tgLogger.Debug(
-		"submitting transaction undelegate",
-		"params: ",
-		fmt.Sprint(
-			_operator,
-		),
-	)
-
-	tg.transactionMutex.Lock()
-	defer tg.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tg.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tg.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tg.contract.Undelegate(
-		transactorOptions,
-		_operator,
-	)
-	if err != nil {
-		return transaction, tg.errorResolver.ResolveError(
-			err,
-			tg.transactorOptions.From,
-			nil,
-			"undelegate",
-			_operator,
-		)
-	}
-
-	tgLogger.Infof(
-		"submitted transaction undelegate with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tg.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tg.contract.Undelegate(
-				transactorOptions,
-				_operator,
-			)
-			if err != nil {
-				return nil, tg.errorResolver.ResolveError(
-					err,
-					tg.transactorOptions.From,
-					nil,
-					"undelegate",
-					_operator,
-				)
-			}
-
-			tgLogger.Infof(
-				"submitted transaction undelegate with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tg.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallUndelegate(
-	_operator common.Address,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tg.transactorOptions.From,
-		blockNumber, nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"undelegate",
-		&result,
-		_operator,
-	)
-
-	return err
-}
-
-func (tg *TokenGrant) UndelegateGasEstimate(
-	_operator common.Address,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tg.callerOptions.From,
-		tg.contractAddress,
-		"undelegate",
-		tg.contractABI,
-		tg.transactor,
-		_operator,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tg *TokenGrant) CancelRevokedStake(
-	_operator common.Address,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tgLogger.Debug(
-		"submitting transaction cancelRevokedStake",
-		"params: ",
-		fmt.Sprint(
-			_operator,
-		),
-	)
-
-	tg.transactionMutex.Lock()
-	defer tg.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tg.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tg.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tg.contract.CancelRevokedStake(
-		transactorOptions,
-		_operator,
-	)
-	if err != nil {
-		return transaction, tg.errorResolver.ResolveError(
-			err,
-			tg.transactorOptions.From,
-			nil,
-			"cancelRevokedStake",
-			_operator,
-		)
-	}
-
-	tgLogger.Infof(
-		"submitted transaction cancelRevokedStake with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tg.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tg.contract.CancelRevokedStake(
-				transactorOptions,
-				_operator,
-			)
-			if err != nil {
-				return nil, tg.errorResolver.ResolveError(
-					err,
-					tg.transactorOptions.From,
-					nil,
-					"cancelRevokedStake",
-					_operator,
-				)
-			}
-
-			tgLogger.Infof(
-				"submitted transaction cancelRevokedStake with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tg.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallCancelRevokedStake(
-	_operator common.Address,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tg.transactorOptions.From,
-		blockNumber, nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"cancelRevokedStake",
-		&result,
-		_operator,
-	)
-
-	return err
-}
-
-func (tg *TokenGrant) CancelRevokedStakeGasEstimate(
-	_operator common.Address,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tg.callerOptions.From,
-		tg.contractAddress,
-		"cancelRevokedStake",
-		tg.contractABI,
-		tg.transactor,
-		_operator,
 	)
 
 	return result, err
@@ -731,7 +1139,7 @@ func (tg *TokenGrant) RecoverStake(
 
 	go tg.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -759,7 +1167,7 @@ func (tg *TokenGrant) RecoverStake(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -810,16 +1218,16 @@ func (tg *TokenGrant) RecoverStakeGasEstimate(
 }
 
 // Transaction submission.
-func (tg *TokenGrant) AuthorizeStakingContract(
-	_stakingContract common.Address,
+func (tg *TokenGrant) UndelegateRevoked(
+	_operator common.Address,
 
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	tgLogger.Debug(
-		"submitting transaction authorizeStakingContract",
+		"submitting transaction undelegateRevoked",
 		"params: ",
 		fmt.Sprint(
-			_stakingContract,
+			_operator,
 		),
 	)
 
@@ -845,57 +1253,57 @@ func (tg *TokenGrant) AuthorizeStakingContract(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := tg.contract.AuthorizeStakingContract(
+	transaction, err := tg.contract.UndelegateRevoked(
 		transactorOptions,
-		_stakingContract,
+		_operator,
 	)
 	if err != nil {
 		return transaction, tg.errorResolver.ResolveError(
 			err,
 			tg.transactorOptions.From,
 			nil,
-			"authorizeStakingContract",
-			_stakingContract,
+			"undelegateRevoked",
+			_operator,
 		)
 	}
 
 	tgLogger.Infof(
-		"submitted transaction authorizeStakingContract with id: [%v] and nonce [%v]",
+		"submitted transaction undelegateRevoked with id: [%v] and nonce [%v]",
 		transaction.Hash().Hex(),
 		transaction.Nonce(),
 	)
 
 	go tg.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
 			transactorOptions.GasPrice = newGasPrice
 
-			transaction, err := tg.contract.AuthorizeStakingContract(
+			transaction, err := tg.contract.UndelegateRevoked(
 				transactorOptions,
-				_stakingContract,
+				_operator,
 			)
 			if err != nil {
 				return nil, tg.errorResolver.ResolveError(
 					err,
 					tg.transactorOptions.From,
 					nil,
-					"authorizeStakingContract",
-					_stakingContract,
+					"undelegateRevoked",
+					_operator,
 				)
 			}
 
 			tgLogger.Infof(
-				"submitted transaction authorizeStakingContract with id: [%v] and nonce [%v]",
+				"submitted transaction undelegateRevoked with id: [%v] and nonce [%v]",
 				transaction.Hash().Hex(),
 				transaction.Nonce(),
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -907,8 +1315,8 @@ func (tg *TokenGrant) AuthorizeStakingContract(
 }
 
 // Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallAuthorizeStakingContract(
-	_stakingContract common.Address,
+func (tg *TokenGrant) CallUndelegateRevoked(
+	_operator common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -920,26 +1328,26 @@ func (tg *TokenGrant) CallAuthorizeStakingContract(
 		tg.caller,
 		tg.errorResolver,
 		tg.contractAddress,
-		"authorizeStakingContract",
+		"undelegateRevoked",
 		&result,
-		_stakingContract,
+		_operator,
 	)
 
 	return err
 }
 
-func (tg *TokenGrant) AuthorizeStakingContractGasEstimate(
-	_stakingContract common.Address,
+func (tg *TokenGrant) UndelegateRevokedGasEstimate(
+	_operator common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := ethutil.EstimateGas(
 		tg.callerOptions.From,
 		tg.contractAddress,
-		"authorizeStakingContract",
+		"undelegateRevoked",
 		tg.contractABI,
 		tg.transactor,
-		_stakingContract,
+		_operator,
 	)
 
 	return result, err
@@ -1015,7 +1423,7 @@ func (tg *TokenGrant) Stake(
 
 	go tg.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -1049,7 +1457,7 @@ func (tg *TokenGrant) Stake(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -1106,142 +1514,6 @@ func (tg *TokenGrant) StakeGasEstimate(
 		_stakingContract,
 		_amount,
 		_extraData,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tg *TokenGrant) WithdrawRevoked(
-	_id *big.Int,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tgLogger.Debug(
-		"submitting transaction withdrawRevoked",
-		"params: ",
-		fmt.Sprint(
-			_id,
-		),
-	)
-
-	tg.transactionMutex.Lock()
-	defer tg.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tg.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tg.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tg.contract.WithdrawRevoked(
-		transactorOptions,
-		_id,
-	)
-	if err != nil {
-		return transaction, tg.errorResolver.ResolveError(
-			err,
-			tg.transactorOptions.From,
-			nil,
-			"withdrawRevoked",
-			_id,
-		)
-	}
-
-	tgLogger.Infof(
-		"submitted transaction withdrawRevoked with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tg.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tg.contract.WithdrawRevoked(
-				transactorOptions,
-				_id,
-			)
-			if err != nil {
-				return nil, tg.errorResolver.ResolveError(
-					err,
-					tg.transactorOptions.From,
-					nil,
-					"withdrawRevoked",
-					_id,
-				)
-			}
-
-			tgLogger.Infof(
-				"submitted transaction withdrawRevoked with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tg.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallWithdrawRevoked(
-	_id *big.Int,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tg.transactorOptions.From,
-		blockNumber, nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"withdrawRevoked",
-		&result,
-		_id,
-	)
-
-	return err
-}
-
-func (tg *TokenGrant) WithdrawRevokedGasEstimate(
-	_id *big.Int,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tg.callerOptions.From,
-		tg.contractAddress,
-		"withdrawRevoked",
-		tg.contractABI,
-		tg.transactor,
-		_id,
 	)
 
 	return result, err
@@ -1305,7 +1577,7 @@ func (tg *TokenGrant) CancelStake(
 
 	go tg.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -1333,7 +1605,7 @@ func (tg *TokenGrant) CancelStake(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -1383,279 +1655,435 @@ func (tg *TokenGrant) CancelStakeGasEstimate(
 	return result, err
 }
 
-// Transaction submission.
-func (tg *TokenGrant) UndelegateRevoked(
-	_operator common.Address,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tgLogger.Debug(
-		"submitting transaction undelegateRevoked",
-		"params: ",
-		fmt.Sprint(
-			_operator,
-		),
-	)
-
-	tg.transactionMutex.Lock()
-	defer tg.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tg.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tg.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tg.contract.UndelegateRevoked(
-		transactorOptions,
-		_operator,
-	)
-	if err != nil {
-		return transaction, tg.errorResolver.ResolveError(
-			err,
-			tg.transactorOptions.From,
-			nil,
-			"undelegateRevoked",
-			_operator,
-		)
-	}
-
-	tgLogger.Infof(
-		"submitted transaction undelegateRevoked with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tg.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tg.contract.UndelegateRevoked(
-				transactorOptions,
-				_operator,
-			)
-			if err != nil {
-				return nil, tg.errorResolver.ResolveError(
-					err,
-					tg.transactorOptions.From,
-					nil,
-					"undelegateRevoked",
-					_operator,
-				)
-			}
-
-			tgLogger.Infof(
-				"submitted transaction undelegateRevoked with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tg.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallUndelegateRevoked(
-	_operator common.Address,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tg.transactorOptions.From,
-		blockNumber, nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"undelegateRevoked",
-		&result,
-		_operator,
-	)
-
-	return err
-}
-
-func (tg *TokenGrant) UndelegateRevokedGasEstimate(
-	_operator common.Address,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tg.callerOptions.From,
-		tg.contractAddress,
-		"undelegateRevoked",
-		tg.contractABI,
-		tg.transactor,
-		_operator,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tg *TokenGrant) Withdraw(
-	_id *big.Int,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tgLogger.Debug(
-		"submitting transaction withdraw",
-		"params: ",
-		fmt.Sprint(
-			_id,
-		),
-	)
-
-	tg.transactionMutex.Lock()
-	defer tg.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tg.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tg.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tg.contract.Withdraw(
-		transactorOptions,
-		_id,
-	)
-	if err != nil {
-		return transaction, tg.errorResolver.ResolveError(
-			err,
-			tg.transactorOptions.From,
-			nil,
-			"withdraw",
-			_id,
-		)
-	}
-
-	tgLogger.Infof(
-		"submitted transaction withdraw with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tg.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tg.contract.Withdraw(
-				transactorOptions,
-				_id,
-			)
-			if err != nil {
-				return nil, tg.errorResolver.ResolveError(
-					err,
-					tg.transactorOptions.From,
-					nil,
-					"withdraw",
-					_id,
-				)
-			}
-
-			tgLogger.Infof(
-				"submitted transaction withdraw with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tg.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tg *TokenGrant) CallWithdraw(
-	_id *big.Int,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tg.transactorOptions.From,
-		blockNumber, nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"withdraw",
-		&result,
-		_id,
-	)
-
-	return err
-}
-
-func (tg *TokenGrant) WithdrawGasEstimate(
-	_id *big.Int,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tg.callerOptions.From,
-		tg.contractAddress,
-		"withdraw",
-		tg.contractABI,
-		tg.transactor,
-		_id,
-	)
-
-	return result, err
-}
-
 // ----- Const Methods ------
+
+func (tg *TokenGrant) GrantStakes(
+	arg0 common.Address,
+) (common.Address, error) {
+	var result common.Address
+	result, err := tg.contract.GrantStakes(
+		tg.callerOptions,
+		arg0,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"grantStakes",
+			arg0,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) GrantStakesAtBlock(
+	arg0 common.Address,
+	blockNumber *big.Int,
+) (common.Address, error) {
+	var result common.Address
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"grantStakes",
+		&result,
+		arg0,
+	)
+
+	return result, err
+}
+
+func (tg *TokenGrant) UnlockedAmount(
+	_id *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+	result, err := tg.contract.UnlockedAmount(
+		tg.callerOptions,
+		_id,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"unlockedAmount",
+			_id,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) UnlockedAmountAtBlock(
+	_id *big.Int,
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"unlockedAmount",
+		&result,
+		_id,
+	)
+
+	return result, err
+}
+
+type GrantStakeDetails struct {
+	GrantId         *big.Int
+	Amount          *big.Int
+	StakingContract common.Address
+}
+
+func (tg *TokenGrant) GetGrantStakeDetails(
+	operator common.Address,
+) (GrantStakeDetails, error) {
+	var result GrantStakeDetails
+	result, err := tg.contract.GetGrantStakeDetails(
+		tg.callerOptions,
+		operator,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"getGrantStakeDetails",
+			operator,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) GetGrantStakeDetailsAtBlock(
+	operator common.Address,
+	blockNumber *big.Int,
+) (GrantStakeDetails, error) {
+	var result GrantStakeDetails
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"getGrantStakeDetails",
+		&result,
+		operator,
+	)
+
+	return result, err
+}
+
+func (tg *TokenGrant) GranteesToOperators(
+	arg0 common.Address,
+	arg1 *big.Int,
+) (common.Address, error) {
+	var result common.Address
+	result, err := tg.contract.GranteesToOperators(
+		tg.callerOptions,
+		arg0,
+		arg1,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"granteesToOperators",
+			arg0,
+			arg1,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) GranteesToOperatorsAtBlock(
+	arg0 common.Address,
+	arg1 *big.Int,
+	blockNumber *big.Int,
+) (common.Address, error) {
+	var result common.Address
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"granteesToOperators",
+		&result,
+		arg0,
+		arg1,
+	)
+
+	return result, err
+}
+
+func (tg *TokenGrant) GetGrants(
+	_granteeOrGrantManager common.Address,
+) ([]*big.Int, error) {
+	var result []*big.Int
+	result, err := tg.contract.GetGrants(
+		tg.callerOptions,
+		_granteeOrGrantManager,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"getGrants",
+			_granteeOrGrantManager,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) GetGrantsAtBlock(
+	_granteeOrGrantManager common.Address,
+	blockNumber *big.Int,
+) ([]*big.Int, error) {
+	var result []*big.Int
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"getGrants",
+		&result,
+		_granteeOrGrantManager,
+	)
+
+	return result, err
+}
+
+func (tg *TokenGrant) GrantIndices(
+	arg0 common.Address,
+	arg1 *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+	result, err := tg.contract.GrantIndices(
+		tg.callerOptions,
+		arg0,
+		arg1,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"grantIndices",
+			arg0,
+			arg1,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) GrantIndicesAtBlock(
+	arg0 common.Address,
+	arg1 *big.Int,
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"grantIndices",
+		&result,
+		arg0,
+		arg1,
+	)
+
+	return result, err
+}
+
+type grants struct {
+	GrantManager     common.Address
+	Grantee          common.Address
+	RevokedAt        *big.Int
+	RevokedAmount    *big.Int
+	RevokedWithdrawn *big.Int
+	Revocable        bool
+	Amount           *big.Int
+	Duration         *big.Int
+	Start            *big.Int
+	Cliff            *big.Int
+	Withdrawn        *big.Int
+	Staked           *big.Int
+	StakingPolicy    common.Address
+}
+
+func (tg *TokenGrant) Grants(
+	arg0 *big.Int,
+) (grants, error) {
+	var result grants
+	result, err := tg.contract.Grants(
+		tg.callerOptions,
+		arg0,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"grants",
+			arg0,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) GrantsAtBlock(
+	arg0 *big.Int,
+	blockNumber *big.Int,
+) (grants, error) {
+	var result grants
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"grants",
+		&result,
+		arg0,
+	)
+
+	return result, err
+}
+
+func (tg *TokenGrant) AvailableToStake(
+	_grantId *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+	result, err := tg.contract.AvailableToStake(
+		tg.callerOptions,
+		_grantId,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"availableToStake",
+			_grantId,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) AvailableToStakeAtBlock(
+	_grantId *big.Int,
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"availableToStake",
+		&result,
+		_grantId,
+	)
+
+	return result, err
+}
+
+func (tg *TokenGrant) BalanceOf(
+	_owner common.Address,
+) (*big.Int, error) {
+	var result *big.Int
+	result, err := tg.contract.BalanceOf(
+		tg.callerOptions,
+		_owner,
+	)
+
+	if err != nil {
+		return result, tg.errorResolver.ResolveError(
+			err,
+			tg.callerOptions.From,
+			nil,
+			"balanceOf",
+			_owner,
+		)
+	}
+
+	return result, err
+}
+
+func (tg *TokenGrant) BalanceOfAtBlock(
+	_owner common.Address,
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tg.callerOptions.From,
+		blockNumber,
+		nil,
+		tg.contractABI,
+		tg.caller,
+		tg.errorResolver,
+		tg.contractAddress,
+		"balanceOf",
+		&result,
+		_owner,
+	)
+
+	return result, err
+}
 
 func (tg *TokenGrant) Balances(
 	arg0 common.Address,
@@ -1745,94 +2173,6 @@ func (tg *TokenGrant) WithdrawableAtBlock(
 	return result, err
 }
 
-func (tg *TokenGrant) AvailableToStake(
-	_grantId *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-	result, err := tg.contract.AvailableToStake(
-		tg.callerOptions,
-		_grantId,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"availableToStake",
-			_grantId,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) AvailableToStakeAtBlock(
-	_grantId *big.Int,
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"availableToStake",
-		&result,
-		_grantId,
-	)
-
-	return result, err
-}
-
-func (tg *TokenGrant) UnlockedAmount(
-	_id *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-	result, err := tg.contract.UnlockedAmount(
-		tg.callerOptions,
-		_id,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"unlockedAmount",
-			_id,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) UnlockedAmountAtBlock(
-	_id *big.Int,
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"unlockedAmount",
-		&result,
-		_id,
-	)
-
-	return result, err
-}
-
 type Grant struct {
 	Amount        *big.Int
 	Withdrawn     *big.Int
@@ -1886,138 +2226,6 @@ func (tg *TokenGrant) GetGrantAtBlock(
 	return result, err
 }
 
-func (tg *TokenGrant) Token() (common.Address, error) {
-	var result common.Address
-	result, err := tg.contract.Token(
-		tg.callerOptions,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"token",
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) TokenAtBlock(
-	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"token",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tg *TokenGrant) BalanceOf(
-	_owner common.Address,
-) (*big.Int, error) {
-	var result *big.Int
-	result, err := tg.contract.BalanceOf(
-		tg.callerOptions,
-		_owner,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"balanceOf",
-			_owner,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) BalanceOfAtBlock(
-	_owner common.Address,
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"balanceOf",
-		&result,
-		_owner,
-	)
-
-	return result, err
-}
-
-type GrantStakeDetails struct {
-	GrantId         *big.Int
-	Amount          *big.Int
-	StakingContract common.Address
-}
-
-func (tg *TokenGrant) GetGrantStakeDetails(
-	operator common.Address,
-) (GrantStakeDetails, error) {
-	var result GrantStakeDetails
-	result, err := tg.contract.GetGrantStakeDetails(
-		tg.callerOptions,
-		operator,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"getGrantStakeDetails",
-			operator,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) GetGrantStakeDetailsAtBlock(
-	operator common.Address,
-	blockNumber *big.Int,
-) (GrantStakeDetails, error) {
-	var result GrantStakeDetails
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"getGrantStakeDetails",
-		&result,
-		operator,
-	)
-
-	return result, err
-}
-
 func (tg *TokenGrant) StakeBalanceOf(
 	_address common.Address,
 ) (*big.Int, error) {
@@ -2062,146 +2270,10 @@ func (tg *TokenGrant) StakeBalanceOfAtBlock(
 	return result, err
 }
 
-func (tg *TokenGrant) GetGranteeOperators(
-	grantee common.Address,
-) ([]common.Address, error) {
-	var result []common.Address
-	result, err := tg.contract.GetGranteeOperators(
-		tg.callerOptions,
-		grantee,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"getGranteeOperators",
-			grantee,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) GetGranteeOperatorsAtBlock(
-	grantee common.Address,
-	blockNumber *big.Int,
-) ([]common.Address, error) {
-	var result []common.Address
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"getGranteeOperators",
-		&result,
-		grantee,
-	)
-
-	return result, err
-}
-
-func (tg *TokenGrant) GrantIndices(
-	arg0 common.Address,
-	arg1 *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-	result, err := tg.contract.GrantIndices(
-		tg.callerOptions,
-		arg0,
-		arg1,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"grantIndices",
-			arg0,
-			arg1,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) GrantIndicesAtBlock(
-	arg0 common.Address,
-	arg1 *big.Int,
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"grantIndices",
-		&result,
-		arg0,
-		arg1,
-	)
-
-	return result, err
-}
-
-func (tg *TokenGrant) NumGrants() (*big.Int, error) {
-	var result *big.Int
-	result, err := tg.contract.NumGrants(
-		tg.callerOptions,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"numGrants",
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) NumGrantsAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"numGrants",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tg *TokenGrant) GranteesToOperators(
-	arg0 common.Address,
-	arg1 *big.Int,
-) (common.Address, error) {
+func (tg *TokenGrant) Token() (common.Address, error) {
 	var result common.Address
-	result, err := tg.contract.GranteesToOperators(
+	result, err := tg.contract.Token(
 		tg.callerOptions,
-		arg0,
-		arg1,
 	)
 
 	if err != nil {
@@ -2209,18 +2281,14 @@ func (tg *TokenGrant) GranteesToOperators(
 			err,
 			tg.callerOptions.From,
 			nil,
-			"granteesToOperators",
-			arg0,
-			arg1,
+			"token",
 		)
 	}
 
 	return result, err
 }
 
-func (tg *TokenGrant) GranteesToOperatorsAtBlock(
-	arg0 common.Address,
-	arg1 *big.Int,
+func (tg *TokenGrant) TokenAtBlock(
 	blockNumber *big.Int,
 ) (common.Address, error) {
 	var result common.Address
@@ -2233,70 +2301,8 @@ func (tg *TokenGrant) GranteesToOperatorsAtBlock(
 		tg.caller,
 		tg.errorResolver,
 		tg.contractAddress,
-		"granteesToOperators",
+		"token",
 		&result,
-		arg0,
-		arg1,
-	)
-
-	return result, err
-}
-
-type grants struct {
-	GrantManager     common.Address
-	Grantee          common.Address
-	RevokedAt        *big.Int
-	RevokedAmount    *big.Int
-	RevokedWithdrawn *big.Int
-	Revocable        bool
-	Amount           *big.Int
-	Duration         *big.Int
-	Start            *big.Int
-	Cliff            *big.Int
-	Withdrawn        *big.Int
-	Staked           *big.Int
-	StakingPolicy    common.Address
-}
-
-func (tg *TokenGrant) Grants(
-	arg0 *big.Int,
-) (grants, error) {
-	var result grants
-	result, err := tg.contract.Grants(
-		tg.callerOptions,
-		arg0,
-	)
-
-	if err != nil {
-		return result, tg.errorResolver.ResolveError(
-			err,
-			tg.callerOptions.From,
-			nil,
-			"grants",
-			arg0,
-		)
-	}
-
-	return result, err
-}
-
-func (tg *TokenGrant) GrantsAtBlock(
-	arg0 *big.Int,
-	blockNumber *big.Int,
-) (grants, error) {
-	var result grants
-
-	err := ethutil.CallAtBlock(
-		tg.callerOptions.From,
-		blockNumber,
-		nil,
-		tg.contractABI,
-		tg.caller,
-		tg.errorResolver,
-		tg.contractAddress,
-		"grants",
-		&result,
-		arg0,
 	)
 
 	return result, err
@@ -2354,13 +2360,13 @@ func (tg *TokenGrant) GetGrantUnlockingScheduleAtBlock(
 	return result, err
 }
 
-func (tg *TokenGrant) GetGrants(
-	_granteeOrGrantManager common.Address,
-) ([]*big.Int, error) {
-	var result []*big.Int
-	result, err := tg.contract.GetGrants(
+func (tg *TokenGrant) GetGranteeOperators(
+	grantee common.Address,
+) ([]common.Address, error) {
+	var result []common.Address
+	result, err := tg.contract.GetGranteeOperators(
 		tg.callerOptions,
-		_granteeOrGrantManager,
+		grantee,
 	)
 
 	if err != nil {
@@ -2368,19 +2374,19 @@ func (tg *TokenGrant) GetGrants(
 			err,
 			tg.callerOptions.From,
 			nil,
-			"getGrants",
-			_granteeOrGrantManager,
+			"getGranteeOperators",
+			grantee,
 		)
 	}
 
 	return result, err
 }
 
-func (tg *TokenGrant) GetGrantsAtBlock(
-	_granteeOrGrantManager common.Address,
+func (tg *TokenGrant) GetGranteeOperatorsAtBlock(
+	grantee common.Address,
 	blockNumber *big.Int,
-) ([]*big.Int, error) {
-	var result []*big.Int
+) ([]common.Address, error) {
+	var result []common.Address
 
 	err := ethutil.CallAtBlock(
 		tg.callerOptions.From,
@@ -2390,21 +2396,18 @@ func (tg *TokenGrant) GetGrantsAtBlock(
 		tg.caller,
 		tg.errorResolver,
 		tg.contractAddress,
-		"getGrants",
+		"getGranteeOperators",
 		&result,
-		_granteeOrGrantManager,
+		grantee,
 	)
 
 	return result, err
 }
 
-func (tg *TokenGrant) GrantStakes(
-	arg0 common.Address,
-) (common.Address, error) {
-	var result common.Address
-	result, err := tg.contract.GrantStakes(
+func (tg *TokenGrant) NumGrants() (*big.Int, error) {
+	var result *big.Int
+	result, err := tg.contract.NumGrants(
 		tg.callerOptions,
-		arg0,
 	)
 
 	if err != nil {
@@ -2412,19 +2415,17 @@ func (tg *TokenGrant) GrantStakes(
 			err,
 			tg.callerOptions.From,
 			nil,
-			"grantStakes",
-			arg0,
+			"numGrants",
 		)
 	}
 
 	return result, err
 }
 
-func (tg *TokenGrant) GrantStakesAtBlock(
-	arg0 common.Address,
+func (tg *TokenGrant) NumGrantsAtBlock(
 	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
+) (*big.Int, error) {
+	var result *big.Int
 
 	err := ethutil.CallAtBlock(
 		tg.callerOptions.From,
@@ -2434,15 +2435,383 @@ func (tg *TokenGrant) GrantStakesAtBlock(
 		tg.caller,
 		tg.errorResolver,
 		tg.contractAddress,
-		"grantStakes",
+		"numGrants",
 		&result,
-		arg0,
 	)
 
 	return result, err
 }
 
 // ------ Events -------
+
+func (tg *TokenGrant) StakingContractAuthorized(
+	opts *ethutil.SubscribeOpts,
+	grantManagerFilter []common.Address,
+) *TgStakingContractAuthorizedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TgStakingContractAuthorizedSubscription{
+		tg,
+		opts,
+		grantManagerFilter,
+	}
+}
+
+type TgStakingContractAuthorizedSubscription struct {
+	contract           *TokenGrant
+	opts               *ethutil.SubscribeOpts
+	grantManagerFilter []common.Address
+}
+
+type tokenGrantStakingContractAuthorizedFunc func(
+	GrantManager common.Address,
+	StakingContract common.Address,
+	blockNumber uint64,
+)
+
+func (scas *TgStakingContractAuthorizedSubscription) OnEvent(
+	handler tokenGrantStakingContractAuthorizedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TokenGrantStakingContractAuthorized)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.GrantManager,
+					event.StakingContract,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := scas.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (scas *TgStakingContractAuthorizedSubscription) Pipe(
+	sink chan *abi.TokenGrantStakingContractAuthorized,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(scas.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := scas.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tgLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - scas.opts.PastBlocks
+
+				tgLogger.Infof(
+					"subscription monitoring fetching past StakingContractAuthorized events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := scas.contract.PastStakingContractAuthorizedEvents(
+					fromBlock,
+					nil,
+					scas.grantManagerFilter,
+				)
+				if err != nil {
+					tgLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tgLogger.Infof(
+					"subscription monitoring fetched [%v] past StakingContractAuthorized events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := scas.contract.watchStakingContractAuthorized(
+		sink,
+		scas.grantManagerFilter,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tg *TokenGrant) watchStakingContractAuthorized(
+	sink chan *abi.TokenGrantStakingContractAuthorized,
+	grantManagerFilter []common.Address,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tg.contract.WatchStakingContractAuthorized(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			grantManagerFilter,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tgLogger.Errorf(
+			"subscription to event StakingContractAuthorized had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tgLogger.Errorf(
+			"subscription to event StakingContractAuthorized failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tg *TokenGrant) PastStakingContractAuthorizedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+	grantManagerFilter []common.Address,
+) ([]*abi.TokenGrantStakingContractAuthorized, error) {
+	iterator, err := tg.contract.FilterStakingContractAuthorized(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		grantManagerFilter,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past StakingContractAuthorized events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TokenGrantStakingContractAuthorized, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tg *TokenGrant) TokenGrantCreated(
+	opts *ethutil.SubscribeOpts,
+) *TgTokenGrantCreatedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TgTokenGrantCreatedSubscription{
+		tg,
+		opts,
+	}
+}
+
+type TgTokenGrantCreatedSubscription struct {
+	contract *TokenGrant
+	opts     *ethutil.SubscribeOpts
+}
+
+type tokenGrantTokenGrantCreatedFunc func(
+	Id *big.Int,
+	blockNumber uint64,
+)
+
+func (tgcs *TgTokenGrantCreatedSubscription) OnEvent(
+	handler tokenGrantTokenGrantCreatedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TokenGrantTokenGrantCreated)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.Id,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := tgcs.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tgcs *TgTokenGrantCreatedSubscription) Pipe(
+	sink chan *abi.TokenGrantTokenGrantCreated,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(tgcs.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := tgcs.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tgLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - tgcs.opts.PastBlocks
+
+				tgLogger.Infof(
+					"subscription monitoring fetching past TokenGrantCreated events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := tgcs.contract.PastTokenGrantCreatedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tgLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tgLogger.Infof(
+					"subscription monitoring fetched [%v] past TokenGrantCreated events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := tgcs.contract.watchTokenGrantCreated(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tg *TokenGrant) watchTokenGrantCreated(
+	sink chan *abi.TokenGrantTokenGrantCreated,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tg.contract.WatchTokenGrantCreated(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tgLogger.Errorf(
+			"subscription to event TokenGrantCreated had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tgLogger.Errorf(
+			"subscription to event TokenGrantCreated failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tg *TokenGrant) PastTokenGrantCreatedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TokenGrantTokenGrantCreated, error) {
+	iterator, err := tg.contract.FilterTokenGrantCreated(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past TokenGrantCreated events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TokenGrantTokenGrantCreated, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
 
 func (tg *TokenGrant) TokenGrantRevoked(
 	opts *ethutil.SubscribeOpts,
@@ -2996,375 +3365,6 @@ func (tg *TokenGrant) PastTokenGrantWithdrawnEvents(
 	}
 
 	events := make([]*abi.TokenGrantTokenGrantWithdrawn, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tg *TokenGrant) StakingContractAuthorized(
-	opts *ethutil.SubscribeOpts,
-	grantManagerFilter []common.Address,
-) *TgStakingContractAuthorizedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TgStakingContractAuthorizedSubscription{
-		tg,
-		opts,
-		grantManagerFilter,
-	}
-}
-
-type TgStakingContractAuthorizedSubscription struct {
-	contract           *TokenGrant
-	opts               *ethutil.SubscribeOpts
-	grantManagerFilter []common.Address
-}
-
-type tokenGrantStakingContractAuthorizedFunc func(
-	GrantManager common.Address,
-	StakingContract common.Address,
-	blockNumber uint64,
-)
-
-func (scas *TgStakingContractAuthorizedSubscription) OnEvent(
-	handler tokenGrantStakingContractAuthorizedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TokenGrantStakingContractAuthorized)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.GrantManager,
-					event.StakingContract,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := scas.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (scas *TgStakingContractAuthorizedSubscription) Pipe(
-	sink chan *abi.TokenGrantStakingContractAuthorized,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(scas.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := scas.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tgLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - scas.opts.PastBlocks
-
-				tgLogger.Infof(
-					"subscription monitoring fetching past StakingContractAuthorized events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := scas.contract.PastStakingContractAuthorizedEvents(
-					fromBlock,
-					nil,
-					scas.grantManagerFilter,
-				)
-				if err != nil {
-					tgLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tgLogger.Infof(
-					"subscription monitoring fetched [%v] past StakingContractAuthorized events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := scas.contract.watchStakingContractAuthorized(
-		sink,
-		scas.grantManagerFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tg *TokenGrant) watchStakingContractAuthorized(
-	sink chan *abi.TokenGrantStakingContractAuthorized,
-	grantManagerFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tg.contract.WatchStakingContractAuthorized(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			grantManagerFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tgLogger.Errorf(
-			"subscription to event StakingContractAuthorized had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tgLogger.Errorf(
-			"subscription to event StakingContractAuthorized failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tg *TokenGrant) PastStakingContractAuthorizedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	grantManagerFilter []common.Address,
-) ([]*abi.TokenGrantStakingContractAuthorized, error) {
-	iterator, err := tg.contract.FilterStakingContractAuthorized(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		grantManagerFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past StakingContractAuthorized events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TokenGrantStakingContractAuthorized, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tg *TokenGrant) TokenGrantCreated(
-	opts *ethutil.SubscribeOpts,
-) *TgTokenGrantCreatedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TgTokenGrantCreatedSubscription{
-		tg,
-		opts,
-	}
-}
-
-type TgTokenGrantCreatedSubscription struct {
-	contract *TokenGrant
-	opts     *ethutil.SubscribeOpts
-}
-
-type tokenGrantTokenGrantCreatedFunc func(
-	Id *big.Int,
-	blockNumber uint64,
-)
-
-func (tgcs *TgTokenGrantCreatedSubscription) OnEvent(
-	handler tokenGrantTokenGrantCreatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TokenGrantTokenGrantCreated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.Id,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := tgcs.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tgcs *TgTokenGrantCreatedSubscription) Pipe(
-	sink chan *abi.TokenGrantTokenGrantCreated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(tgcs.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := tgcs.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tgLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - tgcs.opts.PastBlocks
-
-				tgLogger.Infof(
-					"subscription monitoring fetching past TokenGrantCreated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := tgcs.contract.PastTokenGrantCreatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tgLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tgLogger.Infof(
-					"subscription monitoring fetched [%v] past TokenGrantCreated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := tgcs.contract.watchTokenGrantCreated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tg *TokenGrant) watchTokenGrantCreated(
-	sink chan *abi.TokenGrantTokenGrantCreated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tg.contract.WatchTokenGrantCreated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tgLogger.Errorf(
-			"subscription to event TokenGrantCreated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tgLogger.Errorf(
-			"subscription to event TokenGrantCreated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tg *TokenGrant) PastTokenGrantCreatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TokenGrantTokenGrantCreated, error) {
-	iterator, err := tg.contract.FilterTokenGrantCreated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past TokenGrantCreated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TokenGrantTokenGrantCreated, 0)
 
 	for iterator.Next() {
 		event := iterator.Event


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-common/pull/64

Updated the `keep-common` dependency version to use the new `ethlike` package and regenerated contract bindings. This change is one of the steps which prepares the codebase to be ready for supporting new chains.