### PR TITLE
Fix bug when updating data after withdrawal is completed

### DIFF
--- a/solidity/dashboard/src/sagas/coverage-pool.js
+++ b/solidity/dashboard/src/sagas/coverage-pool.js
@@ -389,20 +389,23 @@ export function* subscribeToWithdrawalCompletedEvent() {
       shareOfPool
     )
 
-    yield put(
-      covTokenUpdated({
-        pendingWithdrawal: "0",
-        withdrawalInitiatedTimestamp: "0",
-        shareOfPool,
-        covBalance: updatedCovBalance,
-        covTotalSupply: updatedCovTotalSupply,
-        estimatedRewards,
-        estimatedKeepBalance,
-        totalValueLockedInUSD,
-        totalValueLocked,
-        apy,
-      })
-    )
+    const covTokenUpdatedData = {
+      shareOfPool,
+      covBalance: updatedCovBalance,
+      covTotalSupply: updatedCovTotalSupply,
+      estimatedRewards,
+      estimatedKeepBalance,
+      totalValueLockedInUSD,
+      totalValueLocked,
+      apy,
+    }
+
+    if (isAddressedToCurrentAddress) {
+      covTokenUpdatedData.pendingWithdrawal = "0"
+      covTokenUpdatedData.withdrawalInitiatedTimestamp = "0"
+    }
+
+    yield put(covTokenUpdated(covTokenUpdatedData))
   }
 }
 


### PR DESCRIPTION
There is a bug that causes the Pending Withdrawal to disappear when another user
complete his own withdrawal. The pending withdrawal for current user was not
visible in such case unless he refresh the page. This PR fixes that.