### PR TITLE
Move migration and publishing of contracts (Ethereum) to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
           root: /tmp/docs
           paths:
             - solidity/*
-  # GitHub Actions equivalent of this job (.github/workflows/client.yml) has been created as part of work on RFC-18
+  # GitHub Actions equivalent of this job (.github/workflows/client.yml) 
+  # has been created as part of work on RFC-18
   build_client_and_test_go:
     executor: docker-git
     steps:
@@ -91,6 +92,8 @@ jobs:
           root: /tmp/keep-client
           paths:
             - docker-images
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   migrate_contracts:
     executor: docker-node
     steps:
@@ -148,6 +151,8 @@ jobs:
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-client
           tag: latest
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   publish_contract_data:
     executor: gcp-cli/default
     steps:
@@ -164,7 +169,8 @@ jobs:
           command: |
             cd /tmp/keep-client/contracts
             gsutil -m cp * gs://${CONTRACT_DATA_BUCKET}/keep-core
-
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   publish_npm_package:
     executor: docker-node
     steps:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -12,23 +12,32 @@ on:
       - ".github/workflows/contracts.yml"
   pull_request:
     branches:
-      # TODO: Run on all branches or only on master (to be decided) 
-      # after we're fully migrated from Circle CI
+      # TODO: Run on all branches after we're fully migrated from Circle CI
       - "rfc-18/**"
       - master
     paths:
       - "solidity/**"
       - "!solidity/dashboard/**"
       - ".github/workflows/contracts.yml"
+  workflow_dispatch:
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    defaults:
+      run:
+        working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: ${{ matrix.node-version }}
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -40,22 +49,32 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - name: Install dependencies
-        working-directory: ./solidity
         run: npm ci
+
       - name: Build solidity contracts
-        working-directory: ./solidity
         run: npm run compile
+
       - name: Run tests
-        working-directory: ./solidity
         run: npm run test
+
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    defaults:
+      run:
+        working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: ${{ matrix.node-version }}
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -67,9 +86,106 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - name: Install dependencies
-        working-directory: ./solidity
         run: npm ci
+
       - name: Lint
-        working-directory: ./solidity
         run: npm run lint
+
+  migrate-and-publish-ethereum:
+    needs: [build-and-test, lint]
+    # TODO: Remove 'rfc-18/' condition once migration to GH Actions is done
+    if: |
+      (startsWith(github.ref, 'refs/heads/rfc-18/')
+        || github.ref == 'refs/heads/master')
+        && (github.event_name == 'push'
+        || github.event_name == 'workflow_dispatch')
+    # TODO: Implement similiar for keep-dev (should execute for rfc-18... & master branch)
+    environment: keep-test # currently keep-test requires manual aproval of job
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-solidity-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Migrate contracts
+        env: 
+          TRUFFLE_NETWORK: ${{ secrets.TRUFFLE_NETWORK }}
+          ETH_HOSTNAME: ${{ secrets.ETH_HOSTNAME }}
+          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY }}
+        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK # writes artifacts to /home/runner/work/keep-core/keep-core/solidity/build/contracts
+
+      - name: Push contracts to Tenderly
+        # TODO: once below action gets tagged replace `@main` with `@v1` 
+        uses: keep-network/tenderly-push-action@main
+        continue-on-error: true
+        with:
+          working-directory: ./solidity
+          tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
+          tenderly-project: thesis/keep-test
+          eth-network-id: ${{ secrets.ETH_NETWORK_ID }} # currently ='3' (ropsten)
+          github-project-name: keep-core
+          # version-tag: # TODO: resolve npm package version
+
+      - uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
+
+      - name: Upload contract data
+        env: 
+          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
+        run: |
+          cd build/contracts
+          gsutil -m cp * gs://"$CONTRACT_DATA_BUCKET"/keep-core 
+
+      - name: Copy artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r build/contracts/* artifacts/
+
+      - name: Bump up package version
+        uses: keep-network/npm-version-bump@v1
+        with:
+          workDir: ./solidity
+
+      - name: Publish to npm
+        # TODO: --dry-run to be removed once testing of workflow is done
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
+          npm publish --access=public --dry-run 
+
+      # TODO: consider swithing to below action, after tweaking 
+      # (requires some changes, as below config throws an error)
+      # - name: Publish to npm
+      #   uses: JS-DevTools/npm-publish@v1
+      #   with:
+      #     package: ./solidity/package.json
+      #     token: ${{ secrets.NPM_TOKEN }}
+      #     access: public
+      #     dry-run: true # TODO: to be removed once testing of workflow is done

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -135,9 +135,9 @@ jobs:
       
       - name: Migrate contracts
         env: 
-          TRUFFLE_NETWORK: ${{ secrets.TRUFFLE_NETWORK }}
-          ETH_HOSTNAME: ${{ secrets.ETH_HOSTNAME }}
-          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY }}
+          TRUFFLE_NETWORK: ${{ secrets.KEEP_TEST_ETH_TRUFFLE_NETWORK }}
+          ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
+          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK # writes artifacts to /home/runner/work/keep-core/keep-core/solidity/build/contracts
 
       - name: Push contracts to Tenderly
@@ -148,7 +148,7 @@ jobs:
           working-directory: ./solidity
           tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
           tenderly-project: thesis/keep-test
-          eth-network-id: ${{ secrets.ETH_NETWORK_ID }} # currently ='3' (ropsten)
+          eth-network-id: ${{ secrets.KEEP_TEST_ETH_NETWORK_ID }} # currently ='3' (ropsten)
           github-project-name: keep-core
           # version-tag: # TODO: resolve npm package version
 

--- a/solidity/tenderly.yaml
+++ b/solidity/tenderly.yaml
@@ -1,2 +1,7 @@
 account_id: d9a948cf-8667-43df-acb0-ce194f6dda7a
-project_slug: thesis/keep
+projects:
+  thesis/keep:
+    networks:
+    - "1" # mainnet
+  thesis/keep-test:
+    - "3" # ropsten


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and
make the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions. This commit enhances
the workflow for building and testing Solidity with a job migrating
contracts and publishing them to the npm registry. Contracts also get
pushed to Tenderly and uploaded to Google Cloud Storage. For now, only
keep-test configuration is implemented. Implementation for other
environments will be done at a later stage of work on RFC-18.

The `migrate-and-publish-ethereum` job is configured to execute only if
workflow is started by a push or workflow_dispatch event on `master` or
`rfc-18/*` branch. The `rfc-18/*` condition will need to be removed
once whole `build-test-migrate-publish-keep-test` CircleCI process
gets migrated to GH Actions.
Additionally, as we may not always want to migrate and publish
contracts on every push (or workflow_dispatch) on `master`, the job was
configured to require manual approval in GitHub GUI. This is done by
configuration of environment protection rules on `keep-test` and using
`environment: keep-test` config in the workflow.