### PR TITLE
Pin dependencies versions in dashboard

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -3214,35 +3214,35 @@
           }
         },
         "@ledgerhq/devices": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.46.0.tgz",
-          "integrity": "sha512-bQ9YVR0xocVv8sXDiKMabXauLpn870Su71RwumuG9z4o7f/8s710/5NEh7K11mmNJ7ztJsgDeqXq7ai2ZqilUw==",
+          "version": "5.48.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.48.0.tgz",
+          "integrity": "sha512-qIaL0K5Gh9kfePvptB8GGKEHGUAZuJHYmy9eDmIk6RZbgiYJ5njP/u5zQgKxijZArBgssdK/dtxEH4ueTiqkkA==",
           "requires": {
-            "@ledgerhq/errors": "^5.46.0",
-            "@ledgerhq/logs": "^5.46.0",
-            "rxjs": "^6.6.6",
-            "semver": "^7.3.4"
+            "@ledgerhq/errors": "^5.48.0",
+            "@ledgerhq/logs": "^5.48.0",
+            "rxjs": "^6.6.7",
+            "semver": "^7.3.5"
           }
         },
         "@ledgerhq/errors": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.46.0.tgz",
-          "integrity": "sha512-1/q/Tqv+aznX/rO3kdpg3Hv7O3xv68dWHkcfai8BZGTdTIwh6vdguFsdUNJ7eiNxEMKNA9gU+p78ZS/PDzoitQ=="
+          "version": "5.48.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.48.0.tgz",
+          "integrity": "sha512-817t7M0hi7j0xY6uuG0F3kjbkaEP9hHlxfDBpb3EWkTvkg5SgHaDmvHYTjUoE1HhaPypHLjEii7URx2boOfQVA=="
         },
         "@ledgerhq/hw-transport": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.46.0.tgz",
-          "integrity": "sha512-iROB4eowxR7Bg67MEH+OlIsfN+UIjNLULr+A74gEFtMpHB3jvVc/aeq2gezv4fIueQQWV9X5IgNsxkPBI0vgtw==",
+          "version": "5.48.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.48.0.tgz",
+          "integrity": "sha512-fyy55GDu/UU3fxWqltF7+1PabqMzKxyiWvd1Z89DB+8ZZuz3cq0iN7ey9p4zat2YpIFonVIxKJqyYZZelzsGQA==",
           "requires": {
-            "@ledgerhq/devices": "^5.46.0",
-            "@ledgerhq/errors": "^5.46.0",
+            "@ledgerhq/devices": "^5.48.0",
+            "@ledgerhq/errors": "^5.48.0",
             "events": "^3.3.0"
           }
         },
         "@ledgerhq/logs": {
-          "version": "5.46.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.46.0.tgz",
-          "integrity": "sha512-WiFy1uwRhcqkj6aTSha532Nl6Gdsv5GN+Nsbp7pY66Zg+6WUE/SBmpwHEJfEXzEfARI5+A718a3trGinY6Dftg=="
+          "version": "5.48.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.48.0.tgz",
+          "integrity": "sha512-ItOEw1BDsN7q43/uku44izA9y5f6va79KrO5SeYNcojAa3gLn6u02ADLzdHJtuvGEf9DBwCTRPlJmlT7kIaFPQ=="
         },
         "@types/node": {
           "version": "11.11.6",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
-    "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
-    "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
-    "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
+    "@keep-network/keep-core": "1.8.0-pre.6",
+    "@keep-network/keep-ecdsa": "1.7.0-pre.8",
+    "@keep-network/tbtc": "1.1.2-pre.0",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "@walletconnect/web3-subprovider": "^1.3.6",


### PR DESCRIPTION
We pined versions in the dashboard to a specific packages deployed on
ropsten to make sure the dashboard is working fine with the contracts
supported by keep-test nodes.