### PR TITLE
Updated docs pointing to ropsten contracts

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -450,7 +450,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0x234d2182B29c6a64ce3ab6940037b5C8FdAB608e`
+|`0x3D6Ef582590D75d1fBe63B379f626DA1f5b2f810`
 |===
 
 [%header,cols=2*]
@@ -459,10 +459,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0x6c04499B595efdc28CdbEd3f9ed2E83d7dCCC717`
+|`0x0D3735ED83F812417af32CEDD09772b0Ec43dAf6`
 
 |KeepRandomBeaconOperator
-|`0xC8337a94a50d16191513dEF4D1e61A6886BF410f`
+|`0x89361Bd4E69C72194CDcAEcEA3A4df525F22Cb03`
 |===
 
 == Staking


### PR DESCRIPTION
Updated contracts addresses in test environment documentation. The
contracts were migrated in `@keep-network/keep-core@1.6.1-rc.0` and are
currently backed by nodes running in keep-test environment.

Circle CI job: https://app.circleci.com/pipelines/github/keep-network/keep-core/8335/workflows/822c0377-8380-44e2-b60b-b348e4f016ba