### PR TITLE
Document Acceptance Criteria for Random Beacon v2

### DIFF
--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -1,0 +1,438 @@
+:toc: macro
+
+= Random Beacon v2 User Acceptance Criteria
+
+:icons: font
+:numbered:
+toc::[]
+
+== Purpose of the document
+This document stores User Acceptance Criteria for Random Beacon v2 feature. It
+will be used to gain common understanding of how Random Beacon v2 should act and
+will be utilised during the acceptance testing of the feature.
+
+== Usear Acceptance Criteria list
+
+[%header,cols="1,4"]
+|===
+| Area
+| UAC
+
+| Relay request
+| Anyone can send a relay entry request transaction.
+
+| Relay request
+| Processing of each relay entry request should always result in the generation
+  of a random number (relay entry) and sometimes also (if certain conditions are
+  met) in a creation of a new signing group.
+
+| Relay request
+| When sending the relay request, the requester should provide a fixed fee in T.
+
+| Relay request
+| Upon receiving the relay entry request, the random beacon contract should
+  determine validity of the request.
+
+| Relay request
+| When determining validity of the relay entry request, the following aspects
+  should be taken into account: +
+  - isn’t the other relay entry request already pending? +
+  - has the requester provided the exact required fee? (if the fee is lower or
+  higher, the transaction should be reverted) +
+  - is there at least one active signing group?
+
+| Relay request
+| If a relay request is submitted before the previous relay request finished
+  being processed, the new request should be rejected (transaction should be
+  reverted).
+
+| Relay request
+| If the relay entry request is deemed valid, then: +
+  - the fee provided by the requester should be deposited in the maintenance
+  pool (with an intention to cover the reimbursements for DKG-related actions) +
+  - the current relay entry should be used by the beacon to select a signing
+  group from the set of active groups (by hashing the relay entry and applying
+  `modulo no_of_active_groups` operation on the result) +
+  - the random beacon contract should emit an event informing about the signing
+  group selection +
+  - the beacon should start the period of signature submission eligibility +
+  - the selected signing group should start off-chain signature generation (upon
+  noticing event sent by the beacon)
+
+| Relay request
+| If the relay entry request is deemed invalid, then: +
+  - the transaction should be reverted
+
+| Relay request - signature generation
+| Once the active group is selected as a signing group, it is tasked with the
+  generation of a BLS threshold signature (based on the current relay entry and
+  the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
+  signing group).
+
+| Relay request - relay entry submission
+| During the signature submission eligibility period only selected members from
+  the group should be eligible to successfully submit the new relay entry
+  result. +
+  - at the beginning (right after the challenge period passes) only one member
+  (with index `new_entry % group_size` should be eligible +
+  - after fixed amount of blocks another member (with index `(new_entry %
+  group_size ) + 1` should become eligible (previous operator remains eligible)
+  - next members should become eligible after each fixed amount of blocks
+
+| Relay request - relay entry submission
+| Upon receiving the transaction submitting the relay entry, the random beacon
+  contract should determine validity of the transaction.
+
+| Relay request - relay entry submission
+| When determining validity of the relay entry submission, the following aspects
+  should be taken into account: +
+  - is the submitter eligible to submit? +
+  - hasn’t the hard timeout for the relay request be reached?
+
+| Relay request - relay entry submission
+| When requesting a relay entry, it should be possible to pass an optional
+  address parameter - this is the address of a contract implementing
+  `IRandomBeaconConsumer` interface
+
+| Relay request - relay entry submission
+| If the transaction submitting the new relay entry gets approved, then: +
+  - the BLS threshold signature should be accepted as a new relay entry +
+// TODO: revisit if 2 weeks removal time should be a governable parameter and if
+// it should be equall to 2 weeks or a different value
+  - operators who became eligible for submitting the relay entry before the
+  member who submitted the relay entry should be punished by being removed from
+  the sortition pool for a fixed amount of time (2 weeks) (in the same tx) +
+  - if an optional address of the `IRandomBeaconConsumer` interface was provided
+  in the tx, the interface should be called +
+  - the creation of a new signing group should be triggered (only sometimes, if
+  it’s the right time)
+
+| Relay request - relay entry submission
+| The transaction submitting relay entry is not reimbursable (i.e. the submitter
+  must provide the fee required for its processing).
+
+| Relay request - relay entry submission
+| The transaction submitting relay entry should have a predictable cost and the
+  gas cost of this transaction should be as low as possible, below 200k gas.
+
+| Relay request - relay entry submission
+| It should be possible to send low gas callbacks (up to the fixed gas cost
+  value) in the transaction submitting the relay entry.
+
+| Relay request - relay entry submission
+| Failure in the callback function should not revert the relay entry transaction.
+
+| Relay request - relay entry submission
+| The operation removing members from the sortition pool should be as cheap as
+  possible so that the member submitting relay entry does not have to pay any
+  additional costs for removing inactive members from the pool.
+
+| Relay request - relay entry timeouts
+| The soft relay entry timeout equals the group size multiplied by the number of
+  blocks for a member to become eligible to submit relay entry. The timer starts
+  at the moment when the first member becomes eligible (the moment when the
+  relay entry was requested). +
+  The hard relay entry timeout is a set value (measured in time units).
+
+| Relay request - relay entry timeouts
+| If no entry was successfully submitted until soft relay timeout is reached,
+  all operators in the group should start bleeding and losing their T stake. The
+  amount of lost stake should incrementally increase from 0 (at the moment of
+  soft relay entry timeout) to a fixed value (at the moment of hard relay entry
+  timeout)
+
+| Relay entry utilisation
+| Applications wanting to use a relay entry should submit another transaction
+  using the relay entry value previously set by the random beacon
+
+| Relay entry utilisation
+| Smart contract consuming new relay entry needs to implement
+  `IRandomBeaconConsumer` interface
+
+| Group creation
+| New groups should be crated with a fixed frequency of relay request (every
+  `N`-th relay entry request should result in the creation of a new group)
+
+| Group creation
+| If according to group creation frequency the relay entry request is the one
+  that should trigger new group creation, the creation should be triggered once
+  a new relay entry appears on the chain (all off-chain clients should start the
+  process of creation of new group using the new entry value and a view
+  sortition pool function call).
+
+| Group creation
+| Frequency must be rare enough to leave the time for the group creation and
+  then (when the pool gets unlocked) for joining operators to pools
+
+| Group creation
+| Group creation start transaction should be embedded into relay entry request
+  transaction
+
+| Group creation
+| Group creation start transaction should lock the sortition pool and emit the
+  group creation start event
+
+| Group creation
+| Group creation start transaction should be as cheap as possible
+
+| Group creation
+| The sortition pool should weigh operators by stake and allow to select the
+  same operator to group multiple times
+
+| Group creation - genesis
+| Beacon genesis should trigger the first group creation based on a fixed,
+  arbitrary seed value
+
+| Group creation - genesis
+| It should not be possible to perform beacon genesis if they are some active
+  groups.
+
+| Group creation - genesis
+| Everybody should be able to run beacon genesis in the following situations: +
+  - when no groups were created by the random beacon before +
+  or +
+  - when there were some groups created by the random beacon before, but they
+  all have expired
+
+| Group creation
+| Group creation start transaction should result in: +
+  - selection of a candidate group consisting of `group_size` members of
+  sortition pool +
+  - triggering of the DKG (distributed key generation) +
+  - the beacon should start the period of DKG result submission eligibility
+
+| Croup creation - selecting members
+| Upon noticing the group creation start event, clients should choose the
+  sortition pool members to the candidate group based on the current relay
+  entry, ensuring that the higher is the stake of an operator, the higher is his
+  chance of being selected to the group.
+
+| Group creation - DKG
+| After group members are determined, they should perform DKG, resulting in the
+  establishment of one of the below statuses: +
+  - success - together with the list of members of the candidate group, the
+  public key of the group and list of misbehaving members (members who were
+  inactive or were disqualified) +
+  - failure - together with the list of disqualified members
+
+| Group creation - DKG submission
+| When determining validity of the tx submitting the DKG result, the following
+  aspects should be taken into account: +
+  - is the submitter eligible at the moment to send the tx? +
+  - are there enough supporting signatures on the result? +
+  - do the signatures come from the stakers with at least a minimum stake? +
+  Only if all the above conditions have been met, the tx is considered valid.
+
+| Group creation - DKG submission
+| The transaction submitting DKG result should have a predictable cost.
+
+| Group creation - DKG submission
+| At a given moment, only selected members from the group should be eligible to
+  successfully submit the DKG result to the chain: +
+  - at the beginning (right after the challenge period passes) only one member
+  with index `hash(new_group_pubkey) % group_size` should be eligible +
+  - after fixed amount of blocks another member (with index
+  `(hash(new_group_pubkey) % group_size ) + 1` should become eligible (previous
+  operator remains eligible) +
+  - next members should become eligible after each fixed amount of blocks
+
+| Group creation - DKG submission
+| If random beacon deems the transaction submitting the DKG valid, then: +
+  - the DKG result submission eligibility period should finish (all other
+  results should be rejected from now on) +
+  - a challenge period should start
+
+| Group creation - DKG challenge
+| Anyone can send a challenge notification that submitted DKG result contains
+  group members not selected by the pool
+
+| Group creation - DKG challenge
+| Upon processing the challenge notification, the random beacon contract should
+  determine validity of the challenge.
+
+| Group creation - DKG challenge
+| When determining validity of the challenge, the following aspects should be
+  taken into account: +
+  - does it reference existing DKG result (if not, then challenge invalid) +
+  - within or outside of the challenge period for the specified DKG result (if
+  outside, then invalid) +
+  - have all members who signed a DKG result been selected by the sortition pool
+  to be in the group (if yes, then challenge invalid)
+
+| Group creation - DKG challenge
+| If the challenge notification was received within the challenge period and was
+  deemed justified, then: +
+  - the malicious DKG result should be immediately discarded (in the same
+  transaction in which notification happened) +
+  - all sortition pool members who signed the result should be slashed (fixed
+  amount) +
+  - notifier should receive 5% from the total slashed amount
+
+| Group creation - DKG challenge
+| If the challenge notification was received within the challenge period and was
+  not justified, then: +
+  - challenge transaction is reverted
+
+| Group creation - DKG challenge
+| If the challenge notification (justified or not) was received outside of the
+  challenge period, then: +
+  - challenge transaction is reverted
+
+| Group creation - DKG challenge
+| If the challenge notification was received within the challenge period and was
+    deemed justified, then: +
+  - the pool should be unlocked +
+  - the fixed amount reward (in T) should be sent from the maintenance pool to
+  the address specified by the notifier
+
+| Group creation - DKG acceptance
+| Anyone can send a transaction requesting unlocking of the sortition pool and
+  requesting marking of the DKG result as accepted
+
+| Group creation - DKG acceptance
+| Upon processing the transaction unlocking the sortition pool and marking the
+  DKG result as accepted, the random beacon contract should determine validity
+  of the transaction
+
+| Group creation - DKG acceptance
+| When determining validity of the tx unlocking the sortition pool and accepting
+  the DKG result, the following aspects should be taken into account: +
+  - is the sortition pool locked? +
+  - has the challenge period already passed? +
+  Only if all the above conditions have been met, the tx is considered valid.
+
+| Group creation - DKG acceptance
+| If the transaction unlocking the sortition pool and marking the DKG result as
+  accepted gets approved, then: +
+  - the sortition pool should get unlocked +
+  - the DKG result should be accepted and a group should be created based on the
+  candidate group +  
+  - submitter should receive the fixed reward (in T), paid from the maintenance
+  pool to the submitter’s address (in the same tx) +
+// TODO: revisit 2 weeks removal time
+  - operators who became eligible for submitting the DKG result before the
+  member who submitted the DKG result should be punished by being removed from
+  the sortition pool for a fixed amount of time (2 weeks) (in the same tx)
+
+| Group creation - DKG timeout
+| The DKG submission timeout equals the group size multiplied by the number of
+  blocks for a member to become eligible to submit the DKG result. The timer
+  starts at the moment when the first member becomes eligible (the moment when
+  DKG was requested)
+
+| Group creation - DKG timeout
+| Anyone can send a transaction reporting DKG timeout.
+
+| Group creation - DKG timeout
+| Upon noticing the DKG timeout notification, the random beacon contract should
+  determine its validity.
+
+| Group creation - DKG timeout
+| When determining validity of the DKG timeout notification, the following
+  aspects should be taken into account: +
+  - does it reference the existing DKG request? (if not, then notification
+  invalid) +
+  - has the DKG timeout passed? (if not, then notification invalid) +
+  - is the sortition pool in a locked state (if not - meaning somebody already
+  unlocked it - then notification invalid)
+
+| Sortition pool - punishments
+// TODO: revisit 2 weeks removal time
+| Member of the sortition pool can be punished with 2 weeks removal from the
+  pool as a result of: +
+  - misbehavior during the DKG generation +
+  - misbehavior during the DKG submission +
+  - misbehavior during relay entry submission
+
+| Sortition pool - punishments
+| Operators punished with removal from the group should not earn rewards for the
+  time of their absence in the pool.
+
+| Sortition pool - punishments
+// TODO: revisit 2 weeks removal time
+| After 2 weeks punish period elapses, operators removed from the sortition pool
+  should be automatically reinstated in the pool and should be able to earn the
+  rewards again (from membership in the pool and potentially submission of the
+  DKG result or unlocking the pool).
+
+| Sortition pool - punishments
+| The operation removing members from the sortition pool should be as cheap as
+  possible so that the member submitting the relay entry or the DKG result does
+  not have to pay any additional costs for removing inactive members from the
+  pool.
+
+| Sortition pool - rewards
+| Operators in the sortition pool can earn T for multiple activities: +
+  - for staying in the pool (given weekly, proportionally to stake) +
+  - for successful submission of the DKG result (fixed value) +
+  - for successful unlocking of the sortition pool if DKG timed out
+
+| Sortition pool - locking
+| When the sortition pool is locked, no operator can enter the pool
+
+| Sortition pool - locking
+| When the ssortition pool is locked, no operator can leave the pool
+
+| Sortition pool - locking
+| Once the ssortition pool gets unlocked, operators can leave the pool
+
+| Sortition pool - locking
+| Once the ssortition pool gets unlocked, new operators can join the pool
+
+// TODO: Once starting values for governable parameters are agreed upon,
+// add them to the UACs
+
+| Governable parameters
+| The frequency of relay requests should be a governable parameter
+
+| Governable parameters
+| The length of the challenge period should be a governable parameter
+
+| Governable parameters
+| The slashing amount for submitting malicious DKG result should be a governable
+  parameter
+
+| Governable parameters
+| The max slashing amount for not submitting the relay entry before the hard
+  timeout should be a governable parameter.
+
+| Governable parameters
+| The reward for submitting a DKG result should be a governable parameter
+
+| Governable parameters
+| The reward for unlocking the sortition pool if DKG timed out should be a
+  governable parameter
+
+| Governable parameters
+| Number of blocks after which a new operator is added to the list of operators
+  eligible for submitting the DKG result and unlocking the group should be a
+  governable parameter. Its initial value should be set to 10 blocks.
+
+| Governable parameters
+| The value of the fee for processing a relay request should be a governable
+  parameter
+
+| Governable parameters
+| The frequency (in blocks) of adding new group members as eligible to submit
+  relay entry should be a governable parameter. Its initial value should be set
+  to 10 blocks.
+
+| Governable parameters
+| The frequency (in blocks) of adding new group members as eligible to submit a
+  DKG result should be a governable parameter. Its initial value should be set
+  to 10 blocks.
+
+| Governable parameters
+| The hard timeout for a relay entry should be a governable parameter. Its
+  initial value should be set to 48 hours (may be specified in a different unit)
+
+| Governable parameters
+| The callback gas limit should be a governable parameter. Its initial value
+  should be set to 50k gas.
+
+| Governable parameters
+| The Staker DAO should be able to modify all the governable parameters
+
+| Upgradability
+| The random beacon contract should not be upgradeable
+|===

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -37,8 +37,10 @@ will be utilised during the acceptance testing of the feature.
 | When determining validity of the relay entry request, the following aspects
   should be taken into account: +
   - isn’t the other relay entry request already pending? +
-  - has the requester provided the exact required fee? (if the fee is lower or
-  higher, the transaction should be reverted) +
+  - has the requester allowed the random beacon contract to pull the amount 
+  sufficient for covering the fee for the request? (if the allowance is lower, 
+  the transaction should be reverted; if it's higher, only the exact fee amount
+  should be charged) +
   - is there at least one active signing group?
 
 | Relay request

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -64,7 +64,9 @@ utilised during the acceptance testing of the feature.
   selected to sign the entry +
   - the beacon should start the period of signature submission eligibility +
   - the selected signing group should start off-chain signature generation (upon
-  noticing event sent by the beacon).
+  noticing event sent by the beacon). +
+  - the sortition pool should get locked as a preparation for creation of a new
+  signing group (only sometimes, every N-th relay request).
 
 | Relay request
 | If the relay request is deemed invalid, then: +
@@ -72,9 +74,9 @@ utilised during the acceptance testing of the feature.
 
 | Relay request - signature generation
 | Once the active group is selected as a signing group, it is tasked with the
-  generation of a BLS threshold signature (based on the current relay entry and
+  generation of a BLS threshold signature (based on the last relay entry and
   the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
-  signing group).
+  signing group). This signature will be used as a proposed new relay entry.
 
 | Relay request - relay entry submission
 | During the signature submission eligibility period only selected members from
@@ -109,8 +111,9 @@ utilised during the acceptance testing of the feature.
   same tx) +
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
   in the tx, the interface should be called +
-  - the creation of a new signing group should be triggered (only sometimes, if
-  it’s the right time).
+  - the process of creation of a new signing group should be triggered (only
+  sometimes, every N-th relay request, if a creation of group isn't already in
+  progress).
 
 | Relay request - relay entry submission
 | The transaction submitting relay entry is not reimbursable (i.e. the submitter
@@ -216,8 +219,7 @@ utilised during the acceptance testing of the feature.
   submission transaction.
 
 | Group creation
-| Group creation start transaction should lock the sortition pool and emit the
-  group creation start event.
+| Group creation start transaction should emit the group creation start event.
 
 | Group creation
 | Any logic related to group creation should not affect the gas cost of relay
@@ -243,24 +245,23 @@ utilised during the acceptance testing of the feature.
   all have expired.
 
 | Group creation
-| Group creation start transaction should result in: +
-  - selection of a candidate group consisting of `group_size` members of
-  sortition pool +
-  - triggering of the DKG (distributed key generation) +
-  - the beacon should start the period of DKG result submission eligibility.
+| Group creation start transaction should start the period of DKG result
+  submission eligibility.
 
 | Group creation - selecting members
-| Upon noticing the group creation start event, clients should choose the
-  sortition pool members to the candidate group based on the current relay
-  entry, ensuring that the higher is the stake of an operator, the higher is his
-  chance of being selected to the group.
+| Upon noticing the group creation start event, off-chain clients should call
+  the sortition function which should select `group_size` pool members to the
+  candidate group based on the current relay entry, ensuring that the higher is
+  the stake of an operator, the higher is his chance of being selected to the
+  group.
 
 | Group creation - DKG
-| After group members are determined, they should perform off-chain DKG,
-  resulting either in success or timeout. The success result should contain list
-  of members of the candidate group, the public key of the group and list of
-  misbehaving members (members who were inactive or were disqualified) and
-  should be submitted by eligible group member on-chain.
+| After group members are determined, clients should perform off-chain DKG
+  (distributed key generation), resulting either in success or timeout. The
+  success result should contain list of members of the candidate group, the
+  public key of the group and list of misbehaving members (members who were
+  inactive or were disqualified) and should be submitted by eligible group
+  member on-chain.
 
 | Group creation - DKG submission
 | When determining validity of the tx submitting the DKG result, the following
@@ -277,12 +278,13 @@ utilised during the acceptance testing of the feature.
 | Group creation - DKG submission
 | At a given moment, only selected members from the group should be eligible to
   successfully submit the DKG result to the chain: +
-  - at the beginning (right after the challenge period passes) only one member
-  with index `hash(new_group_pubkey) % group_size` should be eligible +
+  - at the beginning (right after group creation start transaction is submitted)
+  only one member, with index `hash(new_group_pubkey) % group_size`, should be
+  eligible +
   - the first eligible operator should be given additional time for submitting
-  the result, to cover for the time of off-chain DKG generation
-  - after fixed amount of blocks another member (with index
-  `(hash(new_group_pubkey) % group_size ) + 1` should become eligible (previous
+  the result, to cover for the time of off-chain DKG generation +
+  - after fixed amount of blocks another member, with index
+  `(hash(new_group_pubkey) % group_size ) + 1`, should become eligible (previous
   operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
 

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -72,12 +72,6 @@ will be utilised during the acceptance testing of the feature.
   the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
   signing group).
 
-| Relay request - signature generation
-| Once the active group is selected as a signing group, it is tasked with the
-  generation of a BLS threshold signature (based on the current relay entry and
-  the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
-  signing group).
-
 | Relay request - relay entry submission
 | During the signature submission eligibility period only selected members from
   the group should be eligible to successfully submit the new relay entry

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -293,8 +293,9 @@ will be utilised during the acceptance testing of the feature.
   - all sortition pool members who signed the result should be slashed (fixed
   amount) (in the same tx) +
   - notifier should receive 5% from the total slashed amount (in the same tx) +
+  - remaning 95% of the total slashed amount shoud be burned +
   - the members of the signing group should be given another chance to publish
-  the DKG result
+  the DKG result +
   - DKG timeout timer and the result submission eligibility order should be
   reset.
 

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -22,9 +22,9 @@ will be utilised during the acceptance testing of the feature.
 | Anyone can send a relay entry request transaction.
 
 | Relay request
-| Processing of each relay entry request should always result in the generation
-  of a random number (relay entry) and sometimes also (if certain conditions are
-  met) in a creation of a new signing group.
+| Successful processing of each relay entry request should always result in the
+  generation of a random number (relay entry) and sometimes also (if certain
+  conditions are met) in a creation of a new signing group.
 
 | Relay request
 | When sending the relay request, the requester should provide a fixed fee in T.
@@ -160,13 +160,16 @@ will be utilised during the acceptance testing of the feature.
   following aspects should be taken into account: +
   - does it reference the existing relay entry request? (if not, then
   notification invalid) +
-  - has the hard relay entry timeout passed? (if not, then notification invalid) +
+  - has the hard relay entry timeout passed? (if not, then notification invalid). +
 
 | Relay request - relay entry timeouts
 | If the hard relay entry timeout notification was deemed justified, then: +
   - the signing group should get terminated +
   - the process of choosing a signing group and tasking it with a relay entry
-  generation should be repeated.
+  generation should be repeated (as part of the same relay entry request) +
+  - if there are no active groups to choose from, the request should get
+  terminated and no result should be produced (in order for the next requests to
+  get processed successfully, the manual genesis must be first triggered).
 
 | Relay entry utilisation
 | Applications wanting to use a relay entry should submit another transaction

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -176,14 +176,14 @@ utilised during the acceptance testing of the feature.
   - does it reference the existing relay request? (if not, then notification
   invalid) +
   - has the hard relay entry timeout passed? (if not, then notification invalid) +
-  - does the transaction include punishing of the misbehaving operators? (if not,
-  then notification invalid).
+  - does the transaction include termination of the inactive group and punishing
+  its operators? (if not, then notification invalid).
 
 | Relay request - relay entry timeouts
 | If the hard relay entry timeout notification was deemed justified, then: +
   - the signing group should get terminated +
   - all signing group members should be punished by being slashed the fixed
-  percentage of T and being excluded from earning rewards for a fixed amount of
+  amount of T and being excluded from earning rewards for a fixed amount of
   time +
   - the process of choosing a signing group and tasking it with a relay entry
   generation should be repeated (as part of the same relay request) +

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -113,7 +113,7 @@ utilised during the acceptance testing of the feature.
   passed, should get slashed the calculated amount of T (all happening in the
   same tx) +
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
-  in the tx, the interface should be called +
+  in the tx, the interface should be called (with a fixed gas limit) +
   - the process of creation of a new signing group should be triggered (only
   sometimes, every N-th relay request, if a creation of group isn't already in
   progress).
@@ -515,8 +515,8 @@ utilised during the acceptance testing of the feature.
   (`sortitionPoolRewardsBanDuration`) should be a governable parameter.
 
 | Governable parameters
-// Initial value: 50k gas?
-| The callback gas limit (`callbackGasLimit`) should be a governable parameter.
+| The callback gas limit (`callbackGasLimit`) should be a governable parameter
+  and should be initially set to `50000`.
 
 | Governable parameters
 | All random beacon governable parameters should be modifiable by the authorized

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -57,8 +57,8 @@ utilised during the acceptance testing of the feature.
 
 | Relay request
 | If the relay request is deemed valid, then: +
-  - the fee charged from the requester should be deposited in the maintenance
-  pool (the T balance of the random beacon contract) +
+  - the fee charged from the requester should be deposited in the rewards pool
+  (the T balance of the random beacon contract) +
   - signing groups that reached the expiration threshold should get expired +
   - the last relay entry should be used by the beacon to select a signing
   group from the set of active groups (by hashing the relay entry and applying
@@ -187,7 +187,7 @@ utilised during the acceptance testing of the feature.
   - the notifier should receive fixed part of the total slashed amount (in the
   same tx) +
   - remaning part of the total slashed amount should be burned or allocated for
-  the maintenance pool of the staking contract +
+  the rewards pool of the staking contract +
   - the process of choosing a signing group and tasking it with a relay entry
   generation should be repeated (as part of the same relay request) +
   - if there are no active groups to choose from, the request should get
@@ -324,7 +324,7 @@ utilised during the acceptance testing of the feature.
   amount) (in the same tx) +
   - notifier should receive 5% from the total slashed amount (in the same tx) +
   - remaning 95% of the total slashed amount should be burned or allocated for
-  the maintenance pool of the staking contract +
+  the rewards pool of the staking contract +
   - the members of the signing group should be given another chance to publish
   the DKG result +
   - DKG timeout timer and the result submission eligibility order should be
@@ -370,7 +370,7 @@ utilised during the acceptance testing of the feature.
   - the DKG result should be accepted and a group should be created based on the
   candidate group +
   - the DKG result accepter should receive the fixed reward (in T), paid from
-  the maintenance pool to the submitter’s address (in the same tx) +
+  the rewards pool to the submitter’s address (in the same tx) +
   - operators marked as inactive/disqualified during DKG protocol execution
   should be punished by being excluded from earning rewards for a fixed amount
   of time (in the same tx) +
@@ -405,8 +405,8 @@ utilised during the acceptance testing of the feature.
 | Group creation - DKG timeout
 | If the DKG timeout notification was deemed justified, then: +
   - the pool should be unlocked +
-  - the fixed amount reward (in T) should be sent from the maintenance pool to
-  the notifier.
+  - the fixed amount reward (in T) should be sent from the rewards pool to the
+  notifier.
 
 | Group expiration
 | Each group created in the system should reach expiration threshold after a

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -46,7 +46,9 @@ utilised during the acceptance testing of the feature.
   sufficient for covering the fee for the request? (if the allowance is lower, 
   the transaction should be reverted; if it's higher, only the exact fee amount
   should be charged) +
-  - is there at least one active signing group?
+  - does the transaction perform expiration of all signing groups that reached
+  the fixed expiration threshold? +
+  - is there at least one active signing group remaining? +
 
 | Relay request
 | If a relay request is submitted before the previous relay request finished
@@ -57,6 +59,7 @@ utilised during the acceptance testing of the feature.
 | If the relay request is deemed valid, then: +
   - the fee charged from the requester should be deposited in the maintenance
   pool (the T balance of the random beacon contract) +
+  - signing groups that reached the expiration threshold should get expired +
   - the last relay entry should be used by the beacon to select a signing
   group from the set of active groups (by hashing the relay entry and applying
   `modulo no_of_active_groups` operation on the result) +
@@ -401,6 +404,16 @@ utilised during the acceptance testing of the feature.
   - the fixed amount reward (in T) should be sent from the maintenance pool to
   the notifier.
 
+| Group expiration
+| Each group created in the system should reach expiration threshold after a
+  fixed period of time.
+
+| Group expiration
+| Group expiration should be performed in the relay request transaction.
+
+| Group expiration
+| A group that expired should be no longer selected for any new work.
+
 | Sortition pool - punishments
 | Member of the sortition pool can be punished with temporary exclusion from 
   earning rewards as a result of: +
@@ -449,6 +462,11 @@ utilised during the acceptance testing of the feature.
 | Every `N`-th relay request initiates creation of a new signing group.
   This group creation frequency (`groupCreationFrequency`) should be a governable
   parameter.
+
+| Governable parameters
+| The time since the creation of a new signing group after that group gets
+  expired (`groupLifetime`) should be a governable parameter and should be
+  initally set to `80640 blocks` (~2 weeks, assuming 15s block time).
 
 | Governable parameters
 | The length of the challenge period (`resultChallengePeriodLength`) should be a

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -443,30 +443,29 @@ utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | Every `N`-th relay request initiates creation of a new signing group.
-  This group creation frequency should be a governable parameter.
-
-| Governable parameters
-| The length of the challenge period should be a governable parameter.
-
-| Governable parameters
-| The slashing amount for submitting malicious DKG result should be a governable
+  This group creation frequency (`groupCreationFrequency`) should be a governable
   parameter.
 
 | Governable parameters
+| The length of the challenge period (`resultChallengePeriodLength`) should be a
+  governable parameter and should be initally set to `1440 blocks`.
+
+| Governable parameters
+| The slashing amount for submitting malicious DKG result
+  (`maliciousDkgResultSlashingAmount`) should be a governable parameter.
+
+| Governable parameters
 | The max slashing amount for not submitting the relay entry before the hard
-  timeout should be a governable parameter.
+  timeout (`relayEntrySubmissionFailureSlashingAmount`) should be a governable
+  parameter and should be initally set to `1000e18` (1000 T)
 
 | Governable parameters
-| The reward for submitting a DKG result should be a governable parameter.
+| The reward for submitting a DKG result (`dkgResultSubmissionReward`) should be
+  a governable parameter.
 
 | Governable parameters
-| The reward for unlocking the sortition pool if DKG timed out should be a
-  governable parameter.
-
-| Governable parameters
-| Number of blocks after which a new operator is added to the list of operators
-  eligible for submitting the DKG result and unlocking the group should be a
-  governable parameter. Its initial value should be set to 10 blocks.
+| The reward for unlocking the sortition pool if DKG timed out
+  (`sortitionPoolUnlockingReward`) should be a governable parameter.
 
 | Governable parameters
 | The value of the fee for processing a relay request should be a governable
@@ -474,27 +473,28 @@ utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | The frequency (in blocks) of adding new group members as eligible to submit
-  relay entry should be a governable parameter. Its initial value should be set
-  to 10 blocks.
+  relay entry (`relayEntrySubmissionEligibilityDelay`) should be a governable
+  parameter. Its initial value should be set to 10 blocks.
 
 | Governable parameters
 | The frequency (in blocks) of adding new group members as eligible to submit a
-  DKG result should be a governable parameter. Its initial value should be set
-  to 10 blocks.
+  DKG result (`resultSubmissionEligibilityDelay`) should be a governable
+  parameter. Its initial value should be set to 10 blocks.
 
 | Governable parameters
-| The hard timeout for a relay entry should be a governable parameter. Its
-  initial value should be set to 24 hours (expressed in blocks, where we assume
-  `1 block = 15s`).
+| The hard timeout for a relay entry (`relayEntryHardTimeout`) should be a
+  governable parameter. Its initial value should be set to `5760 blocks` (~24h,
+  assuming 15s block time).
 
+// Initial value: 3 weeks?
 | Governable parameters
 | The length of the period during which operators won't be able to earn rewards
   as a punishment for misbehaviour during submission of DKG or relay entry
-  should be a governable parameter. Its initial value should be set to 3 weeks.
+  (`sortitionPoolRewardsBanDuration`) should be a governable parameter.
 
 | Governable parameters
-| The callback gas limit should be a governable parameter. Its initial value
-  should be set to 50k gas.
+// Initial value: 50k gas?
+| The callback gas limit (`callbackGasLimit`) should be a governable parameter.
 
 | Governable parameters
 | All random beacon governable parameters should be modifiable by the authorized

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -306,7 +306,7 @@ utilised during the acceptance testing of the feature.
   - does it reference existing DKG result (if not, then challenge invalid) +
   - within or outside of the challenge period for the specified DKG result (if
   outside, then invalid) +
-  - have all members who signed a DKG result been selected by the sortition pool
+  - have all members included in the result been selected by the sortition pool
   to be in the group (if yes, then challenge invalid).
 
 | Group creation - DKG challenge
@@ -335,8 +335,8 @@ utilised during the acceptance testing of the feature.
   - challenge transaction is reverted.
 
 | Group creation - DKG acceptance
-| Anyone can send a transaction requesting unlocking of the sortition pool and
-  requesting marking of the DKG result as accepted.
+| Anyone can request unlocking of the sortition pool and marking of the DKG
+  result as accepted (but not all requests will be processed positively).
 
 | Group creation - DKG acceptance
 | Upon processing the transaction unlocking the sortition pool and marking the
@@ -348,7 +348,14 @@ utilised during the acceptance testing of the feature.
   the DKG result, the following aspects should be taken into account: +
   - is the sortition pool locked? +
   - has the challenge period already passed? +
+  - is the sender eligible to accept the DKG result? +
   Only if all the above conditions have been met, the tx is considered valid.
+
+| Group creation - DKG acceptance
+| At the beginning (right after DKG result is submitted on chain) only the
+  submitter should be eligible to accept the DKG result and earn the reward.
+  After a fixed amount of time everybody should become eliglible to accept the
+  DKG result.
 
 | Group creation - DKG acceptance
 | If the transaction unlocking the sortition pool and marking the DKG result as

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -509,31 +509,30 @@ be utilized during the acceptance testing of the feature.
   the locked or in the unlocked state (e.g. operator can be slashed during the
   lock as a result of relay entry timeout).
 
-// TODO: Once starting values for governable parameters are agreed upon,
-// add them to the UACs
-
 | Governable parameters
 | Every `N`-th relay request initiates a creation of a new signing group.
   This group creation frequency (`groupCreationFrequency`) should be a governable
-  parameter.
+  parameter and should be initially set to `5`.
 
 | Governable parameters
 | The time since the creation of a new signing group after that group gets
   expired (`groupLifetime`) should be a governable parameter and should be
-  initially set to `80640 blocks` (~2 weeks, assuming 15s block time).
+  initially set to `403200 blocks` (~10 weeks, assuming 15s block time).
 
 | Governable parameters
 | The length of the challenge period (`resultChallengePeriodLength`) should be a
-  governable parameter and should be initially set to `1440 blocks`.
+  governable parameter and should be initially set to `11520 blocks` (~48h,
+  assuming 15s block time).
 
 | Governable parameters
 | The slashing amount for submitting malicious DKG result
-  (`maliciousDkgResultSlashingAmount`) should be a governable parameter.
+  (`maliciousDkgResultSlashingAmount`) should be a governable parameter and
+  should be initially set to `50000e18` (50000 T).
 
 | Governable parameters
 | The reward for notifying about an operator notoriously ignoring their duty in
   the relay entry generation (`ineligibleOperatorNotifierReward`) should be
-  a governable parameter.
+  a governable parameter and should be initially set to `0`.
 
 | Governable parameters
 | The max slashing amount for not submitting the relay entry before the hard
@@ -544,21 +543,22 @@ be utilized during the acceptance testing of the feature.
 | Percentage of the amount slashed from the group as a result of a hard timeout,
   transferred as a reward to the notifier,
   (`relayEntryTimeoutNotificationRewardMultiplier`) should be a governable
-  parameter.
+  parameter. Its initial value should be set to `40`.
 
 | Governable parameters
 | The reward for submitting a DKG result (`dkgResultSubmissionReward`) should be
-  a governable parameter.
+  a governable parameter and should be initially set to `1000e18` (1000 T).
 
 | Governable parameters
 | The reward for unlocking the sortition pool if DKG timed out
-  (`sortitionPoolUnlockingReward`) should be a governable parameter.
+  (`sortitionPoolUnlockingReward`) should be a governable parameter and should
+  be initially set to `100e18` (100 T).
 
 | Governable parameters
 | Percentage of the amount slashed from the group as a result of signing a
   malicious DKG result, transferred as a reward to the notifier,
   (`dkgMaliciousResultNotificationRewardMultiplier`) should be a governable
-  parameter.
+  parameter.  Its initial value should be set to `100`.
 
 | Governable parameters
 | The value of the fee for processing a relay request should be a governable
@@ -567,33 +567,34 @@ be utilized during the acceptance testing of the feature.
 | Governable parameters
 | The frequency (in blocks) of adding new group members as eligible to submit
   relay entry (`relayEntrySubmissionEligibilityDelay`) should be a governable
-  parameter. Its initial value should be set to 10 blocks.
+  parameter. Its initial value should be set to `20` blocks.
 
 | Governable parameters
 | The frequency (in blocks) of adding new group members as eligible to submit a
   DKG result (`resultSubmissionEligibilityDelay`) should be a governable
-  parameter. Its initial value should be set to 10 blocks.
+  parameter. Its initial value should be set to `20` blocks.
 
 | Governable parameters
 | The hard timeout for a relay entry (`relayEntryHardTimeout`) should be a
   governable parameter. Its initial value should be set to `5760 blocks` (~24h,
   assuming 15s block time).
 
-// Initial value: 3 weeks?
 | Governable parameters
 | The length of the period during which operators won't be able to earn rewards
   as a punishment for misbehavior during submission of DKG or relay entry
-  (`sortitionPoolRewardsBanDuration`) should be a governable parameter.
+  (`sortitionPoolRewardsBanDuration`) should be a governable parameter. Its
+  initial value should be set to `2 weeks`.
 
 | Governable parameters
 | The amount slashed from the members of the group that leaked signature 
-  (`unauthorizedSigningSlashingAmount`) should be a governable parameter.
+  (`unauthorizedSigningSlashingAmount`) should be a governable parameter and
+  should be initially set to `100e3 * 1e18` (100 000 T).
 
 | Governable parameters
 | Percentage of the amount slashed from the members of the group that leaked
   signature, transferred as a reward to the notifier,
   (`unauthorizedSigningNotificationRewardMultiplier`) should be a governable
-  parameter.
+  parameter.  Its initial value should be set to `50`.
 
 | Governable parameters
 | The callback gas limit (`callbackGasLimit`) should be a governable parameter

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -410,10 +410,21 @@ will be utilised during the acceptance testing of the feature.
 | When the sortition pool is locked, no operator can leave the pool.
 
 | Sortition pool - locking
+| When the sortition pool is locked, no operator can update its state.
+
+| Sortition pool - locking
 | Once the sortition pool gets unlocked, operators can leave the pool.
 
 | Sortition pool - locking
 | Once the sortition pool gets unlocked, new operators can join the pool.
+
+| Sortition pool - locking
+| Once the sortition pool gets unlocked, operators can update their state.
+
+| Sortition pool - locking
+| Operator's staked amount can change regardless if the pool is at the moment in
+  the locked or in the unlocked state (e.g. operator can be slashed during the
+  lock as a result of relay entry timeout).
 
 // TODO: Once starting values for governable parameters are agreed upon,
 // add them to the UACs

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -124,10 +124,6 @@ utilised during the acceptance testing of the feature.
   gas cost of this transaction should be as low as possible, below 200k gas used.
 
 | Relay request - relay entry submission
-| It should be possible to send low gas callbacks (up to the fixed gas cost
-  value) in the transaction submitting the relay entry.
-
-| Relay request - relay entry submission
 | Failure in the callback function should not revert the relay entry transaction.
 
 | Relay request - relay entry submission
@@ -191,11 +187,12 @@ utilised during the acceptance testing of the feature.
   terminated and no result should be produced (in order for the next requests to
   get processed successfully, the manual genesis must be first triggered).
 
-| Relay entry utilisation
-| Applications wanting to use a relay entry should submit another transaction
-  using the relay entry value previously set by the random beacon.
+| Relay entry callback
+| Applications wanting to use a relay entry should submit another transaction,
+  outside of the random beacon, in case the callback gas limit was not
+  sufficient.
 
-| Relay entry utilisation
+| Relay entry callback
 | Smart contract consuming new relay entry needs to implement
   `IRandomBeaconConsumer` interface.
 

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -351,7 +351,7 @@ utilised during the acceptance testing of the feature.
   Only if all the above conditions have been met, the tx is considered valid.
 
 | Group creation - DKG acceptance
-| At the beginning (right after DKG result is submitted on chain) only the
+| At the beginning (right after DKG result is submitted on chain) only the result
   submitter should be eligible to accept the DKG result and earn the reward.
   After a fixed amount of time everybody should become eliglible to accept the
   DKG result.
@@ -362,8 +362,8 @@ utilised during the acceptance testing of the feature.
   - the sortition pool should get unlocked +
   - the DKG result should be accepted and a group should be created based on the
   candidate group +  
-  - submitter should receive the fixed reward (in T), paid from the maintenance
-  pool to the submitter’s address (in the same tx) +
+  - the DKG result accepter should receive the fixed reward (in T), paid from
+  the maintenance pool to the submitter’s address (in the same tx) +
   - operators who became eligible for submitting the DKG result before the
   member who submitted the DKG result should be punished by being excluded from
   earning rewards for a fixed amount of time (in the same tx).

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -131,9 +131,9 @@ utilised during the acceptance testing of the feature.
 | Failure in the callback function should not revert the relay entry transaction.
 
 | Relay request - relay entry submission
-| The operation removing members from the sortition pool should be as cheap as
+| The operation excluding members from earning the rewards should be as cheap as
   possible so that the member submitting relay entry does not have to pay any
-  additional costs for removing inactive members from the pool.
+  additional costs for that exclusion.
 
 | Relay request - relay entry timeouts
 | The soft relay entry timeout equals the group size multiplied by the number of
@@ -399,14 +399,9 @@ utilised during the acceptance testing of the feature.
   - misbehavior during relay entry submission.
 
 | Sortition pool - punishments
-| Operators punished with removal from the group should not earn rewards for the
-  time of their absence in the pool.
-
-| Sortition pool - punishments
-| The operation removing members from the sortition pool should be as cheap as
+| The operation excluding members from earning the rewards should be as cheap as
   possible so that the member submitting the relay entry or the DKG result does
-  not have to pay any additional costs for removing inactive members from the
-  pool.
+  not have to pay any additional costs for that exclusion.
 
 | Sortition pool - rewards
 | Operators in the sortition pool can earn T for multiple activities: +

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -57,11 +57,11 @@ will be utilised during the acceptance testing of the feature.
   group selection +
   - the beacon should start the period of signature submission eligibility +
   - the selected signing group should start off-chain signature generation (upon
-  noticing event sent by the beacon)
+  noticing event sent by the beacon).
 
 | Relay request
 | If the relay entry request is deemed invalid, then: +
-  - the transaction should be reverted
+  - the transaction should be reverted.
 
 | Relay request - signature generation
 | Once the active group is selected as a signing group, it is tasked with the
@@ -77,7 +77,7 @@ will be utilised during the acceptance testing of the feature.
   (with index `new_entry % group_size` should be eligible +
   - after fixed amount of blocks another member (with index `(new_entry %
   group_size ) + 1` should become eligible (previous operator remains eligible)
-  - next members should become eligible after each fixed amount of blocks
+  - next members should become eligible after each fixed amount of blocks.
 
 | Relay request - relay entry submission
 | Upon receiving the transaction submitting the relay entry, the random beacon
@@ -92,7 +92,7 @@ will be utilised during the acceptance testing of the feature.
 | Relay request - relay entry submission
 | When requesting a relay entry, it should be possible to pass an optional
   address parameter - this is the address of a contract implementing
-  `IRandomBeaconConsumer` interface
+  `IRandomBeaconConsumer` interface.
 
 | Relay request - relay entry submission
 | If the transaction submitting the new relay entry gets approved, then: +
@@ -105,7 +105,7 @@ will be utilised during the acceptance testing of the feature.
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
   in the tx, the interface should be called +
   - the creation of a new signing group should be triggered (only sometimes, if
-  it’s the right time)
+  it’s the right time).
 
 | Relay request - relay entry submission
 | The transaction submitting relay entry is not reimbursable (i.e. the submitter
@@ -139,19 +139,46 @@ will be utilised during the acceptance testing of the feature.
   all operators in the group should start bleeding and losing their T stake. The
   amount of lost stake should incrementally increase from 0 (at the moment of
   soft relay entry timeout) to a fixed value (at the moment of hard relay entry
-  timeout)
+  timeout).
+
+| Relay request - relay entry timeouts
+| If no entry was successfully submitted until soft relay timeout is reached,
+  all operators in the group should start bleeding and losing their T stake. The
+  amount of lost stake should incrementally increase from 0 (at the moment of
+  soft relay entry timeout) to a fixed value (at the moment of hard relay entry
+  timeout).
+
+| Relay request - relay entry timeouts
+| Anyone can send a transaction reporting hard relay entry timeout.
+
+| Relay request - relay entry timeouts
+| Upon noticing the hard relay entry timeout notification, the random beacon
+  contract should determine its validity.
+
+| Relay request - relay entry timeouts
+| When determining validity of the hard relay entry timeout notification, the
+  following aspects should be taken into account: +
+  - does it reference the existing relay entry request? (if not, then
+  notification invalid) +
+  - has the hard relay entry timeout passed? (if not, then notification invalid) +
+
+| Relay request - relay entry timeouts
+| If the hard relay entry timeout notification was deemed justified, then: +
+  - the signing group should get terminated +
+  - the process of choosing a signing group and tasking it with a relay entry
+  generation should be repeated.
 
 | Relay entry utilisation
 | Applications wanting to use a relay entry should submit another transaction
-  using the relay entry value previously set by the random beacon
+  using the relay entry value previously set by the random beacon.
 
 | Relay entry utilisation
 | Smart contract consuming new relay entry needs to implement
-  `IRandomBeaconConsumer` interface
+  `IRandomBeaconConsumer` interface.
 
 | Group creation
 | New groups should be crated with a fixed frequency of relay request (every
-  `N`-th relay entry request should result in the creation of a new group)
+  `N`-th relay entry request should result in the creation of a new group).
 
 | Group creation
 | If according to group creation frequency the relay entry request is the one
@@ -162,26 +189,26 @@ will be utilised during the acceptance testing of the feature.
 
 | Group creation
 | Frequency must be rare enough to leave the time for the group creation and
-  then (when the pool gets unlocked) for joining operators to pools
+  then (when the pool gets unlocked) for joining operators to pools.
 
 | Group creation
 | Group creation start transaction should be embedded into relay entry request
-  transaction
+  transaction.
 
 | Group creation
 | Group creation start transaction should lock the sortition pool and emit the
-  group creation start event
+  group creation start event.
 
 | Group creation
-| Group creation start transaction should be as cheap as possible
+| Group creation start transaction should be as cheap as possible.
 
 | Group creation
 | The sortition pool should weigh operators by stake and allow to select the
-  same operator to group multiple times
+  same operator to group multiple times.
 
 | Group creation - genesis
 | Beacon genesis should trigger the first group creation based on a fixed,
-  arbitrary seed value
+  arbitrary seed value.
 
 | Group creation - genesis
 | It should not be possible to perform beacon genesis if they are some active
@@ -192,14 +219,14 @@ will be utilised during the acceptance testing of the feature.
   - when no groups were created by the random beacon before +
   or +
   - when there were some groups created by the random beacon before, but they
-  all have expired
+  all have expired.
 
 | Group creation
 | Group creation start transaction should result in: +
   - selection of a candidate group consisting of `group_size` members of
   sortition pool +
   - triggering of the DKG (distributed key generation) +
-  - the beacon should start the period of DKG result submission eligibility
+  - the beacon should start the period of DKG result submission eligibility.
 
 | Croup creation - selecting members
 | Upon noticing the group creation start event, clients should choose the
@@ -208,12 +235,11 @@ will be utilised during the acceptance testing of the feature.
   chance of being selected to the group.
 
 | Group creation - DKG
-| After group members are determined, they should perform DKG, resulting in the
-  establishment of one of the below statuses: +
-  - success - together with the list of members of the candidate group, the
-  public key of the group and list of misbehaving members (members who were
-  inactive or were disqualified) +
-  - failure - together with the list of disqualified members
+| After group members are determined, they should perform off-chain DKG,
+  resulting either in success or timeout. The success result should contain list
+  of members of the candidate group, the public key of the group and list of
+  misbehaving members (members who were inactive or were disqualified) and
+  should be submitted by eligible group member on-chain.
 
 | Group creation - DKG submission
 | When determining validity of the tx submitting the DKG result, the following
@@ -234,17 +260,17 @@ will be utilised during the acceptance testing of the feature.
   - after fixed amount of blocks another member (with index
   `(hash(new_group_pubkey) % group_size ) + 1` should become eligible (previous
   operator remains eligible) +
-  - next members should become eligible after each fixed amount of blocks
+  - next members should become eligible after each fixed amount of blocks.
 
 | Group creation - DKG submission
 | If random beacon deems the transaction submitting the DKG valid, then: +
   - the DKG result submission eligibility period should finish (all other
   results should be rejected from now on) +
-  - a challenge period should start
+  - a challenge period should start.
 
 | Group creation - DKG challenge
 | Anyone can send a challenge notification that submitted DKG result contains
-  group members not selected by the pool
+  group members not selected by the pool.
 
 | Group creation - DKG challenge
 | Upon processing the challenge notification, the random beacon contract should
@@ -257,7 +283,7 @@ will be utilised during the acceptance testing of the feature.
   - within or outside of the challenge period for the specified DKG result (if
   outside, then invalid) +
   - have all members who signed a DKG result been selected by the sortition pool
-  to be in the group (if yes, then challenge invalid)
+  to be in the group (if yes, then challenge invalid).
 
 | Group creation - DKG challenge
 | If the challenge notification was received within the challenge period and was
@@ -265,34 +291,29 @@ will be utilised during the acceptance testing of the feature.
   - the malicious DKG result should be immediately discarded (in the same
   transaction in which notification happened) +
   - all sortition pool members who signed the result should be slashed (fixed
-  amount) +
-  - notifier should receive 5% from the total slashed amount
+  amount) (in the same tx) +
+  - notifier should receive 5% from the total slashed amount (in the same tx) +
+  - the members of the signing group should be given another chance to publish
+  the DKG result.
 
 | Group creation - DKG challenge
 | If the challenge notification was received within the challenge period and was
   not justified, then: +
-  - challenge transaction is reverted
+  - challenge transaction is reverted.
 
 | Group creation - DKG challenge
 | If the challenge notification (justified or not) was received outside of the
   challenge period, then: +
-  - challenge transaction is reverted
-
-| Group creation - DKG challenge
-| If the challenge notification was received within the challenge period and was
-    deemed justified, then: +
-  - the pool should be unlocked +
-  - the fixed amount reward (in T) should be sent from the maintenance pool to
-  the address specified by the notifier
+  - challenge transaction is reverted.
 
 | Group creation - DKG acceptance
 | Anyone can send a transaction requesting unlocking of the sortition pool and
-  requesting marking of the DKG result as accepted
+  requesting marking of the DKG result as accepted.
 
 | Group creation - DKG acceptance
 | Upon processing the transaction unlocking the sortition pool and marking the
   DKG result as accepted, the random beacon contract should determine validity
-  of the transaction
+  of the transaction.
 
 | Group creation - DKG acceptance
 | When determining validity of the tx unlocking the sortition pool and accepting
@@ -312,13 +333,13 @@ will be utilised during the acceptance testing of the feature.
 // TODO: revisit 2 weeks removal time
   - operators who became eligible for submitting the DKG result before the
   member who submitted the DKG result should be punished by being removed from
-  the sortition pool for a fixed amount of time (2 weeks) (in the same tx)
+  the sortition pool for a fixed amount of time (2 weeks) (in the same tx).
 
 | Group creation - DKG timeout
 | The DKG submission timeout equals the group size multiplied by the number of
   blocks for a member to become eligible to submit the DKG result. The timer
   starts at the moment when the first member becomes eligible (the moment when
-  DKG was requested)
+  DKG was requested).
 
 | Group creation - DKG timeout
 | Anyone can send a transaction reporting DKG timeout.
@@ -334,15 +355,20 @@ will be utilised during the acceptance testing of the feature.
   invalid) +
   - has the DKG timeout passed? (if not, then notification invalid) +
   - is the sortition pool in a locked state (if not - meaning somebody already
-  unlocked it - then notification invalid)
+  unlocked it - then notification invalid).
+
+| Group creation - DKG timeout
+| If the DKG timeout notification was deemed justified, then: +
+  - the pool should be unlocked +
+  - the fixed amount reward (in T) should be sent from the maintenance pool to
+  the notifier.
 
 | Sortition pool - punishments
 // TODO: revisit 2 weeks removal time
 | Member of the sortition pool can be punished with 2 weeks removal from the
   pool as a result of: +
-  - misbehavior during the DKG generation +
   - misbehavior during the DKG submission +
-  - misbehavior during relay entry submission
+  - misbehavior during relay entry submission.
 
 | Sortition pool - punishments
 | Operators punished with removal from the group should not earn rewards for the
@@ -365,43 +391,43 @@ will be utilised during the acceptance testing of the feature.
 | Operators in the sortition pool can earn T for multiple activities: +
   - for staying in the pool (given weekly, proportionally to stake) +
   - for successful submission of the DKG result (fixed value) +
-  - for successful unlocking of the sortition pool if DKG timed out
+  - for successful unlocking of the sortition pool if DKG timed out.
 
 | Sortition pool - locking
-| When the sortition pool is locked, no operator can enter the pool
+| When the sortition pool is locked, no operator can enter the pool.
 
 | Sortition pool - locking
-| When the ssortition pool is locked, no operator can leave the pool
+| When the ssortition pool is locked, no operator can leave the pool.
 
 | Sortition pool - locking
-| Once the ssortition pool gets unlocked, operators can leave the pool
+| Once the ssortition pool gets unlocked, operators can leave the pool.
 
 | Sortition pool - locking
-| Once the ssortition pool gets unlocked, new operators can join the pool
+| Once the ssortition pool gets unlocked, new operators can join the pool.
 
 // TODO: Once starting values for governable parameters are agreed upon,
 // add them to the UACs
 
 | Governable parameters
-| The frequency of relay requests should be a governable parameter
+| The frequency of relay requests should be a governable parameter.
 
 | Governable parameters
-| The length of the challenge period should be a governable parameter
+| The length of the challenge period should be a governable parameter.
 
 | Governable parameters
 | The slashing amount for submitting malicious DKG result should be a governable
-  parameter
+  parameter.
 
 | Governable parameters
 | The max slashing amount for not submitting the relay entry before the hard
   timeout should be a governable parameter.
 
 | Governable parameters
-| The reward for submitting a DKG result should be a governable parameter
+| The reward for submitting a DKG result should be a governable parameter.
 
 | Governable parameters
 | The reward for unlocking the sortition pool if DKG timed out should be a
-  governable parameter
+  governable parameter.
 
 | Governable parameters
 | Number of blocks after which a new operator is added to the list of operators
@@ -410,7 +436,7 @@ will be utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | The value of the fee for processing a relay request should be a governable
-  parameter
+  parameter.
 
 | Governable parameters
 | The frequency (in blocks) of adding new group members as eligible to submit
@@ -431,8 +457,9 @@ will be utilised during the acceptance testing of the feature.
   should be set to 50k gas.
 
 | Governable parameters
-| The Staker DAO should be able to modify all the governable parameters
+| All random beacon governable parameters should be modifiable by the authorized
+  entity.
 
 | Upgradability
-| The random beacon contract should not be upgradeable
+| The random beacon contract should not be upgradeable.
 |===

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -289,6 +289,8 @@ will be utilised during the acceptance testing of the feature.
   successfully submit the DKG result to the chain: +
   - at the beginning (right after the challenge period passes) only one member
   with index `hash(new_group_pubkey) % group_size` should be eligible +
+  - the first eligible operator should be given additional time for submitting
+  the result, to cover for the time of off-chain DKG generation
   - after fixed amount of blocks another member (with index
   `(hash(new_group_pubkey) % group_size ) + 1` should become eligible (previous
   operator remains eligible) +
@@ -372,9 +374,10 @@ will be utilised during the acceptance testing of the feature.
 
 | Group creation - DKG timeout
 | The DKG submission timeout equals the group size multiplied by the number of
-  blocks for a member to become eligible to submit the DKG result. The timer
-  starts at the moment when the first member becomes eligible (the moment when
-  DKG was requested). The timer gets reset when a valid DKG result challenge is
+  blocks for a member to become eligible to submit the DKG result plus the
+  number of blocks covering for the time of DKG generation. The timer should
+  start when the first member becomes eligible (the moment when DKG was
+  requested). The timer gets reset when a valid DKG result challenge is
   submitted. 
 
 | Group creation - DKG timeout

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -402,9 +402,9 @@ will be utilised during the acceptance testing of the feature.
 | Sortition pool - punishments
 // TODO: revisit 2 weeks removal time
 | After 2 weeks punish period elapses, operators removed from the sortition pool
-  should be automatically reinstated in the pool and should be able to earn the
-  rewards again (from membership in the pool and potentially submission of the
-  DKG result or unlocking the pool).
+  should be able to manually re-register in the sortition pool and should be
+  able to earn the rewards again (from membership in the pool and potentially
+  submission of the DKG result or unlocking the pool).
 
 | Sortition pool - punishments
 | The operation removing members from the sortition pool should be as cheap as

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -290,8 +290,9 @@ utilised during the acceptance testing of the feature.
   - a challenge period should start.
 
 | Group creation - DKG challenge
-| Anyone can send a challenge notification that submitted DKG result contains
-  group members not selected by the pool.
+| Anyone can send a challenge notification informing that submitted DKG result
+  is malitious (contains corrupted data, group members not selected by the pool,
+  or incorrect supporting signatures).
 
 | Group creation - DKG challenge
 | Upon processing the challenge notification, the random beacon contract should
@@ -303,8 +304,9 @@ utilised during the acceptance testing of the feature.
   - does it reference existing DKG result (if not, then challenge invalid) +
   - within or outside of the challenge period for the specified DKG result (if
   outside, then invalid) +
-  - have all members included in the result been selected by the sortition pool
-  to be in the group (if yes, then challenge invalid).
+  - is referenced DKG result indeed malitious (contains corrupted data, group
+  members not selected by the pool, or incorrect supporting signatures)? (if no,
+  then challenge invalid).
 
 | Group creation - DKG challenge
 | If the challenge notification was received within the challenge period and was

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -441,6 +441,33 @@ utilised during the acceptance testing of the feature.
 | Group expiration
 | A group that expired should be no longer selected for any new work.
 
+| Groups - punishing for unauthorised signing
+| It should be possible for any operator to send a notication informing about
+  unauthorized groups signing (leaked signature).
+
+| Groups - punishing for unauthorised signing
+| Upon receiving the transaction notifying about the unauthorized groups
+  signing, the random beacon should determine its validity.
+  
+| Groups - punishing for unauthorised signing
+  When determining validity of transaction notifying about the unauthorized
+  groups signing, the following aspects should be taken into account: +
+  - is the group indicated by the submitter as the one that leaked signature 
+  active and non-terminated? +
+  - does the signature provided by the submitter match the provided message and
+  the corresponding public key?
+
+| Groups - punishing for unauthorised signing
+| If the transaction notifying about the unauthorized groups signing is deemed
+  valid, then: +
+  - the group that leaked the signature should get terminated (in the same tx) +
+  - all members of the group should get slashed a fixed amount of T (in the same
+  tx) +
+  - notifier should receive fixed part of the total slashed amount (in the same
+  tx) +
+  - remaning part of the total slashed amount should be burned or allocated for
+  the rewards pool of the staking contract.
+  
 | Sortition pool - punishments
 | Member of the sortition pool can be punished with temporary exclusion from 
   earning rewards as a result of: +
@@ -556,6 +583,16 @@ utilised during the acceptance testing of the feature.
 | The length of the period during which operators won't be able to earn rewards
   as a punishment for misbehaviour during submission of DKG or relay entry
   (`sortitionPoolRewardsBanDuration`) should be a governable parameter.
+
+| Governable parameters
+| The amount slashed from the members of the group that leaked signature 
+  (`unauthorizedSigningSlashingAmount`) should be a governable parameter.
+
+| Governable parameters
+| Percentage of the amount slashed from the members of the group that leaked
+  signature, transfered as a reward to the notifier,
+  (`unauthorizedSigningNotificationRewardMultiplier`) should be a governable
+  parameter.
 
 | Governable parameters
 | The callback gas limit (`callbackGasLimit`) should be a governable parameter

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -318,8 +318,9 @@ utilised during the acceptance testing of the feature.
   transaction in which notification happened) +
   - all sortition pool members who signed the result should be slashed (fixed
   amount) (in the same tx) +
-  - notifier should receive 5% from the total slashed amount (in the same tx) +
-  - remaning 95% of the total slashed amount should be burned or allocated for
+  - notifier should receive fixed part of the total slashed amount (in the same
+  tx) +
+  - remaning part of the total slashed amount should be burned or allocated for
   the rewards pool of the staking contract +
   - the members of the signing group should be given another chance to publish
   the DKG result +
@@ -482,7 +483,7 @@ utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | Percentage of the amount slashed from the group as a result of a hard timeout,
-  transfered as a reward to the notifier 
+  transfered as a reward to the notifier,
   (`relayEntryTimeoutNotificationRewardMultiplier`) should be a governable
   parameter.
 
@@ -493,6 +494,12 @@ utilised during the acceptance testing of the feature.
 | Governable parameters
 | The reward for unlocking the sortition pool if DKG timed out
   (`sortitionPoolUnlockingReward`) should be a governable parameter.
+
+| Governable parameters
+| Percentage of the amount slashed from the group as a result of signing a
+  malitious DKG result, transfered as a reward to the notifier,
+  (`dkgMaliciousResultNotificationRewardMultiplier`) should be a governable
+  parameter.
 
 | Governable parameters
 | The value of the fee for processing a relay request should be a governable

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -281,8 +281,6 @@ utilised during the acceptance testing of the feature.
   - at the beginning (right after group creation start transaction is submitted)
   only one member, with index `hash(new_group_pubkey) % group_size`, should be
   eligible +
-  - the first eligible operator should be given additional time for submitting
-  the result, to cover for the time of off-chain DKG generation +
   - after fixed amount of blocks another member, with index
   `(hash(new_group_pubkey) % group_size ) + 1`, should become eligible (previous
   operator remains eligible) +

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -7,9 +7,9 @@
 toc::[]
 
 == Purpose of the document
-This document stores User Acceptance Criteria for Random Beacon v2 feature. It
-will be used to gain common understanding of how Random Beacon v2 should act and
-will be utilised during the acceptance testing of the feature.
+This document stores User Acceptance Criteria for Random Beacon v2. It will be
+used to gain common understanding of how Random Beacon v2 should act and will be
+utilised during the acceptance testing of the feature.
 
 == User Acceptance Criteria list
 
@@ -19,24 +19,29 @@ will be utilised during the acceptance testing of the feature.
 | UAC
 
 | Relay request
-| Anyone can send a relay entry request transaction.
+| Anyone can request for a relay entry.
 
 | Relay request
-| Successful processing of each relay entry request should always result in the
-  generation of a random number (relay entry) and sometimes also (if certain
+| Successful processing of each relay request should always result in the
+  generation of a relay entry (random number) and sometimes also (if certain
   conditions are met) in a creation of a new signing group.
 
 | Relay request
 | When sending the relay request, the requester should provide a fixed fee in T.
 
 | Relay request
-| Upon receiving the relay entry request, the random beacon contract should
-  determine validity of the request.
+| When requesting a relay entry, it should be possible to pass an optional
+  address parameter - this is the address of a contract implementing
+  `IRandomBeaconConsumer` interface.
 
 | Relay request
-| When determining validity of the relay entry request, the following aspects
-  should be taken into account: +
-  - isn’t the other relay entry request already pending? +
+| Upon receiving the relay request, the random beacon contract should determine
+  validity of the request.
+
+| Relay request
+| When determining validity of the relay request, the following aspects should
+  be taken into account: +
+  - isn’t the other relay request already pending? +
   - has the requester allowed the random beacon contract to pull the amount 
   sufficient for covering the fee for the request? (if the allowance is lower, 
   the transaction should be reverted; if it's higher, only the exact fee amount
@@ -49,21 +54,20 @@ will be utilised during the acceptance testing of the feature.
   reverted).
 
 | Relay request
-| If the relay entry request is deemed valid, then: +
+| If the relay request is deemed valid, then: +
   - the fee charged from the requester should be deposited in the maintenance
-  pool (the T balance of the random beacon contract) (with an intention to cover
-  the reimbursements for DKG-related actions) +
-  - the current relay entry should be used by the beacon to select a signing
+  pool (the T balance of the random beacon contract) +
+  - the last relay entry should be used by the beacon to select a signing
   group from the set of active groups (by hashing the relay entry and applying
   `modulo no_of_active_groups` operation on the result) +
-  - the random beacon contract should emit an event informing about the signing
-  group selection +
+  - the random beacon contract should emit an event informing about the group
+  selected to sign the entry +
   - the beacon should start the period of signature submission eligibility +
   - the selected signing group should start off-chain signature generation (upon
   noticing event sent by the beacon).
 
 | Relay request
-| If the relay entry request is deemed invalid, then: +
+| If the relay request is deemed invalid, then: +
   - the transaction should be reverted.
 
 | Relay request - signature generation
@@ -74,12 +78,11 @@ will be utilised during the acceptance testing of the feature.
 
 | Relay request - relay entry submission
 | During the signature submission eligibility period only selected members from
-  the group should be eligible to successfully submit the new relay entry
-  result. +
-  - at the beginning (right after the challenge period passes) only one member
-  (with index `new_entry % group_size` should be eligible +
-  - after fixed amount of blocks another member (with index `(new_entry %
-  group_size ) + 1` should become eligible (previous operator remains eligible) +
+  the group should be eligible to successfully submit the new relay entry: +
+  - at the beginning only one member, with index `new_entry % group_size`,
+  should be eligible +
+  - after fixed amount of blocks another member, with index `(new_entry %
+  group_size ) + 1`, should become eligible (previous operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
 
 | Relay request - relay entry submission
@@ -95,11 +98,6 @@ will be utilised during the acceptance testing of the feature.
   aplicable)? +
   - is the BLS threshold signature valid? +
   - is the relay request in progress?
-
-| Relay request - relay entry submission
-| When requesting a relay entry, it should be possible to pass an optional
-  address parameter - this is the address of a contract implementing
-  `IRandomBeaconConsumer` interface.
 
 | Relay request - relay entry submission
 | If the transaction submitting the new relay entry gets approved, then: +
@@ -120,7 +118,7 @@ will be utilised during the acceptance testing of the feature.
 
 | Relay request - relay entry submission
 | The transaction submitting relay entry should have a predictable cost and the
-  gas cost of this transaction should be as low as possible, below 200k gas.
+  gas cost of this transaction should be as low as possible, below 200k gas used.
 
 | Relay request - relay entry submission
 | It should be possible to send low gas callbacks (up to the fixed gas cost
@@ -148,7 +146,7 @@ will be utilised during the acceptance testing of the feature.
   amount of lost stake should incrementally increase from 0 (at the moment of
   soft relay entry timeout) to a fixed value (at the moment of hard relay entry
   timeout). The slashing will be applied in transaction: +
-  - submitting the relay entry submission (if the result got submitted by one of
+  - submitting the relay entry (if the result got submitted by one of
   the operators between soft and hard timeout) +
   - notifying about relay entry timeout (if no result was submitted before the
   hard timeout).
@@ -172,8 +170,8 @@ will be utilised during the acceptance testing of the feature.
 | Relay request - relay entry timeouts
 | When determining validity of the hard relay entry timeout notification, the
   following aspects should be taken into account: +
-  - does it reference the existing relay entry request? (if not, then
-  notification invalid) +
+  - does it reference the existing relay request? (if not, then notification
+  invalid) +
   - has the hard relay entry timeout passed? (if not, then notification invalid) +
   - does the transaction include punishing of the misbehaving operators? (if not,
   then notification invalid).
@@ -185,7 +183,7 @@ will be utilised during the acceptance testing of the feature.
   percentage of T and being excluded from earning rewards for a fixed amount of
   time +
   - the process of choosing a signing group and tasking it with a relay entry
-  generation should be repeated (as part of the same relay entry request) +
+  generation should be repeated (as part of the same relay request) +
   - if there are no active groups to choose from, the request should get
   terminated and no result should be produced (in order for the next requests to
   get processed successfully, the manual genesis must be first triggered).
@@ -200,12 +198,12 @@ will be utilised during the acceptance testing of the feature.
 
 | Group creation
 | New groups should be created with a fixed frequency of relay requests (every
-  `N`-th relay entry request should result in the creation of a new group).
+  `N`-th relay request should result in the creation of a new group).
 
 | Group creation
-| If according to group creation frequency the relay entry request is the one
-  that should trigger new group creation, the creation should be triggered once
-  a new relay entry appears on the chain (all off-chain clients should start the
+| If according to group creation frequency the relay request is the one that
+  should trigger new group creation, the creation should be triggered once a new
+  relay entry appears on the chain (all off-chain clients should start the
   process of creation of new group using the new entry value and a view
   sortition pool function call).
 
@@ -222,7 +220,8 @@ will be utilised during the acceptance testing of the feature.
   group creation start event.
 
 | Group creation
-| Group creation start transaction should be as cheap as possible.
+| Any logic related to group creation should not affect the gas cost of relay
+  entry transactions by more than a couple of thousands of gas units.
 
 | Group creation
 | The sortition pool should weigh operators by stake and allow to select the
@@ -318,7 +317,8 @@ will be utilised during the acceptance testing of the feature.
   - all sortition pool members who signed the result should be slashed (fixed
   amount) (in the same tx) +
   - notifier should receive 5% from the total slashed amount (in the same tx) +
-  - remaning 95% of the total slashed amount shoud be burned +
+  - remaning 95% of the total slashed amount should be burned or allocated for
+  the maintenance pool of the staking contract +
   - the members of the signing group should be given another chance to publish
   the DKG result +
   - DKG timeout timer and the result submission eligibility order should be
@@ -441,7 +441,8 @@ will be utilised during the acceptance testing of the feature.
 // add them to the UACs
 
 | Governable parameters
-| The frequency of relay requests should be a governable parameter.
+| Every `N`-th relay request initiates creation of a new signing group.
+  This group creation frequency should be a governable parameter.
 
 | Governable parameters
 | The length of the challenge period should be a governable parameter.

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -93,6 +93,32 @@ utilised during the acceptance testing of the feature.
   group_size ) + 1`, should become eligible (previous operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
 
+| Relay request - punishing inactive operators
+| It should be possible for a member of the group to send a notication informing
+  about group members notoriously ignoring their duty in relay entry (what will
+  be considered as ignoring the duties and how will it be checked should depend
+  on the off-chain algorithm - suggested mechanism: heartbeats).
+  
+| Relay request - punishing inactive operators
+| Upon receiving the transaction notifying about the misbehaving operators, the
+  random beacon should determine its validity.
+  
+| Relay request - punishing inactive operators
+  When determining validity of the transaction notifying about the misbehaving
+  operators, the following aspects should be taken into account: +
+  - was the transaction signed by at least half of the operators in the group? +
+  - are the operators who signed the transactions members of an active,
+  non-terminated group?
+
+| Relay request - punishing inactive operators
+| If the transaction notifying about the misbehaving operators gets approved,
+  then: +
+  - operators deemed as misbehaving should be excluded from earning the
+  sortition-pool rewards for a fixed amount of time +
+  - the submitter of the claim should get rewarded a fixed amount of T (per one
+  misbehaving operator) from the special reward pool (funded from the savings
+  made by previous exclusions of the operators from earning the rewards).
+
 | Relay request - relay entry submission
 | Upon receiving the transaction submitting the relay entry, the random beacon
   contract should determine validity of the transaction.
@@ -475,6 +501,11 @@ utilised during the acceptance testing of the feature.
 | Governable parameters
 | The slashing amount for submitting malicious DKG result
   (`maliciousDkgResultSlashingAmount`) should be a governable parameter.
+
+| Governable parameters
+| The reward for notifying about an operator notouriously ignoring their duty in
+  the relay entry generation (`ineligibleOperatorNotifierReward`) should be
+  a governable parameter.
 
 | Governable parameters
 | The max slashing amount for not submitting the relay entry before the hard

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -472,7 +472,8 @@ utilised during the acceptance testing of the feature.
 | Member of the sortition pool can be punished with temporary exclusion from 
   earning rewards as a result of: +
   - inactivity or disqualification during off-chain DKG +
-  - misbehavior during the DKG submission.
+  - misbehavior during the DKG submission +
+  - notorious ignoring of the duties during relay entry generation.
 
 | Sortition pool - punishments
 | The operation excluding members from earning the rewards should be as cheap as

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -104,7 +104,7 @@ be utilized during the acceptance testing of the feature.
   random beacon should determine its validity.
   
 | Relay request - punishing inactive operators
-  When determining validity of the transaction notifying about the misbehaving
+|  When determining validity of the transaction notifying about the misbehaving
   operators, the following aspects should be taken into account: +
   - was the transaction signed by at least half of the operators in the group? +
   - are the operators who signed the transactions members of an active,
@@ -450,7 +450,7 @@ be utilized during the acceptance testing of the feature.
   signing, the random beacon should determine its validity.
   
 | Groups - punishing for unauthorized signing
-  When determining validity of transaction notifying about the unauthorized
+| When determining validity of transaction notifying about the unauthorized
   groups signing, the following aspects should be taken into account: +
   - is the group indicated by the submitter as the one that leaked signature 
   active and non-terminated? +

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -184,6 +184,10 @@ utilised during the acceptance testing of the feature.
   - all signing group members should be punished by being slashed the fixed
   amount of T and being excluded from earning rewards for a fixed amount of
   time +
+  - the notifier should receive fixed part of the total slashed amount (in the
+  same tx) +
+  - remaning part of the total slashed amount should be burned or allocated for
+  the maintenance pool of the staking contract +
   - the process of choosing a signing group and tasking it with a relay entry
   generation should be repeated (as part of the same relay request) +
   - if there are no active groups to choose from, the request should get
@@ -364,7 +368,7 @@ utilised during the acceptance testing of the feature.
   accepted gets approved, then: +
   - the sortition pool should get unlocked +
   - the DKG result should be accepted and a group should be created based on the
-  candidate group +  
+  candidate group +
   - the DKG result accepter should receive the fixed reward (in T), paid from
   the maintenance pool to the submitter’s address (in the same tx) +
   - operators marked as inactive/disqualified during DKG protocol execution
@@ -479,7 +483,13 @@ utilised during the acceptance testing of the feature.
 | Governable parameters
 | The max slashing amount for not submitting the relay entry before the hard
   timeout (`relayEntrySubmissionFailureSlashingAmount`) should be a governable
-  parameter and should be initally set to `1000e18` (1000 T)
+  parameter and should be initally set to `1000e18` (1000 T).
+
+| Governable parameters
+| Percentage of the amount slashed from the group as a result of a hard timeout,
+  transfered as a reward to the notifier 
+  (`relayEntryTimeoutNotificationRewardMultiplier`) should be a governable
+  parameter.
 
 | Governable parameters
 | The reward for submitting a DKG result (`dkgResultSubmissionReward`) should be

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -98,7 +98,9 @@ will be utilised during the acceptance testing of the feature.
   - is the submitter eligible to submit? +
   - hasn’t the hard timeout for the relay request be reached? +
   - does the transaction include punishing of misbehaving operators (when
-  aplicable)?
+  aplicable)? +
+  - is the BLS threshold signature valid? +
+  - is the relay request in progress?
 
 | Relay request - relay entry submission
 | When requesting a relay entry, it should be possible to pass an optional

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -124,7 +124,8 @@ utilised during the acceptance testing of the feature.
 
 | Relay request - relay entry submission
 | The transaction submitting relay entry should have a predictable cost and the
-  gas cost of this transaction should be as low as possible, below 200k gas used.
+  gas cost of this transaction should be as low as possible, below 200k gas used
+  (when no callback is executed).
 
 | Relay request - relay entry submission
 | Failure in the callback function should not revert the relay entry transaction.

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -72,6 +72,12 @@ will be utilised during the acceptance testing of the feature.
   the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
   signing group).
 
+| Relay request - signature generation
+| Once the active group is selected as a signing group, it is tasked with the
+  generation of a BLS threshold signature (based on the current relay entry and
+  the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
+  signing group).
+
 | Relay request - relay entry submission
 | During the signature submission eligibility period only selected members from
   the group should be eligible to successfully submit the new relay entry
@@ -150,6 +156,15 @@ will be utilised during the acceptance testing of the feature.
   amount of lost stake should incrementally increase from 0 (at the moment of
   soft relay entry timeout) to a fixed value (at the moment of hard relay entry
   timeout).
+
+| Relay request - relay entry timeouts
+| The hard relay entry timeout can occur as a result of the following two
+  scenarios: +
+  - the signing group did not generate the BLS threshold signature (e.g. because
+  of not reaching the `blsThreshold`) and hence operators elgible to publish the
+  result had nothing to submit +
+  - the signing group did genearte the BLS threshold signature, but none of the
+  eligible operators have submitted the result.
 
 | Relay request - relay entry timeouts
 | Anyone can send a transaction reporting hard relay entry timeout.

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -267,6 +267,7 @@ will be utilised during the acceptance testing of the feature.
   aspects should be taken into account: +
   - is the submitter eligible at the moment to send the tx? +
   - are there enough supporting signatures on the result? +
+  - are all the signatures valid? +
   - do the signatures come from the stakers with at least a minimum stake? +
   Only if all the above conditions have been met, the tx is considered valid.
 

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -50,8 +50,9 @@ will be utilised during the acceptance testing of the feature.
 
 | Relay request
 | If the relay entry request is deemed valid, then: +
-  - the fee provided by the requester should be deposited in the maintenance
-  pool (with an intention to cover the reimbursements for DKG-related actions) +
+  - the fee charged from the requester should be deposited in the maintenance
+  pool (the T balance of the random beacon contract) (with an intention to cover
+  the reimbursements for DKG-related actions) +
   - the current relay entry should be used by the beacon to select a signing
   group from the set of active groups (by hashing the relay entry and applying
   `modulo no_of_active_groups` operation on the result) +

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -364,6 +364,9 @@ utilised during the acceptance testing of the feature.
   candidate group +  
   - the DKG result accepter should receive the fixed reward (in T), paid from
   the maintenance pool to the submitter’s address (in the same tx) +
+  - operators marked as inactive/disqualified during DKG protocol execution
+  should be punished by being excluded from earning rewards for a fixed amount
+  of time (in the same tx) +
   - operators who became eligible for submitting the DKG result before the
   member who submitted the DKG result should be punished by being excluded from
   earning rewards for a fixed amount of time (in the same tx).
@@ -401,6 +404,7 @@ utilised during the acceptance testing of the feature.
 | Sortition pool - punishments
 | Member of the sortition pool can be punished with temporary exclusion from 
   earning rewards as a result of: +
+  - inactivity or disqualification during off-chain DKG +
   - misbehavior during the DKG submission +
   - misbehavior during relay entry submission.
 

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -104,13 +104,11 @@ will be utilised during the acceptance testing of the feature.
 | Relay request - relay entry submission
 | If the transaction submitting the new relay entry gets approved, then: +
   - the BLS threshold signature should be accepted as a new relay entry +
-// TODO: revisit if 2 weeks removal time should be a governable parameter and if
-// it should be equal to 2 weeks or a different value
   - operators who became eligible for submitting the relay entry before the
-  member who submitted the relay entry should be punished by being removed from
-  the sortition pool for a fixed amount of time (2 weeks) and, if the soft
-  timeout has passed, should get slashed the calculated amount of T (all
-  happening in the same tx) +
+  member who submitted the relay entry should be punished by being excluded from
+  earning rewards for a fixed amount of time and, if the soft timeout has
+  passed, should get slashed the calculated amount of T (all happening in the
+  same tx) +
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
   in the tx, the interface should be called +
   - the creation of a new signing group should be triggered (only sometimes, if
@@ -183,10 +181,9 @@ will be utilised during the acceptance testing of the feature.
 | Relay request - relay entry timeouts
 | If the hard relay entry timeout notification was deemed justified, then: +
   - the signing group should get terminated +
-// TODO: revisit 2 weeks removal time
   - all signing group members should be punished by being slashed the fixed
-  percentage of T and being removed from the sortition pool for a fixed amount
-  of time (2 weeks) +
+  percentage of T and being excluded from earning rewards for a fixed amount of
+  time +
   - the process of choosing a signing group and tasking it with a relay entry
   generation should be repeated (as part of the same relay entry request) +
   - if there are no active groups to choose from, the request should get
@@ -361,10 +358,9 @@ will be utilised during the acceptance testing of the feature.
   candidate group +  
   - submitter should receive the fixed reward (in T), paid from the maintenance
   pool to the submitter’s address (in the same tx) +
-// TODO: revisit 2 weeks removal time
   - operators who became eligible for submitting the DKG result before the
-  member who submitted the DKG result should be punished by being removed from
-  the sortition pool for a fixed amount of time (2 weeks) (in the same tx).
+  member who submitted the DKG result should be punished by being excluded from
+  earning rewards for a fixed amount of time (in the same tx).
 
 | Group creation - DKG timeout
 | The DKG submission timeout equals the group size multiplied by the number of
@@ -397,22 +393,14 @@ will be utilised during the acceptance testing of the feature.
   the notifier.
 
 | Sortition pool - punishments
-// TODO: revisit 2 weeks removal time
-| Member of the sortition pool can be punished with 2 weeks removal from the
-  pool as a result of: +
+| Member of the sortition pool can be punished with temporary exclusion from 
+  earning rewards as a result of: +
   - misbehavior during the DKG submission +
   - misbehavior during relay entry submission.
 
 | Sortition pool - punishments
 | Operators punished with removal from the group should not earn rewards for the
   time of their absence in the pool.
-
-| Sortition pool - punishments
-// TODO: revisit 2 weeks removal time
-| After 2 weeks punish period elapses, operators removed from the sortition pool
-  should be able to manually re-register in the sortition pool and should be
-  able to earn the rewards again (from membership in the pool and potentially
-  submission of the DKG result or unlocking the pool).
 
 | Sortition pool - punishments
 | The operation removing members from the sortition pool should be as cheap as
@@ -496,6 +484,11 @@ will be utilised during the acceptance testing of the feature.
 | The hard timeout for a relay entry should be a governable parameter. Its
   initial value should be set to 24 hours (expressed in blocks, where we assume
   `1 block = 15s`).
+
+| Governable parameters
+| The length of the period during which operators won't be able to earn rewards
+  as a punishment for misbehaviour during submission of DKG or relay entry
+  should be a governable parameter. Its initial value should be set to 3 weeks.
 
 | Governable parameters
 | The callback gas limit should be a governable parameter. Its initial value

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -85,7 +85,7 @@ will be utilised during the acceptance testing of the feature.
   - at the beginning (right after the challenge period passes) only one member
   (with index `new_entry % group_size` should be eligible +
   - after fixed amount of blocks another member (with index `(new_entry %
-  group_size ) + 1` should become eligible (previous operator remains eligible)
+  group_size ) + 1` should become eligible (previous operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
 
 | Relay request - relay entry submission
@@ -96,7 +96,9 @@ will be utilised during the acceptance testing of the feature.
 | When determining validity of the relay entry submission, the following aspects
   should be taken into account: +
   - is the submitter eligible to submit? +
-  - hasn’t the hard timeout for the relay request be reached?
+  - hasn’t the hard timeout for the relay request be reached? +
+  - does the transaction include punishing of misbehaving operators (when
+  aplicable)?
 
 | Relay request - relay entry submission
 | When requesting a relay entry, it should be possible to pass an optional
@@ -110,7 +112,9 @@ will be utilised during the acceptance testing of the feature.
 // it should be equal to 2 weeks or a different value
   - operators who became eligible for submitting the relay entry before the
   member who submitted the relay entry should be punished by being removed from
-  the sortition pool for a fixed amount of time (2 weeks) (in the same tx) +
+  the sortition pool for a fixed amount of time (2 weeks) and, if the soft
+  timeout has passed, should get slashed the calculated amount of T (all
+  happening in the same tx) +
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
   in the tx, the interface should be called +
   - the creation of a new signing group should be triggered (only sometimes, if
@@ -141,21 +145,19 @@ will be utilised during the acceptance testing of the feature.
   blocks for a member to become eligible to submit relay entry. The timer starts
   at the moment when the first member becomes eligible (the moment when the
   relay entry was requested). +
-  The hard relay entry timeout is a set value (measured in time units).
+  The hard relay entry timeout is a set value (expressed in blocks) and is
+  measured since the reaching of soft relay entry timeout.
 
 | Relay request - relay entry timeouts
 | If no entry was successfully submitted until soft relay timeout is reached,
   all operators in the group should start bleeding and losing their T stake. The
   amount of lost stake should incrementally increase from 0 (at the moment of
   soft relay entry timeout) to a fixed value (at the moment of hard relay entry
-  timeout).
-
-| Relay request - relay entry timeouts
-| If no entry was successfully submitted until soft relay timeout is reached,
-  all operators in the group should start bleeding and losing their T stake. The
-  amount of lost stake should incrementally increase from 0 (at the moment of
-  soft relay entry timeout) to a fixed value (at the moment of hard relay entry
-  timeout).
+  timeout). The slashing will be applied in transaction: +
+  - submitting the relay entry submission (if the result got submitted by one of
+  the operators between soft and hard timeout) +
+  - notifying about relay entry timeout (if no result was submitted before the
+  hard timeout).
 
 | Relay request - relay entry timeouts
 | The hard relay entry timeout can occur as a result of the following two
@@ -178,11 +180,17 @@ will be utilised during the acceptance testing of the feature.
   following aspects should be taken into account: +
   - does it reference the existing relay entry request? (if not, then
   notification invalid) +
-  - has the hard relay entry timeout passed? (if not, then notification invalid). +
+  - has the hard relay entry timeout passed? (if not, then notification invalid) +
+  - does the transaction include punishing of the misbehaving operators? (if not,
+  then notification invalid).
 
 | Relay request - relay entry timeouts
 | If the hard relay entry timeout notification was deemed justified, then: +
   - the signing group should get terminated +
+// TODO: revisit 2 weeks removal time
+  - all signing group members should be punished by being slashed the fixed
+  percentage of T and being removed from the sortition pool for a fixed amount
+  of time (2 weeks) +
   - the process of choosing a signing group and tasking it with a relay entry
   generation should be repeated (as part of the same relay entry request) +
   - if there are no active groups to choose from, the request should get
@@ -487,7 +495,8 @@ will be utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | The hard timeout for a relay entry should be a governable parameter. Its
-  initial value should be set to 48 hours (may be specified in a different unit)
+  initial value should be set to 24 hours (expressed in blocks, where we assume
+  `1 block = 15s`).
 
 | Governable parameters
 | The callback gas limit should be a governable parameter. Its initial value

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -294,7 +294,8 @@ will be utilised during the acceptance testing of the feature.
   amount) (in the same tx) +
   - notifier should receive 5% from the total slashed amount (in the same tx) +
   - the members of the signing group should be given another chance to publish
-  the DKG result.
+  the DKG result
+  - DKG timeout timer and the result subission eligibility order shoul be reset.
 
 | Group creation - DKG challenge
 | If the challenge notification was received within the challenge period and was
@@ -339,7 +340,8 @@ will be utilised during the acceptance testing of the feature.
 | The DKG submission timeout equals the group size multiplied by the number of
   blocks for a member to become eligible to submit the DKG result. The timer
   starts at the moment when the first member becomes eligible (the moment when
-  DKG was requested).
+  DKG was requested). The timer gets reset when a valid DKG result challenge is
+  submitted. 
 
 | Group creation - DKG timeout
 | Anyone can send a transaction reporting DKG timeout.

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -198,7 +198,7 @@ will be utilised during the acceptance testing of the feature.
   `IRandomBeaconConsumer` interface.
 
 | Group creation
-| New groups should be created with a fixed frequency of relay request (every
+| New groups should be created with a fixed frequency of relay requests (every
   `N`-th relay entry request should result in the creation of a new group).
 
 | Group creation
@@ -213,8 +213,8 @@ will be utilised during the acceptance testing of the feature.
   then (when the pool gets unlocked) for joining operators to pools.
 
 | Group creation
-| Group creation start transaction should be embedded into relay entry request
-  transaction.
+| Group creation start transaction should be embedded into relay entry
+  submission transaction.
 
 | Group creation
 | Group creation start transaction should lock the sortition pool and emit the

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -8,8 +8,8 @@ toc::[]
 
 == Purpose of the document
 This document stores User Acceptance Criteria for Random Beacon v2. It will be
-used to gain common understanding of how Random Beacon v2 should act and will be
-utilised during the acceptance testing of the feature.
+used to gain a common understanding of how Random Beacon v2 should act and will
+be utilized during the acceptance testing of the feature.
 
 == User Acceptance Criteria list
 
@@ -19,7 +19,7 @@ utilised during the acceptance testing of the feature.
 | UAC
 
 | Relay request
-| Anyone can request for a relay entry.
+| Anyone can request a relay entry.
 
 | Relay request
 | Successful processing of each relay request should always result in the
@@ -68,7 +68,7 @@ utilised during the acceptance testing of the feature.
   - the beacon should start the period of signature submission eligibility +
   - the selected signing group should start off-chain signature generation (upon
   noticing event sent by the beacon). +
-  - the sortition pool should get locked as a preparation for creation of a new
+  - the sortition pool should get locked as preparation for creation of a new
   signing group (only sometimes, every N-th relay request).
 
 | Relay request
@@ -89,15 +89,15 @@ utilised during the acceptance testing of the feature.
    minimize the gas cost and distribute costs: +
    - at the beginning only one member, with index `new_entry % group_size`,
   should be eligible to submit a new relay entry +
-  - after fixed amount of blocks another member, with index `(new_entry %
+  - after a fixed amount of blocks another member, with index `(new_entry %
   group_size ) + 1`, should become eligible (previous operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
 
 | Relay request - punishing inactive operators
-| It should be possible for a member of the group to send a notication informing
-  about group members notoriously ignoring their duty in relay entry (what will
-  be considered as ignoring the duties and how will it be checked should depend
-  on the off-chain algorithm - suggested mechanism: heartbeats).
+| It should be possible for a member of the group to send a notification
+  informing about group members notoriously ignoring their duty in relay entry
+  (what will be considered as ignoring the duties and how will it be checked
+  should depend on the off-chain algorithm - suggested mechanism: heartbeats).
   
 | Relay request - punishing inactive operators
 | Upon receiving the transaction notifying about the misbehaving operators, the
@@ -126,7 +126,7 @@ utilised during the acceptance testing of the feature.
 | Relay request - relay entry submission
 | When determining validity of the relay entry submission, the following aspects
   should be taken into account: +
-  - hasn’t the hard timeout for the relay request be reached? +
+  - hasn’t the hard timeout for the relay request been reached? +
   - is the BLS threshold signature valid? +
   - is the relay request in progress?
 
@@ -136,7 +136,7 @@ utilised during the acceptance testing of the feature.
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
   in the tx, the interface should be called (with a fixed gas limit) +
   - the process of creation of a new signing group should be triggered (only
-  sometimes, every N-th relay request, if a creation of group isn't already in
+  sometimes, every N-th relay request, if creation of group isn't already in
   progress).
 
 | Relay request - relay entry submission
@@ -162,14 +162,14 @@ utilised during the acceptance testing of the feature.
   at the moment when the first member becomes eligible (the moment when the
   relay entry was requested). +
   The hard relay entry timeout is a set value (expressed in blocks) and is
-  measured since the reaching of soft relay entry timeout.
+  measured since the reaching of the soft relay entry timeout.
 
 | Relay request - relay entry timeouts
 | If no entry was successfully submitted until soft relay timeout is reached,
   all operators in the group should start bleeding and losing their T stake. The
   amount of lost stake should incrementally increase from 0 (at the moment of
   soft relay entry timeout) to a fixed value (at the moment of hard relay entry
-  timeout). The slashing will be applied in transaction: +
+  timeout). The slashing will be applied in the transaction: +
   - submitting the relay entry (if the result got submitted by one of
   the operators between soft and hard timeout) +
   - notifying about relay entry timeout (if no result was submitted before the
@@ -179,9 +179,9 @@ utilised during the acceptance testing of the feature.
 | The hard relay entry timeout can occur as a result of the following two
   scenarios: +
   - the signing group did not generate the BLS threshold signature (e.g. because
-  of not reaching the `blsThreshold`) and hence operators elgible to publish the
+  of not reaching the `blsThreshold`) and hence operators eligible to publish the
   result had nothing to submit +
-  - the signing group did genearte the BLS threshold signature, but none of the
+  - the signing group did generate the BLS threshold signature, but none of the
   eligible operators have submitted the result.
 
 | Relay request - relay entry timeouts
@@ -206,9 +206,9 @@ utilised during the acceptance testing of the feature.
   - all signing group members should be punished by being slashed the fixed
   amount of T and being excluded from earning rewards for a fixed amount of
   time +
-  - the notifier should receive fixed part of the total slashed amount (in the
+  - the notifier should receive a fixed part of the total slashed amount (in the
   same tx) +
-  - remaning part of the total slashed amount should be burned or allocated for
+  - remaining part of the total slashed amount should be burned or allocated for
   the rewards pool of the staking contract +
   - the process of choosing a signing group and tasking it with a relay entry
   generation should be repeated (as part of the same relay request) +
@@ -249,7 +249,7 @@ utilised during the acceptance testing of the feature.
 
 | Group creation
 | Any logic related to group creation should not affect the gas cost of relay
-  entry transactions by more than a couple of thousands of gas units.
+  entry transactions by more than a couple of thousand units of gas.
 
 | Group creation
 | The sortition pool should weigh operators by stake and allow to select the
@@ -283,10 +283,10 @@ utilised during the acceptance testing of the feature.
 
 | Group creation - DKG
 | After group members are determined, clients should perform off-chain DKG
-  (distributed key generation), resulting either in success or timeout. The
-  success result should contain list of members of the candidate group, the
+  (distributed key generation), resulting in either a success or a timeout. The
+  success result should contain a list of members of the candidate group, the
   public key of the group and list of misbehaving members (members who were
-  inactive or were disqualified) and should be submitted by eligible group
+  inactive or were disqualified) and should be submitted by the eligible group
   member on-chain.
 
 | Group creation - DKG submission
@@ -307,7 +307,7 @@ utilised during the acceptance testing of the feature.
   - at the beginning (right after group creation start transaction is submitted)
   only one member, with index `hash(new_group_pubkey) % group_size`, should be
   eligible +
-  - after fixed amount of blocks another member, with index
+  - after a fixed amount of blocks another member, with index
   `(hash(new_group_pubkey) % group_size ) + 1`, should become eligible (previous
   operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
@@ -320,7 +320,7 @@ utilised during the acceptance testing of the feature.
 
 | Group creation - DKG challenge
 | Anyone can send a challenge notification informing that submitted DKG result
-  is malitious (contains corrupted data, group members not selected by the pool,
+  is malicious (contains corrupted data, group members not selected by the pool,
   or incorrect supporting signatures).
 
 | Group creation - DKG challenge
@@ -330,10 +330,10 @@ utilised during the acceptance testing of the feature.
 | Group creation - DKG challenge
 | When determining validity of the challenge, the following aspects should be
   taken into account: +
-  - does it reference existing DKG result (if not, then challenge invalid) +
+  - does it reference an existing DKG result (if not, then challenge invalid) +
   - within or outside of the challenge period for the specified DKG result (if
   outside, then invalid) +
-  - is referenced DKG result indeed malitious (contains corrupted data, group
+  - is referenced DKG result indeed malicious (contains corrupted data, group
   members not selected by the pool, or incorrect supporting signatures)? (if no,
   then challenge invalid).
 
@@ -344,9 +344,9 @@ utilised during the acceptance testing of the feature.
   transaction in which notification happened) +
   - all sortition pool members who signed the result should be slashed (fixed
   amount) (in the same tx) +
-  - notifier should receive fixed part of the total slashed amount (in the same
+  - notifier should receive a fixed part of the total slashed amount (in the same
   tx) +
-  - remaning part of the total slashed amount should be burned or allocated for
+  - remaining part of the total slashed amount should be burned or allocated for
   the rewards pool of the staking contract +
   - the members of the signing group should be given another chance to publish
   the DKG result +
@@ -383,7 +383,7 @@ utilised during the acceptance testing of the feature.
 | Group creation - DKG acceptance
 | At the beginning (right after DKG result is submitted on chain) only the result
   submitter should be eligible to accept the DKG result and earn the reward.
-  After a fixed amount of time everybody should become eliglible to accept the
+  After a fixed amount of time everybody should become eligible to accept the
   DKG result.
 
 | Group creation - DKG acceptance
@@ -432,7 +432,7 @@ utilised during the acceptance testing of the feature.
   notifier.
 
 | Group expiration
-| Each group created in the system should reach expiration threshold after a
+| Each group created in the system should reach the expiration threshold after a
   fixed period of time.
 
 | Group expiration
@@ -441,15 +441,15 @@ utilised during the acceptance testing of the feature.
 | Group expiration
 | A group that expired should be no longer selected for any new work.
 
-| Groups - punishing for unauthorised signing
-| It should be possible for any operator to send a notication informing about
+| Groups - punishing for unauthorized signing
+| It should be possible for any operator to send a notification informing about
   unauthorized groups signing (leaked signature).
 
-| Groups - punishing for unauthorised signing
+| Groups - punishing for unauthorized signing
 | Upon receiving the transaction notifying about the unauthorized groups
   signing, the random beacon should determine its validity.
   
-| Groups - punishing for unauthorised signing
+| Groups - punishing for unauthorized signing
   When determining validity of transaction notifying about the unauthorized
   groups signing, the following aspects should be taken into account: +
   - is the group indicated by the submitter as the one that leaked signature 
@@ -463,9 +463,9 @@ utilised during the acceptance testing of the feature.
   - the group that leaked the signature should get terminated (in the same tx) +
   - all members of the group should get slashed a fixed amount of T (in the same
   tx) +
-  - notifier should receive fixed part of the total slashed amount (in the same
+  - notifier should receive a fixed part of the total slashed amount (in the same
   tx) +
-  - remaning part of the total slashed amount should be burned or allocated for
+  - remaining part of the total slashed amount should be burned or allocated for
   the rewards pool of the staking contract.
   
 | Sortition pool - punishments
@@ -513,36 +513,36 @@ utilised during the acceptance testing of the feature.
 // add them to the UACs
 
 | Governable parameters
-| Every `N`-th relay request initiates creation of a new signing group.
+| Every `N`-th relay request initiates a creation of a new signing group.
   This group creation frequency (`groupCreationFrequency`) should be a governable
   parameter.
 
 | Governable parameters
 | The time since the creation of a new signing group after that group gets
   expired (`groupLifetime`) should be a governable parameter and should be
-  initally set to `80640 blocks` (~2 weeks, assuming 15s block time).
+  initially set to `80640 blocks` (~2 weeks, assuming 15s block time).
 
 | Governable parameters
 | The length of the challenge period (`resultChallengePeriodLength`) should be a
-  governable parameter and should be initally set to `1440 blocks`.
+  governable parameter and should be initially set to `1440 blocks`.
 
 | Governable parameters
 | The slashing amount for submitting malicious DKG result
   (`maliciousDkgResultSlashingAmount`) should be a governable parameter.
 
 | Governable parameters
-| The reward for notifying about an operator notouriously ignoring their duty in
+| The reward for notifying about an operator notoriously ignoring their duty in
   the relay entry generation (`ineligibleOperatorNotifierReward`) should be
   a governable parameter.
 
 | Governable parameters
 | The max slashing amount for not submitting the relay entry before the hard
   timeout (`relayEntrySubmissionFailureSlashingAmount`) should be a governable
-  parameter and should be initally set to `1000e18` (1000 T).
+  parameter and should be initially set to `1000e18` (1000 T).
 
 | Governable parameters
 | Percentage of the amount slashed from the group as a result of a hard timeout,
-  transfered as a reward to the notifier,
+  transferred as a reward to the notifier,
   (`relayEntryTimeoutNotificationRewardMultiplier`) should be a governable
   parameter.
 
@@ -556,7 +556,7 @@ utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | Percentage of the amount slashed from the group as a result of signing a
-  malitious DKG result, transfered as a reward to the notifier,
+  malicious DKG result, transferred as a reward to the notifier,
   (`dkgMaliciousResultNotificationRewardMultiplier`) should be a governable
   parameter.
 
@@ -582,7 +582,7 @@ utilised during the acceptance testing of the feature.
 // Initial value: 3 weeks?
 | Governable parameters
 | The length of the period during which operators won't be able to earn rewards
-  as a punishment for misbehaviour during submission of DKG or relay entry
+  as a punishment for misbehavior during submission of DKG or relay entry
   (`sortitionPoolRewardsBanDuration`) should be a governable parameter.
 
 | Governable parameters
@@ -591,7 +591,7 @@ utilised during the acceptance testing of the feature.
 
 | Governable parameters
 | Percentage of the amount slashed from the members of the group that leaked
-  signature, transfered as a reward to the notifier,
+  signature, transferred as a reward to the notifier,
   (`unauthorizedSigningNotificationRewardMultiplier`) should be a governable
   parameter.
 

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -11,7 +11,7 @@ This document stores User Acceptance Criteria for Random Beacon v2 feature. It
 will be used to gain common understanding of how Random Beacon v2 should act and
 will be utilised during the acceptance testing of the feature.
 
-== Usear Acceptance Criteria list
+== User Acceptance Criteria list
 
 [%header,cols="1,4"]
 |===
@@ -98,7 +98,7 @@ will be utilised during the acceptance testing of the feature.
 | If the transaction submitting the new relay entry gets approved, then: +
   - the BLS threshold signature should be accepted as a new relay entry +
 // TODO: revisit if 2 weeks removal time should be a governable parameter and if
-// it should be equall to 2 weeks or a different value
+// it should be equal to 2 weeks or a different value
   - operators who became eligible for submitting the relay entry before the
   member who submitted the relay entry should be punished by being removed from
   the sortition pool for a fixed amount of time (2 weeks) (in the same tx) +
@@ -177,7 +177,7 @@ will be utilised during the acceptance testing of the feature.
   `IRandomBeaconConsumer` interface.
 
 | Group creation
-| New groups should be crated with a fixed frequency of relay request (every
+| New groups should be created with a fixed frequency of relay request (every
   `N`-th relay entry request should result in the creation of a new group).
 
 | Group creation
@@ -211,7 +211,7 @@ will be utilised during the acceptance testing of the feature.
   arbitrary seed value.
 
 | Group creation - genesis
-| It should not be possible to perform beacon genesis if they are some active
+| It should not be possible to perform beacon genesis if there are some active
   groups.
 
 | Group creation - genesis
@@ -228,7 +228,7 @@ will be utilised during the acceptance testing of the feature.
   - triggering of the DKG (distributed key generation) +
   - the beacon should start the period of DKG result submission eligibility.
 
-| Croup creation - selecting members
+| Group creation - selecting members
 | Upon noticing the group creation start event, clients should choose the
   sortition pool members to the candidate group based on the current relay
   entry, ensuring that the higher is the stake of an operator, the higher is his
@@ -295,7 +295,8 @@ will be utilised during the acceptance testing of the feature.
   - notifier should receive 5% from the total slashed amount (in the same tx) +
   - the members of the signing group should be given another chance to publish
   the DKG result
-  - DKG timeout timer and the result subission eligibility order shoul be reset.
+  - DKG timeout timer and the result submission eligibility order should be
+  reset.
 
 | Group creation - DKG challenge
 | If the challenge notification was received within the challenge period and was
@@ -399,13 +400,13 @@ will be utilised during the acceptance testing of the feature.
 | When the sortition pool is locked, no operator can enter the pool.
 
 | Sortition pool - locking
-| When the ssortition pool is locked, no operator can leave the pool.
+| When the sortition pool is locked, no operator can leave the pool.
 
 | Sortition pool - locking
-| Once the ssortition pool gets unlocked, operators can leave the pool.
+| Once the sortition pool gets unlocked, operators can leave the pool.
 
 | Sortition pool - locking
-| Once the ssortition pool gets unlocked, new operators can join the pool.
+| Once the sortition pool gets unlocked, new operators can join the pool.
 
 // TODO: Once starting values for governable parameters are agreed upon,
 // add them to the UACs

--- a/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
+++ b/docs/acceptance-criteria/uacs-rfc-19-random-beacon-v2.adoc
@@ -81,11 +81,14 @@ utilised during the acceptance testing of the feature.
   the data provided by at least `blsThreshold=(group_size/2) + 1` members of the
   signing group). This signature will be used as a proposed new relay entry.
 
-| Relay request - relay entry submission
-| During the signature submission eligibility period only selected members from
-  the group should be eligible to successfully submit the new relay entry: +
-  - at the beginning only one member, with index `new_entry % group_size`,
-  should be eligible +
+ | Relay request - relay entry submission
+ | Anyone can send a transaction submitting a new relay entry.
+
+ | Relay request - relay entry submission
+ | Off-chain clients are expected to agree and follow the following order to
+   minimize the gas cost and distribute costs: +
+   - at the beginning only one member, with index `new_entry % group_size`,
+  should be eligible to submit a new relay entry +
   - after fixed amount of blocks another member, with index `(new_entry %
   group_size ) + 1`, should become eligible (previous operator remains eligible) +
   - next members should become eligible after each fixed amount of blocks.
@@ -97,21 +100,13 @@ utilised during the acceptance testing of the feature.
 | Relay request - relay entry submission
 | When determining validity of the relay entry submission, the following aspects
   should be taken into account: +
-  - is the submitter eligible to submit? +
   - hasn’t the hard timeout for the relay request be reached? +
-  - does the transaction include punishing of misbehaving operators (when
-  aplicable)? +
   - is the BLS threshold signature valid? +
   - is the relay request in progress?
 
 | Relay request - relay entry submission
 | If the transaction submitting the new relay entry gets approved, then: +
   - the BLS threshold signature should be accepted as a new relay entry +
-  - operators who became eligible for submitting the relay entry before the
-  member who submitted the relay entry should be punished by being excluded from
-  earning rewards for a fixed amount of time and, if the soft timeout has
-  passed, should get slashed the calculated amount of T (all happening in the
-  same tx) +
   - if an optional address of the `IRandomBeaconConsumer` interface was provided
   in the tx, the interface should be called (with a fixed gas limit) +
   - the process of creation of a new signing group should be triggered (only
@@ -423,8 +418,7 @@ utilised during the acceptance testing of the feature.
 | Member of the sortition pool can be punished with temporary exclusion from 
   earning rewards as a result of: +
   - inactivity or disqualification during off-chain DKG +
-  - misbehavior during the DKG submission +
-  - misbehavior during relay entry submission.
+  - misbehavior during the DKG submission.
 
 | Sortition pool - punishments
 | The operation excluding members from earning the rewards should be as cheap as

--- a/docs/rfc/rfc-19-random-beacon-v2.adoc
+++ b/docs/rfc/rfc-19-random-beacon-v2.adoc
@@ -61,9 +61,9 @@ operators noticed the problem.
 New groups should be created with a fixed, governable frequency of relay
 requests. Instead of a ticket-based approach for group selection, we should
 use sortition pools. Group creation start transaction should be embedded into
-transaction submitting relay entry and should lock a sortition pool. From this
-moment, no operator can enter or leave the pool. Once a new relay entry appears
-on the chain, all off-chain clients should perform group selection optimistically, 
+relay request transaction and should lock a sortition pool. From this moment,
+no operator can enter or leave the pool. Once a new relay entry appears on the
+chain, all off-chain clients should perform group selection optimistically, 
 using the new entry value and a view sortition pool function call.
 After determining group members, clients should perform DKG as usual. 
 Once the group submits the result to the chain, a challenge period starts.

--- a/docs/rfc/rfc-19-random-beacon-v2.adoc
+++ b/docs/rfc/rfc-19-random-beacon-v2.adoc
@@ -61,9 +61,9 @@ operators noticed the problem.
 New groups should be created with a fixed, governable frequency of relay
 requests. Instead of a ticket-based approach for group selection, we should
 use sortition pools. Group creation start transaction should be embedded into
-relay request transaction and should lock a sortition pool. From this moment,
-no operator can enter or leave the pool. Once a new relay entry appears on the
-chain, all off-chain clients should perform group selection optimistically, 
+transaction submitting relay entry and should lock a sortition pool. From this
+moment, no operator can enter or leave the pool. Once a new relay entry appears
+on the chain, all off-chain clients should perform group selection optimistically, 
 using the new entry value and a view sortition pool function call.
 After determining group members, clients should perform DKG as usual. 
 Once the group submits the result to the chain, a challenge period starts.


### PR DESCRIPTION
The document stores User Acceptance Criteria for Random Beacon v2
feature. It will be used to gain common understanding of how Random
Beacon v2 should act and will be utilised during the acceptance testing
of the feature.