### PR TITLE
Rename `-solidity-version` parameter suffix with `-contracts-version`

### DIFF
--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -89,17 +89,17 @@ jobs:
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version
-            keep-ecdsa-solidity-version = github.com/keep-network/keep-ecdsa/solidity#version
-            tbtc-solidity-version = github.com/keep-network/tbtc/solidity#version
+            keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
+            keep-ecdsa-contracts-version = github.com/keep-network/keep-ecdsa/solidity#version
+            tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 
       - name: Resolve latest contracts
         if: github.event_name == 'workflow_dispatch'
         run: |
             npm install --save-exact \
-              @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-solidity-version }} \
-              @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-solidity-version }} \
-              @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-solidity-version }}
+              @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
+              @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }} \
+              @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Change introduced for better understandability of parameter's meaning.

Refs:
https://github.com/keep-network/keep-ecdsa/pull/864
https://github.com/keep-network/tbtc/pull/814
https://github.com/keep-network/tbtc.js/pull/127
https://github.com/keep-network/upstream-builds-query/pull/3
https://github.com/keep-network/coverage-pools/pull/157