### PR TITLE
Change misbehaved from bytes to uint8[]

### DIFF
--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -40,8 +40,8 @@ library DKG {
         uint256 submitterMemberIndex;
         // Generated candidate group public key
         bytes groupPubKey;
-        // Bytes array of misbehaved (disqualified or inactive)
-        bytes misbehaved;
+        // Array of misbehaved members indices (disqualified or inactive).
+        uint8[] misbehaved;
         // Concatenation of signatures from members supporting the result.
         // The message to be signed by each member is keccak256 hash of the
         // calculated group public key, misbehaved members as bytes and DKG
@@ -209,10 +209,11 @@ library DKG {
     ///      `\x19Ethereum signed message:\n` before signing, so the message to
     ///      sign is:
     ///      `\x19Ethereum signed message:\n${keccak256(groupPubKey,misbehaved,startBlock)}`
+    ///      Members indexing in the group starts with 1.
     /// @param submitterMemberIndex Claimed submitter candidate group member index
     /// @param groupPubKey Generated candidate group public key
-    /// @param misbehaved Bytes array of misbehaved (disqualified or inactive)
-    ///        group members indexes; Indexes reflect positions of members in the group,
+    /// @param misbehaved Array of misbehaved (disqualified or inactive) group
+    ///        members indices; Indices reflect positions of members in the group,
     ///        as outputted by the group selection protocol.
     /// @param signatures Concatenation of signatures from members supporting the
     ///        result.
@@ -224,7 +225,7 @@ library DKG {
         Data storage self,
         uint256 submitterMemberIndex,
         bytes memory groupPubKey,
-        bytes memory misbehaved,
+        uint8[] calldata misbehaved,
         bytes memory signatures,
         uint256[] memory signingMemberIndices,
         address[] memory members

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -57,9 +57,8 @@ library DKG {
         address[] members;
     }
 
-    /// @notice States for phases of group creation.
-    /// The states doesn't include timeouts which should be tracked and notified
-    /// individually.
+    /// @notice States for phases of group creation. The states doesn't include
+    ///         timeouts which should be tracked and notified individually.
     enum State {
         // Group creation is not in progress. It is a state set after group creation
         // completion either by timeout or by a result approval.

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.6;
 
-import "./BytesLib.sol";
-
 /// @notice This library is used as a registry of created groups.
 /// @dev This library should be used along with DKG library that ensures linear
 /// groups creation (only one group creation happens at a time). A candidate group
 /// has to be popped or activated before adding a new candidate group.
 library Groups {
-    using BytesLib for bytes;
-
     event CandidateGroupRegistered(bytes indexed groupPubKey);
 
     event CandidateGroupRemoved(bytes indexed groupPubKey);
@@ -37,14 +33,14 @@ library Groups {
     /// @param groupPubKey Generated candidate group public key
     /// @param members Addresses of candidate group members as outputted by the
     ///        group selection protocol.
-    /// @param misbehaved Bytes array of misbehaved (disqualified or inactive)
-    ///        group members indexes; Indexes reflect positions of members in the group,
+    /// @param misbehaved Array of misbehaved (disqualified or inactive) group
+    ///        members indices; Indices reflect positions of members in the group,
     ///        as outputted by the group selection protocol.
     function addCandidateGroup(
         Data storage self,
         bytes calldata groupPubKey,
         address[] memory members,
-        bytes memory misbehaved
+        uint8[] calldata misbehaved
     ) internal {
         bytes32 groupPubKeyHash = keccak256(groupPubKey);
 
@@ -76,16 +72,16 @@ library Groups {
     /// @param group The group storage.
     /// @param members Group member addresses as outputted by the group selection
     ///        protocol.
-    /// @param misbehaved Bytes array of misbehaved (disqualified or inactive)
-    ///        group members indexes in ascending order; Indexes reflect positions
+    /// @param misbehaved Array of misbehaved (disqualified or inactive) group
+    ///        members indices in ascending order; Indices reflect positions
     ///        of members in the group as outputted by the group selection
-    ///        protocol - member indexes start from 1.
+    ///        protocol - member indices start from 1.
     // TODO: This function should be optimized for members storing.
     // See https://github.com/keep-network/keep-core/pull/2666/files#r732629138
     function setGroupMembers(
         Group storage group,
         address[] memory members,
-        bytes memory misbehaved
+        uint8[] calldata misbehaved
     ) private {
         group.members = members;
 
@@ -93,8 +89,8 @@ library Groups {
         // member with the last element and reduce array length
         uint256 i = misbehaved.length;
         while (i > 0) {
-            // group member indexes start from 1, so we need to -1 on misbehaved
-            uint256 memberArrayPosition = misbehaved.toUint8(i - 1) - 1;
+            // group member indices start from 1, so we need to -1 on misbehaved
+            uint8 memberArrayPosition = misbehaved[i - 1] - 1;
             group.members[memberArrayPosition] = group.members[
                 group.members.length - 1
             ];

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -61,9 +61,9 @@ library Groups {
         Group storage group = self.groupsData[groupPubKeyHash];
         group.groupPubKey = groupPubKey;
 
-        self.groupsRegistry.push(groupPubKeyHash);
-
         setGroupMembers(group, members, misbehaved);
+
+        self.groupsRegistry.push(groupPubKeyHash);
 
         emit CandidateGroupRegistered(groupPubKey);
     }

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -29,7 +29,8 @@ library Groups {
     }
 
     /// @notice Adds a new candidate group. The group is stored with group public
-    ///         key and active members, but is not yet activated.
+    ///         key and group members, but is not yet activated.
+    /// @dev The group members list is stored with all misbehaved members filtered out.
     /// @param groupPubKey Generated candidate group public key
     /// @param members Addresses of candidate group members as outputted by the
     ///        group selection protocol.

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.6;
 
 /// @notice This library is used as a registry of created groups.
 /// @dev This library should be used along with DKG library that ensures linear
-/// groups creation (only one group creation happens at a time). A candidate group
-/// has to be popped or activated before adding a new candidate group.
+///      groups creation (only one group creation happens at a time). A candidate
+///      group has to be popped or activated before adding a new candidate group.
 library Groups {
     event CandidateGroupRegistered(bytes indexed groupPubKey);
 
@@ -29,7 +29,7 @@ library Groups {
     }
 
     /// @notice Adds a new candidate group. The group is stored with group public
-    /// key and active members, but is not yet activated.
+    ///         key and active members, but is not yet activated.
     /// @param groupPubKey Generated candidate group public key
     /// @param members Addresses of candidate group members as outputted by the
     ///        group selection protocol.
@@ -145,7 +145,7 @@ library Groups {
     // TODO: Add group termination and expiration
 
     /// @notice Gets the number of active groups. Candidate, expired and terminated
-    /// groups are not counted as active.
+    ///         groups are not counted as active.
     function numberOfActiveGroups(Data storage self)
         internal
         view

--- a/solidity/random-beacon/contracts/test/GroupsStub.sol
+++ b/solidity/random-beacon/contracts/test/GroupsStub.sol
@@ -17,7 +17,7 @@ contract GroupsStub {
     function addCandidateGroup(
         bytes calldata groupPubKey,
         address[] memory members,
-        bytes memory misbehaved
+        uint8[] calldata misbehaved
     ) external {
         groups.addCandidateGroup(groupPubKey, members, misbehaved);
     }

--- a/solidity/random-beacon/test/Groups.test.ts
+++ b/solidity/random-beacon/test/Groups.test.ts
@@ -66,12 +66,10 @@ describe("Groups", () => {
           const misbehavedIndices: number[] = [1]
 
           beforeEach(async () => {
-            const misbehaved = ethers.utils.hexlify(misbehavedIndices)
-
             tx = await groups.addCandidateGroup(
               groupPublicKey,
               members,
-              misbehaved
+              misbehavedIndices
             )
           })
 
@@ -89,12 +87,10 @@ describe("Groups", () => {
           const misbehavedIndices: number[] = [constants.groupSize]
 
           beforeEach(async () => {
-            const misbehaved = ethers.utils.hexlify(misbehavedIndices)
-
             tx = await groups.addCandidateGroup(
               groupPublicKey,
               members,
-              misbehaved
+              misbehavedIndices
             )
           })
 
@@ -112,12 +108,10 @@ describe("Groups", () => {
           const misbehavedIndices: number[] = [24]
 
           beforeEach(async () => {
-            const misbehaved = ethers.utils.hexlify(misbehavedIndices)
-
             tx = await groups.addCandidateGroup(
               groupPublicKey,
               members,
-              misbehaved
+              misbehavedIndices
             )
           })
 
@@ -135,12 +129,10 @@ describe("Groups", () => {
           const misbehavedIndices: number[] = [1, 16, 35, constants.groupSize]
 
           beforeEach(async () => {
-            const misbehaved = ethers.utils.hexlify(misbehavedIndices)
-
             tx = await groups.addCandidateGroup(
               groupPublicKey,
               members,
-              misbehaved
+              misbehavedIndices
             )
           })
 
@@ -157,10 +149,12 @@ describe("Groups", () => {
           const misbehavedIndices: number[] = [0]
 
           it("should panic", async () => {
-            const misbehaved = ethers.utils.hexlify(misbehavedIndices)
-
             await expect(
-              groups.addCandidateGroup(groupPublicKey, members, misbehaved)
+              groups.addCandidateGroup(
+                groupPublicKey,
+                members,
+                misbehavedIndices
+              )
             ).to.be.revertedWith(
               "reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)"
             )
@@ -173,10 +167,12 @@ describe("Groups", () => {
             const misbehavedIndices: number[] = [constants.groupSize + 1]
 
             it("should panic", async () => {
-              const misbehaved = ethers.utils.hexlify(misbehavedIndices)
-
               await expect(
-                groups.addCandidateGroup(groupPublicKey, members, misbehaved)
+                groups.addCandidateGroup(
+                  groupPublicKey,
+                  members,
+                  misbehavedIndices
+                )
               ).to.be.revertedWith(
                 "reverted with panic code 0x32 (Array accessed at an out-of-bounds or negative index)"
               )

--- a/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
@@ -151,7 +151,7 @@ describe("RandomBeacon - Callback", () => {
             .connect(requester)
             .requestRelayEntry(callbackContract.address)
 
-          const tx = await randomBeacon
+          await randomBeacon
             .connect(submitter)
             .submitRelayEntry(16, blsData.groupSignature)
 

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -395,6 +395,7 @@ describe("RandomBeacon - Group Creation", () => {
 
   describe("submitDkgResult", async () => {
     // TODO: Add more tests to cover the DKG result verification function thoroughly.
+    // TODO: Add tests to cover misbehaved members
 
     context("with initial contract state", async () => {
       it("should revert with 'current state is not AWAITING_RESULT' error", async () => {

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -439,9 +439,7 @@ describe("RandomBeacon - Group Creation", () => {
 
           it("should revert with less than threshold signers", async () => {
             const filteredSigners = new Map(
-              Array.from(signers).filter(
-                ([index]) => index < constants.signatureThreshold
-              )
+              Array.from(signers).slice(0, constants.signatureThreshold - 1)
             )
 
             await expect(
@@ -461,9 +459,7 @@ describe("RandomBeacon - Group Creation", () => {
 
             beforeEach(async () => {
               const filteredSigners = new Map(
-                Array.from(signers).filter(
-                  ([index]) => index <= constants.signatureThreshold
-                )
+                Array.from(signers).slice(0, constants.signatureThreshold)
               )
 
               ;({

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -129,7 +129,7 @@ describe("RandomBeacon - Relay", () => {
 
     context("when no groups exist", () => {
       it("should revert", async () => {
-        // TODO: Implement once proper `selectGroup` is ready.
+        // TODO: The error message should be updated to more meaningful text once `selectGroup` is ready.
         await expect(
           randomBeacon.connect(requester).requestRelayEntry(ZERO_ADDRESS)
         ).to.be.revertedWith(

--- a/solidity/random-beacon/test/functions/index.ts
+++ b/solidity/random-beacon/test/functions/index.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers"
 
 // eslint-disable-next-line import/prefer-default-export
-export function to1e18(n) {
+export function to1e18(n: number): BigNumber {
   const decimalMultiplier = BigNumber.from(10).pow(18)
   return BigNumber.from(n).mul(decimalMultiplier)
 }

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -13,13 +13,13 @@ export type DkgGroupSigners = Map<number, Address>
 export interface DkgResult {
   submitterMemberIndex: number
   groupPubKey: string
-  misbehaved: string
+  misbehaved: number[]
   signatures: string
   signingMemberIndices: number[]
   members: string[]
 }
 
-export const noMisbehaved = "0x"
+export const noMisbehaved = []
 
 export async function getDkgGroupSigners(
   groupSize: number = constants.groupSize,
@@ -101,11 +101,11 @@ export async function signAndSubmitDkgResult(
 async function signDkgResult(
   signers: DkgGroupSigners,
   groupPublicKey: string,
-  misbehaved: string,
+  misbehaved: number[],
   startBlock: number
 ) {
   const resultHash = ethers.utils.solidityKeccak256(
-    ["bytes", "bytes", "uint256"],
+    ["bytes", "uint8[]", "uint256"],
     [groupPublicKey, misbehaved, startBlock]
   )
 


### PR DESCRIPTION
This change reduces the complexity of the code by expecting misbehaved to be
an array of uint8 members indices.

This PR also has some follow-up changes from https://github.com/keep-network/keep-core/pull/2666.

Gas usage for this PR:
```
·-----------------------------------------------|---------------------------|-------------|-----------------------------·
|              Solc version: 0.8.6              ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
················································|···························|·············|······························
|  Methods                                                                                                              │
·····················|··························|·············|·············|·············|···············|··············
|  Contract          ·  Method                  ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
·····················|··························|·············|·············|·············|···············|··············
|  GroupsStub        ·  activateCandidateGroup  ·      57396  ·      83270  ·      74566  ·           32  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  GroupsStub        ·  addCandidateGroup       ·     234003  ·    1660877  ·     902589  ·          100  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  GroupsStub        ·  popCandidateGroup       ·      30113  ·      41615  ·      34283  ·           23  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  RandomBeaconStub  ·  approveDkgResult        ·      88453  ·      90453  ·      89739  ·           14  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  RandomBeaconStub  ·  challengeDkgResult      ·      54440  ·      68120  ·      66930  ·           23  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  RandomBeaconStub  ·  genesis                 ·          -  ·          -  ·      47004  ·           70  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  RandomBeaconStub  ·  notifyDkgTimeout        ·      31645  ·      31956  ·      31878  ·            4  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  RandomBeaconStub  ·  submitDkgResult         ·     754595  ·    2147609  ·    1877716  ·           62  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  RandomBeaconStub  ·  transferOwnership       ·          -  ·          -  ·      28623  ·            1  ·          -  │
·····················|··························|·············|·············|·············|···············|··············
|  Deployments                                  ·                                         ·  % of limit   ·             │
················································|·············|·············|·············|···············|··············
|  BLS                                          ·          -  ·          -  ·     761370  ·        2.5 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  GroupsStub                                   ·          -  ·          -  ·     851253  ·        2.8 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance                       ·          -  ·          -  ·    2419957  ·        8.1 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  RandomBeaconStub                             ·          -  ·          -  ·    3866958  ·       12.9 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  SortitionPoolStub                            ·          -  ·          -  ·     175483  ·        0.6 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  TestToken                                    ·          -  ·          -  ·    1271337  ·        4.2 %  ·          -  │
·-----------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

Gas usage for main:
```
·--------------------------------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                                 Solc version: 0.8.6                                  ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
·······················································································|···························|·············|······························
|  Methods                                                                                                                                                     │
···························|···························································|·············|·············|·············|···············|··············
|  Contract                ·  Method                                                   ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
···························|···························································|·············|·············|·············|···············|··············
|  CallbackContractStub    ·  setFailureFlag                                           ·          -  ·          -  ·      43630  ·            1  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  GroupsStub              ·  activateCandidateGroup                                   ·      57396  ·      83270  ·      74566  ·           32  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  GroupsStub              ·  addCandidateGroup                                        ·     234103  ·    1660977  ·     902684  ·          100  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  GroupsStub              ·  popCandidateGroup                                        ·      30113  ·      41615  ·      34283  ·           23  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginCallbackGasLimitUpdate                              ·      35082  ·      69306  ·      66175  ·           11  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginDkgResultChallengePeriodLengthUpdate                ·      35075  ·      69275  ·      65855  ·           10  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginDkgResultSubmissionEligibilityDelayUpdate           ·          -  ·          -  ·      69292  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginDkgResultSubmissionRewardUpdate                     ·          -  ·          -  ·      69215  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginGroupCreationFrequencyUpdate                        ·      35050  ·      69250  ·      65830  ·           10  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginGroupLifetimeUpdate                                 ·      69276  ·      69288  ·      69277  ·           10  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginMaliciousDkgResultSlashingAmountUpdate              ·          -  ·          -  ·      69249  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginRelayEntryHardTimeoutUpdate                         ·          -  ·          -  ·      69204  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginRelayEntrySubmissionEligibilityDelayUpdate          ·      35071  ·      69271  ·      65851  ·           10  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginRelayEntrySubmissionFailureSlashingAmountUpdate     ·          -  ·          -  ·      69204  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginRelayRequestFeeUpdate                               ·          -  ·          -  ·      69205  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  beginSortitionPoolUnlockingRewardUpdate                  ·          -  ·          -  ·      69248  ·            8  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeCallbackGasLimitUpdate                           ·          -  ·          -  ·      51478  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeDkgResultChallengePeriodLengthUpdate             ·          -  ·          -  ·      44736  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeDkgResultSubmissionEligibilityDelayUpdate        ·          -  ·          -  ·      44633  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeDkgResultSubmissionRewardUpdate                  ·          -  ·          -  ·      42021  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeGroupCreationFrequencyUpdate                     ·          -  ·          -  ·      42020  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeGroupLifetimeUpdate                              ·          -  ·          -  ·      41976  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeMaliciousDkgResultSlashingAmountUpdate           ·          -  ·          -  ·      41929  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeRelayEntryHardTimeoutUpdate                      ·          -  ·          -  ·      51485  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeRelayEntrySubmissionEligibilityDelayUpdate       ·          -  ·          -  ·      51504  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeRelayEntrySubmissionFailureSlashingAmountUpdate  ·          -  ·          -  ·      42041  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeRelayRequestFeeUpdate                            ·          -  ·          -  ·      51530  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance  ·  finalizeSortitionPoolUnlockingRewardUpdate               ·          -  ·          -  ·      42041  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  approveDkgResult                                         ·      88453  ·      90453  ·      90068  ·           26  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  challengeDkgResult                                       ·      54440  ·      68120  ·      66930  ·           23  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  genesis                                                  ·          -  ·          -  ·      47004  ·           82  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  notifyDkgTimeout                                         ·      31645  ·      31956  ·      31878  ·            4  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  registerMemberCandidate                                  ·          -  ·          -  ·      50101  ·            2  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  requestRelayEntry                                        ·      81304  ·     137644  ·     120475  ·           18  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  submitDkgResult                                          ·     754806  ·    2147836  ·    1921703  ·           74  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  submitRelayEntry                                         ·     334002  ·     383617  ·     361905  ·            9  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  transferOwnership                                        ·          -  ·          -  ·      28623  ·          137  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  updateDkgParameters                                      ·      35104  ·      37928  ·      35185  ·          140  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  updateGroupCreationParameters                            ·      35186  ·      35210  ·      35209  ·          140  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  updateRelayEntryParameters                               ·      40378  ·      65806  ·      62283  ·          162  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  updateRewardParameters                                   ·      69408  ·      69444  ·      69443  ·          140  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  updateSlashingParameters                                 ·      35185  ·      35221  ·      35220  ·          140  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  RelayStub               ·  setCurrentRequestStartBlock                              ·          -  ·          -  ·      43329  ·            1  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  SortitionPoolStub       ·  setOperatorEligibility                                   ·      24242  ·      44154  ·      34198  ·            2  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  TestToken               ·  approve                                                  ·          -  ·          -  ·      46287  ·           17  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  TestToken               ·  mint                                                     ·      53418  ·      70518  ·      68506  ·           17  ·          -  │
···························|···························································|·············|·············|·············|···············|··············
|  Deployments                                                                         ·                                         ·  % of limit   ·             │
·······················································································|·············|·············|·············|···············|··············
|  BLS                                                                                 ·          -  ·          -  ·     761370  ·        2.5 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  CallbackContractStub                                                                ·          -  ·          -  ·     142873  ·        0.5 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  GroupsStub                                                                          ·          -  ·          -  ·     850437  ·        2.8 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  RandomBeaconGovernance                                                              ·    2419945  ·    2419957  ·    2419945  ·        8.1 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  RandomBeaconStub                                                                    ·    3874550  ·    3874562  ·    3874550  ·       12.9 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  RelayStub                                                                           ·          -  ·          -  ·     269917  ·        0.9 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  SortitionPoolStub                                                                   ·          -  ·          -  ·     175483  ·        0.6 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  TestAltBn128                                                                        ·          -  ·          -  ·    3793813  ·       12.6 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  TestModUtils                                                                        ·          -  ·          -  ·    5833418  ·       19.4 %  ·          -  │
·······················································································|·············|·············|·············|···············|··············
|  TestToken                                                                           ·          -  ·          -  ·    1271337  ·        4.2 %  ·          -  │
·--------------------------------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·

  359 passing (2m)
```