### PR TITLE
Fix uniswap broken links

### DIFF
--- a/solidity/dashboard/src/constants/constants.js
+++ b/solidity/dashboard/src/constants/constants.js
@@ -67,7 +67,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
     contractName: LP_REWARDS_KEEP_ETH_CONTRACT_NAME,
     label: "KEEP + ETH",
     viewPoolLink:
-      "https://info.uniswap.org/pair/0xe6f19dab7d43317344282f803f8e8d240708174a",
+      "https://v2.info.uniswap.org/pair/0xe6f19dab7d43317344282f803f8e8d240708174a",
     address: "0xe6f19dab7d43317344282f803f8e8d240708174a",
     pool: "UNISWAP",
     lpTokens: [
@@ -85,7 +85,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
     contractName: LP_REWARDS_KEEP_TBTC_CONTRACT_NAME,
     label: "KEEP + TBTC",
     viewPoolLink:
-      "https://info.uniswap.org/pair/0x38c8ffee49f286f25d25bad919ff7552e5daf081",
+      "https://v2.info.uniswap.org/pair/0x38c8ffee49f286f25d25bad919ff7552e5daf081",
     address: "0x38c8ffee49f286f25d25bad919ff7552e5daf081",
     pool: "UNISWAP",
     lpTokens: [
@@ -103,7 +103,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
     contractName: LP_REWARDS_TBTC_ETH_CONTRACT_NAME,
     label: "TBTC + ETH",
     viewPoolLink:
-      "https://info.uniswap.org/pair/0x854056fd40c1b52037166285b2e54fee774d33f6",
+      "https://v2.info.uniswap.org/pair/0x854056fd40c1b52037166285b2e54fee774d33f6",
     address: "0x854056fd40c1b52037166285b2e54fee774d33f6",
     pool: "UNISWAP",
     lpTokens: [


### PR DESCRIPTION
Closes: #2454 

On the Liquidity page the links that point to Uniswap are broken due to
their update from v2 to v3. This commit will fix it and links redirect
correctly to the v2 pools.