### PR TITLE
Update liquidity cards

### DIFF
--- a/solidity-v1/dashboard/src/components/KeepOnlyPool.jsx
+++ b/solidity-v1/dashboard/src/components/KeepOnlyPool.jsx
@@ -166,7 +166,7 @@ const KeepOnlyPool = ({
               <APY.TooltipContent />
             </MetricsTile.Tooltip>
             <APY
-              apy={apy}
+              apy={0}
               isFetching={isAPYFetching}
               className="liquidity__info-tile__title text-mint-100"
             />

--- a/solidity-v1/dashboard/src/components/KeepOnlyPool.jsx
+++ b/solidity-v1/dashboard/src/components/KeepOnlyPool.jsx
@@ -144,6 +144,7 @@ const KeepOnlyPool = ({
             <SubmitButton
               className="btn btn-primary btn-lg"
               onSubmitAction={addKEEP}
+              disabled={true}
             >
               {gt(lpBalance, 0) ? "add more keep" : "deposit keep"}
             </SubmitButton>

--- a/solidity-v1/dashboard/src/constants/constants.js
+++ b/solidity-v1/dashboard/src/constants/constants.js
@@ -58,6 +58,8 @@ export const LINK = {
       "https://forum.keep.network/t/shifting-incentives-towards-tbtc-v2-and-coverage-pool-version-2/322",
     removeIncentivesForKEEPTBTCpool:
       "https://forum.keep.network/t/proposal-remove-incentives-for-the-keep-tbtc-pool/56",
+    removeIncentivesForTBTCETHpool:
+      "https://forum.keep.network/t/proposal-to-remove-incentives-for-tbtc-eth-pool/341",
   },
   tbtcDapp: "https://dapp.tbtc.network",
 }

--- a/solidity-v1/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity-v1/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -52,6 +52,10 @@ const cards = [
     pool: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.pool,
     lpTokens: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.lpTokens,
     wrapperClassName: "tbtc-eth",
+    incentivesRemoved: true,
+    incentivesRemovedBannerProps: {
+      link: LINK.proposals.removeIncentivesForTBTCETHpool,
+    },
   },
   {
     id: "TBTC_SADDLE",


### PR DESCRIPTION
This PR updates cards on the Liquidity page.

Main changes:
- zero out KEEP-only pool APY,
- convert the TBTC/ETH pool to a `incentives removed` pool.