### PR TITLE
Change swap links to the ETH<>KEEP pairs

### DIFF
--- a/solidity/dashboard/src/pages/OverviewPage.jsx
+++ b/solidity/dashboard/src/pages/OverviewPage.jsx
@@ -133,7 +133,7 @@ const OverviewFirstSection = () => {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={"https://balancer.exchange/#/swap"}
+            href={"https://balancer.exchange/#/swap/ether/0x85eee30c52b0b379b046fb0f85f4f3dc3009afec"}
             className="text-black mr-2"
           >
             Balancer
@@ -144,7 +144,7 @@ const OverviewFirstSection = () => {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={"https://app.uniswap.org/#/swap"}
+            href={"https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0x85eee30c52b0b379b046fb0f85f4f3dc3009afec"}
             className="text-black"
           >
             Uniswap

--- a/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -103,7 +103,7 @@ const LiquidityPage = ({ headerTitle }) => {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href={"https://balancer.exchange/#/swap"}
+                href={"https://balancer.exchange/#/swap/ether/0x85eee30c52b0b379b046fb0f85f4f3dc3009afec"}
                 className="text-link"
               >
                 Balancer
@@ -112,7 +112,7 @@ const LiquidityPage = ({ headerTitle }) => {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href={"https://app.uniswap.org/#/swap"}
+                href={"https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0x85eee30c52b0b379b046fb0f85f4f3dc3009afec"}
                 className="text-link"
               >
                 Uniswap


### PR DESCRIPTION
URL change for the "Get KEEP tokens" links.

Routes users to the ETH<>KEEP pairs on [Balancer](https://balancer.exchange/#/swap/ether/0x85eee30c52b0b379b046fb0f85f4f3dc3009afec) and [Uniswap](https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0x85eee30c52b0b379b046fb0f85f4f3dc3009afec)