### PR TITLE
Allow anyone to approve the DKG result if the submitter is late

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -533,14 +533,14 @@ contract RandomBeacon is Ownable {
         dkg.complete();
     }
 
-    /// @notice Approves DKG result. Can be called after challenge period for
-    ///         the submitted result is finished. For the first
+    /// @notice Approves DKG result. Can be called when the challenge period for
+    ///         the submitted result is finished. Considers the submitted result
+    ///         as valid, pays reward to the approver, bans misbehaved group
+    ///         members from the sortition pool rewards, and completes the group
+    ///         creation by activating the candidate group. For the first
     ///         `resultSubmissionEligibilityDelay` blocks after the end of the
     ///         challenge period can be called only by the DKG result submitter.
-    ///         After that can be called by anyone. Considers the submitted
-    ///         result as valid, pays reward to the approver, bans misbehaved
-    ///         group members from the sortition pool rewards and completes the
-    ///         group creation by activating the candidate group.
+    ///         After that time, can be called by anyone.
     function approveDkgResult() external {
         dkg.approveResult();
 

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -394,12 +394,12 @@ library DKG {
         self.sortitionPool.unlock();
     }
 
-    /// @notice Approves DKG result. Can be called after challenge period for
-    ///         the submitted result is finished. For the first
-    ///         `resultSubmissionEligibilityDelay` blocks after the end of the
-    ///         challenge period can be called only by the DKG result submitter.
-    ///         After that can be called by anyone. Considers the submitted
-    ///         result as valid and completes the group creation.
+    /// @notice Approves DKG result. Can be called when the challenge period for
+    ///         the submitted result is finished. Considers the submitted result
+    ///         as valid. For the first `resultSubmissionEligibilityDelay`
+    ///         blocks after the end of the challenge period can be called only
+    ///         by the DKG result submitter. After that time, can be called by
+    ///         anyone.
     function approveResult(Data storage self) internal {
         require(
             currentState(self) == State.CHALLENGE,

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -406,18 +406,18 @@ library DKG {
             "current state is not CHALLENGE"
         );
 
+        uint256 challengePeriodEnd = self.submittedResultBlock +
+            self.parameters.resultChallengePeriodLength;
+
         require(
-            block.number >
-                self.submittedResultBlock +
-                    self.parameters.resultChallengePeriodLength,
+            block.number > challengePeriodEnd,
             "challenge period has not passed yet"
         );
 
         require(
             msg.sender == self.resultSubmitter ||
                 block.number >
-                self.submittedResultBlock +
-                    self.parameters.resultChallengePeriodLength +
+                challengePeriodEnd +
                     self.parameters.resultSubmissionEligibilityDelay,
             "Only the DKG result submitter can approve the result at this moment"
         );

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -1487,15 +1487,15 @@ describe("RandomBeacon - Group Creation", () => {
           await mineBlocksTo(startBlock + dkgTimeout)
         })
 
-        context("called by a submitter", async () => {
+        context("called by a third party", async () => {
           let tx: ContractTransaction
           let initialNotifierBalance: BigNumber
 
           beforeEach(async () => {
             initialNotifierBalance = await testToken.balanceOf(
-              await submitter.getAddress()
+              await thirdParty.getAddress()
             )
-            tx = await randomBeacon.connect(submitter).notifyDkgTimeout()
+            tx = await randomBeacon.connect(thirdParty).notifyDkgTimeout()
           })
 
           it("should emit DkgTimedOut event", async () => {
@@ -1508,7 +1508,7 @@ describe("RandomBeacon - Group Creation", () => {
 
           it("should reward the notifier with tokens from maintenance pool", async () => {
             const currentNotifierBalance: BigNumber = await testToken.balanceOf(
-              await submitter.getAddress()
+              await thirdParty.getAddress()
             )
             expect(
               currentNotifierBalance.sub(initialNotifierBalance)

--- a/solidity/random-beacon/test/utils/groups.ts
+++ b/solidity/random-beacon/test/utils/groups.ts
@@ -1,4 +1,4 @@
-import { helpers } from "hardhat"
+import { helpers, ethers } from "hardhat"
 import { noMisbehaved, signAndSubmitDkgResult } from "./dkg"
 import { constants, params } from "../fixtures"
 import blsData from "../data/bls"
@@ -13,14 +13,19 @@ export async function createGroup(
   signers: Operator[]
 ): Promise<void> {
   const { blockNumber: startBlock } = await randomBeacon.genesis()
+  const submitterIndex = 1
   await mineBlocks(constants.offchainDkgTime)
   await signAndSubmitDkgResult(
     randomBeacon,
     blsData.groupPubKey,
     signers,
     startBlock,
-    noMisbehaved
+    noMisbehaved,
+    submitterIndex
   )
+
   await mineBlocks(params.dkgResultChallengePeriodLength)
-  await randomBeacon.approveDkgResult()
+  await randomBeacon
+    .connect(await ethers.getSigner(signers[submitterIndex - 1].address))
+    .approveDkgResult()
 }


### PR DESCRIPTION
This PR modifies the random beacon so that anyone can call the `approveDkgResult` function and receive the DKG submission reward if the submitter does not do that on time.

The submitter has `resultSubmissionEligibilityDelay` blocks after the end of the challenge period to approve the result.
If they are late, anyone can approve the result and receive the reward.  

Additional modification: when the balance of the maintenance pool is not enough, the reward submitter receives whatever tokens there are on the maintenance pool.