### PR TITLE
`ExchangeRate` component updates

### DIFF
--- a/solidity-v1/dashboard/src/components/coverage-pools/ExchangeRate.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/ExchangeRate.jsx
@@ -1,9 +1,10 @@
 import React from "react"
+import BigNumber from "bignumber.js"
 import { Keep } from "../../contracts"
-import TokenAmount from "../TokenAmount"
 
 const BaseExchangeRate = ({
   covToken,
+  collateralToken,
   amount,
   htmlTag = "div",
   className = "",
@@ -12,13 +13,9 @@ const BaseExchangeRate = ({
   return (
     <Tag className={className}>
       {`1 ${covToken.symbol}`} =&nbsp;
-      <TokenAmount
-        amount={amount}
-        decimalsToDisplay={3}
-        wrapperClassName="flex-inline"
-        amountClassName=""
-        symbolClassName=""
-      />
+      {collateralToken.displayAmountWithSymbol(amount, 3, (amount) =>
+        new BigNumber(amount).toFormat(3, BigNumber.ROUND_DOWN)
+      )}
     </Tag>
   )
 }
@@ -33,6 +30,7 @@ export const CoveragePoolV1ExchangeRate = ({
   <BaseExchangeRate
     {...restProps}
     covToken={covToken}
+    collateralToken={collateralToken}
     amount={Keep.coveragePoolV1.estimatedBalanceFor(
       collateralToken.fromTokenUnit(1).toString(),
       covTotalSupply,

--- a/solidity-v1/dashboard/src/components/coverage-pools/ExchangeRate.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/ExchangeRate.jsx
@@ -11,7 +11,7 @@ const BaseExchangeRate = ({
   const Tag = htmlTag
   return (
     <Tag className={className}>
-      {`1 ${covToken.symbol}`} = ~
+      {`1 ${covToken.symbol}`} =&nbsp;
       <TokenAmount
         amount={amount}
         decimalsToDisplay={3}

--- a/solidity-v1/dashboard/src/utils/token.utils.js
+++ b/solidity-v1/dashboard/src/utils/token.utils.js
@@ -72,13 +72,16 @@ export class Token {
    *
    * @param {*} amount An amount in the samllest unit of the token.
    * @param {number} decimals How many decimal places we want to display in the amount.
+   * @param {Function} formattingFn Function that formats the amount to display.
    *
    * @return {string} Formatted amount in readble format.
    */
-  displayAmount = (amount, decimals = this.decimalsToDisplay) => {
-    return this._displayAmount(amount, decimals, (amount, decimals) => {
-      return this.toFormat(amount, decimals)
-    })
+  displayAmount = (
+    amount,
+    decimals = this.decimalsToDisplay,
+    formattingFn = this.toFormat
+  ) => {
+    return this._displayAmount(amount, decimals, formattingFn)
   }
 
   /**
@@ -104,11 +107,19 @@ export class Token {
    * Displays an amount with a token symbol.
    *
    * @param {*} amount An amount to display.
+   * @param {number} decimals How many decimal places we want to display in the amount.
+   * @param {Function} formattingFn Function that formats the amount to display.
    *
    * @return {string} Formatted amount with a token symbol.
    */
-  displayAmountWithSymbol = (amount) => {
-    return `${this.displayAmount(amount)} ${this.symbol}`
+  displayAmountWithSymbol = (
+    amount,
+    decimals = this.decimalsToDisplay,
+    formattingFn = this.toFormat
+  ) => {
+    return `${this.displayAmount(amount, decimals, formattingFn)} ${
+      this.symbol
+    }`
   }
 
   /**


### PR DESCRIPTION
This PR updates the `ExchangeRate` component based on the users' usability studies.

Main changes:
* always keep 3 decimal places in exchange rate no matter what (so for example `1.000`; `1.100`; `1.110`; `1.111`)
* remove tilda completely,