### PR TITLE
Improve helper text in explorer mode address form

### DIFF
--- a/solidity/dashboard/src/components/ExplorerModeAddressForm.jsx
+++ b/solidity/dashboard/src/components/ExplorerModeAddressForm.jsx
@@ -14,9 +14,10 @@ const ExplorerModeAddressForm = ({ submitAction, onCancel }) => {
       <FormInput
         name="address"
         type="text"
-        label="Enter an address"
+        label="Enter an Ethereum address"
+        tooltipProps={{ direction: "top" }}
         tooltipText={
-          "Enter an address with which you would like to view the dashboard"
+          "Enter an Ethereum address to preview its read-only version of the dashboard."
         }
       />
       <div
@@ -28,7 +29,7 @@ const ExplorerModeAddressForm = ({ submitAction, onCancel }) => {
         }}
       >
         <SubmitButton
-          className="btn btn-primary"
+          className="btn btn-lg btn-primary"
           type="submit"
           onSubmitAction={onSubmit}
           withMessageActionIsPending={false}

--- a/solidity/dashboard/src/components/FormInput.jsx
+++ b/solidity/dashboard/src/components/FormInput.jsx
@@ -17,6 +17,7 @@ const FormInput = ({
   additionalInfoText,
   leftIcon,
   inputAddon,
+  tooltipProps = {},
   ...props
 }) => {
   const [field, meta, helpers] = useField(props.name, props.type)
@@ -61,6 +62,7 @@ const FormInput = ({
               delay={0}
               triggerComponent={Icons.MoreInfo}
               className="input__label__info-container__tooltip"
+              {...tooltipProps}
             >
               {tooltipText}
             </Tooltip>


### PR DESCRIPTION
The helper text is not giving enough context as to what an address
is/what this will do. Also here we moved a tooltip over above the form
input instead of over it for better readability. Based on the comments
posted in #2442.