### PR TITLE
Balance monitoring retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec
-	github.com/keep-network/keep-common v1.5.1
+	github.com/keep-network/keep-common v1.7.0
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.5.1 h1:zgUUe2zJNFo9gSgH3RZc+rkm0jpNMK45PJVnJ992U5E=
-github.com/keep-network/keep-common v1.5.1/go.mod h1:g4RTDmhQMgwnlkU5bzW6cSz9dM+0UiQDPtow5NWdYbc=
+github.com/keep-network/keep-common v1.7.0 h1:K9OOam4VWfEVf+tMtl0HSwRxGZ/l6JiD1+UXKKCjXOA=
+github.com/keep-network/keep-common v1.7.0/go.mod h1:g4RTDmhQMgwnlkU5bzW6cSz9dM+0UiQDPtow5NWdYbc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/chain/ethereum/balance_monitoring.go
+++ b/pkg/chain/ethereum/balance_monitoring.go
@@ -61,7 +61,7 @@ func (ec *ethereumChain) balanceMonitor() (*ethutil.BalanceMonitor, error) {
 	) (*ethereum.Wei, error) {
 		ctx, cancelCtx := context.WithTimeout(
 			context.Background(),
-			1*time.Minute,
+			30*time.Second,
 		)
 		defer cancelCtx()
 

--- a/pkg/chain/ethereum/balance_monitoring.go
+++ b/pkg/chain/ethereum/balance_monitoring.go
@@ -21,6 +21,10 @@ var defaultBalanceAlertThreshold = ethereum.WrapWei(
 // check should be triggered.
 const defaultBalanceMonitoringTick = 10 * time.Minute
 
+// defaultBalanceMonitoringRetryTimeout determines the timeout for balance check
+// at each tick.
+const defaultBalanceMonitoringRetryTimeout = 5 * time.Minute
+
 // initializeBalanceMonitoring sets up the balance monitoring process
 func (ec *ethereumChain) initializeBalanceMonitoring(ctx context.Context) {
 	balanceMonitor, err := ec.balanceMonitor()
@@ -39,6 +43,7 @@ func (ec *ethereumChain) initializeBalanceMonitoring(ctx context.Context) {
 		ec.Address(),
 		alertThreshold,
 		defaultBalanceMonitoringTick,
+		defaultBalanceMonitoringRetryTimeout,
 	)
 
 	logger.Infof(


### PR DESCRIPTION
We want to use a retry mechanism for single executions of the balance check.
The retries will be performed during the period of retry timeout, logging a warning on each error. When the timeout is hit an error will be logged and retries stopped. The next balance check will be triggered at the next tick.

The same changes were introduced in keep-ecdsa client in https://github.com/keep-network/keep-ecdsa/pull/905
Reference changes in keep-common: https://github.com/keep-network/keep-common/pull/82