### PR TITLE
Update `keep-core` and `tbtc` dependencies

### DIFF
--- a/solidity-v1/dashboard/package-lock.json
+++ b/solidity-v1/dashboard/package-lock.json
@@ -2730,9 +2730,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.8.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.6.tgz",
-      "integrity": "sha512-XcVCKx8LU+LWgFT6AVZ9Wz2RLt/m5mJ9ongSUeBZDZ9dy3dhaGMKdJnk12fztUcEIiHfyAINZ91UiS3HPyGQsA==",
+      "version": "1.8.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz",
+      "integrity": "sha512-QVkpO5X28Vczj/xHezV0z2UuMw8QFaR3C8x/d6+3adedsL3nCxgveIGTUcXSuYpBqfx0v4/xT+9bIK7BwLkGPw==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"
@@ -2785,53 +2785,18 @@
       "from": "github:keep-network/prettier-config-keep#a1a333e",
       "dev": true
     },
-    "@keep-network/sortition-pools": {
-      "version": "1.2.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz",
-      "integrity": "sha512-6Tusle8KGZldO8jbFDfxChdgI6hMpTAW4LG+cAkf7jgRR48o6NkUiA7mDoWk/+dlitpHrQpWT1JM4N7aR/4/EQ==",
-      "requires": {
-        "@openzeppelin/contracts": "^2.4.0"
-      }
-    },
     "@keep-network/tbtc": {
-      "version": "1.1.2-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-pre.0.tgz",
-      "integrity": "sha512-zfijjLLcDuK8F/brgxScA/HpESLlJl8Jvr61BC6pIhDzPDrcVaqnG2sioLZurvoJeuXf0VnISSixvWpuNLlPPQ==",
+      "version": "1.1.2-dev.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/tbtc/-/tbtc-1.1.2-dev.0.tgz",
+      "integrity": "sha512-G/JbDht/IgdX8Ety0i0iUl+kB2J2ofiAmNw+HmN/YUN9BYFhhzQqltPtYjS/krBkWzBYmNJmZBFeX/h+q4EJvA==",
       "requires": {
         "@celo/contractkit": "^1.0.2",
-        "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+        "@keep-network/keep-ecdsa": ">1.9.0-dev <1.9.0-ropsten",
         "@summa-tx/bitcoin-spv-sol": "^3.1.0",
         "@summa-tx/relay-sol": "^2.0.2",
         "openzeppelin-solidity": "2.3.0"
       },
       "dependencies": {
-        "@keep-network/keep-core": {
-          "version": "1.8.0-pre.16",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.16.tgz",
-          "integrity": "sha512-zn4YVHoKTdaPUAi2WgBzhZcPwFiyUwck5asbv0dQ7HiY0XKTbAzhTTgaDDgiEKUwqLkNJRNLYqtVaFvzlql6DQ==",
-          "requires": {
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.4.0"
-          },
-          "dependencies": {
-            "openzeppelin-solidity": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
-              "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
-            }
-          }
-        },
-        "@keep-network/keep-ecdsa": {
-          "version": "1.7.0-pre.12",
-          "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.12.tgz",
-          "integrity": "sha512-ro28FRMha8EcNVo4at6t/B5UsCCOaW954qmxvNjczgZkrErHFCGEc2lEnqWZUCwET1uLloIj6VYuTuht+zIOfg==",
-          "requires": {
-            "@keep-network/keep-core": "1.8.0-pre.16",
-            "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
-            "@openzeppelin/upgrades": "^2.7.2",
-            "openzeppelin-solidity": "2.3.0"
-          }
-        },
         "openzeppelin-solidity": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",

--- a/solidity-v1/dashboard/package.json
+++ b/solidity-v1/dashboard/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "@0x/subproviders": "^6.0.8",
     "@keep-network/coverage-pools": ">1.1.0-dev <1.1.0-ropsten",
-    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-ropsten",
+    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@keep-network/keep-ecdsa": ">1.9.0-dev <1.9.0-ropsten",
-    "@keep-network/tbtc": ">1.1.2-pre <1.1.2-rc",
+    "@keep-network/tbtc": ">1.1.2-dev <1.1.2-pre",
     "@keep-network/tbtc-v2": ">0.1.1-dev <0.1.1-ropsten",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",


### PR DESCRIPTION
We recently published first `-dev` suffixed npm package for
`@keep-network/tbtc` (`1.1.2-dev.0`). Now we're updating dependencies in
KEEP dashboard to reflect that change.
We're also updating incorrectly configured dependency to `keep-core`
package - we want to only include `-dev` packages in the smver range.