### PR TITLE
No longer set CI_GITHUB_TOKEN for load-env-variables action

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -128,8 +128,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -212,8 +210,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -285,8 +281,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or


### PR DESCRIPTION
The `keep-network/ci` repository storing the config files used by the
`load-env-variables` action is no longer private. This means that we
no longer need to authenticate curl with the token allowing access to
the repository.

See also:
https://github.com/keep-network/keep-ecdsa/pull/818
https://github.com/keep-network/tbtc/pull/803
https://github.com/keep-network/tbtc-dapp/pull/397