### PR TITLE
Updated guides with latest ropsten contracts

### DIFF
--- a/docs/run-random-beacon.adoc
+++ b/docs/run-random-beacon.adoc
@@ -450,7 +450,7 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |TokenStaking
-|`0x9b20291F016f5CcF8956585681C6c338082925BC`
+|`0x120BC70c5a8C9C8cD83e1E9CD73bed819A18D537`
 |===
 
 [%header,cols=2*]
@@ -459,10 +459,10 @@ Contract addresses needed to boot the Random Beacon client:
 |
 
 |KeepRandomBeaconService
-|`0x70DB2e8bd0835FcEF45c7584938e7FD1442fabdd`
+|`0xb09ec9c5e33506D89501eE83B37741e3bf4b3565`
 
 |KeepRandomBeaconOperator
-|`0xC5312D5E85263362fF6283b0e9F7E2a242a4d4D8`
+|`0xc7fbeA51dDAd25d8074800031459e7B719612eFf`
 |===
 
 


### PR DESCRIPTION
We update guides with addresses of the contracts that were recently
migrated on ropsten and are backed by keep-test nodes.

Job that migrated contracts:
https://github.com/keep-network/keep-core/runs/3680852601?check_suite_focus=true