### PR TITLE
Updates to run client guide after ropsten migrations

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -450,7 +450,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0x3D6Ef582590D75d1fBe63B379f626DA1f5b2f810`
+|`0xF63bF51797377Af850CBBdd51Ed8f3D238ea907D`
 |===
 
 [%header,cols=2*]
@@ -459,10 +459,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0x0D3735ED83F812417af32CEDD09772b0Ec43dAf6`
+|`0x50BD3A8E3b1749E82A3C604db6559cab9C6232bD`
 
 |KeepRandomBeaconOperator
-|`0x89361Bd4E69C72194CDcAEcEA3A4df525F22Cb03`
+|`0x7728660fC0C8a48986f902Cb41C98931cd32C7B0`
 |===
 
 == Staking


### PR DESCRIPTION
Updated addresses of contracts from the latest migration to ropsten that
is supported by nodes running in keep-test environment.

The migration:
https://github.com/keep-network/keep-core/actions/runs/686297746