### PR TITLE
Change value of the CHAIN_API_URL

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Migrate contracts on Ethereum
         if: github.event.inputs.environment != 'alfajores'
         env:
-          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_WS }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK


### PR DESCRIPTION
We've changed the names of the secrets and need to update the workflow
configs accordingly. The change of secret name was introduced to
differentiate between WS and HTTP urls.

Refs:
* https://github.com/keep-network/keep-ecdsa/pull/872
* https://github.com/keep-network/tbtc/pull/818
* https://github.com/keep-network/local-setup/pull/104