### PR TITLE
Cov pools improvements

### DIFF
--- a/solidity/dashboard/src/components/AuthorizeContracts.jsx
+++ b/solidity/dashboard/src/components/AuthorizeContracts.jsx
@@ -7,7 +7,7 @@ import { KEEP } from "../utils/token.utils"
 import StatusBadge, { BADGE_STATUS } from "./StatusBadge"
 import { shortenAddress } from "../utils/general.utils"
 import resourceTooltipProps from "../constants/tooltips"
-import Tooltip from "./Tooltip"
+import Tooltip, { TOOLTIP_DIRECTION } from "./Tooltip"
 import { AUTH_CONTRACTS_LABEL } from "../constants/constants"
 
 const AuthorizeContracts = ({
@@ -152,7 +152,7 @@ const AuthorizeContractItem = ({
             }
             simple
             delay={10}
-            direction="top"
+            direction={TOOLTIP_DIRECTION.TOP}
             contentWrapperStyles={styles.tooltipContentWrapper}
             triggerComponent={() => (
               <SubmitButton

--- a/solidity/dashboard/src/components/ConnectWalletBtn.jsx
+++ b/solidity/dashboard/src/components/ConnectWalletBtn.jsx
@@ -1,6 +1,6 @@
 import React from "react"
 import WalletOptions from "./WalletOptions"
-import Tooltip from "./Tooltip"
+import Tooltip, { TOOLTIP_DIRECTION } from "./Tooltip"
 
 const ConnectWalletBtn = ({
   text,
@@ -9,7 +9,7 @@ const ConnectWalletBtn = ({
 }) => {
   return (
     <Tooltip
-      direction="top"
+      direction={TOOLTIP_DIRECTION.TOP}
       simple
       className="empty-state__wallet-options-tooltip"
       triggerComponent={() => (

--- a/solidity/dashboard/src/components/Tooltip.jsx
+++ b/solidity/dashboard/src/components/Tooltip.jsx
@@ -1,10 +1,15 @@
 import React, { useEffect, useState, useRef } from "react"
 import { CSSTransition } from "react-transition-group"
 
+export const TOOLTIP_DIRECTION = {
+  TOP: "top",
+  BOTTOM: "bottom",
+}
+
 const Tooltip = ({
   triggerComponent: TriggerComponent,
   children,
-  direction = "bottom",
+  direction = TOOLTIP_DIRECTION.BOTTOM,
   simple = false,
   delay = 300,
   className = "",
@@ -14,6 +19,8 @@ const Tooltip = ({
 }) => {
   const timeout = useRef(null)
   const [active, setActive] = useState(false)
+  const contentRef = useRef(null)
+  const arrowRef = useRef(null)
 
   useEffect(() => {
     return () => {
@@ -23,7 +30,31 @@ const Tooltip = ({
     }
   })
 
+  /**
+   * Check if tooltip is out of the RIGHT side of the view.
+   * If it is it will move the tooltip to the left.
+   */
+  const handleDropdownPosition = () => {
+    if (!contentRef || !contentRef.current) return
+    if (!arrowRef || !arrowRef.current) return
+    const contentRect = contentRef.current.getBoundingClientRect()
+    const contentRightX = contentRect.x + contentRect.width
+
+    if (contentRightX > window.outerWidth) {
+      contentRef.current.style.transform = `translateX(calc(-100% + 9px))`
+      if (direction === TOOLTIP_DIRECTION.TOP) {
+        contentRef.current.style.borderBottomRightRadius = "0"
+      } else if (direction === TOOLTIP_DIRECTION.BOTTOM) {
+        contentRef.current.style.borderTopRightRadius = "0"
+      }
+
+      arrowRef.current.style.left = "auto"
+      arrowRef.current.style.right = "calc(0%)"
+    }
+  }
+
   const showTooltip = () => {
+    handleDropdownPosition()
     setActive(true)
     clearTimeout(timeout.current)
   }
@@ -64,7 +95,9 @@ const Tooltip = ({
           style={contentWrapperStyles}
           onMouseEnter={showTooltip}
           onMouseLeave={hideTooltip}
+          ref={contentRef}
         >
+          <div ref={arrowRef} className={"tooltip__arrow"} />
           {children}
         </div>
       </CSSTransition>

--- a/solidity/dashboard/src/components/coverage-pools/LearnMoreBanner.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/LearnMoreBanner.jsx
@@ -9,7 +9,7 @@ const LearnMoreBanner = ({ onClose }) => {
       <Banner.CloseIcon onClick={onClose} />
       <div className="banner__content-wrapper">
         <Banner.Icon icon={Icons.CoveragePool} />
-        <Banner.Title className="h3 text-white">
+        <Banner.Title className="h3 text-white banner__title--font-weight-600">
           <p className="mb-0">Deposit KEEP in the coverage pool to</p>
           <p className="mb-0">secure the network and earn rewards.</p>
         </Banner.Title>

--- a/solidity/dashboard/src/components/coverage-pools/LearnMoreBanner.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/LearnMoreBanner.jsx
@@ -11,7 +11,7 @@ const LearnMoreBanner = ({ onClose }) => {
         <Banner.Icon icon={Icons.CoveragePool} />
         <Banner.Title className="h3 text-white">
           <p className="mb-0">Deposit KEEP in the coverage pool to</p>
-          <p className="mb-0">secure the network and earn rewards</p>
+          <p className="mb-0">secure the network and earn rewards.</p>
         </Banner.Title>
         <NavLink
           to="/coverage-pools/how-it-works"

--- a/solidity/dashboard/src/components/coverage-pools/MetricsSection.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/MetricsSection.jsx
@@ -6,6 +6,7 @@ import { Skeleton } from "../skeletons"
 import TokenAmount from "../TokenAmount"
 import ResourceTooltip from "../ResourceTooltip"
 import OnlyIf from "../OnlyIf"
+import { TOOLTIP_DIRECTION } from "../Tooltip"
 
 const MetricsSection = ({
   tvl,
@@ -42,7 +43,7 @@ const MetricsSection = ({
 
       <section className={`metrics__reward-rate ${classes.rewardRate || ""}`}>
         <MetricsTile className="bg-mint-10">
-          <MetricsTile.Tooltip direction="top">
+          <MetricsTile.Tooltip direction={TOOLTIP_DIRECTION.TOP}>
             The rate of rewards that you will receive annually.
           </MetricsTile.Tooltip>
           <APY
@@ -58,7 +59,7 @@ const MetricsSection = ({
         className={`metrics__total-rewards ${classes.totalRewards || ""}`}
       >
         <MetricsTile className="bg-mint-10">
-          <MetricsTile.Tooltip direction="top">
+          <MetricsTile.Tooltip direction={TOOLTIP_DIRECTION.TOP}>
             Rewards distributed from the rewards pool contract since the start
             of the pool.
           </MetricsTile.Tooltip>
@@ -81,7 +82,7 @@ const MetricsSection = ({
         className={`metrics__lifetime-covered ${classes.lifetimeCovered || ""}`}
       >
         <MetricsTile className="bg-mint-10">
-          <MetricsTile.Tooltip direction="top">
+          <MetricsTile.Tooltip direction={TOOLTIP_DIRECTION.TOP}>
             Amount of KEEP used from the coverage pool to cover a loss since the
             start of the pool.
           </MetricsTile.Tooltip>

--- a/solidity/dashboard/src/css/banner.less
+++ b/solidity/dashboard/src/css/banner.less
@@ -123,7 +123,10 @@
     .banner__title {
       &:extend(.h3);
       margin-bottom: 2rem;
-      font-weight: 600;
+
+      &--font-weight-600 {
+        font-weight: 600;
+      }
     }
 
     .banner__icon {

--- a/solidity/dashboard/src/css/banner.less
+++ b/solidity/dashboard/src/css/banner.less
@@ -123,6 +123,7 @@
     .banner__title {
       &:extend(.h3);
       margin-bottom: 2rem;
+      font-weight: 600;
     }
 
     .banner__icon {

--- a/solidity/dashboard/src/css/buttons.less
+++ b/solidity/dashboard/src/css/buttons.less
@@ -55,7 +55,7 @@ button,
     font-size: 0.75rem;
     line-height: 1.25rem;
     background-color: @color-black;
-    border-color: @color-black;
+    border: 0.5px solid @color-black;
     color: @primary-color;
     padding: 1rem 2.25rem;
 
@@ -91,7 +91,7 @@ button,
     background-color: @white;
     border: 0.5px solid @color-black;
     color: @color-black;
-    padding: 1rem 2rem;
+    padding: 1rem 2.25rem;
 
     &:after {
       position: absolute;
@@ -130,14 +130,6 @@ button,
 
   &-transparent {
     background-color: transparent;
-  }
-
-  &-tertiary {
-    font-weight: 500;
-    font-size: 0.75rem;
-    line-height: 1.5rem;
-    padding: 0.325rem 0.75rem;
-    padding: 0.5rem 0.75rem;
   }
 }
 

--- a/solidity/dashboard/src/css/timeline.less
+++ b/solidity/dashboard/src/css/timeline.less
@@ -94,6 +94,7 @@
 
   h4 {
     color: @color-grey-60;
+    margin: 0.4rem 0;
   }
 
   &--active {

--- a/solidity/dashboard/src/css/tooltip.less
+++ b/solidity/dashboard/src/css/tooltip.less
@@ -21,7 +21,7 @@
         top: 2rem;
       }
 
-      &:after {
+      .tooltip__arrow {
         content: "";
         height: 0;
         width: 0;
@@ -40,7 +40,7 @@
   &--top {
     .tooltip__content-wrapper {
       bottom: calc(100% + @tooltip-arrow-size);
-      &::after {
+      .tooltip__arrow {
         top: 100%;
         border-bottom: none;
         border-top: @tooltip-arrow-size solid @color-black;

--- a/solidity/dashboard/src/pages/OverviewPage.jsx
+++ b/solidity/dashboard/src/pages/OverviewPage.jsx
@@ -28,9 +28,8 @@ const OverviewPage = (props) => {
   const { isConnected } = useWeb3Context()
   const address = useWeb3Address()
   const dispatch = useDispatch()
-  const { covTokensAvailableToWithdraw } = useSelector(
-    (state) => state.coveragePool
-  )
+  const { covTokensAvailableToWithdraw, withdrawalInitiatedTimestamp } =
+    useSelector((state) => state.coveragePool)
 
   useEffect(() => {
     if (isConnected) {
@@ -101,9 +100,11 @@ const OverviewPage = (props) => {
         <CoveragePoolsComponents.LearnMoreBanner onClose={hideBanner} />
       </OnlyIf>
       <OverviewFirstSection />
-      <PendingWithdrawals
-        covTokensAvailableToWithdraw={covTokensAvailableToWithdraw}
-      />
+      <OnlyIf condition={withdrawalInitiatedTimestamp > 0}>
+        <PendingWithdrawals
+          covTokensAvailableToWithdraw={covTokensAvailableToWithdraw}
+        />
+      </OnlyIf>
       <TokenOverview
         totalKeepTokenBalance={totalKeepTokenBalance}
         totalOwnedStakedBalance={totalOwnedStakedBalance}


### PR DESCRIPTION
Fixes: #2591 

Styling improvements for cov pools:
- [x] hide **Pending Withdrawal** section in **Overview** page when there are no pending withdrawals
- [x] add weight and dot at the end to the tile of the coverage pools banner
- [x] set same height for primary, secondary and tertiary buttons
- [x] add more space between title and description in the timeline card
- [ ] ~~add more side margins to the cov pools page~~ (the main objective behind this was to prevent tooltips from being cutted out of the viewport. Since it was resolved i decided to not adding more margins here)
- [x] make sure tooltips aren't cut out in some resolutions (when they are close to borders)<details><summary>Screenshot - tooltip fix</summary>
![image](https://user-images.githubusercontent.com/40306834/133261350-ae6f8718-ac98-466f-9d82-dfa91baa8eac.png)
</details>