### PR TITLE
Ignore `external` directory in git and prettier

### DIFF
--- a/solidity-v1/dashboard/.gitignore
+++ b/solidity-v1/dashboard/.gitignore
@@ -7,6 +7,9 @@
 # production
 /build
 
+# generated
+/external
+
 # misc
 .DS_Store
 

--- a/solidity-v1/dashboard/.prettierignore
+++ b/solidity-v1/dashboard/.prettierignore
@@ -1,4 +1,5 @@
 build/
+external/
 node_modules/
 public/
 # This is an auto-generated file and is not included in repo.


### PR DESCRIPTION
An `external/npm/@keep-network/keep-core/artifacts` directory is created
every time the `threshold-network/solidity-contracts` dependency is
installed. This is due to a workaround in
`threshold-network/solidity-contracts` which allows us to use contracts
which come from different repos and share the same name. Creation of
the `external` folder is a by-product of that. We don't need to track
changes in that folder or run prettier on its files.