### PR TITLE
Fix creating a contract instance

### DIFF
--- a/solidity-v1/dashboard/src/lib/keep/index.js
+++ b/solidity-v1/dashboard/src/lib/keep/index.js
@@ -153,7 +153,10 @@ class Keep {
         // Otherwise, it means an artifact was built by Hardhat.
         address = artifact.address
         deploymentTxnHash = artifact.transactionHash
-        deployedAtBlock = artifact.receipt.blockNumber
+        deployedAtBlock =
+          artifact.receipt && artifact.receipt.blockNumber
+            ? artifact.receipt.blockNumber
+            : 1
       }
       return { address, deploymentTxnHash, deployedAtBlock }
     }


### PR DESCRIPTION
Fix creating a contract instance from the hardhat artifact. In some
cases, the artifact doesn't include `receipt` object and
`transactionHash` so we need to set the `deployedAtBlock` to `1`. This
is not an ideal solution because we should fetch past events from the
deployment block- some node providers (eg. Alchemy) block requests if
the block range is greater than 2k.