### PR TITLE
Remove fields from relay library

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -261,8 +261,6 @@ contract RandomBeacon is Ownable {
         dkg.setResultSubmissionEligibilityDelay(10);
 
         relay.initSeedEntry();
-        relay.initSortitionPool(_sortitionPool);
-        relay.initTToken(_tToken);
         relay.setRelayEntrySubmissionEligibilityDelay(10);
         relay.setRelayEntryHardTimeout(5760); // ~24h assuming 15s block time
         relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);
@@ -624,6 +622,12 @@ contract RandomBeacon is Ownable {
 
         relay.requestEntry(groupId);
 
+        tToken.safeTransferFrom(
+            msg.sender,
+            address(this),
+            relay.relayRequestFee
+        );
+
         callback.setCallbackContract(callbackContract);
 
         // If the current request should trigger group creation we need to lock
@@ -651,7 +655,7 @@ contract RandomBeacon is Ownable {
         );
 
         (uint32[] memory inactiveMembers, uint256 slashingAmount) = relay
-            .submitEntry(submitterIndex, entry, group);
+            .submitEntry(sortitionPool, submitterIndex, entry, group);
 
         if (inactiveMembers.length > 0) {
             banFromRewards(inactiveMembers, sortitionPoolRewardsBanDuration);


### PR DESCRIPTION
Removed fields `tToken` and `sortitionPool` from the `Relay` library in order to lower the size of the `RandomBeacon` contract.

I decided to move the transfer of T tokens from `requestEntry`  to `RandomBeacon` as we already have all the operations on T tokens in RandomBeacon and not in libraries.

Size of the `RandomBeacon` contract: `17.352` -> `17.150` 
Gas usage:
-  `submitRelayEntry`:  `424651` -> `423625`
- `requestRelayEntry`:  `124672` -> `124640`

 