### PR TITLE
Use `-dev` suffix in the versioning of the `keep-core` module

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0-pre",
+  "version": "1.8.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0-pre",
+  "version": "1.8.0-dev",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`-dev` suffix will be used for the versioning of the `keep-core` module
built with the purpose of being used on development environment.
Packages with the `-dev`-suffix will be pushed to the NPM registry by
the `NPM` GH Actions workflow.
Note that packages meant for the test environment (Ropsten) will be
versioned independently, based on the suffix provided during manual
triggering of the `Main` workflow in `ci` project.