### PR TITLE
Filtering out grants that ended up having 0 balance

### DIFF
--- a/token-tracker/src/truth-sources/token-grant.js
+++ b/token-tracker/src/truth-sources/token-grant.js
@@ -162,7 +162,9 @@ export class TokenGrantTruthSource extends ITruthSource {
         grant.balance.isub(grant.escrowRevoked)
       }
 
-      tokenGrants.push(grant)
+      if (grant.balance.gtn(0)) {
+        tokenGrants.push(grant)
+      }
     }
 
     dumpDataToFile(tokenGrants, TOKEN_GRANT_OUTPUT_PATH)


### PR DESCRIPTION
When calculating KEEP balances for a grant address, we need to filter out addresses that ended up having zero KEEP amount.