### PR TITLE
Added governable parameter ineligibleOperatorNotifierReward

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -97,6 +97,9 @@ contract RandomBeacon is Ownable {
     ///         `sortitionPoolUnlockingReward`.
     uint256 public sortitionPoolUnlockingReward;
 
+    /// @notice Reward in T for notifying the operator is ineligible.
+    uint256 public ineligibleOperatorNotifierReward;
+
     /// @notice Slashing amount for supporting malicious DKG result. Every
     ///         DKG result submitted can be challenged for the time of
     ///         `dkgResultChallengePeriodLength`. If the DKG result submitted
@@ -164,6 +167,7 @@ contract RandomBeacon is Ownable {
     event RewardParametersUpdated(
         uint256 dkgResultSubmissionReward,
         uint256 sortitionPoolUnlockingReward,
+        uint256 ineligibleOperatorNotifierReward,
         uint256 sortitionPoolRewardsBanDuration,
         uint256 relayEntryTimeoutNotificationRewardMultiplier,
         uint256 dkgMaliciousResultNotificationRewardMultiplier
@@ -271,6 +275,7 @@ contract RandomBeacon is Ownable {
         groupLifetime = 2 weeks;
         dkgResultSubmissionReward = 0;
         sortitionPoolUnlockingReward = 0;
+        ineligibleOperatorNotifierReward = 0;
         maliciousDkgResultSlashingAmount = 50000e18;
         sortitionPoolRewardsBanDuration = 2 weeks;
         relayEntryTimeoutNotificationRewardMultiplier = 5;
@@ -389,6 +394,8 @@ contract RandomBeacon is Ownable {
     ///      validating parameters.
     /// @param _dkgResultSubmissionReward New DKG result submission reward
     /// @param _sortitionPoolUnlockingReward New sortition pool unlocking reward
+    /// @param _ineligibleOperatorNotifierReward New value of the ineligible
+    ///        operator notifier reward.
     /// @param _sortitionPoolRewardsBanDuration New sortition pool rewards
     ///        ban duration in seconds.
     /// @param _relayEntryTimeoutNotificationRewardMultiplier New value of the
@@ -398,18 +405,21 @@ contract RandomBeacon is Ownable {
     function updateRewardParameters(
         uint256 _dkgResultSubmissionReward,
         uint256 _sortitionPoolUnlockingReward,
+        uint256 _ineligibleOperatorNotifierReward,
         uint256 _sortitionPoolRewardsBanDuration,
         uint256 _relayEntryTimeoutNotificationRewardMultiplier,
         uint256 _dkgMaliciousResultNotificationRewardMultiplier
     ) external onlyOwner {
         dkgResultSubmissionReward = _dkgResultSubmissionReward;
         sortitionPoolUnlockingReward = _sortitionPoolUnlockingReward;
+        ineligibleOperatorNotifierReward = _ineligibleOperatorNotifierReward;
         sortitionPoolRewardsBanDuration = _sortitionPoolRewardsBanDuration;
         relayEntryTimeoutNotificationRewardMultiplier = _relayEntryTimeoutNotificationRewardMultiplier;
         dkgMaliciousResultNotificationRewardMultiplier = _dkgMaliciousResultNotificationRewardMultiplier;
         emit RewardParametersUpdated(
             dkgResultSubmissionReward,
             sortitionPoolUnlockingReward,
+            ineligibleOperatorNotifierReward,
             sortitionPoolRewardsBanDuration,
             relayEntryTimeoutNotificationRewardMultiplier,
             dkgMaliciousResultNotificationRewardMultiplier

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -52,6 +52,9 @@ contract RandomBeaconGovernance is Ownable {
     uint256 public newSortitionPoolUnlockingReward;
     uint256 public sortitionPoolUnlockingRewardChangeInitiated;
 
+    uint256 public newIneligibleOperatorNotifierReward;
+    uint256 public ineligibleOperatorNotifierRewardChangeInitiated;
+
     uint256 public newRelayEntrySubmissionFailureSlashingAmount;
     uint256 public relayEntrySubmissionFailureSlashingAmountChangeInitiated;
 
@@ -103,6 +106,7 @@ contract RandomBeaconGovernance is Ownable {
     // - sortition pool rewards ban duration
     // - malicious DKG result slashing amount
     // - sortition pool unlocking reward
+    // - ineligible operator notifier reward
     // - relay entry timeout notification reward multiplier
     // - DKG malicious result notification reward multiplier
     uint256 internal constant STANDARD_PARAMETER_GOVERNANCE_DELAY = 12 hours;
@@ -170,6 +174,14 @@ contract RandomBeaconGovernance is Ownable {
     );
     event SortitionPoolUnlockingRewardUpdated(
         uint256 sortitionPoolUnlockingReward
+    );
+
+    event IneligibleOperatorNotifierRewardUpdateStarted(
+        uint256 ineligibleOperatorNotifierReward,
+        uint256 timestamp
+    );
+    event IneligibleOperatorNotifierRewardUpdated(
+        uint256 ineligibleOperatorNotifierReward
     );
 
     event RelayEntrySubmissionFailureSlashingAmountUpdateStarted(
@@ -617,6 +629,7 @@ contract RandomBeaconGovernance is Ownable {
         randomBeacon.updateRewardParameters(
             newDkgResultSubmissionReward,
             randomBeacon.sortitionPoolUnlockingReward(),
+            randomBeacon.ineligibleOperatorNotifierReward(),
             randomBeacon.sortitionPoolRewardsBanDuration(),
             randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
             randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
@@ -659,12 +672,57 @@ contract RandomBeaconGovernance is Ownable {
         randomBeacon.updateRewardParameters(
             randomBeacon.dkgResultSubmissionReward(),
             newSortitionPoolUnlockingReward,
+            randomBeacon.ineligibleOperatorNotifierReward(),
             randomBeacon.sortitionPoolRewardsBanDuration(),
             randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
             randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
         );
         sortitionPoolUnlockingRewardChangeInitiated = 0;
         newSortitionPoolUnlockingReward = 0;
+    }
+
+    /// @notice Begins the ineligible operator notifier reward update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newIneligibleOperatorNotifierReward New ineligible operator
+    ///        notifier reward.
+    function beginIneligibleOperatorNotifierRewardUpdate(
+        uint256 _newIneligibleOperatorNotifierReward
+    ) external onlyOwner {
+        /* solhint-disable not-rely-on-time */
+        newIneligibleOperatorNotifierReward = _newIneligibleOperatorNotifierReward;
+        ineligibleOperatorNotifierRewardChangeInitiated = block.timestamp;
+        emit IneligibleOperatorNotifierRewardUpdateStarted(
+            _newIneligibleOperatorNotifierReward,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the ineligible operator notifier reward update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeIneligibleOperatorNotifierRewardUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(
+            ineligibleOperatorNotifierRewardChangeInitiated,
+            STANDARD_PARAMETER_GOVERNANCE_DELAY
+        )
+    {
+        emit IneligibleOperatorNotifierRewardUpdated(
+            newIneligibleOperatorNotifierReward
+        );
+        // slither-disable-next-line reentrancy-no-eth
+        randomBeacon.updateRewardParameters(
+            randomBeacon.dkgResultSubmissionReward(),
+            randomBeacon.sortitionPoolUnlockingReward(),
+            newIneligibleOperatorNotifierReward,
+            randomBeacon.sortitionPoolRewardsBanDuration(),
+            randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
+            randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
+        );
+        ineligibleOperatorNotifierRewardChangeInitiated = 0;
+        newIneligibleOperatorNotifierReward = 0;
     }
 
     /// @notice Begins the sortition pool rewards ban duration update process.
@@ -702,6 +760,7 @@ contract RandomBeaconGovernance is Ownable {
         randomBeacon.updateRewardParameters(
             randomBeacon.dkgResultSubmissionReward(),
             randomBeacon.sortitionPoolUnlockingReward(),
+            randomBeacon.ineligibleOperatorNotifierReward(),
             newSortitionPoolRewardsBanDuration,
             randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
             randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
@@ -753,6 +812,7 @@ contract RandomBeaconGovernance is Ownable {
         randomBeacon.updateRewardParameters(
             randomBeacon.dkgResultSubmissionReward(),
             randomBeacon.sortitionPoolUnlockingReward(),
+            randomBeacon.ineligibleOperatorNotifierReward(),
             randomBeacon.sortitionPoolRewardsBanDuration(),
             newRelayEntryTimeoutNotificationRewardMultiplier,
             randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
@@ -804,6 +864,7 @@ contract RandomBeaconGovernance is Ownable {
         randomBeacon.updateRewardParameters(
             randomBeacon.dkgResultSubmissionReward(),
             randomBeacon.sortitionPoolUnlockingReward(),
+            randomBeacon.ineligibleOperatorNotifierReward(),
             randomBeacon.sortitionPoolRewardsBanDuration(),
             randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
             newDkgMaliciousResultNotificationRewardMultiplier
@@ -1116,6 +1177,21 @@ contract RandomBeaconGovernance is Ownable {
         return
             getRemainingChangeTime(
                 sortitionPoolUnlockingRewardChangeInitiated,
+                STANDARD_PARAMETER_GOVERNANCE_DELAY
+            );
+    }
+
+    /// @notice Get the time remaining until the ineligible operator notifier
+    ///         reward can be updated.
+    /// @return Remaining time in seconds.
+    function getRemainingIneligibleOperatorNotifierRewardUpdateTime()
+        external
+        view
+        returns (uint256)
+    {
+        return
+            getRemainingChangeTime(
+                ineligibleOperatorNotifierRewardChangeInitiated,
                 STANDARD_PARAMETER_GOVERNANCE_DELAY
             );
     }

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -238,7 +238,8 @@ describe("RandomBeacon - Parameters", () => {
   describe("updateRewardParameters", () => {
     const dkgResultSubmissionReward = 100
     const sortitionPoolUnlockingReward = 200
-    const sortitionPoolRewardsBanDuration = 300
+    const ineligibleOperatorNotifierReward = 300
+    const sortitionPoolRewardsBanDuration = 400
     const relayEntryTimeoutNotificationRewardMultiplier = 10
     const dkgMaliciousResultNotificationRewardMultiplier = 20
 
@@ -250,6 +251,7 @@ describe("RandomBeacon - Parameters", () => {
             .updateRewardParameters(
               dkgResultSubmissionReward,
               sortitionPoolUnlockingReward,
+              ineligibleOperatorNotifierReward,
               sortitionPoolRewardsBanDuration,
               relayEntryTimeoutNotificationRewardMultiplier,
               dkgMaliciousResultNotificationRewardMultiplier
@@ -266,6 +268,7 @@ describe("RandomBeacon - Parameters", () => {
           .updateRewardParameters(
             dkgResultSubmissionReward,
             sortitionPoolUnlockingReward,
+            ineligibleOperatorNotifierReward,
             sortitionPoolRewardsBanDuration,
             relayEntryTimeoutNotificationRewardMultiplier,
             dkgMaliciousResultNotificationRewardMultiplier
@@ -282,6 +285,12 @@ describe("RandomBeacon - Parameters", () => {
         expect(await randomBeacon.sortitionPoolUnlockingReward()).to.be.equal(
           sortitionPoolUnlockingReward
         )
+      })
+
+      it("should update the ineligible operator notifier reward", async () => {
+        expect(
+          await randomBeacon.ineligibleOperatorNotifierReward()
+        ).to.be.equal(ineligibleOperatorNotifierReward)
       })
 
       it("should update the sortition pool rewards ban duration", async () => {
@@ -308,6 +317,7 @@ describe("RandomBeacon - Parameters", () => {
           .withArgs(
             dkgResultSubmissionReward,
             sortitionPoolUnlockingReward,
+            ineligibleOperatorNotifierReward,
             sortitionPoolRewardsBanDuration,
             relayEntryTimeoutNotificationRewardMultiplier,
             dkgMaliciousResultNotificationRewardMultiplier


### PR DESCRIPTION
This PR adds the parameter `ineligibleOperatorNotifierReward`.

The initial value assigned in the constructor of `RandomBeacon` is `0`.
The delay between change initiation and finalisation is `12h`.
There are no restrictions on what the value of this parameter can be.