### PR TITLE
Bump the KEEP Token Dashboard version to v1.15.0-pre

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.12.0
+        image: keepnetwork/token-dashboard:v1.14.0
         ports:
           - containerPort: 80

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.14.0-pre",
+  "version": "1.15.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.14.0-pre",
+  "version": "1.15.0-pre",
   "private": true,
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The v1.14.0 has been released.