### PR TITLE
Pending withdrawal cooldown update without refresh

### DIFF
--- a/solidity/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import {
   claimTokensFromWithdrawal,
   withdrawAssetPool,
@@ -32,6 +32,16 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
     pendingWithdrawal,
     withdrawalInitiatedTimestamp,
   } = useSelector((state) => state.coveragePool)
+  const [currentDateInUnix, setCurrentDateInUnix] = useState(moment().unix())
+
+  useEffect(() => {
+    const myInterval = setInterval(() => {
+      setCurrentDateInUnix(moment().unix())
+    }, 1000)
+    return () => {
+      clearInterval(myInterval)
+    }
+  })
 
   const onClaimTokensSubmitButtonClick = async (covAmount, awaitingPromise) => {
     dispatch(
@@ -171,7 +181,7 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
 
   const renderLoadingBarCooldownStatus = (timestamp) => {
     const withdrawalDate = moment.unix(timestamp)
-    const currentDate = moment()
+    const currentDate = moment.unix(currentDateInUnix)
     const endOfWithdrawalDelayDate = moment
       .unix(timestamp)
       .add(withdrawalDelay, "seconds")
@@ -222,7 +232,7 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
   }
 
   const isWithdrawalDelayOver = (pendingWithdrawalTimestamp) => {
-    const currentDate = moment()
+    const currentDate = moment.unix(currentDateInUnix)
     const endOfWithdrawalDelayDate = moment
       .unix(pendingWithdrawalTimestamp)
       .add(withdrawalDelay, "seconds")
@@ -231,7 +241,7 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
   }
 
   const isWithdrawalTimeoutOver = (pendingWithdrawalTimestamp) => {
-    const currentDate = moment()
+    const currentDate = moment.unix(currentDateInUnix)
     const endOfWithdrawalTimeoutDate = moment
       .unix(pendingWithdrawalTimestamp)
       .add(withdrawalDelay, "seconds")
@@ -241,7 +251,7 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
   }
 
   const renderTimeLeftToClaimText = (pendingWithdrawalTimestamp) => {
-    const currentDate = moment()
+    const currentDate = moment.unix(currentDateInUnix)
     const endOfWithdrawalDelayDate = moment
       .unix(pendingWithdrawalTimestamp)
       .add(withdrawalDelay, "seconds")

--- a/solidity/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
@@ -276,10 +276,10 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
       .duration(endOfWithdrawalTimeoutDate.diff(currentDate))
       .seconds()
 
-    const timeToClaimText =
+    const timeToClaimWithUnits =
       days > 0
-        ? `Available for: ${days}d ${hours}h ${minutes}m`
-        : `Available for: ${hours}h ${minutes}m ${seconds}s`
+        ? `${days}d ${hours}h ${minutes}m`
+        : `${hours}h ${minutes}m ${seconds}s`
 
     let timeToClaim = <></>
     if (!isWithdrawalTimeoutOver(pendingWithdrawalTimestamp)) {
@@ -288,7 +288,12 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
           className={"coverage-pool__withdrawal-claim-tokens-info-container"}
         >
           <div className={"coverage-pool__withdrawal-available-for"}>
-            <h4>{timeToClaimText}</h4>
+            <h4>
+              Available for:{" "}
+              <span className={days > 0 ? "text-black" : "text-error"}>
+                {timeToClaimWithUnits}
+              </span>
+            </h4>
             <Tooltip
               simple
               delay={0}


### PR DESCRIPTION
Updates the cooldown time and progress bar for pending withdrawal without the need to refresh the page.

<details>
<summary>Example</summary>

https://user-images.githubusercontent.com/40306834/134727454-27e58481-ba03-414a-b60a-eb03c75a5434.mov
</details>

Also changes the color of the time available for claiming tokens to red, when there is less than 1 day to claim the tokens.

<details>
<summary>Example</summary>

![image](https://user-images.githubusercontent.com/40306834/134727697-b604615d-ea31-4236-a256-c2fc2a0540bd.png)
</details>


