### PR TITLE
Updated guides with latest ropsten contracts

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -450,7 +450,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0xF63bF51797377Af850CBBdd51Ed8f3D238ea907D`
+|`0x9b20291F016f5CcF8956585681C6c338082925BC`
 |===
 
 [%header,cols=2*]
@@ -459,10 +459,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0x50BD3A8E3b1749E82A3C604db6559cab9C6232bD`
+|`0x70DB2e8bd0835FcEF45c7584938e7FD1442fabdd`
 
 |KeepRandomBeaconOperator
-|`0x7728660fC0C8a48986f902Cb41C98931cd32C7B0`
+|`0xC5312D5E85263362fF6283b0e9F7E2a242a4d4D8`
 |===
 
 


### PR DESCRIPTION
We update guides with addresses of the contracts that were recently
migrated on ropsten and are backed by keep-test nodes.

Job that migrated contracts:
https://github.com/keep-network/keep-core/actions/runs/1182831560