### PR TITLE
Remove artifact folder before copying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 ./solidity/truffle.js
+artifacts/
 build/
 vendor/
 _local/

--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -89,6 +89,7 @@ CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY
     npx truffle migrate --reset --network $NETWORK
 
 printf "${LOG_START}Copying contract artifacts...${LOG_END}"
+rm -rf artifacts
 cp -r build/contracts artifacts
 npm link
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,7 @@ CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY \
     npx truffle migrate --reset --network $NETWORK
 
 printf "${LOG_START}Copying contract artifacts...${LOG_END}"
+rm -rf artifacts
 cp -r build/contracts artifacts
 npm link
 


### PR DESCRIPTION
This PR adds a small change - `artifact` folder is removed before copying contract artefacts.
Also the `artifacts/` directory is added to `.gitignore`.