### PR TITLE
Removed unused code from random beacon

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -617,8 +617,6 @@ contract RandomBeacon is Ownable {
 
         groups.activateCandidateGroup();
         dkg.complete();
-        // TODO: Check if this function is cheap enough and it will be
-        //       profitable for the DKG result submitter to call it.
     }
 
     /// @notice Challenges DKG result. If the submitted result is proved to be

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -108,19 +108,6 @@ library DKG {
     /// @dev Size of a group in the threshold relay.
     uint256 public constant groupSize = 64;
 
-    /// @dev The minimum number of group members needed to interact according to
-    ///      the protocol to provide signatures for the DKG result. The adversary
-    ///      can not learn anything about the key as long as it does not break into
-    ///      groupThreshold+1 of members.
-    uint256 public constant groupThreshold = 33;
-
-    /// @dev The minimum number of active and properly behaving group members
-    ///      during the DKG needed to accept the result. This number is higher
-    ///      than `groupThreshold` to keep a safety margin for members becoming
-    ///      inactive after DKG so that the group can still produce a relay
-    ///      entry.
-    uint256 public constant activeThreshold = 58; // 90% of groupSize
-
     /// @notice Time in blocks after which DKG result is complete and ready to be
     //          published by clients.
     uint256 public constant offchainDkgTime = 5 * (1 + 5) + 2 * (1 + 10) + 20;

--- a/solidity/random-beacon/contracts/libraries/Relay.sol
+++ b/solidity/random-beacon/contracts/libraries/Relay.sol
@@ -16,7 +16,6 @@ pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "./AltBn128.sol";
 import "./BLS.sol";
 import "./Groups.sol";

--- a/solidity/random-beacon/contracts/libraries/Submission.sol
+++ b/solidity/random-beacon/contracts/libraries/Submission.sol
@@ -92,41 +92,4 @@ library Submission {
                 firstEligibleIndex <= submitterIndex;
         }
     }
-
-    /// @notice Determines a list of members which should be considered as
-    ///         inactive due to not submitting on their turn.
-    ///         Inactive members are determined using the eligibility queue and
-    ///         are taken from the <firstEligibleIndex, submitterIndex) range.
-    ///         It also handles the `submitterIndex < firstEligibleIndex` case
-    ///         and wraps the queue accordingly.
-    /// @param submitterIndex Index of the submitter.
-    /// @param firstEligibleIndex First index of the given eligibility range.
-    /// @param groupMembers IDs of the group members.
-    /// @return An array of members IDs which should be considered inactive due
-    ///         to not submitting on their turn.
-    function getInactiveMembers(
-        uint256 submitterIndex,
-        uint256 firstEligibleIndex,
-        uint32[] memory groupMembers
-    ) internal view returns (uint32[] memory) {
-        uint256 groupSize = groupMembers.length;
-
-        uint256 inactiveMembersCount = submitterIndex >= firstEligibleIndex
-            ? submitterIndex - firstEligibleIndex
-            : groupSize - (firstEligibleIndex - submitterIndex);
-
-        uint32[] memory inactiveMembersIDs = new uint32[](inactiveMembersCount);
-
-        for (uint256 i = 0; i < inactiveMembersCount; i++) {
-            uint256 memberIndex = firstEligibleIndex + i;
-
-            if (memberIndex > groupSize) {
-                memberIndex = memberIndex - groupSize;
-            }
-
-            inactiveMembersIDs[i] = groupMembers[memberIndex - 1];
-        }
-
-        return inactiveMembersIDs;
-    }
 }

--- a/solidity/random-beacon/contracts/test/SubmissionStub.sol
+++ b/solidity/random-beacon/contracts/test/SubmissionStub.sol
@@ -37,17 +37,4 @@ contract SubmissionStub {
                 lastEligibleIndex
             );
     }
-
-    function getInactiveMembers(
-        uint256 submitterIndex,
-        uint256 firstEligibleIndex,
-        uint32[] memory groupMembers
-    ) external view returns (uint32[] memory) {
-        return
-            Submission.getInactiveMembers(
-                submitterIndex,
-                firstEligibleIndex,
-                groupMembers
-            );
-    }
 }

--- a/solidity/random-beacon/test/Submission.test.ts
+++ b/solidity/random-beacon/test/Submission.test.ts
@@ -73,59 +73,6 @@ describe("Submission", () => {
     })
   })
 
-  describe("getInactiveMembers", () => {
-    let groupMembers: OperatorID[]
-
-    beforeEach(async () => {
-      groupMembers = [1, 2, 3, 4, 5, 6, 7, 8]
-    })
-
-    context("when submitter index is the first eligible index", () => {
-      it("should return empty inactive members list", async () => {
-        const inactiveMembers = await submissionStub.getInactiveMembers(
-          5,
-          5,
-          groupMembers
-        )
-
-        await expect(inactiveMembers.length).to.be.equal(0)
-      })
-    })
-
-    context("when submitter index is bigger than first eligible index", () => {
-      it("should return a proper inactive members list", async () => {
-        const inactiveMembers = await submissionStub.getInactiveMembers(
-          8,
-          5,
-          groupMembers
-        )
-
-        await expect(inactiveMembers.length).to.be.equal(3)
-        await expect(inactiveMembers[0]).to.be.equal(groupMembers[4])
-        await expect(inactiveMembers[1]).to.be.equal(groupMembers[5])
-        await expect(inactiveMembers[2]).to.be.equal(groupMembers[6])
-      })
-    })
-
-    context("when submitter index is smaller than first eligible index", () => {
-      it("should return a proper inactive members list", async () => {
-        const inactiveMembers = await submissionStub.getInactiveMembers(
-          3,
-          5,
-          groupMembers
-        )
-
-        await expect(inactiveMembers.length).to.be.equal(6)
-        await expect(inactiveMembers[0]).to.be.equal(groupMembers[4])
-        await expect(inactiveMembers[1]).to.be.equal(groupMembers[5])
-        await expect(inactiveMembers[2]).to.be.equal(groupMembers[6])
-        await expect(inactiveMembers[3]).to.be.equal(groupMembers[7])
-        await expect(inactiveMembers[4]).to.be.equal(groupMembers[0])
-        await expect(inactiveMembers[5]).to.be.equal(groupMembers[1])
-      })
-    })
-  })
-
   async function assertMembersEligible(
     protocolStartBlock: number,
     checkedMembers: number[]

--- a/solidity/random-beacon/test/Submission.test.ts
+++ b/solidity/random-beacon/test/Submission.test.ts
@@ -3,7 +3,6 @@
 import { ethers, helpers, waffle } from "hardhat"
 import { expect } from "chai"
 import type { SubmissionStub } from "../typechain"
-import { OperatorID } from "./utils/operators"
 import blsData from "./data/bls"
 
 const { mineBlocks } = helpers.time


### PR DESCRIPTION
This PR removes unnecessary TODO related to performance of `approveDkgResult`.
The cost of approveDkgResult is `213813` on average and `247436` max.

Some unused constants and functions are removed as well.