### PR TITLE
Move build&publish of Token Dashboard dApp to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,8 @@ jobs:
             # curl CIRCLE_API_BUILD/keep-tecdsa?branch=${CIRCLE_BRANCH}
             echo "Eventually trigger downstream for $CIRCLE_BRANCH"
 
+  # GitHub Actions equivalent of this job (.github/workflows/token-dashboard.yml) 
+  # has been created as part of work on RFC-18
   build_token_dashboard_dapp:
     executor: docker-node
     steps:
@@ -251,6 +253,8 @@ jobs:
           root: /tmp/keep-dapp-token-dashboard
           paths:
             - docker-images
+  # GitHub Actions equivalent of this job (.github/workflows/token-dashboard.yml) 
+  # has been created as part of work on RFC-18
   publish_token_dashboard_dapp:
     executor: gcp-gcr/default
     steps:
@@ -345,7 +349,9 @@ workflows:
       - build_token_dashboard_dapp:
           filters:
             branches:
-              ignore: master
+              ignore: 
+                - master
+                - /rfc-18\/.*/
   build-test-publish-keep-dev:
     jobs:
       - build_client_and_test_go:

--- a/.github/workflows/token-dashboard.yml
+++ b/.github/workflows/token-dashboard.yml
@@ -1,0 +1,87 @@
+name: Token Dashboard dApp
+
+#TODO: extend the conditions once workflow gets tested together with other workflows
+on:
+  push:
+    branches:
+      # TODO: Run on master after we're fully migrated from Circle CI
+      # - master
+      - "rfc-18/**"
+    paths:
+      - "solidity/dashboard/**"
+      - ".github/workflows/token-dashboard.yml"
+  pull_request:
+    branches:
+      # TODO: Run on all branches after we're fully migrated from Circle CI
+      - "rfc-18/**"
+    paths:
+      - "solidity/dashboard/**"
+      - ".github/workflows/token-dashboard.yml"
+
+jobs:
+  build-publish-token-dashboard-dapp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity/dashboard
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+
+      - name: Cache resolved contracts
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-resolved-contracts
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Resolve latest contracts
+        run: |
+            npm update \
+              @keep-network/keep-core \
+              @keep-network/keep-ecdsa \
+              @keep-network/tbtc
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Google Container Registry
+        if:  |
+          startsWith(github.ref, 'refs/heads/releases/ropsten')
+            || startsWith(github.ref, 'refs/heads/rfc-18/ropsten')
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.GCR_REGISTRY_URL }}
+          username: _json_key
+          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
+
+      - name: Build and publish Keep Token Dashboard dApp image
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_NAME: 'keep-dapp-token-dashboard-wip' # TODO: change later to 'keep-dapp-token-dashboard'
+          GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+        with:
+          # GCR image should be named according to following convention:
+          # HOSTNAME/PROJECT-ID/IMAGE:TAG
+          # We don't use TAG yet, will be added at later stages of work on RFC-18.
+          tags: ${{ secrets.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
+          labels: revision=${{ github.sha }}
+          push: |
+            ${{ startsWith(github.ref, 'refs/heads/releases')
+              || startsWith(github.ref, 'refs/heads/rfc-18/ropsten') }}


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvment and make
the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions. This commit creates a
GitHub Action workfow for building of Token Dashboard dApp and
publishing it in keep-test Google Container Registry.