### PR TITLE
Fix test occasionally failing due to value close to expected

### DIFF
--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -782,7 +782,7 @@ describe("TokenStakingEscrow", () => {
       expect(await escrow.withdrawable(operator)).to.eq.BN(0)
       expectCloseTo(
         await anotherEscrow.depositedAmount(operator),
-        web3.utils.toWei("150000"), // 300k - 150k KEEP\
+        web3.utils.toWei("150000"), // 300k - 150k KEEP
         "invalid deposited amount for operator"
       )
     })

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -780,7 +780,8 @@ describe("TokenStakingEscrow", () => {
       await escrow.migrate(operator, anotherEscrow.address, { from: grantee })
 
       expect(await escrow.withdrawable(operator)).to.eq.BN(0)
-      expectCloseTo(await anotherEscrow.depositedAmount(operator), 
+      expectCloseTo(
+        await anotherEscrow.depositedAmount(operator),
         web3.utils.toWei("150000"), // 300k - 150k KEEP\
         "invalid deposited amount for operator"
       )

--- a/solidity/test/token_stake/TestTokenStakingEscrow.js
+++ b/solidity/test/token_stake/TestTokenStakingEscrow.js
@@ -780,8 +780,9 @@ describe("TokenStakingEscrow", () => {
       await escrow.migrate(operator, anotherEscrow.address, { from: grantee })
 
       expect(await escrow.withdrawable(operator)).to.eq.BN(0)
-      expect(await anotherEscrow.depositedAmount(operator)).to.eq.BN(
-        web3.utils.toWei("150000") // 300k - 150k KEEP
+      expectCloseTo(await anotherEscrow.depositedAmount(operator), 
+        web3.utils.toWei("150000"), // 300k - 150k KEEP\
+        "invalid deposited amount for operator"
       )
     })
 


### PR DESCRIPTION
The test TokenStakingEscrow was ocassionally failing because
value differs in time and it can happen that it's not exactly the
expected one but it's very close.
After the change 1% margin is applied when comparing the
values.
Sample execution where the test was failing:
https://github.com/keep-network/keep-core/runs/2378321057