### PR TITLE
Fix tooltip style problems in Overview page

### DIFF
--- a/solidity/dashboard/src/css/tooltip.less
+++ b/solidity/dashboard/src/css/tooltip.less
@@ -51,7 +51,7 @@
         .tooltip {
             &__content-wrapper {
                 letter-spacing: 0px;
-                font-weight: 400;
+                font-weight: normal;
                 position: absolute;
                 background: @white;
                 box-shadow: 0px 2px 10px rgba(129, 129, 129, 0.5);

--- a/solidity/dashboard/src/css/tooltip.less
+++ b/solidity/dashboard/src/css/tooltip.less
@@ -50,6 +50,8 @@
     &--bottom, &--top {
         .tooltip {
             &__content-wrapper {
+                letter-spacing: 0px;
+                font-weight: 400;
                 position: absolute;
                 background: @white;
                 box-shadow: 0px 2px 10px rgba(129, 129, 129, 0.5);


### PR DESCRIPTION
Fix the spacing issue with the tooltip in Overview page by overwriting the
styles imposed by <h> tag.

Closes: #2202 