### PR TITLE
Move building and publishing of Solidity initcontainer to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
           root: /tmp/keep-client
           paths:
             - docker-images
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   build_initcontainer:
     executor: docker-git
     steps:
@@ -132,6 +134,8 @@ jobs:
           registry-url: $GCR_REGISTRY_URL
           image: keep-client
           tag: latest
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   publish_initcontainer_provision_keep_client:
     executor: gcp-gcr/default
     steps:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -162,7 +162,7 @@ jobs:
           CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
         run: |
           cd build/contracts
-          gsutil -m cp * gs://"$CONTRACT_DATA_BUCKET"/keep-core 
+          gsutil -m cp * gs://"$CONTRACT_DATA_BUCKET"/keep-core
 
       - name: Copy artifacts
         run: |
@@ -178,9 +178,9 @@ jobs:
         # TODO: --dry-run to be removed once testing of workflow is done
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --dry-run 
+          npm publish --access=public --dry-run
 
-      # TODO: consider swithing to below action, after tweaking 
+      # TODO: consider swithing to below action, after tweaking
       # (requires some changes, as below config throws an error)
       # - name: Publish to npm
       #   uses: JS-DevTools/npm-publish@v1
@@ -189,3 +189,62 @@ jobs:
       #     token: ${{ secrets.NPM_TOKEN }}
       #     access: public
       #     dry-run: true # TODO: to be removed once testing of workflow is done
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # TODO: consider adding version to the name
+          name: Contracts (Node.js ${{ matrix.node-version }})
+          path: ./solidity/build/contracts/*
+
+  build-and-publish-initcontainer:
+    needs: [migrate-and-publish-ethereum]
+    if: needs.migrate-and-publish-ethereum.result == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Contracts (Node.js ${{ matrix.node-version }})
+          path: ./infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Google Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.GCR_REGISTRY_URL }}
+          username: _json_key
+          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
+
+      - name: Build and publish initcontainer
+        uses: docker/build-push-action@v2
+        env:
+          # TODO: change later to 'initcontainer-provision-keep-client'
+          IMAGE_NAME: 'initcontainer-provision-keep-client-wip'
+          GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+        with:
+          context: ./infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
+          # GCR image should be named according to following convention:
+          # HOSTNAME/PROJECT-ID/IMAGE:TAG
+          # We don't use TAG yet, will be added at later stages of work on RFC-18.
+          tags: ${{ secrets.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
+          labels: |
+            revision=${{ github.sha }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and 
make the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions. This PR enhances 
the Solidity workflow with a job building Solidity initcontainer and 
publishing it to the Google Container Registry. For now, only keep-test
configuration is implemented. Implementation for other environments 
will be done at a later stage of work on RFC-18.

The `build-and-publish-initcontainer` job is configured to execute 
after successful execution of `migrate-and-publish-ethereum`. As 
`build-and-publish-initcontainer` requires artifacts from 
`migrate-and-publish-ethereum`, they are passed between jobs using
`actions/upload-artifact` and `action/download-artifact` actions.
The artifacts will be also available for manual download from workflow
run page in GitHub GUI (default storage period is 90 days). If stored
artifacts turn out to take too much space, the retention period can be
changed globally in project's settings, or locally in 
`actions/upload-artifact` configuration (`retention-days` parameter).