### PR TITLE
Add Max Amount button to Withdraw ETH modal

### DIFF
--- a/solidity-v1/dashboard/src/components/WithdrawETHModal.jsx
+++ b/solidity-v1/dashboard/src/components/WithdrawETHModal.jsx
@@ -13,6 +13,7 @@ import { connect } from "react-redux"
 import MaxAmountAddon from "./MaxAmountAddon"
 import useSetMaxAmountToken from "../hooks/useSetMaxAmountToken"
 import AvailableTokenForm from "./AvailableTokenForm"
+import { ETH } from "../utils/token.utils"
 
 const WithdrawETHModal = ({
   operatorAddress,
@@ -85,7 +86,12 @@ export default React.memo(connect(null, mapDispatchToProps)(WithdrawETHModal))
 
 const WithdrawETHForm = (props) => {
   const { availableETHInWei } = props
-  const setMaxAmount = useSetMaxAmountToken("ethAmount", availableETHInWei)
+  const setMaxAmount = useSetMaxAmountToken(
+    "ethAmount",
+    availableETHInWei,
+    ETH,
+    ETH.decimals
+  )
   return (
     <AvailableTokenForm
       formInputProps={{


### PR DESCRIPTION
There was a suggestion to add a **Max Amount** button when withdrawing ETH. This PR adds that.

![image](https://user-images.githubusercontent.com/40306834/130908263-ffe31fb6-923b-49b7-8ec5-e96fc4d6d224.png)
