### PR TITLE
Uncommenting tests because group termination is implemented

### DIFF
--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -630,6 +630,8 @@ describe("RandomBeacon - Relay", () => {
       context(
         "when no active groups exist after timeout is reported and DKG is awaiting seed",
         () => {
+          let tx: ContractTransaction
+
           beforeEach(async () => {
             // `groupSize * relayEntrySubmissionEligibilityDelay +
             // relayEntryHardTimeout`.
@@ -638,20 +640,18 @@ describe("RandomBeacon - Relay", () => {
             // Simulate DKG is awaiting a seed.
             await (randomBeacon as RandomBeaconStub).publicDkgLockState()
 
-            await randomBeacon.connect(notifier).reportRelayEntryTimeout()
+            tx = await randomBeacon.connect(notifier).reportRelayEntryTimeout()
           })
 
           it("should notify DKG seed timed out", async () => {
-            // TODO: Uncomment those assertions once termination is implemented.
-            // expect(await randomBeacon.getGroupCreationState()).to.be.equal(
-            //   dkgState.IDLE
-            // )
-            // expect(await sortitionPool.isLocked()).to.be.false
+            expect(await randomBeacon.getGroupCreationState()).to.be.equal(
+              dkgState.IDLE
+            )
+            expect(await sortitionPool.isLocked()).to.be.false
           })
 
           it("should emit DkgSeedTimedOut event", async () => {
-            // TODO: Uncomment those assertions once termination is implemented.
-            // await expect(tx).to.emit(randomBeacon, "DkgSeedTimedOut")
+            await expect(tx).to.emit(randomBeacon, "DkgSeedTimedOut")
           })
         }
       )


### PR DESCRIPTION
Groups termination is in `main`. Uncommenting a couple of tests that were waiting for group termination functionality.