### PR TITLE
Fix adding comments to dashboard PRs

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -60,10 +60,10 @@ jobs:
     # A pull_request event is a PR; leave a comment with the preview URL.
     - if: github.event_name == 'pull_request'
       name: Post preview URL to PR
-      uses: actions/github-script@v3
+      uses: actions/github-script@v5
       with:
         script: |
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
We need to call the `issues.createComment` command using `github.rest.`
context, because the Octokit context available via github no longer has
REST methods accessible directly
(https://github.com/actions/github-script#breaking-changes-in-v5).
Also, we need to use `v5` of the `github-script` action, which supports
the new changes.