### PR TITLE
Pin dashboard dependencies versions on ropsten

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.11.0",
+  "version": "1.12.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1418,64 +1418,62 @@
         }
       }
     },
-    "@celo/contractkit": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-0.3.8.tgz",
-      "integrity": "sha512-lEXciI3tYnDKNdyazW6etR/ZFm0wrNlX1OxNgzv5D8HCPJcFSUF3Bi4fYtL/Ocx2oHNpK4k3eDZ6aj+ZbkRC+Q==",
+    "@celo/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-CKWx0UyeYTGIQLPzcopA6Y0CDcapga0fTHod3ZVYjVlH/HsVQlm2MjSQp8iTMeLu91mPYDo581HcATlCkZ58Rg=="
+    },
+    "@celo/connect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/connect/-/connect-1.1.0.tgz",
+      "integrity": "sha512-XUIKhI6BeYYD6ZA5P09ZspuUdYIa+Cg2rGavrGaWXa03SHXpJVy9iG/NhcGC9VpNrDCeW4TdNFhEveXnnDWsrg==",
       "requires": {
-        "@celo/utils": "0.1.11",
-        "@ledgerhq/hw-app-eth": "^5.11.0",
-        "@ledgerhq/hw-transport": "^5.11.0",
+        "@celo/utils": "1.1.0",
+        "@types/debug": "^4.1.5",
+        "@types/utf8": "^2.1.6",
+        "bignumber.js": "^9.0.0",
+        "debug": "^4.1.1",
+        "utf8": "3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@celo/contractkit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-1.1.0.tgz",
+      "integrity": "sha512-PgAMR71A08cZGhOICtrNj8EfYMon7PWNMQD+52X38CvfVJkg+/d56vfgbhBTHluQEhRTA/F0Y9MG3qgSUAzvDg==",
+      "requires": {
+        "@celo/base": "1.1.0",
+        "@celo/connect": "1.1.0",
+        "@celo/utils": "1.1.0",
+        "@celo/wallet-local": "1.1.0",
         "@types/debug": "^4.1.5",
         "bignumber.js": "^9.0.0",
         "cross-fetch": "3.0.4",
         "debug": "^4.1.1",
-        "eth-lib": "^0.2.8",
-        "ethereumjs-util": "^5.2.0",
         "fp-ts": "2.1.1",
         "io-ts": "2.0.1",
-        "web3": "1.2.4",
-        "web3-core": "1.2.4",
-        "web3-core-helpers": "1.2.4",
-        "web3-eth-abi": "1.2.4",
-        "web3-eth-contract": "1.2.4",
-        "web3-utils": "1.2.4"
+        "moment": "^2.29.0",
+        "web3": "1.3.4"
       },
       "dependencies": {
-        "@ledgerhq/devices": {
-          "version": "5.23.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.23.0.tgz",
-          "integrity": "sha512-XR9qTwn14WwN8VSMsYD9NTX/TgkmrTnXEh0pIj6HMRZwFzBPzslExOcXuCm3V9ssgAEAxv3VevfV8UulvvZUXA==",
-          "requires": {
-            "@ledgerhq/errors": "^5.23.0",
-            "@ledgerhq/logs": "^5.23.0",
-            "rxjs": "^6.6.3"
-          }
-        },
-        "@ledgerhq/errors": {
-          "version": "5.23.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.23.0.tgz",
-          "integrity": "sha512-qtpX8aFrUUlYfOMu7BxTvxqUa8CniE+tEBpVEjYUhVbFdVJjM4ouwJD++RtQkMAU2c5jE7xb12WnUnf5BlAgLQ=="
-        },
-        "@ledgerhq/hw-transport": {
-          "version": "5.23.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.23.0.tgz",
-          "integrity": "sha512-ICTG3Bst62SkC+lYYFgpKk5G4bAOxeIvptXnTLOhf6VqeN7gdHfiRzZwNPnKzI2pxmcEVbBitgsxEIEQJmDKVA==",
-          "requires": {
-            "@ledgerhq/devices": "^5.23.0",
-            "@ledgerhq/errors": "^5.23.0",
-            "events": "^3.2.0"
-          }
-        },
-        "@ledgerhq/logs": {
-          "version": "5.23.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.23.0.tgz",
-          "integrity": "sha512-88M8RkVHl44k6MAhfrYhx25opnJV24/2XpuTUVklID11f9rBdE+6RZ9OMs39dyX2sDv7TuzIPi5nTRoCqZMDYw=="
-        },
         "@types/node": {
-          "version": "12.12.58",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.58.tgz",
-          "integrity": "sha512-Be46CNIHWAagEfINOjmriSxuv7IVcqbGe+sDSg2SYCEz/0CRBy7LRASGfRbD8KZkqoePU73Wsx3UvOSFcq/9hA=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "cross-fetch": {
           "version": "3.0.4",
@@ -1487,11 +1485,542 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
+          }
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "moment": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "oboe": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+          "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        },
+        "swarm-js": {
+          "version": "0.1.40",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+          "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request": "^1.0.1"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "util": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4.tgz",
+          "integrity": "sha512-D6cMb2EtTMLHgdGbkTPGl/Qi7DAfczR+Lp7iFX3bcu/bsD9V8fZW69hA8v5cRPNGzXUwVQebk3bS17WKR4cD2w==",
+          "requires": {
+            "web3-bzz": "1.3.4",
+            "web3-core": "1.3.4",
+            "web3-eth": "1.3.4",
+            "web3-eth-personal": "1.3.4",
+            "web3-net": "1.3.4",
+            "web3-shh": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4.tgz",
+          "integrity": "sha512-DBRVQB8FAgoAtZCpp2GAGPCJjgBgsuwOKEasjV044AAZiONpXcKHbkO6G1SgItIixnrJsRJpoGLGw52Byr6FKw==",
+          "requires": {
+            "@types/node": "^12.12.6",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.4.tgz",
+          "integrity": "sha512-7OJu46RpCEfTerl+gPvHXANR2RkLqAfW7l2DAvQ7wN0pnCzl9nEfdgW6tMhr31k3TR2fWucwKzCyyxMGzMHeSA==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-requestmanager": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.4.tgz",
+          "integrity": "sha512-n7BqDalcTa1stncHMmrnFtyTgDhX5Fy+avNaHCf6qcOP2lwTQC8+mdHVBONWRJ6Yddvln+c8oY/TAaB6PzWK0A==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.4.tgz",
+          "integrity": "sha512-JxmQrujsAWYRRN77P/RY7XuZDCzxSiiQJrgX/60Lfyf7FF1Y0le4L/UMCi7vUJnuYkbU1Kfl9E0udnqwyPqlvQ==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.4.tgz",
+          "integrity": "sha512-V61dZIeBwogg6hhZZUt0qL9hTp1WDhnsdjP++9fhTDr4vy/Gz8T5vibqT2LLg6lQC8i+Py33yOpMeMNjztaUaw==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.4.tgz",
+          "integrity": "sha512-xriouCrhVnVDYQ04TZXdEREZm0OOJzkSEsoN5bu4JYsA6e/HzROeU+RjDpMUxFMzN4wxmFZ+HWbpPndS3QwMag==",
+          "requires": {
+            "underscore": "1.9.1",
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.3.4",
+            "web3-providers-http": "1.3.4",
+            "web3-providers-ipc": "1.3.4",
+            "web3-providers-ws": "1.3.4"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4.tgz",
+          "integrity": "sha512-drVHVDxh54hv7xmjIm44g4IXjfGj022fGw4/meB5R2D8UATFI40F73CdiBlyqk3DysP9njDOLTJFSQvEkLFUOg==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4"
+          }
+        },
+        "web3-eth": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4.tgz",
+          "integrity": "sha512-8OIVMLbvmx+LB5RZ4tDhXuFGWSdNMrCZ4HM0+PywQ08uEcmAcqTMFAn4vdPii+J8gCatZR501r1KdzX3SDLoPw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-eth-abi": "1.3.4",
+            "web3-eth-accounts": "1.3.4",
+            "web3-eth-contract": "1.3.4",
+            "web3-eth-ens": "1.3.4",
+            "web3-eth-iban": "1.3.4",
+            "web3-eth-personal": "1.3.4",
+            "web3-net": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz",
+          "integrity": "sha512-PVSLXJ2dzdXsC+R24llIIEOS6S1KhG5qwNznJjJvXZFe3sqgdSe47eNvwUamZtCBjcrdR/HQr+L/FTxqJSf80Q==",
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "underscore": "1.9.1",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4.tgz",
+          "integrity": "sha512-gz9ReSmQEjqbYAjpmAx+UZF4CVMbyS4pfjSYWGAnNNI+Xz0f0u0kCIYXQ1UEaE+YeLcYiE+ZlZdgg6YoatO5nA==",
+          "requires": {
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-utils": "1.3.4"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.4.tgz",
+          "integrity": "sha512-Fvy8ZxUksQY2ePt+XynFfOiSqxgQtMn4m2NJs6VXRl2Inl17qyRi/nIJJVKTcENLocm+GmZ/mxq2eOE5u02nPg==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "underscore": "1.9.1",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-eth-abi": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4.tgz",
+          "integrity": "sha512-b0580tQyQwpV2wyacwQiBEfQmjCUln5iPhge3IBIMXaI43BUNtH3lsCL9ERFQeOdweB4o+6rYyNYr6xbRcSytg==",
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-eth-abi": "1.3.4",
+            "web3-eth-contract": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.4.tgz",
+          "integrity": "sha512-Y7/hLjVvIN/OhaAyZ8L/hxbTqVX6AFTl2RwUXR6EEU9oaLydPcMjAx/Fr8mghUvQS3QJSr+UGubP3W4SkyNiYw==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4.tgz",
+          "integrity": "sha512-JiTbaktYVk1j+S2EDooXAhw5j/VsdvZfKRmHtXUe/HizPM9ETXmj1+ne4RT6m+950jQ7DJwUF3XU1FKYNtEDwQ==",
+          "requires": {
+            "@types/node": "^12.12.6",
+            "web3-core": "1.3.4",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-net": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-net": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4.tgz",
+          "integrity": "sha512-wVyqgVC3Zt/0uGnBiR3GpnsS8lvOFTDgWZMxAk9C6Guh8aJD9MUc7pbsw5rHrPUVe6S6RUfFJvh/Xq8oMIQgSw==",
+          "requires": {
+            "web3-core": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.4.tgz",
+          "integrity": "sha512-aIg/xHXvxpqpFU70sqfp+JC3sGkLfAimRKTUhG4oJZ7U+tTcYTHoxBJj+4A3Id4JAoKiiv0k1/qeyQ8f3rMC3g==",
+          "requires": {
+            "web3-core-helpers": "1.3.4",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.4.tgz",
+          "integrity": "sha512-E0CvXEJElr/TIlG1YfJeO3Le5NI/4JZM+1SsEdiPIfBUAJN18oOoum138EBGKv5+YaLKZUtUuJSXWjIIOR/0Ig==",
+          "requires": {
+            "oboe": "2.1.5",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.4.tgz",
+          "integrity": "sha512-WBd9hk2fUAdrbA3kUyUk94ZeILtE6txLeoVVvIKAw2bPegx+RjkLyxC1Du0oceKgQ/qQWod8CCzl1E/GgTP+MQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-shh": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4.tgz",
+          "integrity": "sha512-zoeww5mxLh3xKcqbX85irQbtFe5pc5XwrgjvmdMkhkOdZzPASlWOgqzUFtaPykpLwC3yavVx4jG5RqifweXLUA==",
+          "requires": {
+            "web3-core": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-net": "1.3.4"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
+          "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+          "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+          "requires": {
+            "bufferutil": "^4.0.1",
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "typedarray-to-buffer": "^3.1.5",
+            "utf-8-validate": "^5.0.2",
+            "yaeti": "^0.0.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        }
+      }
+    },
+    "@celo/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-FulCMswjXZZjylBV/veKQ8ESCPdfF2CBitPQL6EWinIv8UIJysQJkINjKDNBzegeHd/hDL6acXXFDv2ehmNynQ==",
+      "requires": {
+        "@celo/base": "1.1.0",
+        "@types/country-data": "^0.0.0",
+        "@types/elliptic": "^6.4.9",
+        "@types/ethereumjs-util": "^5.2.0",
+        "@types/google-libphonenumber": "^7.4.17",
+        "@types/lodash": "^4.14.136",
+        "@types/node": "^10.12.18",
+        "@types/randombytes": "^2.0.0",
+        "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
+        "bigi": "^1.1.0",
+        "bignumber.js": "^9.0.0",
+        "bip32": "2.0.5",
+        "bip39": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
+        "bls12377js": "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6",
+        "bn.js": "4.11.8",
+        "buffer-reverse": "^1.0.1",
+        "country-data": "^0.0.31",
+        "crypto-js": "^3.1.9-1",
+        "elliptic": "^6.5.4",
+        "ethereumjs-util": "^5.2.0",
+        "fp-ts": "2.1.1",
+        "google-libphonenumber": "^3.2.15",
+        "io-ts": "2.0.1",
+        "keccak256": "^1.0.0",
+        "lodash": "^4.17.14",
+        "numeral": "^2.0.6",
+        "web3-eth-abi": "1.3.4",
+        "web3-utils": "1.3.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+        },
+        "bip39": {
+          "version": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
+          "from": "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2",
+          "requires": {
+            "@types/node": "11.11.6",
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "11.11.6",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+              "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+            }
+          }
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
           }
         },
         "eth-lib": {
@@ -1504,366 +2033,23 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "ethers": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-          "requires": {
-            "@types/node": "^10.3.2",
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.3",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "10.17.33",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.33.tgz",
-              "integrity": "sha512-Z761mij1nxISY1GhZv2Ie/6ofe0JQTcMtcyFCJ9ItZzRvCwLyktyoPKzpugFqW2T7lCwUCSqpQbDo8Eol9r2EA=="
-            },
-            "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
-              }
-            }
-          }
-        },
-        "events": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        },
-        "rxjs": {
-          "version": "6.6.3",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "scrypt-js": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-        },
-        "web3": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
-          "integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
-          "requires": {
-            "@types/node": "^12.6.1",
-            "web3-bzz": "1.2.4",
-            "web3-core": "1.2.4",
-            "web3-eth": "1.2.4",
-            "web3-eth-personal": "1.2.4",
-            "web3-net": "1.2.4",
-            "web3-shh": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-bzz": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
-          "integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
-          "requires": {
-            "@types/node": "^10.12.18",
-            "got": "9.6.0",
-            "swarm-js": "0.1.39",
-            "underscore": "1.9.1"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "10.17.33",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.33.tgz",
-              "integrity": "sha512-Z761mij1nxISY1GhZv2Ie/6ofe0JQTcMtcyFCJ9ItZzRvCwLyktyoPKzpugFqW2T7lCwUCSqpQbDo8Eol9r2EA=="
-            }
-          }
-        },
-        "web3-core": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
-          "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
-          "requires": {
-            "@types/bignumber.js": "^5.0.0",
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^12.6.1",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-requestmanager": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
-          "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-eth-iban": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
-          "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-promievent": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
-          "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "eventemitter3": "3.1.2"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
-          "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4",
-            "web3-providers-http": "1.2.4",
-            "web3-providers-ipc": "1.2.4",
-            "web3-providers-ws": "1.2.4"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
-          "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
-          "requires": {
-            "eventemitter3": "3.1.2",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4"
-          }
-        },
-        "web3-eth": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
-          "integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-eth-abi": "1.2.4",
-            "web3-eth-accounts": "1.2.4",
-            "web3-eth-contract": "1.2.4",
-            "web3-eth-ens": "1.2.4",
-            "web3-eth-iban": "1.2.4",
-            "web3-eth-personal": "1.2.4",
-            "web3-net": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
         "web3-eth-abi": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
-          "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz",
+          "integrity": "sha512-PVSLXJ2dzdXsC+R24llIIEOS6S1KhG5qwNznJjJvXZFe3sqgdSe47eNvwUamZtCBjcrdR/HQr+L/FTxqJSf80Q==",
           "requires": {
-            "ethers": "4.0.0-beta.3",
+            "@ethersproject/abi": "5.0.7",
             "underscore": "1.9.1",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
-          "integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
-          "requires": {
-            "@web3-js/scrypt-shim": "^0.1.0",
-            "any-promise": "1.3.0",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "ethereumjs-common": "^1.3.2",
-            "ethereumjs-tx": "^2.1.1",
-            "underscore": "1.9.1",
-            "uuid": "3.3.2",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-utils": "1.2.4"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-            }
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
-          "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
-          "requires": {
-            "@types/bn.js": "^4.11.4",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-promievent": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-eth-abi": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-ens": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
-          "integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
-          "requires": {
-            "eth-ens-namehash": "2.0.8",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-promievent": "1.2.4",
-            "web3-eth-abi": "1.2.4",
-            "web3-eth-contract": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
-          "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "web3-utils": "1.2.4"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
-          "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
-          "requires": {
-            "@types/node": "^12.6.1",
-            "web3-core": "1.2.4",
-            "web3-core-helpers": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-net": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-net": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
-          "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
-          "requires": {
-            "web3-core": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-utils": "1.2.4"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
-          "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
-          "requires": {
-            "web3-core-helpers": "1.2.4",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
-          "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
-          "requires": {
-            "oboe": "2.1.4",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
-          "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
-          "requires": {
-            "@web3-js/websocket": "^1.0.29",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.4"
-          }
-        },
-        "web3-shh": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
-          "integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
-          "requires": {
-            "web3-core": "1.2.4",
-            "web3-core-method": "1.2.4",
-            "web3-core-subscriptions": "1.2.4",
-            "web3-net": "1.2.4"
+            "web3-utils": "1.3.4"
           }
         },
         "web3-utils": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
-          "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
+          "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
           "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
             "ethereum-bloom-filters": "^1.0.6",
             "ethjs-unit": "0.1.6",
             "number-to-bn": "1.7.0",
@@ -1873,93 +2059,76 @@
           },
           "dependencies": {
             "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            },
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
-              }
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
             }
           }
         }
       }
     },
-    "@celo/utils": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
-      "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
+    "@celo/wallet-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/wallet-base/-/wallet-base-1.1.0.tgz",
+      "integrity": "sha512-dYrWWopiBdf9J47Tgb/DvSvh6cs1mh4RytAlQgAOms/kYLJ7aTVtDvTGFQ01fUn3hyk31AmpahS6ebcf81YvRQ==",
       "requires": {
-        "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
-        "bigi": "^1.1.0",
+        "@celo/base": "1.1.0",
+        "@celo/connect": "1.1.0",
+        "@celo/utils": "1.1.0",
+        "@types/debug": "^4.1.5",
+        "@types/ethereumjs-util": "^5.2.0",
         "bignumber.js": "^9.0.0",
-        "bip32": "2.0.5",
-        "bip39": "3.0.2",
-        "bls12377js": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
-        "bn.js": "4.11.8",
-        "buffer-reverse": "^1.0.1",
-        "country-data": "^0.0.31",
-        "crypto-js": "^3.1.9-1",
-        "elliptic": "^6.4.1",
-        "ethereumjs-util": "^5.2.0",
-        "futoin-hkdf": "^1.0.3",
-        "google-libphonenumber": "^3.2.4",
-        "keccak256": "^1.0.0",
-        "lodash": "^4.17.14",
-        "numeral": "^2.0.6",
-        "web3-utils": "1.2.4"
+        "debug": "^4.1.1",
+        "eth-lib": "^0.2.8",
+        "ethereumjs-util": "^5.2.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-        },
-        "bip39": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
-          "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "@types/node": "11.11.6",
-            "create-hash": "^1.1.0",
-            "pbkdf2": "^3.0.9",
-            "randombytes": "^2.0.1"
+            "ms": "2.1.2"
           }
         },
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-        },
         "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "web3-utils": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
-          "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@celo/wallet-local": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@celo/wallet-local/-/wallet-local-1.1.0.tgz",
+      "integrity": "sha512-SJUUZTUQTYcQdBvG5rzABRWegpeiMMSzK1aaLEgqdzFLZj8moizrlNpBWvUi5qnoESWzhwWI6os4rABRc0wRVQ==",
+      "requires": {
+        "@celo/connect": "1.1.0",
+        "@celo/utils": "1.1.0",
+        "@celo/wallet-base": "1.1.0",
+        "@types/ethereumjs-util": "^5.2.0",
+        "eth-lib": "^0.2.8",
+        "ethereumjs-util": "^5.2.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
           }
         }
       }
@@ -2458,105 +2627,52 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.7.0.tgz",
-      "integrity": "sha512-jU0ol4L5a7vFUXCTlYGsjZYhl87cUpiAYz9LgDgvM3sGmwNIVZ9dY3gziINXIbSSFZjoqh3eGDxDPcQmA+Rjrg==",
+      "version": "1.8.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.6.tgz",
+      "integrity": "sha512-XcVCKx8LU+LWgFT6AVZ9Wz2RLt/m5mJ9ongSUeBZDZ9dy3dhaGMKdJnk12fztUcEIiHfyAINZ91UiS3HPyGQsA==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"
-      },
-      "dependencies": {
-        "openzeppelin-solidity": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
-          "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
-        }
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.6.0.tgz",
-      "integrity": "sha512-di/o4SGTlBUDbC0XnedDiE2XmvNCRfamsm+9jtO79jLN171bf+c9qr4iq/lxMteW5wZGwd1fziNJiwczXf7YcQ==",
+      "version": "1.7.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.8.tgz",
+      "integrity": "sha512-SqCGfW0ElBsx3iTTR/8YtHT8H6C0uPIb+P5HqD1ei5Typy+H1WUBVLjUQ6YPNraMtTGmBFmG6LUvrY7WCCTC2A==",
       "requires": {
-        "@keep-network/keep-core": "1.6.0",
-        "@keep-network/sortition-pools": "1.2.0-pre.3",
+        "@keep-network/keep-core": "^1.8.0-pre.6",
+        "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0"
       },
       "dependencies": {
-        "@keep-network/keep-core": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0.tgz",
-          "integrity": "sha512-zVA1rvbaxyQ7riJsTCz90u1ILjhA4wYz6n/+F4ntlo7kMJ7iwYfKcscF9bhvA/wCBKECbqWrk0lL85QkTF+CDA==",
-          "requires": {
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.4.0"
-          },
-          "dependencies": {
-            "openzeppelin-solidity": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
-              "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
-            }
-          }
+        "openzeppelin-solidity": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
         }
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.2.0-pre.3",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.3.tgz",
-      "integrity": "sha512-MlhhegYQ/bG/vA9IT8Vxgn+ojvluC0YENF+Ic3xJNP6Ir/MEWH6gC7rDeaILzOJdqSVV5/8I53aTbYSRwzHoSg==",
+      "version": "1.2.0-pre.6",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz",
+      "integrity": "sha512-6Tusle8KGZldO8jbFDfxChdgI6hMpTAW4LG+cAkf7jgRR48o6NkUiA7mDoWk/+dlitpHrQpWT1JM4N7aR/4/EQ==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@keep-network/tbtc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.0.tgz",
-      "integrity": "sha512-V4sGR/t61PgkEF11GDZL5QNijVSdDhL7A7larcOSSCmKJOugxd5s+d+NdhYcHZhX9IS58ebtepvZan8TydHUHw==",
+      "version": "1.1.2-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-pre.0.tgz",
+      "integrity": "sha512-zfijjLLcDuK8F/brgxScA/HpESLlJl8Jvr61BC6pIhDzPDrcVaqnG2sioLZurvoJeuXf0VnISSixvWpuNLlPPQ==",
       "requires": {
-        "@keep-network/keep-ecdsa": "1.2.1",
+        "@celo/contractkit": "^1.0.2",
+        "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
         "@summa-tx/bitcoin-spv-sol": "^3.1.0",
         "@summa-tx/relay-sol": "^2.0.2",
         "openzeppelin-solidity": "2.3.0"
       },
       "dependencies": {
-        "@keep-network/keep-core": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.0.tgz",
-          "integrity": "sha512-c8efKWPx5da6OSdcm9/uvdDqrfwDcYAExNqPvomhLFC0dATEEFHsr/QOAqiBm4wCZZtWMKt0dYTm5QpGtx5TXQ==",
-          "requires": {
-            "@openzeppelin/contracts-ethereum-package": "^2.4.0",
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.4.0"
-          },
-          "dependencies": {
-            "openzeppelin-solidity": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
-              "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
-            }
-          }
-        },
-        "@keep-network/keep-ecdsa": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.1.tgz",
-          "integrity": "sha512-Oz0thgLoemt/nK6dl+MONU7TEoNR3lfbnMY/Aa0oWGcwR5PlNMiBVzYY7OT4oLZIK/MxEHDOWRQAijZEQffI7g==",
-          "requires": {
-            "@keep-network/keep-core": "1.3.0",
-            "@keep-network/sortition-pools": "1.1.2",
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.3.0"
-          }
-        },
-        "@keep-network/sortition-pools": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.2.tgz",
-          "integrity": "sha512-bBaKyxkXDc8kJHq3qeESMrJ02m+Wbh6Uz9qUpWn8Zq3aTZaKXRZfGWT+J71OiBlAdyB4WoHZymrddWHkjImHdQ==",
-          "requires": {
-            "@openzeppelin/contracts": "^2.4.0"
-          }
-        },
         "openzeppelin-solidity": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
@@ -2732,11 +2848,6 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
       "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
     },
-    "@openzeppelin/contracts-ethereum-package": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
-      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
-    },
     "@openzeppelin/upgrades": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
@@ -2760,9 +2871,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.7.tgz",
-          "integrity": "sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "axios": {
           "version": "0.18.1",
@@ -2887,9 +2998,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2911,9 +3022,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2936,9 +3047,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2961,9 +3072,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -3036,10 +3147,608 @@
         "dotenv": "^8.2.0"
       },
       "dependencies": {
+        "@celo/contractkit": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/@celo/contractkit/-/contractkit-0.3.8.tgz",
+          "integrity": "sha512-lEXciI3tYnDKNdyazW6etR/ZFm0wrNlX1OxNgzv5D8HCPJcFSUF3Bi4fYtL/Ocx2oHNpK4k3eDZ6aj+ZbkRC+Q==",
+          "requires": {
+            "@celo/utils": "0.1.11",
+            "@ledgerhq/hw-app-eth": "^5.11.0",
+            "@ledgerhq/hw-transport": "^5.11.0",
+            "@types/debug": "^4.1.5",
+            "bignumber.js": "^9.0.0",
+            "cross-fetch": "3.0.4",
+            "debug": "^4.1.1",
+            "eth-lib": "^0.2.8",
+            "ethereumjs-util": "^5.2.0",
+            "fp-ts": "2.1.1",
+            "io-ts": "2.0.1",
+            "web3": "1.2.4",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-eth-contract": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "@celo/utils": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
+          "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
+          "requires": {
+            "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+            "bigi": "^1.1.0",
+            "bignumber.js": "^9.0.0",
+            "bip32": "2.0.5",
+            "bip39": "3.0.2",
+            "bls12377js": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+            "bn.js": "4.11.8",
+            "buffer-reverse": "^1.0.1",
+            "country-data": "^0.0.31",
+            "crypto-js": "^3.1.9-1",
+            "elliptic": "^6.4.1",
+            "ethereumjs-util": "^5.2.0",
+            "futoin-hkdf": "^1.0.3",
+            "google-libphonenumber": "^3.2.4",
+            "keccak256": "^1.0.0",
+            "lodash": "^4.17.14",
+            "numeral": "^2.0.6",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "@ledgerhq/devices": {
+          "version": "5.46.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.46.0.tgz",
+          "integrity": "sha512-bQ9YVR0xocVv8sXDiKMabXauLpn870Su71RwumuG9z4o7f/8s710/5NEh7K11mmNJ7ztJsgDeqXq7ai2ZqilUw==",
+          "requires": {
+            "@ledgerhq/errors": "^5.46.0",
+            "@ledgerhq/logs": "^5.46.0",
+            "rxjs": "^6.6.6",
+            "semver": "^7.3.4"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "5.46.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.46.0.tgz",
+          "integrity": "sha512-1/q/Tqv+aznX/rO3kdpg3Hv7O3xv68dWHkcfai8BZGTdTIwh6vdguFsdUNJ7eiNxEMKNA9gU+p78ZS/PDzoitQ=="
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "5.46.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.46.0.tgz",
+          "integrity": "sha512-iROB4eowxR7Bg67MEH+OlIsfN+UIjNLULr+A74gEFtMpHB3jvVc/aeq2gezv4fIueQQWV9X5IgNsxkPBI0vgtw==",
+          "requires": {
+            "@ledgerhq/devices": "^5.46.0",
+            "@ledgerhq/errors": "^5.46.0",
+            "events": "^3.3.0"
+          }
+        },
+        "@ledgerhq/logs": {
+          "version": "5.46.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.46.0.tgz",
+          "integrity": "sha512-WiFy1uwRhcqkj6aTSha532Nl6Gdsv5GN+Nsbp7pY66Zg+6WUE/SBmpwHEJfEXzEfARI5+A718a3trGinY6Dftg=="
+        },
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        },
+        "@umpirsky/country-list": {
+          "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+          "from": "git://github.com/umpirsky/country-list.git#05fda51"
+        },
+        "bip39": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+          "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+          "requires": {
+            "@types/node": "11.11.6",
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "bls12377js": {
+          "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+          "from": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+          "requires": {
+            "@stablelib/blake2xs": "0.10.4",
+            "@types/node": "^12.11.7",
+            "big-integer": "^1.6.44",
+            "chai": "^4.2.0",
+            "mocha": "^6.2.2",
+            "ts-node": "^8.4.1",
+            "typescript": "^3.6.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
         "bn.js": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "cross-fetch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+          "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+          "requires": {
+            "node-fetch": "2.6.0",
+            "whatwg-fetch": "3.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "ethers": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.56",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+              "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+            },
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            }
+          }
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "web3": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
+          "integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.4",
+            "web3-core": "1.2.4",
+            "web3-eth": "1.2.4",
+            "web3-eth-personal": "1.2.4",
+            "web3-net": "1.2.4",
+            "web3-shh": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
+          "integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.56",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+              "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
+          "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
+          "requires": {
+            "@types/bignumber.js": "^5.0.0",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-requestmanager": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
+          "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
+          "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-promievent": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
+          "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
+          "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4",
+            "web3-providers-http": "1.2.4",
+            "web3-providers-ipc": "1.2.4",
+            "web3-providers-ws": "1.2.4"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
+          "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
+          "integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-eth-accounts": "1.2.4",
+            "web3-eth-contract": "1.2.4",
+            "web3-eth-ens": "1.2.4",
+            "web3-eth-iban": "1.2.4",
+            "web3-eth-personal": "1.2.4",
+            "web3-net": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
+          "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
+          "integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
+          "requires": {
+            "@web3-js/scrypt-shim": "^0.1.0",
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
+          "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-promievent": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
+          "integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-promievent": "1.2.4",
+            "web3-eth-abi": "1.2.4",
+            "web3-eth-contract": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
+          "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
+          "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.4",
+            "web3-core-helpers": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-net": "1.2.4",
+            "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.20.7",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+              "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            }
+          }
+        },
+        "web3-net": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
+          "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
+          "requires": {
+            "web3-core": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-utils": "1.2.4"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
+          "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
+          "requires": {
+            "web3-core-helpers": "1.2.4",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
+          "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
+          "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
+          "requires": {
+            "@web3-js/websocket": "^1.0.29",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.4"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
+          "integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
+          "requires": {
+            "web3-core": "1.2.4",
+            "web3-core-method": "1.2.4",
+            "web3-core-subscriptions": "1.2.4",
+            "web3-net": "1.2.4"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
+          "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -3233,10 +3942,23 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/country-data": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@types/country-data/-/country-data-0.0.0.tgz",
+      "integrity": "sha512-lIxCk6G7AwmUagQ4gIQGxUBnvAq664prFD9nSAz6dgd1XmBXBtZABV/op+QsJsIyaP1GZsf/iXhYKHX3azSRCw=="
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "requires": {
+        "@types/bn.js": "*"
+      }
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3258,6 +3980,15 @@
         }
       }
     },
+    "@types/ethereumjs-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+      "integrity": "sha512-qwQgQqXXTRv2h2AlJef+tMEszLFkCB9dWnrJYIdAwqjubERXEc/geB+S3apRw0yQyTVnsBf8r6BhlrE8vx+3WQ==",
+      "requires": {
+        "@types/bn.js": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
@@ -3266,6 +3997,11 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/google-libphonenumber": {
+      "version": "7.4.19",
+      "resolved": "https://registry.npmjs.org/@types/google-libphonenumber/-/google-libphonenumber-7.4.19.tgz",
+      "integrity": "sha512-Rm2VhKzu4UofafuTrNTG6fy+385x1PIomnTGGSzOXGbKLpXAhNlUG+7F6UdcIosM5JMvXcJBnwUW/u4qQmt0yg=="
     },
     "@types/hdkey": {
       "version": "0.7.1",
@@ -3302,6 +4038,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3327,6 +4068,14 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
+    "@types/randombytes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
+      "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/react": {
       "version": "16.9.41",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
@@ -3340,6 +4089,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/utf8": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/utf8/-/utf8-2.1.6.tgz",
+      "integrity": "sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA=="
     },
     "@types/web3-provider-engine": {
       "version": "14.0.0",
@@ -3430,8 +4184,8 @@
       }
     },
     "@umpirsky/country-list": {
-      "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-      "from": "git://github.com/umpirsky/country-list.git#05fda51"
+      "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+      "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
     },
     "@walletconnect/client": {
       "version": "1.3.6",
@@ -5633,8 +6387,8 @@
       }
     },
     "bls12377js": {
-      "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
-      "from": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
+      "version": "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6",
+      "from": "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6",
       "requires": {
         "@stablelib/blake2xs": "0.10.4",
         "@types/node": "^12.11.7",
@@ -5646,9 +6400,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.58",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.58.tgz",
-          "integrity": "sha512-Be46CNIHWAagEfINOjmriSxuv7IVcqbGe+sDSg2SYCEz/0CRBy7LRASGfRbD8KZkqoePU73Wsx3UvOSFcq/9hA=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         }
       }
     },
@@ -6175,15 +6929,15 @@
       }
     },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -8378,7 +9132,7 @@
       "dev": true
     },
     "eslint-config-keep": {
-      "version": "git+https://github.com/keep-network/eslint-config-keep.git#13a8031dc087f084cb28bd9ce20c7a4f956f8c89",
+      "version": "git+https://github.com/keep-network/eslint-config-keep.git#fed0f9a92d4bb4abbf738266d7521b56a08987ee",
       "from": "git+https://github.com/keep-network/eslint-config-keep.git",
       "dev": true,
       "requires": {
@@ -8967,7 +9721,7 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
@@ -9731,9 +10485,9 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "requires": {
         "is-buffer": "~2.0.3"
       }
@@ -10041,9 +10795,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "futoin-hkdf": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.2.tgz",
-      "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.3.tgz",
+      "integrity": "sha512-oR75fYk3B3X9/B02Y6vusrBKucrpC6VjxhRL+C6B7FwUpuSRHbhBNG3AZbcE/xPyJmEQWsyqUFp3VeNNbA3S7A=="
     },
     "ganache-core": {
       "version": "2.10.2",
@@ -22853,7 +23607,7 @@
               "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.11.8",
@@ -24244,9 +24998,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.13.tgz",
-      "integrity": "sha512-USnpjJkD8St+wyshy154lF74JeauNCd8vrcusSlWjSFWitXzl7ZSuCunA/XxeVLqBv6DShrSfFMYdwGZ7x4hOw=="
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.19.tgz",
+      "integrity": "sha512-zevRvpUuc88wIXa+ijlMprAc8SrldUtYY2vQpfymmxyZ2ksct6gFrGxccpo28+zjvjK51VoSUaDUHS24XYp6dA=="
     },
     "got": {
       "version": "9.6.0",
@@ -25062,9 +25816,9 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-callable": {
       "version": "1.2.0",
@@ -26621,12 +27375,23 @@
       }
     },
     "keccak256": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.0.tgz",
-      "integrity": "sha512-8qv2vJdQk+Aa2tFXo8zYodm+6DgXqUOqvNJhj1p1V2pxQJT1oNKxNF+zWfhtKXNLZdLvyxjB/dvd9GwcvTHSQQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
+      "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
       "requires": {
         "bn.js": "^4.11.8",
-        "keccak": "^1.4.0"
+        "keccak": "^3.0.1"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
       }
     },
     "keyv": {
@@ -27916,6 +28681,11 @@
         "semver": "^5.4.1"
       }
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -28376,9 +29146,9 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
     "openzeppelin-solidity": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
+      "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
     },
     "opn": {
       "version": "5.5.0",
@@ -28670,9 +29440,9 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -33044,9 +33814,9 @@
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
@@ -33307,9 +34077,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
     },
     "typescript-compare": {
       "version": "0.0.2",
@@ -34300,9 +35070,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
-          "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
         }
       }
     },
@@ -34320,9 +35090,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.7.tgz",
-          "integrity": "sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         }
       }
     },
@@ -34410,9 +35180,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
-          "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -34560,9 +35330,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.7.tgz",
-          "integrity": "sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A=="
+          "version": "12.20.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+          "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         }
       }
     },

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,13 +1,13 @@
 {
   "name": "dashboard",
-  "version": "1.11.0",
+  "version": "1.12.0-pre",
   "private": true,
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
-    "@keep-network/keep-core": "1.7.0",
-    "@keep-network/keep-ecdsa": "1.6.0",
-    "@keep-network/tbtc": "1.1.0",
+    "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
+    "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "@walletconnect/web3-subprovider": "^1.3.6",


### PR DESCRIPTION
The dashboard is built and published automatically for keep-test on master merge. It's using versions provided in `package.json`. With this commit, we're hardcoding the versions of contracts deployed already to ropsten and used in keep-test environment. Once a change to the dashboard is merged to master (with these versions) it's published to the keep-test bucket and we can deploy it to keep-test environment.

Following packages are used:
keep-core@1.8.0-pre.6 -- https://github.com/keep-network/keep-core/actions/runs/686297746
keep-ecdsa@1.7.0-pre.8 -- https://github.com/keep-network/keep-ecdsa/actions/runs/690005293
tbtc@1.1.2-pre.0 -- https://github.com/keep-network/tbtc/actions/runs/698185957