### PR TITLE
Fix displaying paid-back delegations

### DIFF
--- a/solidity/dashboard/src/services/token-staking.service.js
+++ b/solidity/dashboard/src/services/token-staking.service.js
@@ -283,7 +283,11 @@ export const getOperatorsOfGrantee = async (address) => {
   const {
     allOperators,
     operatorToGrantDetailsMap,
-  } = await getAllGranteeOperators(Array.from(granteeOperators), granteeGrants)
+  } = await getAllGranteeOperators(
+    Array.from(granteeOperators),
+    granteeGrants,
+    address
+  )
 
   return { allOperators, granteeGrants, operatorToGrantDetailsMap }
 }
@@ -309,7 +313,12 @@ export const getOperatorsOfManagedGrantee = async (address) => {
   const {
     allOperators,
     operatorToGrantDetailsMap,
-  } = await getAllGranteeOperators(Array.from(operators), grantIds, true)
+  } = await getAllGranteeOperators(
+    Array.from(operators),
+    grantIds,
+    address,
+    true
+  )
 
   return { allOperators, granteeGrants: grantIds, operatorToGrantDetailsMap }
 }
@@ -325,6 +334,7 @@ export const getOperatorsOfManagedGrantee = async (address) => {
  * @param {string[]} granteeOperators The result of the
  * `TokenGrant::getGranteeOperators`.
  * @param {string[]} grantIds Array of all grantee grants ids.
+ * @param {string} grantee Grantee address.
  * @param {boolean} isManagedGrant The flag informs that grants in `grantIds`
  * param are managed grants.
  * @return {Promise<string[]>} Array of all grantee operators.
@@ -332,6 +342,7 @@ export const getOperatorsOfManagedGrantee = async (address) => {
 const getAllGranteeOperators = async (
   granteeOperators,
   grantIds,
+  grantee,
   isManagedGrant = false
 ) => {
   const {
@@ -378,9 +389,26 @@ const getAllGranteeOperators = async (
         activeOperators
       )
 
+  // Fetching paid back delegations. Paid-back delegations are as the
+  // delegations from liquid tokens in the new `TokenStaking` contract. So we
+  // want to display them as delegations from liquid tokens ,not from a grant.
+  const paidBackDelegations = isEmptyArray(activeOperators)
+    ? []
+    : (
+        await stakingPortBackerContract.getPastEvents("StakePaidBack", {
+          fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingPortBackerContract,
+          filter: { owner: grantee, operator: activeOperators },
+        })
+      ).map((_) => _.returnValues.operator)
+
+  const operatorsToFilterOut = [
+    ...operatorsOfPortBacker,
+    ...paidBackDelegations,
+  ]
+
   // We want to skip copied delegations.
   activeOperators = activeOperators.filter(
-    (operator) => !operatorsOfPortBacker.includes(operator)
+    (operator) => !operatorsToFilterOut.includes(operator)
   )
 
   let operatorToGrantDetailsMap = {}


### PR DESCRIPTION
The paid-back delegations from `StakingPortBacker` contract should be
displayed as delegations from liquid tokens, not from a grant. So we
need to filterout paid back delegations while fetching delegations from
a grant. Otherwise, the delegations will be duplicated and be displayed
under `Wallet Tokens` and `Granted Tokens` tab on the `Delegations`
page.