### PR TITLE
Fix group selection event deduplication logic

### DIFF
--- a/pkg/beacon/relay/gjkr/states.go
+++ b/pkg/beacon/relay/gjkr/states.go
@@ -36,6 +36,25 @@ const (
 	combinationStateActiveBlocks = 20
 )
 
+// ProtocolBlocks returns the total number of blocks it takes to execute
+// all the required work defined by the GJKR protocol.
+func ProtocolBlocks() uint64 {
+	return ephemeralKeyPairStateDelayBlocks +
+		ephemeralKeyPairStateActiveBlocks +
+		commitmentStateDelayBlocks +
+		commitmentStateActiveBlocks +
+		commitmentVerificationStateDelayBlocks +
+		commitmentVerificationStateActiveBlocks +
+		pointsShareStateDelayBlocks +
+		pointsShareStateActiveBlocks +
+		pointsValidationStateDelayBlocks +
+		pointsValidationStateActiveBlocks +
+		keyRevealStateDelayBlocks +
+		keyRevealStateActiveBlocks +
+		combinationStateDelayBlocks +
+		combinationStateActiveBlocks
+}
+
 // ephemeralKeyPairGenerationState is the state during which members broadcast
 // public ephemeral keys generated for other members of the group.
 // `EphemeralPublicKeyMessage`s are valid in this state.


### PR DESCRIPTION
We deduplicate `GroupSelectionStarted` events by keeping them into the `pendingGroupSelections` cache. Duplicated events may occur due to chain reorgs or because of the subscription monitoring mechanism which re-fetches past events in case something bad happens with the WebSocket connection pointing to the Ethereum node.

So far, we removed the current group selection from cache just after ticket submission terminated. We can't do that because a duplicated event can come right after the removal and trigger a new DKG breaking the ongoing one.

To fix the problem, we need to hold the cache entry for the maximum DKG duration time. We should also do it regardless of the protocol outcome on the host node as other nodes may still execute the protocol successfully.

Worth flagging that removing the cache entry after hitting the DKG timeout is enough and we don't need to monitor for a successful group registration. A successful group registration means we never have to trigger group selection
again for the group seed we hold in the cache so we don't have to bother about removing the cache entry just after the group is registered. In the contrary, when the current group selection fails, we need to remove the cache entry once the timeout is hit to allow the node to retry the group selection for that seed as soon as possible.