### PR TITLE
Disable client workflows for solidity directory

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/**"
       - "token-stakedrop/**"
       - "solidity-v1/dashboard/**"
+      - "solidity/**"
   pull_request:
   workflow_dispatch:
     inputs:
@@ -42,7 +43,7 @@ jobs:
         with:
           filters: |
             path-filter:
-              - './!((docs|infrastructure|scripts|token-stakedrop|(solidity-v1/dashboard))/**)'
+              - './!((docs|infrastructure|scripts|token-stakedrop|(solidity-v1/dashboard)|solidity)/**)'
 
   client-build-test-publish:
     needs: client-detect-changes


### PR DESCRIPTION
The solidity directory contains contracts for V2 which are not yet
supported by the client. There is no need to invoke the client workflow
in case of updates to those files.
We should enable it back later, when we start working on the client for
V2.