### PR TITLE
Script to resolve stake owners from Keep TokenStaking contract

### DIFF
--- a/solidity-v1/scripts/resolve-owners.js
+++ b/solidity-v1/scripts/resolve-owners.js
@@ -56,19 +56,18 @@ module.exports = async function () {
         const grant = await tokenGrant.getGrant.call(grantId)
         const grantee = grant.grantee
 
+        let grantType = "[SG]" // assume standard grant by default
+
         for (let j = 0; j < managedGrantCreatedEvents.length; j++) {
           if (grantee == managedGrantCreatedEvents[j].args["grantAddress"]) {
             // it is managed grant delegation
-            console.log(
-              `[MG], ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
-            )
-            continue
+            grantType = "[MG]"
+            break
           }
         }
 
-        // it is not managed grant delegation (standard grant)
         console.log(
-          `[SG], ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
+            `${grantType}, ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
         )
       }
     }

--- a/solidity-v1/scripts/resolve-owners.js
+++ b/solidity-v1/scripts/resolve-owners.js
@@ -1,0 +1,81 @@
+const TokenGrant = artifacts.require("./TokenGrant.sol")
+const TokenStaking = artifacts.require("./TokenStaking.sol")
+const ManagedGrantFactory = artifacts.require("./ManagedGrantFactory.sol")
+
+module.exports = async function () {
+  try {
+    const tokenGrant = await TokenGrant.at(
+      "0x175989c71fd023d580c65f5dc214002687ff88b7"
+    )
+    const tokenStaking = await TokenStaking.at(
+      "0x1293a54e160d1cd7075487898d65266081a15458"
+    )
+    const managedGrantFactory = await ManagedGrantFactory.at(
+      "0x43cf9e26857b188868051bdcfacedbb38531964e"
+    )
+
+    const allEventsOpts = { fromBlock: 0, toBlock: "latest" }
+    const stakeDelegatedEvents = await tokenStaking.getPastEvents(
+      "StakeDelegated",
+      allEventsOpts
+    )
+    const managedGrantCreatedEvents = await managedGrantFactory.getPastEvents(
+      "ManagedGrantCreated",
+      allEventsOpts
+    )
+
+    for (let i = 0; i < stakeDelegatedEvents.length; i++) {
+      const operator = stakeDelegatedEvents[i].args["operator"]
+
+      const delegationInfo = await tokenStaking.getDelegationInfo.call(operator)
+
+      // skip those who undelegated
+      if (delegationInfo.undelegatedAt != 0) {
+        continue
+      }
+
+      // skip those who canceled their delegation
+      if (delegationInfo.amount == 0) {
+        continue
+      }
+
+      const owner = await tokenStaking.ownerOf.call(operator)
+      const grantStake = await tokenGrant.grantStakes(operator)
+
+      if (grantStake == "0x0000000000000000000000000000000000000000") {
+        // it is liquid token delegation
+        console.log(`[LI], ${owner}, ${operator}`)
+      } else {
+        // it is grant delegation
+        const grantStakeDetails = await tokenGrant.getGrantStakeDetails.call(
+          operator
+        )
+        const grantId = grantStakeDetails.grantId
+        const stakingContract = grantStakeDetails.stakingContract
+
+        const grant = await tokenGrant.getGrant.call(grantId)
+        const grantee = grant.grantee
+
+        for (let j = 0; j < managedGrantCreatedEvents.length; j++) {
+          if (grantee == managedGrantCreatedEvents[j].args["grantAddress"]) {
+            // it is managed grant delegation
+            console.log(
+              `[MG], ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
+            )
+            continue
+          }
+        }
+
+        // it is not managed grant delegation (standard grant)
+        console.log(
+          `[SG], ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
+        )
+      }
+    }
+  } catch (err) {
+    console.error("unexpected error:", err)
+    process.exit(1)
+  }
+
+  process.exit()
+}

--- a/solidity-v1/scripts/resolve-owners.js
+++ b/solidity-v1/scripts/resolve-owners.js
@@ -67,7 +67,7 @@ module.exports = async function () {
         }
 
         console.log(
-            `${grantType}, ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
+          `${grantType}, ${owner}, ${operator}, ${grantId}, ${stakingContract}, ${grantee}`
         )
       }
     }


### PR DESCRIPTION
See https://github.com/threshold-network/solidity-contracts/pull/26
See https://github.com/threshold-network/solidity-contracts/pull/7

T staking contract supports existing KEEP stakes by allowing KEEP stakers
to use their stakes in T network and weights them based on KEEP<>T token
ratio. KEEP stake owner is cached in T staking contract and used to restrict
access to all `onlyOwnerOrOperator` functions. To cache KEEP staking contract
in T staking contract, we first need to resolve the owner. Resolving liquid
KEEP stake owner is easy - `TokenStaking.ownerOf` gives the answer immediately.
Resolving token grant stake owner is complicated and not possible to do on-chain
from an external contract. Keep `TokenStaking` knows the grant ID but does
not expose it externally. Going through `TokenGrant` may not always give the
right answer. Finally, we never know on-chain if we are dealing with
a `ManagedGrant` or not. Porting all this complexity to T staking contract does
not feel like the right choice.

It's time to make a tradeoff.

To solve this problem, we resolve all owners off-chain based on events and
hardcode them in `KeepStake` library. Worth noting, owner of a grant delegation
can never change in Keep `TokenStaking` contract and this is why hardcoding
should be acceptable.

Operator-owner pairs are resolved in the following way:

1. Take all Keep `TokenStaking` delegations ever.
2. Filter out undelegated operators.
3. Filter out canceled delegations.
4. Fetch grant stake information from `TokenGrant` for that operator
   to determine if we are dealing with grant delegation.
5. Fetch grantee address from Keep `TokenGrant` contract.
6. Check if we are dealing with `ManagedGrant` by looking for all created
   `ManagedGrants` and comparing their address against grantee address
   fetched from `TokenGrant` contract.