### PR TITLE
KEEP Token Dashboard release v1.10.0

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
37a513e3f7fcade6567d543fa2952aaf2488834b is the commit hash for token-dashboard/v1.10.0

This bundles work from https://github.com/keep-network/keep-core/milestone/45?closed=1