### PR TITLE
Eliminated ISortitionPool from RandomBeacon contract

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -20,42 +20,9 @@ import "./libraries/Groups.sol";
 import "./libraries/Relay.sol";
 import "./libraries/Groups.sol";
 import "./libraries/Callback.sol";
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-/// @title Sortition Pool contract interface
-/// @notice This is an interface with just a few function signatures of the
-///         Sortition Pool contract, which is available at
-///         https://github.com/keep-network/sortition-pools/blob/main/contracts/SortitionPool.sol
-///
-/// TODO: Add a dependency to `keep-network/sortition-pools` and use sortition
-///       pool interface from there.
-interface ISortitionPool {
-    function lock() external;
-
-    function unlock() external;
-
-    function insertOperator(address operator) external;
-
-    function banRewards(uint32[] calldata operators, uint256 duration) external;
-
-    function updateOperatorStatus(uint32 id) external;
-
-    function isOperatorInPool(address operator) external view returns (bool);
-
-    function isOperatorEligible(address operator) external view returns (bool);
-
-    function getIDOperator(uint32 id) external view returns (address);
-
-    function getIDOperators(uint32[] calldata ids)
-        external
-        view
-        returns (address[] memory);
-
-    function getOperatorID(address operator) external view returns (uint32);
-
-    function isLocked() external view returns (bool);
-}
 
 /// @title Staking contract interface
 /// @notice This is an interface with just a few function signatures of the
@@ -146,7 +113,7 @@ contract RandomBeacon is Ownable {
     ///         operator affected.
     uint256 public relayEntryTimeoutNotificationRewardMultiplier;
 
-    ISortitionPool public sortitionPool;
+    SortitionPool public sortitionPool;
     IERC20 public tToken;
     IRandomBeaconStaking public staking;
 
@@ -258,7 +225,7 @@ contract RandomBeacon is Ownable {
     ///      be updated with `update*` functions after the contract deployment
     ///      and before transferring the ownership to the governance contract.
     constructor(
-        ISortitionPool _sortitionPool,
+        SortitionPool _sortitionPool,
         IERC20 _tToken,
         IRandomBeaconStaking _staking
     ) {

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.6;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "./BytesLib.sol";
-import {ISortitionPool} from "../RandomBeacon.sol";
 
 library DKG {
     using BytesLib for bytes;
@@ -20,7 +20,7 @@ library DKG {
 
     struct Data {
         // Address of the Sortition Pool contract.
-        ISortitionPool sortitionPool;
+        SortitionPool sortitionPool;
         // DKG parameters. The parameters should persist between DKG executions.
         // They should be updated with dedicated set functions only when DKG is not
         // in progress.
@@ -135,7 +135,7 @@ library DKG {
 
     /// @notice Initializes the sortitionPool parameter. Can be performed only once.
     /// @param _sortitionPool Value of the parameter.
-    function initSortitionPool(Data storage self, ISortitionPool _sortitionPool)
+    function initSortitionPool(Data storage self, SortitionPool _sortitionPool)
         internal
     {
         require(
@@ -289,7 +289,7 @@ library DKG {
 
         require(submitterMemberIndex > 0, "Invalid submitter index");
 
-        ISortitionPool sortitionPool = self.sortitionPool;
+        SortitionPool sortitionPool = self.sortitionPool;
 
         require(
             sortitionPool.getIDOperator(members[submitterMemberIndex - 1]) ==

--- a/solidity/random-beacon/contracts/libraries/Relay.sol
+++ b/solidity/random-beacon/contracts/libraries/Relay.sol
@@ -16,9 +16,9 @@ pragma solidity ^0.8.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "./BLS.sol";
 import "./Groups.sol";
-import {ISortitionPool} from "../RandomBeacon.sol";
 
 library Relay {
     using SafeERC20 for IERC20;
@@ -40,7 +40,7 @@ library Relay {
         // Data of current request.
         Request currentRequest;
         // Address of the Sortition Pool contract.
-        ISortitionPool sortitionPool;
+        SortitionPool sortitionPool;
         // Address of the T token contract.
         IERC20 tToken;
         // Fee paid by the relay requester.
@@ -93,7 +93,7 @@ library Relay {
     /// @notice Initializes the sortitionPool parameter. Can be performed
     ///         only once.
     /// @param _sortitionPool Value of the parameter.
-    function initSortitionPool(Data storage self, ISortitionPool _sortitionPool)
+    function initSortitionPool(Data storage self, SortitionPool _sortitionPool)
         internal
     {
         require(

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -1,14 +1,15 @@
 pragma solidity ^0.8.6;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "../RandomBeacon.sol";
 import "../libraries/DKG.sol";
 import "../libraries/Callback.sol";
 import "../libraries/Groups.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract RandomBeaconStub is RandomBeacon {
     constructor(
-        ISortitionPool _sortitionPool,
+        SortitionPool _sortitionPool,
         IERC20 _tToken,
         IRandomBeaconStaking _staking
     ) RandomBeacon(_sortitionPool, _tToken, _staking) {}

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -10,7 +10,7 @@ import type {
   RandomBeaconGovernance,
   RandomBeaconStub,
   TestToken,
-  ISortitionPool,
+  SortitionPool,
 } from "../typechain"
 import {
   genesis,
@@ -60,7 +60,7 @@ describe("RandomBeacon - Group Creation", () => {
   let randomBeaconGovernance: RandomBeaconGovernance
   let randomBeacon: RandomBeaconStub & RandomBeacon
   let testToken: TestToken
-  let sortitionPool: ISortitionPool
+  let sortitionPool: SortitionPool
 
   before(async () => {
     thirdParty = await ethers.getSigner((await getUnnamedAccounts())[1])
@@ -83,9 +83,9 @@ describe("RandomBeacon - Group Creation", () => {
     await testToken.mint(randomBeacon.address, to1e18(100))
 
     sortitionPool = (await ethers.getContractAt(
-      "ISortitionPool",
+      "SortitionPool",
       await randomBeacon.sortitionPool()
-    )) as ISortitionPool
+    )) as SortitionPool
   })
 
   describe("genesis", async () => {

--- a/solidity/random-beacon/test/RandomBeacon.Pool.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Pool.test.ts
@@ -61,13 +61,10 @@ describe("RandomBeacon - Pool", () => {
   })
 
   describe("updateOperatorStatus", () => {
-    let operatorID: number
-
     beforeEach(async () => {
       // Operator is registered and gas deposit is made.
       await stakingStub.setStake(operator.address, constants.minimumStake)
       await randomBeacon.connect(operator).registerOperator()
-      operatorID = await sortitionPool.getOperatorID(operator.address)
 
       // Simulate the operator became ineligible.
       await stakingStub.setStake(operator.address, 0)

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -28,7 +28,6 @@ import { registerOperators, Operator, OperatorID } from "./utils/operators"
 const { time } = helpers
 const { mineBlocks } = time
 const ZERO_ADDRESS = ethers.constants.AddressZero
-const TWO_WEEKS = 1209600 // 2 weeks in seconds
 
 const fixture = async () => {
   const deployment = await randomBeaconDeployment()
@@ -310,7 +309,6 @@ describe("RandomBeacon - Relay", () => {
                 "when other than first eligible member submits before the soft timeout",
                 () => {
                   let tx: ContractTransaction
-                  let txTimestamp: number
 
                   beforeEach(async () => {
                     // We wait 20 blocks to make two more members eligible.
@@ -323,12 +321,6 @@ describe("RandomBeacon - Relay", () => {
                         firstEligibleMemberIndex + 2,
                         blsData.groupSignature
                       )
-
-                    // Wait until tx is mined to get tx block timestamp.
-                    const receipt = await tx.wait()
-                    txTimestamp = (
-                      await ethers.provider.getBlock(receipt.blockNumber)
-                    ).timestamp
                   })
 
                   it("should ban sortition pool rewards for members who did not submit", async () => {
@@ -416,7 +408,6 @@ describe("RandomBeacon - Relay", () => {
                 "when other than first eligible member submits after the soft timeout",
                 () => {
                   let tx: ContractTransaction
-                  let txTimestamp: number
 
                   beforeEach(async () => {
                     // Let's assume we want to submit the relay entry after 75%
@@ -438,12 +429,6 @@ describe("RandomBeacon - Relay", () => {
                         firstEligibleMemberIndex - 1,
                         blsData.groupSignature
                       )
-
-                    // Wait until tx is mined to get tx block timestamp.
-                    const receipt = await tx.wait()
-                    txTimestamp = (
-                      await ethers.provider.getBlock(receipt.blockNumber)
-                    ).timestamp
                   })
 
                   it("should ban sortition pool rewards for members who did not submit", async () => {

--- a/solidity/random-beacon/test/utils/operators.ts
+++ b/solidity/random-beacon/test/utils/operators.ts
@@ -17,7 +17,7 @@ export async function registerOperators(
   const operators: Operator[] = []
 
   const sortitionPool = await ethers.getContractAt(
-    "ISortitionPool",
+    "SortitionPool",
     await randomBeacon.sortitionPool()
   )
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2715

We do not need to use an interface because we use real `SortitionPool`
in tests to see what are the real gas costs. Additionally, cleared up some
linter warnings in tests. Warnings were not related to the changes in
this PR but they were annoying in PR diff and when linting the whole code.

