### PR TITLE
Block MM connection when Tally is injected by default

### DIFF
--- a/solidity-v1/dashboard/src/components/WalletOptions.jsx
+++ b/solidity-v1/dashboard/src/components/WalletOptions.jsx
@@ -12,6 +12,7 @@ import {
 } from "../connectors"
 import { MODAL_TYPES, WALLETS } from "../constants/constants"
 import { ExplorerModeConnector } from "../connectors/explorer-mode-connector"
+import { messageType, useShowMessage } from "./Message"
 
 const WALLETS_OPTIONS = [
   {
@@ -85,12 +86,23 @@ const renderWallet = (wallet) => <Wallet key={wallet.label} {...wallet} />
 const Wallet = ({ label, icon: IconComponent, connector, modalType }) => {
   const { openModal } = useModal()
   const { connectAppWithWallet } = useWeb3Context()
+  const showMessage = useShowMessage()
 
   const openWalletModal = () => {
-    openModal(modalType, {
-      connector,
-      connectAppWithWallet,
-    })
+    if (label === "MetaMask" && window.ethereum?.isTally) {
+      showMessage({
+        messageType: messageType.ERROR,
+        messageProps: {
+          content: `Please uncheck "Use Tally as default wallet" option in Tally wallet to connect to MetaMask`,
+          sticky: true,
+        },
+      })
+    } else {
+      openModal(modalType, {
+        connector,
+        connectAppWithWallet,
+      })
+    }
   }
 
   return (


### PR DESCRIPTION
There was a bug with Tally and MetaMask - if "use Tally as default wallet"
option in Tally was checked, then the app automatically connected to Tally 
wallet when we picked MetaMask, but displayed the MetaMask logo next to user 
address, which might be confused for some users.
We decided to block the possibility to connect to MM in such case and print
proper message, that tells user to uncheck the "use Tally as default wallet"
option if he wants to connect to MetaMask.


![image](https://user-images.githubusercontent.com/40306834/147109185-72a9b395-1ea0-4f27-9542-7a3d9ddc04e9.png)
