### PR TITLE
Update dashboard dependendencies to tbtc-v2 project

### DIFF
--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -81,6 +81,7 @@ jobs:
               @keep-network/keep-core \
               @keep-network/keep-ecdsa \
               @keep-network/tbtc \
+              @keep-network/tbtc-v2 \
               @keep-network/coverage-pools
 
       - name: Get upstream packages' versions
@@ -93,6 +94,7 @@ jobs:
             keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
             keep-ecdsa-contracts-version = github.com/keep-network/keep-ecdsa/solidity#version
             tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
+            tbtc-v2-contracts-version = github.com/keep-network/tbtc-v2/solidity#version
             coverage-pools-version = github.com/keep-network/coverage-pools#version
 
       - name: Resolve latest contracts
@@ -102,6 +104,7 @@ jobs:
               @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
               @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }} \
               @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
+              @keep-network/tbtc-v2@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
               @keep-network/coverage-pools@${{ steps.upstream-builds-query.outputs.coverage-pools-version }}
 
       - name: NPM build

--- a/.github/workflows/dashboard-testnet.yml
+++ b/.github/workflows/dashboard-testnet.yml
@@ -104,7 +104,7 @@ jobs:
               @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
               @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }} \
               @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
-              @keep-network/tbtc-v2@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
+              @keep-network/tbtc-v2@${{ steps.upstream-builds-query.outputs.tbtc-v2-contracts-version }} \
               @keep-network/coverage-pools@${{ steps.upstream-builds-query.outputs.coverage-pools-version }}
 
       - name: NPM build

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -2711,6 +2711,24 @@
         }
       }
     },
+    "@keep-network/tbtc-v2": {
+      "version": "0.1.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc-v2/-/tbtc-v2-0.1.1-dev.0.tgz",
+      "integrity": "sha512-VTIj6OH9i4t//J22LJCoybE6pmXHFgvbyLDCdlWNO/igtaPh+2TSougJkx05pSQP92/CL+3izgjKHem0Vkd9HA==",
+      "requires": {
+        "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
+        "@openzeppelin/contracts": "^4.1.0",
+        "@tenderly/hardhat-tenderly": "^1.0.12",
+        "@thesis/solidity-contracts": "github:thesis/solidity-contracts#507c647"
+      },
+      "dependencies": {
+        "@openzeppelin/contracts": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
+          "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
+        }
+      }
+    },
     "@ledgerhq/devices": {
       "version": "4.78.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-4.78.0.tgz",
@@ -3917,6 +3935,52 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tenderly/hardhat-tenderly": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.0.12.tgz",
+      "integrity": "sha512-zx2zVpbBxGWVp+aLgf59sZR5lxdqfq/PjqUhga6+iazukQNu/Y6pLfVnCcF1ggvLsf7gnMjwLe3YEx/GxCAykQ==",
+      "requires": {
+        "axios": "^0.21.1",
+        "fs-extra": "^9.0.1",
+        "js-yaml": "^3.14.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz",
@@ -3945,6 +4009,20 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
           "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
+        }
+      }
+    },
+    "@thesis/solidity-contracts": {
+      "version": "github:thesis/solidity-contracts#507c64759a2783196b505365e0cb4bf13c1ad1fa",
+      "from": "github:thesis/solidity-contracts#507c647",
+      "requires": {
+        "@openzeppelin/contracts": "^4.1.0"
+      },
+      "dependencies": {
+        "@openzeppelin/contracts": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
+          "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
         }
       }
     },
@@ -5386,6 +5464,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -9,7 +9,7 @@
     "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
     "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
     "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
-    "@keep-network/tbtc-v2": "file:../../../tbtc-v2/solidity",
+    "@keep-network/tbtc-v2": ">0.1.1-dev <0.1.1-ropsten",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "@walletconnect/web3-subprovider": "^1.3.6",


### PR DESCRIPTION
The `tbtc-v2` contracts intended to be used for building of Token
Dashboard will be published to the NPM registry under name with the
`-dev` suffix. We need to update the dependencies configuration in
`package.json` and `package-lock.json` dashboard files to use those
published packages.
For deployment of Dashboard on Testnet we're not using the dependencies
configured in the `package-lock.json`, instead we specify the exact version
we want to use when running the deployment workflow.

Ref: https://github.com/keep-network/keep-core/pull/2571