### PR TITLE
Update keep-common to Latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.4.1-0.20210319095805-ebf46d0b62db
+	github.com/keep-network/keep-common v1.4.1-0.20210503154715-f16f7bd7efa8
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v1.4.1-0.20210319095805-ebf46d0b62db h1:CrAKFfc0ynlQv0M/IwTVALSh6nDF3Kki71Y6GGybJQk=
 github.com/keep-network/keep-common v1.4.1-0.20210319095805-ebf46d0b62db/go.mod h1:E515VGCNeth7/yJafIWcZyZrHslQHBUKwIjpdipqMM4=
+github.com/keep-network/keep-common v1.4.1-0.20210503154715-f16f7bd7efa8 h1:EHXQS+2nN8fJNaPj32wf4XrZBxgEnyJaSbER/vTSeuk=
+github.com/keep-network/keep-common v1.4.1-0.20210503154715-f16f7bd7efa8/go.mod h1:E515VGCNeth7/yJafIWcZyZrHslQHBUKwIjpdipqMM4=
 github.com/kilic/bls12-381 v0.0.0-20201226121925-69dacb279461/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -12,7 +12,7 @@ import (
 var logger = log.Logger("keep-diagnostics")
 
 // Initialize sets up the diagnostics registry and enables diagnostics server.
-func Initialize(port int) (*diagnostics.DiagnosticsRegistry, bool) {
+func Initialize(port int) (*diagnostics.Registry, bool) {
 	if port == 0 {
 		return nil, false
 	}
@@ -27,7 +27,7 @@ func Initialize(port int) (*diagnostics.DiagnosticsRegistry, bool) {
 // RegisterConnectedPeersSource registers the diagnostics source providing
 // information about connected peers.
 func RegisterConnectedPeersSource(
-	registry *diagnostics.DiagnosticsRegistry,
+	registry *diagnostics.Registry,
 	netProvider net.Provider,
 ) {
 	registry.RegisterSource("connected_peers", func() string {
@@ -62,7 +62,7 @@ func RegisterConnectedPeersSource(
 // RegisterClientInfoSource registers the diagnostics source providing
 // information about the client itself.
 func RegisterClientInfoSource(
-	registry *diagnostics.DiagnosticsRegistry,
+	registry *diagnostics.Registry,
 	netProvider net.Provider,
 ) {
 	registry.RegisterSource("client_info", func() string {

--- a/pkg/net/libp2p/channel_test.go
+++ b/pkg/net/libp2p/channel_test.go
@@ -178,7 +178,7 @@ func TestCreateTopicValidator(t *testing.T) {
 		authorIDBytes, _ := authorID.Marshal()
 		message := &pubsubpb.Message{From: authorIDBytes}
 
-		actualResult := validator(nil, peer.ID(i), &pubsub.Message{Message: message})
+		actualResult := validator(nil, authorID, &pubsub.Message{Message: message})
 
 		if expectedResults[i] != actualResult {
 			t.Errorf(


### PR DESCRIPTION
We'd like to update keep-ecdsa for [this](https://github.com/keep-network/keep-ecdsa/pull/756#discussion_r619166506), but that puts ecdsa and core on different versions of common. To remedy that, we'll update core, and then update both core and common in ecdsa.

Tagging @Shadowfiend for review