### PR TITLE
Fix fetching APY w/o connected wallet

### DIFF
--- a/solidity/dashboard/src/__tests__/saga/rootSaga.test.js
+++ b/solidity/dashboard/src/__tests__/saga/rootSaga.test.js
@@ -14,6 +14,26 @@ import * as liquidityRewards from "../../sagas/liquidity-rewards"
 import * as operator from "../../sagas/operartor"
 import * as authorization from "../../sagas/authorization"
 
+const {
+  watchFetchLiquidityRewardsAPY,
+  ...restliquidityRewards
+} = liquidityRewards
+
+const sagas = [...Object.values(messagesSaga), watchFetchLiquidityRewardsAPY]
+
+const loginRequiredSagas = [
+  ...Object.values(delegateStakeSaga),
+  watchSendTransactionRequest,
+  ...Object.values(tokenGrantSaga),
+  ...Object.values(copyStakeSaga),
+  ...Object.values(subscriptions),
+  ...Object.values(keepTokenBalance),
+  ...Object.values(rewards),
+  ...Object.values(restliquidityRewards),
+  ...Object.values(operator),
+  ...Object.values(authorization),
+]
+
 describe("Test root saga", () => {
   it("should start correctly and handle login flow", () => {
     const mockTasks = [fork(() => {}), fork(() => {})]
@@ -46,6 +66,11 @@ describe("Test root saga step by step", () => {
 
   beforeAll(() => {
     generator = rootSaga()
+  })
+
+  it("should run sagas", () => {
+    const expectedYieldAll = all(sagas.map(fork))
+    expect(generator.next().value).toStrictEqual(expectedYieldAll)
   })
 
   it("should wait for start action", () => {
@@ -96,21 +121,7 @@ describe("Test account switching saga step by step", () => {
   })
 
   it("should fork all sagas", () => {
-    const expectedAllYield = all(
-      [
-        ...Object.values(messagesSaga),
-        ...Object.values(delegateStakeSaga),
-        watchSendTransactionRequest,
-        ...Object.values(tokenGrantSaga),
-        ...Object.values(copyStakeSaga),
-        ...Object.values(subscriptions),
-        ...Object.values(keepTokenBalance),
-        ...Object.values(rewards),
-        ...Object.values(liquidityRewards),
-        ...Object.values(operator),
-        ...Object.values(authorization),
-      ].map(fork)
-    )
+    const expectedAllYield = all(loginRequiredSagas.map(fork))
     expect(generator.next().value).toStrictEqual(expectedAllYield)
   })
 

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -49,14 +49,17 @@ import {
 
 const CONTRACT_DEPLOYMENT_BLOCK_CACHE = {}
 
-export const getContractDeploymentBlockNumber = async (contractName) => {
+export const getContractDeploymentBlockNumber = async (
+  contractName,
+  web3Instance
+) => {
   if (
     CONTRACT_DEPLOYMENT_BLOCK_CACHE?.[contractName] !== undefined &&
     CONTRACT_DEPLOYMENT_BLOCK_CACHE?.[contractName] !== null
   ) {
     return CONTRACT_DEPLOYMENT_BLOCK_CACHE[contractName]
   }
-  const web3 = await Web3Loaded
+  const web3 = web3Instance || (await Web3Loaded)
   const blockNumber = await contractDeployedAtBlock(
     web3,
     contracts[contractName].artifact

--- a/solidity/dashboard/src/services/liquidity-rewards.js
+++ b/solidity/dashboard/src/services/liquidity-rewards.js
@@ -349,7 +349,8 @@ class TokenGeyserLPRewards extends LiquidityRewards {
       "TokensLocked",
       {
         fromBlock: await getContractDeploymentBlockNumber(
-          KEEP_TOKEN_GEYSER_CONTRACT_NAME
+          KEEP_TOKEN_GEYSER_CONTRACT_NAME,
+          this.web3
         ),
       }
     )


### PR DESCRIPTION
The APY on the Liquidity rewards page should be fetched w/o connected wallet.
The saga which fetches APY should start in the root saga before the
login/logout flow.