### PR TITLE
Gas-optimized version of submitRelayEntry when soft timeout has not passed

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -715,6 +715,28 @@ contract RandomBeacon is Ownable {
         }
     }
 
+    /// @notice Creates a new relay entry. Gas-optimized version that can be
+    ///         called only before the soft timeout. This should be the majority
+    ///         of cases.
+    /// @param entry Group BLS signature over the previous entry.
+    function submitRelayEntry2(bytes calldata entry) external {
+        // TODO: rename to just `submitRelayEntry`; it's a temporary workaround
+        // to avoid problems with overloaded functions in unit tests
+        Groups.Group storage group = groups.getGroup(
+            relay.currentRequestGroupID
+        );
+
+        relay.submitEntryBeforeSoftTimeout(entry, group.groupPubKey);
+
+        // If DKG is awaiting a seed, that means the we should start the actual
+        // group creation process.
+        if (dkg.currentState() == DKG.State.AWAITING_SEED) {
+            dkg.start(uint256(keccak256(entry)));
+        }
+
+        callback.executeCallback(uint256(keccak256(entry)), callbackGasLimit);
+    }
+
     /// @notice Creates a new relay entry.
     /// @param entry Group BLS signature over the previous entry.
     /// @param groupMembers Group member ids that participated in dkg (excluding IA/DQ).

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -719,9 +719,7 @@ contract RandomBeacon is Ownable {
     ///         called only before the soft timeout. This should be the majority
     ///         of cases.
     /// @param entry Group BLS signature over the previous entry.
-    function submitRelayEntry2(bytes calldata entry) external {
-        // TODO: rename to just `submitRelayEntry`; it's a temporary workaround
-        // to avoid problems with overloaded functions in unit tests
+    function submitRelayEntry(bytes calldata entry) external {
         Groups.Group storage group = groups.getGroup(
             relay.currentRequestGroupID
         );

--- a/solidity/random-beacon/contracts/libraries/Relay.sol
+++ b/solidity/random-beacon/contracts/libraries/Relay.sol
@@ -110,7 +110,6 @@ library Relay {
         );
     }
 
-
     /// @notice Creates a new relay entry. Gas-optimized version that can be
     ///         called only before the soft timeout. This should be the majority
     ///         of cases.

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -57,9 +57,8 @@ contract RandomBeaconStub is RandomBeacon {
 
     function isGroupTerminated(uint64 groupId) external view returns (bool) {
         bytes32 groupPubKeyHash = groups.groupsRegistry[groupId];
-        Groups.Group memory group = groups.groupsData[groupPubKeyHash];
 
-        return group.terminated;
+        return groups.groupsData[groupPubKeyHash].terminated;
     }
 
     function publicDkgLockState() external {

--- a/solidity/random-beacon/contracts/test/RelayStub.sol
+++ b/solidity/random-beacon/contracts/test/RelayStub.sol
@@ -18,11 +18,7 @@ contract RelayStub {
         relay.currentRequestStartBlock = uint64(block.number);
     }
 
-    function getSlashingFactor()
-        external
-        view
-        returns (uint256)
-    {
+    function getSlashingFactor() external view returns (uint256) {
         return relay.getSlashingFactor();
     }
 }

--- a/solidity/random-beacon/contracts/test/RelayStub.sol
+++ b/solidity/random-beacon/contracts/test/RelayStub.sol
@@ -18,11 +18,11 @@ contract RelayStub {
         relay.currentRequestStartBlock = uint64(block.number);
     }
 
-    function getSlashingFactor(uint256 groupSize)
+    function getSlashingFactor()
         external
         view
         returns (uint256)
     {
-        return relay.getSlashingFactor(groupSize);
+        return relay.getSlashingFactor();
     }
 }

--- a/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
@@ -54,7 +54,6 @@ describe("RandomBeacon - Callback", () => {
   let testToken: TestToken
   let callbackContract: CallbackContractStub
   let callbackContract1: CallbackContractStub
-  let membersIDs: OperatorID[]
 
   before(async () => {
     requester = await ethers.getSigner((await getUnnamedAccounts())[1])
@@ -68,7 +67,6 @@ describe("RandomBeacon - Callback", () => {
     testToken = contracts.testToken as TestToken
     callbackContract = contracts.callbackContractStub as CallbackContractStub
     callbackContract1 = contracts.callbackContractStub1 as CallbackContractStub
-    membersIDs = signers.map((member) => member.id)
   })
 
   describe("requestRelayEntry", () => {
@@ -108,7 +106,7 @@ describe("RandomBeacon - Callback", () => {
 
         await randomBeacon
           .connect(submitter)
-          .submitRelayEntry(blsData.groupSignature, membersIDs)
+          ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
         await approveTestToken()
 
@@ -129,7 +127,7 @@ describe("RandomBeacon - Callback", () => {
 
         await randomBeacon
           .connect(submitter)
-          .submitRelayEntry(blsData.groupSignature, membersIDs)
+          ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
         await approveTestToken()
 
@@ -169,7 +167,7 @@ describe("RandomBeacon - Callback", () => {
 
           await randomBeacon
             .connect(submitter)
-            .submitRelayEntry(blsData.groupSignature, membersIDs)
+            ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
           const lastEntry = await callbackContract.lastEntry()
           await expect(lastEntry).to.equal(blsData.groupSignatureUint256)
@@ -199,7 +197,7 @@ describe("RandomBeacon - Callback", () => {
 
           const tx = await randomBeacon
             .connect(submitter)
-            .submitRelayEntry(blsData.groupSignature, membersIDs)
+            ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
           await expect(tx)
             .to.emit(randomBeacon, "CallbackFailed")
@@ -219,7 +217,7 @@ describe("RandomBeacon - Callback", () => {
 
           const tx = await randomBeacon
             .connect(submitter)
-            .submitRelayEntry(blsData.groupSignature, membersIDs)
+            ["submitRelayEntry(bytes)"](blsData.groupSignature)
 
           await expect(tx)
             .to.emit(randomBeacon, "CallbackFailed")

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -277,7 +277,7 @@ describe("RandomBeacon - Relay", () => {
     })
   })
 
-  describe("submitRelayEntry happy path", () => {
+  describe("submitRelayEntry before the soft timeout - happy path", () => {
     before(async () => {
       await createSnapshot()
 
@@ -393,7 +393,7 @@ describe("RandomBeacon - Relay", () => {
     })
   })
 
-  describe("submitRelayEntry after the soft timeout", () => {
+  describe("submitRelayEntry before and after the soft timeout", () => {
     before(async () => {
       await createSnapshot()
 

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -277,7 +277,7 @@ describe("RandomBeacon - Relay", () => {
     })
   })
 
-  describe("submitRelayEntry before the soft timeout - happy path", () => {
+  describe("submitRelayEntry(bytes)", () => {
     before(async () => {
       await createSnapshot()
 
@@ -393,7 +393,7 @@ describe("RandomBeacon - Relay", () => {
     })
   })
 
-  describe("submitRelayEntry before and after the soft timeout", () => {
+  describe("submitRelayEntry(bytes,uint32[])", () => {
     before(async () => {
       await createSnapshot()
 

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -309,7 +309,7 @@ describe("RandomBeacon - Relay", () => {
 
               tx = await randomBeacon
                 .connect(submitter)
-                .submitRelayEntry(blsData.groupSignature, membersIDs)
+                .submitRelayEntry2(blsData.groupSignature)
             })
 
             after(async () => {
@@ -837,7 +837,7 @@ describe("RandomBeacon - Relay", () => {
           testGroupSize * params.relayEntrySubmissionEligibilityDelay
         )
 
-        expect(await relayStub.getSlashingFactor(testGroupSize)).to.be.equal(0)
+        expect(await relayStub.getSlashingFactor()).to.be.equal(0)
       })
     })
 
@@ -851,7 +851,7 @@ describe("RandomBeacon - Relay", () => {
         // `submissionDelay` factor. If so we can calculate the slashing factor
         // as `(submissionDelay * 1e18) / relayEntryHardTimeout` which
         // gives `1 * 1e18 / 100 = 10000000000000000` (1%).
-        expect(await relayStub.getSlashingFactor(testGroupSize)).to.be.equal(
+        expect(await relayStub.getSlashingFactor()).to.be.equal(
           BigNumber.from("10000000000000000")
         )
       })
@@ -870,7 +870,7 @@ describe("RandomBeacon - Relay", () => {
           // `submissionDelay` factor. If so we can calculate the slashing
           // factor as `(submissionDelay * 1e18) / relayEntryHardTimeout` which
           // gives `100 * 1e18 / 100 = 1000000000000000000` (100%).
-          expect(await relayStub.getSlashingFactor(testGroupSize)).to.be.equal(
+          expect(await relayStub.getSlashingFactor()).to.be.equal(
             BigNumber.from("1000000000000000000")
           )
         })
@@ -890,7 +890,7 @@ describe("RandomBeacon - Relay", () => {
           // We are exceeded the soft timeout by a value bigger than the
           // hard timeout. In that case the maximum value (100%) of the slashing
           // factor should be returned.
-          expect(await relayStub.getSlashingFactor(testGroupSize)).to.be.equal(
+          expect(await relayStub.getSlashingFactor()).to.be.equal(
             BigNumber.from("1000000000000000000")
           )
         })

--- a/solidity/random-beacon/test/system/e2e.test.ts
+++ b/solidity/random-beacon/test/system/e2e.test.ts
@@ -145,10 +145,7 @@ describe("System -- e2e", () => {
 
         const txSubmitRelayEntry = await randomBeacon
           .connect(dkgResult.submitter)
-          .submitRelayEntry(
-            blsData.groupSignatures[i - 1],
-            groupMembers[signingGroupIds[i - 1]]
-          )
+          ["submitRelayEntry(bytes)"](blsData.groupSignatures[i - 1])
 
         // every 5th relay request triggers a new dkg
         if (i % groupCreationFrequency === 0) {


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-core/pull/2768

# Background

In case the soft timeout has not passed yet, there is no point to calculate
the slashing factor in `submitRelayEntry`. Also, because there is no slashing,
passing group members is not necessary and computing group members hash
to compare it with the value stored in groups registry is not necessary.

# Details

This is a competing approach to the one in #2772 aiming at making minimal
changes to the codebase. It's up to @nkuba and @dimpar to decide with
which approach we want to continue.


Gas usage is pretty much the same but the contract has a little bit less bytecode
in this version:

In #2772:
```
 |  RandomBeacon            ·     (was: 22.630) now 22.549  │
 ···························|··············
 |  RandomBeaconStub        ·     (was: 24.180) now 23.897  │
```

Here:
```
 |  RandomBeacon            ·     22.406  │
 ···························|··············
 |  RandomBeaconStub        ·     23.956  │
```

This will be important for changes in https://github.com/keep-network/keep-core/issues/2715 where we will need to add more code
to `RandomBeacon` contract.

Worth noting, with two versions of `submitEntry` we can go even lower by making
the slasheable version `public` and linking the contract as external. Skipping it
until it is really needed to do not complicate the deployment:

```
 |  RandomBeacon            ·     22.331  │
 ···························|··············
 |  RandomBeaconStub        ·     23.881  │
```

# Outstanding work

This changeset is still a draft. The list of things that still need to be done include:
- [x] fixing tests for delay factor calculations,
- [x] adding more tests for the new `submitRelayEntry2` function,
- [x] renaming `submitRelayEntry2` to just `submitRelayEntry` and dealing with
  overloaded calls in unit tests.