### PR TITLE
Adding cron for daily tests and builds on Meercode

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,4 +1,4 @@
-name: Go / keep-core
+name: Go
 
 on:
   schedule:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,6 +1,8 @@
-name: Go
+name: Go / keep-core
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,6 +1,8 @@
-name: Solidity
+name: Solidity / keep-core
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,4 +1,4 @@
-name: Solidity / keep-core
+name: Solidity
 
 on:
   schedule:

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -1,6 +1,8 @@
 name: Token Dashboard / Testnet
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
      - main


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.