### PR TITLE
Modified signature validation: get only signer addresses on challenge

### DIFF
--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -209,13 +209,12 @@ contract DKGValidator {
             )
         );
 
+        uint256[] calldata signingMembersIndices = result.signingMembersIndices;
         uint32[] memory signingMemberIds = new uint32[](
-            result.signingMembersIndices.length
+            signingMembersIndices.length
         );
-        for (uint256 i = 0; i < result.signingMembersIndices.length; i++) {
-            signingMemberIds[i] = result.members[
-                result.signingMembersIndices[i] - 1
-            ];
+        for (uint256 i = 0; i < signingMembersIndices.length; i++) {
+            signingMemberIds[i] = result.members[signingMembersIndices[i] - 1];
         }
 
         address[] memory signingMemberAddresses = sortitionPool.getIDOperators(

--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -209,15 +209,17 @@ contract DKGValidator {
             )
         );
 
-        uint32[] memory signerIds = new uint32[](
+        uint32[] memory signingMemberIds = new uint32[](
             result.signingMembersIndices.length
         );
         for (uint256 i = 0; i < result.signingMembersIndices.length; i++) {
-            signerIds[i] = result.members[result.signingMembersIndices[i] - 1];
+            signingMemberIds[i] = result.members[
+                result.signingMembersIndices[i] - 1
+            ];
         }
 
-        address[] memory signersAddresses = sortitionPool.getIDOperators(
-            signerIds
+        address[] memory signingMemberAddresses = sortitionPool.getIDOperators(
+            signingMemberIds
         );
 
         bytes memory current; // Current signature to be checked.
@@ -232,7 +234,7 @@ contract DKGValidator {
                 current
             );
 
-            if (signersAddresses[i] != recoveredAddress) {
+            if (signingMemberAddresses[i] != recoveredAddress) {
                 return false;
             }
         }

--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -209,16 +209,21 @@ contract DKGValidator {
             )
         );
 
-        address[] memory membersAddresses = sortitionPool.getIDOperators(
-            result.members
+        uint32[] memory signerIds = new uint32[](
+            result.signingMembersIndices.length
+        );
+        for (uint256 i = 0; i < result.signingMembersIndices.length; i++) {
+            signerIds[i] = result.members[result.signingMembersIndices[i] - 1];
+        }
+
+        address[] memory signersAddresses = sortitionPool.getIDOperators(
+            signerIds
         );
 
         bytes memory current; // Current signature to be checked.
 
         uint256 signaturesCount = result.signatures.length / signatureByteSize;
         for (uint256 i = 0; i < signaturesCount; i++) {
-            uint256 memberIndex = result.signingMembersIndices[i];
-
             current = result.signatures.slice(
                 signatureByteSize * i,
                 signatureByteSize
@@ -227,7 +232,7 @@ contract DKGValidator {
                 current
             );
 
-            if (membersAddresses[memberIndex - 1] != recoveredAddress) {
+            if (signersAddresses[i] != recoveredAddress) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR modifies validation of DKG result during challenge: instead of getting addresses of all operators from sortition-pool, we just get addresses of the operators that signed the result. 

When running tests in `RandomBeacon.GroupCreation.test.ts` the average gas consumption for `challengeDkgResult` decreased from `1201940` to `1160869`.

