### PR TITLE
Updated .dockerignore content

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,18 @@
 # Top-level directories unrelated to the build.
-Dockerfile
 .*
 docs
-.circleci
+infrastructure
 scripts
-testnet*
+
+# Top-level files unrealted to the build.
+CODEOWNERS
+crytic-config.json
+Dockerfile
+*.adoc
 
 # NPM stuff.
 **/node_modules/*
 
 # Go stuff.
-vendor
 **/gen/*/**/*.go
 !pkg/chain/gen/cmd/cmd*.go


### PR DESCRIPTION
.dockerignore felt a little outdated. We introduced couple of updates:
- removed entries perfixed with `.` as these are already covered by `.*`,
- removed `testnet*` as I believe is no longer expected to happen,
- added `infrastructure` directory as these are not needed,
- ignored couple of top-level files,
- removed `vendor` as we swithched to go modules.