### PR TITLE
Clarification renames of DKG result properties, documentation improvements

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -409,7 +409,7 @@ contract RandomBeacon is Ownable {
         groups.addCandidateGroup(
             dkgResult.groupPubKey,
             dkgResult.members,
-            dkgResult.misbehaved
+            dkgResult.misbehavedMembersIndices
         );
     }
 

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -58,8 +58,8 @@ library DKG {
         // Indices of members corresponding to each signature. Must be in
         // range [1, 64] and unique.
         uint256[] signingMembersIndices;
-        // IDs of candidate group members as outputted by the group selection
-        // protocol.
+        // Identifiers of candidate group members as outputted by the group
+        // selection protocol.
         uint32[] members;
     }
 
@@ -236,8 +236,8 @@ library DKG {
     ///        result.
     /// @param signingMembersIndices Indices of members corresponding to each
     ///        signature; have to be unique
-    /// @param members Addresses of candidate group members as outputted by the
-    ///        group selection protocol.
+    /// @param members Identifiers of candidate group members as outputted by
+    ///        the group selection protocol.
     function verify(
         Data storage self,
         uint256 submitterMemberIndex,

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -70,6 +70,13 @@ library Groups {
 
     /// @notice Sets addresses of members for the group eliminating members at
     ///         positions pointed by the misbehaved array.
+    ///
+    ///         NOTE THAT THIS FUNCTION CHANGES ORDER OF MEMBERS IN THE GROUP
+    ///         IF THERE IS AT LEAST ONE MISBEHAVED MEMBER
+    ///
+    ///         The final group members indexes should be obtained post-DKG
+    ///         and they may differ from the ones outputted by the group
+    ///         selection protocol.
     /// @param group The group storage.
     /// @param members Group member addresses as outputted by the group selection
     ///        protocol.

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -33,14 +33,15 @@ library Groups {
     /// @param groupPubKey Generated candidate group public key
     /// @param members Addresses of candidate group members as outputted by the
     ///        group selection protocol.
-    /// @param misbehaved Array of misbehaved (disqualified or inactive) group
-    ///        members indices; Indices reflect positions of members in the group,
-    ///        as outputted by the group selection protocol.
+    /// @param misbehavedMembersIndices Array of misbehaved (disqualified or
+    ///        inactive) group members indices; Indices reflect positions of
+    ///        members in the group, as outputted by the group selection
+    ///        protocol.
     function addCandidateGroup(
         Data storage self,
         bytes calldata groupPubKey,
         uint32[] calldata members,
-        uint8[] calldata misbehaved
+        uint8[] calldata misbehavedMembersIndices
     ) internal {
         bytes32 groupPubKeyHash = keccak256(groupPubKey);
 
@@ -60,7 +61,7 @@ library Groups {
         Group storage group = self.groupsData[groupPubKeyHash];
         group.groupPubKey = groupPubKey;
 
-        setGroupMembers(group, members, misbehaved);
+        setGroupMembers(group, members, misbehavedMembersIndices);
 
         self.groupsRegistry.push(groupPubKeyHash);
 
@@ -72,25 +73,23 @@ library Groups {
     /// @param group The group storage.
     /// @param members Group member addresses as outputted by the group selection
     ///        protocol.
-    /// @param misbehaved Array of misbehaved (disqualified or inactive) group
-    ///        members indices in ascending order; Indices reflect positions
+    /// @param misbehavedMembersIndices Array of misbehaved (disqualified or
+    ///        inactive) group members. Indices reflect positions
     ///        of members in the group as outputted by the group selection
-    ///        protocol - member indices start from 1.
-    // TODO: This function should be optimized for members storing.
-    // See https://github.com/keep-network/keep-core/pull/2666/files#r732629138
+    ///        protocol.
     function setGroupMembers(
         Group storage group,
         uint32[] calldata members,
-        uint8[] calldata misbehaved
+        uint8[] calldata misbehavedMembersIndices
     ) private {
         group.members = members;
 
         // Iterate misbehaved array backwards, replace misbehaved
         // member with the last element and reduce array length
-        uint256 i = misbehaved.length;
+        uint256 i = misbehavedMembersIndices.length;
         while (i > 0) {
             // group member indices start from 1, so we need to -1 on misbehaved
-            uint8 memberArrayPosition = misbehaved[i - 1] - 1;
+            uint8 memberArrayPosition = misbehavedMembersIndices[i - 1] - 1;
             group.members[memberArrayPosition] = group.members[
                 group.members.length - 1
             ];

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -69,7 +69,7 @@ library Groups {
     }
 
     /// @notice Sets addresses of members for the group eliminating members at
-    ///         positions pointed by the misbehaved array.
+    ///         positions pointed by the misbehavedMembersIndices array.
     ///
     ///         NOTE THAT THIS FUNCTION CHANGES ORDER OF MEMBERS IN THE GROUP
     ///         IF THERE IS AT LEAST ONE MISBEHAVED MEMBER

--- a/solidity/random-beacon/contracts/test/GroupsStub.sol
+++ b/solidity/random-beacon/contracts/test/GroupsStub.sol
@@ -17,9 +17,9 @@ contract GroupsStub {
     function addCandidateGroup(
         bytes calldata groupPubKey,
         uint32[] calldata members,
-        uint8[] calldata misbehaved
+        uint8[] calldata misbehavedMembrsIndices
     ) external {
-        groups.addCandidateGroup(groupPubKey, members, misbehaved);
+        groups.addCandidateGroup(groupPubKey, members, misbehavedMembrsIndices);
     }
 
     function popCandidateGroup() external {

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -77,7 +77,7 @@ export async function signAndSubmitDkgResult(
 async function signDkgResult(
   signers: Operator[],
   groupPublicKey: string,
-  misbehaved: number[],
+  misbehavedMembersIndices: number[],
   startBlock: number
 ): Promise<{
   members: number[]
@@ -86,7 +86,7 @@ async function signDkgResult(
 }> {
   const resultHash = ethers.utils.solidityKeccak256(
     ["bytes", "uint8[]", "uint256"],
-    [groupPublicKey, misbehaved, startBlock]
+    [groupPublicKey, misbehavedMembersIndices, startBlock]
   )
 
   const members: number[] = []

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -9,9 +9,9 @@ import { Operator } from "./sortitionpool"
 export interface DkgResult {
   submitterMemberIndex: number
   groupPubKey: string
-  misbehaved: number[]
+  misbehavedMembersIndices: number[]
   signatures: string
-  signingMemberIndices: number[]
+  signingMembersIndices: number[]
   members: number[]
 }
 
@@ -46,22 +46,22 @@ export async function signAndSubmitDkgResult(
   dkgResultHash: string
   members: number[]
 }> {
-  const { members, signingMemberIndices, signaturesBytes } =
+  const { members, signingMembersIndices, signaturesBytes } =
     await signDkgResult(signers, groupPublicKey, noMisbehaved, startBlock)
 
   const dkgResult: DkgResult = {
     submitterMemberIndex: submitterIndex,
     groupPubKey: blsData.groupPubKey,
-    misbehaved: noMisbehaved,
+    misbehavedMembersIndices: noMisbehaved,
     signatures: signaturesBytes,
-    signingMemberIndices,
+    signingMembersIndices,
     members,
   }
 
   const dkgResultHash = ethers.utils.keccak256(
     ethers.utils.defaultAbiCoder.encode(
       [
-        "(uint256 submitterMemberIndex, bytes groupPubKey, uint8[] misbehaved, bytes signatures, uint256[] signingMemberIndices, uint32[] members)",
+        "(uint256 submitterMemberIndex, bytes groupPubKey, uint8[] misbehavedMembersIndices, bytes signatures, uint256[] signingMembersIndices, uint32[] members)",
       ],
       [dkgResult]
     )
@@ -81,7 +81,7 @@ async function signDkgResult(
   startBlock: number
 ): Promise<{
   members: number[]
-  signingMemberIndices: number[]
+  signingMembersIndices: number[]
   signaturesBytes: string
 }> {
   const resultHash = ethers.utils.solidityKeccak256(
@@ -90,7 +90,7 @@ async function signDkgResult(
   )
 
   const members: number[] = []
-  const signingMemberIndices: number[] = []
+  const signingMembersIndices: number[] = []
   const signatures: string[] = []
 
   for (let i = 0; i < signers.length; i++) {
@@ -98,8 +98,7 @@ async function signDkgResult(
     const signerIndex: number = i + 1
 
     members.push(id)
-
-    signingMemberIndices.push(signerIndex)
+    signingMembersIndices.push(signerIndex)
 
     const ethersSigner = await ethers.getSigner(address)
     const signature = await ethersSigner.signMessage(
@@ -111,5 +110,5 @@ async function signDkgResult(
 
   const signaturesBytes: string = ethers.utils.hexConcat(signatures)
 
-  return { members, signingMemberIndices, signaturesBytes }
+  return { members, signingMembersIndices, signaturesBytes }
 }


### PR DESCRIPTION
Set of follow-up updates after merging #2676 and #2677. No more changes
planned in this PR, the rest of follow-up comments will be addressed in separate PRs.

I strongly encourage to review this PR commit-by-commit.

d717c08 addresses [follow-up comment](https://github.com/keep-network/keep-core/pull/2676#pullrequestreview-793582051) from #2676:

> Second, I think we should rename `misbehaved` to `misbehavedMembersIndices`
and clearly state it should be a set of member indices in range [1, 64]. We do have
`submitterMemberIndex` and `signingMemberIndices` so let's keep it consistent. 

`signingMemberIndices` field has been renamed to `signingMembersIndices` to
clearly indicate indices come from multiple members and are not indices of
a single member.

`misbehaved` field been renamed to `misbehavedMembersIndices` to keep it aligned
with `signingMembersIndices` and `submitterMemberIndex`.

Documentation has been updated to clearly state all these fields should use
values from `[1, 64]` range.

b8761c9 addresses [follow-up comment](https://github.com/keep-network/keep-core/pull/2677#discussion_r739670066) from #2677: `members` are no longer addresses;
these are unique identifiers of operators.

32159d2 addresses [follow-up comment](https://github.com/keep-network/keep-core/pull/2676#pullrequestreview-793582051) from #2676:

> Finally, it is crucial to note that `Groups.setGroupMembers` CHANGES THE ORDER
of members in the group if `misbehaved` is non-empty, compared to what was
outputted by sortition pool. This is very important information to clients and needs to
be reflected in the documentation.

Added a note to `setGroupMembers` that the member indexes may change.
It is very important to understand the final member indexes will be
different from the ones outputted by the group selection protocol in
case at least one group member was misbehaving.
The final group member indexes should be obtained post-DKG.



