### PR TITLE
Bump docker image version to v1.16.1

### DIFF
--- a/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
+++ b/infrastructure/kube/keep-prd/keep-dapp-token-dashboard-deployment.yaml
@@ -21,6 +21,6 @@ spec:
     spec:
       containers:
       - name: keep-dapp-token-dashboard
-        image: keepnetwork/token-dashboard:v1.16.0
+        image: keepnetwork/token-dashboard:v1.16.1
         ports:
           - containerPort: 80


### PR DESCRIPTION
Bump docker image version from 1.16.0 to 1.16.1

ref: https://github.com/keep-network/keep-core/pull/2782