### PR TITLE
Don't use matrix in jobs required for merging PR which can be skipped

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,19 +32,15 @@ jobs:
       github.event_name != 'pull_request'
         || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     defaults:
       run:
         working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -73,19 +69,15 @@ jobs:
       github.event_name != 'pull_request'
         || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     defaults:
       run:
         working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -31,19 +31,15 @@ jobs:
       github.event_name != 'pull_request'
         || needs.dashboard-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     defaults:
       run:
         working-directory: ./solidity/dashboard
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
 
       - name: Cache Global NPM Cache
         uses: actions/cache@v2


### PR DESCRIPTION
In previous PRs/commits we've implemented functionality allowing for
skipping of particular jobs triggered by `pull_request` event if the PR
doesn't introduce changes to specified files/paths. This wa done to
allow setting such jobs as required for PR merge (PR can be merged if a
required job is Passed os Skipped).
When job is being set in GitHub settings as required for PR merge, it's
name must be specified - usually that name is a `job_id`, but when
`matrix` strategy is being used in the job, the name will consist of
`job_id` and matrix value (e.g. `contracts-lint (12.x)`. Unfortunately
we discovered that appending of the `job_id` with matrix value
happens when job is being executed, but does not happen for jobs that
are being skipped. This means that we cannot set neither job
`contracts-lint (12.x)` nor `contracts-lint` as required, because there
will be situations when required job will not get executed (instead a
similarly named job will be executed).
To mitigate that problem we will no longer use `matrix` strategy in jobs
set as required for PRs which also can be skipped due to `path-filter`.
This way name of the job will remain the same for executed and skipped
jobs, allowing us to have it configured as required for PR merge.