### PR TITLE
Ensure the group added is not an activated one

### DIFF
--- a/solidity/random-beacon/contracts/libraries/BLS.sol
+++ b/solidity/random-beacon/contracts/libraries/BLS.sol
@@ -22,7 +22,7 @@ library BLS {
 
     /// @dev Wraps the functionality of BLS.verify, but hashes a message to
     ///      a point on G1 and marshal to bytes first to allow raw bytes
-    ///      verificaion.
+    ///      verification.
     function verifyBytes(
         bytes memory publicKey,
         bytes memory message,

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -58,9 +58,15 @@ library Groups {
         // We use group from storage that is assumed to be a struct set to the
         // default values. We need to remember to overwrite fields in case a
         // candidate group was already registered before and popped.
+        // To ensure we modify only a new group or a popped one, we check the
+        // group has not been activated.
         Group storage group = self.groupsData[groupPubKeyHash];
-        group.groupPubKey = groupPubKey;
+        require(
+            group.activationTimestamp == 0,
+            "Cannot add group that has been activated"
+        );
 
+        group.groupPubKey = groupPubKey;
         setGroupMembers(group, members, misbehavedMembersIndices);
 
         self.groupsRegistry.push(groupPubKeyHash);

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -943,7 +943,7 @@ describe("RandomBeacon - Group Creation", () => {
             }
           )
 
-          context("with dkg result approved", async () => {
+          context("with DKG result already submitted", async () => {
             beforeEach(async () => {
               await mineBlocksTo(startBlock + constants.offchainDkgTime)
 
@@ -969,7 +969,7 @@ describe("RandomBeacon - Group Creation", () => {
             })
           })
 
-          context("with dkg result challenged", async () => {
+          context("with DKG result challenged", async () => {
             beforeEach(async () => {
               await mineBlocksTo(startBlock + constants.offchainDkgTime)
 
@@ -2090,5 +2090,8 @@ async function assertDkgResultCleanData(randomBeacon: RandomBeaconStub) {
 }
 
 function mixSigners(signers: Operator[]): Operator[] {
-  return [...signers.slice(0, 63), signers[0]]
+  return signers
+    .map((v) => ({ v, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ v }) => v)
 }


### PR DESCRIPTION
This PR ensures we do not allow a group that has been activated to be modified with the function `addCandidateGroup`.

There is already a [test](https://github.com/keep-network/keep-core/blob/8c36b9065418a8046d2553051ff4653d3ddccf09/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts#L972) where the group is popped (because of a challenge) and the `submitDkgResult` is [repeated](https://github.com/keep-network/keep-core/blob/8c36b9065418a8046d2553051ff4653d3ddccf09/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts#L1019) with the same group and group data is updated. This is what we want to allow.

We could consider adding a test where the group is activated (successful submit + approve) and later we receive a new `submitDkgResult` with the same group (the same `groupPubKey`). This is what we do not want to allow.