### PR TITLE
Refactor workflows to add deployment of contracts migrated on Celo

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -53,13 +53,11 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
+        if: github.event_name == 'workflow_dispatch'
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          # TODO: Consider passing of `environment` input instead of using 
-          # hardcoded value. Would require some rework in action's code or
-          # in config files.
-          environment: 'ropsten' 
+          environment: ${{ github.event.inputs.environment }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -99,7 +97,17 @@ jobs:
           username: _json_key
           password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
+      - name: Build Docker Runtime Image
+        if: github.event_name != 'workflow_dispatch'
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_NAME: 'keep-client'
+        with:
+          labels: revision=${{ github.sha }}
+          push: false
+
       - name: Build and publish Docker Runtime Image
+        if: github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v2
         env:
           IMAGE_NAME: 'keep-client'
@@ -109,7 +117,7 @@ jobs:
           # We don't use TAG yet, will be added at later stages of work on RFC-18.
           tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
           labels: revision=${{ github.sha }}
-          push: ${{ github.event_name == 'workflow_dispatch' }}
+          push: true
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -87,14 +87,6 @@ jobs:
             go-build-env \
             gotestsum
 
-      - name: Login to Google Container Registry
-        if: github.event_name == 'workflow_dispatch'
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.GCR_REGISTRY_URL }}
-          username: _json_key
-          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
       - name: Build Docker Runtime Image
         if: github.event_name != 'workflow_dispatch'
         uses: docker/build-push-action@v2
@@ -103,6 +95,14 @@ jobs:
         with:
           labels: revision=${{ github.sha }}
           push: false
+      
+      - name: Login to Google Container Registry
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.GCR_REGISTRY_URL }}
+          username: _json_key
+          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Build and publish Docker Runtime Image
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -151,16 +151,16 @@ jobs:
       - name: Migrate contracts on Ethereum
         if: github.event.inputs.environment != 'alfajores'
         env:
-          ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
-          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: |
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 
       - name: Migrate contracts on Celo
         if: github.event.inputs.environment == 'alfajores'
         env:
-          CELO_HOSTNAME: ${{ secrets.KEEP_TEST_CELO_HOSTNAME }}
-          CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_CELO_HOSTNAME }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
       

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -110,14 +110,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  contracts-migrate-and-publish-ethereum:
+  contracts-migrate-and-publish:
     needs: [contracts-build-and-test]
     if: github.event_name == 'workflow_dispatch'
-    environment: keep-test # line can be deleted once we'll no longer use environment protection
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     defaults:
       run:
         working-directory: ./solidity
@@ -131,15 +127,11 @@ jobs:
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          # TODO: Consider passing of `environment` input instead of using 
-          # hardcoded value. Would require some rework in action's code or
-          # in config files.
-          environment: 'ropsten'
+          environment: ${{ github.event.inputs.environment }}
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -156,11 +148,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Migrate contracts
-        env: 
+      - name: Migrate contracts on Ethereum
+        if: github.event.inputs.environment != 'alfajores'
+        env:
           ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
           CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
+
+      - name: Migrate contracts on Celo
+        if: github.event.inputs.environment == 'alfajores'
+        env:
+          CELO_HOSTNAME: ${{ secrets.KEEP_TEST_CELO_HOSTNAME }}
+          CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
+            ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
       
       - name: Copy artifacts
@@ -178,7 +179,8 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Push contracts to Tenderly
-        # TODO: once below action gets tagged replace `@main` with `@v1` 
+        if: github.event.inputs.environment == 'ropsten'
+        # TODO: once below action gets tagged replace `@main` with `@v1`
         uses: keep-network/tenderly-push-action@main
         continue-on-error: true
         with:
@@ -197,16 +199,13 @@ jobs:
       - name: Upload keep-core contracts for initcontainer build
         uses: actions/upload-artifact@v2
         with:
-          name: Contracts (Node.js ${{ matrix.node-version }})
+          name: Contracts
           path: ./solidity/build/contracts/*
 
   contracts-build-and-publish-initcontainer:
-    needs: [contracts-migrate-and-publish-ethereum]
-    if: needs.contracts-migrate-and-publish-ethereum.result == 'success'
+    needs: [contracts-migrate-and-publish]
+    if: needs.contracts-migrate-and-publish.result == 'success'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     steps:
       - uses: actions/checkout@v2
 
@@ -215,15 +214,12 @@ jobs:
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          # TODO: Consider passing of `environment` input instead of using 
-          # hardcoded value. Would require some rework in action's code or
-          # in config files.
-          environment: 'ropsten'
+          environment: ${{ github.event.inputs.environment }}
 
       - name: Download migrated contracts artifacts
         uses: actions/download-artifact@v2
         with:
-          name: Contracts (Node.js ${{ matrix.node-version }})
+          name: Contracts
           path: ./infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
 
       - name: Set up Docker Buildx
@@ -247,7 +243,7 @@ jobs:
       - name: Build and publish initcontainer
         uses: docker/build-push-action@v2
         env:
-          IMAGE_NAME: 'initcontainer-provision-keep-client'
+          IMAGE_NAME: initcontainer-provision-keep-client-${{ github.event.inputs.environment }}
         with:
           context: ./infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
           # GCR image should be named according to following convention:
@@ -270,64 +266,5 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
-          version: ${{ needs.contracts-migrate-and-publish-ethereum.outputs.version }}
+          version: ${{ needs.contracts-migrate-and-publish.outputs.version }}
 
-  contracts-migrate-and-publish-celo:
-    needs: [contracts-build-and-test]
-    if: github.event_name == 'workflow_dispatch'
-    environment: keep-test # line can be deleted once we'll no longer use environment protection
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        with:
-          # TODO: Consider passing of `environment` input instead of using 
-          # hardcoded value. Would require some rework in action's code or
-          # in config files.
-          environment: 'alfajores'
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "12.x"
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Migrate contracts
-        env:
-          CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
-            ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
-        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
-
-      # TODO: Add copy to `artifacts` dir and NPM publish steps once it's clear
-      # how artifacts should be tagged. Once that's done, no longer publish
-      # contracts to GC Bucket.
-
-      - uses: google-github-actions/setup-gcloud@v0.2.0
-        with:
-          project_id: ${{ env.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
-      - name: Upload contract data
-        run: |
-          cd build/contracts
-          gsutil -m cp * gs://${{ env.CONTRACT_DATA_BUCKET }}/keep-core-celo

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Build and publish initcontainer
         uses: docker/build-push-action@v2
         env:
-          IMAGE_NAME: initcontainer-provision-keep-client-${{ github.event.inputs.environment }}
+          IMAGE_NAME: initcontainer-provision-keep-client-${{ env.CHAIN }}
         with:
           context: ./infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/
           # GCR image should be named according to following convention:

--- a/infrastructure/kube/keep-dev/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-0-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
+        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-dev/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-1-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
+        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-dev/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-2-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
+        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-dev/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-3-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
+        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-dev/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-client-4-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client
+        image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-dev/keep-network-relay-request-cronjob.yaml
+++ b/infrastructure/kube/keep-dev/keep-network-relay-request-cronjob.yaml
@@ -39,7 +39,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
           - name: initcontainer-provision-keep-client
-            image: gcr.io/keep-dev-fe24/keep-client-initcontainer
+            image: gcr.io/keep-dev-fe24/keep-client-initcontainer-ethereum
             env:
               - name: KEEP_CLIENT_TYPE
                 value: relay-requester

--- a/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
+        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
+        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
+        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
+        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
         command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "start"]
       initContainers:
       - name: initcontainer-provision-keep-client
-        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
+        image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client-ethereum
         imagePullPolicy: Always
         env:
           - name: ETH_RPC_URL

--- a/infrastructure/kube/keep-test/keep-network-ropsten-relay-request-cronjob.yaml
+++ b/infrastructure/kube/keep-test/keep-network-ropsten-relay-request-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
             command: ["keep-client", "-config", "/mnt/keep-client/config/keep-client-config.toml", "relay", "request"]
           initContainers:
           - name: initcontainer-provision-keep-client
-            image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client
+            image: gcr.io/keep-test-f3e0/initcontainer-provision-keep-client-ethereum
             imagePullPolicy: Always
             env:
               - name: KEEP_CLIENT_TYPE

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -48,7 +48,7 @@ module.exports = {
 
     alfajores: {
       provider: function () {
-        const kit = Kit.newKit("https://alfajores-forno.celo-testnet.org")
+        const kit = Kit.newKit(process.env.CELO_HOSTNAME)
         kit.addAccount(process.env.CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY)
         return kit.web3.currentProvider
       },

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -13,7 +13,7 @@ module.exports = {
     keep_dev: {
       provider: function () {
         return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY],
+          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
           providerOrUrl: "http://localhost:8545",
         })
       },
@@ -24,7 +24,7 @@ module.exports = {
     keep_dev_vpn: {
       provider: function () {
         return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY],
+          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
           providerOrUrl: "http://eth-tx-node.default.svc.cluster.local:8545",
         })
       },
@@ -35,8 +35,8 @@ module.exports = {
     ropsten: {
       provider: function () {
         return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY],
-          providerOrUrl: process.env.ETH_HOSTNAME,
+          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
+          providerOrUrl: process.env.CHAIN_API_URL,
         })
       },
       gas: 6000000,
@@ -48,8 +48,8 @@ module.exports = {
 
     alfajores: {
       provider: function () {
-        const kit = Kit.newKit(process.env.CELO_HOSTNAME)
-        kit.addAccount(process.env.CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY)
+        const kit = Kit.newKit(process.env.CHAIN_API_URL)
+        kit.addAccount(process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY)
         return kit.web3.currentProvider
       },
       network_id: 44787,


### PR DESCRIPTION
Workflows have been refactored so that Celo-related artifacts could be
deployed in the chain of automatic execusions triggered by the manual
dispatch of the `Main` workflow in the `ci` project (with `environment`
set to `alfajores`).

Similar changes have been introduced to keep-core and tbtc
workflows. See:
https://github.com/keep-network/keep-ecdsa/pull/823
https://github.com/keep-network/tbtc/pull/804