### PR TITLE
Migration and staking bugfixes 🐛 ❌ 

### DIFF
--- a/solidity-v1/dashboard/package-lock.json
+++ b/solidity-v1/dashboard/package-lock.json
@@ -32032,6 +32032,22 @@
         }
       }
     },
+    "react-tooltip": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
+      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/solidity-v1/dashboard/package.json
+++ b/solidity-v1/dashboard/package.json
@@ -30,6 +30,7 @@
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.1",
+    "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.3.0",
     "recharts": "^1.8.5",
     "redux": "^4.0.5",

--- a/solidity-v1/dashboard/src/components/Chip.jsx
+++ b/solidity-v1/dashboard/src/components/Chip.jsx
@@ -6,12 +6,14 @@ const Chip = ({
   size = "small",
   color = "emphasis",
   className = "",
+  style = {},
 }) => {
   return (
     <span
       className={`chip chip--${color} chip--${
         icon ? "icon" : size
       } ${className}`}
+      style={style}
     >
       {icon ? icon : text}
     </span>

--- a/solidity-v1/dashboard/src/components/DataTable.jsx
+++ b/solidity-v1/dashboard/src/components/DataTable.jsx
@@ -27,7 +27,7 @@ export class DataTable extends React.Component {
   }
 
   renderItemRow = (item, index) => {
-    const { itemFieldId } = this.props
+    const { itemFieldId, centered } = this.props
     return (
       <tr key={`${item[itemFieldId]}-${index}`}>
         {React.Children.map(this.props.children, (column, index) => {
@@ -36,7 +36,11 @@ export class DataTable extends React.Component {
           } = column
           const cellKey = `${item[itemFieldId]}-${field}-${item[field]}-${index}`
           return (
-            <td key={cellKey} className={column.props.tdClassName}>
+            <td
+              key={cellKey}
+              className={column.props.tdClassName}
+              style={{ verticalAlign: centered ? "middle" : "baseline" }}
+            >
               <span className="responsive-header">{column.props.header}</span>
               {this.renderColumnContent(column, item)}
             </td>

--- a/solidity-v1/dashboard/src/components/DelegatedTokensTable.jsx
+++ b/solidity-v1/dashboard/src/components/DelegatedTokensTable.jsx
@@ -10,6 +10,7 @@ import Tile from "./Tile"
 import { SubmitButton } from "./Button"
 import { connect } from "react-redux"
 import web3Utils from "web3-utils"
+import useUpdateInitializedDelegations from "../hooks/useUpdateInitializedDelegations"
 
 const DelegatedTokensTable = ({
   delegatedTokens,
@@ -19,6 +20,7 @@ const DelegatedTokensTable = ({
   addKeep,
   undelegationPeriod,
 }) => {
+  useUpdateInitializedDelegations(delegatedTokens)
   const getAvailableToStakeFromGrant = useCallback(
     (grantId) => {
       const grant = grants.find(({ id }) => id === grantId)

--- a/solidity-v1/dashboard/src/components/DelegatedTokensTable.jsx
+++ b/solidity-v1/dashboard/src/components/DelegatedTokensTable.jsx
@@ -11,6 +11,7 @@ import { SubmitButton } from "./Button"
 import { connect } from "react-redux"
 import web3Utils from "web3-utils"
 import useUpdateInitializedDelegations from "../hooks/useUpdateInitializedDelegations"
+import Chip from "./Chip"
 
 const DelegatedTokensTable = ({
   delegatedTokens,
@@ -60,13 +61,30 @@ const DelegatedTokensTable = ({
         data={delegatedTokens}
         itemFieldId="operatorAddress"
         noDataMessage="No delegated tokens."
+        centered
       >
         <Column
           header="amount"
           field="amount"
-          renderContent={({ amount }) =>
-            `${KEEP.displayAmountWithSymbol(amount)}`
-          }
+          renderContent={({ amount, isFromGrant }) => {
+            return (
+              <>
+                <div>{KEEP.displayAmountWithSymbol(amount)}</div>
+                <div className={"text-grey-50"} style={{ fontSize: "14px" }}>
+                  {isFromGrant ? "Grant Tokens" : "Wallet Tokens"}
+                  <Chip
+                    text={"BONDED"}
+                    size="tiny"
+                    color="primary"
+                    style={{
+                      marginLeft: "0.6rem",
+                      padding: "0.3rem 0.4rem",
+                    }}
+                  />
+                </div>
+              </>
+            )
+          }}
         />
         <Column
           header="status"
@@ -83,12 +101,17 @@ const DelegatedTokensTable = ({
                 : formatDate(delegation.initializationOverAt)
 
             return (
-              <StatusBadge
-                status={BADGE_STATUS[delegationStatus]}
-                className="self-start"
-                text={statusBadgeText}
-                onlyIcon={delegationStatus === COMPLETE_STATUS}
-              />
+              <>
+                <StatusBadge
+                  status={BADGE_STATUS[delegationStatus]}
+                  className="self-start"
+                  text={statusBadgeText}
+                  onlyIcon={delegationStatus === COMPLETE_STATUS}
+                />
+                <div className={"text-grey-50"} style={{ fontSize: "14px" }}>
+                  {delegation.initializationOverAt.format("HH:mm:ss")}
+                </div>
+              </>
             )
           }}
         />

--- a/solidity-v1/dashboard/src/components/DelegatedTokensTable.jsx
+++ b/solidity-v1/dashboard/src/components/DelegatedTokensTable.jsx
@@ -11,7 +11,6 @@ import { SubmitButton } from "./Button"
 import { connect } from "react-redux"
 import web3Utils from "web3-utils"
 import useUpdateInitializedDelegations from "../hooks/useUpdateInitializedDelegations"
-import Chip from "./Chip"
 
 const DelegatedTokensTable = ({
   delegatedTokens,
@@ -72,15 +71,6 @@ const DelegatedTokensTable = ({
                 <div>{KEEP.displayAmountWithSymbol(amount)}</div>
                 <div className={"text-grey-50"} style={{ fontSize: "14px" }}>
                   {isFromGrant ? "Grant Tokens" : "Wallet Tokens"}
-                  <Chip
-                    text={"BONDED"}
-                    size="tiny"
-                    color="primary"
-                    style={{
-                      marginLeft: "0.6rem",
-                      padding: "0.3rem 0.4rem",
-                    }}
-                  />
                 </div>
               </>
             )

--- a/solidity-v1/dashboard/src/components/ProgressBar.jsx
+++ b/solidity-v1/dashboard/src/components/ProgressBar.jsx
@@ -4,6 +4,7 @@ import CircularProgressBar from "./CircularProgressBar"
 import { percentageOf, sub, lt } from "../utils/arithmetics.utils"
 import { formatValue } from "../utils/general.utils"
 import { colors } from "../constants/colors"
+import ReactTooltip from "react-tooltip"
 
 const defaultValue = 0
 const totalDefaultValue = 1
@@ -57,12 +58,38 @@ const ProgressBarInline = ({
   )
 }
 
-const ProgressBarInlineItem = ({ value = "0", color = colors.secondary }) => {
+const ProgressBarInlineItem = ({
+  value = "0",
+  color = colors.secondary,
+  label = "progress-bar-inline-item",
+  withTooltip = false,
+  renderTooltip = null,
+}) => {
   const { total } = useProgressBarContext()
 
   const barWidth = useMemo(() => calculateWidth(value, total), [value, total])
 
-  return (
+  const tooltipId = useMemo(
+    () => label.replace(/\s+/g, "-").toLowerCase(),
+    [label]
+  )
+
+  return withTooltip ? (
+    <>
+      <div
+        className={"progress-bar"}
+        style={{
+          width: `${barWidth}%`,
+          backgroundColor: color,
+        }}
+        data-tip
+        data-for={tooltipId}
+      />
+      <ReactTooltip id={tooltipId} effect="solid">
+        {renderTooltip ? renderTooltip : value}
+      </ReactTooltip>
+    </>
+  ) : (
     <div
       className={"progress-bar"}
       style={{

--- a/solidity-v1/dashboard/src/components/ResourceTooltip.jsx
+++ b/solidity-v1/dashboard/src/components/ResourceTooltip.jsx
@@ -38,12 +38,7 @@ const ResourceTooltip = ({
   return (
     <Tooltip
       className={tooltipClassName}
-      triggerComponent={() => (
-        <Icons.Tooltip
-          color={iconColor}
-          backgroundColor={iconBackgroundColor}
-        />
-      )}
+      triggerComponent={() => <Icons.MoreInfo className={"resource-tooltip"} />}
     >
       <ResourceTooltipContent {...restProps} />
     </Tooltip>

--- a/solidity-v1/dashboard/src/components/Tooltip.jsx
+++ b/solidity-v1/dashboard/src/components/Tooltip.jsx
@@ -107,14 +107,8 @@ const Tooltip = ({
 
 Tooltip.Divider = () => <hr className="tooltip__divider" />
 
-Tooltip.Header = ({
-  icon: IconComponent,
-  text,
-  className = "",
-  iconProps = {},
-}) => (
+Tooltip.Header = ({ text, className = "" }) => (
   <div className={`tooltip__header ${className}`}>
-    <IconComponent className="tooltip__header__icon" {...iconProps} />
     <div className="tooltip__header__title">{text}</div>
   </div>
 )

--- a/solidity-v1/dashboard/src/components/Undelegations.jsx
+++ b/solidity-v1/dashboard/src/components/Undelegations.jsx
@@ -9,7 +9,6 @@ import { DataTable, Column } from "./DataTable"
 import Tile from "./Tile"
 import resourceTooltipProps from "../constants/tooltips"
 import useUpdatePendingUndelegations from "../hooks/useUpdatePendingUndelegations"
-import Chip from "./Chip"
 
 const Undelegations = ({ undelegations, title }) => {
   useUpdatePendingUndelegations(undelegations)
@@ -34,15 +33,6 @@ const Undelegations = ({ undelegations, title }) => {
                 <div>{KEEP.displayAmountWithSymbol(amount)}</div>
                 <div className={"text-grey-50"} style={{ fontSize: "14px" }}>
                   {isFromGrant ? "Grant Tokens" : "Wallet Tokens"}
-                  <Chip
-                    text={"BONDED"}
-                    size="tiny"
-                    color="primary"
-                    style={{
-                      marginLeft: "0.6rem",
-                      padding: "0.3rem 0.4rem",
-                    }}
-                  />
                 </div>
               </>
             )

--- a/solidity-v1/dashboard/src/components/Undelegations.jsx
+++ b/solidity-v1/dashboard/src/components/Undelegations.jsx
@@ -8,8 +8,11 @@ import { PENDING_STATUS, COMPLETE_STATUS } from "../constants/constants"
 import { DataTable, Column } from "./DataTable"
 import Tile from "./Tile"
 import resourceTooltipProps from "../constants/tooltips"
+import useUpdatePendingUndelegations from "../hooks/useUpdatePendingUndelegations"
 
 const Undelegations = ({ undelegations, title }) => {
+  useUpdatePendingUndelegations(undelegations)
+
   return (
     <Tile>
       <DataTable

--- a/solidity-v1/dashboard/src/components/Undelegations.jsx
+++ b/solidity-v1/dashboard/src/components/Undelegations.jsx
@@ -20,7 +20,7 @@ const Undelegations = ({ undelegations, title }) => {
         itemFieldId="operatorAddress"
         title="Undelegations"
         withTooltip={true}
-        tooltipProps={resourceTooltipProps.recoverTokens}
+        tooltipProps={resourceTooltipProps.claimTokensFromUndelegation}
         noDataMessage="No undelegated tokens."
       >
         <Column

--- a/solidity-v1/dashboard/src/components/Undelegations.jsx
+++ b/solidity-v1/dashboard/src/components/Undelegations.jsx
@@ -9,6 +9,7 @@ import { DataTable, Column } from "./DataTable"
 import Tile from "./Tile"
 import resourceTooltipProps from "../constants/tooltips"
 import useUpdatePendingUndelegations from "../hooks/useUpdatePendingUndelegations"
+import Chip from "./Chip"
 
 const Undelegations = ({ undelegations, title }) => {
   useUpdatePendingUndelegations(undelegations)
@@ -22,13 +23,30 @@ const Undelegations = ({ undelegations, title }) => {
         withTooltip={true}
         tooltipProps={resourceTooltipProps.claimTokensFromUndelegation}
         noDataMessage="No undelegated tokens."
+        centered
       >
         <Column
           header="amount"
           field="amount"
-          renderContent={({ amount }) =>
-            `${KEEP.displayAmountWithSymbol(amount)}`
-          }
+          renderContent={({ amount, isFromGrant }) => {
+            return (
+              <>
+                <div>{KEEP.displayAmountWithSymbol(amount)}</div>
+                <div className={"text-grey-50"} style={{ fontSize: "14px" }}>
+                  {isFromGrant ? "Grant Tokens" : "Wallet Tokens"}
+                  <Chip
+                    text={"BONDED"}
+                    size="tiny"
+                    color="primary"
+                    style={{
+                      marginLeft: "0.6rem",
+                      padding: "0.3rem 0.4rem",
+                    }}
+                  />
+                </div>
+              </>
+            )
+          }}
         />
         <Column
           header="status"
@@ -45,12 +63,17 @@ const Undelegations = ({ undelegations, title }) => {
                 : formatDate(undelegation.undelegationCompleteAt)
 
             return (
-              <StatusBadge
-                status={BADGE_STATUS[undelegationStatus]}
-                className="self-start"
-                text={statusBadgeText}
-                onlyIcon={undelegationStatus === COMPLETE_STATUS}
-              />
+              <>
+                <StatusBadge
+                  status={BADGE_STATUS[undelegationStatus]}
+                  className="self-start"
+                  text={statusBadgeText}
+                  onlyIcon={undelegationStatus === COMPLETE_STATUS}
+                />
+                <div className={"text-grey-50"} style={{ fontSize: "14px" }}>
+                  {undelegation.undelegationCompleteAt.format("HH:mm:ss")}
+                </div>
+              </>
             )
           }}
         />

--- a/solidity-v1/dashboard/src/components/UpgradeToTButton.jsx
+++ b/solidity-v1/dashboard/src/components/UpgradeToTButton.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { LINK } from "../constants/constants"
+
+const UpgradeToTButton = ({ className }) => {
+  return (
+    <a
+      href={LINK.thresholdDapp}
+      rel="noopener noreferrer"
+      target="_blank"
+      className={`btn ${className}`}
+    >
+      upgrade to t ↗
+    </a>
+  )
+}
+
+export default UpgradeToTButton

--- a/solidity-v1/dashboard/src/components/coverage-pools/MetricsSection.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/MetricsSection.jsx
@@ -22,8 +22,8 @@ const MetricsSection = ({
   return (
     <section className={`tile coverage-pool__metrics ${classes.root || ""}`}>
       <section className={`metrics__tvl ${classes.tvl || ""}`}>
-        <h2 className="h2--alt text-grey-70 mb-1">
-          Total Value Locked
+        <div className="mb-1 flex row center">
+          <h2 className={"h2--alt text-grey-70"}>Total Value Locked</h2>
           <ResourceTooltip
             tooltipClassName="ml-1"
             title="Total Value Locked"
@@ -31,7 +31,7 @@ const MetricsSection = ({
             redirectLink="/coverage-pools/how-it-works"
             linkText="How it Works"
           />
-        </h2>
+        </div>
         <TokenAmount
           amount={tvl}
           amountClassName="h1 text-mint-100"

--- a/solidity-v1/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
+++ b/solidity-v1/dashboard/src/components/coverage-pools/PendingWithdrawals.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { reinitiateWithdraw } from "../../actions/coverage-pool"
 import { useDispatch, useSelector } from "react-redux"
 import { useModal } from "../../hooks/useModal"
@@ -21,6 +21,7 @@ import {
   MODAL_TYPES,
 } from "../../constants/constants"
 import AddToCalendar from "../AddToCalendar"
+import useCurrentDate from "../../hooks/useCurrentDate"
 
 const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
   const dispatch = useDispatch()
@@ -35,16 +36,7 @@ const PendingWithdrawals = ({ covTokensAvailableToWithdraw }) => {
     pendingWithdrawal,
     withdrawalInitiatedTimestamp,
   } = useSelector((state) => state.coveragePool)
-  const [currentDateInUnix, setCurrentDateInUnix] = useState(moment().unix())
-
-  useEffect(() => {
-    const myInterval = setInterval(() => {
-      setCurrentDateInUnix(moment().unix())
-    }, 1000)
-    return () => {
-      clearInterval(myInterval)
-    }
-  })
+  const currentDateInUnix = useCurrentDate()
 
   const onClaimTokensSubmitButtonClick = (covAmount) => {
     openModal(MODAL_TYPES.CovPoolClaimTokens, {

--- a/solidity-v1/dashboard/src/components/modal/staking/ConfirmRecovering.jsx
+++ b/solidity-v1/dashboard/src/components/modal/staking/ConfirmRecovering.jsx
@@ -12,11 +12,14 @@ export const ConfirmRecovering = withBaseModal(
 
     return (
       <>
-        <ModalHeader>Are you sure?</ModalHeader>
+        <ModalHeader>Claiming tokens</ModalHeader>
         <ModalBody>
-          <h3>You’re about to claim tokens.</h3>
+          <h3>You’re about to claim your undelegated tokens.</h3>
           <div className="text-grey-60 mt-1">
-            <span>Claiming will deposit delegated tokens in the</span>
+            <span>
+              Because these are tokens from your grant, claiming will deposit
+              the undelegated tokens in the
+            </span>
             &nbsp;
             <span>
               <ViewAddressInBlockExplorer
@@ -24,7 +27,7 @@ export const ConfirmRecovering = withBaseModal(
                 text="TokenStakingEscrow contract."
               />
             </span>
-            <p>You can withdraw them via Release tokens.</p>
+            <p>Withdraw them afterwards, via Release tokens</p>
           </div>
           <form onSubmit={formik.handleSubmit} className="mt-2">
             <FormInputBase

--- a/solidity-v1/dashboard/src/components/modal/staking/ConfirmRecovering.jsx
+++ b/solidity-v1/dashboard/src/components/modal/staking/ConfirmRecovering.jsx
@@ -8,15 +8,15 @@ import { withBaseModal } from "../withBaseModal"
 
 export const ConfirmRecovering = withBaseModal(
   ({ tokenStakingEscrowAddress, onConfirm, onClose }) => {
-    const formik = useTypeTextToConfirmFormik("RECOVER", onConfirm)
+    const formik = useTypeTextToConfirmFormik("CLAIM", onConfirm)
 
     return (
       <>
         <ModalHeader>Are you sure?</ModalHeader>
         <ModalBody>
-          <h3>You’re about to recover tokens.</h3>
+          <h3>You’re about to claim tokens.</h3>
           <div className="text-grey-60 mt-1">
-            <span>Recovering will deposit delegated tokens in the</span>
+            <span>Claiming will deposit delegated tokens in the</span>
             &nbsp;
             <span>
               <ViewAddressInBlockExplorer
@@ -32,7 +32,7 @@ export const ConfirmRecovering = withBaseModal(
               type="text"
               onChange={formik.handleChange}
               value={formik.values.confirmationText}
-              label={"Type RECOVER to confirm."}
+              label={"Type CLAIM to confirm."}
               placeholder=""
               hasError={formik.errors.confirmationText}
               errorMsg={formik.errors.confirmationText}
@@ -45,7 +45,7 @@ export const ConfirmRecovering = withBaseModal(
             type="submit"
             onClick={formik.handleSubmit}
           >
-            recover
+            claim
           </Button>
           <Button className="btn btn-unstyled" onClick={onClose}>
             Cancel

--- a/solidity-v1/dashboard/src/components/modal/staking/ViewTransactionSuccessModal.jsx
+++ b/solidity-v1/dashboard/src/components/modal/staking/ViewTransactionSuccessModal.jsx
@@ -4,12 +4,14 @@ import * as Icons from "../../Icons"
 import { colors } from "../../../constants/colors"
 import { ViewInBlockExplorer } from "../../ViewInBlockExplorer"
 import Button from "../../Button"
+import OnlyIf from "../../OnlyIf"
 
 const ViewTransactionSuccessModal = ({
   modalHeader,
   furtherDescription = "",
   txHash,
   onClose,
+  renderAdditionalButtons = null,
 }) => {
   return (
     <>
@@ -31,6 +33,9 @@ const ViewTransactionSuccessModal = ({
         </h4>
       </ModalBody>
       <ModalFooter>
+        <OnlyIf condition={renderAdditionalButtons}>
+          {renderAdditionalButtons}
+        </OnlyIf>
         <Button className="btn btn-secondary btn-lg" onClick={onClose}>
           close
         </Button>

--- a/solidity-v1/dashboard/src/components/modal/staking/claim/TokensClaimed.jsx
+++ b/solidity-v1/dashboard/src/components/modal/staking/claim/TokensClaimed.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { withBaseModal } from "../../withBaseModal"
 import ViewTransactionSuccessModal from "../ViewTransactionSuccessModal"
+import UpgradeToTButton from "../../../UpgradeToTButton"
 
 const TokensClaimedComponent = ({ txHash, onClose }) => {
   return (
@@ -9,6 +10,9 @@ const TokensClaimedComponent = ({ txHash, onClose }) => {
       furtherDescription={"Go to the Threshold dapp to coplete upgrade"}
       txHash={txHash}
       onClose={onClose}
+      renderAdditionalButtons={
+        <UpgradeToTButton className={"btn-primary btn-lg mr-1"} />
+      }
     />
   )
 }

--- a/solidity-v1/dashboard/src/components/modal/threshold/GrantTokensWithdrawn.jsx
+++ b/solidity-v1/dashboard/src/components/modal/threshold/GrantTokensWithdrawn.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { withBaseModal } from "../withBaseModal"
 import ViewTransactionSuccessModal from "../staking/ViewTransactionSuccessModal"
+import UpgradeToTButton from "../../UpgradeToTButton"
 
 const GrantTokensWithdrawnComponent = ({ txHash, onClose }) => {
   return (
@@ -9,6 +10,9 @@ const GrantTokensWithdrawnComponent = ({ txHash, onClose }) => {
       furtherDescription={"Go to the Threshold dapp to coplete upgrade"}
       txHash={txHash}
       onClose={onClose}
+      renderAdditionalButtons={
+        <UpgradeToTButton className={"btn-primary btn-lg mr-1"} />
+      }
     />
   )
 }

--- a/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
+++ b/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
@@ -16,7 +16,7 @@ const AllocationProgressBar = ({
   secondaryValueLegendLabel = "",
   isDataFetching = false,
 }) => {
-  const percentageValue = useMemo(() => {
+  const displayPercentageValue = useMemo(() => {
     if (isDataFetching) {
       return "--"
     }
@@ -26,16 +26,27 @@ const AllocationProgressBar = ({
       const secondaryValueBN = secondaryValue
         ? new BigNumber(secondaryValue)
         : 0
+      const actualProgressBarValueBN = currentValueBN.plus(secondaryValueBN)
       const totalValueBN = new BigNumber(totalValue)
-      return Math.round(
-        currentValueBN
-          .plus(secondaryValueBN)
-          .div(totalValueBN)
-          .multipliedBy(100)
-          .toNumber()
+      const percentageValue = Math.round(
+        actualProgressBarValueBN.div(totalValueBN).multipliedBy(100).toNumber()
       )
+
+      if (
+        percentageValue === 100 &&
+        !actualProgressBarValueBN.isEqualTo(totalValueBN)
+      ) {
+        return ">99%"
+      } else if (
+        percentageValue === 0 &&
+        !actualProgressBarValueBN.isEqualTo(totalValueBN)
+      ) {
+        return "<1%"
+      } else {
+        return `${percentageValue}%`
+      }
     } else {
-      return 0
+      return "0%"
     }
   }, [currentValue, secondaryValue, totalValue, isDataFetching])
 
@@ -91,10 +102,7 @@ const AllocationProgressBar = ({
             </OnlyIf>
           </ProgressBar>
           <span className="text-grey-70 ml-1 allocation-progress-bar__percentage-value">
-            {/** TODO: 2 decimal places, maybe even print it as >99 % and <1%
-              // when there is small difference betweent currentValue and total
-              // Value */}
-            {percentageValue}%
+            {displayPercentageValue}
           </span>
         </div>
       </div>

--- a/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
+++ b/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
@@ -39,7 +39,7 @@ const AllocationProgressBar = ({
         return ">99%"
       } else if (
         percentageValue === 0 &&
-        !actualProgressBarValueBN.isEqualTo(totalValueBN)
+        !actualProgressBarValueBN.isEqualTo("0")
       ) {
         return "<1%"
       } else {

--- a/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
+++ b/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
@@ -4,6 +4,7 @@ import { colors } from "../../constants/colors"
 import OnlyIf from "../OnlyIf"
 import { add, gt } from "../../utils/arithmetics.utils"
 import BigNumber from "bignumber.js"
+import TokenAmount from "../TokenAmount"
 
 const AllocationProgressBar = ({
   title,
@@ -12,8 +13,8 @@ const AllocationProgressBar = ({
   className = "",
   secondaryValue = null,
   withLegend = false,
-  currentValueLegendLabel = "",
-  secondaryValueLegendLabel = "",
+  currentValueLabel = "",
+  secondaryValueLabel = "",
   isDataFetching = false,
 }) => {
   const displayPercentageValue = useMemo(() => {
@@ -50,6 +51,16 @@ const AllocationProgressBar = ({
     }
   }, [currentValue, secondaryValue, totalValue, isDataFetching])
 
+  const renderProgressBarTooltipTooltip = (value) => {
+    return (
+      <TokenAmount
+        amount={value}
+        symbolClassName="upgrade-token-tile-row__token-amount-symbol"
+        amountClassName="upgrade-token-tile-row__token-amount-amount"
+      />
+    )
+  }
+
   return (
     <div className={`allocation-progress-bar ${className}`}>
       <div>
@@ -64,15 +75,23 @@ const AllocationProgressBar = ({
               height={20}
             >
               <ProgressBar.InlineItem
+                label={currentValueLabel}
                 value={
                   isDataFetching ? 0 : add(currentValue, secondaryValue || 0)
                 }
                 color={colors.secondary}
+                withTooltip
+                renderTooltip={renderProgressBarTooltipTooltip(currentValue)}
               />
               <OnlyIf condition={!!secondaryValue}>
                 <ProgressBar.InlineItem
+                  label={secondaryValueLabel}
                   value={isDataFetching ? 0 : secondaryValue}
                   color={colors.yellowSecondary}
+                  withTooltip
+                  renderTooltip={renderProgressBarTooltipTooltip(
+                    secondaryValue
+                  )}
                 />
               </OnlyIf>
             </ProgressBar.Inline>
@@ -83,7 +102,7 @@ const AllocationProgressBar = ({
                 >
                   <ProgressBar.LegendItem
                     value={secondaryValue?.toString()}
-                    label={secondaryValueLegendLabel}
+                    label={secondaryValueLabel}
                     color={colors.yellowSecondary}
                     className={
                       "allocation-progress-bar__progress-bar-legend-item"
@@ -91,7 +110,7 @@ const AllocationProgressBar = ({
                   />
                   <ProgressBar.LegendItem
                     value={currentValue?.toString()}
-                    label={currentValueLegendLabel}
+                    label={currentValueLabel}
                     color={colors.secondary}
                     className={
                       "allocation-progress-bar__progress-bar-legend-item"

--- a/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
+++ b/solidity-v1/dashboard/src/components/threshold/AllocationProgressBar.jsx
@@ -3,6 +3,7 @@ import ProgressBar, { ProgressBarLegendContext } from "../ProgressBar"
 import { colors } from "../../constants/colors"
 import OnlyIf from "../OnlyIf"
 import { add, gt } from "../../utils/arithmetics.utils"
+import BigNumber from "bignumber.js"
 
 const AllocationProgressBar = ({
   title,
@@ -21,8 +22,17 @@ const AllocationProgressBar = ({
     }
 
     if (gt(totalValue, 0)) {
+      const currentValueBN = new BigNumber(currentValue)
+      const secondaryValueBN = secondaryValue
+        ? new BigNumber(secondaryValue)
+        : 0
+      const totalValueBN = new BigNumber(totalValue)
       return Math.round(
-        (add(currentValue, secondaryValue | 0) / totalValue) * 100
+        currentValueBN
+          .plus(secondaryValueBN)
+          .div(totalValueBN)
+          .multipliedBy(100)
+          .toNumber()
       )
     } else {
       return 0

--- a/solidity-v1/dashboard/src/components/threshold/UpgradeTokensTile.jsx
+++ b/solidity-v1/dashboard/src/components/threshold/UpgradeTokensTile.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react"
 import TokenAmount from "../TokenAmount"
 import Button from "../Button"
 import NavLink from "../NavLink"
+import UpgradeToTButton from "../UpgradeToTButton"
 
 const UpgradeTokensTile = ({
   title,
@@ -65,14 +66,9 @@ UpgradeTokensTile.Button = ({
 
 UpgradeTokensTile.Link = ({ linkText, to = "", className = "" }) => {
   return (
-    <a
-      href={to}
-      rel="noopener noreferrer"
-      target="_blank"
-      className={`btn btn-primary btn-md upgrade-tokens-tile__button ${className}`}
-    >
-      {linkText} ↗
-    </a>
+    <UpgradeToTButton
+      className={"btn-primary btn-md upgrade-tokens-tile__button"}
+    />
   )
 }
 

--- a/solidity-v1/dashboard/src/constants/tooltips.js
+++ b/solidity-v1/dashboard/src/constants/tooltips.js
@@ -8,10 +8,10 @@ const resourceTooltipProps = {
     title: "Cliff",
     content: "A cliff is a set period of time before vesting begins.",
   },
-  recoverTokens: {
-    title: "Recover Tokens",
+  claimTokensFromUndelegation: {
+    title: "Claim Tokens",
     content:
-      "Click recover tokens to return the undelegated tokens to your token balance.",
+      "Click claim to return the undelegated tokens to your token balance.",
   },
   beaconEarnings: {
     title: "Beacon Earnings",

--- a/solidity-v1/dashboard/src/css/add-to-calendar.less
+++ b/solidity-v1/dashboard/src/css/add-to-calendar.less
@@ -18,4 +18,5 @@
 
 .bullets__add-to-calendar {
   text-indent: 0 !important;
+  margin-left: 0.2rem;
 }

--- a/solidity-v1/dashboard/src/css/tooltip.less
+++ b/solidity-v1/dashboard/src/css/tooltip.less
@@ -128,3 +128,9 @@
     }
   }
 }
+
+.resource-tooltip {
+  path {
+    fill: @color-grey-70;
+  }
+}

--- a/solidity-v1/dashboard/src/hooks/useCurrentDate.js
+++ b/solidity-v1/dashboard/src/hooks/useCurrentDate.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react"
+import moment from "moment"
+
+/**
+ * Uses current date in unix updated every second
+ * @return {number} - current date in unix timestamp
+ */
+const useCurrentDate = () => {
+  const [currentDateInUnix, setCurrentDateInUnix] = useState(moment().unix())
+
+  useEffect(() => {
+    const myInterval = setInterval(() => {
+      setCurrentDateInUnix(moment().unix())
+    }, 1000)
+    return () => {
+      clearInterval(myInterval)
+    }
+  })
+
+  return currentDateInUnix
+}
+
+export default useCurrentDate

--- a/solidity-v1/dashboard/src/hooks/useUpdateInitializedDelegations.js
+++ b/solidity-v1/dashboard/src/hooks/useUpdateInitializedDelegations.js
@@ -1,0 +1,34 @@
+import { useDispatch } from "react-redux"
+import { useEffect } from "react"
+import moment from "moment"
+
+/**
+ * Check if there are any initialized delegations and updates them to be completed
+ * @param {array} delegations - array of delegations
+ */
+const useUpdateInitializedDelegations = (delegations) => {
+  const dispatch = useDispatch()
+  useEffect(() => {
+    const currentDate = moment()
+    const initializedDelegations = delegations.filter(
+      (delegation) => !!delegation.isInInitializationPeriod
+    )
+
+    for (const initializedDelegation of initializedDelegations) {
+      if (currentDate.isAfter(initializedDelegation.initializationOverAt)) {
+        console.log("update bro")
+        dispatch({
+          type: "staking/update_delegation",
+          payload: {
+            operatorAddress: initializedDelegation.operatorAddress,
+            values: {
+              isInInitializationPeriod: false,
+            },
+          },
+        })
+      }
+    }
+  }, [dispatch, delegations])
+}
+
+export default useUpdateInitializedDelegations

--- a/solidity-v1/dashboard/src/hooks/useUpdateInitializedDelegations.js
+++ b/solidity-v1/dashboard/src/hooks/useUpdateInitializedDelegations.js
@@ -16,7 +16,6 @@ const useUpdateInitializedDelegations = (delegations) => {
 
     for (const initializedDelegation of initializedDelegations) {
       if (currentDate.isAfter(initializedDelegation.initializationOverAt)) {
-        console.log("update bro")
         dispatch({
           type: "staking/update_delegation",
           payload: {

--- a/solidity-v1/dashboard/src/hooks/useUpdatePendingUndelegations.js
+++ b/solidity-v1/dashboard/src/hooks/useUpdatePendingUndelegations.js
@@ -1,0 +1,33 @@
+import { useEffect } from "react"
+import moment from "moment"
+import { useDispatch } from "react-redux"
+
+/**
+ * Check if there are any pending undelegations and updates them to be completed
+ * @param {array} undelegations - array of undelegations
+ */
+const useUpdatePendingUndelegations = (undelegations) => {
+  const dispatch = useDispatch()
+  useEffect(() => {
+    const currentDate = moment()
+    const pendingUndelegations = undelegations.filter(
+      (undelegation) => !undelegation.canRecoverStake
+    )
+
+    for (const pendingUndelegation of pendingUndelegations) {
+      if (currentDate.isAfter(pendingUndelegation.undelegationCompleteAt)) {
+        dispatch({
+          type: "staking/update_undelegation",
+          payload: {
+            operatorAddress: pendingUndelegation.operatorAddress,
+            values: {
+              canRecoverStake: true,
+            },
+          },
+        })
+      }
+    }
+  }, [dispatch, undelegations])
+}
+
+export default useUpdatePendingUndelegations

--- a/solidity-v1/dashboard/src/pages/grants/TokenGrantsPage.jsx
+++ b/solidity-v1/dashboard/src/pages/grants/TokenGrantsPage.jsx
@@ -88,7 +88,7 @@ const TokenGrantOverview = React.memo(({ tokenGrant }) => {
       <div className="staked-details">
         <TokenGrantStakedDetails
           selectedGrant={tokenGrant}
-          stakedAmount={tokenGrant.stakedAmount}
+          stakedAmount={tokenGrant.staked}
         />
       </div>
     </section>
@@ -104,8 +104,8 @@ export const TokenGrantStakedDetails = ({ selectedGrant, stakedAmount }) => {
           items={[
             {
               value: stakedAmount,
-              color: colors.grey70,
-              backgroundStroke: colors.grey10,
+              color: colors.primary,
+              backgroundStroke: colors.bgSuccess,
               label: "Staked",
             },
           ]}
@@ -122,8 +122,8 @@ export const TokenGrantStakedDetails = ({ selectedGrant, stakedAmount }) => {
       </div>
       <div className="ml-2 mt-1 self-start flex-1">
         <h5 className="text-grey-70">staked</h5>
-        <h4 className="text-grey-70">{KEEP.displayAmount(stakedAmount)}</h4>
-        <div className="flex wrap text-smaller text-grey-40">
+        <h3 className="text-grey-70">{KEEP.displayAmount(stakedAmount)}</h3>
+        <div className="flex wrap text-smaller text-grey-60">
           of&nbsp;
           <TokenAmount
             amount={selectedGrant.amount}
@@ -157,8 +157,8 @@ const TokenGrantUnlockingdDetails = ({
           items={[
             {
               value: selectedGrant.unlocked,
-              backgroundStroke: colors.bgSuccess,
-              color: colors.primary,
+              backgroundStroke: colors.grey10,
+              color: colors.grey70,
               label: "Unlocked",
             },
             {
@@ -186,10 +186,10 @@ const TokenGrantUnlockingdDetails = ({
         }`}
       >
         <h5 className="text-grey-70">unlocked</h5>
-        <h4 className="text-grey-70">
+        <h3 className="text-grey-70">
           {KEEP.displayAmount(selectedGrant.unlocked)}
-        </h4>
-        <div className="flex wrap text-smaller text-grey-40">
+        </h3>
+        <div className="flex wrap text-smaller text-grey-60">
           of&nbsp;
           <TokenAmount
             amount={selectedGrant.amount}
@@ -218,7 +218,7 @@ const TokenGrantUnlockingdDetails = ({
                 onSubmitAction={onReleaseTokens}
                 withMessageActionIsPending={false}
               >
-                release tokens
+                withdraw
               </SubmitButton>
             )}
           </div>

--- a/solidity-v1/dashboard/src/pages/threshold/ThresholdUpgradePage.jsx
+++ b/solidity-v1/dashboard/src/pages/threshold/ThresholdUpgradePage.jsx
@@ -219,24 +219,24 @@ const ThresholdUpgradePage = () => {
       <section className="tile staked">
         <div className="staked__title-container">
           <h3 className="staked__title">Staked</h3>
-          <div className="staked__additional-info">
-            <span className="staked__additional-info-row mr-2">
-              <Icons.Success
-                width={16}
-                height={16}
-                className="staked__additional-info-icon staked__additional-info-icon--color-green"
-              />{" "}
-              ECDSA
-            </span>
-            <span className="staked__additional-info-row">
-              <Icons.Success
-                width={16}
-                height={16}
-                className="staked__additional-info-icon staked__additional-info-icon--color-green"
-              />{" "}
-              Random Beacon
-            </span>
-          </div>
+          {/* <div className="staked__additional-info">*/}
+          {/*  <span className="staked__additional-info-row mr-2">*/}
+          {/*    <Icons.Success*/}
+          {/*      width={16}*/}
+          {/*      height={16}*/}
+          {/*      className="staked__additional-info-icon staked__additional-info-icon--color-green"*/}
+          {/*    />{" "}*/}
+          {/*    ECDSA*/}
+          {/*  </span>*/}
+          {/*  <span className="staked__additional-info-row">*/}
+          {/*    <Icons.Success*/}
+          {/*      width={16}*/}
+          {/*      height={16}*/}
+          {/*      className="staked__additional-info-icon staked__additional-info-icon--color-green"*/}
+          {/*    />{" "}*/}
+          {/*    Random Beacon*/}
+          {/*  </span>*/}
+          {/* </div>*/}
         </div>
         {isDataFetching ? (
           <TokenAmountSkeleton

--- a/solidity-v1/dashboard/src/pages/threshold/ThresholdUpgradePage.jsx
+++ b/solidity-v1/dashboard/src/pages/threshold/ThresholdUpgradePage.jsx
@@ -159,6 +159,7 @@ const ThresholdUpgradePage = () => {
         <AllocationProgressBar
           title={"wallet"}
           currentValue={keepBalance}
+          currentValueLabel={"unstaked wallet balance"}
           totalValue={notStakedTotalAmount}
           className={"mb-1"}
           isDataFetching={isDataFetching}
@@ -166,6 +167,7 @@ const ThresholdUpgradePage = () => {
         <AllocationProgressBar
           title={"available grant allocation"}
           currentValue={totalGrantedReadyToReleaseTokens}
+          currentValueLabel={"unstaked grant balance"}
           totalValue={notStakedTotalAmount}
           className={"mb-2"}
           isDataFetching={isDataFetching}
@@ -263,13 +265,14 @@ const ThresholdUpgradePage = () => {
           className={"mb-1"}
           secondaryValue={totalStakedPendingKeep}
           withLegend
-          currentValueLegendLabel={"Staked"}
-          secondaryValueLegendLabel={"Pending Undelegation"}
+          currentValueLabel={"Staked"}
+          secondaryValueLabel={"Pending Undelegation"}
           isDataFetching={isDataFetching}
         />
         <AllocationProgressBar
           title={"undelegated"}
           currentValue={totalUndelegatedAvailableKeep}
+          currentValueLabel={"Undelegated"}
           totalValue={stakedTotalAmount}
           className={"mb-3"}
           isDataFetching={isDataFetching}

--- a/solidity-v1/dashboard/src/pages/threshold/ThresholdUpgradePage.jsx
+++ b/solidity-v1/dashboard/src/pages/threshold/ThresholdUpgradePage.jsx
@@ -18,6 +18,8 @@ import { useModal } from "../../hooks/useModal"
 import { LINK, MODAL_TYPES } from "../../constants/constants"
 import TokenAmountSkeleton from "../../components/skeletons/TokenAmountSkeleton"
 import ResourceTooltip from "../../components/ResourceTooltip"
+import useUpdatePendingUndelegations from "../../hooks/useUpdatePendingUndelegations"
+import useUpdateInitializedDelegations from "../../hooks/useUpdateInitializedDelegations"
 
 const ThresholdUpgradePage = () => {
   const { isConnected } = useWeb3Context()
@@ -41,6 +43,9 @@ const ThresholdUpgradePage = () => {
   const { delegations, undelegations, isDelegationDataFetching } = useSelector(
     (state) => state.staking
   )
+
+  useUpdateInitializedDelegations(delegations)
+  useUpdatePendingUndelegations(undelegations)
 
   const { grants, isFetching: isGrantDataFetching } = useSelector(
     (state) => state.tokenGrants

--- a/solidity-v1/dashboard/src/reducers/staking.js
+++ b/solidity-v1/dashboard/src/reducers/staking.js
@@ -66,6 +66,27 @@ const stakingReducer = (state = initialState, action) => {
         ...state,
         delegations: [action.payload, ...state.delegations],
       }
+    case "staking/update_delegation":
+      if (state.delegations.length === 0) return state
+
+      return {
+        ...state,
+        delegations: state.delegations.map((delegation) => {
+          if (
+            isSameEthAddress(
+              delegation.operatorAddress,
+              action.payload.operatorAddress
+            )
+          ) {
+            return {
+              ...delegation,
+              ...action.payload.values,
+            }
+          }
+
+          return delegation
+        }),
+      }
     case "staking/remove_delegation":
       return {
         ...state,
@@ -102,6 +123,27 @@ const stakingReducer = (state = initialState, action) => {
           [...state.undelegations],
           action.payload
         ),
+      }
+    case "staking/update_undelegation":
+      if (state.undelegations.length === 0) return state
+
+      return {
+        ...state,
+        undelegations: state.undelegations.map((undelegation) => {
+          if (
+            isSameEthAddress(
+              undelegation.operatorAddress,
+              action.payload.operatorAddress
+            )
+          ) {
+            return {
+              ...undelegation,
+              ...action.payload.values,
+            }
+          }
+
+          return undelegation
+        }),
       }
     case "staking/top_up_initiated":
       return {

--- a/solidity-v1/dashboard/src/reducers/token-grant.js
+++ b/solidity-v1/dashboard/src/reducers/token-grant.js
@@ -96,7 +96,7 @@ const grantStaked = (grantToUpdate, { value }) => {
   grantToUpdate.readyToRelease = gt(grantToUpdate.readyToRelease, 0)
     ? grantToUpdate.readyToRelease
     : "0"
-  if (lt(value, grantToUpdate.availableToStake)) {
+  if (gt(value, grantToUpdate.availableToStake)) {
     grantToUpdate.availableToStake = "0"
   } else {
     grantToUpdate.availableToStake = sub(
@@ -112,7 +112,7 @@ const grantWithdrawn = (
   grantToUpdate,
   { amount, availableToStake, operator }
 ) => {
-  if (lt(amount, grantToUpdate.readyToRelease)) {
+  if (gt(amount, grantToUpdate.readyToRelease)) {
     grantToUpdate.readyToRelease = "0"
   } else {
     grantToUpdate.readyToRelease = sub(

--- a/solidity-v1/dashboard/src/sagas/subscriptions.js
+++ b/solidity-v1/dashboard/src/sagas/subscriptions.js
@@ -352,7 +352,7 @@ function* observeRecoveredStakeEvent() {
         yield put({ type: "staking/remove_undelegation", payload: operator })
 
         yield put({
-          type: "staking/update_owned_undelegations_token_balance",
+          type: "staking/update_owned_undelegations_tokens_balance",
           payload: { operation: sub, value: recoveredUndelegation.amount },
         })
       }


### PR DESCRIPTION
Some overall bug fixes 🐛 ❌  for the T Migration and keep staking

Changes:
- fix percentage calculations for the progress bar in `staked` tab when there is pending undelegation
- creates `useCurrentDate` hook, that returns current date in unix timestamp updated every seconds
- semi-fix of the bug that caued the need to refresh the page after executing a transaction that updates the status of Delegation or Undelegation. Now, you don't have to refresh the page, but you still have to go to another page and then comeback to the previous one to fetch the data again
- fix updating staked value after recovering tokens, which was not updated at all because of a typo in action name
- display ">99%" and "<1%" in AllocationProgressBar when there is really small amount of (for example) unstaked grant tokens compared to unstaked wallet tokens
- rename `recover tokens` occurences in dapp to `claim tokens`
- add `upgrade to t` button to threshold modals
- improve text of the claiming tokens modal
- fix `readyToRelease` calculation after doing a stake from grant tokens (it causes to reduce the value of stake to 0 until user refresh the page)
- restyle `Token Grants` page and fix displaying staked tokens in circular progress bar there
- remove `ECDSA` and `Random Beacon` flags from `Staked` tile (for now)
- restyle Delegations and Undelegations table (add the possibility to center the whole tab, add info if the stake is from Wallet or from Granted Tokens)
- restyle resource tooltip and use more info icon everywhere
- restyle Total Value Locked tooltip
- install `react-tooltip` library
- add tooltips to allocation progress bars
- add margin to AddToCalnedar button so it looks better in success modal when undelegating the stake