### PR TITLE
Updated `sortition-pools` dependency to the most recent one

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -493,7 +493,7 @@ contract RandomBeacon is Ownable {
 
         sortitionPool.insertOperator(
             operator,
-            staking.eligibleStake(msg.sender, address(this))
+            staking.eligibleStake(operator, address(this))
         );
     }
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -42,6 +42,11 @@ interface IRandomBeaconStaking {
         address notifier,
         address[] memory operators
     ) external;
+
+    function eligibleStake(address operator, address operatorContract)
+        external
+        view
+        returns (uint256);
 }
 
 /// @title Keep Random Beacon
@@ -486,21 +491,18 @@ contract RandomBeacon is Ownable {
             "Operator is already registered"
         );
 
-        sortitionPool.insertOperator(operator);
+        sortitionPool.insertOperator(
+            operator,
+            staking.eligibleStake(msg.sender, address(this))
+        );
     }
 
     /// @notice Updates the sortition pool status of the caller.
     function updateOperatorStatus() external {
         sortitionPool.updateOperatorStatus(
-            sortitionPool.getOperatorID(msg.sender)
+            msg.sender,
+            staking.eligibleStake(msg.sender, address(this))
         );
-    }
-
-    /// @notice Checks whether the given operator is eligible to join the
-    ///         sortition pool.
-    /// @param operator Address of the operator
-    function isOperatorEligible(address operator) external view returns (bool) {
-        return sortitionPool.isOperatorEligible(operator);
     }
 
     /// @notice Triggers group selection if there are no active groups.

--- a/solidity/random-beacon/contracts/test/StakingStub.sol
+++ b/solidity/random-beacon/contracts/test/StakingStub.sol
@@ -40,7 +40,7 @@ contract StakingStub is IRandomBeaconStaking {
     function eligibleStake(
         address operator,
         address // operatorContract
-    ) external view returns (uint256) {
+    ) external view override returns (uint256) {
         return stakedTokens[operator];
     }
 

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -19,7 +19,7 @@
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'"
   },
   "dependencies": {
-    "@keep-network/sortition-pools": "1.2.0-dev.11",
+    "@keep-network/sortition-pools": "1.2.0-dev.14",
     "@openzeppelin/contracts": "^4.3.3",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },

--- a/solidity/random-beacon/test/RandomBeacon.Pool.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Pool.test.ts
@@ -75,34 +75,4 @@ describe("RandomBeacon - Pool", () => {
       })
     })
   })
-
-  describe("isOperatorEligible", () => {
-    context("when the operator is eligible to join the sortition pool", () => {
-      beforeEach(async () => {
-        await stakingStub.setStake(operator.address, constants.minimumStake)
-      })
-
-      it("should return true", async () => {
-        await expect(await randomBeacon.isOperatorEligible(operator.address)).to
-          .be.true
-      })
-    })
-
-    context(
-      "when the operator is not eligible to join the sortition pool",
-      () => {
-        beforeEach(async () => {
-          await stakingStub.setStake(
-            operator.address,
-            constants.minimumStake.sub(1)
-          )
-        })
-
-        it("should return false", async () => {
-          await expect(await randomBeacon.isOperatorEligible(operator.address))
-            .to.be.false
-        })
-      }
-    )
-  })
 })

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -79,8 +79,6 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
 
   const SortitionPool = await ethers.getContractFactory("SortitionPool")
   const sortitionPool = (await SortitionPool.deploy(
-    stakingStub.address,
-    constants.minimumStake,
     constants.poolWeightDivisor
   )) as SortitionPool
 

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -593,10 +593,10 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
-"@keep-network/sortition-pools@1.2.0-dev.11":
-  version "1.2.0-dev.11"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.11.tgz#b2f52aa658cd234a893ff32f2488e7fbb515dd5a"
-  integrity sha512-dHbIAS3JgZmtla3Ap8K2RH2XrlRhUB9bi7PRdrDU1B12qUEp68SNbHf0xgZrucOluQtBFg8q6KXsnWEZknulVQ==
+"@keep-network/sortition-pools@1.2.0-dev.14":
+  version "1.2.0-dev.14"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.14.tgz#7b694fc9feb2aad7f879112a62b4bffc1a3b9f07"
+  integrity sha512-wQB1pnqTZQejjPjsOidVqOahJLZzhI5vNfF8kHWantfByRC1D/DqkC+OUNmFyq8kET6WBNdVWbVMD7mvYQdmmw==
   dependencies:
     "@openzeppelin/contracts" "^4.3.2"
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2715

See https://github.com/keep-network/sortition-pools/pull/135
See https://github.com/keep-network/sortition-pools/pull/136
See https://github.com/keep-network/sortition-pools/pull/137


This is a preparation for T staking contract integration but will also allow
to use `selectGroup` for challenges given that in the most recent version this
function is not protected by `onlyOwner` modifier.

Sortition pool does not longer expose `isEligibleFunction`. Everyone who
has the minimum required authorization for Random Beacon on T staking contract
will be able to join the pool. Removed `RandomBeacon.isEligible`.

I have also updated `RandomBeacon.registerOperator` and
`RandomBeacon.updateOperatorStatus`. `SortitionPool` contract does no longer
work with staking contract and it requires the contract owner to pass the
current authorization amount. These functions will be reworked during the
integration with T staking contract. For now, I am just making everything
to compile and work with the most recent `sortition-pools` version.