### PR TITLE
TokenDistributor: Sign deployed contract address along with destination address

### DIFF
--- a/solidity/contracts/token-distribution/TokenDistributor.sol
+++ b/solidity/contracts/token-distribution/TokenDistributor.sol
@@ -62,7 +62,11 @@ contract TokenDistributor is Ownable {
 
     mapping(uint256 => uint256) private claimedBitMap;
 
-    event TokensAllocated(bytes32 merkleRoot, uint256 amount);
+    event TokensAllocated(
+        bytes32 merkleRoot,
+        uint256 amount,
+        uint256 unclaimedUnlockTimestamp
+    );
 
     event TokensClaimed(
         uint256 indexed index,
@@ -172,7 +176,7 @@ contract TokenDistributor is Ownable {
                 _unclaimedUnlockDurationSec;
         }
 
-        emit TokensAllocated(_merkleRoot, _amount);
+        emit TokensAllocated(_merkleRoot, _amount, unclaimedUnlockTimestamp);
     }
 
     /// @notice Withdraws unclaimed tokens to the destination address. The function

--- a/solidity/test/token-distribution/TokenDistributorTest.js
+++ b/solidity/test/token-distribution/TokenDistributorTest.js
@@ -37,6 +37,7 @@ describe("TokenDistributor", () => {
   let recipient
   let claimDestination
   let thirdParty
+  let signature
 
   const freshDeployment = async () => {
     testToken = await TestToken.new({ from: owner })
@@ -64,6 +65,12 @@ describe("TokenDistributor", () => {
     )
 
     await freshDeployment()
+
+    signature = signDestinationAddress(
+      testData.recipient.privateKey,
+      tokenDistributor.address,
+      claimDestination
+    )
   })
 
   beforeEach(async () => {
@@ -247,9 +254,9 @@ describe("TokenDistributor", () => {
       await tokenDistributor.claim(
         recipient,
         claimDestination,
-        testData.signature.v,
-        testData.signature.r,
-        testData.signature.s,
+        signature.v,
+        signature.r,
+        signature.s,
         testData.merkle.claims[recipient].index,
         testData.merkle.claims[recipient].amount,
         testData.merkle.claims[recipient].proof
@@ -271,13 +278,19 @@ describe("TokenDistributor", () => {
     })
 
     it("emits event", async function () {
+      const signature = signDestinationAddress(
+        testData.recipient.privateKey,
+        tokenDistributor.address,
+        claimDestination
+      )
+
       expectEvent(
         await tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
           testData.merkle.claims[recipient].proof
@@ -298,9 +311,10 @@ describe("TokenDistributor", () => {
         submitter,
         shouldRevert
       ) {
-        const signature = web3.eth.accounts.sign(
-          web3.utils.keccak256(claimDestination),
-          signerPrivateKey
+        const signature = signDestinationAddress(
+          signerPrivateKey,
+          tokenDistributor.address,
+          claimDestination
         )
 
         claimFuncCall = tokenDistributor.claim(
@@ -374,15 +388,14 @@ describe("TokenDistributor", () => {
         "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
       )
 
-      const malleableS =
-        "0x" + secp256k1N.sub(toBN(testData.signature.s)).toJSON()
+      const malleableS = "0x" + secp256k1N.sub(toBN(signature.s)).toJSON()
 
       await expectRevert(
         tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
+          signature.v,
+          signature.r,
           malleableS,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
@@ -395,9 +408,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v - 27,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v - 27,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
           testData.merkle.claims[recipient].proof
@@ -411,9 +424,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           ZERO_ADDRESS,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
           testData.merkle.claims[recipient].proof
@@ -425,9 +438,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           recipient,
           ZERO_ADDRESS,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
           testData.merkle.claims[recipient].proof
@@ -445,9 +458,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
           testData.merkle.claims[recipient].proof
@@ -460,9 +473,9 @@ describe("TokenDistributor", () => {
       await tokenDistributor.claim(
         recipient,
         claimDestination,
-        testData.signature.v,
-        testData.signature.r,
-        testData.signature.s,
+        signature.v,
+        signature.r,
+        signature.s,
         testData.merkle.claims[recipient].index,
         testData.merkle.claims[recipient].amount,
         testData.merkle.claims[recipient].proof
@@ -472,9 +485,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           testData.merkle.claims[recipient].amount,
           testData.merkle.claims[recipient].proof
@@ -488,9 +501,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[recipient].index,
           toBN(testData.merkle.claims[recipient].amount).addn(1),
           testData.merkle.claims[recipient].proof
@@ -504,9 +517,9 @@ describe("TokenDistributor", () => {
         tokenDistributor.claim(
           recipient,
           claimDestination,
-          testData.signature.v,
-          testData.signature.r,
-          testData.signature.s,
+          signature.v,
+          signature.r,
+          signature.s,
           testData.merkle.claims[thirdParty].index,
           testData.merkle.claims[thirdParty].amount,
           testData.merkle.claims[thirdParty].proof
@@ -574,9 +587,9 @@ describe("TokenDistributor", () => {
       await tokenDistributor.claim(
         recipient,
         claimDestination,
-        testData.signature.v,
-        testData.signature.r,
-        testData.signature.s,
+        signature.v,
+        signature.r,
+        signature.s,
         testData.merkle.claims[recipient].index,
         testData.merkle.claims[recipient].amount,
         testData.merkle.claims[recipient].proof
@@ -636,6 +649,19 @@ describe("TokenDistributor", () => {
       )
     })
   })
+
+  function signDestinationAddress(
+    signerPrivateKey,
+    tokenDistributorAddress,
+    destinationAddress
+  ) {
+    const digest = web3.utils.soliditySha3(
+      tokenDistributorAddress,
+      destinationAddress
+    )
+
+    return web3.eth.accounts.sign(digest, signerPrivateKey)
+  }
 
   async function importAccountFromPrivateKey(privateKey) {
     const password = "password"

--- a/solidity/test/token-distribution/testData.json
+++ b/solidity/test/token-distribution/testData.json
@@ -11,14 +11,6 @@
     "address": "0x8f733469c5d1fCee27a7E4c5433517ccAD992e6C",
     "privateKey": "0xd889eda11a6cfb36248b65e9e525c99d13e34d835cf81d063212483a65ec43bb"
   },
-  "signature": {
-    "message": "0x54eb9b035164b6d75fa1548d432dcf1c3c4e069bc9b64398ff9d76998577dcee",
-    "messageHash": "0xfee0fafe229b9b5a0d09d3bf7025eadc104e457752d267283bf31f49f7aa97f7",
-    "v": "0x1b",
-    "r": "0xeaf83e40545ba1fa5261ecbcda24973210c24974111a35eee881624fbf38bc21",
-    "s": "0x2b8b60138f1035b71193ffe7c6607429d1d01cebf016a69fed421a416bdf3582",
-    "signature": "0xeaf83e40545ba1fa5261ecbcda24973210c24974111a35eee881624fbf38bc212b8b60138f1035b71193ffe7c6607429d1d01cebf016a69fed421a416bdf35821b"
-  },
   "merkle": {
     "merkleRoot": "0xb83c6e12d9018f63a9741859cd7a8852e7808af9f9adb37d14d6eb7fd91153fe",
     "tokenTotal": "0x20b34706499fd319400000",


### PR DESCRIPTION
To prevent reusability of the signatures in other contracts that require
signature of an address we included the contract's address in the message
to sign to increase the uniqueness of the message.

In order to claim an airdrop, users have to sign a message with the destination address.
However: the signature is not somehow tied to the deployed TokenDistributor contract and
could be re-used, either in another instance of the same contract or in another contract that
uses a similar signature.

A user signs a message to claim the Keep distribution. An attacker notices the signature
and reuses it in a different contract that requires a signature of an address. The results can
be unexpected for the user that produces the signature because they do not want for their
signature to be re-used in a different context.