### PR TITLE
Clarified there can only one candidate group - description and tests

### DIFF
--- a/solidity-v1/contracts/cryptography/BLS.sol
+++ b/solidity-v1/contracts/cryptography/BLS.sol
@@ -48,7 +48,7 @@ library BLS {
 
     /**
      * @dev VerifyBytes wraps the functionality of BLS.verify, but hashes a message
-     * to a point on G1 and marshal to bytes first to allow raw bytes verificaion.
+     * to a point on G1 and marshal to bytes first to allow raw bytes verification.
      */
     function verifyBytes(
         bytes memory publicKey,

--- a/solidity/random-beacon/contracts/libraries/BLS.sol
+++ b/solidity/random-beacon/contracts/libraries/BLS.sol
@@ -22,7 +22,7 @@ library BLS {
 
     /// @dev Wraps the functionality of BLS.verify, but hashes a message to
     ///      a point on G1 and marshal to bytes first to allow raw bytes
-    ///      verificaion.
+    ///      verification.
     function verifyBytes(
         bytes memory publicKey,
         bytes memory message,

--- a/solidity/random-beacon/contracts/libraries/Groups.sol
+++ b/solidity/random-beacon/contracts/libraries/Groups.sol
@@ -42,6 +42,8 @@ library Groups {
     /// @notice Adds a new candidate group. The group is stored with group public
     ///         key and group members, but is not yet activated.
     /// @dev The group members list is stored with all misbehaved members filtered out.
+    ///      The code calling this function should ensure that the number of
+    ///      candidate (not activated) groups is never more than one.
     /// @param groupPubKey Generated candidate group public key
     /// @param members Addresses of candidate group members as outputted by the
     ///        group selection protocol.

--- a/solidity/random-beacon/test/Groups.test.ts
+++ b/solidity/random-beacon/test/Groups.test.ts
@@ -549,7 +549,7 @@ describe("Groups", () => {
         const groupPublicKey1 = "0x0001"
         const groupPublicKey2 = "0x0002"
 
-        context("when both groups are candidate", async () => {
+        context("when candidate group added after activation", async () => {
           let tx: ContractTransaction
 
           beforeEach(async () => {
@@ -652,7 +652,7 @@ describe("Groups", () => {
         const groupPublicKey1 = groupPublicKey
         const groupPublicKey2 = groupPublicKey
 
-        context("when both groups are candidate", async () => {
+        context("when the first group is active", async () => {
           let tx: ContractTransaction
 
           beforeEach(async () => {
@@ -722,13 +722,11 @@ describe("Groups", () => {
 
         it("should remove registered group", async () => {
           const groupsRegistry = await groups.getGroupsRegistry()
-
           expect(groupsRegistry).to.be.lengthOf(0)
         })
 
         it("should not update stored group data", async () => {
           const storedGroup = await groups.getGroup(groupPublicKey)
-
           expect(storedGroup.groupPubKey).to.be.equal(groupPublicKey)
           expect(storedGroup.activationBlockNumber).to.be.equal(0)
           expect(storedGroup.members).to.be.deep.equal(members)
@@ -761,57 +759,10 @@ describe("Groups", () => {
         const groupPublicKey1 = "0x0001"
         const groupPublicKey2 = "0x0002"
 
-        context("when both groups are candidate", async () => {
-          let tx: ContractTransaction
-
-          beforeEach(async () => {
-            await groups.addCandidateGroup(
-              groupPublicKey1,
-              members1,
-              noMisbehaved
-            )
-            await groups.addCandidateGroup(
-              groupPublicKey2,
-              members2,
-              noMisbehaved
-            )
-
-            tx = await groups.popCandidateGroup()
-          })
-
-          it("should emit CandidateGroupRemoved event", async () => {
-            await expect(tx)
-              .to.emit(groups, "CandidateGroupRemoved")
-              .withArgs(groupPublicKey2)
-          })
-
-          it("should remove registered group", async () => {
-            const groupsRegistry = await groups.getGroupsRegistry()
-
-            expect(groupsRegistry).to.be.lengthOf(1)
-            expect(groupsRegistry[0]).to.deep.equal(keccak256(groupPublicKey1))
-          })
-
-          it("should not update stored group data", async () => {
-            const storedGroup1 = await groups.getGroup(groupPublicKey1)
-
-            expect(storedGroup1.groupPubKey).to.be.equal(groupPublicKey1)
-            expect(storedGroup1.activationBlockNumber).to.be.equal(0)
-            expect(storedGroup1.members).to.be.deep.equal(members1)
-
-            const storedGroup2 = await groups.getGroup(groupPublicKey2)
-
-            expect(storedGroup2.groupPubKey).to.be.equal(groupPublicKey2)
-            expect(storedGroup2.activationBlockNumber).to.be.equal(0)
-            expect(storedGroup2.members).to.be.deep.equal(members2)
-          })
-        })
-
         context("when the other group is active", async () => {
           let activationBlockNumber1: number
           let tx: ContractTransaction
 
-          // TODO: Update as the latest group got activated
           beforeEach(async () => {
             await groups.addCandidateGroup(
               groupPublicKey1,
@@ -853,57 +804,6 @@ describe("Groups", () => {
               activationBlockNumber1
             )
             expect(storedGroup1.members).to.be.deep.equal(members1)
-
-            const storedGroup2 = await groups.getGroup(groupPublicKey2)
-
-            expect(storedGroup2.groupPubKey).to.be.equal(groupPublicKey2)
-            expect(storedGroup2.activationBlockNumber).to.be.equal(0)
-            expect(storedGroup2.members).to.be.deep.equal(members2)
-          })
-        })
-      })
-
-      context("with the same group public key", async () => {
-        const groupPublicKey1 = groupPublicKey
-        const groupPublicKey2 = groupPublicKey
-
-        context("when both groups are candidate", async () => {
-          let tx: ContractTransaction
-
-          beforeEach(async () => {
-            await groups.addCandidateGroup(
-              groupPublicKey1,
-              members1,
-              noMisbehaved
-            )
-            await groups.addCandidateGroup(
-              groupPublicKey2,
-              members2,
-              noMisbehaved
-            )
-
-            tx = await groups.popCandidateGroup()
-          })
-
-          it("should emit CandidateGroupRemoved event", async () => {
-            await expect(tx)
-              .to.emit(groups, "CandidateGroupRemoved")
-              .withArgs(groupPublicKey2)
-          })
-
-          it("should remove registered group", async () => {
-            const groupsRegistry = await groups.getGroupsRegistry()
-
-            expect(groupsRegistry).to.be.lengthOf(1)
-            expect(groupsRegistry[0]).to.deep.equal(keccak256(groupPublicKey1))
-          })
-
-          it("should not update stored group data", async () => {
-            const storedGroup1 = await groups.getGroup(groupPublicKey1)
-
-            expect(storedGroup1.groupPubKey).to.be.equal(groupPublicKey1)
-            expect(storedGroup1.activationBlockNumber).to.be.equal(0)
-            expect(storedGroup1.members).to.be.deep.equal(members2)
 
             const storedGroup2 = await groups.getGroup(groupPublicKey2)
 

--- a/solidity/random-beacon/test/Groups.test.ts
+++ b/solidity/random-beacon/test/Groups.test.ts
@@ -652,43 +652,46 @@ describe("Groups", () => {
         const groupPublicKey1 = groupPublicKey
         const groupPublicKey2 = groupPublicKey
 
-        context("when the first group is active", async () => {
-          let tx: ContractTransaction
+        context(
+          "when the first group was challenged and replaced",
+          async () => {
+            let tx: ContractTransaction
 
-          beforeEach(async () => {
-            await groups.addCandidateGroup(
-              groupPublicKey1,
-              members1,
-              noMisbehaved
-            )
+            beforeEach(async () => {
+              await groups.addCandidateGroup(
+                groupPublicKey1,
+                members1,
+                noMisbehaved
+              )
 
-            tx = await groups.activateCandidateGroup()
-          })
+              await groups.popCandidateGroup()
 
-          it("should emit GroupActivated event", async () => {
-            await expect(tx)
-              .to.emit(groups, "GroupActivated")
-              .withArgs(0, groupPublicKey1)
-          })
+              await groups.addCandidateGroup(
+                groupPublicKey2,
+                members2,
+                noMisbehaved
+              )
 
-          it("should not emit GroupActivated event", async () => {
-            await expect(
-              groups.addCandidateGroup(groupPublicKey2, members2, noMisbehaved)
-            ).to.be.revertedWith(
-              "group with this public key was already activated"
-            )
-          })
+              tx = await groups.activateCandidateGroup()
+            })
 
-          it("should set activation block number for the group", async () => {
-            expect(
-              (await groups.getGroup(groupPublicKey1)).activationBlockNumber
-            ).to.be.equal(tx.blockNumber)
-          })
+            it("should emit GroupActivated event", async () => {
+              await expect(tx)
+                .to.emit(groups, "GroupActivated")
+                .withArgs(0, groupPublicKey2)
+            })
 
-          it("should increase number of active groups", async () => {
-            expect(await groups.numberOfActiveGroups()).to.be.equal(1)
-          })
-        })
+            it("should set activation block number for the group", async () => {
+              expect(
+                (await groups.getGroup(groupPublicKey2)).activationBlockNumber
+              ).to.be.equal(tx.blockNumber)
+            })
+
+            it("should increase number of active groups", async () => {
+              expect(await groups.numberOfActiveGroups()).to.be.equal(1)
+            })
+          }
+        )
       })
     })
   })

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -2080,5 +2080,8 @@ async function assertDkgResultCleanData(randomBeacon: RandomBeaconStub) {
 }
 
 function mixSigners(signers: Operator[]): Operator[] {
-  return [...signers.slice(0, 63), signers[0]]
+  return signers
+    .map((v) => ({ v, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ v }) => v)
 }


### PR DESCRIPTION
This PR:
- adds a description to the `addCandidateGroup` function that clarifies we can have at most one candidate (not activated) group.
- fixes some typos
- updates confusing test descriptions suggesting we can have more than one candidate group
- removes tests where there are two candidate groups (the library allows it, but the code using the library does not).  

Note: `addCandidateGroup` is called in `submitDkgResult`.
[Here](https://github.com/keep-network/keep-core/blob/001ca97953b23a16954e6ebae26f7e07e2c00532/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts#L959) is the test checking we cannot `submitDkgResult` when there is another one in progress. 