### PR TITLE
Use path-filter action in workflows to support required checks in PRs

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -33,8 +33,7 @@ jobs:
     needs: client-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.client-detect-changes.outputs.path-filter == 'true') 
+        && needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -98,8 +97,7 @@ jobs:
     needs: client-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.client-detect-changes.outputs.path-filter == 'true') 
+        && needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -4,11 +4,37 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "infrastructure/**"
+      - "scripts/**"
+      - "token-stakedrop/**"
+      - "solidity/dashboard/**"
   pull_request:
   workflow_dispatch:
 
 jobs:
-  build-test-publish:
+  client-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event_name == 'pull_request' 
+    - uses: dorny/paths-filter@v2
+      if: github.event_name == 'pull_request' 
+      id: filter
+      with:
+        filters: |
+          path-filter:
+            - './!((docs|infrastructure|scripts|token-stakedrop|(solidity/dashboard))/**)'
+
+  client-build-test-publish:
+    needs: client-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.client-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,9 +71,8 @@ jobs:
 
       - name: Login to Google Container Registry
         if:  |
-            github.ref == 'refs/heads/master'
-              && (github.event_name == 'push'
-              || github.event_name == 'workflow_dispatch')
+          github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ secrets.GCR_REGISTRY_URL }}
@@ -67,10 +92,14 @@ jobs:
           labels: revision=${{ github.sha }}
           push: |
             ${{ github.ref == 'refs/heads/master'
-              && (github.event_name == 'push'
-              || github.event_name == 'workflow_dispatch') }}
+              && github.event_name != 'pull_request' }}
 
-  scan:
+  client-scan:
+    needs: client-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.client-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -33,7 +33,7 @@ jobs:
     needs: client-detect-changes
     if: |
       github.event_name != 'pull_request'
-        && needs.client-detect-changes.outputs.path-filter == 'true'
+        || needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -97,7 +97,7 @@ jobs:
     needs: client-detect-changes
     if: |
       github.event_name != 'pull_request'
-        && needs.client-detect-changes.outputs.path-filter == 'true'
+        || needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -8,13 +8,30 @@ on:
       - "solidity/**"
       - "!solidity/dashboard/**"
   pull_request:
-    paths:
-      - "solidity/**"
-      - "!solidity/dashboard/**"
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  contracts-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event_name == 'pull_request' 
+    - uses: dorny/paths-filter@v2
+      if: github.event_name == 'pull_request' 
+      id: filter
+      with:
+        filters: |
+          path-filter:
+            - './solidity/!(dashboard/**)/**'
+
+  contracts-build-and-test:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,7 +68,12 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  lint:
+  contracts-lint:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -85,12 +107,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  migrate-and-publish-ethereum:
-    needs: [build-and-test, lint]
+  contracts-migrate-and-publish-ethereum:
+    needs: [contracts-build-and-test, contracts-lint]
     if: |
       github.ref == 'refs/heads/master'
-        && (github.event_name == 'push'
-        || github.event_name == 'workflow_dispatch')
+        && github.event_name != 'pull_request'
     environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
     strategy:
@@ -175,9 +196,9 @@ jobs:
           name: Contracts (Node.js ${{ matrix.node-version }})
           path: ./solidity/build/contracts/*
 
-  build-and-publish-initcontainer:
-    needs: [migrate-and-publish-ethereum]
-    if: needs.migrate-and-publish-ethereum.result == 'success'
+  contracts-build-and-publish-initcontainer:
+    needs: [contracts-migrate-and-publish-ethereum]
+    if: needs.contracts-migrate-and-publish-ethereum.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -226,12 +247,11 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-  migrate-and-publish-celo:
-    needs: [build-and-test, lint]
+  contracts-migrate-and-publish-celo:
+    needs: [contracts-build-and-test, contracts-lint]
     if: |
       github.ref == 'refs/heads/master'
-        && (github.event_name == 'push'
-        || github.event_name == 'workflow_dispatch')
+        && github.event_name != 'pull_request'
     environment: keep-test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -30,8 +30,7 @@ jobs:
     needs: contracts-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
+        && needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,8 +71,7 @@ jobs:
     needs: contracts-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
+        && needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         filters: |
           path-filter:
-            - './solidity/!(dashboard/**)/**'
+            - './solidity/!(dashboard)/**'
 
   contracts-build-and-test:
     needs: contracts-detect-changes

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -30,7 +30,7 @@ jobs:
     needs: contracts-detect-changes
     if: |
       github.event_name != 'pull_request'
-        && needs.contracts-detect-changes.outputs.path-filter == 'true'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
     needs: contracts-detect-changes
     if: |
       github.event_name != 'pull_request'
-        && needs.contracts-detect-changes.outputs.path-filter == 'true'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -29,8 +29,7 @@ jobs:
     needs: dashboard-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.dashboard-detect-changes.outputs.path-filter == 'true') 
+        && needs.dashboard-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -29,7 +29,7 @@ jobs:
     needs: dashboard-detect-changes
     if: |
       github.event_name != 'pull_request'
-        && needs.dashboard-detect-changes.outputs.path-filter == 'true'
+        || needs.dashboard-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -1,6 +1,5 @@
 name: Token Dashboard / Testnet
 
-#TODO: extend the conditions once workflow gets tested together with other workflows
 on:
   push:
     branches:
@@ -8,12 +7,30 @@ on:
     paths:
       - "solidity/dashboard/**"
   pull_request:
-    paths:
-      - "solidity/dashboard/**"
   workflow_dispatch:
 
 jobs:
-  build-and-publish:
+  dashboard-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event_name == 'pull_request' 
+    - uses: dorny/paths-filter@v2
+      if: github.event_name == 'pull_request' 
+      id: filter
+      with:
+        filters: |
+          path-filter:
+            - './solidity/dashboard/**'
+
+  dashboard-build-and-publish:
+    needs: dashboard-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.dashboard-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,7 +77,9 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Google Container Registry
-        if: github.event_name == 'push'
+        if: |
+          github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ secrets.GCR_REGISTRY_URL }}
@@ -80,7 +99,6 @@ jobs:
           labels: revision=${{ github.sha }}
           push: |
             ${{ github.ref == 'refs/heads/master'
-              && (github.event_name == 'push'
-              || github.event_name == 'workflow_dispatch') }} 
+              && github.event_name != 'pull_request' }} 
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and to
make the processes faster and less error prone. We've migrated most of
CircleCI jobs to GitHub Actions. Now we want to introduce branch
protection rules on master, requiring the passing of particular jobs
before merging PR to master. Those jobs are:
* client-build-test-publish
* client-scan
* contracts-build-and-test
* contracts-lint
* dashboard-build-and-publish

What's more, we want to execute workflows containing those jobs only if
there were changes in particular paths. GitHub Actions allows for
specifying those paths by using `on.<event_name>.paths` syntax.
Unfortunately, such configuration for the `pull-request` event clashes
with the functionality of protected branches.
Example: If we set branch protection rule requiring the passing of
`job_a` and `job_a` will be part of `workflow_a` using
`on.pull_request.paths = folder_a` setting, the `workflow_a` won't be
started if we create PR that changes some files outside of `folder_a`.
Hence `job_a` won't be executed. But the PR will still require `job_a`
to be passing (or skipped) and will not allow for the merge of the PR
to the protected branch.
As skipping of the required jobs doesn't block the PRs from merging, we
decided to move the checking of paths for `pull_request` events from
workflow level to job level. It's not something natively supported by
GH Actions, but there is a `dorny/paths-filter` action that allows for
doing exactly that. We've set up the action to execute only if a
workflow was started by the `pull_request` event. Action checks the
list of files changed by the PR and when any of the files matches
provided filter, it sets the output to `true`. We then use that output
as a condition for execution of rest of the jobs in the workflow. This
way, if a particular job is required for the PR, but the path
conditions are not met, the job will be skipped (allowing for PR
merge).

Here is a summary what has been configured for particular workflows:

Client:
* workflow dispatch:
    Everything executed
* push on `master`:
    Everything executed if there are any changes OUTSIDE of these paths:
    - `docs/**`
    - `infrastructure/**`
    - `scripts/**`
    - `token-stakedrop/**`
    - `solidity/dashboard/**`
* pull_request:
    Everything (except publishing) executed if there are any changes
    OUTSIDE of these paths:
    - `docs/**`
    - `infrastructure/**`
    - `scripts/**`
    - `token-stakedrop/**`
    - `solidity/dashboard/**`

Solidity:
* workflow dispatch:
    Everything executed
* push on `master`
    Everything executed if there are changes IN:
    - `solidity/**` (unless it's just `solidity/dashboard/**`)
* pull_request:
    Everything (except migrating/publishing contracts and 
    building/publishing initcontainer) executed if there are changes IN:
    - `solidity/**` (unless it's just `solidity/dashboard/**`)

Token Dashboard / Testnet:
* workflow dispatch:
    Everything executed
* push on `master`:
    Everything executed f there are any changes IN:
    - `solidity/dashboard/**`
* pull_request:
    Everything (except publishing) executed if there are changes IN:
    - `solidity/dashboard/**`