### PR TITLE
Display `transaction is pending` modal

### DIFF
--- a/solidity-v1/dashboard/src/components/modal/threshold/ThresholdLoadingModal.jsx
+++ b/solidity-v1/dashboard/src/components/modal/threshold/ThresholdLoadingModal.jsx
@@ -4,13 +4,22 @@ import { StakeOnThresholdTimeline } from "./components"
 import { STAKE_ON_THRESHOLD_TIMELINE_STEPS } from "../../../constants/constants"
 import { KeepLoadingIndicator } from "../../Loadable"
 import { withTimeline } from "../withTimeline"
+import { ViewInBlockExplorer } from "../../ViewInBlockExplorer"
+import OnlyIf from "../../OnlyIf"
 
-const ThresholdLoadingModal = ({ text }) => {
+const ThresholdLoadingModal = ({ text, txHash = null }) => {
   return (
     <>
       <ModalBody className={"threshold-loading-modal-body"}>
         <KeepLoadingIndicator />
-        <p>{text}</p>
+        <p>{txHash ? "Pending..." : text}</p>
+        <OnlyIf condition={txHash}>
+          <ViewInBlockExplorer
+            type="tx"
+            id={txHash}
+            text="View transaction on Etherscan"
+          />
+        </OnlyIf>
       </ModalBody>
     </>
   )

--- a/solidity-v1/dashboard/src/sagas/keep-to-t-staking.js
+++ b/solidity-v1/dashboard/src/sagas/keep-to-t-staking.js
@@ -81,6 +81,15 @@ function* authorizeAndStakeKeepToT(action) {
           contract: stakingContract,
           methodName: "authorizeOperatorContract",
           args: [operator, operatorContractAddress],
+          options: {
+            onTransactionHashAction: (txHash) =>
+              showModal({
+                modalType: MODAL_TYPES.ThresholdAuthorizationLoadingModal,
+                modalProps: {
+                  txHash,
+                },
+              }),
+          },
         },
       })
     } catch (err) {
@@ -106,6 +115,15 @@ function* authorizeAndStakeKeepToT(action) {
         contract: Keep.keepToTStaking.thresholdStakingContract.instance,
         methodName: "stakeKeep",
         args: [operator],
+        options: {
+          onTransactionHashAction: (txHash) =>
+            showModal({
+              modalType: MODAL_TYPES.ThresholdStakeConfirmationLoadingModal,
+              modalProps: {
+                txHash,
+              },
+            }),
+        },
       },
     })
   } catch (err) {


### PR DESCRIPTION
While a transaction is pending we should display a modal indicating that
fact with a link to the transaction details.