### PR TITLE
Modified validation of group members: iterate instead of hashing

### DIFF
--- a/solidity/random-beacon/contracts/DKGValidator.sol
+++ b/solidity/random-beacon/contracts/DKGValidator.sol
@@ -175,18 +175,20 @@ contract DKGValidator {
         view
         returns (bool)
     {
-        // Compute the actual group members hash by selecting actual members IDs
-        // based on seed used for current DKG execution.
-        bytes32 actualGroupMembersHash = keccak256(
-            abi.encodePacked(
-                sortitionPool.selectGroup(groupSize, bytes32(seed))
-            )
+        uint32[] calldata resultMembers = result.members;
+        uint32[] memory actualGroupMembers = sortitionPool.selectGroup(
+            groupSize,
+            bytes32(seed)
         );
-
-        // TODO: check what is more efficient - computing hash or iterating
-        return
-            keccak256(abi.encodePacked(result.members)) ==
-            actualGroupMembersHash;
+        if (resultMembers.length != actualGroupMembers.length) {
+            return false;
+        }
+        for (uint256 i = 0; i < resultMembers.length; i++) {
+            if (resultMembers[i] != actualGroupMembers[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /// @notice Performs validation of signatures supplied in DKG result.


### PR DESCRIPTION
This PR modifies the way group members are validated during DKG result challenge: instead of calculating hash, group members are iterated and compared one by one.

After this change `challengeDkgResult` seems to be cheaper in the optimistic case, but slightly more expensive in the pessimistic.
It is also faster in case the lengths of received and actual members are different. 

Iterating:
- optimistic (first operator mismatch): 1142513
- pessimistic (last operator mismatch): 1167251

Hashing (note the cost the same in both cases):
- optimistic: 1160070
- pessimistic: 1160070

Note: I could only test it via `challengeDkgResult` function and not dedicated `DKGValidator` tests (for some reason gas reporter doesn't show the output from `DKGValidator` - maybe because those are `view` functions?)