### PR TITLE
Moved DKG result signature validation to challengeDkgResult 

### DIFF
--- a/solidity/random-beacon/.solhintignore
+++ b/solidity/random-beacon/.solhintignore
@@ -1,2 +1,1 @@
 node_modules/
-contracts/hardhat-dependency-compiler/

--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -108,12 +108,6 @@ contract DKGValidator {
                     return (false, "Corrupted misbehaved members indices");
                 }
             }
-            uint8 last = misbehavedMembersIndices[
-                misbehavedMembersIndices.length - 1
-            ];
-            if (last < 1 || last > groupSize) {
-                return (false, "Corrupted misbehaved members indices");
-            }
         }
 
         // Each signature needs to be 65 bytes long and signatures need to be
@@ -149,12 +143,6 @@ contract DKGValidator {
         }
         for (uint256 i = 1; i < signingMembersIndices.length; i++) {
             if (signingMembersIndices[i - 1] >= signingMembersIndices[i]) {
-                return (false, "Corrupted signing member indices");
-            }
-            uint256 last = signingMembersIndices[
-                signingMembersIndices.length - 1
-            ];
-            if (last < 1 || last > groupSize) {
                 return (false, "Corrupted signing member indices");
             }
         }

--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -93,10 +93,15 @@ contract DKGValidator {
             return (false, "Too many members misbehaving during DKG");
         }
         if (misbehavedMembersIndices.length > 1) {
+            if (
+                misbehavedMembersIndices[0] < 1 ||
+                misbehavedMembersIndices[misbehavedMembersIndices.length - 1] >
+                64
+            ) {
+                return (false, "Corrupted misbehaved members indices");
+            }
             for (uint256 i = 1; i < misbehavedMembersIndices.length; i++) {
                 if (
-                    misbehavedMembersIndices[i - 1] < 1 ||
-                    misbehavedMembersIndices[i - 1] > groupSize ||
                     misbehavedMembersIndices[i - 1] >=
                     misbehavedMembersIndices[i]
                 ) {
@@ -136,12 +141,14 @@ contract DKGValidator {
 
         // Signing member indices needs to be unique, between [1,64], and sorted
         // in ascending order.
+        if (
+            signingMembersIndices[0] < 1 ||
+            signingMembersIndices[signingMembersIndices.length - 1] > 64
+        ) {
+            return (false, "Corrupted signing member indices");
+        }
         for (uint256 i = 1; i < signingMembersIndices.length; i++) {
-            if (
-                signingMembersIndices[i - 1] < 1 ||
-                signingMembersIndices[i - 1] > groupSize ||
-                signingMembersIndices[i - 1] >= signingMembersIndices[i]
-            ) {
+            if (signingMembersIndices[i - 1] >= signingMembersIndices[i]) {
                 return (false, "Corrupted signing member indices");
             }
             uint256 last = signingMembersIndices[

--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "./libraries/BytesLib.sol";
+import "./libraries/DKG.sol";
+
+pragma solidity ^0.8.6;
+
+/// @title DKG result validator
+/// @notice DKGValidator allows performing a full validation of DKG result,
+///         including checking the format of fields in the result, declared
+///         selected group members, and signatures of operators supporting the
+///         result. The operator submitting the result should perform the
+///         validation using a free contract call before submitting the result
+///         to ensure their result is valid and can not be challenged. All other
+///         network operators should perform validation of the submitted result
+///         using a free contract call and challenge the result if the
+///         validation fails.
+contract DKGValidator {
+    using BytesLib for bytes;
+    using ECDSA for bytes32;
+
+    /// @dev Size of a group in the threshold relay.
+    uint256 public constant groupSize = 64;
+
+    /// @dev The minimum number of group members needed to interact according to
+    ///      the protocol to produce a relay entry. The adversary can not learn
+    ///      anything about the key as long as it does not break into
+    ///      groupThreshold+1 of members.
+    uint256 public constant groupThreshold = 33;
+
+    /// @dev The minimum number of active and properly behaving group members
+    ///      during the DKG needed to accept the result. This number is higher
+    ///      than `groupThreshold` to keep a safety margin for members becoming
+    ///      inactive after DKG so that the group can still produce a relay
+    ///      entry.
+    uint256 public constant activeThreshold = 58; // 90% of groupSize
+
+    SortitionPool public sortitionPool;
+
+    constructor(SortitionPool _sortitionPool) {
+        sortitionPool = _sortitionPool;
+    }
+
+    /// @notice Performs a full validation of DKG result, including checking the
+    ///         format of fields in the result, declared selected group members,
+    ///         and signatures of operators supporting the result.
+    /// @param seed seed used to start the DKG and select group members
+    /// @param startBlock DKG start block
+    /// @return isValid true if the result is valid, false otherwise
+    /// @return errorMsg validation error message; empty for a valid result
+    function validate(
+        DKG.Result calldata result,
+        uint256 seed,
+        uint256 startBlock
+    ) external view returns (bool isValid, string memory errorMsg) {
+        (bool hasValidFields, string memory error) = validateFields(result);
+        if (!hasValidFields) {
+            return (false, error);
+        }
+
+        if (!validateSignatures(result, startBlock)) {
+            return (false, "Invalid signatures");
+        }
+
+        if (!validateGroupMembers(result, seed)) {
+            return (false, "Invalid group members");
+        }
+
+        return (true, "");
+    }
+
+    /// @notice Performs a static validation of DKG result fields: lengths,
+    ///         ranges, and order of arrays.
+    /// @return isValid true if the result is valid, false otherwise
+    /// @return errorMsg validation error message; empty for a valid result
+    function validateFields(DKG.Result calldata result)
+        public
+        view
+        returns (bool isValid, string memory errorMsg)
+    {
+        // Group public key needs to be 128 bytes long.
+        if (result.groupPubKey.length != 128) {
+            return (false, "Malformed group public key");
+        }
+
+        // The number of misbehaved members can not exceed the threshold.
+        // Misbehaved member indices needs to be unique, between [1,64],
+        // and sorted in ascending order.
+        uint8[] calldata misbehavedMembersIndices = result
+            .misbehavedMembersIndices;
+        if (groupSize - misbehavedMembersIndices.length < activeThreshold) {
+            return (false, "Too many members misbehaving during DKG");
+        }
+        if (misbehavedMembersIndices.length > 1) {
+            for (uint256 i = 1; i < misbehavedMembersIndices.length; i++) {
+                if (
+                    misbehavedMembersIndices[i - 1] < 1 ||
+                    misbehavedMembersIndices[i - 1] > groupSize ||
+                    misbehavedMembersIndices[i - 1] >=
+                    misbehavedMembersIndices[i]
+                ) {
+                    return (false, "Corrupted misbehaved members indices");
+                }
+            }
+            uint8 last = misbehavedMembersIndices[
+                misbehavedMembersIndices.length - 1
+            ];
+            if (last < 1 || last > groupSize) {
+                return (false, "Corrupted misbehaved members indices");
+            }
+        }
+
+        // Each signature needs to be 65 bytes long and signatures need to be
+        // provided.
+        uint256 signaturesCount = result.signatures.length / 65;
+        if (result.signatures.length == 0) {
+            return (false, "No signatures provided");
+        }
+        if (result.signatures.length % 65 != 0) {
+            return (false, "Malformed signatures array");
+        }
+
+        // We expect the same amount of signatures as the number of declared
+        // group member indices that signed the result.
+        uint256[] calldata signingMembersIndices = result.signingMembersIndices;
+        if (signaturesCount != signingMembersIndices.length) {
+            return (false, "Unexpected signatures count");
+        }
+        if (signaturesCount < groupThreshold) {
+            return (false, "Too few signatures");
+        }
+        if (signaturesCount > groupSize) {
+            return (false, "Too many signatures");
+        }
+
+        // Signing member indices needs to be unique, between [1,64], and sorted
+        // in ascending order.
+        for (uint256 i = 1; i < signingMembersIndices.length; i++) {
+            if (
+                signingMembersIndices[i - 1] < 1 ||
+                signingMembersIndices[i - 1] > groupSize ||
+                signingMembersIndices[i - 1] >= signingMembersIndices[i]
+            ) {
+                return (false, "Corrupted signing member indices");
+            }
+            uint256 last = signingMembersIndices[
+                signingMembersIndices.length - 1
+            ];
+            if (last < 1 || last > groupSize) {
+                return (false, "Corrupted signing member indices");
+            }
+        }
+
+        return (true, "");
+    }
+
+    /// @notice Performs validation of group members as declared in DKG
+    ///         result against group members selected by the sortition pool.
+    /// @param seed seed used to start the DKG and select group members
+    /// @return true if group members matches; false otherwise
+    function validateGroupMembers(DKG.Result calldata result, uint256 seed)
+        public
+        view
+        returns (bool)
+    {
+        // Compute the actual group members hash by selecting actual members IDs
+        // based on seed used for current DKG execution.
+        bytes32 actualGroupMembersHash = keccak256(
+            abi.encodePacked(
+                sortitionPool.selectGroup(groupSize, bytes32(seed))
+            )
+        );
+
+        // TODO: check what is more efficient - computing hash or iterating
+        return
+            keccak256(abi.encodePacked(result.members)) ==
+            actualGroupMembersHash;
+    }
+
+    /// @notice Performs validation of signatures supplied in DKG result.
+    ///         Note that this function does not check if addresses which
+    ///         supplied signatures supporting the result are the ones selected
+    ///         to the group by sortition pool. This function should be used
+    ///         together with `validateGroupMembers`.
+    /// @param startBlock DKG start block
+    /// @return true if group members matches; false otherwise
+    function validateSignatures(DKG.Result calldata result, uint256 startBlock)
+        public
+        view
+        returns (bool)
+    {
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                result.groupPubKey,
+                result.misbehavedMembersIndices,
+                startBlock
+            )
+        );
+
+        address[] memory membersAddresses = sortitionPool.getIDOperators(
+            result.members
+        );
+
+        bytes memory current; // Current signature to be checked.
+
+        uint256 signaturesCount = result.signatures.length / 65;
+        for (uint256 i = 0; i < signaturesCount; i++) {
+            uint256 memberIndex = result.signingMembersIndices[i];
+
+            current = result.signatures.slice(65 * i, 65);
+            address recoveredAddress = hash.toEthSignedMessageHash().recover(
+                current
+            );
+
+            if (membersAddresses[memberIndex - 1] != recoveredAddress) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -198,7 +198,8 @@ contract RandomBeacon is Ownable {
 
     event DkgResultChallenged(
         bytes32 indexed resultHash,
-        address indexed challenger
+        address indexed challenger,
+        string reason
     );
 
     event DkgMaliciousResultSlashed(
@@ -259,7 +260,8 @@ contract RandomBeacon is Ownable {
     constructor(
         SortitionPool _sortitionPool,
         IERC20 _tToken,
-        IRandomBeaconStaking _staking
+        IRandomBeaconStaking _staking,
+        DKGValidator _dkgValidator
     ) {
         sortitionPool = _sortitionPool;
         tToken = _tToken;
@@ -279,7 +281,7 @@ contract RandomBeacon is Ownable {
         // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(100000 * 1e18);
 
-        dkg.initSortitionPool(_sortitionPool);
+        dkg.init(_sortitionPool, _dkgValidator);
         dkg.setResultChallengePeriodLength(1440); // ~6h assuming 15s block time
         dkg.setResultSubmissionEligibilityDelay(10);
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -204,7 +204,7 @@ contract RandomBeacon is Ownable {
     event DkgMaliciousResultSlashed(
         bytes32 indexed resultHash,
         uint256 slashingAmount,
-        address[] groupMembers
+        address maliciousSubmitter
     );
 
     event DkgStateLocked();
@@ -275,7 +275,7 @@ contract RandomBeacon is Ownable {
         maliciousDkgResultSlashingAmount = 50000e18;
         sortitionPoolRewardsBanDuration = 2 weeks;
         relayEntryTimeoutNotificationRewardMultiplier = 5;
-        dkgMaliciousResultNotificationRewardMultiplier = 5;
+        dkgMaliciousResultNotificationRewardMultiplier = 100;
         // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(100000 * 1e18);
 
@@ -590,26 +590,29 @@ contract RandomBeacon is Ownable {
     /// @param dkgResult Result to challenge. Must match the submitted result
     ///        stored during `submitDkgResult`.
     function challengeDkgResult(DKG.Result calldata dkgResult) external {
-        (bytes32 maliciousResultHash, uint32[] memory maliciousMembers) = dkg
+        (bytes32 maliciousResultHash, uint32 maliciousSubmitter) = dkg
             .challengeResult(dkgResult);
 
         uint256 slashingAmount = maliciousDkgResultSlashingAmount;
-        address[] memory maliciousMembersAddresses = sortitionPool
-            .getIDOperators(maliciousMembers);
+        address maliciousSubmitterAddresses = sortitionPool.getIDOperator(
+            maliciousSubmitter
+        );
 
         groups.popCandidateGroup();
 
         emit DkgMaliciousResultSlashed(
             maliciousResultHash,
             slashingAmount,
-            maliciousMembersAddresses
+            maliciousSubmitterAddresses
         );
 
+        address[] memory operatorWrapper = new address[](1);
+        operatorWrapper[0] = maliciousSubmitterAddresses;
         staking.seize(
             slashingAmount,
             dkgMaliciousResultNotificationRewardMultiplier,
             msg.sender,
-            maliciousMembersAddresses
+            operatorWrapper
         );
     }
 

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -401,9 +401,16 @@ library DKG {
             "result under challenge is different than the submitted one"
         );
 
+        // https://github.com/crytic/slither/issues/982
+        // slither-disable-next-line unused-return
         try
             self.dkgValidator.validate(result, self.seed, self.startBlock)
-        returns (bool isValid, string memory errorMsg) {
+        returns (
+            // slither-disable-next-line uninitialized-local,variable-scope
+            bool isValid,
+            // slither-disable-next-line uninitialized-local,variable-scope
+            string memory errorMsg
+        ) {
             if (isValid) {
                 revert("unjustified challenge");
             }

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.6;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "../RandomBeacon.sol";
+import "../DKGValidator.sol";
 import "../libraries/DKG.sol";
 import "../libraries/Callback.sol";
 import "../libraries/Groups.sol";
@@ -11,8 +12,9 @@ contract RandomBeaconStub is RandomBeacon {
     constructor(
         SortitionPool _sortitionPool,
         IERC20 _tToken,
-        IRandomBeaconStaking _staking
-    ) RandomBeacon(_sortitionPool, _tToken, _staking) {}
+        IRandomBeaconStaking _staking,
+        DKGValidator _dkgValidator
+    ) RandomBeacon(_sortitionPool, _tToken, _staking, _dkgValidator) {}
 
     function getDkgData() external view returns (DKG.Data memory) {
         return dkg;

--- a/solidity/random-beacon/test/DKGValidator.test.ts
+++ b/solidity/random-beacon/test/DKGValidator.test.ts
@@ -1,0 +1,350 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions, no-await-in-loop */
+
+import { BigNumber } from "ethers"
+import { ethers, helpers, getUnnamedAccounts, waffle } from "hardhat"
+import { expect } from "chai"
+
+import blsData from "./data/bls"
+
+import { constants } from "./fixtures"
+import { selectGroup } from "./utils/groups"
+import { signDkgResult, DkgResult, noMisbehaved } from "./utils/dkg"
+import { Operator } from "./utils/operators"
+
+import type { SortitionPool, DKGValidator } from "../typechain"
+
+const { to1e18 } = helpers.number
+
+const fixture = async () => {
+  const SortitionPool = await ethers.getContractFactory("SortitionPool")
+  const sortitionPool = (await SortitionPool.deploy(
+    constants.poolWeightDivisor
+  )) as SortitionPool
+
+  const DKGValidator = await ethers.getContractFactory("DKGValidator")
+  const dkgValidator = (await DKGValidator.deploy(
+    sortitionPool.address
+  )) as DKGValidator
+  await dkgValidator.deployed()
+
+  return {
+    sortitionPool,
+    dkgValidator,
+  }
+}
+
+describe("DKGValidator", () => {
+  const dkgSeed: BigNumber = BigNumber.from(
+    "31415926535897932384626433832795028841971693993751058209749445923078164062862"
+  )
+  const dkgStartBlock = 1337
+  const groupPublicKey: string = ethers.utils.hexValue(blsData.groupPubKey)
+
+  let selectedOperators
+
+  let prepareDkgResult
+  let validator: DKGValidator
+
+  beforeEach("load test fixture", async () => {
+    const contracts = await waffle.loadFixture(fixture)
+    const { sortitionPool } = contracts
+    validator = contracts.dkgValidator
+
+    const operators = (await getUnnamedAccounts()).slice(0, constants.groupSize)
+    for (let i = 0; i < operators.length; i++) {
+      await sortitionPool.insertOperator(operators[i], to1e18(100))
+    }
+
+    selectedOperators = await selectGroup(sortitionPool, dkgSeed)
+
+    prepareDkgResult = async (
+      _groupMembers: Operator[],
+      _signers: Operator[],
+      _groupPublicKey: string,
+      _misbehaved: number[],
+      _startBlock: number,
+      _numberOfSignatures = 33,
+      _submitterIndex = 1
+    ) => {
+      const { signingMembersIndices, signaturesBytes } = await signDkgResult(
+        _signers,
+        _groupPublicKey,
+        _misbehaved,
+        _startBlock,
+        _numberOfSignatures
+      )
+
+      const dkgResult: DkgResult = {
+        submitterMemberIndex: _submitterIndex,
+        groupPubKey: _groupPublicKey,
+        misbehavedMembersIndices: _misbehaved,
+        signatures: signaturesBytes,
+        signingMembersIndices,
+        members: _groupMembers.map((m) => m.id),
+      }
+
+      return dkgResult
+    }
+  })
+
+  describe("validate", () => {
+    const testValidate = async (_groupMembers, _signers, _groupPublicKey) => {
+      const dkgResult = await prepareDkgResult(
+        _groupMembers,
+        _signers,
+        _groupPublicKey,
+        noMisbehaved,
+        dkgStartBlock
+      )
+
+      const result = await validator.validate(dkgResult, dkgSeed, dkgStartBlock)
+
+      return {
+        isValid: result[0],
+        errorMsg: result[1],
+      }
+    }
+
+    context("for a valid DKG result", () => {
+      it("should pass", async () => {
+        const result = await testValidate(
+          selectedOperators,
+          selectedOperators,
+          groupPublicKey
+        )
+
+        expect(result.isValid).to.be.true
+        expect(result.errorMsg).to.equal("")
+      })
+    })
+
+    // just a basic test ensuring group members validation
+    // is called; detailed test cases are implemented for
+    // validateGroupMembers function
+    context("for a DKG result with invalid group members", () => {
+      it("should return validation error", async () => {
+        const shuffledOperators = shuffle(selectedOperators)
+
+        const result = await testValidate(
+          shuffledOperators,
+          shuffledOperators,
+          groupPublicKey
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Invalid group members")
+      })
+    })
+
+    // just a basic test ensuring signatures validation
+    // is called; detailed test cases are implemented for
+    // validateSignatures function
+    context("for a DKG result with invalid signatures", () => {
+      it("should return validation error", async () => {
+        const shuffledOperators = shuffle(selectedOperators)
+
+        const result = await testValidate(
+          selectedOperators,
+          shuffledOperators,
+          groupPublicKey
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Invalid signatures")
+      })
+    })
+  })
+
+  describe("validateFields", () => {
+    const testValidateFields = async (
+      _groupMembers,
+      _groupPublicKey,
+      _misbehaved,
+      _numberOfSignatures = 33
+    ) => {
+      const dkgResult = await prepareDkgResult(
+        _groupMembers,
+        _groupMembers,
+        _groupPublicKey,
+        _misbehaved,
+        dkgStartBlock,
+        _numberOfSignatures
+      )
+
+      const result = await validator.validateFields(dkgResult)
+
+      return {
+        isValid: result[0],
+        errorMsg: result[1],
+      }
+    }
+
+    context("for a valid DKG result", () => {
+      it("should pass", async () => {
+        const result = await testValidateFields(
+          selectedOperators,
+          groupPublicKey,
+          noMisbehaved
+        )
+
+        expect(result.isValid).to.be.true
+        expect(result.errorMsg).to.equal("")
+      })
+    })
+
+    context("for malformed group public key", () => {
+      it("should return validation error", async () => {
+        const empty = "0x"
+        const tooShort = groupPublicKey.substring(0, groupPublicKey.length - 2)
+        const tooLong = `${groupPublicKey}ff`
+
+        let result = await testValidateFields(
+          selectedOperators,
+          empty,
+          noMisbehaved
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Malformed group public key")
+
+        result = await testValidateFields(
+          selectedOperators,
+          tooShort,
+          noMisbehaved
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Malformed group public key")
+
+        result = await testValidateFields(
+          selectedOperators,
+          tooLong,
+          noMisbehaved
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Malformed group public key")
+      })
+    })
+
+    context("for malformed misbehaved array", () => {
+      it("should return validation error", async () => {
+        const lessThanOne = [0, 1, 2]
+        const higherThanGroupSize = [1, 2, 65]
+        const unsorted = [1, 2, 3, 60, 4]
+
+        let result = await testValidateFields(
+          selectedOperators,
+          groupPublicKey,
+          lessThanOne
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Corrupted misbehaved members indices")
+
+        result = await testValidateFields(
+          selectedOperators,
+          groupPublicKey,
+          higherThanGroupSize
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Corrupted misbehaved members indices")
+
+        result = await testValidateFields(
+          selectedOperators,
+          groupPublicKey,
+          unsorted
+        )
+
+        expect(result.isValid).to.be.false
+        expect(result.errorMsg).to.equal("Corrupted misbehaved members indices")
+      })
+    })
+
+    // TODO: expand tests to ensure all possible cases of corrupted input
+    //       data are covered;
+  })
+
+  describe("validateGroupMembers", () => {
+    const testValidateGroupMembers = async (_groupMembers) => {
+      const dkgResult = await prepareDkgResult(
+        _groupMembers,
+        _groupMembers,
+        groupPublicKey,
+        noMisbehaved,
+        dkgStartBlock
+      )
+
+      return validator.validateGroupMembers(dkgResult, dkgSeed)
+    }
+
+    context("for a valid DKG result", () => {
+      it("should pass", async () => {
+        const isValid = await testValidateGroupMembers(selectedOperators)
+        expect(isValid).to.be.true
+      })
+    })
+
+    context("for operators other than selected", () => {
+      it("should fail the validation", async () => {
+        const isValid = await testValidateGroupMembers(
+          shuffle(selectedOperators)
+        )
+        expect(isValid).to.be.false
+      })
+    })
+  })
+
+  describe("validateSignatures", () => {
+    const testValidateSignatures = async (_groupMembers, _signers) => {
+      const dkgResult = await prepareDkgResult(
+        _groupMembers,
+        _signers,
+        groupPublicKey,
+        noMisbehaved,
+        dkgStartBlock
+      )
+
+      return validator.validateSignatures(dkgResult, dkgStartBlock)
+    }
+
+    context("for a valid DKG result", () => {
+      it("should pass", async () => {
+        const isValid = await testValidateSignatures(
+          selectedOperators,
+          selectedOperators
+        )
+
+        expect(isValid).to.be.true
+      })
+    })
+
+    context(
+      "for signature provided by one malicious, selected operator",
+      () => {
+        it("should fail the validation", async () => {
+          const maliciousSigners = Array(constants.groupSize).fill(
+            selectedOperators[0]
+          )
+          const isValid = await testValidateSignatures(
+            selectedOperators,
+            maliciousSigners
+          )
+
+          expect(isValid).to.be.false
+        })
+      }
+    )
+
+    // TODO: expand tests to ensure all possible cases of corrupted input
+    //       data are covered;
+  })
+})
+
+function shuffle(operators: Operator[]): Operator[] {
+  return operators
+    .map((v) => ({ v, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ v }) => v)
+}

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -1492,15 +1492,15 @@ describe("RandomBeacon - Group Creation", () => {
                 .withArgs(dkgResultHash, await anotherSubmitter.getAddress())
             })
 
-              it("should activate a candidate group", async () => {
-                const storedGroup = await randomBeacon["getGroup(bytes)"](
-                  groupPublicKey
-                )
+            it("should activate a candidate group", async () => {
+              const storedGroup = await randomBeacon["getGroup(bytes)"](
+                groupPublicKey
+              )
 
-                expect(storedGroup.activationBlockNumber).to.be.equal(
-                  tx.blockNumber
-                )
-              })
+              expect(storedGroup.activationBlockNumber).to.be.equal(
+                tx.blockNumber
+              )
+            })
 
             it("should reward the submitter with tokens from maintenance pool", async () => {
               const currentSubmitterBalance: BigNumber =

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -1743,7 +1743,7 @@ describe("RandomBeacon - Group Creation", () => {
           let resultSubmissionBlock: number
           let dkgResultHash: string
           let dkgResult: DkgResult
-          let expectedSigners: string[]
+          let submitter: SignerWithAddress
 
           beforeEach(async () => {
             let tx: ContractTransaction
@@ -1760,10 +1760,9 @@ describe("RandomBeacon - Group Creation", () => {
               noMisbehaved
             ))
 
-            expectedSigners = await sortitionPool.getIDOperators(
-              dkgResult.signingMembersIndices.map(
-                (index) => dkgResult.members[index - 1]
-              )
+            submitter = await getDkgResultSubmitterSigner(
+              randomBeacon,
+              dkgResult
             )
 
             resultSubmissionBlock = tx.blockNumber
@@ -1803,17 +1802,17 @@ describe("RandomBeacon - Group Creation", () => {
               it("should emit DkgMaliciousResultSlashed event", async () => {
                 await expect(tx)
                   .to.emit(randomBeacon, "DkgMaliciousResultSlashed")
-                  .withArgs(dkgResultHash, to1e18(50000), expectedSigners)
+                  .withArgs(dkgResultHash, to1e18(50000), submitter.address)
               })
 
-              it("should slash members who signed the result", async () => {
+              it("should slash malicious result submitter", async () => {
                 await expect(tx)
                   .to.emit(staking, "Seized")
                   .withArgs(
                     to1e18(50000),
-                    5,
+                    100,
                     await thirdParty.getAddress(),
-                    expectedSigners
+                    [submitter.address]
                   )
               })
             })
@@ -1861,17 +1860,17 @@ describe("RandomBeacon - Group Creation", () => {
               it("should emit DkgMaliciousResultSlashed event", async () => {
                 await expect(tx)
                   .to.emit(randomBeacon, "DkgMaliciousResultSlashed")
-                  .withArgs(dkgResultHash, to1e18(50000), expectedSigners)
+                  .withArgs(dkgResultHash, to1e18(50000), submitter.address)
               })
 
-              it("should slash members who signed the result", async () => {
+              it("should slash malicious result submitter", async () => {
                 await expect(tx)
                   .to.emit(staking, "Seized")
                   .withArgs(
                     to1e18(50000),
-                    5,
+                    100,
                     await thirdParty.getAddress(),
-                    expectedSigners
+                    [submitter.address]
                   )
               })
             })

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -291,7 +291,7 @@ describe("RandomBeacon - Group Creation", () => {
               randomBeacon,
               groupPublicKey,
               // Mix signers to make the result malicious
-              mixSigners(await selectGroup(randomBeacon, genesisSeed)),
+              mixSigners(await selectGroup(sortitionPool, genesisSeed)),
               startBlock,
               noMisbehaved
             ))
@@ -461,7 +461,7 @@ describe("RandomBeacon - Group Creation", () => {
               randomBeacon,
               groupPublicKey,
               // Mix signers to make the result malicious.
-              mixSigners(await selectGroup(randomBeacon, genesisSeed)),
+              mixSigners(await selectGroup(sortitionPool, genesisSeed)),
               startBlock,
               noMisbehaved
             ))
@@ -1021,7 +1021,7 @@ describe("RandomBeacon - Group Creation", () => {
                 randomBeacon,
                 groupPublicKey,
                 // Mix signers to make the result malicious.
-                mixSigners(await selectGroup(randomBeacon, genesisSeed)),
+                mixSigners(await selectGroup(sortitionPool, genesisSeed)),
                 startBlock,
                 noMisbehaved
               )
@@ -1418,7 +1418,7 @@ describe("RandomBeacon - Group Creation", () => {
               randomBeacon,
               groupPublicKey,
               // Mix signers to make the result malicious.
-              mixSigners(await selectGroup(randomBeacon, genesisSeed)),
+              mixSigners(await selectGroup(sortitionPool, genesisSeed)),
               startBlock,
               noMisbehaved,
               maliciousSubmitter
@@ -1817,7 +1817,7 @@ describe("RandomBeacon - Group Creation", () => {
               randomBeacon,
               groupPublicKey,
               // Mix signers to make the result malicious.
-              mixSigners(await selectGroup(randomBeacon, genesisSeed)),
+              mixSigners(await selectGroup(sortitionPool, genesisSeed)),
               startBlock,
               noMisbehaved
             ))
@@ -1972,7 +1972,10 @@ describe("RandomBeacon - Group Creation", () => {
           let tx: ContractTransaction
 
           beforeEach(async () => {
-            const selectedSigners = await selectGroup(randomBeacon, genesisSeed)
+            const selectedSigners = await selectGroup(
+              sortitionPool,
+              genesisSeed
+            )
             const maliciousSigners = Array(constants.groupSize).fill(signers[0])
             const submitterIndex = 1
             const submitter = selectedSigners[submitterIndex - 1].address

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -561,6 +561,49 @@ describe("RandomBeacon - Group Creation", () => {
             await mineBlocksTo(startBlock + constants.offchainDkgTime)
           })
 
+          context("with malformed group public key", async () => {
+            it("should revert", async () => {
+              const empty = "0x"
+              const tooShort = groupPublicKey.substring(
+                0,
+                groupPublicKey.length - 2
+              )
+              const tooLong = `${groupPublicKey}ff`
+
+              await expect(
+                signAndSubmitArbitraryDkgResult(
+                  randomBeacon,
+                  empty,
+                  signers,
+                  startBlock,
+                  noMisbehaved
+                )
+              ).to.be.revertedWith("Malformed group public key")
+
+              await expect(
+                signAndSubmitArbitraryDkgResult(
+                  randomBeacon,
+                  tooShort,
+                  signers,
+                  startBlock,
+                  noMisbehaved
+                )
+              ).to.be.revertedWith("Malformed group public key")
+
+              await expect(
+                signAndSubmitArbitraryDkgResult(
+                  randomBeacon,
+                  tooLong,
+                  signers,
+                  startBlock,
+                  noMisbehaved
+                )
+              ).to.be.revertedWith("Malformed group public key")
+            })
+          })
+          // TODO: expand tests to ensure all possible cases of corrupted input
+          //       data are covered
+
           context("with less signatures on the result than required", () => {
             it("should revert", async () => {
               const filteredSigners = signers.slice(
@@ -1383,10 +1426,8 @@ describe("RandomBeacon - Group Creation", () => {
             await randomBeacon.challengeDkgResult(dkgResult)
 
             await mineBlocks(
-              params.dkgResultSubmissionEligibilityDelay *
-                anotherSubmitterIndex
+              params.dkgResultSubmissionEligibilityDelay * anotherSubmitterIndex
             )
-
             ;({
               transaction: tx,
               dkgResult,
@@ -1828,12 +1869,9 @@ describe("RandomBeacon - Group Creation", () => {
               it("should slash malicious result submitter", async () => {
                 await expect(tx)
                   .to.emit(staking, "Seized")
-                  .withArgs(
-                    to1e18(50000),
-                    100,
-                    await thirdParty.getAddress(),
-                    [submitter.address]
-                  )
+                  .withArgs(to1e18(50000), 100, await thirdParty.getAddress(), [
+                    submitter.address,
+                  ])
               })
             })
           })
@@ -1886,12 +1924,9 @@ describe("RandomBeacon - Group Creation", () => {
               it("should slash malicious result submitter", async () => {
                 await expect(tx)
                   .to.emit(staking, "Seized")
-                  .withArgs(
-                    to1e18(50000),
-                    100,
-                    await thirdParty.getAddress(),
-                    [submitter.address]
-                  )
+                  .withArgs(to1e18(50000), 100, await thirdParty.getAddress(), [
+                    submitter.address,
+                  ])
               })
             })
           })

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -2,6 +2,7 @@ import { Contract } from "ethers"
 import { ethers, helpers, getNamedAccounts } from "hardhat"
 import type {
   SortitionPool,
+  DKGValidator,
   RandomBeaconStub,
   RandomBeaconGovernance,
   StakingStub,
@@ -88,6 +89,12 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
   const dkg = await DKG.deploy()
   await dkg.deployed()
 
+  const DKGValidator = await ethers.getContractFactory("DKGValidator")
+  const dkgValidator = (await DKGValidator.deploy(
+    sortitionPool.address
+  )) as DKGValidator
+  await dkgValidator.deployed()
+
   const RandomBeacon = await ethers.getContractFactory("RandomBeaconStub", {
     libraries: {
       BLS: (await blsDeployment()).bls.address,
@@ -97,7 +104,8 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
   const randomBeacon: RandomBeaconStub = await RandomBeacon.deploy(
     sortitionPool.address,
     testToken.address,
-    stakingStub.address
+    stakingStub.address,
+    dkgValidator.address
   )
   await randomBeacon.deployed()
 

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -53,10 +53,15 @@ export async function signAndSubmitCorrectDkgResult(
   dkgResultHash: string
   members: number[]
 }> {
+  const sortitionPool = (await ethers.getContractAt(
+    "SortitionPool",
+    await randomBeacon.sortitionPool()
+  )) as SortitionPool
+
   return signAndSubmitArbitraryDkgResult(
     randomBeacon,
     groupPublicKey,
-    await selectGroup(randomBeacon, seed),
+    await selectGroup(sortitionPool, seed),
     startBlock,
     misbehavedIndices,
     submitterIndex,

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -93,7 +93,7 @@ export async function signAndSubmitArbitraryDkgResult(
 
   const dkgResult: DkgResult = {
     submitterMemberIndex: submitterIndex,
-    groupPubKey: blsData.groupPubKey,
+    groupPubKey: groupPublicKey,
     misbehavedMembersIndices: misbehavedIndices,
     signatures: signaturesBytes,
     signingMembersIndices,

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -3,7 +3,6 @@
 import { ethers } from "hardhat"
 import type { BigNumber, ContractTransaction } from "ethers"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import blsData from "../data/bls"
 import type { RandomBeacon, SortitionPool } from "../../typechain"
 import { Operator } from "./operators"
 // eslint-disable-next-line import/no-cycle
@@ -116,7 +115,7 @@ export async function signAndSubmitArbitraryDkgResult(
   return { transaction, dkgResult, dkgResultHash, members }
 }
 
-async function signDkgResult(
+export async function signDkgResult(
   signers: Operator[],
   groupPublicKey: string,
   misbehavedMembersIndices: number[],

--- a/solidity/random-beacon/test/utils/groups.ts
+++ b/solidity/random-beacon/test/utils/groups.ts
@@ -33,15 +33,13 @@ export async function createGroup(
 }
 
 export async function selectGroup(
-  randomBeacon: RandomBeacon,
+  sortitionPool: SortitionPool,
   seed: BigNumber
 ): Promise<Operator[]> {
-  const sortitionPool = (await ethers.getContractAt(
-    "SortitionPool",
-    await randomBeacon.sortitionPool()
-  )) as SortitionPool
-
-  const identifiers = await randomBeacon.selectGroup(seed.toHexString())
+  const identifiers = await sortitionPool.selectGroup(
+    constants.groupSize,
+    seed.toHexString()
+  )
   const addresses = await sortitionPool.getIDOperators(identifiers)
 
   return identifiers.map((identifier, i) => ({


### PR DESCRIPTION
The previous version was:

In `submitDkgResult` we:
- perform static validation of result (lengths, ranges, sizes)
- check if t+1 signatures signing the result are valid,
- check if all operators who signed the result are in the sortition pool,
- if signatures are not valid or at least one operator is not in the sortition
  pool, the result is rejected.

Then, there is some time to challenge the result and the result is not accepted
until the challenge period is over. The sortition pool is locked for the entire
challenge period.

In `challengeDkgResult` - called by anyone only when something is wrong with the
result - we:
- call sortition pool and check if group members passed in `submitDkgResult` are
  what the sortition pool returns,
- if the expected member list does not match the actual member list, DKG result
  is rejected and all operators who signed the result are slashed.

What we do now:

In `submitDkgResult`:
- check if the submitter is in the sortition pool.

In `challengeDkgResult`:
- perform static validation of the result (lengths, sizes, ranges)
- call sortition pool and check if group members passed in `submitDkgResult`
  are what the sortition pool expects,
- check if t+1 signatures signing the result are valid, and if they come from
  sortition pool members,
- if anything is wrong with the result, slash DKG result submitter.

The previous approach felt wrong for the number of reasons:
- It was expensive!!! More than 1M of gas for a group size of 64 members to
  `submitDkgResult`. This will only get worse for tBTC v2 and a group size of
  100 members. With the alternative approach proposed, the cost should be 
  on average less than 600k.
- Checking if someone is in the sortition pool in `submitDkgResult` is not
  enough. One operator can have multiple signer seats, so we should check the
  stake of the operator. If they provided `S` signatures, we should check that
  their stake is `S*min_stake`. Think of the case when one operator claims they
  have all 64 member seats and we just check if that operator is in the
  sortition pool... It does not make sense, we should check if they have
  `64*min_stake` but it only makes `submitDkgResult` more expensive...
- ...At the same time, we want the minimum stake to be governable and we want to
  be able to lower and increase it. In case the minimum stake was increased, it
  affects only new operators joining the network. Someone not having the minimum
  stake can still be in the sortition pool and be selected by the sortition pool.
  Checking the minimum stake breaks in this case.
- See that we are duplicating some work: in `submitDkgResult` we check if
  members are in the sortition pool and in `challengeDkgResult` we check if they
  were selected by the sortition pool. Challenge checks their sortition pool
  membership implicitly.

In the new approach, minor censorship seems to be the only problem.
We should be fine with accepting this risk if the challenge period is long
enough and the reward for challenging is hefty. We need to move into
submit-challenge-accept model if we want to lower the cost and if miners can
censor transactions for more than 6h, we are not the only ones who have a
problem and this feels like something that needs to be solved on the blockchain
level, not in our protocol. Of course this will all be governable so if we
find a better solution in Q4, we will upgrade.

I have also addressed [this](https://github.com/keep-network/keep-core/pull/2695#discussion_r756127603) and [this](https://github.com/keep-network/keep-core/pull/2695#discussion_r756028278) review comments from #2695.

Gas consumption before (min/max/avg):
```
···························|··································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  approveDkgResult                ·     184343  ·     218862  ·     193086  ·           73  ·          -  │
···························|··································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  challengeDkgResult              ·     984278  ·    1004278  ·     991234  ·           35  ·          -  │
···························|··································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  submitDkgResult                 ·     755531  ·    1057737  ·    1001734  ·          131  ·          -  │
···························|··································|·············|·············|·············|···············|··············
```

Gas consumption after (min/max/avg):
```
···························|··································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  approveDkgResult                ·     184980  ·     219535  ·     193801  ·           73  ·          -  │
···························|··································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  challengeDkgResult              ·    1224991  ·    1277027  ·    1228541  ·           35  ·          -  │
···························|··································|·············|·············|·············|···············|··············
|  RandomBeaconStub        ·  submitDkgResult                 ·     339478  ·     636580  ·     591268  ·          131  ·          -  │
···························|··································|·············|·············|·············|···············|··············
```