### PR TITLE
tBTC reward allocation 2021-10-15 -> 2021-10-22

### DIFF
--- a/solidity/dashboard/src/rewards-allocation/rewards.json
+++ b/solidity/dashboard/src/rewards-allocation/rewards.json
@@ -55164,5 +55164,858 @@
         ]
       }
     }
+  },
+  "0x77e33907e988fa25cc6720705cb4c8605bdab1c68d6d227bb1e9ba96bbf9baed": {
+    "tokenTotal": "0x014eb6f224d084634a7fe5",
+    "claims": {
+      "0x0000000000058fDe63cA64995c9A7E40196Af9F9": {
+        "index": 0,
+        "amount": "0x58776f8fb7302de8a5",
+        "proof": [
+          "0x4e6d605f5fa5cf60b8f33195ba4f12cc9a5f08e2762897fa4be04c9fc522fcbd",
+          "0x160e0fe9f8d9fbfe112bb358c02b22fca8ed088562ea9158d342ac3312b24fc5",
+          "0x0daa0f94615b27312ebaa098013fa3c72c4ff0d2ab7d2c29eedb079817e48651",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x00Cef852246b08B9215772c3f409D28408Bb21bD": {
+        "index": 1,
+        "amount": "0x05f3fb44dbc90b275085",
+        "proof": [
+          "0x04c487c0366ca7e2fadd3b5f746ac8ea79a13f1fdfada96abee4360bfe220e60",
+          "0xf46b62aa84ac28d0e823bd3fd1fdb3dfe6c51f376a57cbe48a138d5cd330c325",
+          "0xc443954d44d7670cc9d7e8b3ad69299c79e9867e1a7b1cf1f5ef56d0d857027f",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x045E511f53DeBF55c9C0B4522f14F602f7C7cA81": {
+        "index": 2,
+        "amount": "0x099394e64b59f239651d",
+        "proof": [
+          "0x7405abca6552dea353e305cb52d6e47085a3bf15a3de8097729ea0063f5bc6b5",
+          "0x4997c0db01bf68c8ae0cf0ff37cbc04f9c71adf1863dfa0a43938c38638e70fe",
+          "0xfcd5bd0814e355af37ecbdc9df0d381586084bddab303087358dd5fbdce03af8",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x07C9a8f8264221906b7b8958951Ce4753D39628B": {
+        "index": 3,
+        "amount": "0x025488c0b288883d4738",
+        "proof": [
+          "0x1c3553268d40b0e47e1bd6a817cb010a54c20217a0ad814dac9cfbfaba18e922",
+          "0x65a1301ff4de2d6e2eace134b8c84e549a3326707eb95e09a4cab6ff71c13304",
+          "0xc50fc2b3d05ef74d9dd8bfc66f5fe33a6da674883f5dac1d00c5ba66fa40a982",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x0ae20e11a065a7E750482E6a7E9eB7eaB7A8137f": {
+        "index": 4,
+        "amount": "0x0fe58062b486f8",
+        "proof": [
+          "0x57bcb334a10d48a8d40ff68f70c8fa6167348fecb2f5345968c4706dcb6de992",
+          "0x3fe3f08fc3f87d0b3b31980f0e01bd974ace08f6b810463ef9b648f8cad8d9ab",
+          "0xdc1427ddc2ec1e76871900c44c6ecae5a8233efc747245dbf87efad35f97256b",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x0d0271d1B2906Cc472A8e75148937967Be788F09": {
+        "index": 5,
+        "amount": "0x0a10a979d67365d3f4fd",
+        "proof": [
+          "0x68aecbe2bf62cd3dbf5d48ece6c6ed953c679f448f885108f5c595e0aae9478e",
+          "0xb9fe8f586e99ae086a01dcd607c3fea210ccbbf7b67045da71a435c8ea346c0c",
+          "0xfcd5bd0814e355af37ecbdc9df0d381586084bddab303087358dd5fbdce03af8",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x1147ccFB4AEFc6e587a23b78724Ef20Ec6e474D4": {
+        "index": 6,
+        "amount": "0x261c8f6dcba0643b39",
+        "proof": [
+          "0x9b6c5de016f08cc1b4d9d06c5a76a522622be90309850f9f200c2b6322f963ae",
+          "0x969e8e67768b774f5463f6bed339021f29d1d7d5396f4599ef5594654a601863",
+          "0x33f32980c2b5df6c7296989865a9afb7a1f2a8f8cf2f182eb92a3360f9df0eec",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x190059F25D91afFB092D145CEBb907817414bCf0": {
+        "index": 7,
+        "amount": "0x0134f0bd89fb349747c0",
+        "proof": [
+          "0x2260bacbd86fc916f6c18613978e73e59439ce2f57a46e0115a61970725adc19",
+          "0x8937ca516b4a01a23aae747e056c3f08dee238d34c228a5703a9c6fa23c147d3",
+          "0xa64c6af5170f9a06029319a4c8556cce3e9f219cb57f054b9219105b8f758f0e",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x1d803c89760F8B4057DB15BCb3B8929E0498D310": {
+        "index": 8,
+        "amount": "0x66fffee4594252a786",
+        "proof": [
+          "0xeb73358189c973cddeb4240a51ed05a16119095653e5600cd88c485693a2e949",
+          "0xad7693de93df3a0f0f6035220ecc0e24c654e4dc94e3c842dbd8c4f13f1793d3",
+          "0x70228bcc9420a94b657470d9de863fcbb2a5a3ef0490f705858aec138c7b61e8",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x1e5801DB6779b44A90104AE856602424D8853807": {
+        "index": 9,
+        "amount": "0x02ed1d13463a1dc6b98b",
+        "proof": [
+          "0x2f3778ca0b09aca6bc8eaf47932e1f89d17fd7e8500c53804b42f4e348b0a134",
+          "0x27679c24cd568512c4e432b1467337c92246f195b29d01e5553fe694bf6353fa",
+          "0xbe765d86cb162ee930adfcf5509e9a80ae3b624eb74c613b7abeb4858748ed31",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x2BAF3650263348f3304c18900A674bB0BF830801": {
+        "index": 10,
+        "amount": "0xc8b53edb1e16329216",
+        "proof": [
+          "0xb5f6f63317f2b0e89799fc719ae2e28c632910b12ed55e3771bacda251b9c39b",
+          "0x353ed19a923880c006380122ee3b7756ab249ad9c346c6bd87048757d652ecbb",
+          "0x39ea328f7a6379d8e9c1fa67d02b594cacc5fc9f02df692e64605667875ebdc1",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x2eBE08379f4fD866E871A9b9E1d5C695154C6A9F": {
+        "index": 11,
+        "amount": "0x045c6b9b72258e3b53dc",
+        "proof": [
+          "0xaf19291de504a09d2c98714404d34155fae6825b1b0262701d22252f82ccd6e1",
+          "0x969e8e67768b774f5463f6bed339021f29d1d7d5396f4599ef5594654a601863",
+          "0x33f32980c2b5df6c7296989865a9afb7a1f2a8f8cf2f182eb92a3360f9df0eec",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x3101927DEeC27A2bfA6c4a6316e3A221f631dB91": {
+        "index": 12,
+        "amount": "0x02b03bcf7c2a9daccacd",
+        "proof": [
+          "0x383840f2f5be3638bfbd4fc9dde1cf355ea71222f65310bdca190efd3ad9aea0",
+          "0x383a57b73740c90089c827597137929d160feaedb0ae8749ae88f7e62ae9d3cd",
+          "0xbe765d86cb162ee930adfcf5509e9a80ae3b624eb74c613b7abeb4858748ed31",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x36C56A69c2aeA23879b59dB0e99D57eF2ff77f06": {
+        "index": 13,
+        "amount": "0x10fbf69fee30d580f028",
+        "proof": [
+          "0x60f58ed6b21319b13a9a7621a982e4da46472458fad109f0804d46b8ff6b2987",
+          "0xb9a79cee764ec81aa16c92668008a33142115dc5e50b0d8532ad67ff3154a0c3",
+          "0xdc1427ddc2ec1e76871900c44c6ecae5a8233efc747245dbf87efad35f97256b",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x39d2aCBCD80d80080541C6eed7e9feBb8127B2Ab": {
+        "index": 14,
+        "amount": "0x02106fd2e8a1b971515f",
+        "proof": [
+          "0xd154d7b728a45009cc35d548b5ff49a15e2e324ea44b750df78147a2c1715271",
+          "0xb5a09825c547c62ef2aac698de47f389ad3b1e05ed9f7e243c01ad3cd0452b0e",
+          "0x0fcf6bd47671f33ebb8ea76bf18838335caf79ff5a909c60246344ab3b7201a2",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x3B9e5ae72d068448bB96786989c0d86FBC0551D1": {
+        "index": 15,
+        "amount": "0x01d02bd263170eaad9cb",
+        "proof": [
+          "0xf78dff46309eb56446e21469637d712d7cc690387bd1aac8e7cf73a3a9078089",
+          "0x7ae571ab6bb22e0c2897f11bb3298300a54001a2fa53743f06b51098a8a74d79"
+        ]
+      },
+      "0x3d7764aE9aC8259E5A5d224F5F56414f9749902a": {
+        "index": 16,
+        "amount": "0x0feab9713eddce8348d7",
+        "proof": [
+          "0x07f8ec851a1b7133b6a84f9fbb3775fcf56414b930632f0ab86c2d0b9c4ef908",
+          "0xf58fc5f275e0878f771dee6a26a3a1d1daacff3dadad2a0b42e4b2b49d3fc579",
+          "0xc443954d44d7670cc9d7e8b3ad69299c79e9867e1a7b1cf1f5ef56d0d857027f",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x44f07be8D08a7Ec1b4BDB92685dA64C02622CFc5": {
+        "index": 17,
+        "amount": "0x032627d7404793c42741",
+        "proof": [
+          "0xc2466fed7f6453fca0eb06fce12ecadf45565a2d4756ae5606f0dfab718ada47",
+          "0x4812c324b1ea26e6bafa43618a9e527700acf400f5268e11fc242a9a9b6f35a6",
+          "0xed41df891168d8ad847c16cc4d87c2616febaeaa284644424ac663fde256ed3d",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x4F4f0D0dfd93513B3f4Cb116Fe9d0A005466F725": {
+        "index": 18,
+        "amount": "0x056a4061335c822d622f",
+        "proof": [
+          "0x516c6687e6c423129602e42f64ec345dc18523de1e34f8a6e5e6f3b960c454c2",
+          "0xe00c153185ec0f186f15c184fd108bb259b0d5749306bd94de97a12b56166171",
+          "0x0daa0f94615b27312ebaa098013fa3c72c4ff0d2ab7d2c29eedb079817e48651",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x4a41c7a884d119eaaefE471D0B3a638226408382": {
+        "index": 19,
+        "amount": "0x063f3af160a6c340e019",
+        "proof": [
+          "0x290a3e12ec9c3a58dda38842959e65262d70f1fd60359352c652c23086006845",
+          "0x8937ca516b4a01a23aae747e056c3f08dee238d34c228a5703a9c6fa23c147d3",
+          "0xa64c6af5170f9a06029319a4c8556cce3e9f219cb57f054b9219105b8f758f0e",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x4bFa10B1538E8E765E995688D8EEc39C717B6797": {
+        "index": 20,
+        "amount": "0x023501345ebf3bf20d90",
+        "proof": [
+          "0xc7dcecae38bf49f26aed015b2c0c0aad08be5a6a34c6ad42153671e0c997cccd",
+          "0x9d3fb291ce4a9ed62b37b8a6ea7c47e03314bdc1db6770cf9cbb03b8e71e5b98",
+          "0xf412af7f7a3984f5a3e596ee6009bf8fc2470c20cc3a0060b46a139364f55adc",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x4c21541f95a00C03C75F38C71DC220bd27cbbEd9": {
+        "index": 21,
+        "amount": "0xd91cc4f09788b0bca6",
+        "proof": [
+          "0x7a0366975c103441d33f9a3a5bc895a402f4451313bda5e8f89b2fd76821dfc2",
+          "0x56f79b8bd9b516856d5846d0062bafe72889c1b685e0a99bdbc61c9b20fd6c99",
+          "0xb86a59e6325b39c4cbd77a23d6b53eaedca546c5bff70a13db820ab7dc263076",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x526c013f8382B050d32d86e7090Ac84De22EdA4D": {
+        "index": 22,
+        "amount": "0x7a370b35124273c172",
+        "proof": [
+          "0x88017dd440b95deee2dfe5cf1e1a6738bf057d7502ca324b91e02342c1c99e20",
+          "0x44e6e67049c83a025065cd0bf3d84f668101f25fc92833e397aa9a7677b710fa",
+          "0xfc0501c456c784bf3bae62cfa6a39f9084470e0b94d0df26fca780c5d28a6b93",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x5CA1F949c75833432d6BC8E3cb6FB23386F63426": {
+        "index": 23,
+        "amount": "0x04e239e941ce0efaef0a",
+        "proof": [
+          "0x89d5d5d2fa115b47301a3b5cd22fce3568a88b3dd61991b6836a00492699d22d",
+          "0x44e6e67049c83a025065cd0bf3d84f668101f25fc92833e397aa9a7677b710fa",
+          "0xfc0501c456c784bf3bae62cfa6a39f9084470e0b94d0df26fca780c5d28a6b93",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x5Df67a14Bf26981543A2Ea33C2EE454CFA42aDA5": {
+        "index": 24,
+        "amount": "0x0a540696ff0769aa90e3",
+        "proof": [
+          "0xb14f853abff537c1480c69db7e5bf3ff242521fcf0e4a8117aab55913bffb2dc",
+          "0xa4a887b44dc6134e721b9ed0fd305bbb114a4634ad27917f08daed07daeaed8a",
+          "0x39ea328f7a6379d8e9c1fa67d02b594cacc5fc9f02df692e64605667875ebdc1",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x5d84DEB482E770479154028788Df79aA7C563aA4": {
+        "index": 25,
+        "amount": "0x0110099e57df596cf5d5",
+        "proof": [
+          "0x80f0248206704119f0e1ae1c90454ee0d572e861636ef94a831ada961630c0aa",
+          "0xde7dda0f34e3b8e8c092cc255abd5aca3bc22c9c86664255816242c513d8a5f7",
+          "0xfc0501c456c784bf3bae62cfa6a39f9084470e0b94d0df26fca780c5d28a6b93",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x64A8856cBD255765D16B901a0B899daefC78FB13": {
+        "index": 26,
+        "amount": "0x14a8ebda5621de77d749",
+        "proof": [
+          "0x587d56e942d403369cf68aa464f3175a9d8343fb3f8dbef89f1f945b1e848403",
+          "0x3fe3f08fc3f87d0b3b31980f0e01bd974ace08f6b810463ef9b648f8cad8d9ab",
+          "0xdc1427ddc2ec1e76871900c44c6ecae5a8233efc747245dbf87efad35f97256b",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x650A9eD18Df873cad98C88dcaC8170531cAD2399": {
+        "index": 27,
+        "amount": "0x1262769c7a8d3ca13f5a",
+        "proof": [
+          "0x7ef28f1bfab51e02d856776a8557d0a087bdbdddec3e3823ccafebfd4200093a",
+          "0x2ebc13642b0ce027578180bbcae2d6006365b3bcbaac60854a6158dd38abeafa",
+          "0xb86a59e6325b39c4cbd77a23d6b53eaedca546c5bff70a13db820ab7dc263076",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x6C76d49322C9f8761A1623CEd89A31490cdB649d": {
+        "index": 28,
+        "amount": "0x66fffee4594252a786",
+        "proof": [
+          "0x20b6594364bc84e3066831164e327ed3c1cfc42c4eee0088fb6ac04f589cc5e3",
+          "0xf5c0383adbc06da594e970d37a12543c6114fae5322dcf5e16023a51baad9cf8",
+          "0xa64c6af5170f9a06029319a4c8556cce3e9f219cb57f054b9219105b8f758f0e",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x6dAfE16b14c95eB99c64e8d4E5435F7574B2825c": {
+        "index": 29,
+        "amount": "0x01557a3693eab43dfaf3",
+        "proof": [
+          "0x578c017f80dcf72beaf78caaef76c7f6790d196db94d62b64079bfcc79c92b55",
+          "0xe00c153185ec0f186f15c184fd108bb259b0d5749306bd94de97a12b56166171",
+          "0x0daa0f94615b27312ebaa098013fa3c72c4ff0d2ab7d2c29eedb079817e48651",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x78c0eF874Df6cb2cD7E724bdF3Ce68f431b79748": {
+        "index": 30,
+        "amount": "0x013679d60b1fd7824093",
+        "proof": [
+          "0xb84629de471cd90c2436e1b4eddd60d56224f3648dc0420558315ef5d6c9ccc9",
+          "0x353ed19a923880c006380122ee3b7756ab249ad9c346c6bd87048757d652ecbb",
+          "0x39ea328f7a6379d8e9c1fa67d02b594cacc5fc9f02df692e64605667875ebdc1",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x7E6332d18719a5463d3867a1a892359509589a3d": {
+        "index": 31,
+        "amount": "0x02ecce44f7a19f70d05d",
+        "proof": [
+          "0xb8ee6372ccf9bae8c9e71064ea5c6434975f3876bd8dbf1c5f2a94c853b572cf",
+          "0xcf7a6fc98ad00e829048f5adf754bcce23df1ceb5f16c81f5b64a0dd99d4f955",
+          "0xed41df891168d8ad847c16cc4d87c2616febaeaa284644424ac663fde256ed3d",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x7a9654B888dEa4Fed7bf4c1cD104Bd45217427dA": {
+        "index": 32,
+        "amount": "0xd6bb9cd71b522c684a",
+        "proof": [
+          "0xdb0a85e86c76e1fd0b57380f39c0d3ca71eddbfbf9c9671147c0ac8814485fcd",
+          "0xf977ca8f14c9f0ef882812e95b67631325d54df0cc23b7bebd57c855fdd3c3ae",
+          "0xcdc369e6690acf9925d838196866d258db6c4e72df198a1290d735650d0b631b",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x7f746e790e97996AC9fE892d48eB8660DeE6786D": {
+        "index": 33,
+        "amount": "0x7906aa27e662f408",
+        "proof": [
+          "0x0d0cbdbc440ac16c720977a08346d9f97aa455e6b74a9a445f4ef4e3c5ebb548",
+          "0xf58fc5f275e0878f771dee6a26a3a1d1daacff3dadad2a0b42e4b2b49d3fc579",
+          "0xc443954d44d7670cc9d7e8b3ad69299c79e9867e1a7b1cf1f5ef56d0d857027f",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x81e1B56db174a935fe81E4b9839d6D92528090f4": {
+        "index": 34,
+        "amount": "0x0ff766e098b7246ceb6f",
+        "proof": [
+          "0x95ee726897377a4a4b720a8215188c41d65d0843e66aa242323f1b898b0666dc",
+          "0x8622d3e6bcbabe66888a4be8cd4e7fcdb51a20a0eda51e01970e11c02d6a1cea",
+          "0x33f32980c2b5df6c7296989865a9afb7a1f2a8f8cf2f182eb92a3360f9df0eec",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x855A951162B1B93D70724484d5bdc9D00B56236B": {
+        "index": 35,
+        "amount": "0xaffcc8e4e2aa0bcc92",
+        "proof": [
+          "0xcb4f6b03d3a99927b164566abb2c50f3382d35e68c8211ee24daa4a5983ba57d",
+          "0x9d3fb291ce4a9ed62b37b8a6ea7c47e03314bdc1db6770cf9cbb03b8e71e5b98",
+          "0xf412af7f7a3984f5a3e596ee6009bf8fc2470c20cc3a0060b46a139364f55adc",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x860EF3f83B6adFEF757F98345c3B8DdcFCA9d152": {
+        "index": 36,
+        "amount": "0x187976f4e63e263428",
+        "proof": [
+          "0xcf29e9f469e05d39313e3e6a1af835951adf35dab57e947720186ac6306319de",
+          "0xb5a09825c547c62ef2aac698de47f389ad3b1e05ed9f7e243c01ad3cd0452b0e",
+          "0x0fcf6bd47671f33ebb8ea76bf18838335caf79ff5a909c60246344ab3b7201a2",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x884e30892B185330478D0D18d0aE665113B98027": {
+        "index": 37,
+        "amount": "0x0150645f824e66e19a43",
+        "proof": [
+          "0xbad083b2832adf0192732e4a8283c50aa2a8f18b3cf32e97fa28dc6a47f27f5f",
+          "0xcf7a6fc98ad00e829048f5adf754bcce23df1ceb5f16c81f5b64a0dd99d4f955",
+          "0xed41df891168d8ad847c16cc4d87c2616febaeaa284644424ac663fde256ed3d",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x8Bd660A764Ca14155F3411a4526a028b6316CB3E": {
+        "index": 38,
+        "amount": "0xd5f05e75fe000cd17a",
+        "proof": [
+          "0x73121c10055afbd66d4ae2f71176e3dd15dbe7666f9c9a4470f9e449823e3a55",
+          "0x4997c0db01bf68c8ae0cf0ff37cbc04f9c71adf1863dfa0a43938c38638e70fe",
+          "0xfcd5bd0814e355af37ecbdc9df0d381586084bddab303087358dd5fbdce03af8",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x9767795d399E86fCc0F600dB6F302F5C0692e0cF": {
+        "index": 39,
+        "amount": "0x04cc72b8a718bba88764",
+        "proof": [
+          "0xcd7f8501296a5772a0bbcefc7ca11d55c5b348b2dd5aa192b96dc7c6eaec0415",
+          "0x3e7dce23fda89e73313689fa3f1a73d4bd0f5556e3c87070be7ead35a3f0eb6a",
+          "0x0fcf6bd47671f33ebb8ea76bf18838335caf79ff5a909c60246344ab3b7201a2",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x9bC8d30d971C9e74298112803036C05db07D73e3": {
+        "index": 40,
+        "amount": "0x1f17ca05ca08f5ece5",
+        "proof": [
+          "0xe5773efd2cd0cc371fa5b888a724721c25dc1cf56762462ab44119561e6a15ac",
+          "0x35ad138ee90aeac320b03c5142d78c06a1a38a46b88aa9272a6b201e646a6d51",
+          "0xcdc369e6690acf9925d838196866d258db6c4e72df198a1290d735650d0b631b",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x9bD818Ab6ACC974f2Cf2BD2EBA7a250126Accb9F": {
+        "index": 41,
+        "amount": "0x0551d3d08578651a43c4",
+        "proof": [
+          "0x86c33a27e88e39fadc2ec79a7438b141ae26ed4b585813cb21315801004ebf10",
+          "0xde7dda0f34e3b8e8c092cc255abd5aca3bc22c9c86664255816242c513d8a5f7",
+          "0xfc0501c456c784bf3bae62cfa6a39f9084470e0b94d0df26fca780c5d28a6b93",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0x9c06Feb7Ebc8065ee11Cd5E8EEdaAFb2909A7087": {
+        "index": 42,
+        "amount": "0x0b98358cf15a75385a64",
+        "proof": [
+          "0xc62767759805a9ec3b77f9d20584bac33c8636392328f46c922e82dd902f990c",
+          "0x2d0aee7f9e3715cba984537584384b30b936ad61af483e1ec0232ab22fea9870",
+          "0xf412af7f7a3984f5a3e596ee6009bf8fc2470c20cc3a0060b46a139364f55adc",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xA543441313F7FA7F9215B84854E6DC8386B93383": {
+        "index": 43,
+        "amount": "0x0e6c3124610a68a21876",
+        "proof": [
+          "0xc2cc3dea3a15dea06bc7fc607b3fe6ae981228b64fc2eb2d4d0e28270efab69c",
+          "0x2d0aee7f9e3715cba984537584384b30b936ad61af483e1ec0232ab22fea9870",
+          "0xf412af7f7a3984f5a3e596ee6009bf8fc2470c20cc3a0060b46a139364f55adc",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xA97c34278162b556A527CFc01B53eb4DDeDFD223": {
+        "index": 44,
+        "amount": "0x34be45042095477cba",
+        "proof": [
+          "0x2d42e742fb026367020a708f74407dafeae1bd94388f4d14a6d874b2c5fd425c",
+          "0x27679c24cd568512c4e432b1467337c92246f195b29d01e5553fe694bf6353fa",
+          "0xbe765d86cb162ee930adfcf5509e9a80ae3b624eb74c613b7abeb4858748ed31",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xABFB52f4CfAC3e6631c19a7e4Aa752110E1187B5": {
+        "index": 45,
+        "amount": "0x0261bca672d575d2f9b7",
+        "proof": [
+          "0x7ff2ed22d0ccc91fc6bad3d30f43949aa24e8fa2fad888962e6676d53e56945b",
+          "0x2ebc13642b0ce027578180bbcae2d6006365b3bcbaac60854a6158dd38abeafa",
+          "0xb86a59e6325b39c4cbd77a23d6b53eaedca546c5bff70a13db820ab7dc263076",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xB2D53Be158Cb8451dFc818bD969877038c1BdeA1": {
+        "index": 46,
+        "amount": "0x01834886e6146fd9b4",
+        "proof": [
+          "0xdfa333aaafc56ee0c8c9cd0f33d74623b615800a91896a5d9eee09da5a9efac7",
+          "0xf977ca8f14c9f0ef882812e95b67631325d54df0cc23b7bebd57c855fdd3c3ae",
+          "0xcdc369e6690acf9925d838196866d258db6c4e72df198a1290d735650d0b631b",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xB62Fc1ADfFb2ab832041528C8178358338d85f76": {
+        "index": 47,
+        "amount": "0x13a33c398d13220ee1",
+        "proof": [
+          "0x18954e010cf6d14f962471070a707b4666f7e134408bc3ee435f6e5438294581",
+          "0x65a1301ff4de2d6e2eace134b8c84e549a3326707eb95e09a4cab6ff71c13304",
+          "0xc50fc2b3d05ef74d9dd8bfc66f5fe33a6da674883f5dac1d00c5ba66fa40a982",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xB7a764884a2fBcfC7177b5c53A7797EE7fF4Bb39": {
+        "index": 48,
+        "amount": "0x0daaf14cc9cfd18cbc39",
+        "proof": [
+          "0xe6773b56c7591285052ae7e094089af7622fa59e5d45fec5c5209c21d5adc139",
+          "0x4708b5ef9c2ba5494ab22358c5c7721663cc1ff4e90b88c6f665f2fad6099006",
+          "0x70228bcc9420a94b657470d9de863fcbb2a5a3ef0490f705858aec138c7b61e8",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xB8A3AE209d153560993BFd8178E60F09B1c682E8": {
+        "index": 49,
+        "amount": "0x2e9d0b276c0585f06137",
+        "proof": [
+          "0x15aee68797e5f5c8f4639c0817c2716931c30b44447da4088152f67cf926c12e",
+          "0x205e4485045067d209c8dbbd61c01f3b239dd4d585388e10d409d92b80df2965",
+          "0xc50fc2b3d05ef74d9dd8bfc66f5fe33a6da674883f5dac1d00c5ba66fa40a982",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xBDE07f1cA107Ef319b0Bb26eBF1d0a5b4c97ffc1": {
+        "index": 50,
+        "amount": "0x098d4c92aa02bfcca1df",
+        "proof": [
+          "0x1317f1464ad5a6a3af6ff0695f87859d9c4a281991a1f2797c2db861e1daf19d",
+          "0x205e4485045067d209c8dbbd61c01f3b239dd4d585388e10d409d92b80df2965",
+          "0xc50fc2b3d05ef74d9dd8bfc66f5fe33a6da674883f5dac1d00c5ba66fa40a982",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xC05e7327F7BF188badD27E31066E6F74bD266A4E": {
+        "index": 51,
+        "amount": "0x0750eb0ec623477b8415",
+        "proof": [
+          "0x76ac1ccc4e78e4064ceef82799f1aebd3db496646e32e80addc1325b7f782d96",
+          "0x56f79b8bd9b516856d5846d0062bafe72889c1b685e0a99bdbc61c9b20fd6c99",
+          "0xb86a59e6325b39c4cbd77a23d6b53eaedca546c5bff70a13db820ab7dc263076",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xD52BfE62a163eB4eC8FC98f06eD3f02695ae491d": {
+        "index": 52,
+        "amount": "0x01abdfcd10daaef62449",
+        "proof": [
+          "0x00925e8bc372e9ed003d89eb62e9c8d7ea51c8e25d8c7e72747eba502673ed3c",
+          "0xf46b62aa84ac28d0e823bd3fd1fdb3dfe6c51f376a57cbe48a138d5cd330c325",
+          "0xc443954d44d7670cc9d7e8b3ad69299c79e9867e1a7b1cf1f5ef56d0d857027f",
+          "0xf5f210aa1a95d724af48d48199285e249f7496022627e3d821df2f935b74a03e",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xE86181D6b672d78D33e83029fF3D0ef4A601B4C4": {
+        "index": 53,
+        "amount": "0x07732083792c4dcbd733",
+        "proof": [
+          "0x6b926c298cf3320fc42282623a9bec0b08dfb4ec52cd44ed1503da295f8f4839",
+          "0xb9fe8f586e99ae086a01dcd607c3fea210ccbbf7b67045da71a435c8ea346c0c",
+          "0xfcd5bd0814e355af37ecbdc9df0d381586084bddab303087358dd5fbdce03af8",
+          "0x6308eb13051a22b4702417e55685d27c5a6b4ac86bf2bc2d8d2dea3f7489ea51",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xF1De9490Bf7298b5F350cE74332Ad7cf8d5cB181": {
+        "index": 54,
+        "amount": "0x04f59798191cfb56c0c2",
+        "proof": [
+          "0xb1743772f9e12a9203502f1d16b4a2ec43d36fbed152834e09464fcf93bd702c",
+          "0xa4a887b44dc6134e721b9ed0fd305bbb114a4634ad27917f08daed07daeaed8a",
+          "0x39ea328f7a6379d8e9c1fa67d02b594cacc5fc9f02df692e64605667875ebdc1",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xF2f5E0a3365c385A3ADCA4F614eD0984dFff52a3": {
+        "index": 55,
+        "amount": "0xabe1dddbb5706bdb4c",
+        "proof": [
+          "0xe746dddf87adbfe32dac992fed2d90b3ac3ccdb9454cd30e2853faec16b12188",
+          "0x4708b5ef9c2ba5494ab22358c5c7721663cc1ff4e90b88c6f665f2fad6099006",
+          "0x70228bcc9420a94b657470d9de863fcbb2a5a3ef0490f705858aec138c7b61e8",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xF35343299a4f80Dd5D917bbe5ddd54eBB820eBd4": {
+        "index": 56,
+        "amount": "0x0a42c05987ab8983",
+        "proof": [
+          "0xf40da2a7837f3823db16f209d779cbf367d204d4db72e523c770599efae596b3",
+          "0x7ae571ab6bb22e0c2897f11bb3298300a54001a2fa53743f06b51098a8a74d79"
+        ]
+      },
+      "0xF4823B1C060b52d9840A2eC92C40973CB8a8f4D6": {
+        "index": 57,
+        "amount": "0x018f538bd2373000f4",
+        "proof": [
+          "0x91944773375e90a6c9ac7ff584e248858f2bbb511e9665e34d75d018a083805c",
+          "0x8622d3e6bcbabe66888a4be8cd4e7fcdb51a20a0eda51e01970e11c02d6a1cea",
+          "0x33f32980c2b5df6c7296989865a9afb7a1f2a8f8cf2f182eb92a3360f9df0eec",
+          "0x0798deda0ef402dbf8fbec2360768f4d31666f40f46b8d6c28edfcc2918cd783",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xa39F6Ca62303229873D06395237307Cd59de806d": {
+        "index": 58,
+        "amount": "0x1fdcc527e0675112",
+        "proof": [
+          "0x480cc4d39a4c18a51203adf1141298ea4939a2c55ee5e9260531b68efeadf2f8",
+          "0x160e0fe9f8d9fbfe112bb358c02b22fca8ed088562ea9158d342ac3312b24fc5",
+          "0x0daa0f94615b27312ebaa098013fa3c72c4ff0d2ab7d2c29eedb079817e48651",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xb034dE6226d765a343dc65932B6c114cB4e1a748": {
+        "index": 59,
+        "amount": "0x04597b26886eb0ad3cf7",
+        "proof": [
+          "0xed9f7c921aa2c9c5da9015478b9c1077f513eb6842f57594a5d965a80cffe3c3",
+          "0xad7693de93df3a0f0f6035220ecc0e24c654e4dc94e3c842dbd8c4f13f1793d3",
+          "0x70228bcc9420a94b657470d9de863fcbb2a5a3ef0490f705858aec138c7b61e8",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xb7c561e2069aCaE2c4480111B1606790BB4E13fE": {
+        "index": 60,
+        "amount": "0x02725ba48c1709dd3eb2",
+        "proof": [
+          "0x1e143106db174d034086e4c4ae11d72d89dffba83b8252d2ce4b6ee71c9bc028",
+          "0xf5c0383adbc06da594e970d37a12543c6114fae5322dcf5e16023a51baad9cf8",
+          "0xa64c6af5170f9a06029319a4c8556cce3e9f219cb57f054b9219105b8f758f0e",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xc5795fa1EADF77FCDa0C6D9F9B340D634C2ba546": {
+        "index": 61,
+        "amount": "0x04cc5c31cb19283f2f7e",
+        "proof": [
+          "0xbca640a49170b9b0d139425b256141d0181d48173cc2fb625ae7897a6ec9e47e",
+          "0x4812c324b1ea26e6bafa43618a9e527700acf400f5268e11fc242a9a9b6f35a6",
+          "0xed41df891168d8ad847c16cc4d87c2616febaeaa284644424ac663fde256ed3d",
+          "0xdb1c628323ca3d75b8ad14b693c71dff5725cab6d3d83dd22b623482b1236355",
+          "0x914a3fa1a158c7a2f8034bfba18f2fff6786807fa39132be25bd62c14c1dd3e0",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xd66cAE89FfBc6E50e6b019e45c1aEc93Dec54781": {
+        "index": 62,
+        "amount": "0x5a076b5c2b4c4c2aaf",
+        "proof": [
+          "0x6770c456131db06787ad83a9860a2756e4efc7c73f502823bfce2088616a648b",
+          "0xb9a79cee764ec81aa16c92668008a33142115dc5e50b0d8532ad67ff3154a0c3",
+          "0xdc1427ddc2ec1e76871900c44c6ecae5a8233efc747245dbf87efad35f97256b",
+          "0xb0a4f0ec65097c621ce14b581b08a2df51a2bd6a4d0529ed12566a0ced58b1d7",
+          "0x398436522994945872f2781b4c847379baf8fd2121782302f9ba2fbf34880886",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xd977144724Bc77FaeFAe219F958AE3947205d0b5": {
+        "index": 63,
+        "amount": "0x0bb4cf968de235355fde",
+        "proof": [
+          "0xe542b545562d2bee7d0a1f6e1bfbfba6e4c869a8e1d2b40b18ff37f4670f230d",
+          "0x35ad138ee90aeac320b03c5142d78c06a1a38a46b88aa9272a6b201e646a6d51",
+          "0xcdc369e6690acf9925d838196866d258db6c4e72df198a1290d735650d0b631b",
+          "0xad3f3cd607d972669e6d9cb7e6f73e581cae7fe908a186d57ccda2d0b975b3fa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xe26E2d93Bbc8fde0e1E3B290Fc927Fb374E7e34e": {
+        "index": 64,
+        "amount": "0x0230f213f9e912b55c8e",
+        "proof": [
+          "0xcd77ef33d8a41a9bf02b2e802cc0b57b44082aed6e5c8c12f40edb62f9cca0aa",
+          "0x3e7dce23fda89e73313689fa3f1a73d4bd0f5556e3c87070be7ead35a3f0eb6a",
+          "0x0fcf6bd47671f33ebb8ea76bf18838335caf79ff5a909c60246344ab3b7201a2",
+          "0x8e5c56235910fd4c7715efbccffc0d48d8361bf2b950af2d969291695652cdaa",
+          "0xdb566435865f83b7956637c9179de261a01e2add93f916b9842f4e62b30ff1eb",
+          "0x4e69904c3f8840797d57887e7f2d54c5e248d68e5d3eb1fa099aef98b0814ba5",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      },
+      "0xe3a2d16dA142E6B190A5d9F7e0C07cc460B58A5F": {
+        "index": 65,
+        "amount": "0x01314e13678a02c469a2",
+        "proof": [
+          "0x443ca4f5987befe851a5048bc92b7aedf90f92a1dadad1f211c88b81b5a29d95",
+          "0x383a57b73740c90089c827597137929d160feaedb0ae8749ae88f7e62ae9d3cd",
+          "0xbe765d86cb162ee930adfcf5509e9a80ae3b624eb74c613b7abeb4858748ed31",
+          "0xc57fc66aec6d12853c9dd0d150508610e87d0eb0bbbbdb55c99303df95cbf849",
+          "0x9cc71cf08c1541d261a0ea6582bdda670da0dc018da71728738e3dab75c69de0",
+          "0xc337213b71816f680c06fcfbf8df76c9f0fef25b14c6073e7aca695419d71f82",
+          "0x00e4a12d08929deea351b8c1c5bc9cdb2af8104662da6f8b414ae8c5c298feb4"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Adding tBTC rewards merkle tree computed in keep-network/keep-ecdsa#925 to KEEP Token Dashboard.