### PR TITLE
Fix tests that fail occasionally with values close to expected

### DIFF
--- a/solidity/test/geyser/TestKeepTokenGeyser.js
+++ b/solidity/test/geyser/TestKeepTokenGeyser.js
@@ -371,24 +371,29 @@ describe("KeepTokenGeyser", async () => {
       })
 
       // Validate stakers' stake token balances.
-      expect(
+      expectCloseTo(
         await stakeToken.balanceOf.call(staker1),
+        stakerInitialBalance1,
         "invalid staker's 1 token balance"
-      ).to.eq.BN(stakerInitialBalance1)
-      expect(
+      )
+      expectCloseTo(
         await stakeToken.balanceOf.call(staker2),
+        stakerInitialBalance2,
         "invalid staker's 2 token balance"
-      ).to.eq.BN(stakerInitialBalance2)
+      )
 
       // Validate stakers' distribution token balances.
-      expect(
+      expectCloseTo(
         await keepToken.balanceOf.call(staker1),
+        expectedRewards1,
         "invalid staker's 1 rewards token balance"
-      ).to.eq.BN(expectedRewards1)
-      expect(
+      )
+
+      expectCloseTo(
         await keepToken.balanceOf.call(staker2),
+        expectedRewards2,
         "invalid staker's 2 rewards token balance"
-      ).to.eq.BN(expectedRewards2)
+      )
     })
 
     async function checkRewards(staker, stakeAmount, expectedRewards, message) {

--- a/solidity/test/geyser/TestKeepTokenGeyser.js
+++ b/solidity/test/geyser/TestKeepTokenGeyser.js
@@ -5,8 +5,7 @@ const {
   time,
 } = require("@openzeppelin/test-helpers")
 const { createSnapshot, restoreSnapshot } = require("../helpers/snapshot.js")
-
-const { toBN } = require("web3-utils")
+const { expectCloseTo } = require("../helpers/numbers.js")
 
 const KeepToken = contract.fromArtifact("KeepToken")
 const TestToken = contract.fromArtifact("TestToken")
@@ -15,8 +14,7 @@ const BatchedPhasedEscrow = contract.fromArtifact("BatchedPhasedEscrow")
 const KeepTokenGeyserRewardsEscrowBeneficiary = contract.fromArtifact(
   "KeepTokenGeyserRewardsEscrowBeneficiary"
 )
-
-const BN = web3.utils.BN
+const { BN, toBN } = web3.utils
 const chai = require("chai")
 chai.use(require("bn-chai")(BN))
 const expect = chai.expect
@@ -425,21 +423,5 @@ describe("KeepTokenGeyser", async () => {
     await stakeToken.approve(tokenGeyser.address, amount, { from: staker })
 
     return await tokenGeyser.stake(amount, [], { from: staker })
-  }
-
-  function expectCloseTo(actual, expected, message) {
-    actualBN = toBN(actual)
-    expectedBN = toBN(expected)
-
-    const delta = actualBN.muln(1).divn(100) // approx. 1%
-
-    if (
-      actualBN.lt(expectedBN.sub(delta)) ||
-      actualBN.gt(expectedBN.add(delta))
-    ) {
-      expect.fail(
-        `${message}\nexpected : ${expectedBN.toString()}\nactual   : ${actualBN.toString()}`
-      )
-    }
   }
 })

--- a/solidity/test/helpers/numbers.js
+++ b/solidity/test/helpers/numbers.js
@@ -1,0 +1,35 @@
+const { toBN } = require("web3-utils")
+const BN = require("bn.js")
+
+const chai = require("chai")
+chai.use(require("bn-chai")(BN))
+const expect = chai.expect
+
+/**
+ * Checks if a value is close to the expected within an allowed deviation.
+ * In case of a value that is outside the delta range it will fail chai expect.
+ *
+ * @param {BN|number|string} actual Actual value.
+ * @param {BN|number|string} expected Expected value.
+ * @param {string} [message] Message in case of failure (optional).
+ * @param {number} [deltaPercent=1] Percent deviation from the expected value that is
+ * acceptable. E.g. value of 5 means that the actual value cannot be different
+ * from the expected value more than 5%. Default value: 1.
+ */
+function expectCloseTo(actual, expected, message, deltaPercent = 1) {
+  actualBN = toBN(actual)
+  expectedBN = toBN(expected)
+
+  const delta = expectedBN.muln(deltaPercent).divn(100) // approx. `deltaPercent` %
+
+  if (
+    actualBN.lt(expectedBN.sub(delta)) ||
+    actualBN.gt(expectedBN.add(delta))
+  ) {
+    expect.fail(
+      `${message}\nexpected : ${expectedBN.toString()}\nactual   : ${actualBN.toString()}`
+    )
+  }
+}
+
+module.exports.expectCloseTo = expectCloseTo

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -5,6 +5,7 @@ const {
   time,
 } = require("@openzeppelin/test-helpers")
 const { createSnapshot, restoreSnapshot } = require("../helpers/snapshot")
+const { expectCloseTo } = require("../helpers/numbers.js")
 
 const {
   grantTokens,
@@ -557,7 +558,11 @@ describe("TokenStakingEscrow", () => {
       const balanceAfter = await token.balanceOf(grantManager)
 
       const diff = balanceAfter.sub(balanceBefore)
-      expect(diff).to.eq.BN(web3.utils.toWei("150000")) // 300k - 150k = 150k KEEP
+      expectCloseTo(
+        diff,
+        web3.utils.toWei("150000"), // 300k - 150k = 150k KEEP
+        "invalid balance"
+      )
     })
 
     it("withdraws entire deposited amount if nothing has been withdrawn before", async () => {


### PR DESCRIPTION
Some tests are failing occasionally due to a value not exactly as expected. There is a time factor so the value may slightly diverge from expectations. With these updates, we're checking if values are close to the expected ones within a specific range.

Sample CI execution that had failures: 
https://github.com/keep-network/keep-core/runs/2113275081
https://github.com/keep-network/keep-core/runs/2352840657

Refs https://github.com/keep-network/keep-core/pull/2354.