### PR TITLE
Passing members hash

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -575,11 +575,7 @@ contract RandomBeacon is Ownable {
     function submitDkgResult(DKG.Result calldata dkgResult) external {
         dkg.submitResult(dkgResult);
 
-        groups.addCandidateGroup(
-            dkgResult.groupPubKey,
-            dkgResult.members,
-            dkgResult.misbehavedMembersIndices
-        );
+        groups.addCandidateGroup(dkgResult.groupPubKey, dkgResult.membersHash);
     }
 
     /// @notice Notifies about DKG timeout. Pays the sortition pool unlocking
@@ -626,8 +622,12 @@ contract RandomBeacon is Ownable {
     /// @param dkgResult Result to challenge. Must match the submitted result
     ///        stored during `submitDkgResult`.
     function challengeDkgResult(DKG.Result calldata dkgResult) external {
+        bytes32 membersHash = groups
+            .getGroup(dkgResult.groupPubKey)
+            .membersHash;
+
         (bytes32 maliciousResultHash, uint32 maliciousSubmitter) = dkg
-            .challengeResult(dkgResult);
+            .challengeResult(dkgResult, membersHash);
 
         uint256 slashingAmount = maliciousDkgResultSlashingAmount;
         address maliciousSubmitterAddresses = sortitionPool.getIDOperator(

--- a/solidity/random-beacon/contracts/libraries/DKG.sol
+++ b/solidity/random-beacon/contracts/libraries/DKG.sol
@@ -82,6 +82,9 @@ library DKG {
         // Identifiers of candidate group members as outputted by the group
         // selection protocol.
         uint32[] members;
+        // Keccak256 hash of group members identifiers that actively took part
+        // in DKG (excluding IA/DQ members).
+        bytes32 membersHash;
     }
 
     /// @notice States for phases of group creation. The states doesn't include
@@ -391,9 +394,14 @@ library DKG {
     /// @dev Can be called during a challenge period for the submitted result.
     /// @param result Result to challenge. Must match the submitted result
     ///        stored during `submitResult`.
+    /// @param groupMembersHash Challenged group members hash.
     /// @return maliciousResultHash Hash of the malicious result.
     /// @return maliciousSubmitter Identifier of the malicious submitter.
-    function challengeResult(Data storage self, Result calldata result)
+    function challengeResult(
+        Data storage self,
+        Result calldata result,
+        bytes32 groupMembersHash
+    )
         external
         returns (bytes32 maliciousResultHash, uint32 maliciousSubmitter)
     {
@@ -417,7 +425,12 @@ library DKG {
         // https://github.com/crytic/slither/issues/982
         // slither-disable-next-line unused-return
         try
-            self.dkgValidator.validate(result, self.seed, self.startBlock)
+            self.dkgValidator.validate(
+                result,
+                self.seed,
+                self.startBlock,
+                groupMembersHash
+            )
         returns (
             // slither-disable-next-line uninitialized-local,variable-scope
             bool isValid,

--- a/solidity/random-beacon/contracts/test/GroupsStub.sol
+++ b/solidity/random-beacon/contracts/test/GroupsStub.sol
@@ -14,16 +14,10 @@ contract GroupsStub {
 
     event GroupActivated(uint64 indexed groupId, bytes indexed groupPubKey);
 
-    function addCandidateGroup(
-        bytes calldata groupPubKey,
-        uint32[] calldata members,
-        uint8[] calldata misbehavedMembersIndices
-    ) external {
-        groups.addCandidateGroup(
-            groupPubKey,
-            members,
-            misbehavedMembersIndices
-        );
+    function addCandidateGroup(bytes calldata groupPubKey, bytes32 membersHash)
+        external
+    {
+        groups.addCandidateGroup(groupPubKey, membersHash);
     }
 
     function popCandidateGroup() external {

--- a/solidity/random-beacon/test/DKGValidator.test.ts
+++ b/solidity/random-beacon/test/DKGValidator.test.ts
@@ -171,11 +171,12 @@ describe("DKGValidator", () => {
         })
         context("when misbehaved indices present in the middle", () => {
           it("should pass", async () => {
-            const misbehavedMemberIds = [22, 28, 46]
+            const misbehavedMemberIds = [22, 28, 46, 53]
             const expectedMembersIds = [...groupMemberIds]
             expectedMembersIds.splice(21, 1) // index -1
             expectedMembersIds.splice(26, 1) // index -2 (cause expectedMembers already shrinked)
             expectedMembersIds.splice(43, 1) // index -3
+            expectedMembersIds.splice(49, 1) // index -4
 
             const result = await testValidate(
               selectedOperators,

--- a/solidity/random-beacon/test/Groups.Expiration.test.ts
+++ b/solidity/random-beacon/test/Groups.Expiration.test.ts
@@ -3,7 +3,7 @@
 import { ethers, waffle, helpers } from "hardhat"
 import { expect } from "chai"
 import type { GroupsStub } from "../typechain"
-import { noMisbehaved } from "./utils/dkg"
+import { noMisbehaved, hashDKGMembers } from "./utils/dkg"
 
 const fixture = async () => {
   const GroupsStub = await ethers.getContractFactory("GroupsStub")
@@ -152,8 +152,7 @@ describe("Groups", () => {
 
         await groups.addCandidateGroup(
           ethers.utils.hexlify(6),
-          members,
-          noMisbehaved
+          hashDKGMembers(members, noMisbehaved)
         )
         await groups.activateCandidateGroup()
 
@@ -292,8 +291,7 @@ describe("Groups", () => {
     for (let i = firstGroup; i < firstGroup + numberOfGroups; i++) {
       await groups.addCandidateGroup(
         ethers.utils.hexlify(i),
-        members,
-        noMisbehaved
+        hashDKGMembers(members, noMisbehaved)
       )
       await groups.activateCandidateGroup()
     }

--- a/solidity/random-beacon/test/Groups.Termination.test.ts
+++ b/solidity/random-beacon/test/Groups.Termination.test.ts
@@ -3,7 +3,7 @@
 import { ethers, waffle, helpers } from "hardhat"
 import { expect } from "chai"
 import type { GroupsStub } from "../typechain"
-import { noMisbehaved } from "./utils/dkg"
+import { noMisbehaved, hashDKGMembers } from "./utils/dkg"
 
 const fixture = async () => {
   const GroupsStub = await ethers.getContractFactory("GroupsStub")
@@ -242,8 +242,7 @@ describe("Groups", () => {
       for (let i = start; i <= numberOfGroups; i++) {
         await groups.addCandidateGroup(
           ethers.utils.hexlify(i),
-          members,
-          noMisbehaved
+          hashDKGMembers(members, noMisbehaved)
         )
         await groups.activateCandidateGroup()
       }

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -21,6 +21,7 @@ import {
   DkgResult,
   noMisbehaved,
   signAndSubmitUnrecoverableDkgResult,
+  hashDKGMembers,
 } from "./utils/dkg"
 import { registerOperators, Operator } from "./utils/operators"
 import { selectGroup, hashUint32Array } from "./utils/groups"
@@ -1318,35 +1319,6 @@ describe("RandomBeacon - Group Creation", () => {
                 })
               }
             )
-
-            context(
-              "when misbehaved members are not in ascending order",
-              async () => {
-                const misbehavedIndices = [2, 9, 30, 11, 60, 64]
-
-                before(async () => {
-                  await createSnapshot()
-                })
-
-                after(async () => {
-                  await restoreSnapshot()
-                })
-
-                it("should revert", async () => {
-                  await expect(
-                    signAndSubmitCorrectDkgResult(
-                      randomBeacon,
-                      groupPublicKey,
-                      genesisSeed,
-                      startBlock,
-                      misbehavedIndices
-                    )
-                  ).to.be.revertedWith(
-                    "Array accessed at an out-of-bounds or negative index"
-                  )
-                })
-              }
-            )
           })
         })
       })
@@ -1450,6 +1422,7 @@ describe("RandomBeacon - Group Creation", () => {
       signatures: "0x01020304",
       signingMembersIndices: [1, 2, 3, 4],
       submitterMemberIndex: 1,
+      membersHash: hashDKGMembers([1, 2, 3, 4], []),
     }
 
     context("with initial contract state", async () => {
@@ -2164,6 +2137,7 @@ describe("RandomBeacon - Group Creation", () => {
       signatures: "0x01020304",
       signingMembersIndices: [1, 2, 3, 4],
       submitterMemberIndex: 1,
+      membersHash: hashDKGMembers([1, 2, 3, 4], []),
     }
 
     context("with initial contract state", async () => {

--- a/solidity/random-beacon/test/Utils.test.ts
+++ b/solidity/random-beacon/test/Utils.test.ts
@@ -1,0 +1,75 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+import { hashDKGMembers } from "./utils/dkg"
+
+describe("utils/dkg", () => {
+  context("hashDKGMembers", () => {
+    const members = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    context("when there are no misbehaved members", () => {
+      const misbehavedMembers = []
+      const expectedMembers = members
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+
+    context("when the first member id is a misbehaved one", () => {
+      // misbehaved member count starts from 1, not 0
+      const misbehavedMembers = [1]
+      // expectedMembers[misbehavedMembers - 1], hence removing "0"
+      const expectedMembers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+
+    context("when the last member id is a misbehaved", () => {
+      // misbehaved member count starts from 1, not 0
+      const misbehavedMembers = [10]
+      // expectedMembers[misbehavedMembers - 1], hence removing "9"
+      const expectedMembers = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+
+    context("when there are multiple misbehaved members", () => {
+      // misbehaved member count starts from 1, not 0
+      const misbehavedMembers = [2, 6, 8]
+      // expectedMembers[misbehavedMembers - 1], hence removing "1,5,7"
+      const expectedMembers = [0, 2, 3, 4, 6, 8, 9]
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+
+    context("when a misbehaved member is not present in members array", () => {
+      const misbehavedMembers = [42]
+      const expectedMembers = members
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+  })
+})

--- a/solidity/random-beacon/test/utils/dkg.test.ts
+++ b/solidity/random-beacon/test/utils/dkg.test.ts
@@ -1,12 +1,12 @@
 import { ethers } from "hardhat"
 import { expect } from "chai"
-import { hashDKGMembers } from "./utils/dkg"
+import { hashDKGMembers } from "./dkg"
 
-describe("utils/dkg", () => {
-  context("hashDKGMembers", () => {
-    const members = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+describe("hashDKGMembers", () => {
+  const members = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
 
-    context("when there are no misbehaved members", () => {
+  context("when there are no misbehaved members", () => {
+    it("should hash all the members", () => {
       const misbehavedMembers = []
       const expectedMembers = members
 
@@ -17,52 +17,14 @@ describe("utils/dkg", () => {
 
       expect(expectedHash).to.be.equal(actualHash)
     })
+  })
 
-    context("when the first member id is a misbehaved one", () => {
+  context("when the first member id is a misbehaved one", () => {
+    it("should hash all but the first member", () => {
       // misbehaved member count starts from 1, not 0
       const misbehavedMembers = [1]
       // expectedMembers[misbehavedMembers - 1], hence removing "0"
-      const expectedMembers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-      const actualHash = hashDKGMembers(members, misbehavedMembers)
-      const expectedHash = ethers.utils.keccak256(
-        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
-      )
-
-      expect(expectedHash).to.be.equal(actualHash)
-    })
-
-    context("when the last member id is a misbehaved", () => {
-      // misbehaved member count starts from 1, not 0
-      const misbehavedMembers = [10]
-      // expectedMembers[misbehavedMembers - 1], hence removing "9"
-      const expectedMembers = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-      const actualHash = hashDKGMembers(members, misbehavedMembers)
-      const expectedHash = ethers.utils.keccak256(
-        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
-      )
-
-      expect(expectedHash).to.be.equal(actualHash)
-    })
-
-    context("when there are multiple misbehaved members", () => {
-      // misbehaved member count starts from 1, not 0
-      const misbehavedMembers = [2, 6, 8]
-      // expectedMembers[misbehavedMembers - 1], hence removing "1,5,7"
-      const expectedMembers = [0, 2, 3, 4, 6, 8, 9]
-
-      const actualHash = hashDKGMembers(members, misbehavedMembers)
-      const expectedHash = ethers.utils.keccak256(
-        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
-      )
-
-      expect(expectedHash).to.be.equal(actualHash)
-    })
-
-    context("when a misbehaved member is not present in members array", () => {
-      const misbehavedMembers = [42]
-      const expectedMembers = members
+      const expectedMembers = [101, 102, 103, 104, 105, 106, 107, 108, 109]
 
       const actualHash = hashDKGMembers(members, misbehavedMembers)
       const expectedHash = ethers.utils.keccak256(
@@ -72,4 +34,53 @@ describe("utils/dkg", () => {
       expect(expectedHash).to.be.equal(actualHash)
     })
   })
+
+  context("when the last member id is a misbehaved", () => {
+    it("should hash all but the last member", () => {
+      // misbehaved member count starts from 1, not 0
+      const misbehavedMembers = [10]
+      // expectedMembers[misbehavedMembers - 1], hence removing "9"
+      const expectedMembers = [100, 101, 102, 103, 104, 105, 106, 107, 108]
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+  })
+
+  context("when there are multiple misbehaved members", () => {
+    it("should hash all but the mishbehaved members", () => {
+      // misbehaved member count starts from 1, not 0
+      const misbehavedMembers = [2, 6, 8]
+      // expectedMembers[misbehavedMembers - 1], hence removing "101,105,107"
+      const expectedMembers = [100, 102, 103, 104, 106, 108, 109]
+
+      const actualHash = hashDKGMembers(members, misbehavedMembers)
+      const expectedHash = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+      )
+
+      expect(expectedHash).to.be.equal(actualHash)
+    })
+  })
+
+  context(
+    "when a misbehaved member is not present in the members array",
+    () => {
+      it("should hash all the members", () => {
+        const misbehavedMembers = [0, 42]
+        const expectedMembers = members
+
+        const actualHash = hashDKGMembers(members, misbehavedMembers)
+        const expectedHash = ethers.utils.keccak256(
+          ethers.utils.defaultAbiCoder.encode(["uint32[]"], [expectedMembers])
+        )
+
+        expect(expectedHash).to.be.equal(actualHash)
+      })
+    }
+  )
 })

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -269,7 +269,7 @@ export async function signDkgResult(
 export function hashDKGMembers(
   members: number[],
   misbehavedMembersIndices: number[]
-) {
+): string {
   if (misbehavedMembersIndices.length > 0) {
     const activeDkgMembers = [...members]
     for (let i = 0; i < misbehavedMembersIndices.length; i++) {

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -273,7 +273,9 @@ export function hashDKGMembers(
   if (misbehavedMembersIndices.length > 0) {
     const activeDkgMembers = [...members]
     for (let i = 0; i < misbehavedMembersIndices.length; i++) {
-      activeDkgMembers.splice(misbehavedMembersIndices[i] - i - 1, 1)
+      if (misbehavedMembersIndices[i] !== 0) {
+        activeDkgMembers.splice(misbehavedMembersIndices[i] - i - 1, 1)
+      }
     }
 
     return ethers.utils.keccak256(

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -115,12 +115,9 @@ export async function signAndSubmitArbitraryDkgResult(
     // eslint-disable-next-line no-param-reassign
     submitterIndex = firstEligibleIndex(ethers.utils.keccak256(groupPublicKey))
   }
-
-  let membersHash: string
-  if (!groupMembersHash) {
+  let membersHash = groupMembersHash
+  if (!membersHash) {
     membersHash = hashDKGMembers(members, misbehavedIndices)
-  } else {
-    membersHash = groupMembersHash
   }
 
   const dkgResult: DkgResult = {

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -49,6 +49,7 @@ export async function signAndSubmitCorrectDkgResult(
   startBlock: number,
   misbehavedIndices: number[],
   submitterIndex?: number,
+  membersHash?: string,
   numberOfSignatures = 33
 ): Promise<{
   transaction: ContractTransaction
@@ -77,6 +78,7 @@ export async function signAndSubmitCorrectDkgResult(
     startBlock,
     misbehavedIndices,
     submitterIndex,
+    membersHash,
     numberOfSignatures
   )
 }
@@ -91,6 +93,7 @@ export async function signAndSubmitArbitraryDkgResult(
   startBlock: number,
   misbehavedIndices: number[],
   submitterIndex?: number,
+  groupMembersHash?: string,
   numberOfSignatures = 33
 ): Promise<{
   transaction: ContractTransaction
@@ -113,7 +116,12 @@ export async function signAndSubmitArbitraryDkgResult(
     submitterIndex = firstEligibleIndex(ethers.utils.keccak256(groupPublicKey))
   }
 
-  const membersHash = hashDKGMembers(members, misbehavedIndices)
+  let membersHash: string
+  if (!groupMembersHash) {
+    membersHash = hashDKGMembers(members, misbehavedIndices)
+  } else {
+    membersHash = groupMembersHash
+  }
 
   const dkgResult: DkgResult = {
     submitterMemberIndex: submitterIndex,


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2756

A hash of group members that actively took part in DKG can be calculated off-chain and passed to the contract's `submitDKGResult()`. This way we skip filtration of the misbehaved members. However, this change requires additional validation during the DKG challenge phase to verify that hash. The reasoning is that the dkg challenge will be done less frequently compared to dkg result submission which overall should save gas. 

## 64 members

### Branch `main`:
```
|  approveDkgResult                ·     185804  ·     247404  ·     205493  │
|  challengeDkgResult              ·     333403  ·    1175701  ·     978235  │
|  submitDkgResult                 ·     306979  ·     479157  ·     395381  │
|  submitRelayEntry (no slashing)  ·     192118  ·     241745  ·     208999  │
|  submitRelayEntry (slashing)     ·     214170  ·     495263  ·     354717  │
```

Bytecode:
```
 |  RandomBeacon            ·     22.507  │
 |  RandomBeaconStub        ·     23.855  │
```

### Current branch `passing-members-hash`:
```
|  approveDkgResult                ·     186422  ·     247907  ·     206113   │
|  challengeDkgResult              ·     336904  ·    1180374  ·     982299   │
|  submitDkgResult                 ·     297301  ·     421691  ·     383470   │
|  submitRelayEntry (no slashing)  ·     192140  ·     241767  ·     209021   |
|  submitRelayEntry (slashing)     ·     214192  ·     495285  ·     354739   │
```

Bytecode:
```
 |  RandomBeacon            ·     22.117  │
 |  RandomBeaconStub        ·     23.465  │
```

### Diff in gas (min-max-avg):
```
|  challengeDkgResult              ·            ·    +60273   ·             │
|  submitDkgResult                 ·     -9678  ·    -57466   ·     -11911  │
```

## 100 members

### Diff max in gas: current branch vs. main (min-max-avg):
```
|  challengeDkgResult: +84500   │ more costly for challengeDkgResult()
|  submitDkgResult:    -90442   | less costly for submitDkgResult()
```