### PR TITLE
Update custom actions paths after moving actions to `ci`

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -119,7 +119,7 @@ jobs:
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -119,7 +119,7 @@ jobs:
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -253,7 +253,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       
       - name: Notify CI about completion of the workflow
-        uses: keep-network/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -178,8 +178,7 @@ jobs:
 
       - name: Push contracts to Tenderly
         if: github.event.inputs.environment == 'ropsten'
-        # TODO: once below action gets tagged replace `@main` with `@v1`
-        uses: keep-network/tenderly-push-action@main
+        uses: keep-network/tenderly-push-action@v1
         continue-on-error: true
         with:
           working-directory: ./solidity

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -253,7 +253,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -129,7 +129,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache Global NPM Cache
         uses: actions/cache@v2

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get upstream packages' versions
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/upstream-builds-query@v1
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -137,7 +137,7 @@ jobs:
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get upstream packages' versions
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/upstream-builds-query@v1
+        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -137,7 +137,7 @@ jobs:
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache node modules


### PR DESCRIPTION
We've moved custom actions used in the Keep/tBTC Continuous Integration
from separate repositories to `ci` repository (under `actions` folder).
We now need to update all the actions' invokations.

Note that temporarily we call the actions on the feature branch - this
is only for testing purposes and will be changed to `@v1` once
tested.

Refs:
https://github.com/keep-network/ci/pull/11
https://github.com/keep-network/keep-ecdsa/pull/868
https://github.com/keep-network/tbtc/pull/816
https://github.com/keep-network/tbtc-dapp/pull/400
https://github.com/keep-network/tbtc.js/pull/128
https://github.com/keep-network/coverage-pools/pull/167

TODO:
- [x] test deployment flow on the feature branch
- [x] point to `@v1` in lines invoking actions (same change required in other repos)