### PR TITLE
Add `development` tag to the published npm package

### DIFF
--- a/.github/workflows/npm-v1.yml
+++ b/.github/workflows/npm-v1.yml
@@ -8,6 +8,7 @@ on:
       - 'solidity-v1/contracts/**'
       - 'solidity-v1/package.json'
       - 'solidity-v1/package-lock.json'
+      - '.github/workflows/npm-v1.yml'
   workflow_dispatch:
 
 jobs:
@@ -49,4 +50,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access=public --tag=development


### PR DESCRIPTION
This change adds an additional environment tag for packages published
during `Publish package` step. This adds a convenient reference to the
latest version of the `@keep-core/solidity-v1` package for development
environment. We also add a new condition for triggering `NPM v1`
workflow - from now on the workflow will be executed also after changes
to the workflow get merged to the `main` branch.