### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/contracts-v1.yml
+++ b/.github/workflows/contracts-v1.yml
@@ -114,6 +114,7 @@ jobs:
           node-version: "14.x"
           cache: "npm"
           cache-dependency-path: solidity-v1/package-lock.json
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -161,8 +162,9 @@ jobs:
           version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm publish --access=public --tag ${{ github.event.inputs.environment }}
 
       - name: Upload keep-core contracts for initcontainer build

--- a/.github/workflows/dashboard-v1-format.yaml
+++ b/.github/workflows/dashboard-v1-format.yaml
@@ -42,7 +42,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-          cache: 'npm'
+          cache: "npm"
+          cache-dependency-path: solidity-v1/dashboard/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/dashboard-v1-testnet.yml
+++ b/.github/workflows/dashboard-v1-testnet.yml
@@ -63,18 +63,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
-
-      - name: Cache Global NPM Cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-global-npm-cache
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
+          cache-dependency-path: solidity-v1/dashboard/package-lock.json
 
       - name: Resolve latest contracts
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/npm-v1.yml
+++ b/.github/workflows/npm-v1.yml
@@ -8,6 +8,7 @@ on:
       - 'solidity-v1/contracts/**'
       - 'solidity-v1/package.json'
       - 'solidity-v1/package-lock.json'
+  workflow_dispatch:
 
 jobs:
   npm-compile-publish-contracts:

--- a/.github/workflows/npm-v1.yml
+++ b/.github/workflows/npm-v1.yml
@@ -20,20 +20,10 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version: "14.x"
+          cache: "npm"
+          cache-dependency-path: solidity-v1/package-lock.json
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/submitter-testnet.yaml
+++ b/.github/workflows/submitter-testnet.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: solidity-v1/package-lock.json
 
       - run: npm ci
@@ -45,6 +45,3 @@ jobs:
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           WATCH_RELAY_ENTRY: true
         run: npx truffle exec ./scripts/request-relay-entry.js --network $TRUFFLE_NETWORK
-
-
-


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-ecdsa/pull/941
* https://github.com/keep-network/tbtc/pull/842
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/sortition-pools/pull/145
* https://github.com/keep-network/local-setup/pull/124
* https://github.com/keep-network/coverage-pools/pull/204
* https://github.com/keep-network/tbtc-v2/pull/88
* https://github.com/threshold-network/solidity-contracts/pull/59