### PR TITLE
Improve modals based on withdrawal status

### DIFF
--- a/solidity-v1/dashboard/src/__tests__/utils/coverage-pools.utils.test.js
+++ b/solidity-v1/dashboard/src/__tests__/utils/coverage-pools.utils.test.js
@@ -1,0 +1,67 @@
+import moment from "moment"
+import { getPendingWithdrawalStatus } from "../../utils/coverage-pools.utils"
+import { PENDING_WITHDRAWAL_STATUS } from "../../constants/constants"
+
+describe("Test getPendingWithdrawalStatus function", () => {
+  let currentDate
+  let withdrawalDelay
+  let withdrawalTimeout
+
+  beforeEach(() => {
+    currentDate = moment()
+    withdrawalDelay = 1814400 // 21 days
+    withdrawalTimeout = 259200 // 3 days
+  })
+
+  it("Should return status pending when current date is before end of withdrawal delay date", () => {
+    const withdrawalInitiatedTimestamp = currentDate.subtract(1, "days").unix()
+
+    const result = getPendingWithdrawalStatus(
+      withdrawalDelay,
+      withdrawalTimeout,
+      withdrawalInitiatedTimestamp
+    )
+
+    expect(result).toBe(PENDING_WITHDRAWAL_STATUS.PENDING)
+  })
+
+  it("Should return status available to withdraw when current date is after end of withdrawal delay date but before end of withdrawal timeout date", () => {
+    const withdrawalInitiatedTimestamp = currentDate
+      .subtract(withdrawalDelay, "seconds")
+      .subtract(1, "days")
+      .unix()
+
+    const result = getPendingWithdrawalStatus(
+      withdrawalDelay,
+      withdrawalTimeout,
+      withdrawalInitiatedTimestamp
+    )
+
+    expect(result).toBe(PENDING_WITHDRAWAL_STATUS.AVAILABLE_TO_WITHDRAW)
+  })
+
+  it("Should return status expire when current date is after end of timeout date", () => {
+    const withdrawalInitiatedTimestamp = currentDate
+      .subtract(withdrawalDelay, "seconds")
+      .subtract(withdrawalTimeout, "seconds")
+      .subtract(1, "days")
+      .unix()
+
+    const result = getPendingWithdrawalStatus(
+      withdrawalDelay,
+      withdrawalTimeout,
+      withdrawalInitiatedTimestamp
+    )
+
+    expect(result).toBe(PENDING_WITHDRAWAL_STATUS.EXPIRED)
+  })
+
+  it("Should return status none when withdrawal initiated timestamp is not provided", () => {
+    const result = getPendingWithdrawalStatus(
+      withdrawalDelay,
+      withdrawalTimeout
+    )
+
+    expect(result).toBe(PENDING_WITHDRAWAL_STATUS.NONE)
+  })
+})

--- a/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
@@ -110,6 +110,9 @@ const IncreaseWithdrawalModal = ({
           componentProps: {
             pendingWithdrawalBalance: pendingWithdrawalBalance,
             amount: amount,
+            withdrawalDelay: withdrawalDelay,
+            withdrawalTimeout: withdrawalTimeout,
+            withdrawalInitiatedTimestamp: withdrawalInitiatedTimestamp,
           },
         })
       )

--- a/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
@@ -126,6 +126,11 @@ const IncreaseWithdrawalModal = ({
     withdrawalInitiatedTimestamp
   )
 
+  const withdrawalInfoTitle =
+    pendingWithdrawalState === PENDING_WITHDRAWAL_STATUS.EXPIRED
+      ? "Your new withdrawal amount"
+      : "You are about to withdraw"
+
   return (
     <ModalWithOverview
       className={`${className} withdraw-modal__main-container`}
@@ -149,13 +154,16 @@ const IncreaseWithdrawalModal = ({
       <OnlyIf condition={step === 2}>
         <WithdrawalInfo
           transactionFinished={transactionFinished}
-          containerTitle={"Your new withdrawal amount"}
+          containerTitle={withdrawalInfoTitle}
           submitBtnText={"withdraw"}
           onBtnClick={onSubmit}
           onCancel={onCancel}
           amount={add(pendingWithdrawalBalance, amount)}
+          pendingWithdrawalBalance={pendingWithdrawalBalance}
+          addedAmount={amount}
           totalValueLocked={totalValueLocked}
           covTotalSupply={covTotalSupply}
+          pendingWithdrawalState={pendingWithdrawalState}
         >
           <div className={"withdraw-modal__data-row"}>
             <h4 className={"text-grey-50"}>Exchange Rate&nbsp;</h4>

--- a/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
@@ -19,6 +19,8 @@ import { CoveragePoolV1ExchangeRate } from "./ExchangeRate"
 import { getPendingWithdrawalStatus } from "../../utils/coverage-pools.utils"
 import { PENDING_WITHDRAWAL_STATUS } from "../../constants/constants"
 
+const ONE_DAY_IN_SECONDS = 86400
+
 const getItems = (covKeepAmount, pendingWithdrawalStatus) => {
   if (pendingWithdrawalStatus === PENDING_WITHDRAWAL_STATUS.PENDING) {
     return [
@@ -423,7 +425,7 @@ const IncreaseWithdrawalModalTile = ({
           }
         >
           <div className={"modal-with-overview__delay text-grey-50"}>
-            {Math.floor(withdrawalDelay / (60 * 60 * 24))} days:{" "}
+            {Math.floor(withdrawalDelay / ONE_DAY_IN_SECONDS)} days:{" "}
             {endOfWithdrawalDelayDate.format("MM/DD")}
           </div>
         </OnlyIf>

--- a/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/IncreaseWithdrawalModal.jsx
@@ -128,8 +128,6 @@ const IncreaseWithdrawalModal = ({
       className={`${className} withdraw-modal__main-container`}
       pendingWithdrawalBalance={pendingWithdrawalBalance}
       addedAmount={amount}
-      totalValueLocked={totalValueLocked}
-      covTotalSupply={covTotalSupply}
       withdrawalDelay={withdrawalDelay}
       withdrawalTimeout={withdrawalTimeout}
       withdrawalInitiatedTimestamp={withdrawalInitiatedTimestamp}
@@ -201,8 +199,6 @@ const IncreaseWithdrawalModal = ({
 
 const IncreaseWithdrawalModalStep1 = ({
   addedAmount,
-  totalValueLocked,
-  covTotalSupply,
   onSubmit,
   onCancel,
   pendingWithdrawalState,
@@ -270,8 +266,6 @@ const ModalWithOverview = ({
         <h4 className={"mb-1"}>Overview</h4>
         <IncreaseWithdrawalModal.Tile
           amount={pendingWithdrawalBalance}
-          totalValueLocked={totalValueLocked}
-          covTotalSupply={covTotalSupply}
           withdrawalDelay={withdrawalDelay}
           withdrawalTimeout={withdrawalTimeout}
           withdrawalInitiatedTimestamp={withdrawalInitiatedTimestamp}
@@ -292,8 +286,6 @@ const ModalWithOverview = ({
         </h4>
         <IncreaseWithdrawalModal.Tile
           amount={add(pendingWithdrawalBalance, addedAmount)}
-          totalValueLocked={totalValueLocked}
-          covTotalSupply={covTotalSupply}
           withdrawalDelay={withdrawalDelay}
           withdrawalTimeout={withdrawalTimeout}
           pendingWithdrawalState={PENDING_WITHDRAWAL_STATUS.NONE}
@@ -306,8 +298,6 @@ const ModalWithOverview = ({
 const IncreaseWithdrawalModalTile = ({
   title,
   amount,
-  totalValueLocked,
-  covTotalSupply,
   withdrawalDelay,
   withdrawalTimeout,
   /** if null then it is a new withdrawal */

--- a/solidity-v1/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
@@ -105,6 +105,8 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
         totalValueLocked,
         covTotalSupply,
         withdrawalDelay,
+        withdrawalTimeout,
+        withdrawalInitiatedTimestamp,
         containerTitle: "You are about to re-initiate this withdrawal:",
       },
       ReinitiateWithdrawalModal

--- a/solidity-v1/dashboard/src/components/coverage-pools/ReinitiateWithdrawalModal.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/ReinitiateWithdrawalModal.jsx
@@ -19,6 +19,8 @@ const ReinitiateWithdrawalModal = ({
   totalValueLocked,
   covTotalSupply,
   withdrawalDelay,
+  withdrawalTimeout,
+  withdrawalInitiatedTimestamp,
   submitBtnText,
   onBtnClick,
   onCancel,
@@ -90,6 +92,8 @@ const ReinitiateWithdrawalModal = ({
             totalValueLocked={totalValueLocked}
             covTotalSupply={covTotalSupply}
             withdrawalDelay={withdrawalDelay}
+            withdrawalTimeout={withdrawalTimeout}
+            withdrawalInitiatedTimestamp={withdrawalInitiatedTimestamp}
             submitBtnText={"withdraw"}
             onBtnClick={onSubmit}
             onCancel={onCancel}

--- a/solidity-v1/dashboard/src/components/coverage-pools/WithdrawalInfo.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/WithdrawalInfo.jsx
@@ -8,6 +8,8 @@ import React from "react"
 import { AcceptTermConfirmationModal } from "../ConfirmationModal"
 import { Keep } from "../../contracts"
 import { CooldownPeriodBanner } from "../coverage-pools"
+import Chip from "../Chip"
+import { PENDING_WITHDRAWAL_STATUS } from "../../constants/constants"
 
 const WithdrawalInfo = ({
   transactionFinished,
@@ -16,8 +18,11 @@ const WithdrawalInfo = ({
   onBtnClick,
   onCancel,
   amount,
+  pendingWithdrawalBalance,
+  addedAmount,
   totalValueLocked,
   covTotalSupply,
+  pendingWithdrawalState = PENDING_WITHDRAWAL_STATUS.NONE,
   children,
 }) => {
   return (
@@ -43,22 +48,93 @@ const WithdrawalInfo = ({
         </h4>
       </OnlyIf>
       <div className={"withdraw-modal__data"}>
-        <TokenAmount
-          amount={amount}
-          wrapperClassName={"withdraw-modal__token-amount"}
-          token={covKEEP}
-        />
-        <TokenAmount
-          wrapperClassName={"withdraw-modal__cov-token-amount"}
-          amount={Keep.coveragePoolV1.estimatedBalanceFor(
-            amount,
-            covTotalSupply,
-            totalValueLocked
-          )}
-          amountClassName={"h3 text-grey-60"}
-          symbolClassName={"h3 text-grey-60"}
-          token={KEEP}
-        />
+        <OnlyIf
+          condition={
+            transactionFinished ||
+            pendingWithdrawalState === PENDING_WITHDRAWAL_STATUS.EXPIRED ||
+            pendingWithdrawalState === PENDING_WITHDRAWAL_STATUS.NONE
+          }
+        >
+          <TokenAmount
+            amount={amount}
+            wrapperClassName={"withdraw-modal__token-amount"}
+            token={covKEEP}
+          />
+          <TokenAmount
+            wrapperClassName={"withdraw-modal__cov-token-amount"}
+            amount={Keep.coveragePoolV1.estimatedBalanceFor(
+              amount,
+              covTotalSupply,
+              totalValueLocked
+            )}
+            amountClassName={"h3 text-grey-60"}
+            symbolClassName={"h3 text-grey-60"}
+            token={KEEP}
+          />
+        </OnlyIf>
+        <OnlyIf
+          condition={
+            !transactionFinished &&
+            (pendingWithdrawalState === PENDING_WITHDRAWAL_STATUS.PENDING ||
+              pendingWithdrawalState ===
+                PENDING_WITHDRAWAL_STATUS.AVAILABLE_TO_WITHDRAW)
+          }
+        >
+          <div
+            className={
+              "withdraw-modal__data-row withdraw-modal__data-row--baseline-align"
+            }
+          >
+            <TokenAmount
+              amount={addedAmount}
+              wrapperClassName={"withdraw-modal__data-row__token-amount"}
+              token={covKEEP}
+            />
+            <TokenAmount
+              wrapperClassName={"withdraw-modal__data-row__cov-token-amount"}
+              amount={Keep.coveragePoolV1.estimatedBalanceFor(
+                addedAmount,
+                covTotalSupply,
+                totalValueLocked
+              )}
+              amountClassName={"h4 text-grey-50"}
+              symbolClassName={"h4 text-grey-50"}
+              token={KEEP}
+            />
+          </div>
+          <div
+            className={
+              "withdraw-modal__data-row withdraw-modal__data-row--baseline-align mb-3"
+            }
+          >
+            <span className={"h4 text-gray-70"}>+</span>
+            <TokenAmount
+              amount={pendingWithdrawalBalance}
+              wrapperClassName={"withdraw-modal__data-row__token-amount"}
+              amountClassName={"h4 text-grey-70"}
+              symbolClassName={"h4 text-grey-70"}
+              token={covKEEP}
+            />
+            <Chip
+              text={`existing`}
+              size="small"
+              className={"withdraw-modal_existing-withdrawal-chip"}
+              color="yellow"
+            />
+            <TokenAmount
+              wrapperClassName={"withdraw-modal__data-row__cov-token-amount"}
+              amount={Keep.coveragePoolV1.estimatedBalanceFor(
+                pendingWithdrawalBalance,
+                covTotalSupply,
+                totalValueLocked
+              )}
+              amountClassName={"h4 text-grey-50"}
+              symbolClassName={"h4 text-grey-50"}
+              token={KEEP}
+            />
+          </div>
+        </OnlyIf>
+
         {children}
       </div>
       <OnlyIf condition={!transactionFinished}>

--- a/solidity-v1/dashboard/src/constants/constants.js
+++ b/solidity-v1/dashboard/src/constants/constants.js
@@ -193,3 +193,10 @@ export const TBTC_TOKEN_VERSION = {
   v1: "v1",
   v2: "v2",
 }
+
+export const PENDING_WITHDRAWAL_STATUS = {
+  NONE: "none",
+  PENDING: "pending",
+  AVAILABLE_TO_WITHDRAW: "available_to_withdraw",
+  EXPIRED: "expired",
+}

--- a/solidity-v1/dashboard/src/css/increase-withdrawal-modal.less
+++ b/solidity-v1/dashboard/src/css/increase-withdrawal-modal.less
@@ -21,7 +21,7 @@
     .modal-with-overview__tile {
       background-color: @white;
       padding: 1rem;
-      border: 1px solid #de7171;
+      border: 1px solid @color-yellow-60;
       box-sizing: border-box;
       box-shadow: 0px 4px 4px rgba(196, 196, 196, 0.3);
       border-radius: 8px;
@@ -38,6 +38,18 @@
         .modal-with-overview__delay {
           margin-left: auto;
         }
+      }
+
+      &--expired {
+        border: 1px solid @color-red-60;
+      }
+
+      &--completed {
+        border: 1px solid @color-brand-mint;
+      }
+
+      &--new {
+        border: 1px solid @color-yellow-100;
       }
     }
 

--- a/solidity-v1/dashboard/src/css/withdraw-modal.less
+++ b/solidity-v1/dashboard/src/css/withdraw-modal.less
@@ -31,6 +31,20 @@
       align-items: center;
       padding: 0.2rem 0;
 
+      &--baseline-align {
+        align-items: baseline;
+      }
+
+      .withdraw-modal_existing-withdrawal-chip {
+        margin-left: 0.5rem;
+        align-self: flex-start;
+      }
+
+      .withdraw-modal__data-row__cov-token-amount {
+        margin-left: auto;
+        font-weight: 400;
+      }
+
       .withdraw-modal__data__value {
         margin-left: auto;
       }

--- a/solidity-v1/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
+++ b/solidity-v1/dashboard/src/pages/coverage-pools/CoveragePoolPage.jsx
@@ -46,6 +46,7 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
     totalAllocatedRewards,
     totalCoverageClaimed,
     withdrawalDelay,
+    withdrawalTimeout,
     pendingWithdrawal,
     withdrawalInitiatedTimestamp,
     hasRiskManagerOpenAuctions,
@@ -149,6 +150,8 @@ const CoveragePoolPage = ({ title, withNewLabel }) => {
           covTotalSupply,
           totalValueLocked,
           withdrawalDelay,
+          withdrawalTimeout,
+          withdrawalInitiatedTimestamp,
           containerTitle: "You are about to re-initiate this withdrawal:",
         },
         ReinitiateWithdrawalModal

--- a/solidity-v1/dashboard/src/sagas/coverage-pool.js
+++ b/solidity-v1/dashboard/src/sagas/coverage-pool.js
@@ -296,6 +296,10 @@ export function* subscribeToWithdrawalInitiatedEvent() {
           transactionHash: event.transactionHash,
           pendingWithdrawalBalance: componentProps?.pendingWithdrawalBalance,
           amount: amount,
+          withdrawalDelay: componentProps?.withdrawalDelay,
+          withdrawalTimeout: componentProps?.withdrawalTimeout,
+          withdrawalInitiatedTimestamp:
+            componentProps?.withdrawalInitiatedTimestamp,
         },
         modalProps: {
           title,

--- a/solidity-v1/dashboard/src/utils/coverage-pools.utils.js
+++ b/solidity-v1/dashboard/src/utils/coverage-pools.utils.js
@@ -1,0 +1,48 @@
+import { PENDING_WITHDRAWAL_STATUS } from "../constants/constants"
+import moment from "moment"
+
+/**
+ * @typedef {"none" | "pending" | "available_to_withdraw" | "expired"} PendingWithdrawalStatus
+ */
+
+/**
+ *
+ * @param {Number} withdrawalDelay - withdrawal delay in seconds
+ * @param {Number} withdrawalTimeout - withdrawal timeout in seconds
+ * @param {Number} withdrawalInitiatedTimestamp - unix timestamp of the
+ * initiated withdrawal
+ * @return {PendingWithdrawalStatus} - returns the status of the withdrawal
+ */
+export const getPendingWithdrawalStatus = (
+  withdrawalDelay,
+  withdrawalTimeout,
+  withdrawalInitiatedTimestamp
+) => {
+  if (!withdrawalDelay || !withdrawalTimeout || !withdrawalInitiatedTimestamp) {
+    return PENDING_WITHDRAWAL_STATUS.NONE
+  }
+
+  const currentDate = moment()
+  const endOfWithdrawalDelayDate = moment
+    .unix(withdrawalInitiatedTimestamp)
+    .add(withdrawalDelay, "seconds")
+  const endOfWithdrawalTimeoutDate = withdrawalInitiatedTimestamp
+    ? moment.unix(withdrawalInitiatedTimestamp)
+    : moment()
+  endOfWithdrawalTimeoutDate
+    .add(withdrawalDelay, "seconds")
+    .add(withdrawalTimeout, "seconds")
+
+  if (currentDate.isSameOrBefore(endOfWithdrawalDelayDate)) {
+    return PENDING_WITHDRAWAL_STATUS.PENDING
+  } else if (
+    currentDate.isAfter(endOfWithdrawalDelayDate) &&
+    currentDate.isSameOrBefore(endOfWithdrawalTimeoutDate)
+  ) {
+    return PENDING_WITHDRAWAL_STATUS.AVAILABLE_TO_WITHDRAW
+  } else if (currentDate.isAfter(endOfWithdrawalTimeoutDate)) {
+    return PENDING_WITHDRAWAL_STATUS.EXPIRED
+  }
+
+  return PENDING_WITHDRAWAL_STATUS.NONE
+}


### PR DESCRIPTION
Changes:

- Change modal Overview section based on existing withdrawal status
  <details>
  <summary>Examples</summary>
  <br>
  
  For "pending" status:
  ![image](https://user-images.githubusercontent.com/40306834/137137766-8ef5441f-5602-4326-9e96-4bf98c1ace6c.png)
  
  For "available to withdraw" status:
  ![image](https://user-images.githubusercontent.com/40306834/137138915-b2d32158-1261-4170-9d1b-697b81014d65.png)



  </details>
- Change the way token amount is displayed when there is existing withdrawal that has "pending" or "available to withdraw" status
  <details>
    <summary>Example</summary>
    <br>
    
    
  ![image](https://user-images.githubusercontent.com/40306834/137139121-dcfc77cb-2906-4640-8c6c-fdc8b3c40733.png)

    
    </details>
- added new method `getPendingWithdrawalStatus` and tests for it