### PR TITLE
Fix fetching paid back delegations

### DIFF
--- a/solidity/dashboard/src/services/token-staking.service.js
+++ b/solidity/dashboard/src/services/token-staking.service.js
@@ -406,7 +406,9 @@ const getAllGranteeOperators = async (
     ? []
     : (
         await stakingPortBackerContract.getPastEvents("StakePaidBack", {
-          fromBlock: CONTRACT_DEPLOY_BLOCK_NUMBER.stakingPortBackerContract,
+          fromBlock: await getContractDeploymentBlockNumber(
+            STAKING_PORT_BACKER_CONTRACT_NAME
+          ),
           filter: { owner: grantee, operator: activeOperators },
         })
       ).map((_) => _.returnValues.operator)


### PR DESCRIPTION
When fetching paidBackDelegations we used the old way of getting the `fromBlock`
number which was changed in 221fea5fd9da01e933e1b1f854243478cdb857c2 commit.