### PR TITLE
Execute chain of workflows by manual triggering of upstream build

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -12,6 +12,18 @@ on:
       - "solidity/dashboard/**"
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment for workflow execution'
+        required: false
+        default: 'dev'
+      upstream_builds:
+        description: 'Upstream builds'
+        required: false
+      ref:
+        description: 'Git reference to checkout (e.g. branch name)'
+        required: false
+        default: 'master'
 
 jobs:
   client-detect-changes:
@@ -19,15 +31,31 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-    - uses: actions/checkout@v2
-      if: github.event_name == 'pull_request' 
-    - uses: dorny/paths-filter@v2
-      if: github.event_name == 'pull_request' 
-      id: filter
-      with:
-        filters: |
-          path-filter:
-            - './!((docs|infrastructure|scripts|token-stakedrop|(solidity/dashboard))/**)'
+      - name: Show workflow metadata
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+            echo "Workflow dispatched on branch: ${{ github.ref }}"
+            echo "environment = ${{ github.event.inputs.environment }}"
+            echo "upstream_builds = ${{ github.event.inputs.upstream_builds }}"
+            echo "ref = ${{ github.event.inputs.ref }}"
+            echo "sha = ${{ github.sha }}"
+
+      - name: Show workflow metadata
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+            echo "ref = ${{ github.ref }}"
+            echo "sha = ${{ github.sha }}"
+
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './!((docs|infrastructure|scripts|token-stakedrop|(solidity/dashboard))/**)'
 
   client-build-test-publish:
     needs: client-detect-changes
@@ -79,9 +107,7 @@ jobs:
             gotestsum
 
       - name: Login to Google Container Registry
-        if: |
-          github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.GCR_REGISTRY_URL }}
@@ -98,14 +124,25 @@ jobs:
           # We don't use TAG yet, will be added at later stages of work on RFC-18.
           tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
           labels: revision=${{ github.sha }}
-          push: |
-            ${{ github.ref == 'refs/heads/master'
-              && github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'workflow_dispatch' }}
+      
+      - name: Notify CI about completion of the workflow
+        if: github.event_name == 'workflow_dispatch'
+        uses: keep-network/notify-workflow-completed@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/keep-network/keep-core"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          ref: ${{ github.event.inputs.ref }}
+          version: ${{ github.sha }} # TODO: replace with version once versioning ready
 
   client-scan:
     needs: client-detect-changes
     if: |
-      github.event_name != 'pull_request'
+      github.event_name == 'push'
         || needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     env:
@@ -128,4 +165,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Lint Go
-        uses: keep-network/golint-action@v1.0.2 
+        uses: keep-network/golint-action@v1.0.2

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -9,6 +9,18 @@ on:
       - "!solidity/dashboard/**"
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment for workflow execution'
+        required: false
+        default: 'dev'
+      upstream_builds:
+        description: 'Upstream builds'
+        required: false
+      ref:
+        description: 'Git reference to checkout (e.g. branch name)'
+        required: false
+        default: 'master'
 
 jobs:
   contracts-detect-changes:
@@ -16,15 +28,31 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-    - uses: actions/checkout@v2
-      if: github.event_name == 'pull_request' 
-    - uses: dorny/paths-filter@v2
-      if: github.event_name == 'pull_request' 
-      id: filter
-      with:
-        filters: |
-          path-filter:
-            - './solidity/!(dashboard)/**'
+      - name: Show workflow metadata
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+            echo "Workflow dispatched on branch: ${{ github.ref }}"
+            echo "environment = ${{ github.event.inputs.environment }}"
+            echo "upstream_builds = ${{ github.event.inputs.upstream_builds }}"
+            echo "ref = ${{ github.event.inputs.ref }}"
+            echo "sha = ${{ github.sha }}"
+
+      - name: Show workflow metadata
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+            echo "ref = ${{ github.ref }}"
+            echo "sha = ${{ github.sha }}"
+
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './solidity/!(dashboard)/**'
 
   contracts-build-and-test:
     needs: contracts-detect-changes
@@ -53,7 +81,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
+            
       - name: Install dependencies
         run: npm ci
 
@@ -66,7 +94,7 @@ jobs:
   contracts-lint:
     needs: contracts-detect-changes
     if: |
-      github.event_name != 'pull_request'
+      github.event_name == 'push'
         || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -98,10 +126,8 @@ jobs:
         run: npm run lint
 
   contracts-migrate-and-publish-ethereum:
-    needs: [contracts-build-and-test, contracts-lint]
-    if: |
-      github.ref == 'refs/heads/master'
-        && github.event_name != 'pull_request'
+    needs: [contracts-build-and-test]
+    if: github.event_name == 'workflow_dispatch'
     environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
     strategy:
@@ -110,6 +136,8 @@ jobs:
     defaults:
       run:
         working-directory: ./solidity
+    outputs:
+      version: ${{ steps.npm-version-bump.outputs.version }}
     steps:
       - uses: actions/checkout@v2
 
@@ -146,8 +174,23 @@ jobs:
       - name: Migrate contracts
         env: 
           ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
-          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: |
+            ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
+      
+      - name: Copy artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r build/contracts/* artifacts/
+
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          work-dir: ./solidity
+          environment: ${{ github.event.inputs.environment }}
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
 
       - name: Push contracts to Tenderly
         # TODO: once below action gets tagged replace `@main` with `@v1` 
@@ -159,37 +202,16 @@ jobs:
           tenderly-project: thesis/keep-test
           eth-network-id: ${{ env.NETWORK_ID }}
           github-project-name: keep-core
-          # version-tag: # TODO: resolve npm package version
-
-      - uses: google-github-actions/setup-gcloud@v0.2.0
-        with:
-          project_id: ${{ env.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
-      - name: Upload contract data
-        run: |
-          cd build/contracts
-          gsutil -m cp * gs://${{ env.CONTRACT_DATA_BUCKET }}/keep-core
-
-      - name: Copy artifacts
-        run: |
-          mkdir -p artifacts
-          cp -r build/contracts/* artifacts/
-
-      - name: Bump up package version
-        uses: keep-network/npm-version-bump@v1
-        with:
-          workDir: ./solidity
+          version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm publish --access=public
 
-      - name: Upload a Build Artifact
+      - name: Upload keep-core contracts for initcontainer build
         uses: actions/upload-artifact@v2
         with:
-          # TODO: consider adding version to the name
           name: Contracts (Node.js ${{ matrix.node-version }})
           path: ./solidity/build/contracts/*
 
@@ -213,7 +235,7 @@ jobs:
           # in config files.
           environment: 'ropsten'
 
-      - name: Download a Build Artifact
+      - name: Download migrated contracts artifacts
         uses: actions/download-artifact@v2
         with:
           name: Contracts (Node.js ${{ matrix.node-version }})
@@ -252,17 +274,24 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+      
+      - name: Notify CI about completion of the workflow
+        uses: keep-network/notify-workflow-completed@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/keep-network/keep-core/solidity"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          ref: ${{ github.event.inputs.ref }}
+          version: ${{ needs.contracts-migrate-and-publish-ethereum.outputs.version }}
 
   contracts-migrate-and-publish-celo:
-    needs: [contracts-build-and-test, contracts-lint]
-    if: |
-      github.ref == 'refs/heads/master'
-        && github.event_name != 'pull_request'
+    needs: [contracts-build-and-test]
+    if: github.event_name == 'workflow_dispatch'
     environment: keep-test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     defaults:
       run:
         working-directory: ./solidity
@@ -279,10 +308,9 @@ jobs:
           # in config files.
           environment: 'alfajores'
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -305,14 +333,4 @@ jobs:
             ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 
-      - uses: google-github-actions/setup-gcloud@v0.2.0
-        with:
-          project_id: ${{ env.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
-      - name: Upload contract data
-        run: |
-          cd build/contracts
-          gsutil -m cp * gs://${{ env.CONTRACT_DATA_BUCKET }}/keep-core-celo
-
-      # TODO: add NPM publish step once it's clear how artifacts should be tagged
+      # TODO: Add copy to `artifacts` dir and NPM publish steps once it's clear how artifacts should be tagged

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -8,6 +8,18 @@ on:
       - "solidity/dashboard/**"
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment for workflow execution'
+        required: false
+        default: 'dev'
+      upstream_builds:
+        description: 'Upstream builds'
+        required: false
+      ref:
+        description: 'Git reference to checkout (e.g. branch name)'
+        required: false
+        default: 'master'
 
 jobs:
   dashboard-detect-changes:
@@ -15,15 +27,31 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-    - uses: actions/checkout@v2
-      if: github.event_name == 'pull_request' 
-    - uses: dorny/paths-filter@v2
-      if: github.event_name == 'pull_request' 
-      id: filter
-      with:
-        filters: |
-          path-filter:
-            - './solidity/dashboard/**'
+      - name: Show workflow metadata
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+            echo "Workflow dispatched on branch: ${{ github.ref }}"
+            echo "environment = ${{ github.event.inputs.environment }}"
+            echo "upstream_builds = ${{ github.event.inputs.upstream_builds }}"
+            echo "ref = ${{ github.event.inputs.ref }}"
+            echo "sha = ${{ github.sha }}"
+
+      - name: Show workflow metadata
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+            echo "ref = ${{ github.ref }}"
+            echo "sha = ${{ github.sha }}"
+
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './solidity/dashboard/**'
 
   dashboard-build-and-publish:
     needs: dashboard-detect-changes
@@ -63,12 +91,22 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Get upstream packages' versions
+        uses: keep-network/upstream-builds-query@main
+        id: upstream-builds-query
+        with:
+          upstream-builds: ${{ github.event.inputs.upstream_builds }}
+          query: |
+            keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version
+            keep-ecdsa-solidity-version = github.com/keep-network/keep-ecdsa/solidity#version
+            tbtc-solidity-version = github.com/keep-network/tbtc/solidity#version
+
       - name: Resolve latest contracts
         run: |
-            npm update \
-              @keep-network/keep-core \
-              @keep-network/keep-ecdsa \
-              @keep-network/tbtc
+            npm install --save-exact \
+              @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-solidity-version }} \
+              @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-solidity-version }} \
+              @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-solidity-version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -82,9 +120,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Google Container Registry
-        if: |
-          github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.GCR_REGISTRY_URL }}
@@ -102,8 +138,19 @@ jobs:
           # We don't use TAG yet, will be added at later stages of work on RFC-18.
           tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
           labels: revision=${{ github.sha }}
-          push: |
-            ${{ github.ref == 'refs/heads/master'
-              && github.event_name != 'pull_request' }} 
+          push: ${{ github.event_name == 'workflow_dispatch' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+      
+      - name: Notify CI about completion of the workflow
+        if: github.event_name == 'workflow_dispatch'
+        uses: keep-network/notify-workflow-completed@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/keep-network/keep-core/dashboard"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          ref: ${{ github.event.inputs.ref }}
+          version: ${{ github.sha }}

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.13.0-pre",
+  "version": "1.13.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,13 +1,13 @@
 {
   "name": "dashboard",
-  "version": "1.13.0-pre",
+  "version": "1.13.0-rc",
   "private": true,
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
-    "@keep-network/keep-core": "1.8.0-pre.6",
-    "@keep-network/keep-ecdsa": "1.7.0-pre.8",
-    "@keep-network/tbtc": "1.1.2-pre.0",
+    "@keep-network/keep-core": ">1.8.0-rc <1.8.0",
+    "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "@walletconnect/web3-subprovider": "^1.3.6",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0-pre.0",
+  "version": "1.8.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0-pre.0",
+  "version": "1.8.0-rc",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -39,7 +39,7 @@ module.exports = {
           providerOrUrl: process.env.ETH_HOSTNAME,
         })
       },
-      gas: 8000000,
+      gas: 6000000,
       network_id: 3,
       skipDryRun: true,
       networkCheckTimeout: 120000,


### PR DESCRIPTION
This commit is part of a bigger work, spanning multiple repositories.
The main purpose of the work is to automate the process of workflows`
executions during product deployment, so that the workflows would be
triggered in a particular logical order and at the correct moment. By
that we mean:
* workflows requiring the presence of artifacts created by other
  workflows would not start before those upstream workflows are
  finished
* successfully executed workflows would automatically kick-off
  downstream workflows specified in the config file
* if any workflow in that chain of executions fails, the downstream
  workflows will not be triggered

To achieve the above requirements, following changes were introduced:
* A repository (called `ci`) managing the order of workflow executions
  was created
* The `config/config.json` file in `ci` repo describes the
  upstream/downstream relations between product modules and workflows
* The `Main` GH Actions workflow in `ci` repo allows for manual
  triggering of workflow deploying specified module, by providing the
  details of its upstream builds (to trigger deploy of the most
  upstream module, `Main` must be triggered with empty
  `upstream_builds` input)
* The triggering of module workflows by the `ci`'s `Main` workflow
  happens thanks to a `keep-network/run-workflow` action working as an
  intermediary (`Main` calls the `run-workflow`, which triggers
  workflow deploying the specified module)
* All NPM modules built as a part of the release process get versioned
  with `<base-version>-<environment>.<build-number>+<branch>.<commit>`
  version (thanks to `keep-network/upstream-builds-query` action that
  reads versions of older deployments and thanks to
  `keep-network/npm-version-bump@v2` action that bumps-up the version
  of the new artifact)
  (note: tagging of artifacts and versioning of docker images will be
  done at the later stage, outside this PR)
* Deployment workflows that are about to successfully finish will be
  executing the `keep-network/notify-workflow-completed` action as the
  last step - the action will then trigger the `ci`'s `Main` workflow
  with appropriate inputs
* Module workflows configuration has been adjusted to support the above
  features
* Conditions of execution of particular jobs/steps have been modified
  - after the changes contracts migration and deployments of artifacts
  happens only for workflows triggered by the `workflow-dispatch`
  event; actions like linting and sec scans are no longer executed for
  workflows triggered by `workflow-dispatch`
* Additionally, a couple of other changes were introduced to improve
  the process of build management:
  - listing of workflow metadata
  - unification of workflows' code
  - decreased amount of the gas sent for Ropsten env (to fix tests
    failing with `... exceeded the block limit`)
  - no longer pushing migrated contracts artifacts to GCP Bucket (see
    #2450 for more details)