### PR TITLE
Expose metrics on `keep-core` testnet nodes

### DIFF
--- a/infrastructure/kube/keep-test/keep-client-0-service.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-service.yaml
@@ -14,6 +14,9 @@ spec:
   - port: 3919
     targetPort: 3919
     name: tcp-3919
+  - port: 9601
+    targetPort: 9601
+    name: tcp-9601
   selector:
     app: keep
     type: beacon

--- a/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-0-statefulset.yaml
@@ -117,6 +117,8 @@ spec:
             value: '3919'
           - name: KEEP_CLIENT_DATA_DIR
             value: /mnt/keep-client/data
+          - name: METRICS_PORT
+            value: '9601'
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config

--- a/infrastructure/kube/keep-test/keep-client-1-service.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-service.yaml
@@ -14,6 +14,9 @@ spec:
   - port: 3919
     targetPort: 3919
     name: tcp-3919
+  - port: 9601
+    targetPort: 9601
+    name: tcp-9601
   selector:
     app: keep
     type: beacon

--- a/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-1-statefulset.yaml
@@ -117,6 +117,8 @@ spec:
             value: '3919'
           - name: KEEP_CLIENT_DATA_DIR
             value: /mnt/keep-client/data
+          - name: METRICS_PORT
+            value: '9601'
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config

--- a/infrastructure/kube/keep-test/keep-client-2-service.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-service.yaml
@@ -14,6 +14,9 @@ spec:
   - port: 3919
     targetPort: 3919
     name: tcp-3919
+  - port: 9601
+    targetPort: 9601
+    name: tcp-9601
   selector:
     app: keep
     type: beacon

--- a/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-2-statefulset.yaml
@@ -122,6 +122,8 @@ spec:
             value: '3919'
           - name: KEEP_CLIENT_DATA_DIR
             value: /mnt/keep-client/data
+          - name: METRICS_PORT
+            value: '9601'
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config

--- a/infrastructure/kube/keep-test/keep-client-3-service.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-service.yaml
@@ -14,6 +14,9 @@ spec:
   - port: 3919
     targetPort: 3919
     name: tcp-3919
+  - port: 9601
+    targetPort: 9601
+    name: tcp-9601
   selector:
     app: keep
     type: beacon

--- a/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-3-statefulset.yaml
@@ -117,6 +117,8 @@ spec:
             value: '3919'
           - name: KEEP_CLIENT_DATA_DIR
             value: /mnt/keep-client/data
+          - name: METRICS_PORT
+            value: '9601'
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config

--- a/infrastructure/kube/keep-test/keep-client-4-service.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-service.yaml
@@ -14,6 +14,9 @@ spec:
   - port: 3919
     targetPort: 3919
     name: tcp-3919
+  - port: 9601
+    targetPort: 9601
+    name: tcp-9601
   selector:
     app: keep
     type: beacon

--- a/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-client-4-statefulset.yaml
@@ -117,6 +117,8 @@ spec:
             value: '3919'
           - name: KEEP_CLIENT_DATA_DIR
             value: /mnt/keep-client/data
+          - name: METRICS_PORT
+            value: '9601'
         volumeMounts:
           - name: keep-client-config
             mountPath: /mnt/keep-client/config

--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-config-template.toml
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/keep-client-config-template.toml
@@ -25,3 +25,6 @@
 
 [Storage]
   DataDir = ""
+
+[Metrics]
+  Port = ""

--- a/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
+++ b/infrastructure/kube/templates/keep-client/initcontainer/provision-keep-client/provision-keep-client.js
@@ -199,6 +199,8 @@ async function createKeepClientConfig() {
 
     parsedConfigFile.Storage.DataDir = process.env.KEEP_CLIENT_DATA_DIR;
 
+    parsedConfigFile.Metrics.Port = Number(process.env.METRICS_PORT)
+
     /*
     tomlify.toToml() writes our Seed/Port values as a float.  The added precision renders our config
     file unreadable by the keep-client as it interprets 3919.0 as a string when it expects an int.


### PR DESCRIPTION
Here we expose metrics on `keep-core` testnet nodes. This is required by the monitoring system.