### PR TITLE
Fix the problem with displaying KEEP tokens in the Overview page

### DIFF
--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -934,4 +934,3 @@ export function* subscribeToLiquidityRewardsEvents() {
     )
   }
 }
-

--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -40,7 +40,7 @@ function* observeKeepTokenTransfer() {
         returnValues: { from, to, value },
       } = yield take(contractEventCahnnel)
 
-      let arithmeticOpration
+      let arithmeticOpration = null
       if (isSameEthAddress(defaultAccount, from)) {
         arithmeticOpration = sub
       } else if (isSameEthAddress(defaultAccount, to)) {
@@ -934,3 +934,4 @@ export function* subscribeToLiquidityRewardsEvents() {
     )
   }
 }
+


### PR DESCRIPTION
Closes: #2339 

In some cases Wallet Balance in the **Overview** page was not displayed properly.

<details>
<summary>Recreating the issue</summary>

I managed to recreate the issue on Ropsten. To do that you must have 2 accounts.

1. Log in on account 1 on Google Chrome
2. Log in on account 2 on Firefox
3. Delegate some tokens to another account with account 1
4. Create token grant for account 1 using account 2
5. After a while the wallet balance of the account #1 will change even though we didn't withdraw the tokens from the grant yet. The issue disappear after refreshing the page.
</details>

There was a problem with `arithmeticOperation` variable in `subscriptions.js` file. We define it in a while loop without setting a value and assign some value later in the if statement. The problem is that this value persists in further iterations of the while loop. I fixed it by assigning a null value to it from the start.

Still, it might be a good idea to do some investigation into the code, because unfortunately i couldn't find the reason why the previous code worked in such an unexpected way.