### PR TITLE
Fix building of Token Dashboard image

### DIFF
--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -73,6 +73,7 @@ jobs:
           IMAGE_NAME: 'keep-dapp-token-dashboard'
           GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
         with:
+          context: ./solidity/dashboard/
           # GCR image should be named according to following convention:
           # HOSTNAME/PROJECT-ID/IMAGE:TAG
           # We don't use TAG yet, will be added at later stages of work on RFC-18.


### PR DESCRIPTION
Step building and publishing the Token Dashboard image was missing the
specification of build context.