### PR TITLE
Liquidity page updates

### DIFF
--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -2662,16 +2662,24 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.7.0-pre.8",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.8.tgz",
-      "integrity": "sha512-SqCGfW0ElBsx3iTTR/8YtHT8H6C0uPIb+P5HqD1ei5Typy+H1WUBVLjUQ6YPNraMtTGmBFmG6LUvrY7WCCTC2A==",
+      "version": "1.8.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.8.0-dev.0.tgz",
+      "integrity": "sha512-DRSPmXklqcZMxW169umN+XjXb1cySHA0lHp3BT7Q4kEKiHatdt50jMzvmrTd9jlwcIj3s9smMq/VF2GYVkWIZQ==",
       "requires": {
-        "@keep-network/keep-core": "^1.8.0-pre.6",
-        "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+        "@keep-network/keep-core": "^1.8.0-dev.1",
+        "@keep-network/sortition-pools": ">1.2.0-dev <1.2.0-pre",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0"
       },
       "dependencies": {
+        "@keep-network/sortition-pools": {
+          "version": "1.2.0-dev.1",
+          "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.1.tgz",
+          "integrity": "sha512-CaOsvxNWHgXRFwPThDn3C/LiCwq9pL8ICLXXkysRSLw1Hx69wLnToaXYuwyXeIEy5pGqe5+288DBIqvJ3T4+jA==",
+          "requires": {
+            "@openzeppelin/contracts": "^2.4.0"
+          }
+        },
         "openzeppelin-solidity": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
@@ -2704,6 +2712,33 @@
         "openzeppelin-solidity": "2.3.0"
       },
       "dependencies": {
+        "@keep-network/keep-core": {
+          "version": "1.8.0-pre.16",
+          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.16.tgz",
+          "integrity": "sha512-zn4YVHoKTdaPUAi2WgBzhZcPwFiyUwck5asbv0dQ7HiY0XKTbAzhTTgaDDgiEKUwqLkNJRNLYqtVaFvzlql6DQ==",
+          "requires": {
+            "@openzeppelin/upgrades": "^2.7.2",
+            "openzeppelin-solidity": "2.4.0"
+          },
+          "dependencies": {
+            "openzeppelin-solidity": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
+              "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
+            }
+          }
+        },
+        "@keep-network/keep-ecdsa": {
+          "version": "1.7.0-pre.12",
+          "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.12.tgz",
+          "integrity": "sha512-ro28FRMha8EcNVo4at6t/B5UsCCOaW954qmxvNjczgZkrErHFCGEc2lEnqWZUCwET1uLloIj6VYuTuht+zIOfg==",
+          "requires": {
+            "@keep-network/keep-core": "1.8.0-pre.16",
+            "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+            "@openzeppelin/upgrades": "^2.7.2",
+            "openzeppelin-solidity": "2.3.0"
+          }
+        },
         "openzeppelin-solidity": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",

--- a/solidity/dashboard/package-lock.json
+++ b/solidity/dashboard/package-lock.json
@@ -2627,28 +2627,105 @@
       }
     },
     "@keep-network/coverage-pools": {
-      "version": "0.0.1-dev.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/coverage-pools/-/coverage-pools-0.0.1-dev.0.tgz",
-      "integrity": "sha512-lKkTi4G6CkoT45g3ssnIrvQYFXUhn6vgqSp8OcWKgBUouZYWvt2Htb/TQFb+p59+z4nWjqA1Z6uFNDu8jujlQA==",
+      "version": "1.1.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/coverage-pools/-/coverage-pools-1.1.0-dev.0.tgz",
+      "integrity": "sha512-0J6IRaxUtz9OUxcBCGAM8iU3DoevHzf0ytg/VDJGfOpLfYw23TPQcUaT+PCMRgg+mxtL4yHt/RpnlBkO7gOqow==",
       "requires": {
-        "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
-        "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
-        "@openzeppelin/contracts": "^4.1.0"
+        "@keep-network/keep-core": "^1.8.0-ropsten.11",
+        "@keep-network/tbtc": "^1.1.2-ropsten.8",
+        "@openzeppelin/contracts": "^4.1.0",
+        "@tenderly/hardhat-tenderly": "^1.0.12",
+        "@thesis/solidity-contracts": "github:thesis/solidity-contracts#a1384af"
       },
       "dependencies": {
         "@keep-network/keep-core": {
-          "version": "1.8.0-dev.1",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-dev.1.tgz",
-          "integrity": "sha512-OOvVxxUYXeBS7qH8zncCHTWqMnByg1/CX5BZ6006v1lWOnBeBS2Wf+n6HnTer5sSkDt6FI0Q2jhJTjh37I570g==",
+          "version": "1.8.0-ropsten.11",
+          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-ropsten.11.tgz",
+          "integrity": "sha512-mHuHb8SgPfXC6gKglYcbeUWWA0+Ijq0tn+f2sN9ZkFpPnAb6Uq4kMTLZle2qqcRkvfqc7JkWvJmDq0kAGdUIrQ==",
           "requires": {
             "@openzeppelin/upgrades": "^2.7.2",
             "openzeppelin-solidity": "2.4.0"
           }
         },
+        "@keep-network/keep-ecdsa": {
+          "version": "1.7.1-ropsten.0",
+          "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.1-ropsten.0.tgz",
+          "integrity": "sha512-gjLogKEoGdi3Bpm20HMEnLxQQfxVmBTgnhZ0YGbkiNoP7UTsF2BrbY+nhPjHfCHogLxCCaCJpaqqAYVzUV7/UA==",
+          "requires": {
+            "@keep-network/keep-core": "1.8.0-ropsten.14",
+            "@keep-network/sortition-pools": ">1.2.0-dev <1.2.0-pre",
+            "@openzeppelin/upgrades": "^2.7.2",
+            "openzeppelin-solidity": "2.3.0"
+          },
+          "dependencies": {
+            "@keep-network/keep-core": {
+              "version": "1.8.0-ropsten.14",
+              "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-ropsten.14.tgz",
+              "integrity": "sha512-DN8YeFDCUTwHjDRT5P7wqEgpyaL21jWjr8I+NcDn10tFy4ispAJT5iVkgSMPOcaorcPXc4e55ExhX1YKJIAq5g==",
+              "requires": {
+                "@openzeppelin/upgrades": "^2.7.2",
+                "openzeppelin-solidity": "2.4.0"
+              },
+              "dependencies": {
+                "openzeppelin-solidity": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
+                  "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
+                }
+              }
+            },
+            "openzeppelin-solidity": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+              "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+            }
+          }
+        },
+        "@keep-network/sortition-pools": {
+          "version": "1.2.0-dev.1",
+          "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.1.tgz",
+          "integrity": "sha512-CaOsvxNWHgXRFwPThDn3C/LiCwq9pL8ICLXXkysRSLw1Hx69wLnToaXYuwyXeIEy5pGqe5+288DBIqvJ3T4+jA==",
+          "requires": {
+            "@openzeppelin/contracts": "^2.4.0"
+          },
+          "dependencies": {
+            "@openzeppelin/contracts": {
+              "version": "2.5.1",
+              "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
+              "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
+            }
+          }
+        },
+        "@keep-network/tbtc": {
+          "version": "1.1.2-ropsten.9",
+          "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-ropsten.9.tgz",
+          "integrity": "sha512-7P+Pc/46L0lwkIhH1/8xPKIxGwiFubZCCysBDzAhF9ff3EyTsL1nNEFneKfMKEZCVBi1HNSZHkJFLMVCORsv2w==",
+          "requires": {
+            "@celo/contractkit": "^1.0.2",
+            "@keep-network/keep-ecdsa": "1.7.1-ropsten.0",
+            "@summa-tx/bitcoin-spv-sol": "^3.1.0",
+            "@summa-tx/relay-sol": "^2.0.2",
+            "openzeppelin-solidity": "2.3.0"
+          },
+          "dependencies": {
+            "openzeppelin-solidity": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+              "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+            }
+          }
+        },
         "@openzeppelin/contracts": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.1.tgz",
-          "integrity": "sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw=="
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
+          "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
+        },
+        "@thesis/solidity-contracts": {
+          "version": "github:thesis/solidity-contracts#a1384afd039f0de4d698872b204a74337c15857f",
+          "from": "github:thesis/solidity-contracts#a1384af",
+          "requires": {
+            "@openzeppelin/contracts": "^4.1.0"
+          }
         }
       }
     },

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
-    "@keep-network/coverage-pools": ">0.0.1-dev <0.0.1-ropsten",
-    "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
+    "@keep-network/coverage-pools": ">1.1.0-dev <1.1.0-ropsten",
+    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-ropsten",
     "@keep-network/keep-ecdsa": ">1.8.0-dev <1.8.0-ropsten",
     "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
     "@keep-network/tbtc-v2": ">0.1.1-dev <0.1.1-ropsten",

--- a/solidity/dashboard/package.json
+++ b/solidity/dashboard/package.json
@@ -7,7 +7,7 @@
     "@0x/subproviders": "^6.0.8",
     "@keep-network/coverage-pools": ">0.0.1-dev <0.0.1-ropsten",
     "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
-    "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/keep-ecdsa": ">1.8.0-dev <1.8.0-ropsten",
     "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
     "@keep-network/tbtc-v2": ">0.1.1-dev <0.1.1-ropsten",
     "@ledgerhq/hw-app-eth": "^5.13.0",

--- a/solidity/dashboard/src/components/KeepOnlyPool.jsx
+++ b/solidity/dashboard/src/components/KeepOnlyPool.jsx
@@ -19,6 +19,8 @@ import { useModal } from "../hooks/useModal"
 import TokenAmount from "./TokenAmount"
 import MetricsTile from "./MetricsTile"
 import RewardMultiplier from "./liquidity/RewardMultiplier"
+import Banner from "./Banner"
+import { LINK } from "../constants/constants"
 
 const KeepOnlyPool = ({
   apy,
@@ -139,11 +141,37 @@ const KeepOnlyPool = ({
               &nbsp;KEEP
             </h4>
           </div>
-
+          <Banner
+            className="liquidity-info-banner liquidity-info-banner--warning mt-2"
+            style={{ maxWidth: "100%" }}
+          >
+            <Banner.Icon
+              icon={Icons.Warning}
+              className="liquidity-info-banner__icon liquidity-info-banner__icon--warning"
+            />
+            <div className="liquidity-info-banner__content">
+              <Banner.Title className="text-grey-60">
+                Incentives removed
+              </Banner.Title>
+              <Banner.Description className="liquidity-info-banner__content__description text-grey-60">
+                The incentives for this pool has been removed and you can no
+                longer deposit the KEEP tokens. You can still withdraw deposited
+                KEEP tokens and rewards that you already earned.&nbsp;
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={LINK.proposals.shiftingIncentivesToCoveragePools}
+                  className="text-grey-60"
+                >
+                  More info
+                </a>
+              </Banner.Description>
+            </div>
+          </Banner>
           <div className="flex row space-between mt-2">
             <SubmitButton
               className="btn btn-primary btn-lg"
-              disabled={!gt(wrappedTokenBalance || 0, 0)}
+              disabled={true}
               onSubmitAction={addKEEP}
             >
               {gt(lpBalance, 0) ? "add more keep" : "deposit keep"}

--- a/solidity/dashboard/src/components/KeepOnlyPool.jsx
+++ b/solidity/dashboard/src/components/KeepOnlyPool.jsx
@@ -161,7 +161,7 @@ const KeepOnlyPool = ({
                   target="_blank"
                   rel="noopener noreferrer"
                   href={LINK.proposals.shiftingIncentivesToCoveragePools}
-                  className="text-grey-60"
+                  className="text-link text-grey-60"
                 >
                   More info
                 </a>

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -13,6 +13,14 @@ import { LIQUIDITY_REWARD_PAIRS } from "../constants/constants"
 import { APY, LPTokenBalance, ShareOfPool } from "./liquidity"
 import MetricsTile from "./MetricsTile"
 
+const defaultIncentivesRemovedBannerProps = {
+  title: "Incentives removed",
+  description:
+    "The incentives for this pool has been removed and you can no longer deposit the lp tokens. You can still withdraw rewards that you already earned.",
+  link: null,
+  linkText: "More info",
+}
+
 const LiquidityRewardCard = ({
   title,
   liquidityPairContractName,
@@ -37,6 +45,9 @@ const LiquidityRewardCard = ({
   isAPYFetching,
   pool,
   incentivesRemoved,
+  incentivesRemovedBannerProps = {
+    ...defaultIncentivesRemovedBannerProps,
+  },
 }) => {
   const hasWrappedTokens = useMemo(
     () => gt(wrappedTokenBalance, 0),
@@ -54,12 +65,14 @@ const LiquidityRewardCard = ({
 
     if (incentivesRemoved) {
       bannerIcon = Icons.Warning
-      bannerTitle = "Incentives removed"
-      bannerDescription =
-        "The incentives for this pool has been removed and you can no longer deposit the lp tokens. You can still withdraw rewards that you already earned."
-      link =
-        "https://forum.keep.network/t/proposal-remove-incentives-for-the-keep-tbtc-pool/56"
-      linkText = "More info"
+      const bannerProps = {
+        ...defaultIncentivesRemovedBannerProps,
+        ...incentivesRemovedBannerProps,
+      }
+      bannerTitle = bannerProps.title
+      bannerDescription = bannerProps.description
+      link = bannerProps.link
+      linkText = bannerProps.linkText
     } else {
       bannerIcon = !hasDepositedWrappedTokens ? Icons.Rewards : Icons.Wallet
       bannerTitle = !hasDepositedWrappedTokens
@@ -78,26 +91,26 @@ const LiquidityRewardCard = ({
     return (
       !hasWrappedTokens && (
         <Banner
-          className={`liquidity__new-user-info ${
-            incentivesRemoved ? "liquidity__new-user-info--warning mt-2" : ""
+          className={`liquidity-info-banner ${
+            incentivesRemoved ? "liquidity-info-banner--warning mt-2" : ""
           }`}
         >
           <Banner.Icon
             icon={bannerIcon}
-            className={`liquidity__rewards-icon ${
-              incentivesRemoved ? "liquidity__rewards-icon--warning" : ""
+            className={`liquidity-info-banner__icon ${
+              incentivesRemoved ? "liquidity-info-banner__icon--warning" : ""
             }`}
           />
-          <div className={"liquidity__new-user-info-text"}>
+          <div className={"liquidity-info-banner__content"}>
             <Banner.Title
-              className={`liquidity-banner__title ${
+              className={`liquidity-info-banner__content__title ${
                 incentivesRemoved ? "text-grey-60" : "text-white"
               }`}
             >
               {bannerTitle}
             </Banner.Title>
             <Banner.Description
-              className={`liquidity-banner__info ${
+              className={`liquidity-info-banner__content__description ${
                 incentivesRemoved ? "text-grey-60" : "text-white"
               }`}
             >

--- a/solidity/dashboard/src/components/LiquidityRewardCard.jsx
+++ b/solidity/dashboard/src/components/LiquidityRewardCard.jsx
@@ -9,7 +9,7 @@ import Tooltip from "./Tooltip"
 import Banner from "./Banner"
 import { KEEP } from "../utils/token.utils"
 import { gt } from "../utils/arithmetics.utils"
-import { LIQUIDITY_REWARD_PAIRS } from "../constants/constants"
+import { POOL_TYPE } from "../constants/constants"
 import { APY, LPTokenBalance, ShareOfPool } from "./liquidity"
 import MetricsTile from "./MetricsTile"
 
@@ -82,10 +82,7 @@ const LiquidityRewardCard = ({
         ? "Get LP tokens by adding liquidity first to the"
         : "Get more by adding liquidity to the"
       link = viewPoolLink
-      linkText =
-        title === LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.label
-          ? "Saddle pool"
-          : "Uniswap pool"
+      linkText = pool === POOL_TYPE.SADDLE ? "Saddle pool" : "Uniswap pool"
     }
 
     return (
@@ -144,9 +141,7 @@ const LiquidityRewardCard = ({
         <h2 className={"h2--alt text-grey-70"}>{title}</h2>
       </div>
       <h4 className="liquidity__card-subtitle text-grey-40">
-        {title === LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.label
-          ? "Saddle Pool"
-          : "Uniswap Pool"}
+        {pool === POOL_TYPE.SADDLE ? "Saddle Pool" : "Uniswap Pool"}
         &nbsp;
         <a
           target="_blank"

--- a/solidity/dashboard/src/constants/constants.js
+++ b/solidity/dashboard/src/constants/constants.js
@@ -1,3 +1,8 @@
+import {
+  createSaddleSwapContract,
+  createSaddleTBTCMetaPool,
+} from "../contracts"
+
 export const KEEP_TOKEN_CONTRACT_NAME = "token"
 export const TOKEN_STAKING_CONTRACT_NAME = "stakingContract"
 export const TOKEN_GRANT_CONTRACT_NAME = "grantContract"
@@ -18,6 +23,8 @@ export const LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME = "LPRewardsTBTCSaddle"
 export const LP_REWARDS_KEEP_ETH_CONTRACT_NAME = "LPRewardsKEEPETHContract"
 export const LP_REWARDS_TBTC_ETH_CONTRACT_NAME = "LPRewardsTBTCETHContract"
 export const LP_REWARDS_KEEP_TBTC_CONTRACT_NAME = "LPRewardsKEEPTBTCContract"
+export const LP_REWARDS_TBTCV2_SADDLE_CONTRACT_NAME = "LPRewardsTBTCSaddle"
+
 export const KEEP_TOKEN_GEYSER_CONTRACT_NAME = "keepTokenGeyserContract"
 export const ECDSA_REWARDS_DISTRRIBUTOR_CONTRACT_NAME =
   "ECDSARewardsDistributorContract"
@@ -78,13 +85,42 @@ export const SIGNING_GROUP_STATUS = {
   ACTIVE: "Active work",
 }
 
+export const POOL_TYPE = {
+  SADDLE: "SADDLE",
+  UNISWAP: "UNISWAP",
+  TOKEN_GEYSER: "TOKEN_GEYSER",
+}
+
 export const LIQUIDITY_REWARD_PAIRS = {
+  TBTCV2_SADDLE: {
+    contractName: LP_REWARDS_TBTCV2_SADDLE_CONTRACT_NAME,
+    label: "TBTC V2 + SADDLE",
+    viewPoolLink: LINK.pools.saddle.tbtcV2,
+    pool: POOL_TYPE.SADDLE,
+    lpTokens: [],
+    options: {
+      createSwapContract: createSaddleTBTCMetaPool,
+      poolTokens: [
+        { name: "TBTC", decimals: 18 },
+        { name: "saddleBTC-V2", decimals: 18 },
+      ],
+    },
+  },
   TBTC_SADDLE: {
     contractName: LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
     label: "TBTC + SADDLE",
     viewPoolLink: "https://saddle.exchange/#/deposit",
-    pool: "SADDLE",
+    pool: POOL_TYPE.SADDLE,
     lpTokens: [],
+    options: {
+      createSwapContract: createSaddleSwapContract,
+      poolTokens: [
+        { name: "TBTC", decimals: 18 },
+        { name: "WBTC", decimals: 8 },
+        { name: "RENBTC", decimals: 8 },
+        { name: "SBTC", decimals: 18 },
+      ],
+    },
   },
   KEEP_ETH: {
     contractName: LP_REWARDS_KEEP_ETH_CONTRACT_NAME,
@@ -92,7 +128,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
     viewPoolLink:
       "https://v2.info.uniswap.org/pair/0xe6f19dab7d43317344282f803f8e8d240708174a",
     address: "0xe6f19dab7d43317344282f803f8e8d240708174a",
-    pool: "UNISWAP",
+    pool: POOL_TYPE.UNISWAP,
     lpTokens: [
       {
         tokenName: "KEEP",
@@ -110,7 +146,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
     viewPoolLink:
       "https://v2.info.uniswap.org/pair/0x38c8ffee49f286f25d25bad919ff7552e5daf081",
     address: "0x38c8ffee49f286f25d25bad919ff7552e5daf081",
-    pool: "UNISWAP",
+    pool: POOL_TYPE.UNISWAP,
     lpTokens: [
       {
         tokenName: "KEEP",
@@ -128,7 +164,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
     viewPoolLink:
       "https://v2.info.uniswap.org/pair/0x854056fd40c1b52037166285b2e54fee774d33f6",
     address: "0x854056fd40c1b52037166285b2e54fee774d33f6",
-    pool: "UNISWAP",
+    pool: POOL_TYPE.UNISWAP,
     lpTokens: [
       {
         tokenName: "TBTC",
@@ -143,7 +179,7 @@ export const LIQUIDITY_REWARD_PAIRS = {
   KEEP_ONLY: {
     contractName: KEEP_TOKEN_GEYSER_CONTRACT_NAME,
     label: "KEEP",
-    pool: "TOKEN_GEYSER",
+    pool: POOL_TYPE.TOKEN_GEYSER,
   },
 }
 

--- a/solidity/dashboard/src/constants/constants.js
+++ b/solidity/dashboard/src/constants/constants.js
@@ -46,6 +46,12 @@ export const LINK = {
       tbtcETH: `https://app.uniswap.org/#/add/v2/0x8daebade922df735c38c80c7ebd708af50815faa/ETH`,
     },
   },
+  proposals: {
+    shiftingIncentivesToCoveragePools:
+      "https://forum.keep.network/t/shifting-incentives-towards-tbtc-v2-and-coverage-pool-version-2/322",
+    removeIncentivesForKEEPTBTCpool:
+      "https://forum.keep.network/t/proposal-remove-incentives-for-the-keep-tbtc-pool/56",
+  },
   tbtcDapp: "https://dapp.tbtc.network",
 }
 

--- a/solidity/dashboard/src/contracts-artifacts/SaddleTBTCMetaPool.json
+++ b/solidity/dashboard/src/contracts-artifacts/SaddleTBTCMetaPool.json
@@ -1,0 +1,722 @@
+{
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "provider",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "tokenAmounts",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "fees",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "invariant",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpTokenSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "AddLiquidity",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newAdminFee",
+          "type": "uint256"
+        }
+      ],
+      "name": "NewAdminFee",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newSwapFee",
+          "type": "uint256"
+        }
+      ],
+      "name": "NewSwapFee",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newWithdrawFee",
+          "type": "uint256"
+        }
+      ],
+      "name": "NewWithdrawFee",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldA",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newA",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "initialTime",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "futureTime",
+          "type": "uint256"
+        }
+      ],
+      "name": "RampA",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "provider",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "tokenAmounts",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpTokenSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "RemoveLiquidity",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "provider",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "tokenAmounts",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "fees",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "invariant",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpTokenSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "RemoveLiquidityImbalance",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "provider",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpTokenAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpTokenSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "boughtId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokensBought",
+          "type": "uint256"
+        }
+      ],
+      "name": "RemoveLiquidityOne",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "currentA",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "time",
+          "type": "uint256"
+        }
+      ],
+      "name": "StopRampA",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "buyer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokensSold",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokensBought",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "soldId",
+          "type": "uint128"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "boughtId",
+          "type": "uint128"
+        }
+      ],
+      "name": "TokenSwap",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "buyer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokensSold",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokensBought",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "soldId",
+          "type": "uint128"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "boughtId",
+          "type": "uint128"
+        }
+      ],
+      "name": "TokenSwapUnderlying",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" },
+        { "internalType": "uint256", "name": "minToMint", "type": "uint256" },
+        { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+      ],
+      "name": "addLiquidity",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "amount", "type": "uint256" }
+      ],
+      "name": "calculateRemoveLiquidity",
+      "outputs": [
+        { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" },
+        { "internalType": "uint8", "name": "tokenIndex", "type": "uint8" }
+      ],
+      "name": "calculateRemoveLiquidityOneToken",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint8", "name": "tokenIndexFrom", "type": "uint8" },
+        { "internalType": "uint8", "name": "tokenIndexTo", "type": "uint8" },
+        { "internalType": "uint256", "name": "dx", "type": "uint256" }
+      ],
+      "name": "calculateSwap",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint8", "name": "tokenIndexFrom", "type": "uint8" },
+        { "internalType": "uint8", "name": "tokenIndexTo", "type": "uint8" },
+        { "internalType": "uint256", "name": "dx", "type": "uint256" }
+      ],
+      "name": "calculateSwapUnderlying",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" },
+        { "internalType": "bool", "name": "deposit", "type": "bool" }
+      ],
+      "name": "calculateTokenAmount",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getA",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getAPrecise",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "index", "type": "uint256" }
+      ],
+      "name": "getAdminBalance",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint8", "name": "index", "type": "uint8" }],
+      "name": "getToken",
+      "outputs": [
+        { "internalType": "contract IERC20", "name": "", "type": "address" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint8", "name": "index", "type": "uint8" }],
+      "name": "getTokenBalance",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "tokenAddress", "type": "address" }
+      ],
+      "name": "getTokenIndex",
+      "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVirtualPrice",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20[]",
+          "name": "_pooledTokens",
+          "type": "address[]"
+        },
+        { "internalType": "uint8[]", "name": "decimals", "type": "uint8[]" },
+        { "internalType": "string", "name": "lpTokenName", "type": "string" },
+        { "internalType": "string", "name": "lpTokenSymbol", "type": "string" },
+        { "internalType": "uint256", "name": "_a", "type": "uint256" },
+        { "internalType": "uint256", "name": "_fee", "type": "uint256" },
+        { "internalType": "uint256", "name": "_adminFee", "type": "uint256" },
+        {
+          "internalType": "address",
+          "name": "lpTokenTargetAddress",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20[]",
+          "name": "_pooledTokens",
+          "type": "address[]"
+        },
+        { "internalType": "uint8[]", "name": "decimals", "type": "uint8[]" },
+        { "internalType": "string", "name": "lpTokenName", "type": "string" },
+        { "internalType": "string", "name": "lpTokenSymbol", "type": "string" },
+        { "internalType": "uint256", "name": "_a", "type": "uint256" },
+        { "internalType": "uint256", "name": "_fee", "type": "uint256" },
+        { "internalType": "uint256", "name": "_adminFee", "type": "uint256" },
+        {
+          "internalType": "address",
+          "name": "lpTokenTargetAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "contract ISwap",
+          "name": "baseSwap",
+          "type": "address"
+        }
+      ],
+      "name": "initializeMetaSwap",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "metaSwapStorage",
+      "outputs": [
+        {
+          "internalType": "contract ISwap",
+          "name": "baseSwap",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "baseVirtualPrice",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "baseCacheLastUpdated",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "futureA", "type": "uint256" },
+        { "internalType": "uint256", "name": "futureTime", "type": "uint256" }
+      ],
+      "name": "rampA",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "amount", "type": "uint256" },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmounts",
+          "type": "uint256[]"
+        },
+        { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+      ],
+      "name": "removeLiquidity",
+      "outputs": [
+        { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" },
+        {
+          "internalType": "uint256",
+          "name": "maxBurnAmount",
+          "type": "uint256"
+        },
+        { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+      ],
+      "name": "removeLiquidityImbalance",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" },
+        { "internalType": "uint8", "name": "tokenIndex", "type": "uint8" },
+        { "internalType": "uint256", "name": "minAmount", "type": "uint256" },
+        { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+      ],
+      "name": "removeLiquidityOneToken",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "newAdminFee", "type": "uint256" }
+      ],
+      "name": "setAdminFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "newSwapFee", "type": "uint256" }
+      ],
+      "name": "setSwapFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "stopRampA",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint8", "name": "tokenIndexFrom", "type": "uint8" },
+        { "internalType": "uint8", "name": "tokenIndexTo", "type": "uint8" },
+        { "internalType": "uint256", "name": "dx", "type": "uint256" },
+        { "internalType": "uint256", "name": "minDy", "type": "uint256" },
+        { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+      ],
+      "name": "swap",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "swapStorage",
+      "outputs": [
+        { "internalType": "uint256", "name": "initialA", "type": "uint256" },
+        { "internalType": "uint256", "name": "futureA", "type": "uint256" },
+        {
+          "internalType": "uint256",
+          "name": "initialATime",
+          "type": "uint256"
+        },
+        { "internalType": "uint256", "name": "futureATime", "type": "uint256" },
+        { "internalType": "uint256", "name": "swapFee", "type": "uint256" },
+        { "internalType": "uint256", "name": "adminFee", "type": "uint256" },
+        {
+          "internalType": "contract LPToken",
+          "name": "lpToken",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint8", "name": "tokenIndexFrom", "type": "uint8" },
+        { "internalType": "uint8", "name": "tokenIndexTo", "type": "uint8" },
+        { "internalType": "uint256", "name": "dx", "type": "uint256" },
+        { "internalType": "uint256", "name": "minDy", "type": "uint256" },
+        { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+      ],
+      "name": "swapUnderlying",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "newOwner", "type": "address" }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "withdrawAdminFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/solidity/dashboard/src/contracts.js
+++ b/solidity/dashboard/src/contracts.js
@@ -21,9 +21,12 @@ import LPRewardsKEEPETH from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPET
 import LPRewardsTBTCETH from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCETH.json"
 import LPRewardsKEEPTBTC from "@keep-network/keep-ecdsa/artifacts/LPRewardsKEEPTBTC.json"
 import LPRewardsTBTCSaddle from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCSaddle.json"
+import LPRewardsTBTCv2Saddle from "@keep-network/keep-ecdsa/artifacts/LPRewardsTBTCv2Saddle.json"
 import KeepOnlyPool from "@keep-network/keep-core/artifacts/KeepVault.json"
 import IERC20 from "@keep-network/keep-core/artifacts/IERC20.json"
 import SaddleSwap from "./contracts-artifacts/SaddleSwap.json"
+import SaddleTBTCMetaPool from "./contracts-artifacts/SaddleTBTCMetaPool.json"
+
 import Web3 from "web3"
 
 import {
@@ -45,6 +48,7 @@ import {
   LP_REWARDS_KEEP_TBTC_CONTRACT_NAME,
   LP_REWARDS_TBTC_SADDLE_CONTRACT_NAME,
   KEEP_TOKEN_GEYSER_CONTRACT_NAME,
+  LP_REWARDS_TBTCV2_SADDLE_CONTRACT_NAME,
 } from "./constants/constants"
 
 import KeepLib from "./lib/keep"
@@ -141,6 +145,9 @@ const contracts = {
   [KEEP_TOKEN_GEYSER_CONTRACT_NAME]: {
     artifact: KeepOnlyPool,
     withDeployBlock: true,
+  },
+  [LP_REWARDS_TBTCV2_SADDLE_CONTRACT_NAME]: {
+    artifact: LPRewardsTBTCv2Saddle,
   },
 }
 
@@ -346,10 +353,19 @@ export const createLPRewardsContract = async (web3, contractName) => {
   return await getContract(web3, artifact, {})
 }
 
-export const createSaddleSwapContract = (web3) => {
+export function createSaddleSwapContract(web3) {
   return createWeb3ContractInstance(
     web3,
     SaddleSwap.abi,
     "0x4f6A43Ad7cba042606dECaCA730d4CE0A57ac62e"
+  )
+}
+
+export function createSaddleTBTCMetaPool(web3) {
+  return createWeb3ContractInstance(
+    web3,
+    SaddleTBTCMetaPool.abi,
+    // https://etherscan.io/address/0xf74ebe6e5586275dc4CeD78F5DBEF31B1EfbE7a5#code
+    "0xf74ebe6e5586275dc4CeD78F5DBEF31B1EfbE7a5"
   )
 }

--- a/solidity/dashboard/src/css/liquidity-page.less
+++ b/solidity/dashboard/src/css/liquidity-page.less
@@ -28,7 +28,8 @@
       margin-right: 0.5rem;
 
       .tbtc-eth&,
-      .tbtc-saddle& {
+      .tbtc-saddle&,
+      .tbtc-v2-saddle& {
         .main-icon {
           circle {
             fill: @white;

--- a/solidity/dashboard/src/css/liquidity-page.less
+++ b/solidity/dashboard/src/css/liquidity-page.less
@@ -55,45 +55,6 @@
     justify-content: center;
   }
 
-  .liquidity__new-user-info {
-    background-color: @secondary-color;
-    color: @white;
-    display: flex;
-    padding: 0.7rem 0.5rem;
-
-    &--warning {
-      background-color: @color-grey-20;
-      padding-right: 0.8rem;
-    }
-
-    .liquidity__rewards-icon {
-      width: 1.5rem;
-      height: 1.5rem;
-      margin: 0.2rem 0.5rem;
-      flex: 0 0 auto;
-
-      path {
-        fill: white;
-      }
-
-      &--warning {
-        path {
-          fill: @color-grey-60;
-        }
-      }
-    }
-
-    .liquidity__new-user-info-text {
-      margin-left: 0.5rem;
-      font-weight: 500;
-
-      .liquidity-banner__info {
-        font-weight: 400;
-        margin-bottom: 0.3rem;
-      }
-    }
-  }
-
   .lp-balance {
     margin: 2rem 0;
 
@@ -264,6 +225,45 @@
       &:nth-child(3) {
         display: block;
       }
+    }
+  }
+}
+
+.liquidity-info-banner {
+  background-color: @secondary-color;
+  color: @white;
+  display: flex;
+  padding: 0.7rem 0.5rem;
+
+  &--warning {
+    background-color: @color-grey-20;
+    padding-right: 0.8rem;
+  }
+
+  .liquidity-info-banner__icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    margin: 0.2rem 0.5rem;
+    flex: 0 0 auto;
+
+    path {
+      fill: white;
+    }
+
+    &--warning {
+      path {
+        fill: @color-grey-60;
+      }
+    }
+  }
+
+  .liquidity-info-banner__content {
+    margin-left: 0.5rem;
+    font-weight: 500;
+
+    .liquidity-info-banner__content__description {
+      font-weight: 400;
+      margin-bottom: 0.3rem;
     }
   }
 }

--- a/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -20,6 +20,18 @@ import KeepOnlyPool from "../../components/KeepOnlyPool"
 
 const cards = [
   {
+    id: "TBTCV2_SADDLE",
+    title: LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE.label,
+    liquidityPairContractName:
+      LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE.contractName,
+    MainIcon: Icons.TBTC,
+    SecondaryIcon: Icons.Saddle,
+    viewPoolLink: LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE.viewPoolLink,
+    pool: LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE.pool,
+    lpTokens: LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE.lpTokens,
+    wrapperClassName: "tbtc-v2-saddle",
+  },
+  {
     id: "KEEP_ETH",
     title: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.label,
     liquidityPairContractName: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.contractName,

--- a/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -7,7 +7,7 @@ import {
 import PageWrapper from "../../components/PageWrapper"
 import CardContainer from "../../components/CardContainer"
 import LiquidityRewardCard from "../../components/LiquidityRewardCard"
-import { LIQUIDITY_REWARD_PAIRS } from "../../constants/constants"
+import { LINK, LIQUIDITY_REWARD_PAIRS } from "../../constants/constants"
 import * as Icons from "../../components/Icons"
 import {
   addMoreLpTokens,
@@ -16,8 +16,62 @@ import {
 import Banner from "../../components/Banner"
 import { useHideComponent } from "../../hooks/useHideComponent"
 import { gt } from "../../utils/arithmetics.utils"
-
 import KeepOnlyPool from "../../components/KeepOnlyPool"
+
+const cards = [
+  {
+    id: "KEEP_ETH",
+    title: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.label,
+    liquidityPairContractName: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.contractName,
+    MainIcon: Icons.KeepBlackGreen,
+    SecondaryIcon: Icons.EthToken,
+    viewPoolLink: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.viewPoolLink,
+    pool: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.pool,
+    lpTokens: LIQUIDITY_REWARD_PAIRS.KEEP_ETH.lpTokens,
+    wrapperClassName: "keep-eth",
+  },
+  {
+    id: "TBTC_ETH",
+    title: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.label,
+    liquidityPairContractName: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.contractName,
+    MainIcon: Icons.TBTC,
+    SecondaryIcon: Icons.EthToken,
+    viewPoolLink: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.viewPoolLink,
+    pool: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.pool,
+    lpTokens: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.lpTokens,
+    wrapperClassName: "tbtc-eth",
+  },
+  {
+    id: "TBTC_SADDLE",
+    title: LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.label,
+    liquidityPairContractName: LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.contractName,
+    MainIcon: Icons.TBTC,
+    SecondaryIcon: Icons.Saddle,
+    viewPoolLink: LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.viewPoolLink,
+    pool: LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.pool,
+    lpTokens: LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.lpTokens,
+    wrapperClassName: "tbtc-saddle",
+    incentivesRemoved: true,
+    incentivesRemovedBannerProps: {
+      link: LINK.proposals.shiftingIncentivesToCoveragePools,
+    },
+  },
+  {
+    id: "KEEP_TBTC",
+    title: LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.label,
+    liquidityPairContractName: LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.contractName,
+    MainIcon: Icons.KeepBlackGreen,
+    SecondaryIcon: Icons.TBTC,
+    viewPoolLink: LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.viewPoolLink,
+    pool: LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.pool,
+    lpTokens: LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.lpTokens,
+    wrapperClassName: "keep-tbtc",
+    incentivesRemoved: true,
+    incentivesRemovedBannerProps: {
+      link: LINK.proposals.removeIncentivesForKEEPTBTCpool,
+    },
+  },
+]
 
 const LiquidityPage = ({ headerTitle }) => {
   const [isBannerVisible, hideBanner] = useHideComponent(false)
@@ -25,7 +79,7 @@ const LiquidityPage = ({ headerTitle }) => {
   const dispatch = useDispatch()
   const address = useWeb3Address()
   const keepTokenBalance = useSelector((state) => state.keepTokenBalance)
-  const { TBTC_SADDLE, KEEP_ETH, TBTC_ETH, KEEP_TBTC, KEEP_ONLY } = useSelector(
+  const { KEEP_ONLY, ...liquidityPools } = useSelector(
     (state) => state.liquidityRewards
   )
 
@@ -136,99 +190,23 @@ const LiquidityPage = ({ headerTitle }) => {
         pool={LIQUIDITY_REWARD_PAIRS.KEEP_ONLY.pool}
       />
       <CardContainer>
-        <LiquidityRewardCard
-          title={LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.label}
-          liquidityPairContractName={
-            LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.contractName
-          }
-          MainIcon={Icons.TBTC}
-          SecondaryIcon={Icons.Saddle}
-          viewPoolLink={LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.viewPoolLink}
-          apy={TBTC_SADDLE.apy}
-          percentageOfTotalPool={TBTC_SADDLE.shareOfPoolInPercent}
-          rewardBalance={TBTC_SADDLE.reward}
-          wrappedTokenBalance={TBTC_SADDLE.wrappedTokenBalance}
-          lpBalance={TBTC_SADDLE.lpBalance}
-          lpTokenBalance={TBTC_SADDLE.lpTokenBalance}
-          rewardMultiplier={TBTC_SADDLE.rewardMultiplier}
-          lpTokens={LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.lpTokens}
-          isFetching={TBTC_SADDLE.isFetching}
-          wrapperClassName="tbtc-saddle"
-          addLpTokens={addLpTokens}
-          withdrawLiquidityRewards={withdrawLiquidityRewards}
-          isAPYFetching={TBTC_SADDLE.isAPYFetching}
-          pool={LIQUIDITY_REWARD_PAIRS.TBTC_SADDLE.pool}
-        />
-        <LiquidityRewardCard
-          title={LIQUIDITY_REWARD_PAIRS.KEEP_ETH.label}
-          liquidityPairContractName={
-            LIQUIDITY_REWARD_PAIRS.KEEP_ETH.contractName
-          }
-          MainIcon={Icons.KeepBlackGreen}
-          SecondaryIcon={Icons.EthToken}
-          viewPoolLink={LIQUIDITY_REWARD_PAIRS.KEEP_ETH.viewPoolLink}
-          apy={KEEP_ETH.apy}
-          percentageOfTotalPool={KEEP_ETH.shareOfPoolInPercent}
-          rewardBalance={KEEP_ETH.reward}
-          wrappedTokenBalance={KEEP_ETH.wrappedTokenBalance}
-          lpBalance={KEEP_ETH.lpBalance}
-          lpTokenBalance={KEEP_ETH.lpTokenBalance}
-          rewardMultiplier={KEEP_ETH.rewardMultiplier}
-          lpTokens={LIQUIDITY_REWARD_PAIRS.KEEP_ETH.lpTokens}
-          isFetching={KEEP_ETH.isFetching}
-          wrapperClassName="keep-eth"
-          addLpTokens={addLpTokens}
-          withdrawLiquidityRewards={withdrawLiquidityRewards}
-          isAPYFetching={KEEP_ETH.isAPYFetching}
-          pool={LIQUIDITY_REWARD_PAIRS.KEEP_ETH.pool}
-        />
-        <LiquidityRewardCard
-          title={LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.label}
-          liquidityPairContractName={
-            LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.contractName
-          }
-          MainIcon={Icons.KeepBlackGreen}
-          SecondaryIcon={Icons.TBTC}
-          viewPoolLink={LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.viewPoolLink}
-          apy={KEEP_TBTC.apy}
-          percentageOfTotalPool={KEEP_TBTC.shareOfPoolInPercent}
-          rewardBalance={KEEP_TBTC.reward}
-          wrappedTokenBalance={KEEP_TBTC.wrappedTokenBalance}
-          lpBalance={KEEP_TBTC.lpBalance}
-          lpTokenBalance={KEEP_TBTC.lpTokenBalance}
-          rewardMultiplier={KEEP_TBTC.rewardMultiplier}
-          lpTokens={LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.lpTokens}
-          isFetching={KEEP_TBTC.isFetching}
-          wrapperClassName="keep-tbtc"
-          addLpTokens={addLpTokens}
-          withdrawLiquidityRewards={withdrawLiquidityRewards}
-          isAPYFetching={KEEP_TBTC.isAPYFetching}
-          pool={LIQUIDITY_REWARD_PAIRS.KEEP_TBTC.pool}
-          incentivesRemoved={true}
-        />
-        <LiquidityRewardCard
-          title={LIQUIDITY_REWARD_PAIRS.TBTC_ETH.label}
-          liquidityPairContractName={
-            LIQUIDITY_REWARD_PAIRS.TBTC_ETH.contractName
-          }
-          MainIcon={Icons.TBTC}
-          SecondaryIcon={Icons.EthToken}
-          viewPoolLink={LIQUIDITY_REWARD_PAIRS.TBTC_ETH.viewPoolLink}
-          apy={TBTC_ETH.apy}
-          percentageOfTotalPool={TBTC_ETH.shareOfPoolInPercent}
-          rewardBalance={TBTC_ETH.reward}
-          wrappedTokenBalance={TBTC_ETH.wrappedTokenBalance}
-          lpBalance={TBTC_ETH.lpBalance}
-          lpTokenBalance={TBTC_ETH.lpTokenBalance}
-          rewardMultiplier={TBTC_ETH.rewardMultiplier}
-          lpTokens={LIQUIDITY_REWARD_PAIRS.TBTC_ETH.lpTokens}
-          isFetching={TBTC_ETH.isFetching}
-          wrapperClassName="tbtc-eth"
-          addLpTokens={addLpTokens}
-          withdrawLiquidityRewards={withdrawLiquidityRewards}
-          isAPYFetching={TBTC_ETH.isAPYFetching}
-          pool={LIQUIDITY_REWARD_PAIRS.TBTC_ETH.pool}
-        />
+        {cards.map(({ id, ...data }) => (
+          <LiquidityRewardCard
+            key={id}
+            {...data}
+            apy={liquidityPools[id].apy}
+            percentageOfTotalPool={liquidityPools[id].shareOfPoolInPercent}
+            rewardBalance={liquidityPools[id].reward}
+            wrappedTokenBalance={liquidityPools[id].wrappedTokenBalance}
+            lpBalance={liquidityPools[id].lpBalance}
+            lpTokenBalance={liquidityPools[id].lpTokenBalance}
+            rewardMultiplier={liquidityPools[id].rewardMultiplier}
+            isFetching={liquidityPools[id].isFetching}
+            addLpTokens={addLpTokens}
+            withdrawLiquidityRewards={withdrawLiquidityRewards}
+            isAPYFetching={liquidityPools[id].isAPYFetching}
+          />
+        ))}
       </CardContainer>
     </PageWrapper>
   )

--- a/solidity/dashboard/src/reducers/liquidity-rewards.js
+++ b/solidity/dashboard/src/reducers/liquidity-rewards.js
@@ -18,11 +18,12 @@ const liquidityPairInitialData = {
 }
 
 const initialState = {
-  TBTC_SADDLE: { ...liquidityPairInitialData },
+  TBTCV2_SADDLE: { ...liquidityPairInitialData },
   KEEP_ETH: { ...liquidityPairInitialData },
   TBTC_ETH: { ...liquidityPairInitialData },
-  KEEP_TBTC: { ...liquidityPairInitialData },
   KEEP_ONLY: { ...liquidityPairInitialData },
+  TBTC_SADDLE: { ...liquidityPairInitialData },
+  KEEP_TBTC: { ...liquidityPairInitialData },
 }
 
 const liquidityRewardsReducer = (state = initialState, action) => {

--- a/solidity/dashboard/src/sagas/liquidity-rewards.js
+++ b/solidity/dashboard/src/sagas/liquidity-rewards.js
@@ -283,7 +283,8 @@ function* fetchLiquidityRewardsAPY(liquidityRewardPair) {
       [LiquidityRewardsFactory, LiquidityRewardsFactory.initialize],
       liquidityRewardPair.pool,
       LPRewardsContract,
-      web3
+      web3,
+      liquidityRewardPair.options
     )
 
     let apy = Infinity

--- a/solidity/dashboard/src/sagas/utils.js
+++ b/solidity/dashboard/src/sagas/utils.js
@@ -110,7 +110,6 @@ export function* subscribeToEventAndEmitData(
         : action(event)
       yield put(_action)
     } catch (error) {
-      console.log("error", error)
       console.error(`Failed subscribing to ${_debugName} event`, error)
       contractEventCahnnel.close()
     }

--- a/solidity/dashboard/src/sagas/utils.js
+++ b/solidity/dashboard/src/sagas/utils.js
@@ -55,6 +55,7 @@ export function* logErrorAndThrow(errorActionType, error, payload = {}) {
  * @param {string} liquidityRewardPair.pool - The type of pool.
  * @param {string} liquidityRewardPair.contractName - The LPRewards contract
  * name for a given liquidity pair.
+ * @param {Object} liquidityRewardPair.options - Additional options that define the pool.
  * @return {LiquidityRewards} Liquidity rewards wrapper.
  */
 export function* getLPRewardsWrapper(liquidityRewardPair) {
@@ -66,7 +67,8 @@ export function* getLPRewardsWrapper(liquidityRewardPair) {
     [LiquidityRewardsFactory, LiquidityRewardsFactory.initialize],
     liquidityRewardPair.pool,
     LPRewardsContract,
-    web3
+    web3,
+    liquidityRewardPair.options
   )
 
   return LiquidityRewards
@@ -108,6 +110,7 @@ export function* subscribeToEventAndEmitData(
         : action(event)
       yield put(_action)
     } catch (error) {
+      console.log("error", error)
       console.error(`Failed subscribing to ${_debugName} event`, error)
       contractEventCahnnel.close()
     }


### PR DESCRIPTION
Depends on: #2571 

This PR updates the Liquidity page by adding info banners to the KEEP only and TBTC/Saddle cards indicating the
incentives for these pools have been removed. Also it adds a new card for the tbtcv2/Saddle pool.

<details>
  <summary>Screenshots</summary>
  
  
![obraz](https://user-images.githubusercontent.com/57687279/134507507-579fa4f7-3638-43ca-a0d1-27580a317b20.png)

![obraz](https://user-images.githubusercontent.com/57687279/134507594-cbf980af-26ef-4177-bf03-7cb2054b0dc5.png)

![obraz](https://user-images.githubusercontent.com/57687279/134507659-6ecf67f5-de35-4627-94f9-9dd05954452a.png)
</details>