### PR TITLE
Splitting relay entry submission

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -741,8 +741,11 @@ contract RandomBeacon is Ownable {
     }
 
     /// @notice Creates a new relay entry.
-    /// @dev It should be called only after a soft timeout. Group members will be
-    ///      slashed. Function reverts if a hard timeout is hit.
+    /// @dev It should be called after a soft timeout is hit when the slashing is
+    ///      involved. It is allowed to call this function before a soft timeout,
+    ///      however it would use more gas compared to the other submitRelayEntry
+    ///      that doesn't take groupMembers param. Function reverts if a hard
+    ///      timeout is hit.
     /// @param entry Group BLS signature over the previous entry.
     /// @param groupMembers Group member ids that participated in dkg (excluding IA/DQ).
     function submitRelayEntry(

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -26,7 +26,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "hardhat/console.sol";
 
 /// @title Staking contract interface
 /// @notice This is an interface with just a few function signatures of the
@@ -770,15 +769,17 @@ contract RandomBeacon is Ownable {
         uint256 currentRequestId = relay.currentRequestID;
         relay.submitEntry(entry, group.groupPubKey);
 
-        address[] memory groupMembersIds = sortitionPool.getIDOperators(groupMembers);
+        address[] memory groupMembersAddresses = sortitionPool.getIDOperators(
+            groupMembers
+        );
 
         // Slashing is involved after a soft timeout.
-        try staking.slash(slashingAmount, groupMembersIds) {
+        try staking.slash(slashingAmount, groupMembersAddresses) {
             // slither-disable-next-line reentrancy-events
             emit RelayEntryDelaySlashed(
                 currentRequestId,
                 slashingAmount,
-                groupMembersIds
+                groupMembersAddresses
             );
         } catch {
             // Should never happen but we want to ensure a non-critical path
@@ -787,7 +788,7 @@ contract RandomBeacon is Ownable {
             emit RelayEntryDelaySlashingFailed(
                 currentRequestId,
                 slashingAmount,
-                groupMembersIds
+                groupMembersAddresses
             );
         }
 
@@ -811,21 +812,21 @@ contract RandomBeacon is Ownable {
         );
         uint256 slashingAmount = relay
             .relayEntrySubmissionFailureSlashingAmount;
-        address[] memory groupMembersIds = sortitionPool.getIDOperators(
+        address[] memory groupMembersAddresses = sortitionPool.getIDOperators(
             groupMembers
         );
 
         emit RelayEntryTimeoutSlashed(
             relay.currentRequestID,
             slashingAmount,
-            groupMembersIds
+            groupMembersAddresses
         );
 
         staking.seize(
             slashingAmount,
             relayEntryTimeoutNotificationRewardMultiplier,
             msg.sender,
-            groupMembersIds
+            groupMembersAddresses
         );
 
         groups.terminateGroup(groupId);
@@ -883,21 +884,21 @@ contract RandomBeacon is Ownable {
 
         groups.terminateGroup(groupId);
 
-        address[] memory groupMembersIds = sortitionPool.getIDOperators(
+        address[] memory groupMembersAddresses = sortitionPool.getIDOperators(
             groupMembers
         );
 
         emit UnauthorizedSigningSlashed(
             groupId,
             unauthorizedSigningSlashingAmount,
-            groupMembersIds
+            groupMembersAddresses
         );
 
         staking.seize(
             unauthorizedSigningSlashingAmount,
             unauthorizedSigningNotificationRewardMultiplier,
             msg.sender,
-            groupMembersIds
+            groupMembersAddresses
         );
     }
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -720,7 +720,6 @@ contract RandomBeacon is Ownable {
     ///      happy scenario without slashing.
     /// @param entry Group BLS signature over the previous entry.
     function submitRelayEntry(bytes calldata entry) external {
-        require(relay.isRequestInProgress(), "No relay request in progress");
         require(
             !relay.hasRequestSoftTimedOut(),
             "Relay submission passed a soft timeout"
@@ -750,7 +749,6 @@ contract RandomBeacon is Ownable {
         bytes calldata entry,
         uint32[] calldata groupMembers
     ) external {
-        require(relay.isRequestInProgress(), "No relay request in progress");
         require(
             relay.hasRequestSoftTimedOut(),
             "Relay did not pass a soft timeout"
@@ -765,6 +763,7 @@ contract RandomBeacon is Ownable {
             "Invalid group members"
         );
 
+        // Slashing is involved after a soft timeout.
         uint256 slashingAmount = relay.calculateSlashingAmount();
         uint256 currentRequestId = relay.currentRequestID;
         relay.submitEntry(entry, group.groupPubKey);
@@ -773,7 +772,6 @@ contract RandomBeacon is Ownable {
             groupMembers
         );
 
-        // Slashing is involved after a soft timeout.
         try staking.slash(slashingAmount, groupMembersAddresses) {
             // slither-disable-next-line reentrancy-events
             emit RelayEntryDelaySlashed(

--- a/solidity/random-beacon/contracts/libraries/Relay.sol
+++ b/solidity/random-beacon/contracts/libraries/Relay.sol
@@ -118,6 +118,7 @@ library Relay {
         bytes calldata entry,
         bytes storage groupPubKey
     ) internal {
+        require(isRequestInProgress(self), "No relay request in progress");
         require(
             BLS._verify(
                 AltBn128.g2Unmarshal(groupPubKey),

--- a/solidity/random-beacon/contracts/libraries/Relay.sol
+++ b/solidity/random-beacon/contracts/libraries/Relay.sol
@@ -147,17 +147,22 @@ library Relay {
         uint256 softTimeoutBlock = self.currentRequestStartBlock +
             (dkgGroupSize * self.relayEntrySubmissionEligibilityDelay);
 
-        uint256 submissionDelay = block.number - softTimeoutBlock;
-        // The slashing amount is a result of a calculated portion of the submission
-        // delay blocks. The max delay can be set up to relayEntryHardTimeout, which
-        // in consequence sets the max slashing amount.
-        if (submissionDelay > self.relayEntryHardTimeout) {
-            submissionDelay = self.relayEntryHardTimeout;
+        if (block.number > softTimeoutBlock) {
+            uint256 submissionDelay = block.number - softTimeoutBlock;
+            // The slashing amount is a result of a calculated portion of the submission
+            // delay blocks. The max delay can be set up to relayEntryHardTimeout, which
+            // in consequence sets the max slashing amount.
+            if (submissionDelay > self.relayEntryHardTimeout) {
+                submissionDelay = self.relayEntryHardTimeout;
+            }
+
+            return
+                (submissionDelay *
+                    self.relayEntrySubmissionFailureSlashingAmount) /
+                self.relayEntryHardTimeout;
         }
 
-        return
-            (submissionDelay * self.relayEntrySubmissionFailureSlashingAmount) /
-            self.relayEntryHardTimeout;
+        return 0;
     }
 
     /// @notice Set relayRequestFee parameter.

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -28,13 +28,11 @@ contract RandomBeaconStub is RandomBeacon {
         external
     {
         bytes32 groupPubKeyHash = keccak256(groupPubKey);
-
         Groups.Group memory group;
         group.groupPubKey = groupPubKey;
         group.membersHash = membersHash;
         /* solhint-disable-next-line not-rely-on-time */
         group.activationBlockNumber = block.number;
-
         groups.groupsData[groupPubKeyHash] = group;
         groups.groupsRegistry.push(groupPubKeyHash);
     }

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -55,9 +55,8 @@ contract RandomBeaconStub is RandomBeacon {
 
     function isGroupTerminated(uint64 groupId) external view returns (bool) {
         bytes32 groupPubKeyHash = groups.groupsRegistry[groupId];
-        Groups.Group memory group = groups.groupsData[groupPubKeyHash];
 
-        return group.terminated;
+        return groups.groupsData[groupPubKeyHash].terminated;
     }
 
     function publicDkgLockState() external {

--- a/solidity/random-beacon/contracts/test/RelayStub.sol
+++ b/solidity/random-beacon/contracts/test/RelayStub.sol
@@ -17,12 +17,4 @@ contract RelayStub {
     function setCurrentRequestStartBlock() external {
         relay.currentRequestStartBlock = uint64(block.number);
     }
-
-    function getSlashingFactor(uint256 groupSize)
-        external
-        view
-        returns (uint256)
-    {
-        return relay.getSlashingFactor(groupSize);
-    }
 }

--- a/solidity/random-beacon/contracts/test/RelayStub.sol
+++ b/solidity/random-beacon/contracts/test/RelayStub.sol
@@ -9,6 +9,8 @@ contract RelayStub {
 
     Relay.Data internal relay;
 
+    bytes public groupPubKey;
+
     constructor() {
         relay.setRelayEntrySubmissionEligibilityDelay(10);
         relay.setRelayEntryHardTimeout(100);
@@ -21,5 +23,12 @@ contract RelayStub {
 
     function calculateSlashingAmount() external returns (uint256) {
         return relay.calculateSlashingAmount();
+    }
+
+    function submitEntry(bytes calldata entry, bytes calldata _groupPubKey)
+        external
+    {
+        groupPubKey = _groupPubKey;
+        relay.submitEntry(entry, groupPubKey);
     }
 }

--- a/solidity/random-beacon/contracts/test/RelayStub.sol
+++ b/solidity/random-beacon/contracts/test/RelayStub.sol
@@ -12,9 +12,14 @@ contract RelayStub {
     constructor() {
         relay.setRelayEntrySubmissionEligibilityDelay(10);
         relay.setRelayEntryHardTimeout(100);
+        relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);
     }
 
     function setCurrentRequestStartBlock() external {
         relay.currentRequestStartBlock = uint64(block.number);
+    }
+
+    function calculateSlashingAmount() external returns (uint256) {
+        return relay.calculateSlashingAmount();
     }
 }

--- a/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
@@ -56,7 +56,6 @@ describe("RandomBeacon - Callback", () => {
   let testToken: TestToken
   let callbackContract: CallbackContractStub
   let callbackContract1: CallbackContractStub
-  let membersIDs: OperatorID[]
 
   before(async () => {
     requester = await ethers.getSigner((await getUnnamedAccounts())[1])
@@ -70,7 +69,6 @@ describe("RandomBeacon - Callback", () => {
     testToken = contracts.testToken as TestToken
     callbackContract = contracts.callbackContractStub as CallbackContractStub
     callbackContract1 = contracts.callbackContractStub1 as CallbackContractStub
-    membersIDs = signers.map((member) => member.id)
   })
 
   describe("requestRelayEntry", () => {
@@ -110,7 +108,7 @@ describe("RandomBeacon - Callback", () => {
 
         await randomBeacon
           .connect(submitter)
-          .submitRelayEntry(blsData.groupSignature, membersIDs)
+          ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
         await approveTestToken()
 
@@ -131,7 +129,7 @@ describe("RandomBeacon - Callback", () => {
 
         await randomBeacon
           .connect(submitter)
-          .submitRelayEntry(blsData.groupSignature, membersIDs)
+          ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
         await approveTestToken()
 
@@ -171,7 +169,7 @@ describe("RandomBeacon - Callback", () => {
 
           await randomBeacon
             .connect(submitter)
-            .submitRelayEntry(blsData.groupSignature, membersIDs)
+            ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
           const lastEntry = await callbackContract.lastEntry()
           await expect(lastEntry).to.equal(blsData.groupSignatureUint256)
@@ -201,7 +199,7 @@ describe("RandomBeacon - Callback", () => {
 
           const tx = await randomBeacon
             .connect(submitter)
-            .submitRelayEntry(blsData.groupSignature, membersIDs)
+            ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
           await expect(tx)
             .to.emit(randomBeacon, "CallbackFailed")
@@ -221,7 +219,7 @@ describe("RandomBeacon - Callback", () => {
 
           const tx = await randomBeacon
             .connect(submitter)
-            .submitRelayEntry(blsData.groupSignature, membersIDs)
+            ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
           await expect(tx)
             .to.emit(randomBeacon, "CallbackFailed")

--- a/solidity/random-beacon/test/system/e2e.test.ts
+++ b/solidity/random-beacon/test/system/e2e.test.ts
@@ -145,10 +145,7 @@ describe("System -- e2e", () => {
 
         const txSubmitRelayEntry = await randomBeacon
           .connect(dkgResult.submitter)
-          .submitRelayEntry(
-            blsData.groupSignatures[i - 1],
-            activeGroupMembers[signingGroupIds[i - 1]]
-          )
+          ["submitRelayEntry(bytes)"](blsData.groupSignatures[i - 1])
 
         // every 5th relay request triggers a new dkg
         if (i % groupCreationFrequency === 0) {


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-core/pull/2768

This PR implements a change described in the issue [2756](https://github.com/keep-network/keep-core/issues/2756), ie. split `submitRelayEntry` into two functions. First handles the happy path without any slashing (before the soft timeout is hit), and another one which handles slashing (after soft timeout is hit).

Implements:
> This can be even further optimized by exposing two versions of `submitRelayEntry` function: one that can be called only before the soft timeout, not requiring group member identifiers to be passed, and another that can be called at any time and requiring this additional parameter.

Another change is around the calculation of the slashing amount. There is no intention of changing the functionality, but rather refactoring for simplification.

Before (branch: `main`)
```
|  approveDkgResult     ·     185764  ·     247364  ·     206239  │
|  challengeDkgResult   ·     333425  ·    1175723  ·     977292  │
|  submitDkgResult      ·     340003  ·     637152  ·     544857  │
|  submitRelayEntry     ·     192481  ·     488134  ·     246530  │
```

Before (branch: `group-members-storage-optimization`):
```
|  approveDkgResult     ·     185742  ·     247342  ·     206217  │
|  challengeDkgResult   ·     333403  ·    1175701  ·     978441  │
|  submitDkgResult      ·     306979  ·     479157  ·     394890  │
|  submitRelayEntry     ·     214082  ·     495202  ·     266195  │
```

After:
```
|  approveDkgResult                ·     185764  ·     247364  ·     205453  │
|  challengeDkgResult              ·     333403  ·    1175701  ·     978581  │
|  submitDkgResult                 ·     306979  ·     479157  ·     395381  │
|  submitRelayEntry (no slashing)  ·     191316  ·     240943  ·     208197  │
|  submitRelayEntry (slashing)     ·     213726  ·     494962  ·     354344  │
```

Byte code
```
 |  RandomBeacon            ·     22.549  │
 |  RandomBeaconStub        ·     23.897  │
```