### PR TITLE
Change type of amount sent when depositing

### DIFF
--- a/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
+++ b/solidity/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
@@ -68,7 +68,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
 
   const onSubmitDepositForm = async (values, awaitingPromise) => {
     const { tokenAmount } = values
-    const amount = KEEP.fromTokenUnit(tokenAmount)
+    const amount = KEEP.fromTokenUnit(tokenAmount).toString()
     await openConfirmationModal(
       {
         modalOptions: {


### PR DESCRIPTION
We are changing the amount type from BigNumber to string because it looks like
it transactions doesn't work with the amount as BigNumber.