### PR TITLE
Expect 33 signatures on the DKG result

### DIFF
--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -40,7 +40,8 @@ export async function signAndSubmitDkgResult(
   signers: Operator[],
   startBlock: number,
   misbehavedIndices: number[],
-  submitterIndex = 1
+  submitterIndex = 1,
+  numberOfSignatures = 33
 ): Promise<{
   transaction: ContractTransaction
   dkgResult: DkgResult
@@ -48,7 +49,13 @@ export async function signAndSubmitDkgResult(
   members: number[]
 }> {
   const { members, signingMembersIndices, signaturesBytes } =
-    await signDkgResult(signers, groupPublicKey, misbehavedIndices, startBlock)
+    await signDkgResult(
+      signers,
+      groupPublicKey,
+      misbehavedIndices,
+      startBlock,
+      numberOfSignatures
+    )
 
   const dkgResult: DkgResult = {
     submitterMemberIndex: submitterIndex,
@@ -79,7 +86,8 @@ async function signDkgResult(
   signers: Operator[],
   groupPublicKey: string,
   misbehavedMembersIndices: number[],
-  startBlock: number
+  startBlock: number,
+  numberOfSignatures: number
 ): Promise<{
   members: number[]
   signingMembersIndices: number[]
@@ -93,12 +101,17 @@ async function signDkgResult(
   const members: number[] = []
   const signingMembersIndices: number[] = []
   const signatures: string[] = []
-
   for (let i = 0; i < signers.length; i++) {
     const { id, address } = signers[i]
+    members.push(id)
+
+    if (signatures.length === numberOfSignatures) {
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
     const signerIndex: number = i + 1
 
-    members.push(id)
     signingMembersIndices.push(signerIndex)
 
     const ethersSigner = await ethers.getSigner(address)


### PR DESCRIPTION
Instead of expecting 48 signatures on the result we now expect just
33 which is the group threshold. Also, we expect that at least 90%
of the group members were active during the DKG. This change allows
to go down with DKG `submitDKGResult` gas costs. For 64 signatures,
the average gas cost is 1124329. For 33 signatures the average gas
cost is 815350.

Expecting more signatures than 33 does not make the protocol any more
secure. Even if we have 64 signatures supporting the result, an
adversary must not corrupt 33+1 members.