### PR TITLE
Validate `misbehavedMembersIndices` submitted in DKG result

### DIFF
--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -231,7 +231,8 @@ library DKG {
     /// @param submitterMemberIndex Claimed submitter candidate group member index
     /// @param groupPubKey Generated candidate group public key
     /// @param misbehavedMembersIndices Array of misbehaved (disqualified or
-    ///        inactive) group members indices; have to be unique
+    ///        inactive) group members indices; have to be unique and in
+    ///        ascending order
     /// @param signatures Concatenation of signatures from members supporting the
     ///        result.
     /// @param signingMembersIndices Indices of members corresponding to each
@@ -277,6 +278,16 @@ library DKG {
             misbehavedMembersIndices.length <= groupSize - signatureThreshold,
             "Unexpected misbehaved members count"
         );
+
+        if (misbehavedMembersIndices.length > 1) {
+            for (uint256 i = 1; i < misbehavedMembersIndices.length; i++) {
+                require(
+                    misbehavedMembersIndices[i - 1] <
+                        misbehavedMembersIndices[i],
+                    "Corrupted misbehaved members indices"
+                );
+            }
+        }
 
         uint256 signaturesCount = signatures.length / 65;
         require(signatures.length >= 65, "Too short signatures array");


### PR DESCRIPTION
Depends on #2679

This PR addresses a [follow-up comment](https://github.com/keep-network/keep-core/pull/2676#pullrequestreview-793582051) from #2676:
> First, in the previous version, it was enough to validate the length of `bytes`. 
Now, we need to make sure elements are not duplicate. We should add validation
to `DKG.validate` function. In most cases, it should be super-cheap as there
should be few elements in `misbehaved`. We can iterate and check `a[i-1] < a[i]`.

For bitmap version, it was enough to validate its length. Since we changed the
bitmap to an array of `uint8` member indexes to save gas on further steps of
DKG (challenging and approving the result), we now need to validate if this
array has the correct format. First, we need to ensure it has the correct length just
like for the bitmap version and secondly - what was added in this commit - we need
to ensure identifiers are unique. Otherwise, some sort of manipulation would be
possible by changing the order and eliminating group members in
`Groups.setGroupMembers`. The validation rule additionally enforces that
`a[i-1] < a[i]`. This allows for simple validation and leaves no space for
manipulating the final group member indexes in `Group.setGroupMembers`.

Tests are not included. There are [no tests for corner cases of DKG result
verification and there are no tests for misbehaved](https://github.com/keep-network/keep-core/blob/16c30709e185136e6fedeeca321a662dedf479c5/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts#L403-L404). This needs to be implemented
and [is captured in the backlog](https://keepnetwork.atlassian.net/browse/CP-144?atlOrigin=eyJpIjoiMmQ2ZjFkMDEyNjEyNDRiNWJiYTA0YWRiZWFkNDAzNGIiLCJwIjoiaiJ9). It is not ideal but I would prefer to do it all
at once later, once all building blocks match each other.