### PR TITLE
Replace the CircleCI build status badge with GHA badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = keep-core
 
-https://circleci.com/gh/keep-network/keep-core[image:https://circleci.com/gh/keep-network/keep-core.svg?style=svg&circle-token=ec728f5ca814b6cb2db5ffeb7258151b752a207e[CircleCI Build Status]]
+https://github.com/keep-network/keep-core/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Solidity/master?event=push&label=Solidity build[Solidity contracts build status]]
+https://github.com/keep-network/keep-core/actions/workflows/client.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Solidity/master?event=push&label=Go build[Go client build status]]
 https://discord.gg/wYezN7v[image:https://img.shields.io/badge/chat-Discord-blueViolet.svg[Chat with us on Discord]]
 
 The core contracts and reference client implementation behind the Keep network,

--- a/solidity/dashboard/README.md
+++ b/solidity/dashboard/README.md
@@ -1,3 +1,5 @@
+![Token Dashboard / Testnet](https://github.com/keep-network/keep-core/actions/workflows/dashboard-testnet.yml/badge.svg?branch=master&event=push)
+
 # KEEP Token Dashboard
 
 A react web app to interact with Keep network staking and token grant contracts.


### PR DESCRIPTION
We no longer use CircleCI to test/build the `keep-core` code. We need to
replace the CircleCI build status badge in the projec'ts README with the
similiar badges for GitHub Actions builds.
Two badges have been introduced in place of the old one:
* Contracts (showing status of the last `Solidity` workflow executed on
`master` branch and triggered by the push event),
* Go client (showing status of the last `Go` workflow executed on
`master` branch and triggered by the push event).

The badges are displayed using `shields.io` tool, which was already used
for the Discord badge.

Also a badge was added in the README of the Token Dashboard:
* Token Dashboard / Testnet (showing status of the last `Token Dashboard
/ Testnet` workflow on `master` branch and triggered by the push event).

This time standard GitHub badge was used, as `shields.io` tool currently
does not support workflows with slash character in their name (see
https://github.com/badges/shields/issues/4559).

Refs:
https://github.com/keep-network/keep-ecdsa/pull/835
https://github.com/keep-network/tbtc/pull/809