### PR TITLE
Fix comment describing value set via `setGroupLifetime`

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -342,7 +342,7 @@ contract RandomBeacon is Ownable {
         relay.setRelayEntryHardTimeout(5760); // ~24h assuming 15s block time
         relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);
 
-        groups.setGroupLifetime(403200); // ~10 months assuming 15s block time
+        groups.setGroupLifetime(403200); // ~10 weeks assuming 15s block time
     }
 
     /// @notice Updates the values of authorization parameters.


### PR DESCRIPTION
The value of `403200` blocks set via the `groups.setGroupLifetime(403200)`
represents ~10 weeks, not 10 months (assuming 15s block time). Updating
the comment to reflect correct value.