### PR TITLE
Publish Keep Dashboard to GCS bucket on testnet

### DIFF
--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -104,39 +104,23 @@ jobs:
               @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
               @keep-network/coverage-pools@${{ steps.upstream-builds-query.outputs.coverage-pools-version }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: NPM install
+        run: npm ci
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      - name: NPM build
+        run: npm run build
 
-      - name: Login to Google Container Registry
+      - name: Deploy to GCP bucket
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/login-action@v1
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
-          registry: ${{ env.GCR_REGISTRY_URL }}
-          username: _json_key
-          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
-      - name: Build and publish Keep Token Dashboard image
-        uses: docker/build-push-action@v2
-        env:
-          IMAGE_NAME: 'keep-dapp-token-dashboard'
-        with:
-          context: ./solidity/dashboard/
-          # GCR image should be named according to following convention:
-          # HOSTNAME/PROJECT-ID/IMAGE:TAG
-          # We don't use TAG yet, will be added at later stages of work on RFC-18.
-          tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
-          labels: revision=${{ github.sha }}
-          push: ${{ github.event_name == 'workflow_dispatch' }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          project: ${{ env.GOOGLE_PROJECT_ID }}
+          bucket-name: keep-test-dashboard-dapp
+          set-website: true
+          home-page-path: index.html
+          error-page-path: index.html
+          build-folder: solidity/dashboard/build
       
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
@@ -150,13 +134,3 @@ jobs:
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ github.sha }}
-
-      - # Temp fix - move cache instead of copying (added below step and
-        # modified value of `cache-to`).
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        # Without the change some jobs were failing with `no space left on device`
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: ${{ env.GOOGLE_PROJECT_ID }}
-          bucket-name: keep-test-dashboard-dapp
+          bucket-name: dashboard.test.keep.network
           set-website: true
           home-page-path: index.html
           error-page-path: index.html

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -104,9 +104,6 @@ jobs:
               @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
               @keep-network/coverage-pools@${{ steps.upstream-builds-query.outputs.coverage-pools-version }}
 
-      - name: NPM install
-        run: npm ci
-
       - name: NPM build
         run: npm run build
 


### PR DESCRIPTION
Here we change the Keep Dashboard testnet job to publish static files to the GCS bucket instead of building and pushing a Docker image. This change is a part of our shift from Kubernetes to GCS as a hosting platform for static websites/dapps.