### PR TITLE
Remove hardhat-dependency-compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ keep-client-snapshot.tar
 yarn-error.log
 
 # Hardhat
-hardhat-dependency-compiler/
 cache/
 export.json
 

--- a/solidity/random-beacon/.prettierignore
+++ b/solidity/random-beacon/.prettierignore
@@ -4,4 +4,3 @@ cache/
 deployments/
 export.json
 typechain/
-hardhat-dependency-compiler/

--- a/solidity/random-beacon/.solhintignore
+++ b/solidity/random-beacon/.solhintignore
@@ -1,2 +1,1 @@
 node_modules/
-hardhat-dependency-compiler/

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -3,7 +3,6 @@ import { HardhatUserConfig } from "hardhat/config"
 import "@keep-network/hardhat-local-networks-config"
 import "@keep-network/hardhat-helpers"
 import "hardhat-deploy"
-import "hardhat-dependency-compiler"
 import "@tenderly/hardhat-tenderly"
 import "@nomiclabs/hardhat-waffle"
 import "hardhat-gas-reporter"
@@ -69,10 +68,6 @@ const config: HardhatUserConfig = {
   },
   mocha: {
     timeout: 60000,
-  },
-  dependencyCompiler: {
-    paths: ["@keep-network/sortition-pools/contracts/SortitionPool.sol"],
-    keep: true,
   },
 }
 

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -43,7 +43,6 @@
     "ethers": "^5.4.7",
     "hardhat": "^2.6.4",
     "hardhat-contract-sizer": "^2.1.1",
-    "hardhat-dependency-compiler": "^1.1.1",
     "hardhat-deploy": "^0.9.1",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.4.1",

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -4984,11 +4984,6 @@ hardhat-contract-sizer@^2.1.1:
     cli-table3 "^0.6.0"
     colors "^1.4.0"
 
-hardhat-dependency-compiler@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/hardhat-dependency-compiler/-/hardhat-dependency-compiler-1.1.2.tgz#02867b7c6dd3de4924d9d3d6593feab8408f1eeb"
-  integrity sha512-LVnsPSZnGvzWVvlpewlkPKlPtFP/S9V41RC1fd/ygZc4jkG8ubNlfE82nwiGw5oPueHSmFi6TACgmyrEOokK8w==
-
 hardhat-deploy@^0.9.1:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.9.3.tgz#cf9a7806c0a86a6f7e9352fc558b26c079983496"


### PR DESCRIPTION
This PR removes the use of `hardhat-dependency-compiler` plugin that was added in https://github.com/keep-network/keep-core/pull/2684 to force compilation of sortition-pools to use it in our tests.
It is no longer needed since we use the sortition-pools in our code and it's automatically compiled.

After merging, it may be needed to remove the `contracts/hardhat-depenedency-compiler` folder from your repo, since it was generated by the plugin (it used to be ignored by git before).