### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - "docs/**"
       - "infrastructure/**"
@@ -23,7 +23,7 @@ on:
       upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
-        default: 'master'
+        default: 'main'
 
 jobs:
   client-detect-changes:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -3,7 +3,7 @@ name: Solidity
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "solidity/**"
       - "!solidity/dashboard/**"
@@ -20,7 +20,7 @@ on:
       upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
-        default: 'master'
+        default: 'main'
 
 jobs:
   contracts-detect-changes:

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -2,7 +2,7 @@ name: Token Dashboard / Mainnet
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
     - solidity/dashboard/**
 
@@ -37,10 +37,10 @@ jobs:
       run: npm run build
       env:
         PUBLIC_URL: /${{ github.head_ref }}
-    # A push event is a master merge; deploy to primary bucket.
+    # A push event is a main merge; deploy to primary bucket.
     # TODO uncomment when mainnet builds happen this way
     #- if: github.event_name == 'push'
-    #  name: Deploy Master to GCP
+    #  name: Deploy Main to GCP
     #  uses: thesis/gcp-storage-bucket-action@v3.1.0
     #  with:
     #    service-key: ${{ secrets.KEEP_DASHBOARD_UPLOADER_SERVICE_KEY_JSON }}

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -3,7 +3,7 @@ name: Token Dashboard / Testnet
 on:
   push:
     branches:
-     - master
+     - main
     paths:
       - "solidity/dashboard/**"
   pull_request:
@@ -19,7 +19,7 @@ on:
       upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
-        default: 'master'
+        default: 'main'
 
 jobs:
   dashboard-detect-changes:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "docs/**"
       - "solidity/**"
@@ -52,7 +52,7 @@ jobs:
           mkdir -p $DOCS_DIR
           mv relay-states.pdf $DOCS_DIR
 
-      # A push event is a master merge; deploy to primary bucket.
+      # A push event is a main merge; deploy to primary bucket.
       - if: github.event_name == 'push'
         name: Upload generated files
         uses: thesis/gcp-storage-bucket-action@v3.1.0
@@ -123,7 +123,7 @@ jobs:
           files: 'docs/*.adoc docs/**/*.adoc'
           args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
 
-      # A push event is a master merge; deploy to primary bucket.
+      # A push event is a main merge; deploy to primary bucket.
       - if: github.event_name == 'push'
         name: Upload asciidocs
         uses: thesis/gcp-storage-bucket-action@v3.1.0
@@ -170,7 +170,7 @@ jobs:
           format: pdf
           args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
 
-      # A push event is a master merge; deploy to primary bucket.
+      # A push event is a main merge; deploy to primary bucket.
       - if: github.event_name == 'push'
         name: Upload asciidocs
         uses: thesis/gcp-storage-bucket-action@v3.1.0

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -3,7 +3,7 @@ name: NPM
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'solidity/contracts/**'
       - 'solidity/package.json'

--- a/README.adoc
+++ b/README.adoc
@@ -50,7 +50,7 @@ They can be used to request
 link:solidity/contracts/IRandomBeacon.sol[miner-resistant random numbers], as
 well as creating and managing keeps. To generate new ECDSA key material and
 request signatures, the contracts can be found in
-link:https://github.com/keep-network/keep-ecdsa/blob/master/solidity/contracts/api/IBondedECDSAKeep.sol[`keep-ecdsa`].
+link:https://github.com/keep-network/keep-ecdsa/blob/main/solidity/contracts/api/IBondedECDSAKeep.sol[`keep-ecdsa`].
 
 === Client Developers
 

--- a/docs/development-process.adoc
+++ b/docs/development-process.adoc
@@ -131,7 +131,7 @@ understanding of what “Done” means. For a milestone item to be considered as
 “Done”, the following requirements must be met: 
 
 * The implemented code has been reviewed and approved by at least one other development team member
-* Code merged to `master` branch
+* Code merged to `main` branch
 * The feature described by the item works as expected
 * The code is implemented according to the guidelines
 * No technical debt other than agreed in the item’s description 

--- a/docs/development/README.adoc
+++ b/docs/development/README.adoc
@@ -93,7 +93,7 @@ repo's `docs` available at https://docs.keep.network/relay-states.pdf. The
 images in the diagram, whose sources are at `img-src/*.tikz`, are also
 available at `+https://docs.keep.network/img/generated/*.png+` (the filenames
 are identical to their TikZ sources, with a `.png` suffix instead of
-`.tikz`). These URLs are for the `master` version of the repo; non-`master`
+`.tikz`). These URLs are for the `main` version of the repo; non-`main`
 branches are instead published to `+https://docs.keep.network/<branch name>/+`.
 
 == Common problems

--- a/docs/development/local-keep-network.adoc
+++ b/docs/development/local-keep-network.adoc
@@ -628,7 +628,7 @@ Environment Name: `keep-dev`
 
 `keep-dev` is a cloud deployed instance of the keep-network complete
 with ETH chain.  This environment is usually deployed with the latest
-`master` and is continuously deployed so uptime is variable.
+`main` and is continuously deployed so uptime is variable.
 
 You do need a `keep-dev` VPN account to access the network and below
 endpoints.  Reach out in the https://www.flowdock.com/app/cardforcoin/ops[DevOps flow] if you do not have one.

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -261,7 +261,7 @@ reference].
 
 == Build from Source
 
-See the https://github.com/keep-network/keep-core/tree/master/docs/development#building[building] section in our developer docs.
+See the https://github.com/keep-network/keep-core/tree/main/docs/development#building[building] section in our developer docs.
 
 == Docker
 
@@ -307,7 +307,7 @@ At Keep we run on GCP + Kube. To accommodate the aforementioned system considera
 - A LoadBalancer Service for each client.
 - A StatefulSet for each client.
 
-You can see our Ropsten Kube configurations https://github.com/keep-network/keep-core/tree/master/infrastructure/kube/keep-test[here]
+You can see our Ropsten Kube configurations https://github.com/keep-network/keep-core/tree/main/infrastructure/kube/keep-test[here]
 
 == Logging
 

--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -261,7 +261,7 @@ reference].
 
 == Build from Source
 
-See the https://github.com/keep-network/keep-core/tree/main/docs/development#building[building] section in our developer docs.
+See the link:development#building[building] section in our developer docs.
 
 == Docker
 
@@ -307,7 +307,7 @@ At Keep we run on GCP + Kube. To accommodate the aforementioned system considera
 - A LoadBalancer Service for each client.
 - A StatefulSet for each client.
 
-You can see our Ropsten Kube configurations https://github.com/keep-network/keep-core/tree/main/infrastructure/kube/keep-test[here]
+You can see our Ropsten Kube configurations link:../infrastructure/kube/keep-test[here]
 
 == Logging
 

--- a/solidity/dashboard/README.md
+++ b/solidity/dashboard/README.md
@@ -73,7 +73,7 @@ When you don’t want to use the local version of `@keep-network/keep-core` anym
 
 ### Internal testnet
 
-A new version of staking dApp is automatically deployed to `keep-dev` internal testnet after each `master` merge. dApp can be accessed at [https://dashboard.dev.keep.network/](https://dashboard.dev.keep.network/) and requires an initial setup in MetaMask before the first use. All the setup described below has to be done only one time. 
+A new version of staking dApp is automatically deployed to `keep-dev` internal testnet after each `main` merge. dApp can be accessed at [https://dashboard.dev.keep.network/](https://dashboard.dev.keep.network/) and requires an initial setup in MetaMask before the first use. All the setup described below has to be done only one time. 
 
 ### MetaMask extension setup
 
@@ -95,7 +95,7 @@ Before MetaMask can be used with `keep-dev` testnet for the first time, it needs
 ### MetaMask KEEP token owner account import
 On `keep-dev`, account `0x0f0977c4161a371b5e5ee6a8f43eb798cd1ae1db` is the owner of contracts including KEEP ERC20 token contract. This account can be used to create token grants and delegate stake to operators. Grantees of tokens can also stake-delegate their grants.
 
-To use this account in the dApp, it needs to be imported from [the JSON file](https://github.com/keep-network/keep-core/blob/master/private-testnet/keyfiles/UTC--2019-03-27T19-05-16.429364100Z--0f0977c4161a371b5e5ee6a8f43eb798cd1ae1db) secured by a [password](https://github.com/keep-network/keep-core/blob/master/private-testnet/eth-account-password.txt).
+To use this account in the dApp, it needs to be imported from [the JSON file](https://github.com/keep-network/keep-core/blob/main/private-testnet/keyfiles/UTC--2019-03-27T19-05-16.429364100Z--0f0977c4161a371b5e5ee6a8f43eb798cd1ae1db) secured by a [password](https://github.com/keep-network/keep-core/blob/main/private-testnet/eth-account-password.txt).
 
 1. Download the account JSON file
 2. Expand the list of accounts and click on `Import Account`

--- a/solidity/dashboard/src/components/resources/DocumentationSection.jsx
+++ b/solidity/dashboard/src/components/resources/DocumentationSection.jsx
@@ -7,7 +7,7 @@ const docs = [
   {
     title: "Run Random Beacon",
     link:
-      "https://github.com/keep-network/keep-core/blob/master/docs/run-random-beacon.adoc",
+      "https://github.com/keep-network/keep-core/blob/main/docs/run-random-beacon.adoc",
   },
   {
     title: "GitBook Staking Documentation",
@@ -17,7 +17,7 @@ const docs = [
   {
     title: "Staking Overview",
     link:
-      "https://github.com/keep-network/keep-core/blob/master/docs/random-beacon/staking/index.adoc ",
+      "https://github.com/keep-network/keep-core/blob/main/docs/random-beacon/staking/index.adoc ",
   },
 ]
 

--- a/solidity/dashboard/src/components/resources/TerminologyDataTable.jsx
+++ b/solidity/dashboard/src/components/resources/TerminologyDataTable.jsx
@@ -6,7 +6,7 @@ const TerminologyDataTable = () => (
     <header className="flex row wrap mb-1">
       <h3 className="text-grey-70">Quick Terminology</h3>
       <a
-        href="https://github.com/keep-network/keep-core/blob/master/docs/glossary.adoc"
+        href="https://github.com/keep-network/keep-core/blob/main/docs/glossary.adoc"
         className="arrow-link"
         style={{ marginLeft: "auto", marginRight: "2rem" }}
       >

--- a/solidity/dashboard/src/services/rewards.js
+++ b/solidity/dashboard/src/services/rewards.js
@@ -48,7 +48,7 @@ export const fetchtTotalDistributedRewards = async (
 
 /**
  * Gets the available rewards based on the output from the merkle object
- * generator (github.com/keep-network/keep-ecdsa/tree/master/staker-rewards) which
+ * generator (github.com/keep-network/keep-ecdsa/tree/main/staker-rewards) which
  * is stored in `src/rewards-allocation/rewards.json` file
  * for the given operators between the interval 0 and the
  * current interval. Note that rewards may already be withdrawn so need to take


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
After the proposed changes get merged to the `master` branch, the
repository should be ready for the migration from `master` to `main`.

To migrate from `master` to `main`:
1. Do a local branch rename with `git branch -m master main`
2. Push the renamed branch `git push -u origin main`
3. In the Github repo settings, rename the default branch: Settings ->
    Branches -> Default branch -> (pencil icon) -> (change `master` to
    `main`) -> (approve)

After migration other contributors should update their local repositories:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Refs:
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc/pull/810
https://github.com/keep-network/tbtc-dapp/pull/399
https://github.com/keep-network/tbtc.js/pull/126
https://github.com/keep-network/keep-common/pull/79
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/local-setup/pull/97
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3
https://github.com/keep-network/load-env-variables/pull/2