### PR TITLE
Run Go workflow only on `rfc-18/**` branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,9 @@ workflows:
       - build_client_and_test_go:
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - /rfc-18\/.*/
           context: keep-dev
       - build_token_dashboard_dapp:
           filters:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,11 +1,16 @@
 name: Go
 
-#TODO: extend the conditions once workflow gets tested together with other workflows 
-on:  
+#TODO: extend the conditions once workflow gets tested together with other workflows
+on:
   push:
     branches:
-      - master
+      # TODO: Run on master after we're fully migrated from Circle CI
+      # - master
+      - "rfc-18/**"
   pull_request:
+    branches:
+      # TODO: Run on all branches after we're fully migrated from Circle CI
+      - "rfc-18/**"
   workflow_dispatch:
 
 jobs:
@@ -21,7 +26,7 @@ jobs:
             --target gobuild \
             --tag go-build-env .
           docker build \
-            --tag keep-client . 
+            --tag keep-client .
       - name: Create test results directory
         run: |
           mkdir test-results
@@ -37,6 +42,6 @@ jobs:
         if: always() # guarantees that this action always runs, even if earlier steps fail
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          files:  ./test-results/unit-tests.xml
+          files: ./test-results/unit-tests.xml
           check_name: Go Test Results # name under which test results will be presented in GitHub (optional)
           comment_on_pr: false # turns off commenting on Pull Requests


### PR DESCRIPTION
We restricted branches for which Go build and test workflow gets
executed. Currently execution duplicates with workflow executed in CircleCI.

We defined `rfc-18/` prefix. For branches with that prefix, jobs will be
executed in GH Actions instead of Circle CI.

Refs: https://github.com/keep-network/keep-core/blob/master/docs/rfc/rfc-18-release-management.adoc
Refs: https://github.com/keep-network/keep-core/pull/2318