### PR TITLE
Use @keep-network/hardhat-helpers

### DIFF
--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -24,7 +24,7 @@
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },
   "devDependencies": {
-    "@keep-network/hardhat-helpers": "^0.2.0-pre.4",
+    "@keep-network/hardhat-helpers": "^0.4.0",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
@@ -1,8 +1,7 @@
-import { ethers, waffle, getUnnamedAccounts } from "hardhat"
+import { ethers, waffle, helpers, getUnnamedAccounts } from "hardhat"
 import { expect } from "chai"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import blsData from "./data/bls"
-import { to1e18 } from "./functions"
 import { constants, randomBeaconDeployment } from "./fixtures"
 import { createGroup } from "./utils/groups"
 import type { DeployedContracts } from "./fixtures"
@@ -14,6 +13,8 @@ import type {
 import { registerOperators, Operator } from "./utils/operators"
 
 const ZERO_ADDRESS = ethers.constants.AddressZero
+
+const { to1e18 } = helpers.number
 
 const fixture = async () => {
   const deployment = await randomBeaconDeployment()

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -19,9 +19,9 @@ import {
   noMisbehaved,
 } from "./utils/dkg"
 import { registerOperators, Operator } from "./utils/operators"
-import { to1e18 } from "./functions"
 
 const { mineBlocks, mineBlocksTo } = helpers.time
+const { to1e18 } = helpers.number
 const { keccak256 } = ethers.utils
 
 const fixture = async () => {

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -12,7 +12,6 @@ import { BigNumber, ContractTransaction } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { Address } from "hardhat-deploy/types"
 import blsData from "./data/bls"
-import { to1e18 } from "./functions"
 import { constants, dkgState, params, randomBeaconDeployment } from "./fixtures"
 import { createGroup } from "./utils/groups"
 import type {
@@ -25,8 +24,8 @@ import type {
 } from "../typechain"
 import { registerOperators, Operator, OperatorID } from "./utils/operators"
 
-const { time } = helpers
-const { mineBlocks } = time
+const { mineBlocks } = helpers.time
+const { to1e18 } = helpers.number
 const ZERO_ADDRESS = ethers.constants.AddressZero
 
 const fixture = async () => {

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -1,12 +1,13 @@
 import { Contract } from "ethers"
-import { ethers, getNamedAccounts } from "hardhat"
+import { ethers, helpers, getNamedAccounts } from "hardhat"
 import type {
   SortitionPool,
   RandomBeaconStub,
   RandomBeaconGovernance,
   StakingStub,
 } from "../../typechain"
-import { to1e18 } from "../functions"
+
+const { to1e18 } = helpers.number
 
 export const constants = {
   groupSize: 64,

--- a/solidity/random-beacon/test/functions/index.ts
+++ b/solidity/random-beacon/test/functions/index.ts
@@ -1,7 +1,0 @@
-import { BigNumber } from "ethers"
-
-// eslint-disable-next-line import/prefer-default-export
-export function to1e18(n: number): BigNumber {
-  const decimalMultiplier = BigNumber.from(10).pow(18)
-  return BigNumber.from(n).mul(decimalMultiplier)
-}

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -580,10 +580,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@keep-network/hardhat-helpers@^0.2.0-pre.4":
-  version "0.2.0-pre.4"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.2.0-pre.4.tgz#692ca5096b2f40aca83c0d1629e2103e7cd8e3d9"
-  integrity sha512-g77I9irZueqxljBo8xJ4J0EpVhWFq+yo1FPe8lAl9udSc4RQ69oyBNSLOZf92YA3DVWakmq0ZQ9RRGX/+8YPYw==
+"@keep-network/hardhat-helpers@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.4.0.tgz#2ac2416c80300624cc4dd17a35798cfa91929dcb"
+  integrity sha512-aH0gFosxal/CjBrPP8f+mYZG0jgRjGMrDFLQf1fuRBHIMIoBdf6Y42EQ6UpmxXoPxK7o21DzBsjLaGFjCEsG3w==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.0":
   version "0.1.0-pre.0"


### PR DESCRIPTION
Common utils functions are defined in @keep-network/hardhat-helpers
package and used across our codebase. Here we switch to use these
helpers instead duplicating the code.