### PR TITLE
Fix broken path filtering in dashboard-format.yaml

### DIFF
--- a/.github/workflows/dashboard-format.yaml
+++ b/.github/workflows/dashboard-format.yaml
@@ -17,7 +17,7 @@ jobs:
   dashboard-detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      dashboard: ${{ steps.filter.outputs.path-filter }}
+      path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
     - uses: actions/checkout@v2
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
Filtering applied in `dashboard-detect-changes` job was creating output
called `dashboard`, whereas the `dashboard-code-format` job was executng
conditionally if (non-existing) `path-filter` output was true or if the
triggering event was different than PR. This way the
`dashboard-code-format` job was never executed for the Pull Requests.
The naming of the output in `dashboard-detect-changes` has been changed
to `path-filter`, which makes it consistent with other workflows.