### PR TITLE
Fix below-fold CTA issue on Rewards empty state page

### DIFF
--- a/solidity/dashboard/src/css/rewards-page.less
+++ b/solidity/dashboard/src/css/rewards-page.less
@@ -163,7 +163,7 @@ section.rewards-overview--random-beacon {
     width: 100%;
     display: grid;
     grid-template-columns: 1.5fr 1fr;
-    grid-template-rows: 1fr 1fr;
+    grid-template-rows: 1fr;
     gap: 1rem;
 
     .skeleton__box {

--- a/solidity/dashboard/src/pages/rewards/EmptyStatePage.jsx
+++ b/solidity/dashboard/src/pages/rewards/EmptyStatePage.jsx
@@ -20,29 +20,12 @@ const EmptyStatePage = () => {
           <Skeleton tag="h5" className="mb-1" color="grey-20" width="65%" />
           <Skeleton tag="h5" className="mb-1" color="grey-20" width="65%" />
         </SkeletonBox>
-
         <SkeletonBox>
           <Skeleton tag="h3" className="mb-2" />
           <Skeleton tag="h5" className="mb-1" color="grey-20" width="65%" />
           <Skeleton tag="h5" className="mb-1" color="grey-20" width="45%" />
           <Skeleton tag="h5" className="mb-1" color="grey-20" width="85%" />
           <Skeleton tag="h5" className="mb-1" color="grey-20" width="40%" />
-        </SkeletonBox>
-
-        <SkeletonBox>
-          <Skeleton tag="h3" className="mb-2" width="75%" />
-          <div className="flex row center mb-2">
-            <Icons.KeepCircle />
-            <Skeleton tag="h3" color="grey-20" className="ml-1" width="50%" />
-          </div>
-          <Skeleton tag="h3" color="grey-30" width="50%" />
-        </SkeletonBox>
-
-        <SkeletonBox>
-          <Skeleton tag="h3" className="mb-2" />
-          <Skeleton tag="h5" className="mb-1" color="grey-20" width="100%" />
-          <Skeleton tag="h5" className="mb-1" color="grey-20" width="85%" />
-          <Skeleton tag="h5" className="mb-1" color="grey-20" width="75%" />
         </SkeletonBox>
       </EmptyState.Skeleton>
       <EmptyState.Title text={title} />


### PR DESCRIPTION
Removes the second skeleton row of the Rewards empty state page to show CTA on smaller screens. Closes #2205.