### PR TITLE
Added governable authorization decrease delay parameter

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -252,6 +252,7 @@ contract RandomBeacon is Ownable {
         sortitionPoolRewardsBanDuration = 2 weeks;
         relayEntryTimeoutNotificationRewardMultiplier = 5;
 
+        // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(100000 * 1e18);
 
         dkg.initSortitionPool(_sortitionPool);

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -848,7 +848,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         emit MinimumAuthorizationUpdated(newMinimumAuthorization);
         // slither-disable-next-line reentrancy-no-eth
-        randomBeacon.updateMinimumAuthorization(newMinimumAuthorization);
+        randomBeacon.updateAuthorizationParameters(newMinimumAuthorization);
         minimumAuthorizationChangeInitiated = 0;
         newMinimumAuthorization = 0;
     }

--- a/solidity/random-beacon/contracts/libraries/Authorization.sol
+++ b/solidity/random-beacon/contracts/libraries/Authorization.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.6;
+
+library Authorization {
+
+    struct Data {
+       uint96 minimumAuthorization;
+    }
+
+    function setMinimumAuthorization(
+        Data storage self,
+        uint96 _minimumAuthorization
+    ) internal {
+        self.minimumAuthorization = _minimumAuthorization;
+    }
+}

--- a/solidity/random-beacon/contracts/libraries/Authorization.sol
+++ b/solidity/random-beacon/contracts/libraries/Authorization.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.6;
 
 library Authorization {
-
     struct Data {
-       uint96 minimumAuthorization;
+        uint96 minimumAuthorization;
+        uint64 authorizationDecreaseDelay;
     }
 
     function setMinimumAuthorization(
@@ -13,5 +13,12 @@ library Authorization {
         uint96 _minimumAuthorization
     ) internal {
         self.minimumAuthorization = _minimumAuthorization;
+    }
+
+    function setAuthorizationDecreaseDelay(
+        Data storage self,
+        uint64 _authorizationDecreaseDelay
+    ) internal {
+        self.authorizationDecreaseDelay = _authorizationDecreaseDelay;
     }
 }

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -92,7 +92,7 @@ describe("RandomBeacon - Parameters", () => {
     })
   })
 
-  describe("updateMinimumAuthorization", () => {
+  describe("updateAuthorizationParameters", () => {
     const minimumAuthorization = 4200000
 
     context("when the caller is not the owner", () => {
@@ -100,7 +100,7 @@ describe("RandomBeacon - Parameters", () => {
         await expect(
           randomBeacon
             .connect(thirdParty)
-            .updateMinimumAuthorization(minimumAuthorization)
+            .updateAuthorizationParameters(minimumAuthorization)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -110,7 +110,7 @@ describe("RandomBeacon - Parameters", () => {
       beforeEach(async () => {
         tx = await randomBeacon
           .connect(governance)
-          .updateMinimumAuthorization(minimumAuthorization)
+          .updateAuthorizationParameters(minimumAuthorization)
       })
 
       it("should update the group creation frequency", async () => {
@@ -119,9 +119,9 @@ describe("RandomBeacon - Parameters", () => {
         )
       })
 
-      it("should emit the MinimumAuthorizationUpdated event", async () => {
+      it("should emit the AuthorizationParametersUpdated event", async () => {
         await expect(tx)
-          .to.emit(randomBeacon, "MinimumAuthorizationUpdated")
+          .to.emit(randomBeacon, "AuthorizationParametersUpdated")
           .withArgs(minimumAuthorization)
       })
     })

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -94,23 +94,31 @@ describe("RandomBeacon - Parameters", () => {
 
   describe("updateAuthorizationParameters", () => {
     const minimumAuthorization = 4200000
+    const authorizationDecreaseDelay = 86400
 
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
             .connect(thirdParty)
-            .updateAuthorizationParameters(minimumAuthorization)
+            .updateAuthorizationParameters(
+              minimumAuthorization,
+              authorizationDecreaseDelay
+            )
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
 
     context("when the caller is the owner", () => {
       let tx
+
       beforeEach(async () => {
         tx = await randomBeacon
           .connect(governance)
-          .updateAuthorizationParameters(minimumAuthorization)
+          .updateAuthorizationParameters(
+            minimumAuthorization,
+            authorizationDecreaseDelay
+          )
       })
 
       it("should update the group creation frequency", async () => {
@@ -119,10 +127,16 @@ describe("RandomBeacon - Parameters", () => {
         )
       })
 
+      it("should update the authorization decrease delay", async () => {
+        expect(await randomBeacon.authorizationDecreaseDelay()).to.be.equal(
+          authorizationDecreaseDelay
+        )
+      })
+
       it("should emit the AuthorizationParametersUpdated event", async () => {
         await expect(tx)
           .to.emit(randomBeacon, "AuthorizationParametersUpdated")
-          .withArgs(minimumAuthorization)
+          .withArgs(minimumAuthorization, authorizationDecreaseDelay)
       })
     })
   })

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -74,7 +74,7 @@ describe("RandomBeaconGovernance", () => {
 
     await randomBeacon
       .connect(governance)
-      .updateMinimumAuthorization(initialMinimumAuthorization)
+      .updateAuthorizationParameters(initialMinimumAuthorization)
 
     const RandomBeaconGovernance = await ethers.getContractFactory(
       "RandomBeaconGovernance"


### PR DESCRIPTION
Refs #2715

This parameter says what delay needs to pass between the time
authorization decrease is requested and the time that request
gets approved. It will protect against free-riders earning rewards
and not being active in the network.

Moved `minimumAuthorization` parameter to `Authorization` library
next to `authorizationDecreaseDelay`. The library will contain
all functions related to updating authorization and sortition pool.