### PR TITLE
tBTC reward allocation 2021-12-21 -> 2022-01-22

### DIFF
--- a/solidity-v1/dashboard/src/pages/rewards/TBTCRewardsPage.jsx
+++ b/solidity-v1/dashboard/src/pages/rewards/TBTCRewardsPage.jsx
@@ -8,7 +8,7 @@ import { SubmitButton } from "../../components/Button"
 // import ProgressBar from "../../components/ProgressBar"
 import Timer from "../../components/Timer"
 import TBTCRewardsDataTable from "../../components/TBTCRewardsDataTable"
-import { ECDSARewardsHelper } from "../../utils/rewardsHelper"
+import { ExtendedECDSARewardsHelper } from "../../utils/rewardsHelper"
 import { useWeb3Address } from "../../components/WithWeb3Context"
 import {
   TokenAmountSkeleton,
@@ -22,9 +22,9 @@ import EmptyStatePage from "./EmptyStatePage"
 const TBTCRewardsPage = () => {
   const dispatch = useDispatch()
   const yourAddress = useWeb3Address()
-  const currentIntervalEndOf = ECDSARewardsHelper.intervalEndOf(
-    ECDSARewardsHelper.currentInterval
-  ).unix()
+  const currentIntervalEndOf = ExtendedECDSARewardsHelper.intervalEndOf(
+    ExtendedECDSARewardsHelper.currentInterval
+  )
 
   const {
     ecdsaAvailableRewardsFetching,
@@ -78,7 +78,8 @@ const TBTCRewardsPage = () => {
 
 const RewardsOverview = ({ balance, isBalanceFetching, withdrawRewards }) => {
   const remainingPeriods =
-    ECDSARewardsHelper.intervals - ECDSARewardsHelper.currentInterval
+    ExtendedECDSARewardsHelper.intervals -
+    ExtendedECDSARewardsHelper.currentInterval
 
   return (
     <section className="tile rewards__overview--tbtc">
@@ -93,7 +94,9 @@ const RewardsOverview = ({ balance, isBalanceFetching, withdrawRewards }) => {
       <div className="rewards__overview__period">
         <h5 className="text-grey-70">current rewards period</h5>
         <span className="rewards-period__date">
-          {ECDSARewardsHelper.periodOf(ECDSARewardsHelper.currentInterval)}
+          {ExtendedECDSARewardsHelper.periodOf(
+            ExtendedECDSARewardsHelper.currentInterval
+          )}
         </span>
         <div className="rewards-period__remaining-periods">
           <Icons.Time width="16" height="16" className="time-icon--grey-30" />

--- a/solidity-v1/dashboard/src/rewards-allocation/rewards.json
+++ b/solidity-v1/dashboard/src/rewards-allocation/rewards.json
@@ -61895,5 +61895,740 @@
         ]
       }
     }
+  },
+  "0xdc8026bc52c1d200477e8aa8d374e934e57c79d1d0c9fa65d121a8f6607987b0": {
+    "tokenTotal": "0x9ed194db19b238bfffe2",
+    "claims": {
+      "0x0000000000058fDe63cA64995c9A7E40196Af9F9": {
+        "index": 0,
+        "amount": "0x0ae7705f04e41e1920",
+        "proof": [
+          "0x09af86443077277ecc1a8c3d8cb01cb52bd6467c8de00a39f52a07214b5f32a4",
+          "0xa26aa54fbcde8d5e8351bde986a405e47e9708c730a320edbd925d9eb89c3311",
+          "0x6278c0ebd726251d75abab0ff70eb1b8fc98d91fcad650dfe9b99810bb1a744e",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x00Cef852246b08B9215772c3f409D28408Bb21bD": {
+        "index": 1,
+        "amount": "0x031a91610726db63d4ab",
+        "proof": [
+          "0x3e8dc16f8a58846b82e357b20017e900335fc6322ab64c732e0b168143edc3c8",
+          "0x642329de8654762b4cab7b9d726c8754f55fe9975c389d452dd3c1d9beeb89df",
+          "0x5558608b16a8c61ab3cb2a5ab0fd60fe7cb0eea76aa1bf5885cf88a2e8824e26",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x045E511f53DeBF55c9C0B4522f14F602f7C7cA81": {
+        "index": 2,
+        "amount": "0x04b9e9643325e1a929f2",
+        "proof": [
+          "0xa921893807aec2ba728e504974ec89a2f19b623ce5314369e594e1dbf94ab624",
+          "0xc9183ba101da5e736deec416122656c953a097ae5c5a0d98de043e4e5df5fb02",
+          "0x1fd6b66000274b16e3b85f9b62d7577bd9aec10a469072051f45270d133ca6d0",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x07C9a8f8264221906b7b8958951Ce4753D39628B": {
+        "index": 3,
+        "amount": "0x011e63e83f81816e6ca9",
+        "proof": [
+          "0x041950f625fb7febf32b19d2b8e0ec2ff9e572320dacd63de280c0c336d4d6cc",
+          "0xaa83dcff12b31bd4e807ae22b9923bfbd86bde1bc120ddfa9438fbda42f2a51c",
+          "0xb17a4dea44e2ff47599bace2bf4595f1774ae4c518ac8b585bc47bffa9881fe5",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x0ae20e11a065a7E750482E6a7E9eB7eaB7A8137f": {
+        "index": 4,
+        "amount": "0x0be43cf800660f",
+        "proof": [
+          "0xaf0f31cf2099320e2d0e54dfc6784220df0def17dfdac431997953ec1372bcc1",
+          "0x78365715a82e5018a64b4dab1697802fc89eedf87f3e63fbd812384b78a2100a",
+          "0x1fd6b66000274b16e3b85f9b62d7577bd9aec10a469072051f45270d133ca6d0",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x0d0271d1B2906Cc472A8e75148937967Be788F09": {
+        "index": 5,
+        "amount": "0x053f691b9416d496ebf6",
+        "proof": [
+          "0xcfd556f704fe003e5891eba3841f2b96bbede9a636fab550afbbf4fcd648b0b8",
+          "0x55ef1504a13c534543f48f35f576bb0d92c70e68155a12b24c4d280b254619c5",
+          "0x6715300accbd2db3120ddde32e8043c6b026b6a5fd042d58e3b247819f11fd7b",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x1147ccFB4AEFc6e587a23b78724Ef20Ec6e474D4": {
+        "index": 6,
+        "amount": "0x1816d27b1110f4819d",
+        "proof": [
+          "0x7d6307b6cffe7e086324a8ce0a6e0d9b597b8adc6a1cc91a0f3b1d2bc5e3e242",
+          "0x51fbf05792b69f0d1e6919d514965ed15479e7dc33438ec27bba9dd08a46fa5c",
+          "0xc692199392b4638841f8e98ea8676686020e9a45acd0030373deaa5a7817f397",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x1d803c89760F8B4057DB15BCb3B8929E0498D310": {
+        "index": 7,
+        "amount": "0x35b3a613223bd33494",
+        "proof": [
+          "0x571f82f17a1906ffd29a5dad83e79322f7bdb36fee44249b0a8890865b640bce",
+          "0xb50df593a8c7fe045cc224730905bd18fded445cbd4c554272b07d5cbe0dbe4d",
+          "0x25feeda275e2d25d2c27eca66e61186eb5c0634b0b471b9b35d7b73e110bbf76",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x1e5801DB6779b44A90104AE856602424D8853807": {
+        "index": 8,
+        "amount": "0x018691f10b7905694409",
+        "proof": [
+          "0x467d631e7e0a8aaaf8c9479afb157b36cdfcd54e237a1e919ae08b4ee61d16cf",
+          "0x642329de8654762b4cab7b9d726c8754f55fe9975c389d452dd3c1d9beeb89df",
+          "0x5558608b16a8c61ab3cb2a5ab0fd60fe7cb0eea76aa1bf5885cf88a2e8824e26",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x2BAF3650263348f3304c18900A674bB0BF830801": {
+        "index": 9,
+        "amount": "0x68a4f70e637243aad7",
+        "proof": [
+          "0x26e2f2708f4672e06a2d3efaee8286675fa98c5aa68c650720d75fa651f94a38",
+          "0x3cba72e3c8c758c7e7531b84dfb7c5b90e7d5f83636ba8b69ebefe4a0de69296",
+          "0x962c6976a0d85f97938363fdb407bf4b571c2cbc8f9b1b3bd63789fc13ddc646",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x2eBE08379f4fD866E871A9b9E1d5C695154C6A9F": {
+        "index": 10,
+        "amount": "0x0223089df1e07eb128bf",
+        "proof": [
+          "0x8b4fea779aae6b86c04b94ad285c43b1f6e9a1bb8feb913fd03d580bb3c34ab9",
+          "0x9b9d76602b60e913d7e551756758ce61dfb82c8b3077602d0e6efc3178ad18ab",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x3101927DEeC27A2bfA6c4a6316e3A221f631dB91": {
+        "index": 11,
+        "amount": "0x01504500eee609d1554a",
+        "proof": [
+          "0xd0d0eacba33bac432318a6608a987db29dec5b0c64a9a3853a30786a9c39487d",
+          "0x55ef1504a13c534543f48f35f576bb0d92c70e68155a12b24c4d280b254619c5",
+          "0x6715300accbd2db3120ddde32e8043c6b026b6a5fd042d58e3b247819f11fd7b",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x36C56A69c2aeA23879b59dB0e99D57eF2ff77f06": {
+        "index": 12,
+        "amount": "0x08daecd8479daff82704",
+        "proof": [
+          "0x237f20725ba887941701e7d27593b029fda29f4911fa4e38a251352cef30ff68",
+          "0x84717939e36e4813127ca96b236d270f56bf6461611963fda3931f30f6a4ffcc",
+          "0x962c6976a0d85f97938363fdb407bf4b571c2cbc8f9b1b3bd63789fc13ddc646",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x39d2aCBCD80d80080541C6eed7e9feBb8127B2Ab": {
+        "index": 13,
+        "amount": "0x0dada5cea73101",
+        "proof": [
+          "0xa63a75c2de9853bcf9f116bf45f44977f5199a50e4555a04d263b324a304d95b",
+          "0xd78419a6c7f7daa312273b7cb0adee01d2f4e603e7743737b9bf02ef83b1d5b8",
+          "0x663bb0a384463454483d7d45ad16faf1c7c510573391b3bc79a916d5b2bea841",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x3B9e5ae72d068448bB96786989c0d86FBC0551D1": {
+        "index": 14,
+        "amount": "0xf2020365993fda385d",
+        "proof": [
+          "0x03c40f823170a2e9bce77400faf229c4edcf935b37bec8e425fbb51582df320c",
+          "0xaa83dcff12b31bd4e807ae22b9923bfbd86bde1bc120ddfa9438fbda42f2a51c",
+          "0xb17a4dea44e2ff47599bace2bf4595f1774ae4c518ac8b585bc47bffa9881fe5",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x3d7764aE9aC8259E5A5d224F5F56414f9749902a": {
+        "index": 15,
+        "amount": "0x073e08bdfb6a075d8cc0",
+        "proof": [
+          "0x8feedc2349c904dfbb9a77659f1815892553564dfca7f88e913a3ef87521106e",
+          "0x8e650d948d8d4b79b87e763142f42bf7c30bc2f83eadf0638495162f6c45ccc9",
+          "0x663bb0a384463454483d7d45ad16faf1c7c510573391b3bc79a916d5b2bea841",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x44f07be8D08a7Ec1b4BDB92685dA64C02622CFc5": {
+        "index": 16,
+        "amount": "0x01923284c61f0ac864b3",
+        "proof": [
+          "0x08a88c3167c02254d380d652f835cc63b366bdf9a0057142b2ee1c08a791c7e3",
+          "0x8c894b17fbac83dae502548c2b01025784e9bb5269455d38288d1f29f0bcc08b",
+          "0xb17a4dea44e2ff47599bace2bf4595f1774ae4c518ac8b585bc47bffa9881fe5",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x4F4f0D0dfd93513B3f4Cb116Fe9d0A005466F725": {
+        "index": 17,
+        "amount": "0x0385a40f1d242ad2d128",
+        "proof": [
+          "0xa10f2991959aab8ec99b88663fde0e11e96f38fa047ac010ffccfe85b6d8f13f",
+          "0xd78419a6c7f7daa312273b7cb0adee01d2f4e603e7743737b9bf02ef83b1d5b8",
+          "0x663bb0a384463454483d7d45ad16faf1c7c510573391b3bc79a916d5b2bea841",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x4a41c7a884d119eaaefE471D0B3a638226408382": {
+        "index": 18,
+        "amount": "0x0341ccf85758c6557379",
+        "proof": [
+          "0xcf8f0f9720299d8dd2851241a520b30019391a2dca2af13fb6b62ea50812f217",
+          "0x6f7a776bc7da252516d11a0d99ccf29295873011c9c6870402498b3c3cc2616f",
+          "0x45f496e05b8098a14a482b85654d488da09fff628ab8cfee7f1450d338f23f32",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x4bFa10B1538E8E765E995688D8EEc39C717B6797": {
+        "index": 19,
+        "amount": "0x010eec53bb77cc4e4312",
+        "proof": [
+          "0x67e3f23c0a5bef2957b806cf5c43296583f368d17237c715c510e33f7c8c95e8",
+          "0x14e3cae19d8a9057bf691e508f09370a5cfe51f9170ffae9633d246977dd90bc",
+          "0x88ab9d7197b9b2a8d546baccf2c8396a9016fdf8a37df53808517d00066ce6f3",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x4c21541f95a00C03C75F38C71DC220bd27cbbEd9": {
+        "index": 20,
+        "amount": "0x71327f5192b27475fc",
+        "proof": [
+          "0x316d9634f83a6bfc43035d3d55bdbf8e723ad8fabc3d328de352e7ef23133832",
+          "0x9772659c9795e7fd61ba898565e5ca730c227b99ff548289516c09d0ccdffe27",
+          "0xc46d7b598ac539a141647835cc2d24ca07e2de2ec3c19b770d9481411b3842b5",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x526c013f8382B050d32d86e7090Ac84De22EdA4D": {
+        "index": 21,
+        "amount": "0x3fb852ef3b483860f5",
+        "proof": [
+          "0x679c77add32939a5865f8661b9da628879d238a44235d8ff848a25e5f8b3eb1b",
+          "0x14e3cae19d8a9057bf691e508f09370a5cfe51f9170ffae9633d246977dd90bc",
+          "0x88ab9d7197b9b2a8d546baccf2c8396a9016fdf8a37df53808517d00066ce6f3",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x5CA1F949c75833432d6BC8E3cb6FB23386F63426": {
+        "index": 22,
+        "amount": "0x028bd69e3b8e3bd5b554",
+        "proof": [
+          "0xe7b5c29c38b0b4ded9945b8783319351aed71c82bb9e51ef3e1a5baf2c7da53a",
+          "0xc33ed92f8e416477dcac3784f57468835d842186316b34aba66e2a3aaa332b96",
+          "0xfecdb02c0e46d7b6f07a0e42270ced883bc53715e20ff058a50707b70254da5d",
+          "0x9b9d76602b60e913d7e551756758ce61dfb82c8b3077602d0e6efc3178ad18ab",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x5d84DEB482E770479154028788Df79aA7C563aA4": {
+        "index": 23,
+        "amount": "0x8dd57dc36f71e09e45",
+        "proof": [
+          "0x3012bf90bb1507acce69eacdd7b3dec417b9f59390c1b00d567ba813860ce28c",
+          "0x9772659c9795e7fd61ba898565e5ca730c227b99ff548289516c09d0ccdffe27",
+          "0xc46d7b598ac539a141647835cc2d24ca07e2de2ec3c19b770d9481411b3842b5",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x64A8856cBD255765D16B901a0B899daefC78FB13": {
+        "index": 24,
+        "amount": "0x0a612e18963917953b76",
+        "proof": [
+          "0x4a8de792e57d399ed77017b427dd0f413028cb29b93058d18c8e3451d5b04fae",
+          "0xe6173f8d584e862173e072cb4acfe31296e67f4a428e9f0aa949b1b579232e6f",
+          "0x5558608b16a8c61ab3cb2a5ab0fd60fe7cb0eea76aa1bf5885cf88a2e8824e26",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x650A9eD18Df873cad98C88dcaC8170531cAD2399": {
+        "index": 25,
+        "amount": "0x08f003381d33629e22b3",
+        "proof": [
+          "0xe7dcd105b0e2ddd50f74f9ddb2bc35802db03a6fcc61e89cdddac0a7d46b48e9",
+          "0x7c6efea455663b79a33c38b6109e9fbb5fabb159276d050e3027351c2133b5f1",
+          "0xfecdb02c0e46d7b6f07a0e42270ced883bc53715e20ff058a50707b70254da5d",
+          "0x9b9d76602b60e913d7e551756758ce61dfb82c8b3077602d0e6efc3178ad18ab",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x6C76d49322C9f8761A1623CEd89A31490cdB649d": {
+        "index": 26,
+        "amount": "0x35b3a613223bd33494",
+        "proof": [
+          "0xbf0164dcad7ecfbfe74f92c3015c99d6cb068c3561652cde26238601d2eb1d03",
+          "0xb7adb4d58d916dde1f5829faee870fb37fd4f387530ea611d301a6d09cc20e97",
+          "0x81c52e1ac9edf5e6d0d2fff9fb3bbb9ee5f2efcb6c173e9ddbf822cba111f3ee",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x6dAfE16b14c95eB99c64e8d4E5435F7574B2825c": {
+        "index": 27,
+        "amount": "0xe26a9494641cdacd04",
+        "proof": [
+          "0xb9c2fcb98b5b915760de7af5e9b17ad4b072461952bedb2066eae049f5a9d8e2",
+          "0x20a7eabe1aa56d9eeef01708be43f56b7be3ad1c7fee710396640044f3bb0fd6",
+          "0x81c52e1ac9edf5e6d0d2fff9fb3bbb9ee5f2efcb6c173e9ddbf822cba111f3ee",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x78c0eF874Df6cb2cD7E724bdF3Ce68f431b79748": {
+        "index": 28,
+        "amount": "0x9de342e76dcc5e8da2",
+        "proof": [
+          "0xb568ad2fe83cb8e509486f9fae53bfdc567db59e23405a07fb6cf9e9ca5ba877",
+          "0x20a7eabe1aa56d9eeef01708be43f56b7be3ad1c7fee710396640044f3bb0fd6",
+          "0x81c52e1ac9edf5e6d0d2fff9fb3bbb9ee5f2efcb6c173e9ddbf822cba111f3ee",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x7E6332d18719a5463d3867a1a892359509589a3d": {
+        "index": 29,
+        "amount": "0x018663b7c149d3868833",
+        "proof": [
+          "0xd48be8f8cd4075a9d8cc96d734d6465e29c616c12916fab41411a9e0abbe0ba8",
+          "0x1016ea661484db5dbfc053f40345bd4048e69d29175fecd0bc2f40bc1974c37a",
+          "0x6715300accbd2db3120ddde32e8043c6b026b6a5fd042d58e3b247819f11fd7b",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x7a9654B888dEa4Fed7bf4c1cD104Bd45217427dA": {
+        "index": 30,
+        "amount": "0x6ff4e5c1bf8170af5f",
+        "proof": [
+          "0x366d6825870ce4bb26b5d92d617b11bd31c6291dea6fb51e2c1bb62bc43834da",
+          "0xafb35b4765a4a42c8d04a7ae09abd1f171ccf823c65d7d025051b6601fd6d4fc",
+          "0xc46d7b598ac539a141647835cc2d24ca07e2de2ec3c19b770d9481411b3842b5",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x7f746e790e97996AC9fE892d48eB8660DeE6786D": {
+        "index": 31,
+        "amount": "0x575e8fcc418655dc",
+        "proof": [
+          "0x74880cc400fc77b99514c9f1d78c13f7896c51b035b9ac712dd88f6d5932d9c4",
+          "0x51fbf05792b69f0d1e6919d514965ed15479e7dc33438ec27bba9dd08a46fa5c",
+          "0xc692199392b4638841f8e98ea8676686020e9a45acd0030373deaa5a7817f397",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x81e1B56db174a935fe81E4b9839d6D92528090f4": {
+        "index": 32,
+        "amount": "0x085313170cbc25391bb5",
+        "proof": [
+          "0x667b2fbd35b1bce8b86d82094cc5f4f40e5008ef5e3f2d036a0ff77d0ca070ab",
+          "0xd1047473439065dd5e0040e2ab0a84c9636a66d543a107a2574f2cf8baecf19b",
+          "0x88ab9d7197b9b2a8d546baccf2c8396a9016fdf8a37df53808517d00066ce6f3",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x855A951162B1B93D70724484d5bdc9D00B56236B": {
+        "index": 33,
+        "amount": "0x013ea8e9e0495588adb3",
+        "proof": [
+          "0xdae08887a4d67fb12aa15c49520be6f9435fd6c19cdeffc566ed6fc066fc930e",
+          "0x9f36f96f5ce7ef0a0495fb3fbdefb43fd20ae627b461135f69c2f2d6a6dcc1ba",
+          "0x663ccbe2ea0f2d9d54ce288a32c99f6aa05617c5050c53181f7b05e9937f24ab",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x860EF3f83B6adFEF757F98345c3B8DdcFCA9d152": {
+        "index": 34,
+        "amount": "0x1f5be1212a955c4490",
+        "proof": [
+          "0x5c40d7949aa8d5b129daa8058933d486e0005fa85c67e2f5c488252bbc7ae077",
+          "0xb50df593a8c7fe045cc224730905bd18fded445cbd4c554272b07d5cbe0dbe4d",
+          "0x25feeda275e2d25d2c27eca66e61186eb5c0634b0b471b9b35d7b73e110bbf76",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x884e30892B185330478D0D18d0aE665113B98027": {
+        "index": 35,
+        "amount": "0x8b1b16f4543fc47a6d",
+        "proof": [
+          "0xdcdf9a075c1b1d25e676c6b87364f5003d13e328db745d31b0e72f0e1677cf63",
+          "0x7041970743682ff170f5f851569c90607056d065a601ca64f02867b23562a1c1",
+          "0x663ccbe2ea0f2d9d54ce288a32c99f6aa05617c5050c53181f7b05e9937f24ab",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x8Bd660A764Ca14155F3411a4526a028b6316CB3E": {
+        "index": 36,
+        "amount": "0x643bb757634329b176",
+        "proof": [
+          "0xcabe3de6e0487eb50ba8ef0207e77abfac6819f706708a900d6563942a0f506d",
+          "0x6f7a776bc7da252516d11a0d99ccf29295873011c9c6870402498b3c3cc2616f",
+          "0x45f496e05b8098a14a482b85654d488da09fff628ab8cfee7f1450d338f23f32",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0x9767795d399E86fCc0F600dB6F302F5C0692e0cF": {
+        "index": 37,
+        "amount": "0x0299595e27c06eab5173",
+        "proof": [
+          "0x570842959b57a7e5740f966e609bb0f507340c8da4a5e648066600687925b4e2",
+          "0x65322b5eebb3ec9b2bfa639127f267646b8dfaf4ceb4af5859ea133843d22ee0",
+          "0x25feeda275e2d25d2c27eca66e61186eb5c0634b0b471b9b35d7b73e110bbf76",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x9bC8d30d971C9e74298112803036C05db07D73e3": {
+        "index": 38,
+        "amount": "0x17096eea5b46eba38b",
+        "proof": [
+          "0x844057cb180dc5a99e1be1a07bf98c2223b5324f507805c0e4bbf8dc924bce50",
+          "0xbb4c897532576813c7da38933025853a7b30c2c1b4fe8e5b46e0cfe7812caae6",
+          "0xc692199392b4638841f8e98ea8676686020e9a45acd0030373deaa5a7817f397",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x9bD818Ab6ACC974f2Cf2BD2EBA7a250126Accb9F": {
+        "index": 39,
+        "amount": "0x0513a4a3439fe6d474",
+        "proof": [
+          "0x05add94f9704af0f70f592a01ad3a19676d0075f03d9fc7f4a84a165c619daff",
+          "0x8c894b17fbac83dae502548c2b01025784e9bb5269455d38288d1f29f0bcc08b",
+          "0xb17a4dea44e2ff47599bace2bf4595f1774ae4c518ac8b585bc47bffa9881fe5",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0x9c06Feb7Ebc8065ee11Cd5E8EEdaAFb2909A7087": {
+        "index": 40,
+        "amount": "0x060b8dd2fa8788d6e1e8",
+        "proof": [
+          "0xb35c4604d9e92d9b58eb392fe1d8f32a0d096c1976502c4dd34d872d48a31c5d",
+          "0x78365715a82e5018a64b4dab1697802fc89eedf87f3e63fbd812384b78a2100a",
+          "0x1fd6b66000274b16e3b85f9b62d7577bd9aec10a469072051f45270d133ca6d0",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xA543441313F7FA7F9215B84854E6DC8386B93383": {
+        "index": 41,
+        "amount": "0x078501bd5ac2d684906f",
+        "proof": [
+          "0xd6ea99f688cedcde5b5eb311fee22669775a1f8f7df1cf092f9ba2feaa6f6cbf",
+          "0x1016ea661484db5dbfc053f40345bd4048e69d29175fecd0bc2f40bc1974c37a",
+          "0x6715300accbd2db3120ddde32e8043c6b026b6a5fd042d58e3b247819f11fd7b",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xA97c34278162b556A527CFc01B53eb4DDeDFD223": {
+        "index": 42,
+        "amount": "0x2167cf5b6468800871",
+        "proof": [
+          "0xdb2dc5dcf715e2c005b05cf71b9945ed1ddff3f67f3ecb2aea22525445bed8cd",
+          "0x9f36f96f5ce7ef0a0495fb3fbdefb43fd20ae627b461135f69c2f2d6a6dcc1ba",
+          "0x663ccbe2ea0f2d9d54ce288a32c99f6aa05617c5050c53181f7b05e9937f24ab",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xABFB52f4CfAC3e6631c19a7e4Aa752110E1187B5": {
+        "index": 43,
+        "amount": "0xef79de36a5438417ea",
+        "proof": [
+          "0x0fcfbdc47bb9e8a138672e35668cf2ac4b7a516f19a75871e4269d4817ebf33b",
+          "0xa26aa54fbcde8d5e8351bde986a405e47e9708c730a320edbd925d9eb89c3311",
+          "0x6278c0ebd726251d75abab0ff70eb1b8fc98d91fcad650dfe9b99810bb1a744e",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xB62Fc1ADfFb2ab832041528C8178358338d85f76": {
+        "index": 44,
+        "amount": "0x0e13fcaba98ee555b8",
+        "proof": [
+          "0xc43ba210ad3faeeed2f4b971c198eb73cece4a7ddec98dcc3da34c9c16b4a88f",
+          "0x041ffaed52c06764e457ebac468a060808df2905e929f3a9faa51f2c64358ccf",
+          "0x45f496e05b8098a14a482b85654d488da09fff628ab8cfee7f1450d338f23f32",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xB7a764884a2fBcfC7177b5c53A7797EE7fF4Bb39": {
+        "index": 45,
+        "amount": "0x06fbd73fac38d0cd3ea9",
+        "proof": [
+          "0x6352e514868ae531324e18108a82fa1398a5640fab8a901c64843eb33036154f",
+          "0xd1047473439065dd5e0040e2ab0a84c9636a66d543a107a2574f2cf8baecf19b",
+          "0x88ab9d7197b9b2a8d546baccf2c8396a9016fdf8a37df53808517d00066ce6f3",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xB8A3AE209d153560993BFd8178E60F09B1c682E8": {
+        "index": 46,
+        "amount": "0x184d8a0a17a9482d6189",
+        "proof": [
+          "0x4c0f42a8109d167e2736458ee2eea0e45e396893702ca9ebf45c024f9030ed0a",
+          "0xe6173f8d584e862173e072cb4acfe31296e67f4a428e9f0aa949b1b579232e6f",
+          "0x5558608b16a8c61ab3cb2a5ab0fd60fe7cb0eea76aa1bf5885cf88a2e8824e26",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xBDE07f1cA107Ef319b0Bb26eBF1d0a5b4c97ffc1": {
+        "index": 47,
+        "amount": "0x04fae657c9e6aaf7f256",
+        "proof": [
+          "0xe72e20160cffed7b1c33e1a3461b5954cac2815f4a072a7f20741dde2292a7a1",
+          "0xc33ed92f8e416477dcac3784f57468835d842186316b34aba66e2a3aaa332b96",
+          "0xfecdb02c0e46d7b6f07a0e42270ced883bc53715e20ff058a50707b70254da5d",
+          "0x9b9d76602b60e913d7e551756758ce61dfb82c8b3077602d0e6efc3178ad18ab",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xD52BfE62a163eB4eC8FC98f06eD3f02695ae491d": {
+        "index": 48,
+        "amount": "0xdf10ad4a83dda293a1",
+        "proof": [
+          "0xdcb4a6973e17ae7361c5e7b1a754058ccb9e6e9bf7a6e3a5ba4bead2e42e3127",
+          "0x7041970743682ff170f5f851569c90607056d065a601ca64f02867b23562a1c1",
+          "0x663ccbe2ea0f2d9d54ce288a32c99f6aa05617c5050c53181f7b05e9937f24ab",
+          "0x73f42d47f02986180d73138b616755b3146d49a1222f1dbb3e4d0cab165817b9",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xE86181D6b672d78D33e83029fF3D0ef4A601B4C4": {
+        "index": 49,
+        "amount": "0x03abfb0570516a2e518e",
+        "proof": [
+          "0xee1446da2c2c5984e4eac3d61f281a9da028192f0f13b252ab0ccffa093af701",
+          "0x7c6efea455663b79a33c38b6109e9fbb5fabb159276d050e3027351c2133b5f1",
+          "0xfecdb02c0e46d7b6f07a0e42270ced883bc53715e20ff058a50707b70254da5d",
+          "0x9b9d76602b60e913d7e551756758ce61dfb82c8b3077602d0e6efc3178ad18ab",
+          "0xbd94e1611cbd0d8dc2947e69cc5d7db334c7b844e5aef75f9d7cc42ec407b719",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xF1De9490Bf7298b5F350cE74332Ad7cf8d5cB181": {
+        "index": 50,
+        "amount": "0x027a256594573cc29411",
+        "proof": [
+          "0x1935784fac1a3ee1268681f0c949bfae03cc627493a31d1f666c0368abf5d838",
+          "0x84717939e36e4813127ca96b236d270f56bf6461611963fda3931f30f6a4ffcc",
+          "0x962c6976a0d85f97938363fdb407bf4b571c2cbc8f9b1b3bd63789fc13ddc646",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xF2f5E0a3365c385A3ADCA4F614eD0984dFff52a3": {
+        "index": 51,
+        "amount": "0x5d1e28e8b006f239fc",
+        "proof": [
+          "0xc88d2ed2455544e64b3af1211341cb0cbc538f90a65d9f3d570d8ba11b3f3873",
+          "0x041ffaed52c06764e457ebac468a060808df2905e929f3a9faa51f2c64358ccf",
+          "0x45f496e05b8098a14a482b85654d488da09fff628ab8cfee7f1450d338f23f32",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xF35343299a4f80Dd5D917bbe5ddd54eBB820eBd4": {
+        "index": 52,
+        "amount": "0x076844491027f989",
+        "proof": [
+          "0x17939d6a0c1bace0c4fbe9944a72455bd37d188594a3e7a99c469e9100cf3144",
+          "0x1e4de6b5353698dcab9f85bfd264b4764806e6fbc1ccc4aafa0f9e8452b1980c",
+          "0x6278c0ebd726251d75abab0ff70eb1b8fc98d91fcad650dfe9b99810bb1a744e",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xa39F6Ca62303229873D06395237307Cd59de806d": {
+        "index": 53,
+        "amount": "0x17006b31528a548a",
+        "proof": [
+          "0x343cb2790d00538fbfedd7a5a54bf8cd95370bc81f5f18add20bd8a6fb99a32c",
+          "0xafb35b4765a4a42c8d04a7ae09abd1f171ccf823c65d7d025051b6601fd6d4fc",
+          "0xc46d7b598ac539a141647835cc2d24ca07e2de2ec3c19b770d9481411b3842b5",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xb034dE6226d765a343dc65932B6c114cB4e1a748": {
+        "index": 54,
+        "amount": "0x02448aebfc4fa177729e",
+        "proof": [
+          "0xba98656e5009f64531bf7b399a915fa0815cd016575fa220f2c13a2acd237baa",
+          "0xb7adb4d58d916dde1f5829faee870fb37fd4f387530ea611d301a6d09cc20e97",
+          "0x81c52e1ac9edf5e6d0d2fff9fb3bbb9ee5f2efcb6c173e9ddbf822cba111f3ee",
+          "0xe344c16ff1560f4c6fc5921c2e8e1229413f71150870f4b8f9ee3fccbd72e7f4",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xb7c561e2069aCaE2c4480111B1606790BB4E13fE": {
+        "index": 55,
+        "amount": "0x014691770a494e9eb613",
+        "proof": [
+          "0x53da4a27d1614f53559e4c22c23eb00779e4c0938d18b1a3ee63aece6d0c6830",
+          "0x65322b5eebb3ec9b2bfa639127f267646b8dfaf4ceb4af5859ea133843d22ee0",
+          "0x25feeda275e2d25d2c27eca66e61186eb5c0634b0b471b9b35d7b73e110bbf76",
+          "0x16ff56b14d6136e3fbc3414c5e355f249f6f319d49daef6b3292d462e8cd6a0c",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xc5795fa1EADF77FCDa0C6D9F9B340D634C2ba546": {
+        "index": 56,
+        "amount": "0x02ee703feec73d5494cb",
+        "proof": [
+          "0xa74f101cadf1cb34d6caaca4293cb1653e842de82428e22ff85241dc4feaa2af",
+          "0xc9183ba101da5e736deec416122656c953a097ae5c5a0d98de043e4e5df5fb02",
+          "0x1fd6b66000274b16e3b85f9b62d7577bd9aec10a469072051f45270d133ca6d0",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xd66cAE89FfBc6E50e6b019e45c1aEc93Dec54781": {
+        "index": 57,
+        "amount": "0x2ef060fcc4270219d0",
+        "proof": [
+          "0x9ba5d5248c7907f18de49eadf2f2d52762c86e8c67f306f070ff55f62714a3cc",
+          "0x8e650d948d8d4b79b87e763142f42bf7c30bc2f83eadf0638495162f6c45ccc9",
+          "0x663bb0a384463454483d7d45ad16faf1c7c510573391b3bc79a916d5b2bea841",
+          "0x622b2e2c38aaaf231174e5dd1e987b8b6371768dce5a292b6f1674ae410e0d7b",
+          "0xd6b90661c925434537b4bb87169242042db07eb57392d3be532d98f939ad00d1",
+          "0x397f6c7ab27606900b5eb85f25e868ed3cfbbe61f60ebffc92a491067b989116"
+        ]
+      },
+      "0xd977144724Bc77FaeFAe219F958AE3947205d0b5": {
+        "index": 58,
+        "amount": "0x0594d786ee8caf829850",
+        "proof": [
+          "0x12afadfa12edc7e0126342f57c552ec2f45e4479dc9a804401110e637cc2a5dd",
+          "0x1e4de6b5353698dcab9f85bfd264b4764806e6fbc1ccc4aafa0f9e8452b1980c",
+          "0x6278c0ebd726251d75abab0ff70eb1b8fc98d91fcad650dfe9b99810bb1a744e",
+          "0x5440ec687b6777d19fa2f7c573d87c3501c9ad5431bb9d383ccf32149cf803d3",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xe26E2d93Bbc8fde0e1E3B290Fc927Fb374E7e34e": {
+        "index": 59,
+        "amount": "0x012476b9562472c5f1a6",
+        "proof": [
+          "0x8b2b53b2729f458ecb2350ca926baf63a139016e8936842ecac6234977a17507",
+          "0xbb4c897532576813c7da38933025853a7b30c2c1b4fe8e5b46e0cfe7812caae6",
+          "0xc692199392b4638841f8e98ea8676686020e9a45acd0030373deaa5a7817f397",
+          "0x2029ea656246050a135f7bffca9ead0243fd2112e9e0f213c29a68cab9e8d148",
+          "0x75fa03d200b08f8e5e6b7ce30076739ee225d7e8c0e466eceda7158f5180847e",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      },
+      "0xe3a2d16dA142E6B190A5d9F7e0C07cc460B58A5F": {
+        "index": 60,
+        "amount": "0x9a2a6a101ee4b276aa",
+        "proof": [
+          "0x2e732b4e7b2572fd3d50ae11492f82437e77ccdd16f7bf13b4135ba7d4650ab7",
+          "0x3cba72e3c8c758c7e7531b84dfb7c5b90e7d5f83636ba8b69ebefe4a0de69296",
+          "0x962c6976a0d85f97938363fdb407bf4b571c2cbc8f9b1b3bd63789fc13ddc646",
+          "0x32400c76023a37ecbb63a7b101b563bb5e7ebd2a12036a22b0da29837aab5054",
+          "0xc43e96429f40caf245ef12045b78520a68671115667d02cae77daa9cfa04a89c",
+          "0x225490710e9b26e1cafc6cbe38ca22f08ae86ef0dd38b72d30f1e4aa0a415763"
+        ]
+      }
+    }
   }
 }

--- a/solidity-v1/dashboard/src/services/rewards.js
+++ b/solidity-v1/dashboard/src/services/rewards.js
@@ -1,6 +1,6 @@
 import web3Utils from "web3-utils"
 import { ContractsLoaded, getContractDeploymentBlockNumber } from "../contracts"
-import { ECDSARewardsHelper } from "../utils/rewardsHelper"
+import { ECDSAPeriodOfResolver } from "../utils/rewardsHelper"
 import { add } from "../utils/arithmetics.utils"
 import { isEmptyArray } from "../utils/array.utils"
 import rewardsData from "../rewards-allocation/rewards.json"
@@ -85,7 +85,7 @@ export const fetchECDSAAvailableRewards = async (operators) => {
           merkleRoot,
           interval,
           amount: web3Utils.toBN(operatorClaim.amount).toString(),
-          rewardsPeriod: ECDSARewardsHelper.periodOf(interval),
+          rewardsPeriod: ECDSAPeriodOfResolver.resolve(interval, merkleRoot),
         })
       }
     }
@@ -108,11 +108,12 @@ export const fetchECDSAClaimedRewards = async (operators) => {
       filter: { operator: operators },
     })
   ).map((event) => {
-    const intervalOf = merkleRoots.indexOf(event.returnValues.merkleRoot)
+    const merkleRoot = event.returnValues.merkleRoot
+    const intervalOf = merkleRoots.indexOf(merkleRoot)
 
     return {
       ...event.returnValues,
-      rewardsPeriod: ECDSARewardsHelper.periodOf(intervalOf),
+      rewardsPeriod: ECDSAPeriodOfResolver.resolve(intervalOf, merkleRoot),
     }
   })
 }


### PR DESCRIPTION
Adding tBTC rewards merkle tree computed in keep-network/keep-ecdsa#950 to KEEP Token Dashboard.

This PR also adjusts the `tBTC Rewards` page to [the proposal](https://forum.keep.network/t/proposal-to-extend-stakedrop-rewards-for-an-additional-4-months/351) that extends stakedrop rewards for an additional 4 months. We will have two more allocations so to simplify calculating the period of the reward we hardcoded the `merkleRoot` in the `ExtendedECDSARewards.intervalsDates` array. After generating the new merkle tree we must add the `merkleRoot` hash to a given interval.