### PR TITLE
Fix broken links in solidity/docs

### DIFF
--- a/solidity/docs/README.md
+++ b/solidity/docs/README.md
@@ -1,9 +1,0 @@
-# Introduction
-
-Welcome to the Keep Network Smart contracts documentation.
-
-- **[Keep Token](./docs/KeepToken/)** A standard ERC20Burnable token based on OpenZeppelin [ERC20Burnable.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20Burnable.sol). Includes implementation for `approveAndCall` pattern.
-
-- **[Token Staking](./docs/TokenStaking/)** A generic token staking contract for a specified standard ERC20Burnable token. A holder of the specified token can delegate its tokens to this contract and recover the stake after specified undelegation period is over.
-
-- **[Token Grant](./docs/TokenGrant/)** A generic token grant contract for a specified standard ERC20Burnable token. Has additional functionality to stake delegate/undelegate token grants. Tokens are granted to the grantee via unlocking scheme and can be released gradually based on the unlocking schedule cliff and unlocking duration. Optionally grant can be revoked by the token grant manager.


### PR DESCRIPTION
Closes: #2334 

This README file is a part of the abandoned Solidity API docs CI build so is no longer valid. More context here: https://www.flowdock.com/app/cardforcoin/tech/threads/-9kWxCim5nVgKG4TttURbggBKgO