### PR TITLE
Coverage pool- fetching data

### DIFF
--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
+    "@keep-network/coverage-pool": "file:../../../coverage-pools",
     "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
     "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
     "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",

--- a/solidity/dashboard/src/__tests__/saga/coverage-pool.test.js
+++ b/solidity/dashboard/src/__tests__/saga/coverage-pool.test.js
@@ -1,0 +1,312 @@
+import { expectSaga } from "redux-saga-test-plan"
+import { throwError } from "redux-saga-test-plan/providers"
+import * as matchers from "redux-saga-test-plan/matchers"
+import { call, select } from "redux-saga/effects"
+import BigNumber from "bignumber.js"
+import {
+  watchFetchTvl,
+  watchFetchAPY,
+  watchFetchCovPoolData,
+  subscribeToCovTokenTransferEvent,
+} from "../../sagas/coverage-pool"
+import selectors from "../../sagas/selectors"
+
+import coveragePoolReducer, {
+  coveragePoolInitialData,
+} from "../../reducers/coverage-pool"
+import { KEEP, Token } from "../../utils/token.utils"
+import {
+  fetchTvlRequest,
+  fetchTvlStart,
+  fetchTvlSuccess,
+  COVERAGE_POOL_FETCH_TVL_ERROR,
+  fetchAPYRequest,
+  fetchAPYStart,
+  fetchAPYSuccess,
+  COVERAGE_POOL_FETCH_APY_ERROR,
+  fetchCovPoolDataRequest,
+  fetchCovPoolDataStart,
+  fetchCovPoolDataSuccess,
+  COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR,
+  covTokenUpdated,
+  COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED,
+} from "../../actions/coverage-pool"
+import { Keep } from "../../contracts"
+import { ZERO_ADDRESS } from "../../utils/ethereum.utils"
+import { add } from "../../utils/arithmetics.utils"
+
+describe("Coverage pool saga test", () => {
+  describe("Fetch tvl watcher", () => {
+    const tvl = KEEP.fromTokenUnit(100000)
+    const keepInUSD = new BigNumber(0.5)
+    const totalAllocatedRewards = KEEP.fromTokenUnit(200000)
+    const tvlInUSD = keepInUSD.multipliedBy(KEEP.toTokenUnit(tvl)).toFormat(2)
+
+    it("should fetch tvl data correctly", () => {
+      return expectSaga(watchFetchTvl)
+        .withReducer(coveragePoolReducer)
+        .provide([
+          [call(Keep.coveragePoolV1.totalValueLocked), tvl],
+          [call(Keep.exchangeService.getKeepTokenPriceInUSD), keepInUSD],
+          [
+            call(Keep.coveragePoolV1.totalAllocatedRewards),
+            totalAllocatedRewards,
+          ],
+        ])
+        .dispatch(fetchTvlRequest())
+        .put(fetchTvlStart())
+        .put(
+          fetchTvlSuccess({
+            tvl,
+            tvlInUSD,
+            totalAllocatedRewards,
+          })
+        )
+        .hasFinalState({
+          ...coveragePoolInitialData,
+          totalValueLocked: tvl,
+          totalValueLockedInUSD: tvlInUSD,
+          isTotalValueLockedFetching: false,
+          tvlError: null,
+          totalAllocatedRewards,
+        })
+        .run()
+    })
+
+    it("should log error if an any Keep lib function has failed", () => {
+      const mockedError = new Error("Fake error")
+      return expectSaga(watchFetchTvl)
+        .withReducer(coveragePoolReducer)
+        .provide([
+          [call(Keep.coveragePoolV1.totalValueLocked), throwError(mockedError)],
+          [call(Keep.exchangeService.getKeepTokenPriceInUSD), keepInUSD],
+          [
+            call(Keep.coveragePoolV1.totalAllocatedRewards),
+            totalAllocatedRewards,
+          ],
+        ])
+        .dispatch(fetchTvlRequest())
+        .put(fetchTvlStart())
+        .put({
+          type: COVERAGE_POOL_FETCH_TVL_ERROR,
+          payload: { error: mockedError.message },
+        })
+        .hasFinalState({
+          ...coveragePoolInitialData,
+          tvlError: mockedError.message,
+        })
+        .run()
+    })
+  })
+
+  describe("Fetch apy watcher", () => {
+    const apy = 0.25
+
+    it("should fetch apy data correctly", () => {
+      return expectSaga(watchFetchAPY)
+        .withReducer(coveragePoolReducer)
+        .provide([[call(Keep.coveragePoolV1.apy), apy]])
+        .dispatch(fetchAPYRequest())
+        .put(fetchAPYStart())
+        .put(fetchAPYSuccess(apy))
+        .hasFinalState({
+          ...coveragePoolInitialData,
+          apy,
+        })
+        .run()
+    })
+
+    it("should log error if function has failed", () => {
+      const mockedError = new Error("Fake error")
+      return expectSaga(watchFetchAPY)
+        .withReducer(coveragePoolReducer)
+        .provide([[call(Keep.coveragePoolV1.apy), throwError(mockedError)]])
+        .dispatch(fetchAPYRequest())
+        .put(fetchAPYStart())
+        .put({
+          type: COVERAGE_POOL_FETCH_APY_ERROR,
+          payload: { error: mockedError.message },
+        })
+        .hasFinalState({
+          ...coveragePoolInitialData,
+          apyError: mockedError.message,
+        })
+        .run()
+    })
+  })
+
+  describe("Fetch cov pool data watcher", () => {
+    const balanceOf = Token.fromTokenUnit("100")
+    const totalSupply = Token.fromTokenUnit("1000")
+    const shareOfPool = 0.5
+    const estimatedKeepBalance = Token.fromTokenUnit("50")
+    const estimatedRewards = Token.fromTokenUnit("10")
+    const address = "0x0"
+
+    it("should fetch apy data correctly", () => {
+      return expectSaga(watchFetchCovPoolData)
+        .withReducer(coveragePoolReducer)
+        .provide([
+          [call(Keep.coveragePoolV1.covBalanceOf, address), balanceOf],
+          [call(Keep.coveragePoolV1.covTotalSupply), totalSupply],
+          [
+            call(Keep.coveragePoolV1.shareOfPool, totalSupply, balanceOf),
+            shareOfPool,
+          ],
+          [
+            call(
+              Keep.coveragePoolV1.estimatedCollateralTokenBalance,
+              shareOfPool
+            ),
+            estimatedKeepBalance,
+          ],
+          [
+            call(Keep.coveragePoolV1.estimatedRewards, address, shareOfPool),
+            estimatedRewards,
+          ],
+        ])
+        .dispatch(fetchCovPoolDataRequest(address))
+        .put(fetchCovPoolDataStart())
+        .put(
+          fetchCovPoolDataSuccess({
+            shareOfPool,
+            covBalance: balanceOf,
+            covTotalSupply: totalSupply,
+            estimatedRewards,
+            estimatedKeepBalance,
+          })
+        )
+        .hasFinalState({
+          ...coveragePoolInitialData,
+          shareOfPool,
+          covBalance: balanceOf,
+          covTotalSupply: totalSupply,
+          estimatedRewards,
+          estimatedKeepBalance,
+        })
+        .run()
+    })
+
+    it("should log error if function has failed", () => {
+      const mockedError = new Error("Fake error")
+
+      return expectSaga(watchFetchCovPoolData)
+        .withReducer(coveragePoolReducer)
+        .provide([
+          [
+            call(Keep.coveragePoolV1.covBalanceOf, address),
+            throwError(mockedError),
+          ],
+        ])
+        .dispatch(fetchCovPoolDataRequest(address))
+        .put(fetchCovPoolDataStart())
+        .put({
+          type: COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR,
+          payload: { error: mockedError.message },
+        })
+        .hasFinalState({
+          ...coveragePoolInitialData,
+          error: mockedError.message,
+        })
+        .run()
+    })
+  })
+
+  describe("Subscribe to cov token transfer event", () => {
+    it("should udpate data correctly if the `Transfer` event has been emitted", () => {
+      const address = "0x086813525A7dC7dafFf015Cdf03896Fd276eab60"
+      const initialCovTotalSupply = Token.fromTokenUnit(100).toString()
+      const initialCovBalance = Token.fromTokenUnit(30).toString()
+      const transferEventData = {
+        from: ZERO_ADDRESS,
+        to: address,
+        value: KEEP.fromTokenUnit("300").toString(),
+      }
+      const mockedEvent = {
+        returnValues: transferEventData,
+      }
+
+      const initialState = {
+        ...coveragePoolInitialData,
+        covTotalSupply: initialCovTotalSupply,
+        covBalance: initialCovBalance,
+      }
+
+      const updatedCovBalance = add(
+        initialCovBalance,
+        transferEventData.value
+      ).toString()
+      const updatedCovTotalSupply = add(
+        initialCovTotalSupply,
+        transferEventData.value
+      ).toString()
+      const updatedShareOfPool = 0.8
+      const estimatedKeepBalance = KEEP.fromTokenUnit(350).toString()
+      const estimatedRewards = KEEP.fromTokenUnit(35).toString()
+      const updatedTvl = KEEP.fromTokenUnit(10000).toString()
+      const keepInUSD = new BigNumber(0.25)
+      const updatedAPY = 0.5
+      const tvlInUSD = new BigNumber(keepInUSD)
+        .multipliedBy(KEEP.toTokenUnit(updatedTvl))
+        .toFormat(2)
+
+      return expectSaga(subscribeToCovTokenTransferEvent)
+        .withReducer(coveragePoolReducer, initialState.coveragePool)
+        .withState(initialState)
+        .provide([
+          [select(selectors.getCoveragePool), initialState],
+          [select(selectors.getUserAddress), address],
+          [
+            matchers.call.fn(Keep.coveragePoolV1.shareOfPool),
+            updatedShareOfPool,
+          ],
+          [
+            matchers.call.fn(
+              Keep.coveragePoolV1.estimatedCollateralTokenBalance
+            ),
+            estimatedKeepBalance,
+          ],
+          [
+            matchers.call.fn(Keep.coveragePoolV1.estimatedRewards),
+            estimatedRewards,
+          ],
+          [matchers.call.fn(Keep.coveragePoolV1.totalValueLocked), updatedTvl],
+          [
+            matchers.call.fn(
+              Keep.coveragePoolV1.exchangeService.getKeepTokenPriceInUSD
+            ),
+            keepInUSD,
+          ],
+          [matchers.call.fn(Keep.coveragePoolV1.apy), updatedAPY],
+        ])
+        .dispatch({
+          type: COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED,
+          payload: { event: mockedEvent },
+        })
+        .put(
+          covTokenUpdated({
+            covBalance: updatedCovBalance,
+            covTotalSupply: updatedCovTotalSupply,
+            shareOfPool: updatedShareOfPool,
+            estimatedKeepBalance,
+            estimatedRewards,
+            totalValueLocked: updatedTvl,
+            totalValueLockedInUSD: tvlInUSD,
+            apy: updatedAPY,
+          })
+        )
+        .hasFinalState({
+          ...initialState,
+          covBalance: updatedCovBalance,
+          covTotalSupply: updatedCovTotalSupply,
+          shareOfPool: updatedShareOfPool,
+          estimatedKeepBalance,
+          estimatedRewards,
+          totalValueLocked: updatedTvl,
+          totalValueLockedInUSD: tvlInUSD,
+          apy: updatedAPY,
+        })
+        .run()
+    })
+  })
+})

--- a/solidity/dashboard/src/__tests__/saga/rootSaga.test.js
+++ b/solidity/dashboard/src/__tests__/saga/rootSaga.test.js
@@ -16,13 +16,16 @@ import * as rewards from "../../sagas/rewards"
 import * as liquidityRewards from "../../sagas/liquidity-rewards"
 import * as operator from "../../sagas/operartor"
 import * as authorization from "../../sagas/authorization"
+import * as coveragePool from "../../sagas/coverage-pool"
 
-const {
+const { watchFetchLiquidityRewardsAPY, ...restliquidityRewards } =
+  liquidityRewards
+
+const sagas = [
+  ...Object.values(messagesSaga),
   watchFetchLiquidityRewardsAPY,
-  ...restliquidityRewards
-} = liquidityRewards
-
-const sagas = [...Object.values(messagesSaga), watchFetchLiquidityRewardsAPY]
+  ...Object.values(coveragePool),
+]
 
 const loginRequiredSagas = [
   ...Object.values(delegateStakeSaga),

--- a/solidity/dashboard/src/__tests__/utils/utils.test.js
+++ b/solidity/dashboard/src/__tests__/utils/utils.test.js
@@ -1,0 +1,30 @@
+import { displayPercentageValue } from "../../utils/general.utils"
+
+describe("Test the `displayPercentageValue`", () => {
+  test("should display correctly if the value is bigger than `max` param", () => {
+    const percentageValue = 150
+    const min = 0.01
+    const max = 149
+
+    const result = displayPercentageValue(percentageValue, false, min, max)
+
+    expect(result).toEqual(`>${max}%`)
+  })
+
+  test("should display correctly if the value is less than `min` param", () => {
+    const percentageValue = 0.00123
+    const min = 0.01
+
+    const result = displayPercentageValue(percentageValue, true, min)
+
+    expect(result).toEqual(`<${min}%`)
+  })
+
+  test("should display correctly if the value is between `min` and `max`", () => {
+    const percentageValue = 100.47
+
+    const result = displayPercentageValue(percentageValue)
+
+    expect(result).toEqual(`${percentageValue}%`)
+  })
+})

--- a/solidity/dashboard/src/__tests__/utils/utils.test.js
+++ b/solidity/dashboard/src/__tests__/utils/utils.test.js
@@ -1,4 +1,4 @@
-import { displayPercentageValue } from "../../utils/general.utils"
+import { displayPercentageValue, isString } from "../../utils/general.utils"
 
 describe("Test the `displayPercentageValue`", () => {
   test("should display correctly if the value is bigger than `max` param", () => {
@@ -26,5 +26,21 @@ describe("Test the `displayPercentageValue`", () => {
     const result = displayPercentageValue(percentageValue)
 
     expect(result).toEqual(`${percentageValue}%`)
+  })
+})
+
+describe("Test `isString`", () => {
+  test("should return true if the value is primitive string", () => {
+    expect(isString("string")).toBeTruthy()
+  })
+
+  test("should return true if the value is String object", () => {
+    // eslint-disable-next-line no-new-wrappers
+    expect(isString(new String("string"))).toBeTruthy()
+  })
+
+  test("should return false if the value is not a primitive string or String object", () => {
+    expect(isString(1)).toBeFalsy()
+    expect(isString(false)).toBeFalsy()
   })
 })

--- a/solidity/dashboard/src/__tests__/web3/contracts.test.js
+++ b/solidity/dashboard/src/__tests__/web3/contracts.test.js
@@ -5,7 +5,8 @@ import {
 import { KEEP_TOKEN_CONTRACT_NAME } from "../../constants/constants"
 
 jest.mock("@keep-network/keep-core/artifacts/KeepToken.json", () => ({
-  networks: { "1": { addrress: "0x0", transactionHash: "0x00" } },
+  abi: [],
+  networks: { 1: { addrress: "0x0", transactionHash: "0x00" } },
 }))
 
 describe("Test `getContractDeploymentBlockNumber` function", () => {

--- a/solidity/dashboard/src/actions/coverage-pool.js
+++ b/solidity/dashboard/src/actions/coverage-pool.js
@@ -3,6 +3,15 @@ export const COVERAGE_POOL_FETCH_TVL_START = "coverage_pool/fetch_tvl_start"
 export const COVERAGE_POOL_FETCH_TVL_SUCCESS = "coverage_pool/fetch_tvl_success"
 export const COVERAGE_POOL_FETCH_TVL_ERROR = "coverage_pool/fetch_tvl_error"
 
+export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST =
+  "coverage_pool/fetch_share_of_pool_request"
+export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_START =
+  "coverage_pool/fetch_share_of_pool_start"
+export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_SUCCESS =
+  "coverage_pool/fetch_share_of_pool_success"
+export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_ERROR =
+  "coverage_pool/fetch_share_of_pool_error"
+
 export const fetchTvlStart = () => {
   return {
     type: COVERAGE_POOL_FETCH_TVL_START,
@@ -12,6 +21,40 @@ export const fetchTvlStart = () => {
 export const fetchTvlSuccess = (data) => {
   return {
     type: COVERAGE_POOL_FETCH_TVL_SUCCESS,
+    payload: data,
+  }
+}
+
+export const fetchTvlRequest = () => {
+  return {
+    type: COVERAGE_POOL_FETCH_TVL_REQUEST,
+  }
+}
+
+export const fetchShareOfPoolStart = () => {
+  return {
+    type: COVERAGE_POOL_FETCH_SHARE_OF_POOL_START,
+  }
+}
+
+export const fetchShareOfPoolRequest = (address) => {
+  return {
+    type: COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST,
+    payload: { address },
+  }
+}
+
+/**
+ * @param {Object} data Cov token info.
+ * @param {string} data.shareOfPool The share of the pool.
+ * @param {string} data.covBalance The user's token balance.
+ * @param {string} data.covTotalSupply The total supply of the cov token.
+ *
+ * @return { { type: string, payload: object }}
+ */
+export const fetchShareOfPoolSuccess = (data) => {
+  return {
+    type: COVERAGE_POOL_FETCH_SHARE_OF_POOL_SUCCESS,
     payload: data,
   }
 }

--- a/solidity/dashboard/src/actions/coverage-pool.js
+++ b/solidity/dashboard/src/actions/coverage-pool.js
@@ -3,14 +3,19 @@ export const COVERAGE_POOL_FETCH_TVL_START = "coverage_pool/fetch_tvl_start"
 export const COVERAGE_POOL_FETCH_TVL_SUCCESS = "coverage_pool/fetch_tvl_success"
 export const COVERAGE_POOL_FETCH_TVL_ERROR = "coverage_pool/fetch_tvl_error"
 
-export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST =
-  "coverage_pool/fetch_share_of_pool_request"
-export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_START =
-  "coverage_pool/fetch_share_of_pool_start"
-export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_SUCCESS =
-  "coverage_pool/fetch_share_of_pool_success"
-export const COVERAGE_POOL_FETCH_SHARE_OF_POOL_ERROR =
-  "coverage_pool/fetch_share_of_pool_error"
+export const COVERAGE_POOL_FETCH_COV_POOL_DATA_REQUEST =
+  "coverage_pool/fetch_cov_pool_data_request"
+export const COVERAGE_POOL_FETCH_COV_POOL_DATA_START =
+  "coverage_pool/fetch_cov_pool_data_start"
+export const COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS =
+  "coverage_pool/fetch_cov_pool_data_success"
+export const COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR =
+  "coverage_pool/fetch_cov_pool_data_error"
+
+export const COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED =
+  "coverage_pool/cov_token_transfer_event_emitted"
+
+export const COVERAGE_POOL_COV_TOKEN_UPDATED = "coverage_pool/cov_token_updated"
 
 export const fetchTvlStart = () => {
   return {
@@ -31,16 +36,39 @@ export const fetchTvlRequest = () => {
   }
 }
 
-export const fetchShareOfPoolStart = () => {
+export const fetchCovPoolDataStart = () => {
   return {
-    type: COVERAGE_POOL_FETCH_SHARE_OF_POOL_START,
+    type: COVERAGE_POOL_FETCH_COV_POOL_DATA_START,
   }
 }
 
-export const fetchShareOfPoolRequest = (address) => {
+export const fetchCovPoolDataRequest = (address) => {
   return {
-    type: COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST,
+    type: COVERAGE_POOL_FETCH_COV_POOL_DATA_REQUEST,
     payload: { address },
+  }
+}
+
+/**
+ * @param {Object} data Cov token info.
+ * @param {string} data.shareOfPool The share of the pool.
+ * @param {string} data.covBalance The user's token balance.
+ * @param {string} data.covTotalSupply The total supply of the cov token.
+ * @param {string} data.estimatedRewards The estimated rewards.
+ *
+ * @return { { type: string, payload: object }}
+ */
+export const fetchCovPoolDataSuccess = (data) => {
+  return {
+    type: COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS,
+    payload: data,
+  }
+}
+
+export const covTokenTransferEventEmitted = (event) => {
+  return {
+    type: COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED,
+    payload: { event },
   }
 }
 
@@ -52,9 +80,9 @@ export const fetchShareOfPoolRequest = (address) => {
  *
  * @return { { type: string, payload: object }}
  */
-export const fetchShareOfPoolSuccess = (data) => {
+export const covTokenUpdated = (data) => {
   return {
-    type: COVERAGE_POOL_FETCH_SHARE_OF_POOL_SUCCESS,
+    type: COVERAGE_POOL_COV_TOKEN_UPDATED,
     payload: data,
   }
 }

--- a/solidity/dashboard/src/actions/coverage-pool.js
+++ b/solidity/dashboard/src/actions/coverage-pool.js
@@ -81,9 +81,12 @@ export const covTokenTransferEventEmitted = (event) => {
 
 /**
  * @param {Object} data Cov token info.
- * @param {string} data.shareOfPool The share of the pool.
- * @param {string} data.covBalance The user's token balance.
- * @param {string} data.covTotalSupply The total supply of the cov token.
+ * @param {string} data.shareOfPool The share of the pool. Tha value should be
+ * between [0, 1].
+ * @param {string} data.covBalance The amount of tokens owned by user in the
+ * smallest unit (18 decimals precision).
+ * @param {string} data.covTotalSupply The total supply of the cov token in the
+ * samallest unit (18 decimals precision).
  *
  * @return { { type: string, payload: object }}
  */

--- a/solidity/dashboard/src/actions/coverage-pool.js
+++ b/solidity/dashboard/src/actions/coverage-pool.js
@@ -19,6 +19,11 @@ export const COVERAGE_POOL_DEPOSIT_ASSET_POOL = "coverage_pool/deposit"
 
 export const COVERAGE_POOL_COV_TOKEN_UPDATED = "coverage_pool/cov_token_updated"
 
+export const COVERAGE_POOL_FETCH_APY_REQUEST = "coverage_pool/fetch_apy_request"
+export const COVERAGE_POOL_FETCH_APY_START = "coverage_pool/fetch_apy_start"
+export const COVERAGE_POOL_FETCH_APY_SUCCESS = "coverage_pool/fetch_apy_success"
+export const COVERAGE_POOL_FETCH_APY_ERROR = "coverage_pool/fetch_apy_error"
+
 export const fetchTvlStart = () => {
   return {
     type: COVERAGE_POOL_FETCH_TVL_START,
@@ -96,5 +101,24 @@ export const depositAssetPool = (amount, meta) => {
       amount,
     },
     meta,
+  }
+}
+
+export const fetchAPYRequest = () => {
+  return {
+    type: COVERAGE_POOL_FETCH_APY_REQUEST,
+  }
+}
+
+export const fetchAPYStart = () => {
+  return {
+    type: COVERAGE_POOL_FETCH_APY_START,
+  }
+}
+
+export const fetchAPYSuccess = (apy) => {
+  return {
+    type: COVERAGE_POOL_FETCH_APY_SUCCESS,
+    payload: apy,
   }
 }

--- a/solidity/dashboard/src/actions/coverage-pool.js
+++ b/solidity/dashboard/src/actions/coverage-pool.js
@@ -15,6 +15,8 @@ export const COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR =
 export const COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED =
   "coverage_pool/cov_token_transfer_event_emitted"
 
+export const COVERAGE_POOL_DEPOSIT_ASSET_POOL = "coverage_pool/deposit"
+
 export const COVERAGE_POOL_COV_TOKEN_UPDATED = "coverage_pool/cov_token_updated"
 
 export const fetchTvlStart = () => {
@@ -84,5 +86,15 @@ export const covTokenUpdated = (data) => {
   return {
     type: COVERAGE_POOL_COV_TOKEN_UPDATED,
     payload: data,
+  }
+}
+
+export const depositAssetPool = (amount, meta) => {
+  return {
+    type: COVERAGE_POOL_DEPOSIT_ASSET_POOL,
+    payload: {
+      amount,
+    },
+    meta,
   }
 }

--- a/solidity/dashboard/src/actions/web3.js
+++ b/solidity/dashboard/src/actions/web3.js
@@ -3,7 +3,6 @@ import {
   KEEP_BONDING_CONTRACT_NAME,
   KEEP_TOKEN_CONTRACT_NAME,
   OPERATOR_CONTRACT_NAME,
-  ASSET_POOL_CONTRACT_NAME,
 } from "../constants/constants"
 
 const WEB3_SEND_TRANSACTION = "web3/send_transaction"
@@ -209,18 +208,6 @@ export const addMoreLpTokens = (
       amount,
       address,
       pool,
-    },
-    meta,
-  }
-}
-
-export const depositAssetPool = (amount, meta) => {
-  return {
-    type: "coverage_pool/deposit",
-    payload: {
-      contractName: ASSET_POOL_CONTRACT_NAME,
-      methodName: "deposit",
-      args: [amount],
     },
     meta,
   }

--- a/solidity/dashboard/src/components/Web3ContextProvider.jsx
+++ b/solidity/dashboard/src/components/Web3ContextProvider.jsx
@@ -67,6 +67,7 @@ class Web3ContextProvider extends React.Component {
 
       await resolveWeb3Deferred(web3)
       Keep.setProvider(connector.getProvider())
+      Keep.defaultAccount = yourAddress
     } catch (error) {
       this.setState({ providerError: error.message, isFetching: false })
       throw error

--- a/solidity/dashboard/src/components/Web3ContextProvider.jsx
+++ b/solidity/dashboard/src/components/Web3ContextProvider.jsx
@@ -7,10 +7,12 @@ import {
   resolveWeb3Deferred,
   Web3Loaded,
   ContractsLoaded,
+  Keep,
 } from "../contracts"
 import { getNetworkName } from "../utils/ethereum.utils"
 import { isSameEthAddress } from "../utils/general.utils"
 import { WALLETS } from "../constants/constants"
+import { getWsUrl } from "../connectors/utils"
 
 class Web3ContextProvider extends React.Component {
   static contextType = MessagesContext
@@ -64,6 +66,7 @@ class Web3ContextProvider extends React.Component {
       web3.eth.defaultAccount = yourAddress
 
       await resolveWeb3Deferred(web3)
+      Keep.setProvider(connector.getProvider())
     } catch (error) {
       this.setState({ providerError: error.message, isFetching: false })
       throw error
@@ -128,6 +131,7 @@ class Web3ContextProvider extends React.Component {
     const web3 = await Web3Loaded
     web3.eth.defaultAccount = yourAddress
     const contracts = await ContractsLoaded
+    Keep.defaultAccount = yourAddress
     for (const contractInstance of Object.values(contracts)) {
       contractInstance.options.from = web3.eth.defaultAccount
     }
@@ -144,6 +148,8 @@ class Web3ContextProvider extends React.Component {
 
   disconnect = async (shouldSetState = true) => {
     const { connector } = this.state
+    // Set provider to the default one to fetch data w/o connected wallet.
+    Keep.setProvider(new Web3.providers.WebsocketProvider(getWsUrl()))
     if (!connector) {
       return
     }

--- a/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
@@ -16,6 +16,7 @@ import {
   getErrorsObj,
 } from "../../forms/common-validators"
 import { lte } from "../../utils/arithmetics.utils"
+import useSetMaxAmountToken from "../../hooks/useSetMaxAmountToken"
 
 const DepositForm = ({
   tokenAmount,
@@ -28,7 +29,7 @@ const DepositForm = ({
   ...formikProps
 }) => {
   const onSubmitBtn = useCustomOnSubmitFormik(onSubmit)
-
+  const onAddonClick = useSetMaxAmountToken("tokenAmount", tokenAmount)
   return (
     <form className="deposit-form">
       <div className="deposit-form__token-amount-wrapper">
@@ -40,10 +41,7 @@ const DepositForm = ({
           normalize={normalizeAmount}
           format={formatAmount}
           inputAddon={
-            <MaxAmountAddon
-              onClick={() => console.log("on clikc addon")}
-              text="Max Stake"
-            />
+            <MaxAmountAddon onClick={onAddonClick} text="Max Stake" />
           }
           additionalInfoText={`KEEP Balance ${KEEP.displayAmountWithSymbol(
             tokenAmount

--- a/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
@@ -23,12 +23,13 @@ const DepositForm = ({ tokenAmount, onSubmit, apy, ...formikProps }) => {
   const onSubmitBtn = useCustomOnSubmitFormik(onSubmit)
   const onAddonClick = useSetMaxAmountToken("tokenAmount", tokenAmount)
 
-  const estimatedReward = formikProps.values.tokenAmount
-    ? KEEP.fromTokenUnit(formikProps.values.tokenAmount)
-        .multipliedBy(apy.toString())
-        .toFixed()
-        .toString()
-    : 0
+  const estimatedReward =
+    formikProps.values.tokenAmount && apy > 0 && isFinite(apy)
+      ? KEEP.fromTokenUnit(formikProps.values.tokenAmount)
+          .multipliedBy(apy.toString())
+          .toFixed()
+          .toString()
+      : 0
 
   return (
     <form className="deposit-form">

--- a/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
@@ -23,10 +23,12 @@ const DepositForm = ({ tokenAmount, onSubmit, apy, ...formikProps }) => {
   const onSubmitBtn = useCustomOnSubmitFormik(onSubmit)
   const onAddonClick = useSetMaxAmountToken("tokenAmount", tokenAmount)
 
-  const estimatedReward = KEEP.fromTokenUnit(formikProps.values.tokenAmount)
-    .multipliedBy(apy.toString())
-    .toFixed()
-    .toString()
+  const estimatedReward = formikProps.values.tokenAmount
+    ? KEEP.fromTokenUnit(formikProps.values.tokenAmount)
+        .multipliedBy(apy.toString())
+        .toFixed()
+        .toString()
+    : 0
 
   return (
     <form className="deposit-form">

--- a/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
@@ -11,6 +11,11 @@ import * as Icons from "../Icons"
 import Chip from "../Chip"
 import TokenAmount from "../TokenAmount"
 import { useCustomOnSubmitFormik } from "../../hooks/useCustomOnSubmitFormik"
+import {
+  validateAmountInRange,
+  getErrorsObj,
+} from "../../forms/common-validators"
+import { lte } from "../../utils/arithmetics.utils"
 
 const DepositForm = ({
   tokenAmount,
@@ -20,6 +25,7 @@ const DepositForm = ({
     { apy: 20, label: "Monthly", reward: "1000000000000000000000" },
     { apy: 30, label: "Yearly", reward: "1000000000000000000000" },
   ],
+  ...formikProps
 }) => {
   const onSubmitBtn = useCustomOnSubmitFormik(onSubmit)
 
@@ -64,6 +70,7 @@ const DepositForm = ({
       <SubmitButton
         className="btn btn-lg btn-primary w-100"
         onSubmitAction={onSubmitBtn}
+        disabled={!(formikProps.isValid && formikProps.dirty)}
       >
         deposit
       </SubmitButton>
@@ -100,13 +107,26 @@ const EstimatedAPYListItem = ({ apy, reward, label }) => {
 }
 
 export default withFormik({
-  validateOnChange: false,
-  validateOnBlur: false,
+  validateOnChange: true,
+  validateOnBlur: true,
   mapPropsToValues: () => ({
     tokenAmount: "0",
   }),
   validate: (values, props) => {
-    return {}
+    const { tokenAmount } = values
+    const errors = {}
+
+    if (lte(props.tokenAmount || 0, 0)) {
+      errors.tokenAmount = "Insufficient funds"
+    } else {
+      errors.tokenAmount = validateAmountInRange(
+        tokenAmount,
+        props.tokenAmount,
+        KEEP.fromTokenUnit(1)
+      )
+    }
+
+    return getErrorsObj(errors)
   },
   displayName: "CovPoolsDepositForm",
 })(DepositForm)

--- a/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/DepositForm.jsx
@@ -17,19 +17,17 @@ import {
 } from "../../forms/common-validators"
 import { lte } from "../../utils/arithmetics.utils"
 import useSetMaxAmountToken from "../../hooks/useSetMaxAmountToken"
+import { displayPercentageValue } from "../../utils/general.utils"
 
-const DepositForm = ({
-  tokenAmount,
-  onSubmit,
-  estimatedRewards = [
-    { apy: 10, label: "Weekly", reward: "1000000000000000000000" },
-    { apy: 20, label: "Monthly", reward: "1000000000000000000000" },
-    { apy: 30, label: "Yearly", reward: "1000000000000000000000" },
-  ],
-  ...formikProps
-}) => {
+const DepositForm = ({ tokenAmount, onSubmit, apy, ...formikProps }) => {
   const onSubmitBtn = useCustomOnSubmitFormik(onSubmit)
   const onAddonClick = useSetMaxAmountToken("tokenAmount", tokenAmount)
+
+  const estimatedReward = KEEP.fromTokenUnit(formikProps.values.tokenAmount)
+    .multipliedBy(apy.toString())
+    .toFixed()
+    .toString()
+
   return (
     <form className="deposit-form">
       <div className="deposit-form__token-amount-wrapper">
@@ -50,7 +48,13 @@ const DepositForm = ({
       </div>
       <List>
         <List.Title className="mb-2">Estimated Rewards</List.Title>
-        <List.Content>{estimatedRewards.map(renderListItem)}</List.Content>
+        <List.Content>
+          <EstimatedAPYListItem
+            apy={apy}
+            reward={estimatedReward}
+            label="Yearly"
+          />
+        </List.Content>
       </List>
       <Divider className="divider divider--tile-fluid" />
 
@@ -76,10 +80,6 @@ const DepositForm = ({
   )
 }
 
-const renderListItem = (item) => (
-  <EstimatedAPYListItem key={item.label} {...item} />
-)
-
 const EstimatedAPYListItem = ({ apy, reward, label }) => {
   return (
     <List.Item className="mb-1">
@@ -92,7 +92,10 @@ const EstimatedAPYListItem = ({ apy, reward, label }) => {
         &nbsp;
         <span className="text-grey-50">{label}</span>
         &nbsp;
-        <Chip text={`${apy}% APY`} size="small" />
+        <Chip
+          text={`${displayPercentageValue(apy * 100, false)} APY`}
+          size="small"
+        />
         <TokenAmount
           wrapperClassName="ml-a"
           amount={reward}

--- a/solidity/dashboard/src/components/coverage-pools/InitiateDepositModal.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/InitiateDepositModal.jsx
@@ -5,7 +5,7 @@ import Banner from "../Banner"
 import * as Icons from "../Icons"
 
 const warningBannerTitle =
-  "Standard cooldown period is 14 days. During this cooldown period, your funds will continue to earn rewards and funds will be at risk of liquidation."
+  "Standard cooldown period is 21 days. During this cooldown period, your funds will continue to earn rewards and funds will be at risk of liquidation."
 
 const InitiateDepositModal = ({
   amount,
@@ -36,7 +36,7 @@ const InitiateDepositModal = ({
         icon={Icons.Time}
         title={warningBannerTitle}
         className="banner--warning mt-2 mb-2"
-      ></Banner>
+      />
     </AcceptTermConfirmationModal>
   )
 }

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -47,6 +47,10 @@ import {
   KEEP_TOKEN_GEYSER_CONTRACT_NAME,
 } from "./constants/constants"
 
+import KeepLib from "./lib/keep"
+import { Web3jsWrapper } from "./lib/web3"
+import { getWsUrl } from "./connectors/utils.js"
+
 const CONTRACT_DEPLOYMENT_BLOCK_CACHE = {}
 
 export const getContractDeploymentBlockNumber = async (
@@ -192,6 +196,9 @@ export function Deferred() {
 
 const ContractsDeferred = new Deferred()
 const Web3Deferred = new Deferred()
+
+/** @type {KeepLib} */
+export const Keep = KeepLib.initialize(new Web3jsWrapper(new Web3(getWsUrl())))
 
 export const Web3Loaded = Web3Deferred.promise
 export const ContractsLoaded = ContractsDeferred.promise

--- a/solidity/dashboard/src/css/banner.less
+++ b/solidity/dashboard/src/css/banner.less
@@ -66,6 +66,7 @@
         width: 16px;
         height: 16px;
         margin-right: 0.625rem;
+        flex-shrink: 0;
     }
 
     .banner__title {

--- a/solidity/dashboard/src/css/coverage-pools-page.less
+++ b/solidity/dashboard/src/css/coverage-pools-page.less
@@ -69,16 +69,16 @@
 
     &__tvl {
         flex: 1;
+
+        .tvl.tvl--usd {
+            color: @color-grey-40;
+            margin-top: 0.75rem;
+            margin-left: 2.25rem;
+        }
     }
 
     &__apy {
         flex: 1;
-
-        > .apy__values {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-between;
-        }
     }
 }
 

--- a/solidity/dashboard/src/css/coverage-pools-page.less
+++ b/solidity/dashboard/src/css/coverage-pools-page.less
@@ -8,27 +8,27 @@
     .banner__title {
         &:extend(.h3);
     }
-
+    
     .banner__close-icon {
         width: 16px;
         height: 16px;
         top: 16px;
         right: 16px;
     }
-
+    
     .checklist-wrapper {
         display: flex;
         flex-wrap: wrap;
-
+        
         @media screen and (min-width: 1000px) {
             margin-top: unset;
             justify-content: space-between;
         }
-
+        
         .checklist__section {
             margin-top: 1rem;
             flex-basis: 250px;
-
+            
             > ul.list__content{
                 > li.list__item {
                     margin-bottom: 0.25rem;
@@ -36,18 +36,18 @@
                         display: inline-block;
                         vertical-align: middle;
                     }
-
+                    
                     svg {
                         width: 1rem;
                         height: 1rem;
-    
+                        
                         path {
                             fill: @color-mint-100;
                         }
                     }
                 }
             }
-
+            
             &--notes {
                 > ul.list__content {
                     > li.list__item {
@@ -61,41 +61,43 @@
             }
         }
     }
-
+    
 }
+
 
 .coverage-pool__overview {
     display: flex;
 
-    &__tvl {
+    &__metrics {
+        display: flex;
         flex: 1;
+        justify-content: center;
+    }
 
+    &__tvl {
         .tvl.tvl--usd {
             color: @color-grey-40;
             margin-top: 0.75rem;
             margin-left: 2.25rem;
         }
     }
-
-    &__apy {
-        flex: 1;
-    }
+    
 }
 
 .coverage-pool__deposit-wrapper {
     display: grid;
     grid-template-areas:
-        "deposit-form   share-of-pool   rewards"
-        "deposit-form   banner          banner";
-
+    "deposit-form   share-of-pool   rewards"
+    "deposit-form   banner          banner";
+    
     grid-template-columns: 2fr 1fr 1fr;
     grid-template-rows: auto;
     gap: 1rem;
-
+    
     .coverage-pool__deposit-form {
         grid-area: deposit-form;
         margin-bottom: 0;
-
+        
         .deposit-form {
             .deposit-form__token-amount-wrapper {
                 background-color: @color-green-bg-light;
@@ -104,17 +106,17 @@
             }
         }
     }
-
+    
     .coverage-pool__share-of-pool {
         grid-area: share-of-pool;
         margin-bottom: 0;
     }
-
+    
     .coverage-pool__rewards {
         grid-area: rewards;
         margin-bottom: 0;
     }
-
+    
     > .coverage-pool__checklist {
         grid-area: banner;
         justify-self: stretch;

--- a/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
+++ b/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
@@ -11,13 +11,13 @@ describe("Test CoveragePoolV1 lib", () => {
     const assetPoolContract = createMockedContract("0x9")
     const rewardPoolContract = createMockedContract("0x8")
     const covTokenContract = createMockedContract("0x7")
-    const corateralTokenContract = createMockedContract("0x6")
+    const collateralToken = createMockedContract("0x6")
 
     coveragePoolV1 = new CoveragePoolV1(
       assetPoolContract,
       rewardPoolContract,
       covTokenContract,
-      corateralTokenContract
+      collateralToken
     )
   })
 
@@ -49,13 +49,13 @@ describe("Test CoveragePoolV1 lib", () => {
 
   it("should return estimated rewards", async () => {
     const shareOfPool = 0.35
-    coveragePoolV1.corateralTokenContract.makeCall.mockResolvedValue(75)
+    coveragePoolV1.collateralToken.makeCall.mockResolvedValue(75)
     coveragePoolV1.rewardPoolContract.makeCall.mockResolvedValue(25)
     const epxectedResult = 35
 
     const result = await coveragePoolV1.estimatedRewards(shareOfPool)
 
-    expect(coveragePoolV1.corateralTokenContract.makeCall).toHaveBeenCalledWith(
+    expect(coveragePoolV1.collateralToken.makeCall).toHaveBeenCalledWith(
       "balanceOf",
       coveragePoolV1.assetPoolContract.address
     )

--- a/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
+++ b/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
@@ -1,23 +1,46 @@
 import CoveragePoolV1 from "../coverage-pool"
+import { Token } from "../../../utils/token.utils"
+import { RewardsPoolArtifact } from "../contracts"
+import { APYCalculator } from "../helper"
+
+jest.mock("../contracts", () => ({
+  RewardsPoolArtifact: {
+    abi: [],
+  },
+}))
+jest.mock("../helper", () => ({
+  APYCalculator: {
+    calculatePoolRewardRate: jest.fn(),
+    calculateAPY: jest.fn(),
+  },
+}))
 
 const createMockedContract = (address) => ({
   makeCall: jest.fn(),
   address: address,
+  getPastEvents: jest.fn(),
 })
 
 describe("Test CoveragePoolV1 lib", () => {
+  /** @type {CoveragePoolV1} */
   let coveragePoolV1
   beforeEach(() => {
     const assetPoolContract = createMockedContract("0x9")
-    const rewardPoolContract = createMockedContract("0x8")
     const covTokenContract = createMockedContract("0x7")
     const collateralToken = createMockedContract("0x6")
+    const exchangeService = {
+      getKeepTokenPriceInUSD: jest.fn(),
+    }
+    const web3 = {
+      createContractInstance: jest.fn(),
+    }
 
     coveragePoolV1 = new CoveragePoolV1(
       assetPoolContract,
-      rewardPoolContract,
       covTokenContract,
-      collateralToken
+      collateralToken,
+      exchangeService,
+      web3
     )
   })
 
@@ -47,21 +70,56 @@ describe("Test CoveragePoolV1 lib", () => {
     expect(result).toEqual(mockedResult)
   })
 
-  it("should return estimated rewards", async () => {
+  it("should return estimated rewards corretly if currently deposited collateral token balance is greater than 0", async () => {
     const shareOfPool = 0.4
+    const address = "0x123"
     const spyOnTvl = jest
       .spyOn(coveragePoolV1, "totalValueLocked")
-      .mockResolvedValue(150)
-    const estimatedKeepBalance = 50
-    // tvl * shareOfPool - estimatedBalance
-    const epxectedResult = 10
+      .mockResolvedValue(Token.fromTokenUnit(150).toString())
 
-    const result = await coveragePoolV1.estimatedRewards(
-      shareOfPool,
-      estimatedKeepBalance
-    )
+    const mockedToEvents = [
+      { returnValues: { value: Token.fromTokenUnit(25).toString() } },
+      { returnValues: { value: Token.fromTokenUnit(25).toString() } },
+    ]
+
+    const mockedFromEvents = []
+
+    const spyOnGetPastTransferEvent = jest
+      .spyOn(coveragePoolV1.collateralToken, "getPastEvents")
+      .mockResolvedValueOnce(mockedToEvents)
+      .mockResolvedValueOnce(mockedFromEvents)
+
+    const epxectedResult = Token.fromTokenUnit(10).toString()
+
+    const result = await coveragePoolV1.estimatedRewards(address, shareOfPool)
 
     expect(spyOnTvl).toHaveBeenCalled()
+    expect(spyOnGetPastTransferEvent).toHaveBeenNthCalledWith(1, "Transfer", {
+      from: address,
+      to: coveragePoolV1.assetPoolContract.address,
+    })
+    expect(spyOnGetPastTransferEvent).toHaveBeenNthCalledWith(2, "Transfer", {
+      from: coveragePoolV1.assetPoolContract.address,
+      to: address,
+    })
+    expect(result).toEqual(epxectedResult.toString())
+  })
+
+  it("the estimated reward balance equlas 0 if the share of pool equlas 0 ", async () => {
+    const shareOfPool = 0
+    const address = "0x123"
+    const spyOnTvl = jest.spyOn(coveragePoolV1, "totalValueLocked")
+
+    const spyOnGetPastTransferEvent = jest.spyOn(
+      coveragePoolV1.collateralToken,
+      "getPastEvents"
+    )
+
+    const epxectedResult = "0"
+    const result = await coveragePoolV1.estimatedRewards(address, shareOfPool)
+
+    expect(spyOnTvl).not.toHaveBeenCalled()
+    expect(spyOnGetPastTransferEvent).not.toHaveBeenCalled()
     expect(result).toEqual(epxectedResult.toString())
   })
 
@@ -106,5 +164,151 @@ describe("Test CoveragePoolV1 lib", () => {
       coveragePoolV1.assetPoolContract.address
     )
     expect(result).toEqual((mockedCollateralBalance * shareOfPool).toString())
+  })
+
+  it("should return the asset pool collateral token balance", async () => {
+    const mockedBalance = Token.fromTokenUnit("300").toString()
+    const spy = jest
+      .spyOn(coveragePoolV1.collateralToken, "makeCall")
+      .mockResolvedValue(mockedBalance)
+
+    const result = await coveragePoolV1.assetPoolCollateralTokenBalance()
+
+    expect(spy).toHaveBeenCalledWith(
+      "balanceOf",
+      coveragePoolV1.assetPoolContract.address
+    )
+    expect(result).toEqual(mockedBalance)
+  })
+
+  describe
+
+  it("should return the reward pool contract", async () => {
+    const mockedRewardPoolContractAddress = "0x123"
+    const spyOnRewardsPool = jest
+      .spyOn(coveragePoolV1.assetPoolContract, "makeCall")
+      .mockResolvedValue(mockedRewardPoolContractAddress)
+
+    const mockedRewardPoolContract = createMockedContract(
+      mockedRewardPoolContractAddress
+    )
+    const spyOnCreateContract = jest
+      .spyOn(coveragePoolV1.web3, "createContractInstance")
+      .mockReturnValue(mockedRewardPoolContract)
+
+    const result = await coveragePoolV1.getRewardPoolContract()
+    const result2 = await coveragePoolV1.getRewardPoolContract()
+
+    expect(spyOnRewardsPool).toHaveBeenCalledWith("rewardsPool")
+    expect(spyOnRewardsPool).toHaveBeenCalledTimes(1)
+    expect(spyOnCreateContract).toHaveBeenCalledWith(
+      RewardsPoolArtifact.abi,
+      mockedRewardPoolContractAddress,
+      coveragePoolV1.assetPoolContract.deploymentTxnHash,
+      coveragePoolV1.assetPoolContract.deployedAtBlock
+    )
+    expect(spyOnCreateContract).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(mockedRewardPoolContract)
+    expect(result).toEqual(result2)
+    expect(coveragePoolV1._rewardPoolContract).toEqual(result)
+  })
+
+  it("should return the reward rate of the rewards pool contract", async () => {
+    const mockedRewardsPoolContract = createMockedContract("0x1234")
+    const spyOnRewardPoolContract = jest
+      .spyOn(coveragePoolV1, "getRewardPoolContract")
+      .mockResolvedValue(mockedRewardsPoolContract)
+
+    const rewardRate = Token.fromTokenUnit("1000").toString()
+    const spyOnMakeCall = jest
+      .spyOn(mockedRewardsPoolContract, "makeCall")
+      .mockResolvedValue(rewardRate)
+
+    const result = await coveragePoolV1.rewardPoolRewardRate()
+
+    expect(spyOnRewardPoolContract).toHaveBeenCalled()
+    expect(spyOnMakeCall).toHaveBeenCalledWith("rewardRate")
+    expect(result).toEqual(rewardRate)
+  })
+
+  it("should return the reward pool per week", async () => {
+    const rewardRate = Token.fromTokenUnit("1000")
+    const spyOnRewardRate = jest
+      .spyOn(coveragePoolV1, "rewardPoolRewardRate")
+      .mockResolvedValue(rewardRate.toString())
+
+    const result = await coveragePoolV1.rewardPoolPerWeek()
+
+    expect(spyOnRewardRate).toHaveBeenCalled()
+    expect(result).toEqual(Token.toTokenUnit(rewardRate).multipliedBy(604800))
+  })
+
+  it("should calculate apy correctly", async () => {
+    const mockedTotalSupply = Token.fromTokenUnit(100)
+    const spyOnTotalSupply = jest
+      .spyOn(coveragePoolV1, "assetPoolCollateralTokenBalance")
+      .mockResolvedValue(mockedTotalSupply)
+
+    const mockedRewardPoolPerWeek = "150"
+    const spyOnRewarPoolPerWeek = jest
+      .spyOn(coveragePoolV1, "rewardPoolPerWeek")
+      .mockResolvedValue(mockedRewardPoolPerWeek)
+
+    const mockedPriceInUSD = 0.5
+    const spyOnGetPriceInUSD = jest
+      .spyOn(coveragePoolV1.exchangeService, "getKeepTokenPriceInUSD")
+      .mockResolvedValue(mockedPriceInUSD)
+
+    const mockedPoolRewardRate = 0.2
+    const spyOnPoolRewardRate = jest
+      .spyOn(APYCalculator, "calculatePoolRewardRate")
+      .mockReturnValue(mockedPoolRewardRate)
+
+    const mockedAPY = 0.99
+    const spyOnAPY = jest
+      .spyOn(APYCalculator, "calculateAPY")
+      .mockReturnValue(mockedAPY)
+
+    const result = await coveragePoolV1.apy()
+
+    expect(spyOnTotalSupply).toHaveBeenCalled()
+    expect(spyOnRewarPoolPerWeek).toHaveBeenCalled()
+    expect(spyOnGetPriceInUSD).toHaveBeenCalled()
+    expect(spyOnPoolRewardRate).toHaveBeenCalledWith(
+      mockedPriceInUSD,
+      mockedRewardPoolPerWeek,
+      Token.toTokenUnit(mockedTotalSupply).multipliedBy(mockedPriceInUSD)
+    )
+    expect(spyOnAPY).toHaveBeenCalledWith(mockedPoolRewardRate)
+    expect(result).toEqual(mockedAPY.toString())
+  })
+
+  it("should return the total allocated rewards", async () => {
+    const mockedRewardsPoolContract = createMockedContract("0x0123")
+    const spyOnGetRewardsPoolContract = jest
+      .spyOn(coveragePoolV1, "getRewardPoolContract")
+      .mockResolvedValue(mockedRewardsPoolContract)
+
+    const mockedEvents = [
+      {
+        returnValues: {
+          amount: Token.fromTokenUnit(30).toString(),
+        },
+      },
+      {
+        returnValues: {
+          amount: Token.fromTokenUnit(30).toString(),
+        },
+      },
+    ]
+    const spyOnGetPastEvents = jest
+      .spyOn(mockedRewardsPoolContract, "getPastEvents")
+      .mockResolvedValue(mockedEvents)
+
+    const result = await coveragePoolV1.totalAllocatedRewards()
+
+    expect(spyOnGetRewardsPoolContract).toHaveBeenCalled()
+    expect(spyOnGetPastEvents).toHaveBeenCalledWith("RewardToppedUp")
+    expect(result.toString()).toEqual(Token.fromTokenUnit(60).toString())
   })
 })

--- a/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
+++ b/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
@@ -1,0 +1,80 @@
+import CoveragePoolV1 from "../coverage-pool"
+
+const createMockedContract = (address) => ({
+  makeCall: jest.fn(),
+  address: address,
+})
+
+describe("Test CoveragePoolV1 lib", () => {
+  let coveragePoolV1
+  beforeEach(() => {
+    const assetPoolContract = createMockedContract("0x9")
+    const rewardPoolContract = createMockedContract("0x8")
+    const covTokenContract = createMockedContract("0x7")
+    const corateralTokenContract = createMockedContract("0x6")
+
+    coveragePoolV1 = new CoveragePoolV1(
+      assetPoolContract,
+      rewardPoolContract,
+      covTokenContract,
+      corateralTokenContract
+    )
+  })
+
+  it("should return the total supply of the cov token", async () => {
+    const mockedResult = "1000"
+    coveragePoolV1.covTokenContract.makeCall.mockResolvedValue(mockedResult)
+
+    const result = await coveragePoolV1.covTotalSupply()
+
+    expect(coveragePoolV1.covTokenContract.makeCall).toHaveBeenCalledWith(
+      "totalSupply"
+    )
+    expect(result).toEqual(mockedResult)
+  })
+
+  it("should return the balance of te cov tokens for the provided address", async () => {
+    const mockedResult = "1000"
+    const mockedAddress = "0x0"
+    coveragePoolV1.covTokenContract.makeCall.mockResolvedValue(mockedResult)
+
+    const result = await coveragePoolV1.covBalanceOf(mockedAddress)
+
+    expect(coveragePoolV1.covTokenContract.makeCall).toHaveBeenCalledWith(
+      "balanceOf",
+      mockedAddress
+    )
+    expect(result).toEqual(mockedResult)
+  })
+
+  it("should return estimated rewards", async () => {
+    const shareOfPool = 0.35
+    coveragePoolV1.corateralTokenContract.makeCall.mockResolvedValue(75)
+    coveragePoolV1.rewardPoolContract.makeCall.mockResolvedValue(25)
+    const epxectedResult = 35
+
+    const result = await coveragePoolV1.estimatedRewards(shareOfPool)
+
+    expect(coveragePoolV1.corateralTokenContract.makeCall).toHaveBeenCalledWith(
+      "balanceOf",
+      coveragePoolV1.assetPoolContract.address
+    )
+    expect(coveragePoolV1.rewardPoolContract.makeCall).toHaveBeenCalledWith(
+      "earned"
+    )
+    expect(result).toEqual(epxectedResult.toString())
+  })
+
+  it("should return the share of pool", async () => {
+    const covBalanceOf = 35
+    const covTotalSupply = 100
+    const expectedResult = covBalanceOf / covTotalSupply
+
+    const result = await coveragePoolV1.shareOfPool(
+      covTotalSupply,
+      covBalanceOf
+    )
+
+    expect(result).toEqual(expectedResult.toString())
+  })
+})

--- a/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
+++ b/solidity/dashboard/src/lib/keep/__tests__/coverage-pool.test.js
@@ -48,20 +48,20 @@ describe("Test CoveragePoolV1 lib", () => {
   })
 
   it("should return estimated rewards", async () => {
-    const shareOfPool = 0.35
-    coveragePoolV1.collateralToken.makeCall.mockResolvedValue(75)
-    coveragePoolV1.rewardPoolContract.makeCall.mockResolvedValue(25)
-    const epxectedResult = 35
+    const shareOfPool = 0.4
+    const spyOnTvl = jest
+      .spyOn(coveragePoolV1, "totalValueLocked")
+      .mockResolvedValue(150)
+    const estimatedKeepBalance = 50
+    // tvl * shareOfPool - estimatedBalance
+    const epxectedResult = 10
 
-    const result = await coveragePoolV1.estimatedRewards(shareOfPool)
+    const result = await coveragePoolV1.estimatedRewards(
+      shareOfPool,
+      estimatedKeepBalance
+    )
 
-    expect(coveragePoolV1.collateralToken.makeCall).toHaveBeenCalledWith(
-      "balanceOf",
-      coveragePoolV1.assetPoolContract.address
-    )
-    expect(coveragePoolV1.rewardPoolContract.makeCall).toHaveBeenCalledWith(
-      "earned"
-    )
+    expect(spyOnTvl).toHaveBeenCalled()
     expect(result).toEqual(epxectedResult.toString())
   })
 
@@ -76,5 +76,35 @@ describe("Test CoveragePoolV1 lib", () => {
     )
 
     expect(result).toEqual(expectedResult.toString())
+  })
+
+  it("should return the total value locked", async () => {
+    const mockedResult = "100"
+    coveragePoolV1.assetPoolContract.makeCall.mockResolvedValue(mockedResult)
+
+    const result = await coveragePoolV1.totalValueLocked()
+
+    expect(coveragePoolV1.assetPoolContract.makeCall).toHaveBeenCalledWith(
+      "totalValue"
+    )
+    expect(result).toEqual(mockedResult)
+  })
+
+  it("should return the estimated collateral token balance", async () => {
+    const mockedCollateralBalance = 100
+    coveragePoolV1.collateralToken.makeCall.mockResolvedValue(
+      mockedCollateralBalance
+    )
+    const shareOfPool = 0.35
+
+    const result = await coveragePoolV1.estimatedCollateralTokenBalance(
+      shareOfPool
+    )
+
+    expect(coveragePoolV1.collateralToken.makeCall).toHaveBeenCalledWith(
+      "balanceOf",
+      coveragePoolV1.assetPoolContract.address
+    )
+    expect(result).toEqual((mockedCollateralBalance * shareOfPool).toString())
   })
 })

--- a/solidity/dashboard/src/lib/keep/__tests__/exchange-api.test.js
+++ b/solidity/dashboard/src/lib/keep/__tests__/exchange-api.test.js
@@ -1,0 +1,100 @@
+import axios from "axios"
+import BigNumber from "bignumber.js"
+
+import { BaseExchange, UniswapV2Exchange } from "../exchange-api"
+
+jest.mock("axios")
+
+describe("Test exchange api", () => {
+  describe("Test BaseExchange", () => {
+    const exchange = new BaseExchange()
+    exchange._getUniswapPairData = jest.fn()
+    exchange._getKeepTokenPriceInUSD = jest.fn()
+    exchange._getBTCPriceInUSD = jest.fn()
+    const mockedPairId = 1
+
+    test("should call function that implements fetching uniswap pair data", () => {
+      exchange.getUniswapPairData(mockedPairId)
+
+      expect(exchange._getUniswapPairData).toHaveBeenCalledWith(mockedPairId)
+    })
+
+    test("should call function that implements fetching KEEP token price", () => {
+      exchange.getKeepTokenPriceInUSD()
+
+      expect(exchange._getKeepTokenPriceInUSD).toHaveBeenCalled()
+    })
+
+    test("should call function that implements fetching BTC price", () => {
+      exchange.getBTCPriceInUSD()
+
+      expect(exchange._getBTCPriceInUSD).toHaveBeenCalled()
+    })
+  })
+
+  describe("Test UniswapV2Exchange", () => {
+    const exchange = new UniswapV2Exchange()
+    const mockedPairId = 1
+
+    const mockedResponse = {
+      data: {
+        data: {
+          pair: {
+            reserveUSD: 30000,
+            reserveETH: 1000,
+            token0: {
+              derivedETH: 0.2,
+            },
+          },
+        },
+      },
+    }
+
+    test("should fetch uniswap pair data correctly", async () => {
+      axios.post.mockResolvedValue(mockedResponse)
+
+      const result = await exchange.getUniswapPairData(mockedPairId)
+
+      const mockCalls = axios.post.mock.calls
+      expect(axios.post).toHaveBeenCalled()
+      expect(mockCalls[0][0]).toEqual(exchange.UNISWAP_API_URL)
+      expect(
+        mockCalls[0][1].query.toString().includes(mockedPairId)
+      ).toBeTruthy()
+
+      expect(result).toStrictEqual(mockedResponse.data.data.pair)
+    })
+
+    test("should fetch keep token price correctly", async () => {
+      const spy = jest.spyOn(exchange, "_getTokenPriceInUSD")
+      const getUniswapPairDataSpy = jest.spyOn(exchange, "_getUniswapPairData")
+      axios.post.mockResolvedValue(mockedResponse)
+      const pairData = mockedResponse.data.data.pair
+      const expectedPrice = new BigNumber(pairData.reserveUSD)
+        .div(pairData.reserveETH)
+        .multipliedBy(pairData.token0.derivedETH)
+
+      const result = await exchange.getKeepTokenPriceInUSD()
+
+      expect(spy).toHaveBeenCalledWith(
+        "0xe6f19dab7d43317344282f803f8e8d240708174a"
+      )
+      expect(getUniswapPairDataSpy).toHaveBeenCalledWith(
+        "0xe6f19dab7d43317344282f803f8e8d240708174a"
+      )
+      expect(result).toEqual(expectedPrice)
+    })
+
+    test("should fetch BTC price correctly", () => {
+      const spy = jest
+        .spyOn(exchange, "_getTokenPriceInUSD")
+        .mockResolvedValue("300")
+
+      exchange.getBTCPriceInUSD()
+
+      expect(spy).toHaveBeenCalledWith(
+        "0xe6f19dab7d43317344282f803f8e8d240708174a"
+      )
+    })
+  })
+})

--- a/solidity/dashboard/src/lib/keep/contracts/index.js
+++ b/solidity/dashboard/src/lib/keep/contracts/index.js
@@ -1,0 +1,105 @@
+import KeepToken from "@keep-network/keep-core/artifacts/KeepToken.json"
+import TokenStaking from "@keep-network/keep-core/artifacts/TokenStaking.json"
+import TokenGrant from "@keep-network/keep-core/artifacts/TokenGrant.json"
+import KeepRandomBeaconOperator from "@keep-network/keep-core/artifacts/KeepRandomBeaconOperator.json"
+import BondedECDSAKeepFactory from "@keep-network/keep-ecdsa/artifacts/BondedECDSAKeepFactory.json"
+import TBTCSystem from "@keep-network/tbtc/artifacts/TBTCSystem.json"
+import KeepBonding from "@keep-network/keep-ecdsa/artifacts/KeepBonding.json"
+// import GuaranteedMinimumStakingPolicy from "@keep-network/keep-core/artifacts/GuaranteedMinimumStakingPolicy.json"
+// import PermissiveStakingPolicy from "@keep-network/keep-core/artifacts/PermissiveStakingPolicy.json"
+import KeepRandomBeaconOperatorStatistics from "@keep-network/keep-core/artifacts/KeepRandomBeaconOperatorStatistics.json"
+// import ManagedGrant from "@keep-network/keep-core/artifacts/ManagedGrant.json"
+import ManagedGrantFactory from "@keep-network/keep-core/artifacts/ManagedGrantFactory.json"
+import TBTCToken from "@keep-network/tbtc/artifacts/TBTCToken.json"
+// import Deposit from "@keep-network/tbtc/artifacts/Deposit.json"
+// import BondedECDSAKeep from "@keep-network/keep-ecdsa/artifacts/BondedECDSAKeep.json"
+import TokenStakingEscrow from "@keep-network/keep-core/artifacts/TokenStakingEscrow.json"
+import StakingPortBacker from "@keep-network/keep-core/artifacts/StakingPortBacker.json"
+import BeaconRewards from "@keep-network/keep-core/artifacts/BeaconRewards.json"
+import ECDSARewardsDistributor from "@keep-network/keep-ecdsa/artifacts/ECDSARewardsDistributor.json"
+import LPRewardsKEEPETH from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPETH.json"
+import LPRewardsTBTCETH from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCETH.json"
+import LPRewardsKEEPTBTC from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPTBTC.json"
+import LPRewardsTBTCSaddle from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCSaddle.json"
+import KeepOnlyPool from "@keep-network/keep-core/artifacts/KeepVault.json"
+// import IERC20 from "@keep-network/keep-core/artifacts/IERC20.json"
+// import SaddleSwap from "../../contracts-artifacts/SaddleSwap.json"
+
+import {
+  KEEP_TOKEN_CONTRACT_NAME,
+  TOKEN_STAKING_CONTRACT_NAME,
+  TOKEN_GRANT_CONTRACT_NAME,
+  OPERATOR_CONTRACT_NAME,
+  KEEP_OPERATOR_STATISTICS_CONTRACT_NAME,
+  MANAGED_GRANT_FACTORY_CONTRACT_NAME,
+  KEEP_BONDING_CONTRACT_NAME,
+  TBTC_TOKEN_CONTRACT_NAME,
+  TBTC_SYSTEM_CONTRACT_NAME,
+  TOKEN_STAKING_ESCROW_CONTRACT_NAME,
+  BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
+  STAKING_PORT_BACKER_CONTRACT_NAME,
+  //   OLD_TOKEN_STAKING_CONTRACT_NAME,
+  LP_REWARDS_KEEP_ETH_CONTRACT_NAME,
+  LP_REWARDS_TBTC_ETH_CONTRACT_NAME,
+  LP_REWARDS_KEEP_TBTC_CONTRACT_NAME,
+  LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
+  KEEP_TOKEN_GEYSER_CONTRACT_NAME,
+} from "../../../constants/constants"
+
+const contracts = {
+  [KEEP_TOKEN_CONTRACT_NAME]: { artifact: KeepToken },
+  [TOKEN_GRANT_CONTRACT_NAME]: { artifact: TokenGrant },
+  [OPERATOR_CONTRACT_NAME]: {
+    artifact: KeepRandomBeaconOperator,
+  },
+  [TOKEN_STAKING_CONTRACT_NAME]: {
+    artifact: TokenStaking,
+  },
+  [KEEP_OPERATOR_STATISTICS_CONTRACT_NAME]: {
+    artifact: KeepRandomBeaconOperatorStatistics,
+  },
+  [MANAGED_GRANT_FACTORY_CONTRACT_NAME]: {
+    artifact: ManagedGrantFactory,
+  },
+  [KEEP_BONDING_CONTRACT_NAME]: {
+    artifact: KeepBonding,
+  },
+  [TBTC_TOKEN_CONTRACT_NAME]: {
+    artifact: TBTCToken,
+  },
+  [TBTC_SYSTEM_CONTRACT_NAME]: {
+    artifact: TBTCSystem,
+  },
+  [TOKEN_STAKING_ESCROW_CONTRACT_NAME]: {
+    artifact: TokenStakingEscrow,
+  },
+  [BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME]: {
+    artifact: BondedECDSAKeepFactory,
+  },
+  [STAKING_PORT_BACKER_CONTRACT_NAME]: {
+    artifact: StakingPortBacker,
+  },
+  beaconRewardsContract: {
+    artifact: BeaconRewards,
+  },
+  ECDSARewardsDistributorContract: {
+    artifact: ECDSARewardsDistributor,
+  },
+  [LP_REWARDS_KEEP_ETH_CONTRACT_NAME]: {
+    artifact: LPRewardsKEEPETH,
+  },
+  [LP_REWARDS_TBTC_ETH_CONTRACT_NAME]: {
+    artifact: LPRewardsTBTCETH,
+  },
+  [LP_REWARDS_KEEP_TBTC_CONTRACT_NAME]: {
+    artifact: LPRewardsKEEPTBTC,
+  },
+  [LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME]: {
+    artifact: LPRewardsTBTCSaddle,
+  },
+  [KEEP_TOKEN_GEYSER_CONTRACT_NAME]: {
+    artifact: KeepOnlyPool,
+  },
+}
+
+export default contracts

--- a/solidity/dashboard/src/lib/keep/contracts/index.js
+++ b/solidity/dashboard/src/lib/keep/contracts/index.js
@@ -24,6 +24,8 @@ import LPRewardsTBTCSaddle from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBT
 import KeepOnlyPool from "@keep-network/keep-core/artifacts/KeepVault.json"
 // import IERC20 from "@keep-network/keep-core/artifacts/IERC20.json"
 import SaddleSwap from "../../../contracts-artifacts/SaddleSwap.json"
+import AssetPool from "@keep-network/coverage-pool/artifacts/AssetPool.json"
+import UnderwriterToken from "@keep-network/coverage-pool/artifacts/UnderwriterToken.json"
 
 export const KEEP_TOKEN_CONTRACT_NAME = "keepTokenContract"
 export const TOKEN_STAKING_CONTRACT_NAME = "stakingContract"
@@ -52,6 +54,9 @@ export const ECDSA_REWARDS_DISTRRIBUTOR_CONTRACT_NAME =
 
 export const SADDLE_SWAP_CONTRACT_NAME = "saddleSwapContract"
 export const SaddleSwapArtifact = SaddleSwap
+
+export const ASSET_POOL_CONTRACT_NAME = "assetPoolContract"
+export const COV_TOKEN_CONTRACT_NAME = "covTokenContract"
 
 const contracts = {
   [KEEP_TOKEN_CONTRACT_NAME]: { artifact: KeepToken },
@@ -106,6 +111,12 @@ const contracts = {
   },
   [KEEP_TOKEN_GEYSER_CONTRACT_NAME]: {
     artifact: KeepOnlyPool,
+  },
+  [ASSET_POOL_CONTRACT_NAME]: {
+    artifact: AssetPool,
+  },
+  [COV_TOKEN_CONTRACT_NAME]: {
+    artifact: UnderwriterToken,
   },
 }
 

--- a/solidity/dashboard/src/lib/keep/contracts/index.js
+++ b/solidity/dashboard/src/lib/keep/contracts/index.js
@@ -23,28 +23,35 @@ import LPRewardsKEEPTBTC from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPT
 import LPRewardsTBTCSaddle from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCSaddle.json"
 import KeepOnlyPool from "@keep-network/keep-core/artifacts/KeepVault.json"
 // import IERC20 from "@keep-network/keep-core/artifacts/IERC20.json"
-// import SaddleSwap from "../../contracts-artifacts/SaddleSwap.json"
+import SaddleSwap from "../../../contracts-artifacts/SaddleSwap.json"
 
-import {
-  KEEP_TOKEN_CONTRACT_NAME,
-  TOKEN_STAKING_CONTRACT_NAME,
-  TOKEN_GRANT_CONTRACT_NAME,
-  OPERATOR_CONTRACT_NAME,
-  KEEP_OPERATOR_STATISTICS_CONTRACT_NAME,
-  MANAGED_GRANT_FACTORY_CONTRACT_NAME,
-  KEEP_BONDING_CONTRACT_NAME,
-  TBTC_TOKEN_CONTRACT_NAME,
-  TBTC_SYSTEM_CONTRACT_NAME,
-  TOKEN_STAKING_ESCROW_CONTRACT_NAME,
-  BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
-  STAKING_PORT_BACKER_CONTRACT_NAME,
-  //   OLD_TOKEN_STAKING_CONTRACT_NAME,
-  LP_REWARDS_KEEP_ETH_CONTRACT_NAME,
-  LP_REWARDS_TBTC_ETH_CONTRACT_NAME,
-  LP_REWARDS_KEEP_TBTC_CONTRACT_NAME,
-  LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
-  KEEP_TOKEN_GEYSER_CONTRACT_NAME,
-} from "../../../constants/constants"
+export const KEEP_TOKEN_CONTRACT_NAME = "keepTokenContract"
+export const TOKEN_STAKING_CONTRACT_NAME = "stakingContract"
+export const TOKEN_GRANT_CONTRACT_NAME = "grantContract"
+export const OPERATOR_CONTRACT_NAME = "keepRandomBeaconOperatorContract"
+export const REGISTRY_CONTRACT_NAME = "registryContract"
+export const KEEP_OPERATOR_STATISTICS_CONTRACT_NAME =
+  "keepRandomBeaconOperatorStatistics"
+export const MANAGED_GRANT_FACTORY_CONTRACT_NAME = "managedGrantFactoryContract"
+export const BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME =
+  "bondedEcdsaKeepFactoryContract"
+export const KEEP_BONDING_CONTRACT_NAME = "keepBondingContract"
+export const TBTC_TOKEN_CONTRACT_NAME = "tbtcTokenContract"
+export const TBTC_SYSTEM_CONTRACT_NAME = "tbtcSystemContract"
+export const TOKEN_STAKING_ESCROW_CONTRACT_NAME = "tokenStakingEscrowContract"
+export const OLD_TOKEN_STAKING_CONTRACT_NAME = "oldTokenStakingContract"
+export const STAKING_PORT_BACKER_CONTRACT_NAME = "stakingPortBackerContract"
+export const LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME =
+  "LPRewardsTBTCSaddleContract"
+export const LP_REWARDS_KEEP_ETH_CONTRACT_NAME = "LPRewardsKEEPETHContract"
+export const LP_REWARDS_TBTC_ETH_CONTRACT_NAME = "LPRewardsTBTCETHContract"
+export const LP_REWARDS_KEEP_TBTC_CONTRACT_NAME = "LPRewardsKEEPTBTCContract"
+export const KEEP_TOKEN_GEYSER_CONTRACT_NAME = "keepTokenGeyserContract"
+export const ECDSA_REWARDS_DISTRRIBUTOR_CONTRACT_NAME =
+  "ECDSARewardsDistributorContract"
+
+export const SADDLE_SWAP_CONTRACT_NAME = "saddleSwapContract"
+export const SaddleSwapArtifact = SaddleSwap
 
 const contracts = {
   [KEEP_TOKEN_CONTRACT_NAME]: { artifact: KeepToken },

--- a/solidity/dashboard/src/lib/keep/contracts/index.js
+++ b/solidity/dashboard/src/lib/keep/contracts/index.js
@@ -26,6 +26,7 @@ import KeepOnlyPool from "@keep-network/keep-core/artifacts/KeepVault.json"
 import SaddleSwap from "../../../contracts-artifacts/SaddleSwap.json"
 import AssetPool from "@keep-network/coverage-pool/artifacts/AssetPool.json"
 import UnderwriterToken from "@keep-network/coverage-pool/artifacts/UnderwriterToken.json"
+import RewardsPool from "@keep-network/coverage-pool/artifacts/RewardsPool.json"
 
 export const KEEP_TOKEN_CONTRACT_NAME = "keepTokenContract"
 export const TOKEN_STAKING_CONTRACT_NAME = "stakingContract"
@@ -57,6 +58,8 @@ export const SaddleSwapArtifact = SaddleSwap
 
 export const ASSET_POOL_CONTRACT_NAME = "assetPoolContract"
 export const COV_TOKEN_CONTRACT_NAME = "covTokenContract"
+
+export const RewardsPoolArtifact = RewardsPool
 
 const contracts = {
   [KEEP_TOKEN_CONTRACT_NAME]: { artifact: KeepToken },

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -1,8 +1,14 @@
 import BigNumber from "bignumber.js"
+import { KEEP } from "../../../utils/token.utils"
+import { APYCalculator } from "../helper"
+import { RewardsPoolArtifact } from "../contracts"
+import { add, sub, gt } from "../../../utils/arithmetics.utils"
+
 /** @typedef { import("../../web3").BaseContract} BaseContract */
 /** @typedef { import("../../web3").Web3LibWrapper} Web3LibWrapper */
 /** @typedef { import("../exchange-api").BaseExchange} BaseExchange */
 
+const REWARD_DURATION = 604800 // 7 days in seconds
 class CoveragePoolV1 {
   /**
    * @param {BaseContract} _assetPoolContract
@@ -23,6 +29,7 @@ class CoveragePoolV1 {
     this.collateralToken = _collateralToken
     this.exchangeService = _exchangeService
     this.web3 = _web3
+    this._rewardPoolContract = undefined
   }
 
   shareOfPool = (covTotalSupply, covBalanceOf) => {
@@ -40,12 +47,31 @@ class CoveragePoolV1 {
     return await this.covTokenContract.makeCall("balanceOf", address)
   }
 
-  estimatedRewards = async (shareOfPool, estimatedCollateralTokenBalance) => {
+  estimatedRewards = async (address, shareOfPool) => {
     const tvl = await this.totalValueLocked()
+    const toAssetPool = (
+      await this.collateralToken.getPastEvents("Transfer", {
+        from: address,
+        to: this.assetPoolContract.address,
+      })
+    ).reduce((reducer, _) => add(reducer, _.returnValues.value), "0")
+    const fromAssetPool = (
+      await this.collateralToken.getPastEvents("Transfer", {
+        from: this.assetPoolContract.address,
+        to: address,
+      })
+    ).reduce((reducer, _) => add(reducer, _.returnValues.value), "0")
+
+    const curretlyDeposited = sub(toAssetPool, fromAssetPool)
+
+    let deposited = 0
+    if (gt(curretlyDeposited, "0")) {
+      deposited = curretlyDeposited
+    }
 
     return new BigNumber(tvl)
       .multipliedBy(shareOfPool)
-      .minus(estimatedCollateralTokenBalance)
+      .minus(deposited)
       .toFixed(0)
       .toString()
   }
@@ -55,10 +81,7 @@ class CoveragePoolV1 {
   }
 
   estimatedCollateralTokenBalance = async (shareOfPool) => {
-    const balanceOfAssetPool = await this.collateralToken.makeCall(
-      "balanceOf",
-      this.assetPoolContract.address
-    )
+    const balanceOfAssetPool = await this.assetPoolCollateralTokenBalance()
 
     return new BigNumber(balanceOfAssetPool)
       .multipliedBy(shareOfPool)
@@ -66,7 +89,70 @@ class CoveragePoolV1 {
       .toString()
   }
 
-  apy = async () => {}
+  assetPoolCollateralTokenBalance = async () => {
+    return await this.collateralToken.makeCall(
+      "balanceOf",
+      this.assetPoolContract.address
+    )
+  }
+
+  rewardPoolPerWeek = async () => {
+    const rewardRate = await this.rewardPoolRewardRate()
+
+    return KEEP.toTokenUnit(rewardRate).multipliedBy(REWARD_DURATION)
+  }
+
+  rewardPoolRewardRate = async () => {
+    const rewardPoolContract = await this.getRewardPoolContract()
+    return await rewardPoolContract.makeCall("rewardRate")
+  }
+
+  /**
+   * @return {Promise<BaseContract>} The reward pool contract.
+   */
+  getRewardPoolContract = async () => {
+    if (!this._rewardPoolContract) {
+      const rewardPoolAddress = await this.assetPoolContract.makeCall(
+        "rewardsPool"
+      )
+      this._rewardPoolContract = this.web3.createContractInstance(
+        RewardsPoolArtifact.abi,
+        rewardPoolAddress,
+        // The `RewardsPool` contract is created in the same transaction as the
+        // `AssetPool` contract (in the `AssetPool` constructor). In thah case
+        // we can pass `deploymentTxnHash` and `deployedAtBlock` from the
+        // `AssetPool` contract.
+        this.assetPoolContract.deploymentTxnHash,
+        this.assetPoolContract.deployedAtBlock
+      )
+    }
+    return this._rewardPoolContract
+  }
+
+  apy = async () => {
+    const totalSupply = await this.assetPoolCollateralTokenBalance()
+    const rewardPoolPerWeek = await this.rewardPoolPerWeek()
+
+    // We know that the collateral token is KEEP. TODO: consider a more abstract
+    // solution to fetch the collateral token price in USD.
+    const collateralTokenPriceInUSD =
+      await this.exchangeService.getKeepTokenPriceInUSD()
+
+    const totalSupplyInUSD = KEEP.toTokenUnit(totalSupply).multipliedBy(
+      collateralTokenPriceInUSD
+    )
+
+    const rewardRate = APYCalculator.calculatePoolRewardRate(
+      collateralTokenPriceInUSD,
+      rewardPoolPerWeek,
+      totalSupplyInUSD
+    )
+
+    return APYCalculator.calculateAPY(rewardRate)
+      .multipliedBy(100)
+      .decimalPlaces(2, BigNumber.ROUND_DOWN)
+      .toString()
+  }
 }
 
 export default CoveragePoolV1

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -1,18 +1,28 @@
 import BigNumber from "bignumber.js"
 /** @typedef { import("../../web3").BaseContract} BaseContract */
+/** @typedef { import("../../web3").Web3LibWrapper} Web3LibWrapper */
+/** @typedef { import("../exchange-api").BaseExchange} BaseExchange */
 
 class CoveragePoolV1 {
   /**
-   *
    * @param {BaseContract} _assetPoolContract
    * @param {BaseContract} _covTokenContract
    * @param {BaseContract} _collateralToken
+   * @param {BaseExchange} _exchangeService
+   * @param {Web3LibWrapper} _web3
    */
-  constructor(_assetPoolContract, _covTokenContract, _collateralToken) {
+  constructor(
+    _assetPoolContract,
+    _covTokenContract,
+    _collateralToken,
+    _exchangeService,
+    _web3
+  ) {
     this.assetPoolContract = _assetPoolContract
     this.covTokenContract = _covTokenContract
     this.collateralToken = _collateralToken
-    this._rewardPoolContractAddress = null
+    this.exchangeService = _exchangeService
+    this.web3 = _web3
   }
 
   shareOfPool = (covTotalSupply, covBalanceOf) => {

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -6,12 +6,12 @@ class CoveragePoolV1 {
    *
    * @param {BaseContract} _assetPoolContract
    * @param {BaseContract} _covTokenContract
-   * @param {BaseContract} _corateralTokenContract
+   * @param {BaseContract} _collateralToken
    */
-  constructor(_assetPoolContract, _covTokenContract, _corateralTokenContract) {
+  constructor(_assetPoolContract, _covTokenContract, _collateralToken) {
     this.assetPoolContract = _assetPoolContract
     this.covTokenContract = _covTokenContract
-    this.corateralTokenContract = _corateralTokenContract
+    this.collateralToken = _collateralToken
     this._rewardPoolContractAddress = null
   }
 
@@ -45,15 +45,11 @@ class CoveragePoolV1 {
   }
 
   corateralTokenAllowance = async (owner, spender) => {
-    return await this.corateralTokenContract.makeCall(
-      "allowance",
-      owner,
-      spender
-    )
+    return await this.collateralToken.makeCall("allowance", owner, spender)
   }
 
   estimatedCorateralTokenBalance = async (shareOfPool) => {
-    const balanceOfAssetPool = await this.corateralTokenContract.makeCall(
+    const balanceOfAssetPool = await this.collateralToken.makeCall(
       "balanceOf",
       this.assetPoolContract.address
     )

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -148,10 +148,16 @@ class CoveragePoolV1 {
       totalSupplyInUSD
     )
 
-    return APYCalculator.calculateAPY(rewardRate)
-      .multipliedBy(100)
-      .decimalPlaces(2, BigNumber.ROUND_DOWN)
-      .toString()
+    return APYCalculator.calculateAPY(rewardRate).toString()
+  }
+
+  totalAllocatedRewards = async () => {
+    const rewardPoolContract = await this.getRewardPoolContract()
+
+    return (await rewardPoolContract.getPastEvents("RewardToppedUp")).reduce(
+      (reducer, _) => add(reducer, _.returnValues.amount),
+      "0"
+    )
   }
 }
 

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -32,21 +32,47 @@ class CoveragePoolV1 {
     this._rewardPoolContract = undefined
   }
 
+  /**
+   * Calculates the share of the coverage pool.
+   * @param {string} covTotalSupply Total supply of the cov token in the
+   * smallest unit. It can be fetched via {@link CoveragePoolV1.covTotalSupply}.
+   * @param {string} covBalanceOf Amount of tokens owned by user in the samllest
+   * unit. It can be fetched via {@link CoveragePoolV1.covBalanceOf}.
+   * @return {string} The share of pool. The value is between [0, 1].
+   */
   shareOfPool = (covTotalSupply, covBalanceOf) => {
     if (new BigNumber(covTotalSupply).isZero()) {
-      return 0
+      return "0"
     }
     return new BigNumber(covBalanceOf).div(covTotalSupply).toString()
   }
 
+  /**
+   * Returns the total supply of the cov token in the smallest unit- 18
+   * ddecimals precision.
+   * @return {Promise<string>} Total supply of the cov token.
+   */
   covTotalSupply = async () => {
     return await this.covTokenContract.makeCall("totalSupply")
   }
 
+  /**
+   * Returns the amount of cov tokens owned by `address`.
+   * @param {string} address User address.
+   * @return {Promise<string>} Aamount of cov tokens owned by `address`.
+   */
   covBalanceOf = async (address) => {
     return await this.covTokenContract.makeCall("balanceOf", address)
   }
 
+  /**
+   * Estimates the current reward balance earned for participating in the pool.
+   * The collateral token is a reward token.
+   * @param {string} address User address.
+   * @param {string} shareOfPool The user's current share of the pool.
+   * @return {Promise<string>} The current reward balance (in collateral token)
+   * in the smallest unit- 18 decimals precision.
+   */
   estimatedRewards = async (address, shareOfPool) => {
     if (shareOfPool <= 0) {
       return "0"
@@ -80,10 +106,24 @@ class CoveragePoolV1 {
       .toString()
   }
 
+  /**
+   * Returns the current collateral token balance of the asset pool plus the
+   * reward amount (in collateral token) earned by the asset pool and not yet
+   * withdrawn to the asset pool.
+   *
+   * @return {Promise<string>}  The total value of asset pool in collateral
+   * token in the smallest unit.
+   */
   totalValueLocked = async () => {
     return await this.assetPoolContract.makeCall("totalValue")
   }
 
+  /**
+   * Estimates the collateral token balance based on the share of the pool.
+   * @param {string | number} shareOfPool The user's current share of the
+   * coverage pool. It can be calculated via {@link CoveragePoolV1#shareOfPool}
+   * @return {Promise<string>} Estimated collateral token balance.
+   */
   estimatedCollateralTokenBalance = async (shareOfPool) => {
     const balanceOfAssetPool = await this.assetPoolCollateralTokenBalance()
 
@@ -93,6 +133,11 @@ class CoveragePoolV1 {
       .toString()
   }
 
+  /**
+   * Returns the `AssetPool` contract's balance of the collateral token.
+   * @return {Promise<string>} The `AssetPool` contract's balance of the
+   * collateral token.
+   */
   assetPoolCollateralTokenBalance = async () => {
     return await this.collateralToken.makeCall(
       "balanceOf",
@@ -100,19 +145,33 @@ class CoveragePoolV1 {
     )
   }
 
+  /**
+   * Calculates the reward pool per week. The `RewardsPool` will earn a given
+   * amount of collateral token per week. Reward tokens from the previous
+   * interval that has not been yet unlocked, are added to the new interval
+   * being created.
+   * @return  {Promise<string>} The reward pool per week (in collateral token)
+   * in the smallest unit.
+   */
   rewardPoolPerWeek = async () => {
     const rewardRate = await this.rewardPoolRewardRate()
 
     return KEEP.toTokenUnit(rewardRate).multipliedBy(REWARD_DURATION)
   }
 
+  /**
+   * Returns the `RewardsPool` contract's rate per second with which reward
+   * tokens are unlocked.
+   * @return {Promise<string>} The rate per second with which reward tokens are
+   * unlocked.
+   */
   rewardPoolRewardRate = async () => {
     const rewardPoolContract = await this.getRewardPoolContract()
     return await rewardPoolContract.makeCall("rewardRate")
   }
 
   /**
-   * @return {Promise<BaseContract>} The reward pool contract.
+   * @return {Promise<BaseContract>} The `RewardsPool` contract.
    */
   getRewardPoolContract = async () => {
     if (!this._rewardPoolContract) {
@@ -133,6 +192,10 @@ class CoveragePoolV1 {
     return this._rewardPoolContract
   }
 
+  /**
+   * Calculates the APY of the coverage pool assuming that there are no calims.
+   * @return {Promise<string>} APY.
+   */
   apy = async () => {
     const totalSupply = await this.assetPoolCollateralTokenBalance()
     const rewardPoolPerWeek = await this.rewardPoolPerWeek()
@@ -155,6 +218,12 @@ class CoveragePoolV1 {
     return APYCalculator.calculateAPY(rewardRate).toString()
   }
 
+  /**
+   * Calculates the total amount of the tokens that were allocated as a reward
+   * to the `RewardsPool` contract.
+   * @return {Promise<string>} The total amount of tokens allocated to
+   * the `RewardsPool` contract.
+   */
   totalAllocatedRewards = async () => {
     const rewardPoolContract = await this.getRewardPoolContract()
 

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -1,0 +1,53 @@
+import BigNumber from "bignumber.js"
+/** @typedef { import("../../web3").BaseContract} BaseContract */
+
+class CoveragePoolV1 {
+  /**
+   *
+   * @param {BaseContract} _assetPoolContract
+   * @param {BaseContract} _rewardPoolContract
+   * @param {BaseContract} _covTokenContract
+   * @param {BaseContract} _corateralTokenContract
+   */
+  constructor(
+    _assetPoolContract,
+    _rewardPoolContract,
+    _covTokenContract,
+    _corateralTokenContract
+  ) {
+    this.assetPoolContract = _assetPoolContract
+    this.rewardPoolContract = _rewardPoolContract
+    this.covTokenContract = _covTokenContract
+    this.corateralTokenContract = _corateralTokenContract
+  }
+
+  shareOfPool = async (covTotalSupply, covBalanceOf) => {
+    return new BigNumber(covBalanceOf).div(covTotalSupply).toString()
+  }
+
+  covTotalSupply = async () => {
+    return await this.covTokenContract.makeCall("totalSupply")
+  }
+
+  covBalanceOf = async (address) => {
+    return await this.covTokenContract.makeCall("balanceOf", address)
+  }
+
+  estimatedRewards = async (shareOfPool) => {
+    const tokensInPool = await this.corateralTokenContract.makeCall(
+      "balanceOf",
+      this.assetPoolContract.address
+    )
+
+    const earned = await this.rewardPoolContract.makeCall("earned")
+
+    return new BigNumber(tokensInPool)
+      .plus(new BigNumber(earned))
+      .multipliedBy(shareOfPool)
+      .toString()
+  }
+
+  apy = async () => {}
+}
+
+export default CoveragePoolV1

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -21,7 +21,7 @@ class CoveragePoolV1 {
     this.corateralTokenContract = _corateralTokenContract
   }
 
-  shareOfPool = async (covTotalSupply, covBalanceOf) => {
+  shareOfPool = (covTotalSupply, covBalanceOf) => {
     return new BigNumber(covBalanceOf).div(covTotalSupply).toString()
   }
 

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -30,12 +30,12 @@ class CoveragePoolV1 {
     return await this.covTokenContract.makeCall("balanceOf", address)
   }
 
-  estimatedRewards = async (shareOfPool, estimatedKeepBalance) => {
+  estimatedRewards = async (shareOfPool, estimatedCollateralTokenBalance) => {
     const tvl = await this.totalValueLocked()
 
     return new BigNumber(tvl)
       .multipliedBy(shareOfPool)
-      .minus(estimatedKeepBalance)
+      .minus(estimatedCollateralTokenBalance)
       .toFixed(0)
       .toString()
   }
@@ -44,11 +44,7 @@ class CoveragePoolV1 {
     return await this.assetPoolContract.makeCall("totalValue")
   }
 
-  corateralTokenAllowance = async (owner, spender) => {
-    return await this.collateralToken.makeCall("allowance", owner, spender)
-  }
-
-  estimatedCorateralTokenBalance = async (shareOfPool) => {
+  estimatedCollateralTokenBalance = async (shareOfPool) => {
     const balanceOfAssetPool = await this.collateralToken.makeCall(
       "balanceOf",
       this.assetPoolContract.address

--- a/solidity/dashboard/src/lib/keep/coverage-pool/index.js
+++ b/solidity/dashboard/src/lib/keep/coverage-pool/index.js
@@ -48,6 +48,10 @@ class CoveragePoolV1 {
   }
 
   estimatedRewards = async (address, shareOfPool) => {
+    if (shareOfPool <= 0) {
+      return "0"
+    }
+
     const tvl = await this.totalValueLocked()
     const toAssetPool = (
       await this.collateralToken.getPastEvents("Transfer", {
@@ -64,7 +68,7 @@ class CoveragePoolV1 {
 
     const curretlyDeposited = sub(toAssetPool, fromAssetPool)
 
-    let deposited = 0
+    let deposited = "0"
     if (gt(curretlyDeposited, "0")) {
       deposited = curretlyDeposited
     }

--- a/solidity/dashboard/src/lib/keep/exchange-api/base.js
+++ b/solidity/dashboard/src/lib/keep/exchange-api/base.js
@@ -1,0 +1,34 @@
+/** @typedef { import("bignumber.js").BigNumber} BigNumber */
+
+class BaseExchange {
+  /**
+   * Returns the Uniswap pair data.
+   *
+   * @param {string} pairId Uniswap pair id- address of the `UniswapV2Pair`
+   * contract.
+   * @return {Object} Uniswap pair data.
+   */
+  getUniswapPairData = async (pairId) => {
+    return await this._getUniswapPairData(pairId)
+  }
+
+  /**
+   * Returns the current KEEP token price in USD based on the exchange data.
+   *
+   * @return {BigNumber} KEEP token price in USD.
+   */
+  getKeepTokenPriceInUSD = async () => {
+    return await this._getKeepTokenPriceInUSD()
+  }
+
+  /**
+   * Returns the current BTC price in USD based on the exchange data.
+   *
+   * @return {BigNumber} BTC price in USD.
+   */
+  getBTCPriceInUSD = async () => {
+    return await this._getBTCPriceInUSD()
+  }
+}
+
+export default BaseExchange

--- a/solidity/dashboard/src/lib/keep/exchange-api/index.js
+++ b/solidity/dashboard/src/lib/keep/exchange-api/index.js
@@ -1,0 +1,4 @@
+import BaseExchange from "./base"
+import UniswapV2Exchange from "./uniswap-v2"
+
+export { BaseExchange, UniswapV2Exchange }

--- a/solidity/dashboard/src/lib/keep/exchange-api/uniswap-v2.js
+++ b/solidity/dashboard/src/lib/keep/exchange-api/uniswap-v2.js
@@ -1,0 +1,73 @@
+import axios from "axios"
+import BigNumber from "bignumber.js"
+import BaseExchange from "./base"
+
+class UniswapV2Exchange extends BaseExchange {
+  UNISWAP_API_URL = "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2"
+
+  _getUniswapPairData = async (pairId) => {
+    const response = await axios.post(this.UNISWAP_API_URL, {
+      query: `query pairquery {
+              pair(id: "${pairId}") {
+                  token0 {
+                      symbol,
+                      derivedETH,
+                  },
+                  token1 {
+                      symbol,
+                      derivedETH,
+                  },
+                  reserve0,
+                  reserve1,
+                  reserveETH,
+                  reserveUSD,
+                  token0Price,
+                  token1Price,
+                  totalSupply,
+              }
+          }`,
+    })
+
+    if (response.data && response.data.errors) {
+      const error = new Error(
+        "Failed fetching data from Uniswap V2 subgraph API."
+      )
+      error.errors = response.data.errors
+      throw error
+    }
+
+    return response.data.data.pair
+  }
+
+  _getTokenPriceInUSD = async (address) => {
+    const pairData = await this._getUniswapPairData(address)
+    const ethPrice = new BigNumber(pairData.reserveUSD).div(pairData.reserveETH)
+
+    return ethPrice.multipliedBy(pairData.token0.derivedETH)
+  }
+
+  /**
+   * Returns the current KEEP token price in USD based on the KEEP/ETH Uniswap
+   * v2 pool.
+   *
+   * @return {BigNumber} KEEP token price in USD.
+   */
+  _getKeepTokenPriceInUSD = async () => {
+    return await this._getTokenPriceInUSD(
+      "0xe6f19dab7d43317344282f803f8e8d240708174a"
+    )
+  }
+
+  /**
+   * Returns the current BTC price in USD based on the TBTC/ETH Uniswap v2 pool.
+   *
+   * @return {BigNumber} BTC price in USD.
+   */
+  _getBTCPriceInUSD = async () => {
+    return await this._getTokenPriceInUSD(
+      "0x854056fd40c1b52037166285b2e54fee774d33f6"
+    )
+  }
+}
+
+export default UniswapV2Exchange

--- a/solidity/dashboard/src/lib/keep/helper/apy-calculator.js
+++ b/solidity/dashboard/src/lib/keep/helper/apy-calculator.js
@@ -1,0 +1,37 @@
+import BigNumber from "bignumber.js"
+
+const WEEKS_IN_YEAR = 52
+
+class APYCalculator {
+  /**
+   * Calculates pool reward rate per number of compouning periods.
+   * @param {number | string | BigNumber} rewardTokenPriceInUSD The price of the reward token in
+   * USD.
+   * @param {number | string | BigNumber} rewardPoolInRewardTokenPerPeriod The
+   * reward pool in the reward token unit per a given period.
+   * @param {number | string | BigNumber} totalStakedInUSD Total value locked in usd.
+   * @return {BigNumber} The pool reward rate per number of compouning periods.
+   */
+  static calculatePoolRewardRate = (
+    rewardTokenPriceInUSD,
+    rewardPoolInRewardTokenPerPeriod,
+    totalStakedInUSD
+  ) => {
+    return new BigNumber(rewardTokenPriceInUSD)
+      .multipliedBy(rewardPoolInRewardTokenPerPeriod)
+      .div(totalStakedInUSD)
+  }
+
+  /**
+   * Calculates the APY- formula: (1 + r/n)^n -1
+   * @param {number | string | BigNumber} poolRewardRate The pool reward rate - it equals
+   * to r/n. It can be calculated by {@link APYCalculator.calculatePoolRewardRate}.
+   * @param {number | string | BigNumber} n Number of compounding periods.
+   * @return {BigNumber} The APY value.
+   */
+  static calculateAPY = (poolRewardRate, n = WEEKS_IN_YEAR) => {
+    return new BigNumber(poolRewardRate).plus(1).pow(n).minus(1)
+  }
+}
+
+export default APYCalculator

--- a/solidity/dashboard/src/lib/keep/helper/index.js
+++ b/solidity/dashboard/src/lib/keep/helper/index.js
@@ -1,0 +1,3 @@
+import APYCalculator from "./apy-calculator"
+
+export { APYCalculator }

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -22,6 +22,7 @@ import {
   LP_REWARDS_KEEP_TBTC_CONTRACT_NAME,
   LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
   KEEP_TOKEN_GEYSER_CONTRACT_NAME,
+  COV_TOKEN_CONTRACT_NAME,
 } from "./contracts"
 
 /** @typedef { import("../web3").Web3LibWrapper} Web3LibWrapper */
@@ -98,7 +99,10 @@ class Keep {
   [KEEP_TOKEN_GEYSER_CONTRACT_NAME];
 
   /** @type {BaseContract} */
-  [SADDLE_SWAP_CONTRACT_NAME]
+  [SADDLE_SWAP_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [COV_TOKEN_CONTRACT_NAME]
 
   initializeContracts = () => {
     const getDeploymentInfo = (artifact) => {

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -157,7 +157,9 @@ class Keep {
     this.coveragePoolV1 = new CoveragePoolV1(
       this.assetPoolContract,
       this.covTokenContract,
-      this.keepTokenContract
+      this.keepTokenContract,
+      this.exchangeService,
+      this.web3
     )
   }
 

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -111,19 +111,32 @@ class Keep {
   initializeContracts = () => {
     const getDeploymentInfo = (artifact) => {
       const { networks } = artifact
-      const networkId = Object.keys(networks)[0]
-
-      const address = networks[networkId].address
-      const deploymentTxnHash = networks[networkId].transactionHash
-      return { address, deploymentTxnHash }
+      let deploymentTxnHash = null
+      let address = null
+      let deployedAtBlock = null
+      if (networks) {
+        // If the JSON artifact has the `networks` field, it means that an
+        // artifact was built by Truffle.
+        const networkId = Object.keys(networks)[0]
+        address = networks[networkId].address
+        deploymentTxnHash = networks[networkId].transactionHash
+      } else {
+        // Otherwise, it means an artifact was built by Hardhat.
+        address = artifact.address
+        deploymentTxnHash = artifact.transactionHash
+        deployedAtBlock = artifact.receipt.blockNumber
+      }
+      return { address, deploymentTxnHash, deployedAtBlock }
     }
 
     for (const [contractName, { artifact }] of Object.entries(contracts)) {
-      const { address, deploymentTxnHash } = getDeploymentInfo(artifact)
+      const { address, deploymentTxnHash, deployedAtBlock } =
+        getDeploymentInfo(artifact)
       this[contractName] = this.web3.createContractInstance(
         artifact.abi,
         address,
-        deploymentTxnHash
+        deploymentTxnHash,
+        deployedAtBlock
       )
     }
 

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -1,7 +1,31 @@
-import contracts from "./contracts"
+import contracts, {
+  SADDLE_SWAP_CONTRACT_NAME,
+  SaddleSwapArtifact,
+} from "./contracts"
 import CoveragePoolV1 from "./coverage-pool"
+import {
+  KEEP_TOKEN_CONTRACT_NAME,
+  TOKEN_STAKING_CONTRACT_NAME,
+  TOKEN_GRANT_CONTRACT_NAME,
+  OPERATOR_CONTRACT_NAME,
+  KEEP_OPERATOR_STATISTICS_CONTRACT_NAME,
+  MANAGED_GRANT_FACTORY_CONTRACT_NAME,
+  KEEP_BONDING_CONTRACT_NAME,
+  TBTC_TOKEN_CONTRACT_NAME,
+  TBTC_SYSTEM_CONTRACT_NAME,
+  TOKEN_STAKING_ESCROW_CONTRACT_NAME,
+  BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME,
+  STAKING_PORT_BACKER_CONTRACT_NAME,
+  OLD_TOKEN_STAKING_CONTRACT_NAME,
+  LP_REWARDS_KEEP_ETH_CONTRACT_NAME,
+  LP_REWARDS_TBTC_ETH_CONTRACT_NAME,
+  LP_REWARDS_KEEP_TBTC_CONTRACT_NAME,
+  LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
+  KEEP_TOKEN_GEYSER_CONTRACT_NAME,
+} from "./contracts"
 
 /** @typedef { import("../web3").Web3LibWrapper} Web3LibWrapper */
+/** @typedef { import("../web3").BaseContract} BaseContract */
 
 class Keep {
   static initialize(web3) {
@@ -19,10 +43,88 @@ class Keep {
     this.web3 = _web3
   }
 
+  /** @type {BaseContract} */
+  [KEEP_TOKEN_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [TOKEN_STAKING_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [TOKEN_GRANT_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [OPERATOR_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [KEEP_OPERATOR_STATISTICS_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [MANAGED_GRANT_FACTORY_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [KEEP_BONDING_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [TBTC_TOKEN_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [TBTC_SYSTEM_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [TOKEN_STAKING_ESCROW_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [BONDED_ECDSA_KEEP_FACTORY_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [STAKING_PORT_BACKER_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [OLD_TOKEN_STAKING_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [LP_REWARDS_KEEP_ETH_CONTRACT_NAME];
+  /** @type {BaseContract} */
+
+  [LP_REWARDS_TBTC_ETH_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [LP_REWARDS_KEEP_TBTC_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [KEEP_TOKEN_GEYSER_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [SADDLE_SWAP_CONTRACT_NAME]
+
   initializeContracts = () => {
-    for (const [contractName, { artifact }] of Object.entries(contracts)) {
-      this[contractName] = this.web3.createContractInstance(artifact)
+    const getDeploymentInfo = (artifact) => {
+      const { networks } = artifact
+      const networkId = Object.keys(networks)[0]
+
+      const address = networks[networkId].address
+      const deploymentTxnHash = networks[networkId].transactionHash
+      return { address, deploymentTxnHash }
     }
+
+    for (const [contractName, { artifact }] of Object.entries(contracts)) {
+      const { address, deploymentTxnHash } = getDeploymentInfo(artifact)
+      this[contractName] = this.web3.createContractInstance(
+        artifact.abi,
+        address,
+        deploymentTxnHash
+      )
+    }
+
+    this.saddleSwapContract = this.web3.createContractInstance(
+      SaddleSwapArtifact.abi,
+      "0x4f6A43Ad7cba042606dECaCA730d4CE0A57ac62e",
+      null,
+      1
+    )
   }
 
   initializeServices = () => {

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -135,6 +135,16 @@ class Keep {
       this.keepTokenContract
     )
   }
+
+  setProvider = (provider) => {
+    this.web3.setProvider(provider)
+
+    for (const [contractName] of Object.entries(contracts)) {
+      this[contractName].setProvider(provider)
+    }
+
+    this.saddleSwapContract.setProvider(provider)
+  }
 }
 
 export default Keep

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -1,0 +1,38 @@
+import contracts from "./contracts"
+import CoveragePoolV1 from "./coverage-pool"
+
+/** @typedef { import("../web3").Web3LibWrapper} Web3LibWrapper */
+
+class Keep {
+  static initialize(web3) {
+    const keep = new Keep(web3)
+    keep.initializeContracts()
+    keep.initializeServices()
+
+    return keep
+  }
+
+  /**
+   * @param {Web3LibWrapper} _web3 The web3 lib wrapper.
+   */
+  constructor(_web3) {
+    this.web3 = _web3
+  }
+
+  initializeContracts = () => {
+    for (const [contractName, { artifact }] of Object.entries(contracts)) {
+      this[contractName] = this.web3.createContractInstance(artifact)
+    }
+  }
+
+  initializeServices = () => {
+    this.coveragePoolV1 = new CoveragePoolV1(
+      this.assetPoolContract,
+      this.rewardPoolContract,
+      this.covTokenContract,
+      this.keepTokenContract
+    )
+  }
+}
+
+export default Keep

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -3,6 +3,7 @@ import contracts, {
   SaddleSwapArtifact,
 } from "./contracts"
 import CoveragePoolV1 from "./coverage-pool"
+import { UniswapV2Exchange } from "./exchange-api"
 import {
   KEEP_TOKEN_CONTRACT_NAME,
   TOKEN_STAKING_CONTRACT_NAME,
@@ -28,6 +29,7 @@ import {
 
 /** @typedef { import("../web3").Web3LibWrapper} Web3LibWrapper */
 /** @typedef { import("../web3").BaseContract} BaseContract */
+/** @typedef { import("./exchange-api").BaseExchange} BaseExchange */
 
 class Keep {
   static initialize(web3) {
@@ -40,9 +42,12 @@ class Keep {
 
   /**
    * @param {Web3LibWrapper} _web3 The web3 lib wrapper.
+   * @param {BaseExchange} exchangeService The exchange service that provides
+   * data from the external exchanges.
    */
-  constructor(_web3) {
+  constructor(_web3, exchangeService = null) {
     this.web3 = _web3
+    this.exchangeService = exchangeService || new UniswapV2Exchange()
   }
 
   /** @type {BaseContract} */

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -142,8 +142,18 @@ class Keep {
     for (const [contractName] of Object.entries(contracts)) {
       this[contractName].setProvider(provider)
     }
-
     this.saddleSwapContract.setProvider(provider)
+  }
+
+  /**
+   * @param {string} acc Account address
+   */
+  set defaultAccount(acc) {
+    this.web3.defaultAccount = acc
+
+    for (const [contractName] of Object.entries(contracts)) {
+      this[contractName].defaultAccount = acc
+    }
   }
 }
 

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -23,6 +23,7 @@ import {
   LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
   KEEP_TOKEN_GEYSER_CONTRACT_NAME,
   COV_TOKEN_CONTRACT_NAME,
+  ASSET_POOL_CONTRACT_NAME,
 } from "./contracts"
 
 /** @typedef { import("../web3").Web3LibWrapper} Web3LibWrapper */
@@ -102,7 +103,10 @@ class Keep {
   [SADDLE_SWAP_CONTRACT_NAME];
 
   /** @type {BaseContract} */
-  [COV_TOKEN_CONTRACT_NAME]
+  [COV_TOKEN_CONTRACT_NAME];
+
+  /** @type {BaseContract} */
+  [ASSET_POOL_CONTRACT_NAME]
 
   initializeContracts = () => {
     const getDeploymentInfo = (artifact) => {

--- a/solidity/dashboard/src/lib/keep/index.js
+++ b/solidity/dashboard/src/lib/keep/index.js
@@ -138,7 +138,6 @@ class Keep {
   initializeServices = () => {
     this.coveragePoolV1 = new CoveragePoolV1(
       this.assetPoolContract,
-      this.rewardPoolContract,
       this.covTokenContract,
       this.keepTokenContract
     )

--- a/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
@@ -124,6 +124,8 @@ describe("Test Web3jsContract wrapper", () => {
   const mockedMethodName = "mockedMethod"
   const mockedMethodCall = jest.fn()
   const mockedMethodSend = jest.fn()
+  const mockedEventFn = jestn.fn()
+  const mockedEventName = "EventName"
 
   const mockedWebjsContractInstance = {
     methods: {
@@ -138,6 +140,9 @@ describe("Test Web3jsContract wrapper", () => {
       address: "0x0",
     },
     setProvider: jest.fn(),
+    events: {
+      [mockedEventName]: mockedEventFn,
+    },
   }
   const deploymentTxnHash = "0x0"
   const web3Wrapper = new Web3jsWrapper({})
@@ -179,9 +184,10 @@ describe("Test Web3jsContract wrapper", () => {
 
     await contract.getPastEvents(eventName, filter, fromBlock)
 
-    expect(
-      mockedWebjsContractInstance.getPastEvents
-    ).toHaveBeenCalledWith(eventName, { fromBlock, filter })
+    expect(mockedWebjsContractInstance.getPastEvents).toHaveBeenCalledWith(
+      eventName,
+      { fromBlock, filter }
+    )
   })
 
   it("should return the contract instance address", () => {
@@ -206,5 +212,19 @@ describe("Test Web3jsContract wrapper", () => {
     expect(mockedWebjsContractInstance.setProvider).toHaveBeenCalledWith(
       provider
     )
+  })
+
+  it("should subscribe to the event", () => {
+    const mockedResult = { on: jest.fn() }
+    const mockedArg1 = "1"
+    const mockedArg2 = 2
+    contract.events[mockedEventName].mockReturnValue(mockedResult)
+
+    const result = contract.on(eventName, mockedArg1, mockedArg2)
+
+    expect(
+      mockedWebjsContractInstance.events[mockedEventName]
+    ).toHaveBeenCalledWith(mockedArg1, mockedArg2)
+    expect(result).toEqual(mockedResult)
   })
 })

--- a/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
@@ -1,0 +1,199 @@
+import {
+  BaseContract,
+  Web3LibWrapper,
+  Web3jsWrapper,
+  ContractFactory,
+} from "../../web3"
+
+describe("Test `BaseContract` wrapper", () => {
+  let contract
+  const mockedContractInstance = {}
+  const deployedAtBlock = "100"
+  const deploymentTxnHash = "0x0"
+  const web3Wrapper = new Web3LibWrapper({})
+
+  beforeEach(() => {
+    contract = new BaseContract(
+      mockedContractInstance,
+      deploymentTxnHash,
+      web3Wrapper
+    )
+
+    contract._makeCall = jest.fn()
+    contract._sendTransaction = jest.fn()
+    contract._getPastEvents = jest.fn()
+  })
+
+  it("should call the `makeCall` correctly", async () => {
+    const mockedMethodName = "method"
+    const mockedArg1 = "arg1"
+    const mockedArg2 = 20
+    const mockedResult = 1
+    contract._makeCall.mockResolvedValue(mockedResult)
+
+    const result = await contract.makeCall(
+      mockedMethodName,
+      mockedArg1,
+      mockedArg2
+    )
+
+    expect(contract._makeCall).toHaveBeenCalledWith(
+      mockedMethodName,
+      mockedArg1,
+      mockedArg2
+    )
+    expect(result).toEqual(mockedResult)
+  })
+
+  it("should call the `sendTransaction` correctly", async () => {
+    const mockedMethodName = "method"
+    const mockedPromiEvent = { on: jest.fn() }
+    contract._sendTransaction.mockResolvedValue(mockedPromiEvent)
+
+    const result = await contract.sendTransaction(mockedMethodName)
+
+    expect(contract._sendTransaction).toHaveBeenCalledWith(mockedMethodName)
+    expect(result).toEqual(mockedPromiEvent)
+  })
+
+  describe("`getPastEvents` test", () => {
+    let mockedEventName
+    let mockedResult
+    let mockedFilter
+    let spyOnGetDeploymentBlock
+
+    beforeEach(() => {
+      mockedEventName = "event"
+      mockedResult = [{ transactionHash: "0x1" }, { transactionHash: "0x2" }]
+      mockedFilter = { indexedParam1: "0x0", indexedParam2: 3 }
+      contract._getPastEvents.mockResolvedValue(mockedResult)
+
+      spyOnGetDeploymentBlock = jest
+        .spyOn(contract, "_getDeploymentBlock")
+        .mockResolvedValue(deployedAtBlock)
+    })
+
+    it("should call the `getPastEvents` correctly w/o `fromBlock` arg", async () => {
+      const result = await contract.getPastEvents(mockedEventName, mockedFilter)
+      expect(contract._getPastEvents).toHaveBeenCalledWith(
+        mockedEventName,
+        mockedFilter,
+        deployedAtBlock
+      )
+      expect(spyOnGetDeploymentBlock).toHaveBeenCalled()
+      expect(result).toEqual(mockedResult)
+    })
+
+    it("should call the `getPastEvents` correctly w/ `fromBlock` arg", async () => {
+      const result = await contract.getPastEvents(
+        mockedEventName,
+        mockedFilter,
+        deployedAtBlock
+      )
+
+      expect(contract._getPastEvents).toHaveBeenCalledWith(
+        mockedEventName,
+        mockedFilter,
+        deployedAtBlock
+      )
+      expect(spyOnGetDeploymentBlock).not.toHaveBeenCalled()
+      expect(result).toEqual(mockedResult)
+    })
+  })
+
+  it("should fetch the deployment block via the web3 wrapper and save in `deployedAtBlock` field", async () => {
+    const mockedTxObj = { blockNumber: 100 }
+    const web3Wrapper = contract.web3
+    const spyOnGetTx = jest
+      .spyOn(web3Wrapper, "getTransaction")
+      .mockResolvedValue(mockedTxObj)
+
+    const result = await contract._getDeploymentBlock()
+    const result2 = await contract._getDeploymentBlock()
+
+    expect(spyOnGetTx).toHaveBeenCalledTimes(1)
+    expect(spyOnGetTx).toHaveBeenCalledWith(contract.deploymentTxnHash)
+    expect(result).toEqual(mockedTxObj.blockNumber.toString())
+    expect(contract.deployedAtBlock).toEqual(result)
+    expect(contract.deployedAtBlock).toEqual(result2)
+  })
+})
+
+describe("Test Web3jsContract wrapper", () => {
+  let contract
+  const mockedMethodName = "mockedMethod"
+  const mockedMethodCall = jest.fn()
+  const mockedMethodSend = jest.fn()
+
+  const mockedWebjsContractInstance = {
+    methods: {
+      [mockedMethodName]: jest.fn(() => ({
+        call: mockedMethodCall,
+        send: mockedMethodSend,
+      })),
+    },
+    getPastEvents: jest.fn(),
+    options: {
+      defaultAccount: null,
+      address: "0x0",
+    },
+  }
+  const deploymentTxnHash = "0x0"
+  const web3Wrapper = new Web3jsWrapper({})
+
+  beforeEach(async () => {
+    contract = await ContractFactory.createWeb3jsContract(
+      mockedWebjsContractInstance,
+      deploymentTxnHash,
+      web3Wrapper
+    )
+  })
+
+  it("should call a provided method", async () => {
+    const mockedArg1 = "0x123"
+    await contract.makeCall(mockedMethodName, mockedArg1)
+
+    expect(
+      mockedWebjsContractInstance.methods[mockedMethodName]
+    ).toHaveBeenCalledWith(mockedArg1)
+    expect(mockedMethodCall).toHaveBeenCalled()
+  })
+
+  it("should send transaction", async () => {
+    const mockedArg1 = "0x123"
+    const mockedArg2 = 1
+
+    await contract.sendTransaction(mockedMethodName, mockedArg1, mockedArg2)
+
+    expect(
+      mockedWebjsContractInstance.methods[mockedMethodName]
+    ).toHaveBeenCalledWith(mockedArg1, mockedArg2)
+    expect(mockedMethodSend).toHaveBeenCalled()
+  })
+
+  it("should get past events", async () => {
+    const eventName = "event"
+    const filter = { indexedParam1: 1, indexedParam2: 2 }
+    const fromBlock = 1
+
+    await contract.getPastEvents(eventName, filter, fromBlock)
+
+    expect(
+      mockedWebjsContractInstance.getPastEvents
+    ).toHaveBeenCalledWith(eventName, { fromBlock, filter })
+  })
+
+  it("should return the contract instance address", () => {
+    const result = contract.address
+
+    expect(result).toEqual(mockedWebjsContractInstance.options.address)
+  })
+
+  it("should set the default account for contract", () => {
+    const mockedDefaultAccount = "0x123456789"
+
+    contract.defaultAccount = mockedDefaultAccount
+
+    expect(contract.defaultAccount).toEqual(mockedDefaultAccount)
+  })
+})

--- a/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
@@ -124,7 +124,7 @@ describe("Test Web3jsContract wrapper", () => {
   const mockedMethodName = "mockedMethod"
   const mockedMethodCall = jest.fn()
   const mockedMethodSend = jest.fn()
-  const mockedEventFn = jestn.fn()
+  const mockedEventFn = jest.fn()
   const mockedEventName = "EventName"
 
   const mockedWebjsContractInstance = {
@@ -198,10 +198,14 @@ describe("Test Web3jsContract wrapper", () => {
 
   it("should set the default account for contract", () => {
     const mockedDefaultAccount = "0x123456789"
+    const spyOnDefaultAccount = jest.spyOn(contract, "defaultAccount", "set")
 
     contract.defaultAccount = mockedDefaultAccount
 
-    expect(contract.defaultAccount).toEqual(mockedDefaultAccount)
+    expect(spyOnDefaultAccount).toHaveBeenCalledWith(mockedDefaultAccount)
+    expect(mockedWebjsContractInstance.options.from).toEqual(
+      mockedDefaultAccount
+    )
   })
 
   it("should set the new provider correctly", () => {
@@ -220,7 +224,7 @@ describe("Test Web3jsContract wrapper", () => {
     const mockedArg2 = 2
     contract.events[mockedEventName].mockReturnValue(mockedResult)
 
-    const result = contract.on(eventName, mockedArg1, mockedArg2)
+    const result = contract.on(mockedEventName, mockedArg1, mockedArg2)
 
     expect(
       mockedWebjsContractInstance.events[mockedEventName]

--- a/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/contract.test.js
@@ -137,6 +137,7 @@ describe("Test Web3jsContract wrapper", () => {
       defaultAccount: null,
       address: "0x0",
     },
+    setProvider: jest.fn(),
   }
   const deploymentTxnHash = "0x0"
   const web3Wrapper = new Web3jsWrapper({})
@@ -195,5 +196,15 @@ describe("Test Web3jsContract wrapper", () => {
     contract.defaultAccount = mockedDefaultAccount
 
     expect(contract.defaultAccount).toEqual(mockedDefaultAccount)
+  })
+
+  it("should set the new provider correctly", () => {
+    const provider = {}
+
+    contract.setProvider(provider)
+
+    expect(mockedWebjsContractInstance.setProvider).toHaveBeenCalledWith(
+      provider
+    )
   })
 })

--- a/solidity/dashboard/src/lib/web3/__tests__/web3.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/web3.test.js
@@ -1,0 +1,111 @@
+import { Web3LibWrapper, Web3jsWrapper } from ".."
+import { ContractFactory } from "../contract"
+
+describe("Test Web3 lib wrapper", () => {
+  const mockedWeb3Lib = {}
+  let web3Wrapper
+
+  beforeEach(() => {
+    web3Wrapper = new Web3LibWrapper(mockedWeb3Lib)
+    web3Wrapper._getTransaction = jest.fn()
+    web3Wrapper._createContractInstance = jest.fn()
+  })
+
+  it("should create web3 lib wrapper correctly", () => {
+    expect(web3Wrapper.lib).toEqual(mockedWeb3Lib)
+  })
+
+  it("should call `getTransaction` correctly", async () => {
+    const mockedResult = { blockNumber: 1 }
+    const hash = "0x0"
+    web3Wrapper._getTransaction.mockResolvedValue(mockedResult)
+
+    const result = await web3Wrapper.getTransaction(hash)
+
+    expect(web3Wrapper._getTransaction).toHaveBeenCalledWith(hash)
+    expect(result).toEqual(mockedResult)
+  })
+
+  it("should call `createContractInstance` correctly", async () => {
+    const mockedResult = {
+      methods: { mockedMethod: { call: () => {}, send: () => {} } },
+    }
+    const mockedArtifact = { abi: [] }
+    web3Wrapper._createContractInstance.mockResolvedValue(mockedResult)
+
+    const result = await web3Wrapper.createContractInstance(mockedArtifact)
+
+    expect(web3Wrapper._createContractInstance).toHaveBeenCalledWith(
+      mockedArtifact
+    )
+    expect(result).toEqual(mockedResult)
+  })
+})
+
+describe("Test Web3.js lib wrapper", () => {
+  const mockedWeb3Lib = {
+    eth: {
+      getTransaction: jest.fn(),
+      Contract: jest.fn(),
+      defaultAccount: null,
+    },
+  }
+
+  let web3Wrapper
+
+  beforeEach(() => {
+    web3Wrapper = new Web3jsWrapper(mockedWeb3Lib)
+  })
+
+  it("should return transaction data by transaction hash", async () => {
+    const hash = "0x0"
+    const mockedResult = { blockNumber: 1 }
+    mockedWeb3Lib.eth.getTransaction.mockResolvedValue(mockedResult)
+
+    const result = await web3Wrapper.getTransaction(hash)
+
+    expect(mockedWeb3Lib.eth.getTransaction).toHaveBeenCalledWith(hash)
+    expect(result).toEqual(mockedResult)
+  })
+
+  it("should create web3 contract instance", () => {
+    const contractData = { address: "0x0", transactionHash: "0x1" }
+    const abi = {}
+    const mockedArtifact = {
+      abi,
+      networks: { 1: contractData },
+    }
+    const mockedWeb3jsContractInstance = {
+      methods: {},
+      options: { defaultAccount: null },
+    }
+
+    mockedWeb3Lib.eth.Contract.mockImplementation(
+      () => mockedWeb3jsContractInstance
+    )
+    const spyOnContractFactory = jest
+      .spyOn(ContractFactory, "createWeb3jsContract")
+      .mockReturnValue({})
+
+    web3Wrapper.createContractInstance(mockedArtifact)
+
+    expect(mockedWeb3Lib.eth.Contract).toHaveBeenCalledWith(
+      abi,
+      contractData.address
+    )
+    expect(spyOnContractFactory).toHaveBeenCalledWith(
+      mockedWeb3jsContractInstance,
+      contractData.transactionHash,
+      web3Wrapper
+    )
+  })
+
+  it("should set the default account correctly", () => {
+    const acc = "0x0123456789"
+
+    web3Wrapper.defaultAccount = acc
+
+    expect(web3Wrapper.defaultAccount).toEqual(acc)
+    expect(mockedWeb3Lib.eth.defaultAccount).toEqual(acc)
+  })
+})

--- a/solidity/dashboard/src/lib/web3/__tests__/web3.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/web3.test.js
@@ -30,13 +30,25 @@ describe("Test Web3 lib wrapper", () => {
     const mockedResult = {
       methods: { mockedMethod: { call: () => {}, send: () => {} } },
     }
-    const mockedArtifact = { abi: [] }
+    const abi = []
+    const address = "0x123"
+    const deploymentTxHash = "0x123456789"
+    const deployetAtBlock = 100
+
     web3Wrapper._createContractInstance.mockResolvedValue(mockedResult)
 
-    const result = await web3Wrapper.createContractInstance(mockedArtifact)
+    const result = await web3Wrapper.createContractInstance(
+      abi,
+      address,
+      deploymentTxHash,
+      deployetAtBlock
+    )
 
     expect(web3Wrapper._createContractInstance).toHaveBeenCalledWith(
-      mockedArtifact
+      abi,
+      address,
+      deploymentTxHash,
+      deployetAtBlock
     )
     expect(result).toEqual(mockedResult)
   })
@@ -69,12 +81,10 @@ describe("Test Web3.js lib wrapper", () => {
   })
 
   it("should create web3 contract instance", () => {
-    const contractData = { address: "0x0", transactionHash: "0x1" }
-    const abi = {}
-    const mockedArtifact = {
-      abi,
-      networks: { 1: contractData },
-    }
+    const abi = []
+    const address = "0x0"
+    const deploymentTxHash = "0x0123"
+
     const mockedWeb3jsContractInstance = {
       methods: {},
       options: { defaultAccount: null },
@@ -87,16 +97,14 @@ describe("Test Web3.js lib wrapper", () => {
       .spyOn(ContractFactory, "createWeb3jsContract")
       .mockReturnValue({})
 
-    web3Wrapper.createContractInstance(mockedArtifact)
+    web3Wrapper.createContractInstance(abi, address, deploymentTxHash)
 
-    expect(mockedWeb3Lib.eth.Contract).toHaveBeenCalledWith(
-      abi,
-      contractData.address
-    )
+    expect(mockedWeb3Lib.eth.Contract).toHaveBeenCalledWith(abi, address)
     expect(spyOnContractFactory).toHaveBeenCalledWith(
       mockedWeb3jsContractInstance,
-      contractData.transactionHash,
-      web3Wrapper
+      deploymentTxHash,
+      web3Wrapper,
+      null
     )
   })
 

--- a/solidity/dashboard/src/lib/web3/__tests__/web3.test.js
+++ b/solidity/dashboard/src/lib/web3/__tests__/web3.test.js
@@ -61,6 +61,7 @@ describe("Test Web3.js lib wrapper", () => {
       Contract: jest.fn(),
       defaultAccount: null,
     },
+    setProvider: jest.fn(),
   }
 
   let web3Wrapper
@@ -115,5 +116,13 @@ describe("Test Web3.js lib wrapper", () => {
 
     expect(web3Wrapper.defaultAccount).toEqual(acc)
     expect(mockedWeb3Lib.eth.defaultAccount).toEqual(acc)
+  })
+
+  it("should set the new provider correctly", () => {
+    const provider = {}
+
+    web3Wrapper.setProvider(provider)
+
+    expect(mockedWeb3Lib.setProvider).toHaveBeenCalledWith(provider)
   })
 })

--- a/solidity/dashboard/src/lib/web3/contract/contract.js
+++ b/solidity/dashboard/src/lib/web3/contract/contract.js
@@ -1,0 +1,171 @@
+/** @typedef { import("../../web3").Web3LibWrapper} Web3LibWrapper */
+
+class BaseContract {
+  /**
+   *
+   * @param {any} _instance The Contract instance of a given web3 library.
+   * @param {string} _deploymentTxnHash The Hash of the deployemnt transaction.
+   * @param {Web3LibWrapper} _web3 The wrapper of the web3 library.
+   * @param {string | null} _deployedAtBlock The block number, when the contract
+   * was deployed. If null, the `deployedAtBlock` is set after the
+   * `_getDeploymentBlock` is called.
+   */
+  constructor(_instance, _deploymentTxnHash, _web3, _deployedAtBlock = null) {
+    this.instance = _instance
+    this.deploymentTxnHash = _deploymentTxnHash
+    this.web3Wrapper = _web3
+    this.deployedAtBlock = _deployedAtBlock
+  }
+
+  /**
+   * Calls the provided contract function with the provided arguments.
+   *
+   * @param {string} methodName Name of the contract function.
+   * @param  {...any} args Arguments of function.
+   *
+   * @return {Promise<any>} response
+   */
+  makeCall = async (methodName, ...args) => {
+    return await this._makeCall(methodName, ...args)
+  }
+
+  /**
+   * Returns a promise combined event emitter. Resolves when the transaction
+   * receipt is available. PromiEvents work like a normal promises with added
+   * `on`, `once` and `off` functions. This way developers can watch for
+   * additional events like on `receipt` or `transactionHash`.
+   *
+   * @param {string} methodName Name of the contract function.
+   * @param  {...any} args Arguments of function.
+   *
+   * @return {any} PromiEvent object.
+   */
+  sendTransaction = async (methodName, ...args) => {
+    return this._sendTransaction(methodName, ...args)
+  }
+
+  /**
+   * Returns a past events for the provided event name.
+   *
+   * @param {string} eventName Name of the contract event.
+   * @param {*} filter Let you filter events by indexed parameters.
+   * @param {number} fromBlock The block number (greater than or equal to) from
+   * which to get events on. By default, it refers to `this.deployedAtBlock`.
+   *
+   * @return {Promise<Array<any>>}
+   */
+  getPastEvents = async (
+    eventName,
+    filter,
+    fromBlock = this.deployedAtBlock
+  ) => {
+    const _fromBlock = !fromBlock ? await this._getDeploymentBlock() : fromBlock
+
+    return await this._getPastEvents(eventName, filter, _fromBlock)
+  }
+
+  /**
+   * @return {string} The address used for this contract instance.
+   */
+  get address() {
+    return this._address
+  }
+
+  /**
+   * @return {Web3LibWrapper} The web3 lib wrapper.
+   */
+  get web3() {
+    return this.web3Wrapper
+  }
+
+  set defaultAccount(defaultAccount) {
+    this._defaultAccount = defaultAccount
+  }
+
+  get defaultAccount() {
+    return this._defaultAccount
+  }
+
+  async _getDeploymentBlock() {
+    if (!this.deployedAtBlock) {
+      const transaction = await this.web3.getTransaction(this.deploymentTxnHash)
+      this.deployedAtBlock = transaction.blockNumber.toString()
+    }
+
+    return this.deployedAtBlock
+  }
+}
+
+/**
+ * A wrapper for Web3.js Contract object {@link https://web3js.readthedocs.io/en/v1.3.4/web3-eth-contract.html}.
+ */
+class Web3jsContractWrapper extends BaseContract {
+  constructor(_instance, _deploymentTxnHash, _web3, _deployedAtBlock = null) {
+    super(_instance, _deploymentTxnHash, _web3, _deployedAtBlock)
+  }
+
+  async _makeCall(methodName, ...args) {
+    return await this.instance.methods[methodName](...args).call()
+  }
+
+  _sendTransaction(methodName, ...args) {
+    return this.instance.methods[methodName](...args).send()
+  }
+
+  async _getPastEvents(eventName, filter, fromBlock) {
+    const searchFilter = { fromBlock, filter }
+    return await this.instance.getPastEvents(eventName, searchFilter)
+  }
+
+  get _address() {
+    return this.instance.options.address
+  }
+
+  /**
+   * Contract's methods {@link https://web3js.readthedocs.io/en/v1.3.4/web3-eth-contract.html#id26}
+   */
+  get methods() {
+    return this.instance.methods
+  }
+
+  /**
+   * Contract's events {@link https://web3js.readthedocs.io/en/v1.3.4/web3-eth-contract.html#contract-events}
+   */
+  get events() {
+    return this.instance.events
+  }
+
+  set _defaultAccount(defaultAccount) {
+    this.instance.options.defaultAccount = defaultAccount
+  }
+
+  get _defaultAccount() {
+    return this.instance.options.defaultAccount
+  }
+}
+
+class ContractFactory {
+  static async createWeb3jsContract(instance, deploymentTxnHash, web3Wrapper) {
+    return new Web3jsContractWrapper(instance, deploymentTxnHash, web3Wrapper)
+  }
+}
+
+/**
+ * @typedef {Object} EventData
+ * @property {Object} returnValues
+ * @property {Object} raw
+ * @property {string} raw.data
+ * @property {string[]} raw.topics
+ * @property {string} event
+ * @property {string} signature
+ * @property {number} logIndex
+ * @property {number} transactionIndex
+ * @property {string} transactionHash
+ * @property {string} blockHash
+ * @property {number} blockNumber
+ * @property {string} address
+ */
+
+export default ContractFactory
+
+export { BaseContract, Web3jsContractWrapper }

--- a/solidity/dashboard/src/lib/web3/contract/contract.js
+++ b/solidity/dashboard/src/lib/web3/contract/contract.js
@@ -156,11 +156,11 @@ class Web3jsContractWrapper extends BaseContract {
   }
 
   set _defaultAccount(defaultAccount) {
-    this.instance.options.defaultAccount = defaultAccount
+    this.instance.options.from = defaultAccount
   }
 
   get _defaultAccount() {
-    return this.instance.options.defaultAccount
+    return this.instance.options.from
   }
 
   /**

--- a/solidity/dashboard/src/lib/web3/contract/contract.js
+++ b/solidity/dashboard/src/lib/web3/contract/contract.js
@@ -1,4 +1,5 @@
 /** @typedef { import("../../web3").Web3LibWrapper} Web3LibWrapper */
+/** @typedef { import("events").EventEmitter } EventEmitter */
 
 class BaseContract {
   /**
@@ -103,6 +104,16 @@ class BaseContract {
   setProvider = (provider) => {
     this._setProvider(provider)
   }
+
+  /**
+   * Subscribes to the contract event
+   *
+   * @param {string} eventName
+   * @return {EventEmitter} The event emitter.
+   */
+  on = (eventName, ...args) => {
+    return this._on(eventName, ...args)
+  }
 }
 
 /**
@@ -159,6 +170,16 @@ class Web3jsContractWrapper extends BaseContract {
    */
   _setProvider = (provider) => {
     this.instance.setProvider(provider)
+  }
+
+  /**
+   * Subscribes to the contract event {@link https://web3js.readthedocs.io/en/v1.3.4/web3-eth-contract.html#contract-events}
+   *
+   * @param {string} eventName
+   * @return {EventEmitter} The event emitter.
+   */
+  _on = (eventName, ...args) => {
+    return this.instance.events[eventName](...args)
   }
 }
 

--- a/solidity/dashboard/src/lib/web3/contract/contract.js
+++ b/solidity/dashboard/src/lib/web3/contract/contract.js
@@ -145,8 +145,18 @@ class Web3jsContractWrapper extends BaseContract {
 }
 
 class ContractFactory {
-  static createWeb3jsContract(instance, deploymentTxnHash, web3Wrapper) {
-    return new Web3jsContractWrapper(instance, deploymentTxnHash, web3Wrapper)
+  static createWeb3jsContract(
+    instance,
+    deploymentTxnHash,
+    web3Wrapper,
+    deployedAtBlock
+  ) {
+    return new Web3jsContractWrapper(
+      instance,
+      deploymentTxnHash,
+      web3Wrapper,
+      deployedAtBlock
+    )
   }
 }
 

--- a/solidity/dashboard/src/lib/web3/contract/contract.js
+++ b/solidity/dashboard/src/lib/web3/contract/contract.js
@@ -94,6 +94,15 @@ class BaseContract {
 
     return this.deployedAtBlock
   }
+
+  /**
+   * Sets a provider for a contract.
+   *
+   * @param {any} provider
+   */
+  setProvider = (provider) => {
+    this._setProvider(provider)
+  }
 }
 
 /**
@@ -141,6 +150,15 @@ class Web3jsContractWrapper extends BaseContract {
 
   get _defaultAccount() {
     return this.instance.options.defaultAccount
+  }
+
+  /**
+   * Sets a provider for a contract.
+   *
+   * @param {any} provider
+   */
+  _setProvider = (provider) => {
+    this.instance.setProvider(provider)
   }
 }
 

--- a/solidity/dashboard/src/lib/web3/contract/contract.js
+++ b/solidity/dashboard/src/lib/web3/contract/contract.js
@@ -145,7 +145,7 @@ class Web3jsContractWrapper extends BaseContract {
 }
 
 class ContractFactory {
-  static async createWeb3jsContract(instance, deploymentTxnHash, web3Wrapper) {
+  static createWeb3jsContract(instance, deploymentTxnHash, web3Wrapper) {
     return new Web3jsContractWrapper(instance, deploymentTxnHash, web3Wrapper)
   }
 }

--- a/solidity/dashboard/src/lib/web3/contract/index.js
+++ b/solidity/dashboard/src/lib/web3/contract/index.js
@@ -1,0 +1,6 @@
+import ContractFactory, {
+  BaseContract,
+  Web3jsContractWrapper,
+} from "./contract"
+
+export { ContractFactory, BaseContract, Web3jsContractWrapper }

--- a/solidity/dashboard/src/lib/web3/index.js
+++ b/solidity/dashboard/src/lib/web3/index.js
@@ -52,7 +52,7 @@ class Web3jsWrapper extends Web3LibWrapper {
     deploymentBlock = null
   ) => {
     const contract = new this.lib.eth.Contract(abi, address)
-    contract.options.defaultAccount = this.defaultAccount
+    contract.options.from = this.defaultAccount
     contract.options.handleRevert = true
 
     return ContractFactory.createWeb3jsContract(

--- a/solidity/dashboard/src/lib/web3/index.js
+++ b/solidity/dashboard/src/lib/web3/index.js
@@ -34,6 +34,10 @@ class Web3LibWrapper {
   set defaultAccount(defaultAccount) {
     this._defaultAccount = defaultAccount
   }
+
+  setProvider = (provider) => {
+    this._setProvider(provider)
+  }
 }
 
 class Web3jsWrapper extends Web3LibWrapper {
@@ -65,6 +69,10 @@ class Web3jsWrapper extends Web3LibWrapper {
 
   get _defaultAccount() {
     return this.lib.eth.defaultAccount
+  }
+
+  _setProvider = (provider) => {
+    this.lib.setProvider(provider)
   }
 }
 

--- a/solidity/dashboard/src/lib/web3/index.js
+++ b/solidity/dashboard/src/lib/web3/index.js
@@ -13,8 +13,18 @@ class Web3LibWrapper {
     return await this._getTransaction(hash)
   }
 
-  createContractInstance = (artifact) => {
-    return this._createContractInstance(artifact)
+  createContractInstance = (
+    abi,
+    address,
+    deploymentTxnHash,
+    deploymentBlock
+  ) => {
+    return this._createContractInstance(
+      abi,
+      address,
+      deploymentTxnHash,
+      deploymentBlock
+    )
   }
 
   get defaultAccount() {
@@ -31,13 +41,12 @@ class Web3jsWrapper extends Web3LibWrapper {
     return await this.lib.eth.getTransaction(hash)
   }
 
-  _createContractInstance = (artifact) => {
-    const { networks, abi } = artifact
-    const networkId = Object.keys(networks)[0]
-
-    const address = networks[networkId].address
-    const deploymentTxnHash = networks[networkId].transactionHash
-
+  _createContractInstance = (
+    abi,
+    address,
+    deploymentTxnHash = null,
+    deploymentBlock = null
+  ) => {
     const contract = new this.lib.eth.Contract(abi, address)
     contract.options.defaultAccount = this.defaultAccount
     contract.options.handleRevert = true
@@ -45,7 +54,8 @@ class Web3jsWrapper extends Web3LibWrapper {
     return ContractFactory.createWeb3jsContract(
       contract,
       deploymentTxnHash,
-      this
+      this,
+      deploymentBlock
     )
   }
 

--- a/solidity/dashboard/src/lib/web3/index.js
+++ b/solidity/dashboard/src/lib/web3/index.js
@@ -27,10 +27,6 @@ class Web3LibWrapper {
 }
 
 class Web3jsWrapper extends Web3LibWrapper {
-  constructor(_lib) {
-    super(_lib)
-  }
-
   _getTransaction = async (hash) => {
     return await this.lib.eth.getTransaction(hash)
   }

--- a/solidity/dashboard/src/lib/web3/index.js
+++ b/solidity/dashboard/src/lib/web3/index.js
@@ -1,0 +1,71 @@
+import {
+  ContractFactory,
+  BaseContract,
+  Web3jsContractWrapper,
+} from "./contract"
+
+class Web3LibWrapper {
+  constructor(_lib) {
+    this.lib = _lib
+  }
+
+  getTransaction = async (hash) => {
+    return await this._getTransaction(hash)
+  }
+
+  createContractInstance = (artifact) => {
+    return this._createContractInstance(artifact)
+  }
+
+  get defaultAccount() {
+    return this._defaultAccount
+  }
+
+  set defaultAccount(defaultAccount) {
+    this._defaultAccount = defaultAccount
+  }
+}
+
+class Web3jsWrapper extends Web3LibWrapper {
+  constructor(_lib) {
+    super(_lib)
+  }
+
+  _getTransaction = async (hash) => {
+    return await this.lib.eth.getTransaction(hash)
+  }
+
+  _createContractInstance = (artifact) => {
+    const { networks, abi } = artifact
+    const networkId = Object.keys(networks)[0]
+
+    const address = networks[networkId].address
+    const deploymentTxnHash = networks[networkId].transactionHash
+
+    const contract = new this.lib.eth.Contract(abi, address)
+    contract.options.defaultAccount = this.defaultAccount
+    contract.options.handleRevert = true
+
+    return ContractFactory.createWeb3jsContract(
+      contract,
+      deploymentTxnHash,
+      this
+    )
+  }
+
+  set _defaultAccount(defaultAccount) {
+    this.lib.eth.defaultAccount = defaultAccount
+  }
+
+  get _defaultAccount() {
+    return this.lib.eth.defaultAccount
+  }
+}
+
+export {
+  Web3jsWrapper,
+  Web3LibWrapper,
+  ContractFactory,
+  BaseContract,
+  Web3jsContractWrapper,
+}

--- a/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
+++ b/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
@@ -16,6 +16,7 @@ import {
   fetchTvlRequest,
   fetchCovPoolDataRequest,
   depositAssetPool,
+  fetchAPYRequest,
 } from "../../actions/coverage-pool"
 import { useWeb3Address } from "../../components/WithWeb3Context"
 import { lte } from "../../utils/arithmetics.utils"
@@ -27,6 +28,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
   const dispatch = useDispatch()
   const {
     totalValueLocked,
+    totalValueLockedInUSD,
     // isTotalValueLockedFetching,
     // isDataFetching,
     shareOfPool,
@@ -35,6 +37,8 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
     // error,
     estimatedRewards,
     estimatedKeepBalance,
+    apy,
+    isApyFetching,
   } = useSelector((state) => state.coveragePool)
   const keepTokenBalance = useSelector((state) => state.keepTokenBalance)
 
@@ -42,6 +46,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
 
   useEffect(() => {
     dispatch(fetchTvlRequest())
+    dispatch(fetchAPYRequest())
   }, [dispatch])
 
   useEffect(() => {
@@ -77,24 +82,23 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
             symbolClassName="h2 text-mint-100"
             withIcon
           />
+          <h3 className="tvl tvl--usd">
+            {`$${totalValueLockedInUSD.toString()} USD`}
+          </h3>
         </section>
         <section className="coverage-pool__overview__apy">
-          <h3 className="text-grey-70 mb-1">Pool APY</h3>
-          <section className="apy__values">
-            <MetricsTile className="bg-mint-10">
-              <APY apy="0.15" className="text-mint-100" />
-              <h5 className="text-grey-60">weekly</h5>
-            </MetricsTile>
-            <MetricsTile className="bg-mint-10">
-              <APY apy="0.50" className="text-mint-100 " />
-              <h5 className="text-grey-60">monthly</h5>
-            </MetricsTile>
-            <MetricsTile className="bg-mint-10">
-              <APY apy="1.40" className="text-mint-100" />
-              <h5 className="text-grey-60">annual</h5>
-            </MetricsTile>
-          </section>
+          <h4 className="text-grey-70 mb-1">Rewards Rate</h4>
+
+          <MetricsTile className="bg-mint-10">
+            <APY
+              apy={apy}
+              isFetching={isApyFetching}
+              className="text-mint-100"
+            />
+            <h5 className="text-grey-60">annual</h5>
+          </MetricsTile>
         </section>
+        {/* TODO add more metrics according to the Figma vies */}
       </section>
 
       <section className="coverage-pool__deposit-wrapper">
@@ -103,6 +107,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
           <DepositForm
             onSubmit={onSubmitDepositForm}
             tokenAmount={keepTokenBalance.value}
+            apy={apy}
           />
         </section>
 
@@ -130,7 +135,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
 
         <section className="tile coverage-pool__rewards">
           <h4 className="text-grey-70 mb-3">Your Rewards</h4>
-          <OnlyIf condition={lte(estimatedRewards, 0) && shareOfPool < 0}>
+          <OnlyIf condition={lte(estimatedRewards, 0) && shareOfPool <= 0}>
             <div className="text-grey-30 text-center">
               You have no rewards yet.&nbsp;
               <br />

--- a/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
+++ b/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
@@ -10,19 +10,19 @@ import {
 import TokenAmount from "../../components/TokenAmount"
 import MetricsTile from "../../components/MetricsTile"
 import { APY } from "../../components/liquidity"
-import { KEEP } from "../../utils/token.utils"
-import { useModal } from "../../hooks/useModal"
+import { Skeleton } from "../../components/skeletons"
+import { useWeb3Address } from "../../components/WithWeb3Context"
+import OnlyIf from "../../components/OnlyIf"
 import {
   fetchTvlRequest,
   fetchCovPoolDataRequest,
   depositAssetPool,
   fetchAPYRequest,
 } from "../../actions/coverage-pool"
-import { useWeb3Address } from "../../components/WithWeb3Context"
+import { useModal } from "../../hooks/useModal"
 import { lte } from "../../utils/arithmetics.utils"
-import OnlyIf from "../../components/OnlyIf"
+import { KEEP } from "../../utils/token.utils"
 import { displayPercentageValue } from "../../utils/general.utils"
-import { Skeleton } from "../../components/skeletons"
 
 const CoveragePoolPage = ({ title, withNewLabel }) => {
   const { openConfirmationModal } = useModal()
@@ -31,11 +31,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
     totalValueLocked,
     totalValueLockedInUSD,
     isTotalValueLockedFetching,
-    // isDataFetching,
     shareOfPool,
-    // covBalance,
-    // covTotalSupply,
-    // error,
     estimatedRewards,
     estimatedKeepBalance,
     apy,

--- a/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
+++ b/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
@@ -22,6 +22,7 @@ import { useWeb3Address } from "../../components/WithWeb3Context"
 import { lte } from "../../utils/arithmetics.utils"
 import OnlyIf from "../../components/OnlyIf"
 import { displayPercentageValue } from "../../utils/general.utils"
+import { Skeleton } from "../../components/skeletons"
 
 const CoveragePoolPage = ({ title, withNewLabel }) => {
   const { openConfirmationModal } = useModal()
@@ -29,7 +30,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
   const {
     totalValueLocked,
     totalValueLockedInUSD,
-    // isTotalValueLockedFetching,
+    isTotalValueLockedFetching,
     // isDataFetching,
     shareOfPool,
     // covBalance,
@@ -39,6 +40,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
     estimatedKeepBalance,
     apy,
     isApyFetching,
+    totalAllocatedRewards,
   } = useSelector((state) => state.coveragePool)
   const keepTokenBalance = useSelector((state) => state.keepTokenBalance)
 
@@ -86,18 +88,38 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
             {`$${totalValueLockedInUSD.toString()} USD`}
           </h3>
         </section>
-        <section className="coverage-pool__overview__apy">
-          <h4 className="text-grey-70 mb-1">Rewards Rate</h4>
+        <div className="coverage-pool__overview__metrics">
+          <section className="metrics__apy">
+            <h4 className="text-grey-70 mb-1">Rewards Rate</h4>
 
-          <MetricsTile className="bg-mint-10">
-            <APY
-              apy={apy}
-              isFetching={isApyFetching}
-              className="text-mint-100"
-            />
-            <h5 className="text-grey-60">annual</h5>
-          </MetricsTile>
-        </section>
+            <MetricsTile className="bg-mint-10 mr-2">
+              <APY
+                apy={apy}
+                isFetching={isApyFetching}
+                className="text-mint-100"
+              />
+              <h5 className="text-grey-60">annual</h5>
+            </MetricsTile>
+          </section>
+          <section className="metrics__total-rewards">
+            <h4 className="text-grey-70 mb-1">Total Rewards</h4>
+
+            <MetricsTile className="bg-mint-10">
+              {isTotalValueLockedFetching ? (
+                <Skeleton tag="h2" shining color="grey-10" />
+              ) : (
+                <TokenAmount
+                  amount={totalAllocatedRewards}
+                  withIcon
+                  withSymbol={false}
+                  withMetricSuffix
+                />
+              )}
+              <h5 className="text-grey-60">pool lifetime</h5>
+            </MetricsTile>
+          </section>
+        </div>
+
         {/* TODO add more metrics according to the Figma vies */}
       </section>
 

--- a/solidity/dashboard/src/reducers/coverage-pool.js
+++ b/solidity/dashboard/src/reducers/coverage-pool.js
@@ -6,13 +6,22 @@ import {
   COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR,
   COVERAGE_POOL_FETCH_COV_POOL_DATA_START,
   COVERAGE_POOL_COV_TOKEN_UPDATED,
+  COVERAGE_POOL_FETCH_APY_START,
+  COVERAGE_POOL_FETCH_APY_SUCCESS,
+  COVERAGE_POOL_FETCH_APY_ERROR,
 } from "../actions/coverage-pool"
 
 export const coveragePoolInitialData = {
   // TVL data
   totalValueLocked: 0,
+  totalValueLockedInUSD: 0,
   isTotalValueLockedFetching: false,
   tvlError: null,
+
+  // APY
+  apy: 0,
+  isApyFetching: false,
+  apyError: null,
 
   isDataFetching: false,
   shareOfPool: 0,
@@ -33,7 +42,8 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
     case COVERAGE_POOL_FETCH_TVL_SUCCESS:
       return {
         ...state,
-        totalValueLocked: action.payload,
+        totalValueLocked: action.payload.tvl,
+        totalValueLockedInUSD: action.payload.tvlInUSD,
         isTotalValueLockedFetching: false,
         tvlError: null,
       }
@@ -62,6 +72,25 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
         ...state,
         isDataFetching: false,
         error: action.payload.error,
+      }
+    case COVERAGE_POOL_FETCH_APY_START:
+      return {
+        ...state,
+        isApyFetching: true,
+      }
+    case COVERAGE_POOL_FETCH_APY_SUCCESS:
+      return {
+        ...state,
+        isApyFetching: false,
+        apy: action.payload,
+        apyError: null,
+      }
+    case COVERAGE_POOL_FETCH_APY_ERROR:
+      return {
+        ...state,
+        isApyFetching: false,
+
+        apyError: action.payload.error,
       }
     default:
       return state

--- a/solidity/dashboard/src/reducers/coverage-pool.js
+++ b/solidity/dashboard/src/reducers/coverage-pool.js
@@ -30,6 +30,7 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
       return {
         ...state,
         totalValueLocked: action.payload,
+        isTotalValueLockedFetching: false,
         tvlError: null,
       }
     case COVERAGE_POOL_FETCH_TVL_ERROR:

--- a/solidity/dashboard/src/reducers/coverage-pool.js
+++ b/solidity/dashboard/src/reducers/coverage-pool.js
@@ -5,6 +5,7 @@ import {
   COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS,
   COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR,
   COVERAGE_POOL_FETCH_COV_POOL_DATA_START,
+  COVERAGE_POOL_COV_TOKEN_UPDATED,
 } from "../actions/coverage-pool"
 
 export const coveragePoolInitialData = {
@@ -19,6 +20,7 @@ export const coveragePoolInitialData = {
   covTotalSupply: 0,
   error: null,
   estimatedRewards: 0,
+  estimatedKeepBalance: 0,
 }
 
 const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
@@ -48,12 +50,10 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
         isDataFetching: true,
       }
     case COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS:
+    case COVERAGE_POOL_COV_TOKEN_UPDATED:
       return {
         ...state,
-        shareOfPool: action.payload.shareOfPool,
-        covBalance: action.payload.covBalance,
-        covTotalSupply: action.payload.covTotalSupply,
-        estimatedRewards: action.payload.estimatedRewards,
+        ...action.payload,
         isDataFetching: false,
         error: null,
       }

--- a/solidity/dashboard/src/reducers/coverage-pool.js
+++ b/solidity/dashboard/src/reducers/coverage-pool.js
@@ -17,6 +17,7 @@ export const coveragePoolInitialData = {
   totalValueLockedInUSD: 0,
   isTotalValueLockedFetching: false,
   tvlError: null,
+  totalAllocatedRewards: 0,
 
   // APY
   apy: 0,
@@ -44,6 +45,7 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
         ...state,
         totalValueLocked: action.payload.tvl,
         totalValueLockedInUSD: action.payload.tvlInUSD,
+        totalAllocatedRewards: action.payload.totalAllocatedRewards,
         isTotalValueLockedFetching: false,
         tvlError: null,
       }

--- a/solidity/dashboard/src/reducers/coverage-pool.js
+++ b/solidity/dashboard/src/reducers/coverage-pool.js
@@ -91,7 +91,6 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
       return {
         ...state,
         isApyFetching: false,
-
         apyError: action.payload.error,
       }
     default:

--- a/solidity/dashboard/src/reducers/coverage-pool.js
+++ b/solidity/dashboard/src/reducers/coverage-pool.js
@@ -2,6 +2,9 @@ import {
   COVERAGE_POOL_FETCH_TVL_START,
   COVERAGE_POOL_FETCH_TVL_SUCCESS,
   COVERAGE_POOL_FETCH_TVL_ERROR,
+  COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS,
+  COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR,
+  COVERAGE_POOL_FETCH_COV_POOL_DATA_START,
 } from "../actions/coverage-pool"
 
 export const coveragePoolInitialData = {
@@ -10,13 +13,12 @@ export const coveragePoolInitialData = {
   isTotalValueLockedFetching: false,
   tvlError: null,
 
-  // shareOfPool
+  isDataFetching: false,
   shareOfPool: 0,
-  isShareOfPoolFetching: false,
-  shareOfPoolError: null,
-
-  weeklyRoi: 0,
-  rewards: 0,
+  covBalance: 0,
+  covTotalSupply: 0,
+  error: null,
+  estimatedRewards: 0,
 }
 
 const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
@@ -38,6 +40,28 @@ const coveragePoolReducer = (state = coveragePoolInitialData, action) => {
         ...state,
         isTotalValueLockedFetching: false,
         tvlError: action.payload.error,
+      }
+
+    case COVERAGE_POOL_FETCH_COV_POOL_DATA_START:
+      return {
+        ...state,
+        isDataFetching: true,
+      }
+    case COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS:
+      return {
+        ...state,
+        shareOfPool: action.payload.shareOfPool,
+        covBalance: action.payload.covBalance,
+        covTotalSupply: action.payload.covTotalSupply,
+        estimatedRewards: action.payload.estimatedRewards,
+        isDataFetching: false,
+        error: null,
+      }
+    case COVERAGE_POOL_FETCH_COV_POOL_DATA_ERROR:
+      return {
+        ...state,
+        isDataFetching: false,
+        error: action.payload.error,
       }
     default:
       return state

--- a/solidity/dashboard/src/sagas/coverage-pool.js
+++ b/solidity/dashboard/src/sagas/coverage-pool.js
@@ -60,7 +60,7 @@ function* fetchCovPoolData(action) {
       balanceOf
     )
     const estimatedKeepBalance = yield call(
-      Keep.coveragePoolV1.estimatedCorateralTokenBalance,
+      Keep.coveragePoolV1.estimatedCollateralTokenBalance,
       shareOfPool
     )
 
@@ -133,7 +133,7 @@ export function* subscribeToCovTokenTransferEvent() {
     )
 
     const estimatedKeepBalance = yield call(
-      Keep.coveragePoolV1.estimatedCorateralTokenBalance,
+      Keep.coveragePoolV1.estimatedCollateralTokenBalance,
       shareOfPool
     )
 

--- a/solidity/dashboard/src/sagas/coverage-pool.js
+++ b/solidity/dashboard/src/sagas/coverage-pool.js
@@ -1,15 +1,28 @@
-import { put, call, takeLatest } from "redux-saga/effects"
+import {
+  put,
+  call,
+  takeLatest,
+  select,
+  take,
+  actionChannel,
+} from "redux-saga/effects"
 import { takeOnlyOnce } from "./effects"
 import {
   COVERAGE_POOL_FETCH_TVL_REQUEST,
   COVERAGE_POOL_FETCH_TVL_ERROR,
+  COVERAGE_POOL_FETCH_COV_POOL_DATA_REQUEST,
+  COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED,
   fetchTvlStart,
   fetchTvlSuccess,
-  fetchShareOfPoolSuccess,
-  COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST,
+  fetchCovPoolDataStart,
+  fetchCovPoolDataSuccess,
+  covTokenUpdated,
 } from "../actions/coverage-pool"
 import { identifyTaskByAddress, logErrorAndThrow, logError } from "./utils"
 import { Keep } from "../contracts"
+import { add, sub } from "../utils/arithmetics.utils"
+import { isSameEthAddress } from "../utils/general.utils"
+import { ZERO_ADDRESS } from "../utils/ethereum.utils"
 
 function* fetchTvl() {
   try {
@@ -31,18 +44,25 @@ export function* watchFetchTvl() {
   yield takeLatest(COVERAGE_POOL_FETCH_TVL_REQUEST, fetchTvl)
 }
 
-function* fetchShareOfPool(action) {
+function* fetchCovPoolData(action) {
   const { address } = action.payload
   try {
+    yield put(fetchCovPoolDataStart())
+
     const balanceOf = yield call(Keep.coveragePoolV1.covBalanceOf, address)
     const totalSupply = yield call(Keep.coveragePoolV1.covTotalSupply)
     const shareOfPool = Keep.coveragePoolV1.shareOfPool(totalSupply, balanceOf)
+    const estimatedRewards = yield call(
+      Keep.coveragePoolV1.estimatedRewards,
+      shareOfPool
+    )
 
     yield put(
-      fetchShareOfPoolSuccess({
+      fetchCovPoolDataSuccess({
         shareOfPool,
         covBalance: balanceOf,
         covTotalSupply: totalSupply,
+        estimatedRewards,
       })
     )
   } catch (error) {
@@ -50,10 +70,63 @@ function* fetchShareOfPool(action) {
   }
 }
 
-export function* watchFetchShareOfPool() {
+export function* watchFetchCovPoolData() {
   yield takeOnlyOnce(
-    COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST,
+    COVERAGE_POOL_FETCH_COV_POOL_DATA_REQUEST,
     identifyTaskByAddress,
-    fetchShareOfPool
+    fetchCovPoolData
   )
+}
+
+export function* subscribeToCovTokenTransferEvent() {
+  const requestChan = yield actionChannel(
+    COVERAGE_POOL_COV_TOKEN_TRANSFER_EVENT_EMITTED
+  )
+
+  while (true) {
+    const {
+      payload: { event },
+    } = yield take(requestChan)
+    const {
+      returnValues: { from, to, value },
+    } = event
+    const { covTotalSupply, covBalance } = yield select(
+      (state) => state.coveragePool
+    )
+
+    const address = yield select((state) => state.app.address)
+    let updatedCovTotalSupply = 0
+    if (isSameEthAddress(from, ZERO_ADDRESS)) {
+      updatedCovTotalSupply = add(covTotalSupply, value)
+    } else if (isSameEthAddress(to, ZERO_ADDRESS)) {
+      updatedCovTotalSupply = add(covTotalSupply, value)
+    }
+
+    let arithmeticOpration = null
+    if (isSameEthAddress(address, from)) {
+      arithmeticOpration = sub
+    } else if (isSameEthAddress(address, to)) {
+      arithmeticOpration = add
+    }
+
+    const updatedCovBalance = arithmeticOpration
+      ? arithmeticOpration(covBalance, value)
+      : covBalance
+
+    const shareOfPool = Keep.coveragePoolV1.shareOfPool(
+      updatedCovTotalSupply,
+      updatedCovBalance
+    )
+
+    // TODO update estimated rewards.
+    const estimatedRewards = 0
+
+    yield put(
+      covTokenUpdated({
+        covBalance: updatedCovBalance,
+        covTotalSupply: updatedCovTotalSupply,
+        shareOfPool,
+      })
+    )
+  }
 }

--- a/solidity/dashboard/src/sagas/coverage-pool.js
+++ b/solidity/dashboard/src/sagas/coverage-pool.js
@@ -43,7 +43,10 @@ function* fetchTvl() {
     const tvl = yield call(Keep.coveragePoolV1.totalValueLocked)
     const keepInUSD = yield call(Keep.exchangeService.getKeepTokenPriceInUSD)
     const tvlInUSD = keepInUSD.multipliedBy(KEEP.toTokenUnit(tvl)).toFormat(2)
-    yield put(fetchTvlSuccess({ tvl, tvlInUSD }))
+    const totalAllocatedRewards = yield call(
+      Keep.coveragePoolV1.totalAllocatedRewards
+    )
+    yield put(fetchTvlSuccess({ tvl, tvlInUSD, totalAllocatedRewards }))
   } catch (error) {
     yield* logError(COVERAGE_POOL_FETCH_TVL_ERROR, error)
   }

--- a/solidity/dashboard/src/sagas/coverage-pool.js
+++ b/solidity/dashboard/src/sagas/coverage-pool.js
@@ -1,27 +1,59 @@
-import { put, call } from "redux-saga/effects"
+import { put, call, takeLatest } from "redux-saga/effects"
 import { takeOnlyOnce } from "./effects"
 import {
   COVERAGE_POOL_FETCH_TVL_REQUEST,
   COVERAGE_POOL_FETCH_TVL_ERROR,
   fetchTvlStart,
   fetchTvlSuccess,
+  fetchShareOfPoolSuccess,
+  COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST,
 } from "../actions/coverage-pool"
-import { identifyTaskByAddress, logErrorAndThrow } from "./utils"
+import { identifyTaskByAddress, logErrorAndThrow, logError } from "./utils"
+import { Keep } from "../contracts"
 
 function* fetchTvl() {
   try {
+    const assetPoolAddress = Keep.coveragePoolV1.assetPoolContract.address
+
     yield put(fetchTvlStart())
-    const tvl = yield call()
+    const tvl = yield call(
+      Keep.coveragePoolV1.corateralTokenContract.makeCall,
+      "balanceOf",
+      assetPoolAddress
+    )
     yield put(fetchTvlSuccess(tvl))
+  } catch (error) {
+    yield* logError(COVERAGE_POOL_FETCH_TVL_ERROR, error)
+  }
+}
+
+export function* watchFetchTvl() {
+  yield takeLatest(COVERAGE_POOL_FETCH_TVL_REQUEST, fetchTvl)
+}
+
+function* fetchShareOfPool(action) {
+  const { address } = action.payload
+  try {
+    const balanceOf = yield call(Keep.coveragePoolV1.covBalanceOf, address)
+    const totalSupply = yield call(Keep.coveragePoolV1.covTotalSupply)
+    const shareOfPool = Keep.coveragePoolV1.shareOfPool(totalSupply, balanceOf)
+
+    yield put(
+      fetchShareOfPoolSuccess({
+        shareOfPool,
+        covBalance: balanceOf,
+        covTotalSupply: totalSupply,
+      })
+    )
   } catch (error) {
     yield* logErrorAndThrow(COVERAGE_POOL_FETCH_TVL_ERROR, error)
   }
 }
 
-export function* watchFetchTvl() {
+export function* watchFetchShareOfPool() {
   yield takeOnlyOnce(
-    COVERAGE_POOL_FETCH_TVL_REQUEST,
+    COVERAGE_POOL_FETCH_SHARE_OF_POOL_REQUEST,
     identifyTaskByAddress,
-    fetchTvl
+    fetchShareOfPool
   )
 }

--- a/solidity/dashboard/src/sagas/coverage-pool.js
+++ b/solidity/dashboard/src/sagas/coverage-pool.js
@@ -166,7 +166,7 @@ function* depositAssetPool(action) {
 
   yield call(sendTransaction, {
     payload: {
-      contract: Keep.coveragePoolV1.corateralTokenContract.instance,
+      contract: Keep.coveragePoolV1.collateralToken.instance,
       methodName: "approveAndCall",
       args: [assetPoolAddress, amount, []],
     },

--- a/solidity/dashboard/src/sagas/index.js
+++ b/solidity/dashboard/src/sagas/index.js
@@ -35,7 +35,11 @@ const loginRequiredSagas = [
   ...Object.values(coveragePool),
 ]
 
-const sagas = [...Object.values(messagesSaga), watchFetchLiquidityRewardsAPY]
+const sagas = [
+  ...Object.values(messagesSaga),
+  watchFetchLiquidityRewardsAPY,
+  ...Object.values(coveragePool),
+]
 
 export default function* rootSaga() {
   yield all(sagas.map(fork))

--- a/solidity/dashboard/src/sagas/index.js
+++ b/solidity/dashboard/src/sagas/index.js
@@ -15,10 +15,8 @@ import * as operator from "./operartor"
 import * as authorization from "./authorization"
 import * as coveragePool from "./coverage-pool"
 
-const {
-  watchFetchLiquidityRewardsAPY,
-  ...restliquidityRewards
-} = liquidityRewards
+const { watchFetchLiquidityRewardsAPY, ...restliquidityRewards } =
+  liquidityRewards
 
 const loginRequiredSagas = [
   ...Object.values(delegateStakeSaga),

--- a/solidity/dashboard/src/sagas/index.js
+++ b/solidity/dashboard/src/sagas/index.js
@@ -30,7 +30,6 @@ const loginRequiredSagas = [
   ...Object.values(restliquidityRewards),
   ...Object.values(operator),
   ...Object.values(authorization),
-  ...Object.values(coveragePool),
 ]
 
 const sagas = [

--- a/solidity/dashboard/src/sagas/selectors.js
+++ b/solidity/dashboard/src/sagas/selectors.js
@@ -1,0 +1,10 @@
+const getUserAddress = (state) => state.app.address
+
+const getCoveragePool = (state) => state.coveragePool
+
+const selectors = {
+  getUserAddress,
+  getCoveragePool,
+}
+
+export default selectors

--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -23,7 +23,7 @@ import {
   covTokenTransferEventEmitted,
   COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS,
 } from "../actions/coverage-pool"
-import Keep from "../lib/keep"
+import { Keep } from "../contracts"
 
 export function* subscribeToKeepTokenTransferEvent() {
   yield take("keep-token/balance_request_success")

--- a/solidity/dashboard/src/sagas/subscriptions.js
+++ b/solidity/dashboard/src/sagas/subscriptions.js
@@ -5,6 +5,7 @@ import {
   getContractsContext,
   getWeb3Context,
   getLPRewardsWrapper,
+  subscribeToEventAndEmitData,
 } from "./utils"
 import { createManagedGrantContractInstance } from "../contracts"
 import { add, sub } from "../utils/arithmetics.utils"
@@ -18,6 +19,11 @@ import {
   OPERATOR_DELEGATION_UNDELEGATED,
   FETCH_OPERATOR_DELEGATIONS_SUCCESS,
 } from "../actions"
+import {
+  covTokenTransferEventEmitted,
+  COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS,
+} from "../actions/coverage-pool"
+import Keep from "../lib/keep"
 
 export function* subscribeToKeepTokenTransferEvent() {
   yield take("keep-token/balance_request_success")
@@ -40,9 +46,15 @@ function* observeKeepTokenTransfer() {
   // Observe and dispatch an action that updates keep token balance.
   while (true) {
     try {
+      const event = yield take(contractEventCahnnel)
       const {
         returnValues: { from, to, value },
-      } = yield take(contractEventCahnnel)
+      } = event
+
+      yield put({
+        type: "keep-token/transfered_event",
+        payload: { event },
+      })
 
       let arithmeticOpration = null
       if (isSameEthAddress(defaultAccount, from)) {
@@ -162,14 +174,13 @@ function* observeStakedEvents() {
         if (!isAddressedToCurrentAccount) {
           // check if current address is a grantee in the managed grant
           try {
-            const managedGrantContractInstance = createManagedGrantContractInstance(
-              web3,
-              grantee
-            )
+            const managedGrantContractInstance =
+              createManagedGrantContractInstance(web3, grantee)
             const granteeAddressInManagedGrant = yield call(
               managedGrantContractInstance.methods.grantee().call
             )
-            delegation.managedGrantContractInstance = managedGrantContractInstance
+            delegation.managedGrantContractInstance =
+              managedGrantContractInstance
             delegation.isManagedGrant = true
 
             // compere a current address with a grantee address from the ManagedGrant contract
@@ -461,11 +472,8 @@ export function* subscribeToTopUpInitiatedEvent() {
 }
 
 function* observeTopUpInitiatedEvent() {
-  const {
-    stakingContract,
-    tokenStakingEscrow,
-    grantContract,
-  } = yield getContractsContext()
+  const { stakingContract, tokenStakingEscrow, grantContract } =
+    yield getContractsContext()
 
   // Other events may also be emitted with the `TopUpInitiated` event.
   const eventsToCheck = [
@@ -529,11 +537,8 @@ export function* subsribeToTopUpCompletedEvent() {
 }
 
 function* observeTopUpCompletedEvent() {
-  const {
-    stakingContract,
-    tokenStakingEscrow,
-    grantContract,
-  } = yield getContractsContext()
+  const { stakingContract, tokenStakingEscrow, grantContract } =
+    yield getContractsContext()
   const eventsToCheck = [
     [grantContract, "TokenGrantStaked"],
     [tokenStakingEscrow, "DepositRedelegated"],
@@ -989,4 +994,18 @@ function* updateOperatorData() {
 export function* subscribeToOperatorUndelegateEvent() {
   yield take(FETCH_OPERATOR_DELEGATIONS_SUCCESS)
   yield fork(updateOperatorData)
+}
+
+export function* observeCovTokenTransferEvent() {
+  yield take(COVERAGE_POOL_FETCH_COV_POOL_DATA_SUCCESS)
+
+  const covTokenContract = Keep.coveragePoolV1.covTokenContract.instance
+
+  yield fork(
+    subscribeToEventAndEmitData,
+    covTokenContract,
+    "Transfer",
+    covTokenTransferEventEmitted,
+    "CovToken.Transfer"
+  )
 }

--- a/solidity/dashboard/src/sagas/utils.js
+++ b/solidity/dashboard/src/sagas/utils.js
@@ -2,6 +2,7 @@ import { call, put, take } from "redux-saga/effects"
 import { Web3Loaded, ContractsLoaded } from "../contracts"
 import { LiquidityRewardsFactory } from "../services/liquidity-rewards"
 import { createSubcribeToContractEventChannel } from "./web3"
+import { isString } from "../utils/general.utils"
 
 /** @typedef { import("../services/liquidity-rewards").LiquidityRewards} LiquidityRewards */
 /** @typedef { import("web3-eth-contract").Contract} Web3jsContract */
@@ -78,10 +79,11 @@ export const identifyTaskBy = (indentificationField) => (action) =>
   action.payload[indentificationField]
 
 /**
- *
+ * A helper saga that subscribes to the contract event and emits an action with
+ * the event data.
  * @param {Web3jsContract} contractInstance A web3 js contract instance.
  * @param {string} eventName The contract event name.
- * @param {string | Function} action The action to emit to the redux.
+ * @param {string | Function} action The action to be emitted to the redux.
  * @param {string} debugName A debug event name.
  */
 export function* subscribeToEventAndEmitData(
@@ -96,12 +98,12 @@ export function* subscribeToEventAndEmitData(
     eventName
   )
   const _debugName = debugName || eventName
-  const isString = typeof action === "string" || action instanceof String
+  const _isString = isString(action)
 
   while (true) {
     try {
       const event = yield take(contractEventCahnnel)
-      const _action = isString
+      const _action = _isString
         ? { type: action, payload: { event } }
         : action(event)
       yield put(_action)

--- a/solidity/dashboard/src/sagas/utils.js
+++ b/solidity/dashboard/src/sagas/utils.js
@@ -1,7 +1,10 @@
-import { call, put } from "redux-saga/effects"
+import { call, put, take } from "redux-saga/effects"
 import { Web3Loaded, ContractsLoaded } from "../contracts"
 import { LiquidityRewardsFactory } from "../services/liquidity-rewards"
+import { createSubcribeToContractEventChannel } from "./web3"
+
 /** @typedef { import("../services/liquidity-rewards").LiquidityRewards} LiquidityRewards */
+/** @typedef { import("web3-eth-contract").Contract} Web3jsContract */
 
 export function* getWeb3Context() {
   return yield Web3Loaded
@@ -73,3 +76,38 @@ export const identifyTaskByAddress = (action) =>
 
 export const identifyTaskBy = (indentificationField) => (action) =>
   action.payload[indentificationField]
+
+/**
+ *
+ * @param {Web3jsContract} contractInstance A web3 js contract instance.
+ * @param {string} eventName The contract event name.
+ * @param {string | Function} action The action to emit to the redux.
+ * @param {string} debugName A debug event name.
+ */
+export function* subscribeToEventAndEmitData(
+  contractInstance,
+  eventName,
+  action,
+  debugName
+) {
+  const contractEventCahnnel = yield call(
+    createSubcribeToContractEventChannel,
+    contractInstance,
+    eventName
+  )
+  const _debugName = debugName || eventName
+  const isString = typeof action === "string" || action instanceof String
+
+  while (true) {
+    try {
+      const event = yield take(contractEventCahnnel)
+      const _action = isString
+        ? { type: action, payload: { event } }
+        : action(event)
+      yield put(_action)
+    } catch (error) {
+      console.error(`Failed subscribing to ${_debugName} event`, error)
+      contractEventCahnnel.close()
+    }
+  }
+}

--- a/solidity/dashboard/src/utils/general.utils.js
+++ b/solidity/dashboard/src/utils/general.utils.js
@@ -158,3 +158,6 @@ export const removeSubstringBetweenCharacter = (
   const final = splittedInput.join(character)
   return final
 }
+
+export const isString = (value) =>
+  typeof value === "string" || value instanceof String

--- a/solidity/dashboard/src/utils/general.utils.js
+++ b/solidity/dashboard/src/utils/general.utils.js
@@ -89,13 +89,12 @@ export const displayPercentageValue = (
     value = formatValue(value)
   }
 
-  let prefix = ""
   if (value > 0 && value <= min) {
-    prefix = `<`
+    return `<${min}%`
   } else if (value >= max) {
-    prefix = `>`
+    return `>${max}%`
   }
-  return `${prefix}${value}%`
+  return `${value}%`
 }
 
 /**

--- a/solidity/dashboard/src/utils/token.utils.js
+++ b/solidity/dashboard/src/utils/token.utils.js
@@ -1,6 +1,5 @@
 import BigNumber from "bignumber.js"
 import * as Icons from "../components/Icons"
-import { isZero, lt } from "./arithmetics.utils"
 
 const metrics = [
   { divisor: 1, symbol: "" },
@@ -160,11 +159,14 @@ export class Token {
   }
 
   _displayAmount = (amount, formattingFn = (amount) => amount) => {
-    if (!amount || isZero(amount)) {
+    const amountInBn = BigNumber.isBigNumber(amount)
+      ? amount
+      : new BigNumber(amount)
+    if (!amount || amountInBn.isZero()) {
       return "0"
     }
 
-    if (lt(amount, this.MIN_AMOUNT_TO_DISPLAY)) {
+    if (amountInBn.lt(this.MIN_AMOUNT_TO_DISPLAY)) {
       return `<${this.MIN_AMOUNT_IN_TOKEN_UNIT}`
     }
 


### PR DESCRIPTION
This PR adds support for fetching coverage pool data from the contracts.

**The main changes**
* `web3` library that provides wrappers for external web3 libraries. These wrappers will help to keep consistent API for external web3 libraries in the entire dapp. This is an introduction to the new approach to how we want to fetch the data from the on-chain contracts. It will make writing unit tests and for example migrations from `web3` to the `ethers.js ` easier.
* `keep` library that provides all contracts that are used in the KEEP Token Dashboard and services(currently provides `CoveragePoolV1` and `ExchangeService`). It will help to maintain and add new services like eg. `CoveragePoolV1` which are responsible for fetching data. It will also make writing unit tests easier. In the future, we will migrate all functions from the `services` dir to this library. It also requires some reorg because some utils from the dapp are used in this library- it should be independent.
* redux sagas that fetching cov pool data via the new `keep` library.
* update the `start_dashboard` script- build and link the `coverage-pool` contracts. Please see https://github.com/keep-network/coverage-pools/pull/103.