### PR TITLE
Fix fetching Random Beacon rewards

### DIFF
--- a/solidity/dashboard/src/pages/rewards/RandomBeaconRewardsPage.jsx
+++ b/solidity/dashboard/src/pages/rewards/RandomBeaconRewardsPage.jsx
@@ -19,7 +19,7 @@ const RandomBeaconRewardsPage = () => {
   useEffect(() => {
     dispatch({
       type: "rewards/beacon_fetch_distributed_rewards_request",
-      payload: yourAddress,
+      payload: { address: yourAddress },
     })
   }, [dispatch, yourAddress])
 


### PR DESCRIPTION
The saga that fetches the Beacon rewards expects object with `address`
property in a payload.