### PR TITLE
Unification of GH Action solidity workflows between keep-core and keep-ecdsa

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -3,6 +3,8 @@ name: Solidity
 on:
   push:
     branches:
+      # TODO: Run only on master after we're fully migrated from Circle CI
+      - "rfc-18/**"
       - master
     paths:
       - "solidity/contracts/**"
@@ -11,6 +13,9 @@ on:
       - ".github/workflows/contracts.yml"
   pull_request:
     branches:
+      # TODO: Run on all branches or only on master (to be decided) 
+      # after we're fully migrated from Circle CI
+      - "rfc-18/**"
       - master
     paths:
       - "solidity/contracts/**"
@@ -19,15 +24,15 @@ on:
       - ".github/workflows/contracts.yml"
 
 jobs:
-  test:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           cache-name: cache-solidity-node-modules
         with:
@@ -41,6 +46,10 @@ jobs:
         working-directory: ./solidity
         run: |
           npm ci
+      - name: Build solidity contracts
+        working-directory: ./solidity
+        run: |
+          npm run compile
       - name: Run tests
         working-directory: ./solidity
         run: |
@@ -49,12 +58,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           cache-name: cache-solidity-node-modules
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -7,9 +7,8 @@ on:
       - "rfc-18/**"
       - master
     paths:
-      - "solidity/contracts/**"
-      - "solidity/package.json"
-      - "solidity/package-lock.json"
+      - "solidity/**"
+      - "!solidity/dashboard/**"
       - ".github/workflows/contracts.yml"
   pull_request:
     branches:
@@ -18,9 +17,8 @@ on:
       - "rfc-18/**"
       - master
     paths:
-      - "solidity/contracts/**"
-      - "solidity/package.json"
-      - "solidity/package-lock.json"
+      - "solidity/**"
+      - "!solidity/dashboard/**"
       - ".github/workflows/contracts.yml"
 
 jobs:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -42,16 +42,13 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         working-directory: ./solidity
-        run: |
-          npm ci
+        run: npm ci
       - name: Build solidity contracts
         working-directory: ./solidity
-        run: |
-          npm run compile
+        run: npm run compile
       - name: Run tests
         working-directory: ./solidity
-        run: |
-          npm run test
+        run: npm run test
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -52,7 +52,6 @@ jobs:
         working-directory: ./solidity
         run: |
           npm run test
-          exit 0
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvment and make
the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions. For keep-core part of
the workflow responsible for testing and linting of Solidity build
was already developed as a GitHub Actions workflow. This commit
introduces four changes to the workflow, to make the implementation
similiar to analogous workflow in keep-core.
Those changes are:
1. Added triggering of workflow on push and pull request events for
'rfc-18/*' branches
2. Updated versions of actions
3. Added step that builds solidity contracts
4. Name of 'test' step changed to 'build-and-test'