### PR TITLE
DKG: check stake of the submitter and operators

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -42,6 +42,15 @@ interface IRandomBeaconStaking {
         address notifier,
         address[] memory operators
     ) external;
+
+    function stakes(address operator)
+        external
+        view
+        returns (
+            uint96 tStake,
+            uint96 keepInTStake,
+            uint96 nuInTStake
+        );
 }
 
 /// @title Keep Random Beacon
@@ -515,6 +524,12 @@ contract RandomBeacon is Ownable {
     /// @param dkgResult DKG result.
     function submitDkgResult(DKG.Result calldata dkgResult) external {
         dkg.submitResult(dkgResult);
+
+        (uint96 submitterStake, , ) = staking.stakes(msg.sender);
+        require(
+            submitterStake >= authorization.minimumAuthorization,
+            "DKG submitter's stake must be >= minimumAuthorization"
+        );
 
         groups.addCandidateGroup(
             dkgResult.groupPubKey,

--- a/solidity/random-beacon/contracts/test/StakingStub.sol
+++ b/solidity/random-beacon/contracts/test/StakingStub.sol
@@ -37,6 +37,21 @@ contract StakingStub is IRandomBeaconStaking {
         }
     }
 
+    function stakes(address operator)
+        external
+        view
+        override
+        returns (
+            uint96 tStake,
+            uint96 keepInTStake,
+            uint96 nuInTStake
+        )
+    {
+        tStake = uint96(stakedTokens[operator]);
+        keepInTStake = 0;
+        nuInTStake = 0;
+    }
+
     function eligibleStake(
         address operator,
         address // operatorContract


### PR DESCRIPTION
#Depends on https://github.com/keep-network/keep-core/pull/2708
This PR adds a check of the DKG submitter's stake.

When a DKG result is submitted, the submitter's stake is compared with the `minimumAuhorization` governable parameter and if it's below it, the transaction is reverted.
