### PR TITLE
Local installation scripts refactoring

### DIFF
--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 LOG_START='\n\e[1;36m' # new line + bold + color
 LOG_END='\n\e[0m' # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
 
 KEEP_CORE_PATH=$PWD
 KEEP_CORE_SOL_PATH="$KEEP_CORE_PATH/solidity"
@@ -17,7 +19,8 @@ help()
 {
    echo -e "\nUsage: ENV_VAR(S) $0"\
            "--config-dir <path>"\
-           "--network <network>"
+           "--network <network>"\
+           "--contracts-only"
    echo -e "\nEnvironment variables:\n"
    echo -e "\tKEEP_CELO_PASSWORD: The password to unlock local Celo accounts to set up delegations."\
            "Required only for 'local' network. Default value is 'password'"
@@ -25,7 +28,9 @@ help()
    echo -e "\nCommand line arguments:\n"
    echo -e "\t--config-dir: Path to keep-core client configuration file(s)"
    echo -e "\t--network: Celo network for keep-core client."\
-                        "Available networks and settings are specified in the 'truffle-config.js'\n"
+                        "Available networks and settings are specified in the 'truffle-config.js'"
+   echo -e "\t--contracts-only: Should execute contracts part only."\
+                        "Client installation will not be executed.\n"
    exit 1 # Exit script after printing help
 }
 
@@ -33,20 +38,22 @@ help()
 for arg in "$@"; do
   shift
   case "$arg" in
-    "--config-dir")  set -- "$@" "-c" ;;
-    "--network")     set -- "$@" "-n" ;;
-    "--help")        set -- "$@" "-h" ;;
-    *)               set -- "$@" "$arg"
+    "--config-dir")      set -- "$@" "-c" ;;
+    "--network")        set -- "$@" "-n" ;;
+    "--contracts-only") set -- "$@" "-m" ;;
+    "--help")           set -- "$@" "-h" ;;
+    *)                  set -- "$@" "$arg"
   esac
 done
 
 # Parse short options
 OPTIND=1
-while getopts "c:n:h" opt
+while getopts "c:n:mh" opt
 do
    case "$opt" in
       c ) config_dir_path="$OPTARG" ;;
       n ) network="$OPTARG" ;;
+      m ) contracts_only=true ;;
       h ) help ;;
       ? ) help ;; # Print help in case parameter is non-existent
    esac
@@ -56,6 +63,7 @@ shift $(expr $OPTIND - 1) # remove options from positional parameters
 # Overwrite default properties
 CONFIG_DIR_PATH=${config_dir_path:-$CONFIG_DIR_PATH_DEFAULT}
 NETWORK=${network:-$NETWORK_DEFAULT}
+CONTRACTS_ONLY=${contracts_only:-false}
 
 # Run script
 printf "${LOG_START}Starting installation...${LOG_END}"
@@ -89,15 +97,19 @@ printf "${LOG_START}Initializing contracts...${LOG_END}"
 CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY \
     npx truffle exec scripts/delegate-tokens.js --network $NETWORK
 
-printf "${LOG_START}Updating keep-core client configs...${LOG_END}"
-for CONFIG_FILE in $CONFIG_DIR_PATH/*.toml
-do
-    KEEP_CORE_CONFIG_FILE_PATH=$CONFIG_FILE \
-    CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY \
-        npx truffle exec scripts/lcl-client-config.js --network $NETWORK
-done
+if [ "$CONTRACTS_ONLY" = false ] ; then
+  printf "${LOG_START}Updating keep-core client configs...${LOG_END}"
+  for CONFIG_FILE in $CONFIG_DIR_PATH/*.toml
+  do
+      KEEP_CORE_CONFIG_FILE_PATH=$CONFIG_FILE \
+      CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY \
+          npx truffle exec scripts/lcl-client-config.js --network $NETWORK
+  done
 
-printf "${LOG_START}Building keep-core client...${LOG_END}"
-cd $KEEP_CORE_PATH
-go generate ./...
-go build -a -o keep-core .
+  printf "${LOG_START}Building keep-core client...${LOG_END}"
+  cd $KEEP_CORE_PATH
+  go generate ./...
+  go build -a -o keep-core .
+fi
+
+printf "${DONE_START}Installation completed!${DONE_END}"

--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -38,7 +38,7 @@ help()
 for arg in "$@"; do
   shift
   case "$arg" in
-    "--config-dir")      set -- "$@" "-c" ;;
+    "--config-dir")     set -- "$@" "-c" ;;
     "--network")        set -- "$@" "-n" ;;
     "--contracts-only") set -- "$@" "-m" ;;
     "--help")           set -- "$@" "-h" ;;

--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -80,7 +80,9 @@ rm -rf build/
 CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY \
     npx truffle migrate --reset --network $NETWORK
 
-KEEP_CORE_SOL_ARTIFACTS_PATH="$KEEP_CORE_SOL_PATH/build/contracts"
+printf "${LOG_START}Creating links...${LOG_END}"
+ln -sf build/contracts artifacts
+npm link
 
 printf "${LOG_START}Initializing contracts...${LOG_END}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 LOG_START='\n\e[1;36m' # new line + bold + color
 LOG_END='\n\e[0m' # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
 
 KEEP_CORE_PATH=$PWD
 KEEP_CORE_SOL_PATH="$KEEP_CORE_PATH/solidity"
@@ -17,7 +19,8 @@ help()
 {
    echo -e "\nUsage: ENV_VAR(S) $0"\
            "--config-dir <path>"\
-           "--network <network>"
+           "--network <network>"\
+           "--contracts-only"
    echo -e "\nEnvironment variables:\n"
    echo -e "\tKEEP_ETHEREUM_PASSWORD: The password to unlock local Ethereum accounts to set up delegations."\
            "Required only for 'local' network. Default value is 'password'"
@@ -25,7 +28,9 @@ help()
    echo -e "\nCommand line arguments:\n"
    echo -e "\t--config-dir: Path to keep-core client configuration file(s)"
    echo -e "\t--network: Ethereum network for keep-core client."\
-                        "Available networks and settings are specified in the 'truffle-config.js'\n"
+                        "Available networks and settings are specified in the 'truffle-config.js'"
+   echo -e "\t--contracts-only: Should execute contracts part only."\
+                        "Client installation will not be executed.\n"
    exit 1 # Exit script after printing help
 }
 
@@ -33,20 +38,22 @@ help()
 for arg in "$@"; do
   shift
   case "$arg" in
-    "--config-dir")  set -- "$@" "-c" ;;
-    "--network")     set -- "$@" "-n" ;;
-    "--help")        set -- "$@" "-h" ;;
-    *)               set -- "$@" "$arg"
+    "--config-dir")      set -- "$@" "-c" ;;
+    "--network")        set -- "$@" "-n" ;;
+    "--contracts-only") set -- "$@" "-m" ;;
+    "--help")           set -- "$@" "-h" ;;
+    *)                  set -- "$@" "$arg"
   esac
 done
 
 # Parse short options
 OPTIND=1
-while getopts "c:n:h" opt
+while getopts "c:n:mh" opt
 do
    case "$opt" in
       c ) config_dir_path="$OPTARG" ;;
       n ) network="$OPTARG" ;;
+      m ) contracts_only=true ;;
       h ) help ;;
       ? ) help ;; # Print help in case parameter is non-existent
    esac
@@ -56,6 +63,7 @@ shift $(expr $OPTIND - 1) # remove options from positional parameters
 # Overwrite default properties
 CONFIG_DIR_PATH=${config_dir_path:-$CONFIG_DIR_PATH_DEFAULT}
 NETWORK=${network:-$NETWORK_DEFAULT}
+CONTRACTS_ONLY=${contracts_only:-false}
 
 # Run script
 printf "${LOG_START}Starting installation...${LOG_END}"
@@ -89,15 +97,19 @@ printf "${LOG_START}Initializing contracts...${LOG_END}"
 CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY \
     npx truffle exec scripts/delegate-tokens.js --network $NETWORK
 
-printf "${LOG_START}Updating keep-core client configs...${LOG_END}"
-for CONFIG_FILE in $CONFIG_DIR_PATH/*.toml
-do
-    KEEP_CORE_CONFIG_FILE_PATH=$CONFIG_FILE \
-    CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY \
-        npx truffle exec scripts/lcl-client-config.js --network $NETWORK
-done
+if [ "$CONTRACTS_ONLY" = false ] ; then
+  printf "${LOG_START}Updating keep-core client configs...${LOG_END}"
+  for CONFIG_FILE in $CONFIG_DIR_PATH/*.toml
+  do
+      KEEP_CORE_CONFIG_FILE_PATH=$CONFIG_FILE \
+      CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY \
+          npx truffle exec scripts/lcl-client-config.js --network $NETWORK
+  done
 
-printf "${LOG_START}Building keep-core client...${LOG_END}"
-cd $KEEP_CORE_PATH
-go generate ./...
-go build -a -o keep-core .
+  printf "${LOG_START}Building keep-core client...${LOG_END}"
+  cd $KEEP_CORE_PATH
+  go generate ./...
+  go build -a -o keep-core .
+fi
+
+printf "${DONE_START}Installation completed!${DONE_END}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,7 +38,7 @@ help()
 for arg in "$@"; do
   shift
   case "$arg" in
-    "--config-dir")      set -- "$@" "-c" ;;
+    "--config-dir")     set -- "$@" "-c" ;;
     "--network")        set -- "$@" "-n" ;;
     "--contracts-only") set -- "$@" "-m" ;;
     "--help")           set -- "$@" "-h" ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,7 +80,9 @@ rm -rf build/
 CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY \
     npx truffle migrate --reset --network $NETWORK
 
-KEEP_CORE_SOL_ARTIFACTS_PATH="$KEEP_CORE_SOL_PATH/build/contracts"
+printf "${LOG_START}Creating links...${LOG_END}"
+ln -sf build/contracts artifacts
+npm link
 
 printf "${LOG_START}Initializing contracts...${LOG_END}"
 


### PR DESCRIPTION
This PR refactors local installation scripts to utilize changes introduced in https://github.com/keep-network/keep-core/pull/2450.

Changes:
- use npm links between local modules to obtain migrated contracts instead of referring to the path where the artifacts sit,
- introduce contracts only flag to installation script to let skip go client installation (useful for dashboard installation),
- update the dashboard start script to utilize the changes to modules installation scripts.

Follow-up PRs in other repositories are expected to be created.