### PR TITLE
Add "incentives removed" warning to the KEEP-TBTC pool

### DIFF
--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -164,7 +164,7 @@ const LiquidityRewardCard = ({
             <APY.TooltipContent />
           </MetricsTile.Tooltip>
           <APY
-            apy={apy}
+            apy={!incentivesRemoved ? apy : 0}
             isFetching={isAPYFetching}
             className="liquidity__info-tile__title text-mint-100"
           />

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -36,6 +36,7 @@ const LiquidityRewardCard = ({
   withdrawLiquidityRewards,
   isAPYFetching,
   pool,
+  incentivesRemoved,
 }) => {
   const hasWrappedTokens = useMemo(() => gt(wrappedTokenBalance, 0), [
     wrappedTokenBalance,
@@ -44,33 +45,72 @@ const LiquidityRewardCard = ({
   const hasDepositedWrappedTokens = useMemo(() => gt(lpBalance, 0), [lpBalance])
 
   const renderUserInfoBanner = () => {
+    let bannerIcon = null
+    let bannerTitle = ""
+    let bannerDescription = ""
+    let link = ""
+    let linkText = ""
+
+    if (incentivesRemoved) {
+      bannerIcon = Icons.Warning
+      bannerTitle = "Incentives removed"
+      bannerDescription =
+        "The incentives for this pool has been removed and you can no longer deposit the lp tokens. You can still withdraw rewards that you already earned."
+      link =
+        "https://forum.keep.network/t/proposal-remove-incentives-for-the-keep-tbtc-pool/56"
+      linkText = "More info"
+    } else {
+      bannerIcon = !hasDepositedWrappedTokens ? Icons.Rewards : Icons.Wallet
+      bannerTitle = !hasDepositedWrappedTokens
+        ? "Start earning rewards"
+        : "No LP Tokens found in wallet"
+      bannerDescription = !hasDepositedWrappedTokens
+        ? "Get LP tokens by adding liquidity first to the"
+        : "Get more by adding liquidity to the"
+      link = viewPoolLink
+      linkText =
+        title === LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.label
+          ? "Saddle pool"
+          : "Uniswap pool"
+    }
+
     return (
       !hasWrappedTokens && (
-        <Banner className="liquidity__new-user-info">
+        <Banner
+          className={`liquidity__new-user-info ${
+            incentivesRemoved ? "liquidity__new-user-info--warning" : ""
+          }`}
+        >
           <Banner.Icon
-            icon={!hasDepositedWrappedTokens ? Icons.Rewards : Icons.Wallet}
-            className={"liquidity__rewards-icon"}
+            icon={bannerIcon}
+            className={`liquidity__rewards-icon ${
+              incentivesRemoved ? "liquidity__rewards-icon--warning" : ""
+            }`}
           />
           <div className={"liquidity__new-user-info-text"}>
-            <Banner.Title className={"liquidity-banner__title text-white"}>
-              {!hasDepositedWrappedTokens
-                ? "Start earning rewards"
-                : "No LP Tokens found in wallet"}
+            <Banner.Title
+              className={`liquidity-banner__title ${
+                incentivesRemoved ? "text-grey-60" : "text-white"
+              }`}
+            >
+              {bannerTitle}
             </Banner.Title>
-            <Banner.Description className="liquidity-banner__info text-white">
-              {!hasDepositedWrappedTokens
-                ? "Get LP tokens by adding liquidity first to the"
-                : "Get more by adding liquidity to the"}
+            <Banner.Description
+              className={`liquidity-banner__info ${
+                incentivesRemoved ? "text-grey-60" : "text-white"
+              }`}
+            >
+              {bannerDescription}
               &nbsp;
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href={viewPoolLink}
-                className="text-white text-link"
+                href={link}
+                className={`text-link ${
+                  incentivesRemoved ? "text-grey-60" : "text-white"
+                }`}
               >
-                {title === LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.label
-                  ? "Saddle pool"
-                  : "Uniswap pool"}
+                {linkText}
               </a>
             </Banner.Description>
           </div>
@@ -139,7 +179,8 @@ const LiquidityRewardCard = ({
           <h6>Your share of POOL</h6>
         </MetricsTile>
       </div>
-      {renderUserInfoBanner()}
+       {renderUserInfoBanner()}
+      {/*{renderIncentivesRemovedBanner()}*/}
       <LPTokenBalance lpTokens={lpTokens} lpTokenBalance={lpTokenBalance} />
       <div className={"liquidity__reward-balance"}>
         <h4 className={"liquidity__reward-balance__title text-grey-70"}>
@@ -168,7 +209,7 @@ const LiquidityRewardCard = ({
       </div>
       <SubmitButton
         className={`liquidity__add-more-tokens btn btn-primary btn-lg w-100`}
-        disabled={!gt(wrappedTokenBalance, 0)}
+        disabled={!gt(wrappedTokenBalance, 0) || incentivesRemoved}
         onSubmitAction={(awaitingPromise) =>
           addLpTokens(
             wrappedTokenBalance,

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -179,8 +179,7 @@ const LiquidityRewardCard = ({
           <h6>Your share of POOL</h6>
         </MetricsTile>
       </div>
-       {renderUserInfoBanner()}
-      {/*{renderIncentivesRemovedBanner()}*/}
+      {renderUserInfoBanner()}
       <LPTokenBalance lpTokens={lpTokens} lpTokenBalance={lpTokenBalance} />
       <div className={"liquidity__reward-balance"}>
         <h4 className={"liquidity__reward-balance__title text-grey-70"}>

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -78,7 +78,7 @@ const LiquidityRewardCard = ({
       !hasWrappedTokens && (
         <Banner
           className={`liquidity__new-user-info ${
-            incentivesRemoved ? "liquidity__new-user-info--warning" : ""
+            incentivesRemoved ? "liquidity__new-user-info--warning mt-2" : ""
           }`}
         >
           <Banner.Icon
@@ -154,31 +154,33 @@ const LiquidityRewardCard = ({
           to your share of the total pool.
         </Tooltip>
       </h4>
-      <div
-        className={`liquidity__info${
-          gt(lpBalance, 0) ? "" : "--locked"
-        } mt-2 mb-2`}
-      >
-        <MetricsTile className="liquidity__info-tile bg-mint-10">
-          <MetricsTile.Tooltip className="liquidity__info-tile__tooltip">
-            <APY.TooltipContent />
-          </MetricsTile.Tooltip>
-          <APY
-            apy={!incentivesRemoved ? apy : 0}
-            isFetching={isAPYFetching}
-            className="liquidity__info-tile__title text-mint-100"
-          />
-          <h6>Estimate of pool apy</h6>
-        </MetricsTile>
-        <MetricsTile className="liquidity__info-tile bg-mint-10">
-          <ShareOfPool
-            className="liquidity__info-tile__title text-mint-100"
-            percentageOfTotalPool={percentageOfTotalPool}
-            isFetching={isFetching}
-          />
-          <h6>Your share of POOL</h6>
-        </MetricsTile>
-      </div>
+      {!incentivesRemoved && (
+        <div
+          className={`liquidity__info${
+            gt(lpBalance, 0) ? "" : "--locked"
+          } mt-2 mb-2`}
+        >
+          <MetricsTile className="liquidity__info-tile bg-mint-10">
+            <MetricsTile.Tooltip className="liquidity__info-tile__tooltip">
+              <APY.TooltipContent />
+            </MetricsTile.Tooltip>
+            <APY
+              apy={apy}
+              isFetching={isAPYFetching}
+              className="liquidity__info-tile__title text-mint-100"
+            />
+            <h6>Estimate of pool apy</h6>
+          </MetricsTile>
+          <MetricsTile className="liquidity__info-tile bg-mint-10">
+            <ShareOfPool
+              className="liquidity__info-tile__title text-mint-100"
+              percentageOfTotalPool={percentageOfTotalPool}
+              isFetching={isFetching}
+            />
+            <h6>Your share of POOL</h6>
+          </MetricsTile>
+        </div>
+      )}
       {renderUserInfoBanner()}
       <LPTokenBalance lpTokens={lpTokens} lpTokenBalance={lpTokenBalance} />
       <div className={"liquidity__reward-balance"}>

--- a/solidity/dashboard/src/css/liquidity-page.less
+++ b/solidity/dashboard/src/css/liquidity-page.less
@@ -59,6 +59,11 @@
     display: flex;
     padding: 0.7rem 0.5rem;
 
+    &--warning {
+      background-color: @color-grey-20;
+      padding-right: 0.8rem;
+    }
+
     .liquidity__rewards-icon {
       width: 1.5rem;
       height: 1.5rem;
@@ -67,6 +72,12 @@
 
       path {
         fill: white;
+      }
+
+      &--warning {
+        path {
+          fill: @color-grey-60;
+        }
       }
     }
 

--- a/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -198,6 +198,7 @@ const LiquidityPage = ({ headerTitle }) => {
           withdrawLiquidityRewards={withdrawLiquidityRewards}
           isAPYFetching={KEEP_TBTC.isAPYFetching}
           pool={LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.pool}
+          incentivesRemoved={true}
         />
         <LiquidityRewardCard
           title={LIQUIDITY_REWARD_PAIRS.TBTC_ETH.label}


### PR DESCRIPTION
Adds a warning to the KEEP-TBTC pool that informs the users that incentives for
this pool has been removed. Also blocks the possibility to add lp tokens to
KEEP-TBTC pool.

Also removes APY and % of the share pool from KEEP-TBTC pool.

![image](https://user-images.githubusercontent.com/40306834/111196569-b829ea80-85bd-11eb-9227-366b5b12443e.png)
