### PR TITLE
[Backport] Update liquidity pools cards

### DIFF
--- a/solidity/dashboard/src/components/KeepOnlyPool.jsx
+++ b/solidity/dashboard/src/components/KeepOnlyPool.jsx
@@ -179,7 +179,7 @@ const KeepOnlyPool = ({
               <APY.TooltipContent />
             </MetricsTile.Tooltip>
             <APY
-              apy={apy}
+              apy={0}
               isFetching={isAPYFetching}
               className="liquidity__info-tile__title text-mint-100"
             />

--- a/solidity/dashboard/src/constants/constants.js
+++ b/solidity/dashboard/src/constants/constants.js
@@ -58,6 +58,8 @@ export const LINK = {
       "https://forum.keep.network/t/shifting-incentives-towards-tbtc-v2-and-coverage-pool-version-2/322",
     removeIncentivesForKEEPTBTCpool:
       "https://forum.keep.network/t/proposal-remove-incentives-for-the-keep-tbtc-pool/56",
+    removeIncentivesForTBTCETHpool:
+      "https://forum.keep.network/t/proposal-to-remove-incentives-for-tbtc-eth-pool/341",
   },
   tbtcDapp: "https://dapp.tbtc.network",
 }

--- a/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -52,6 +52,10 @@ const cards = [
     pool: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.pool,
     lpTokens: LIQUIDITY_REWARD_PAIRS.TBTC_ETH.lpTokens,
     wrapperClassName: "tbtc-eth",
+    incentivesRemoved: true,
+    incentivesRemovedBannerProps: {
+      link: LINK.proposals.removeIncentivesForTBTCETHpool,
+    },
   },
   {
     id: "TBTC_SADDLE",


### PR DESCRIPTION
Backport of: #2701


This PR updates cards on the Liquidity page.

Main changes:
- zero out KEEP-only pool APY,
- convert the TBTC/ETH pool to a `incentives removed` pool.