### PR TITLE
Fix space issue with modals

### DIFF
--- a/solidity/dashboard/src/components/coverage-pools/ClaimTokensModal.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/ClaimTokensModal.jsx
@@ -72,7 +72,7 @@ const ClaimTokensModal = ({
           </h4>
         </div>
       </div>
-      <Divider style={{ margin: "0.5rem 0" }} />
+      <Divider style={{ margin: "0.5rem 0", marginTop: "auto" }} />
       <div className="flex row center mt-2">
         <OnlyIf condition={!transactionFinished}>
           <Button
@@ -89,7 +89,7 @@ const ClaimTokensModal = ({
         </OnlyIf>
         <OnlyIf condition={transactionFinished}>
           <Button
-            className="btn btn-lg btn-secondary"
+            className="btn btn-lg btn-secondary success-modal-close-button"
             disabled={false}
             onClick={onCancel}
           >

--- a/solidity/dashboard/src/components/coverage-pools/InitiateDepositModal.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/InitiateDepositModal.jsx
@@ -83,9 +83,12 @@ const InitiateDepositModal = ({
           <CooldownPeriodBanner />
         </OnlyIf>
         <OnlyIf condition={transactionFinished}>
-          <Divider className="divider divider--tile-fluid" />
+          <Divider
+            className="divider divider--tile-fluid"
+            style={{ margin: "0.5rem 0", marginTop: "auto" }}
+          />
           <Button
-            className="btn btn-lg btn-secondary"
+            className="btn btn-lg btn-secondary success-modal-close-button"
             disabled={false}
             onClick={onCancel}
           >

--- a/solidity/dashboard/src/components/coverage-pools/WithdrawalInfo.jsx
+++ b/solidity/dashboard/src/components/coverage-pools/WithdrawalInfo.jsx
@@ -65,9 +65,12 @@ const WithdrawalInfo = ({
         <CooldownPeriodBanner />
       </OnlyIf>
       <OnlyIf condition={transactionFinished}>
-        <Divider className="divider divider--tile-fluid" />
+        <Divider
+          className="divider divider--tile-fluid"
+          style={{ marginTop: "auto" }}
+        />
         <Button
-          className="btn btn-lg btn-secondary"
+          className="btn btn-lg btn-secondary success-modal-close-button"
           disabled={false}
           onClick={onCancel}
         >

--- a/solidity/dashboard/src/css/modal-with-timeline.less
+++ b/solidity/dashboard/src/css/modal-with-timeline.less
@@ -4,6 +4,12 @@
   .modal-with-timeline-modal__info {
     width: 100%;
     padding: 2rem;
+    display: flex;
+    flex-direction: column;
+
+    .success-modal-close-button {
+      width: 33%;
+    }
   }
 
   .modal-with-timeline__timeline-container {


### PR DESCRIPTION
Add space above close button in modals with timeline

Examples:

![image](https://user-images.githubusercontent.com/40306834/135096694-45821148-435e-471b-bad9-e6dba66e27c9.png)

![image](https://user-images.githubusercontent.com/40306834/135096762-ad5d0ce0-8158-4c3f-ba42-4c1fdf384340.png)

