### PR TITLE
releases/mainnet/token dashboard/v1.10.2

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.10.1
+        image: keepnetwork/token-dashboard:v1.10.2
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
KEEP Token Dashboard v1.10.2 release branch. This release will bundle the work from https://github.com/keep-network/keep-core/milestone/46?closed=1