### PR TITLE
Fix fetching operators of owner

### DIFF
--- a/solidity/dashboard/src/services/token-staking.service.js
+++ b/solidity/dashboard/src/services/token-staking.service.js
@@ -206,7 +206,9 @@ export const getOperatorsOfOwner = async (owner, operatorsFilterParam) => {
   const ownerDelegations = await stakingContract.getPastEvents(
     "StakeDelegated",
     {
-      fromBlock: await getContractDeploymentBlockNumber.stakingContract,
+      fromBlock: await getContractDeploymentBlockNumber(
+        TOKEN_STAKING_CONTRACT_NAME
+      ),
       filter: { owner, ...filterParam },
     }
   )


### PR DESCRIPTION
This PR fixes fetching operators of owner. In the `getOperatorsOfOwner` function we used `getContractDeploymentBlockNumber` in wrong way.