### PR TITLE
Updating initial values of RandomBeacon parameters

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -318,7 +318,7 @@ contract RandomBeacon is Ownable {
 
         // TODO: revisit all initial values
         callbackGasLimit = 50000;
-        groupCreationFrequency = 10;
+        groupCreationFrequency = 5;
 
         dkgResultSubmissionReward = 0;
         sortitionPoolUnlockingReward = 0;
@@ -341,7 +341,7 @@ contract RandomBeacon is Ownable {
         relay.setRelayEntryHardTimeout(5760); // ~24h assuming 15s block time
         relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);
 
-        groups.setGroupLifetime(80640); // ~2weeks assuming 15s block time
+        groups.setGroupLifetime(403200); // ~10 months assuming 15s block time
     }
 
     /// @notice Updates the values of authorization parameters.

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -326,8 +326,8 @@ contract RandomBeacon is Ownable {
         maliciousDkgResultSlashingAmount = 50000e18;
         unauthorizedSigningSlashingAmount = 100e3 * 1e18;
         sortitionPoolRewardsBanDuration = 2 weeks;
-        relayEntryTimeoutNotificationRewardMultiplier = 5;
-        unauthorizedSigningNotificationRewardMultiplier = 5;
+        relayEntryTimeoutNotificationRewardMultiplier = 40;
+        unauthorizedSigningNotificationRewardMultiplier = 50;
         dkgMaliciousResultNotificationRewardMultiplier = 100;
         // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(100000 * 1e18);

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -334,10 +334,10 @@ contract RandomBeacon is Ownable {
 
         dkg.init(_sortitionPool, _dkgValidator);
         dkg.setResultChallengePeriodLength(1440); // ~6h assuming 15s block time
-        dkg.setResultSubmissionEligibilityDelay(10);
+        dkg.setResultSubmissionEligibilityDelay(20);
 
         relay.initSeedEntry();
-        relay.setRelayEntrySubmissionEligibilityDelay(10);
+        relay.setRelayEntrySubmissionEligibilityDelay(20);
         relay.setRelayEntryHardTimeout(5760); // ~24h assuming 15s block time
         relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -321,7 +321,7 @@ contract RandomBeacon is Ownable {
         groupCreationFrequency = 5;
 
         dkgResultSubmissionReward = 1000e18;
-        sortitionPoolUnlockingReward = 0;
+        sortitionPoolUnlockingReward = 100e18;
         ineligibleOperatorNotifierReward = 0;
         maliciousDkgResultSlashingAmount = 50000e18;
         unauthorizedSigningSlashingAmount = 100e3 * 1e18;

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -320,7 +320,7 @@ contract RandomBeacon is Ownable {
         callbackGasLimit = 50000;
         groupCreationFrequency = 5;
 
-        dkgResultSubmissionReward = 0;
+        dkgResultSubmissionReward = 1000e18;
         sortitionPoolUnlockingReward = 0;
         ineligibleOperatorNotifierReward = 0;
         maliciousDkgResultSlashingAmount = 50000e18;

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -337,6 +337,7 @@ contract RandomBeacon is Ownable {
         dkg.setResultSubmissionEligibilityDelay(20);
 
         relay.initSeedEntry();
+        relay.setRelayRequestFee(200e18);
         relay.setRelayEntrySubmissionEligibilityDelay(20);
         relay.setRelayEntryHardTimeout(5760); // ~24h assuming 15s block time
         relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -317,7 +317,7 @@ contract RandomBeacon is Ownable {
         staking = _staking;
 
         // TODO: revisit all initial values
-        callbackGasLimit = 200e3;
+        callbackGasLimit = 50000;
         groupCreationFrequency = 10;
 
         dkgResultSubmissionReward = 0;

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -333,7 +333,7 @@ contract RandomBeacon is Ownable {
         authorization.setMinimumAuthorization(100000 * 1e18);
 
         dkg.init(_sortitionPool, _dkgValidator);
-        dkg.setResultChallengePeriodLength(1440); // ~6h assuming 15s block time
+        dkg.setResultChallengePeriodLength(11520); // ~48h assuming 15s block time
         dkg.setResultSubmissionEligibilityDelay(20);
 
         relay.initSeedEntry();

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -27,21 +27,23 @@ export const dkgState = {
 }
 
 export const params = {
-  relayRequestFee: to1e18(200),
-  relayEntrySubmissionEligibilityDelay: 20,
+  relayRequestFee: 0,
+  relayEntrySubmissionEligibilityDelay: 10,
   relayEntryHardTimeout: 5760,
-  callbackGasLimit: 50000,
-  groupCreationFrequency: 5,
-  groupLifeTime: 403200, // ~10 months assuming 15s block time
-  dkgResultChallengePeriodLength: 11520, // ~48h assuming 15s block time
-  dkgResultSubmissionEligibilityDelay: 20,
-  dkgResultSubmissionReward: to1e18(1000),
-  sortitionPoolUnlockingReward: to1e18(100),
+  callbackGasLimit: 200000,
+  groupCreationFrequency: 10,
+  groupLifeTime: 60 * 60 * 24 * 14, // 2 weeks
+  dkgResultChallengePeriodLength: 1440,
+  dkgResultSubmissionEligibilityDelay: 10,
+  dkgResultSubmissionReward: 0,
+  sortitionPoolUnlockingReward: 0,
   sortitionPoolRewardsBanDuration: 1209600, // 2 weeks
-  relayEntrySubmissionFailureSlashingAmount: to1e18(1000),
-  maliciousDkgResultSlashingAmount: to1e18(50000),
-  relayEntryTimeoutNotificationRewardMultiplier: 40,
-  unauthorizedSigningNotificationRewardMultiplier: 50,
+  relayEntrySubmissionFailureSlashingAmount: ethers.BigNumber.from(10)
+    .pow(18)
+    .mul(1000),
+  maliciousDkgResultSlashingAmount: ethers.BigNumber.from(10)
+    .pow(18)
+    .mul(50000),
 }
 
 // TODO: We should consider using hardhat-deploy plugin for contracts deployment.

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -27,23 +27,21 @@ export const dkgState = {
 }
 
 export const params = {
-  relayRequestFee: 0,
-  relayEntrySubmissionEligibilityDelay: 10,
+  relayRequestFee: to1e18(200),
+  relayEntrySubmissionEligibilityDelay: 20,
   relayEntryHardTimeout: 5760,
-  callbackGasLimit: 200000,
-  groupCreationFrequency: 10,
-  groupLifeTime: 60 * 60 * 24 * 14, // 2 weeks
-  dkgResultChallengePeriodLength: 1440,
-  dkgResultSubmissionEligibilityDelay: 10,
-  dkgResultSubmissionReward: 0,
-  sortitionPoolUnlockingReward: 0,
+  callbackGasLimit: 50000,
+  groupCreationFrequency: 5,
+  groupLifeTime: 403200, // ~10 months assuming 15s block time
+  dkgResultChallengePeriodLength: 11520, // ~48h assuming 15s block time
+  dkgResultSubmissionEligibilityDelay: 20,
+  dkgResultSubmissionReward: to1e18(1000),
+  sortitionPoolUnlockingReward: to1e18(100),
   sortitionPoolRewardsBanDuration: 1209600, // 2 weeks
-  relayEntrySubmissionFailureSlashingAmount: ethers.BigNumber.from(10)
-    .pow(18)
-    .mul(1000),
-  maliciousDkgResultSlashingAmount: ethers.BigNumber.from(10)
-    .pow(18)
-    .mul(50000),
+  relayEntrySubmissionFailureSlashingAmount: to1e18(1000),
+  maliciousDkgResultSlashingAmount: to1e18(50000),
+  relayEntryTimeoutNotificationRewardMultiplier: 40,
+  unauthorizedSigningNotificationRewardMultiplier: 50,
 }
 
 // TODO: We should consider using hardhat-deploy plugin for contracts deployment.

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -38,12 +38,15 @@ export const params = {
   dkgResultSubmissionReward: 0,
   sortitionPoolUnlockingReward: 0,
   sortitionPoolRewardsBanDuration: 1209600, // 2 weeks
-  relayEntrySubmissionFailureSlashingAmount: ethers.BigNumber.from(10)
-    .pow(18)
-    .mul(1000),
-  maliciousDkgResultSlashingAmount: ethers.BigNumber.from(10)
-    .pow(18)
-    .mul(50000),
+  relayEntrySubmissionFailureSlashingAmount: to1e18(1000),
+  maliciousDkgResultSlashingAmount: to1e18(50000),
+  relayEntryTimeoutNotificationRewardMultiplier: 40,
+  unauthorizedSigningNotificationRewardMultiplier: 50,
+  dkgMaliciousResultNotificationRewardMultiplier: 100,
+  ineligibleOperatorNotifierReward: to1e18(200),
+  unauthorizedSigningSlashingAmount: to1e18(100000),
+  minimumAuthorization: to1e18(100000),
+  authorizationDecreaseDelay: 0,
 }
 
 // TODO: We should consider using hardhat-deploy plugin for contracts deployment.
@@ -118,6 +121,8 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
 
   await sortitionPool.connect(deployer).transferOwnership(randomBeacon.address)
 
+  await setFixtureParameters(randomBeacon)
+
   const contracts: DeployedContracts = {
     sortitionPool,
     stakingStub,
@@ -142,4 +147,44 @@ export async function testDeployment(): Promise<DeployedContracts> {
   const newContracts = { randomBeaconGovernance }
 
   return { ...contracts, ...newContracts }
+}
+
+async function setFixtureParameters(randomBeacon: RandomBeaconStub) {
+  await randomBeacon.updateAuthorizationParameters(
+    params.minimumAuthorization,
+    params.authorizationDecreaseDelay
+  )
+
+  await randomBeacon.updateRelayEntryParameters(
+    params.relayRequestFee,
+    params.relayEntrySubmissionEligibilityDelay,
+    params.relayEntryHardTimeout,
+    params.callbackGasLimit
+  )
+
+  await randomBeacon.updateRewardParameters(
+    params.dkgResultSubmissionReward,
+    params.sortitionPoolUnlockingReward,
+    params.ineligibleOperatorNotifierReward,
+    params.sortitionPoolRewardsBanDuration,
+    params.relayEntryTimeoutNotificationRewardMultiplier,
+    params.unauthorizedSigningNotificationRewardMultiplier,
+    params.dkgMaliciousResultNotificationRewardMultiplier
+  )
+
+  await randomBeacon.updateGroupCreationParameters(
+    params.groupCreationFrequency,
+    params.groupLifeTime
+  )
+
+  await randomBeacon.updateDkgParameters(
+    params.dkgResultChallengePeriodLength,
+    params.dkgResultSubmissionEligibilityDelay
+  )
+
+  await randomBeacon.updateSlashingParameters(
+    params.relayEntrySubmissionFailureSlashingAmount,
+    params.maliciousDkgResultSlashingAmount,
+    params.unauthorizedSigningSlashingAmount
+  )
 }


### PR DESCRIPTION
Spreadsheet with cost calculations: https://docs.google.com/spreadsheets/d/1JgRCj6srYCHANA8tmgR1XgvsE3eFrYzwSiaTRGkUI5M/edit?usp=sharing

### Initial callback gas limit set to 50k

This is enough to store relay entry, the block at which the entry
was produced and emit an event.

### Initial entry/DKG result submission eligibility delay set to 20 blocks 

Default mining check interval in the client is 60 sec which is about
4 Ethereum blocks. 20 blocks eligibility delay is a bit more
operator-friendly leaving space for at least 4 gas price bumps.
This is especially important for DKG result submitter who needs
to approve the result to claim the reward.

It also means that the time before soft relay entry timeout is
hit, increased from 160 to 320 minutes.

### DKG result challenge period increased to ~48h

There is no validation in `submitDkgResult` function and we need to
ensure malicious DKG results are caught and eliminated no matter
what. The best approach would be to validate everything in `submitDkgResult`
function but then, the cost of group creation would increase
significantly. 48h should be enough to report the problem even if
Ethereum network hard-forked.

### Group creation frequency set to 5, group lifetime set to ~10 weeks

Creating a group is really expensive. The total gas cost of `submitDkgResult`
followed by `approveDkgResult` is 780849 on average and 526488 minimum.

Assuming the average gas consumption, the cost in ETH is:
100Gwei gas price: 0.0780849 ETH
200Gwei gas price: 0.1561698 ETH
500Gwei gas price: 0.3904245 ETH
1000Gwei gas price: 0.780849 ETH

tBTC is expected to create a new wallet every one week and tBTC will
be the only user of the random beacon initially. It means that with
10 weeks group lifetime and group created every 5 requests, we have
a new group created every 5 weeks and every time, tBTC needs to
provide 20% of the total DKG cost.

### DKG result submission reward set to 1000 T

Assuming the average gas consumption, the cost in ETH is:
100Gwei gas price: 0.0780849 ETH
200Gwei gas price: 0.1561698 ETH
500Gwei gas price: 0.3904245 ETH
1000Gwei gas price: 0.780849 ETH

Assuming 200Gwei gas price and T:ETH ratio same as KEEP:ETH ratio
today (2021-12-02), 1 ETH = 5500 KEEP, the reward in T based on
avg gas cost and 200Gwei gas price should be 858.9339 T.

Setting it to 1000 T to keep it rounded and have some safety margin to
make the reward more attractive

### Initial relay request fee set to 200 T

DKG result submission reward is 1000 T, DKG frequency is 5, so
relay request fee needs to be 1000/5 = 200.

### Sortition pool unlocking reward set to 100 T

The total cost of notifyDkgTimeout is 86883 on average and 85216
minimum.

Assuming the average gas consumption, the cost in ETH is:
100Gwei gas price: 0.0086883 ETH
200Gwei gas price: 0.0173766 ETH
500Gwei gas price: 0.0434415 ETH
1000Gwei gas price: 0.086883 ETH

Assuming 200Gwei gas price and T:ETH ratio same as KEEP:ETH ratio
today (2021-12-02), 1 ETH = 5500 KEEP, the reward in T based on
avg gas cost and 200Gwei gas price should be 95.5713 T.

Setting it to 100 T to keep it rounded and have some safety margin
to make the reward more attractive.

### Updated initial reward multiplier values

Average gas costs are:

- `reportUnauthorizedSigning`: 540505
- `challengeDkgResult`:        1227610
- `reportRelayEntryTimeout`:   407314

Setting reward multipliers proportionally
