### PR TITLE
[Backport] tBTC reward allocation 2022-01-22 -> 2022-02-22

### DIFF
--- a/solidity-v1/dashboard/src/rewards-allocation/rewards.json
+++ b/solidity-v1/dashboard/src/rewards-allocation/rewards.json
@@ -62630,5 +62630,650 @@
         ]
       }
     }
+  },
+  "0xa48918393536de2ba2dfb10b66ea91abb7f66352156d34f2f3ffcbb0b976ba2b": {
+    "tokenTotal": "0x99377d74fcbe325234b9",
+    "claims": {
+      "0x0000000000058fDe63cA64995c9A7E40196Af9F9": {
+        "index": 0,
+        "amount": "0x0b5f2b269873d141a1",
+        "proof": [
+          "0xb15eb825ed6e45fc29183aadced3ccdb7f78ec3a5ac444d3e78774d27a3870be",
+          "0x89fb2ef6d77be9f47707d377c055512de3bb25d8cea0f9e84678d3e850df56b5",
+          "0x72bf45c659fd1557f31510e14af0d223e435bb5fdff22bb2ed5c78295ca52f6e",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x045E511f53DeBF55c9C0B4522f14F602f7C7cA81": {
+        "index": 1,
+        "amount": "0x04edce8f4c3c73055f69",
+        "proof": [
+          "0x10331e37fd798ab177300d71b263afa1108c59f1cdd27c6acb1dc147274ea0ea",
+          "0xf3989c1d64dfdd8db31bd74a20705805787c04434effa88ab02646d9f962a3f7",
+          "0xf978214c884e7fada086fbf1d9160b68a128945a33273bf3181118ae7386c4a5",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x07C9a8f8264221906b7b8958951Ce4753D39628B": {
+        "index": 2,
+        "amount": "0x010efa245712d62e2d85",
+        "proof": [
+          "0xbebea357890b58c379263f0b3404272219ea71d694a1cd44ec8eae4e99f2b995",
+          "0x2cd18c85ee8136e251b8a696c527e4930dbbb36ad8d43bcacadff191a4fd1676",
+          "0x72bf45c659fd1557f31510e14af0d223e435bb5fdff22bb2ed5c78295ca52f6e",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x0ae20e11a065a7E750482E6a7E9eB7eaB7A8137f": {
+        "index": 3,
+        "amount": "0x17ad009a89eae7",
+        "proof": [
+          "0xcb792deaed406974bfabc6bac729f765dd6300e26b5950f165fb385cf1ddcb2e",
+          "0xe12f8dda5b421c44fb91895d8044d3e903ecc541924e7a5be04764d20dbed5b5",
+          "0x950994cc0ea73189376bc04c94002296bf9298c7c7a1c782f605cf4fea5731ae",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x0d0271d1B2906Cc472A8e75148937967Be788F09": {
+        "index": 4,
+        "amount": "0x05790821972244bb3a98",
+        "proof": [
+          "0x9c8f1c9b04f3e9b308a9ad256cc6bd0c2093a007415704887b91bc78e63a1793",
+          "0x4f0a0f4a9af985ced5ed1f2c73eb24c1c68a2cb9260014ecc8b193c7298e59ea",
+          "0x6ac3860b239c600d16ada317a817e084cd341b94aa39ae70804e70b65984ea67",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x1147ccFB4AEFc6e587a23b78724Ef20Ec6e474D4": {
+        "index": 5,
+        "amount": "0x1a75801cc06e572877",
+        "proof": [
+          "0x36d16f5f98dad5aa7ba2a056d2b4ce93ac195761722a35688b1fd25493ffd2bb",
+          "0xf015f57028ca0f0cd901a70e7b0f818b501b57ea7ab3a9e79baa407da949cbd9",
+          "0xecc665a730332c9c6430af5a418f81c16a6b36e9859d5e87278cb0e4037186e5",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x1d803c89760F8B4057DB15BCb3B8929E0498D310": {
+        "index": 6,
+        "amount": "0x38014f194faf448e55",
+        "proof": [
+          "0xbbf42f0a4d3238f3463caacce401a52ff9a3721349a0b752a4e358ac242d4e0c",
+          "0x2cd18c85ee8136e251b8a696c527e4930dbbb36ad8d43bcacadff191a4fd1676",
+          "0x72bf45c659fd1557f31510e14af0d223e435bb5fdff22bb2ed5c78295ca52f6e",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x1e5801DB6779b44A90104AE856602424D8853807": {
+        "index": 7,
+        "amount": "0x019752829e8ed2d98621",
+        "proof": [
+          "0x49806e58c9f73edf09e35027ff31dc1e48f40fff5d0d62cbd3d25193d0f57b06",
+          "0x1b429ab630c290ee7a841fc0d0fc89b16024b11bab100920c272ae12fb15c209",
+          "0x0dc1b9aa4609e9857bfddc0ecb23563539cc224ad0c361e48376dd31ab6fa818",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x2BAF3650263348f3304c18900A674bB0BF830801": {
+        "index": 8,
+        "amount": "0x6d21fd609e3bd5af70",
+        "proof": [
+          "0xc750b945f6c52c70a993165431e77295f39c50d41336827f655ba78375274527",
+          "0x8ad2c5569bc9701583c2e2ff2ba7a33a2d0cffe131a7301587593b3eb7f72593",
+          "0x950994cc0ea73189376bc04c94002296bf9298c7c7a1c782f605cf4fea5731ae",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x2eBE08379f4fD866E871A9b9E1d5C695154C6A9F": {
+        "index": 9,
+        "amount": "0x023a7f330be1e8ab39b9",
+        "proof": [
+          "0x9141f94a97955ad069c0ec813dc441a94febceb9cc7a312dd237ab1d1cfc21e0",
+          "0x9e5783c1e6c54dbd4aaab22a310d6f3b2e0d4c363d3a53f7e1d5c302f7a2f4af",
+          "0x6ac3860b239c600d16ada317a817e084cd341b94aa39ae70804e70b65984ea67",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x3101927DEeC27A2bfA6c4a6316e3A221f631dB91": {
+        "index": 10,
+        "amount": "0x015eb1565346f0d6876a",
+        "proof": [
+          "0x4e05c49b68d0188da8be0dbbedd2e2915d110ed08ce5359f5383f632e78b485d",
+          "0x22805f6afbbc6f699fa5f20a2b957721f1a13ba036ef47d7e79ac64b78e73550",
+          "0x337470bc0fb6f0ed5b0b436a26b735750d6b7378dd3b68097991c1e2ec870f0d",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x36C56A69c2aeA23879b59dB0e99D57eF2ff77f06": {
+        "index": 11,
+        "amount": "0x093c28510f85d90ef52c",
+        "proof": [
+          "0xacc8b1b1eabae9bdc9c9679bf5a6f82e892753718e732955d139505718e24407",
+          "0x9d2a15e963ce4dd3cfb239db738580777a2abc09a58b4788ae20562219771ec0",
+          "0x2e41a34af67544ec9e149177d772a192ca768132d8cfc1beae650fe8c99c8781",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x39d2aCBCD80d80080541C6eed7e9feBb8127B2Ab": {
+        "index": 12,
+        "amount": "0x1ba24ab594699c",
+        "proof": [
+          "0xfa4cb50e6012529c2314885a5c1de286e0eaaa6eff923b102bc8c596e357882f",
+          "0x41734d6441b33d8f8a1bae50dc91a1e2ccf66b98cc421a165b3d37e41d6eac66",
+          "0x0e52d034adf1017833c8af8bbd12d1cc862728e03bf88c0f774798d7976c02a9",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x3B9e5ae72d068448bB96786989c0d86FBC0551D1": {
+        "index": 13,
+        "amount": "0xfc6353c5c024aa6af6",
+        "proof": [
+          "0x280c4d357f6676853a81a9e274c068b876d3ba94d4d1a16ac428d47152b164fb",
+          "0xbe7b662701673a7d8154e4e919fe0a1ed22ac8cece903e8e958fb4677d0b36fc",
+          "0xf978214c884e7fada086fbf1d9160b68a128945a33273bf3181118ae7386c4a5",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x3d7764aE9aC8259E5A5d224F5F56414f9749902a": {
+        "index": 14,
+        "amount": "0x07768a8cc326cbeac739",
+        "proof": [
+          "0x0600cd7eaef87f8b789b6329d696cc2d99e90aeaf6066340549dedbe3763b9c4",
+          "0xf5d9672b30f568e92bf7167a88e2445d159503b7e95d6340616e9f063846b386",
+          "0xb523b6457fdf579ff4c50b778f46d123e1fc759bbe4a9fbc074c54c07db2cc8a",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x44f07be8D08a7Ec1b4BDB92685dA64C02622CFc5": {
+        "index": 15,
+        "amount": "0x0179f2f624688ddd6f80",
+        "proof": [
+          "0x6dc2b6a74bcd03a54b5705efc59f2299fc8dded3311e9fe803e9a69a0540cbf6",
+          "0x9ce82ce583970c47b12c5fa7cffe55b4122b7b5917743636d8a21d112ddd2306",
+          "0x9db9105b545be02031098e8abfe95848aa386d4e6b130335df05a18c4a1e8e8a",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x4F4f0D0dfd93513B3f4Cb116Fe9d0A005466F725": {
+        "index": 16,
+        "amount": "0x03ac5053da5ea69612c0",
+        "proof": [
+          "0x8da944774dcee269605ad998aeecb80d9340eee2273b3cc508b7ad2962c1c023",
+          "0xf483139021e0d9cc1fc9fb511040caf4810bab49e82b836029e81910e6ff9ef9",
+          "0x4c303314619f8edbe6283233952869cfcb45c376b8af4122912056fe4290468a",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x4a41c7a884d119eaaefE471D0B3a638226408382": {
+        "index": 17,
+        "amount": "0x03659055975ebbfc8d8b",
+        "proof": [
+          "0x968b8e0da0b3bbbb6bb28a29ba915d6c0fa573db3aaa5a008f1ad1f7182f88f4",
+          "0x9e5783c1e6c54dbd4aaab22a310d6f3b2e0d4c363d3a53f7e1d5c302f7a2f4af",
+          "0x6ac3860b239c600d16ada317a817e084cd341b94aa39ae70804e70b65984ea67",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x4bFa10B1538E8E765E995688D8EEc39C717B6797": {
+        "index": 18,
+        "amount": "0x011a8b2394ec1274e941",
+        "proof": [
+          "0xebcb1b6470e862f3d02ecea6039544d801eb4b6918aa0b3b3c7446864bfc8958",
+          "0xd5f66f126a1efd0b5935b1fcd5df345cba91f050d7a0ac1cd74e2ca384d2476f",
+          "0xd335ef7fc9c55a4e46faff3012a6551cdbc2398b85d77dc8ef9b9a279d391ea6",
+          "0x0e52d034adf1017833c8af8bbd12d1cc862728e03bf88c0f774798d7976c02a9",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x4c21541f95a00C03C75F38C71DC220bd27cbbEd9": {
+        "index": 19,
+        "amount": "0x760d6f50e4a5d97866",
+        "proof": [
+          "0xe33311e459acdcfe7238589307c6d855a4498df03ff30b357d05246a0ed22d91",
+          "0xcd3d25996bb2183a57ebcc38817811b1ea146c83b89da88255ca69f28e0c5af2",
+          "0xeb1da996db12ac045aef6226b1e4332471f95854dc3354e1901dc7aa71987900",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x526c013f8382B050d32d86e7090Ac84De22EdA4D": {
+        "index": 20,
+        "amount": "0x4273fccf2bb21ad404",
+        "proof": [
+          "0x441ab9ae37a2c4aed974a8953570658e17f031cc5761c72e248744856da35c6f",
+          "0xa9c8b178786f4fb7f31658678377685391c50f735854f1e4359d1d59772a7ff7",
+          "0x0dc1b9aa4609e9857bfddc0ecb23563539cc224ad0c361e48376dd31ab6fa818",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x5CA1F949c75833432d6BC8E3cb6FB23386F63426": {
+        "index": 21,
+        "amount": "0x02a7cbfc3e2b3d9ded1e",
+        "proof": [
+          "0x0629b53a4c889a29a1b69790e63a675336568c7a24a1cc864e1b60376461cf11",
+          "0xf5d9672b30f568e92bf7167a88e2445d159503b7e95d6340616e9f063846b386",
+          "0xb523b6457fdf579ff4c50b778f46d123e1fc759bbe4a9fbc074c54c07db2cc8a",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x5d84DEB482E770479154028788Df79aA7C563aA4": {
+        "index": 22,
+        "amount": "0x93eade1f512e68dc57",
+        "proof": [
+          "0xea9112d2a5f6d2a5f06c0a48bc9964364f6c627cb5dfbdd268b7510f4c7ec6f0",
+          "0xd5f66f126a1efd0b5935b1fcd5df345cba91f050d7a0ac1cd74e2ca384d2476f",
+          "0xd335ef7fc9c55a4e46faff3012a6551cdbc2398b85d77dc8ef9b9a279d391ea6",
+          "0x0e52d034adf1017833c8af8bbd12d1cc862728e03bf88c0f774798d7976c02a9",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x64A8856cBD255765D16B901a0B899daefC78FB13": {
+        "index": 23,
+        "amount": "0x0ac5f1bd14e75a8b9e3f",
+        "proof": [
+          "0xc0aa2c6a0db0622d802f573e807962e0089b0a1938ce598a751518f09a0092e0",
+          "0x8ad2c5569bc9701583c2e2ff2ba7a33a2d0cffe131a7301587593b3eb7f72593",
+          "0x950994cc0ea73189376bc04c94002296bf9298c7c7a1c782f605cf4fea5731ae",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x650A9eD18Df873cad98C88dcaC8170531cAD2399": {
+        "index": 24,
+        "amount": "0x0952263c8dbbc798a6ab",
+        "proof": [
+          "0x3a60fb25c12a6c68f9a23e0fc7bd07261ae5fc3b039ca21a9ece5139907a817a",
+          "0x104bbeb2a661ac64ee3159b85723a714f76f3af66987c246307d0c46bee5cdb2",
+          "0xecc665a730332c9c6430af5a418f81c16a6b36e9859d5e87278cb0e4037186e5",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x6C76d49322C9f8761A1623CEd89A31490cdB649d": {
+        "index": 25,
+        "amount": "0x38014f194faf448e55",
+        "proof": [
+          "0x793e1a44690247b6151fa358173497d10d2117263f229667ce16453d90679175",
+          "0xcbf52c27247f359941127f512ddbe1e5fea3786fc53ac91122582f4aa35c6391",
+          "0x4c303314619f8edbe6283233952869cfcb45c376b8af4122912056fe4290468a",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x78c0eF874Df6cb2cD7E724bdF3Ce68f431b79748": {
+        "index": 26,
+        "amount": "0xa4a8e9afca680b8a56",
+        "proof": [
+          "0xefe3b92db7af2ae95d7123563d67f2669db19e96accfaa743e24c63c33fbbc9e",
+          "0xd84d86d484e9c8b5729f8c83a6683b0230091c8e748077a12e8d7a0855754cb1",
+          "0xd335ef7fc9c55a4e46faff3012a6551cdbc2398b85d77dc8ef9b9a279d391ea6",
+          "0x0e52d034adf1017833c8af8bbd12d1cc862728e03bf88c0f774798d7976c02a9",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x7E6332d18719a5463d3867a1a892359509589a3d": {
+        "index": 27,
+        "amount": "0x0197224dc78ba78a8dfe",
+        "proof": [
+          "0x76db79279e821f4f90efbeec56c2305de0d8fb8de6d5589e275a059b5b257086",
+          "0xcbf52c27247f359941127f512ddbe1e5fea3786fc53ac91122582f4aa35c6391",
+          "0x4c303314619f8edbe6283233952869cfcb45c376b8af4122912056fe4290468a",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x7a9654B888dEa4Fed7bf4c1cD104Bd45217427dA": {
+        "index": 28,
+        "amount": "0x74c2366b4861a8e79d",
+        "proof": [
+          "0x9aa1e0cae5eaf376faa13376625706ac6087db8ac9486f8e8aded65093cbcc12",
+          "0x4f0a0f4a9af985ced5ed1f2c73eb24c1c68a2cb9260014ecc8b193c7298e59ea",
+          "0x6ac3860b239c600d16ada317a817e084cd341b94aa39ae70804e70b65984ea67",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x7f746e790e97996AC9fE892d48eB8660DeE6786D": {
+        "index": 29,
+        "amount": "0xa70c274e8ec6b1a7",
+        "proof": [
+          "0x228d81498f1099561924d7743505d299073a4070b90eb571a9a49fe4cdcb537b",
+          "0xbe7b662701673a7d8154e4e919fe0a1ed22ac8cece903e8e958fb4677d0b36fc",
+          "0xf978214c884e7fada086fbf1d9160b68a128945a33273bf3181118ae7386c4a5",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x81e1B56db174a935fe81E4b9839d6D92528090f4": {
+        "index": 30,
+        "amount": "0x08ae7ae25db23a6c6c77",
+        "proof": [
+          "0x16a4c74c9996b8413d9d6b88459b2125b9efcef17eba0845a092ac65e2dc6657",
+          "0xf3989c1d64dfdd8db31bd74a20705805787c04434effa88ab02646d9f962a3f7",
+          "0xf978214c884e7fada086fbf1d9160b68a128945a33273bf3181118ae7386c4a5",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x860EF3f83B6adFEF757F98345c3B8DdcFCA9d152": {
+        "index": 31,
+        "amount": "0x20b4357d0d6e658ff1",
+        "proof": [
+          "0xad3788baf535dc37c6a5b0db57517e5171f7b6365b4d6165f05e43e1e4cdf055",
+          "0x9d2a15e963ce4dd3cfb239db738580777a2abc09a58b4788ae20562219771ec0",
+          "0x2e41a34af67544ec9e149177d772a192ca768132d8cfc1beae650fe8c99c8781",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x884e30892B185330478D0D18d0aE665113B98027": {
+        "index": 32,
+        "amount": "0x59bc60d7c76b560f50",
+        "proof": [
+          "0xb7102ce36f168bd098db55adf62503f12225bdc928471f146affea850758fe91",
+          "0x89fb2ef6d77be9f47707d377c055512de3bb25d8cea0f9e84678d3e850df56b5",
+          "0x72bf45c659fd1557f31510e14af0d223e435bb5fdff22bb2ed5c78295ca52f6e",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x8Bd660A764Ca14155F3411a4526a028b6316CB3E": {
+        "index": 33,
+        "amount": "0x540420fffa7f9a4bdf",
+        "proof": [
+          "0x297cc8c2cea6d65afb27f67ad72c802f8d9f359268930a95a5b58c3410c9f92e",
+          "0xf015f57028ca0f0cd901a70e7b0f818b501b57ea7ab3a9e79baa407da949cbd9",
+          "0xecc665a730332c9c6430af5a418f81c16a6b36e9859d5e87278cb0e4037186e5",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x9767795d399E86fCc0F600dB6F302F5C0692e0cF": {
+        "index": 34,
+        "amount": "0x02b5e316341b554fb25e",
+        "proof": [
+          "0xd98b75c6d309845bdd042f0b335e3eda446d3e3938d7db0f3444f73da9599912",
+          "0x8682e882537d2f6b6a7f2eb66418e1e6bf61a55a1a59fd0d1af5cc4abea7c4d7",
+          "0xeb1da996db12ac045aef6226b1e4332471f95854dc3354e1901dc7aa71987900",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0x9bC8d30d971C9e74298112803036C05db07D73e3": {
+        "index": 35,
+        "amount": "0x192e1bd60ed8af3a97",
+        "proof": [
+          "0x49e6a8cbeba2ea7b802cff2882cbc5e6ddc359a91b728d83e71c712aee099fdd",
+          "0x22805f6afbbc6f699fa5f20a2b957721f1a13ba036ef47d7e79ac64b78e73550",
+          "0x337470bc0fb6f0ed5b0b436a26b735750d6b7378dd3b68097991c1e2ec870f0d",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0x9c06Feb7Ebc8065ee11Cd5E8EEdaAFb2909A7087": {
+        "index": 36,
+        "amount": "0x064dee66421e19bba3bd",
+        "proof": [
+          "0x5a349e2f0ba5e1d1233d3d749ab263d20752fccde0d63ebe5d15563372e2f6e6",
+          "0x4fdcaaed504ce00fc9517d4e22c658b13db521be99d695b1a3f9244e84be4b70",
+          "0x9db9105b545be02031098e8abfe95848aa386d4e6b130335df05a18c4a1e8e8a",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xA543441313F7FA7F9215B84854E6DC8386B93383": {
+        "index": 37,
+        "amount": "0x07d792da24fba3a6ac1f",
+        "proof": [
+          "0x4ff8869fb49cf9ac818593e5f7aa869c0ba740577e9d253edd4d1699e5904f4b",
+          "0x71ce86f3ccd06a3d54c9bd61c6b8e9191b12c3dee50c6b5dd1038f00a746bebb",
+          "0x337470bc0fb6f0ed5b0b436a26b735750d6b7378dd3b68097991c1e2ec870f0d",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xA97c34278162b556A527CFc01B53eb4DDeDFD223": {
+        "index": 38,
+        "amount": "0x22d69c9ebafe622104",
+        "proof": [
+          "0x0992784bd911348e0aa6e911e14755262d5a123311bd84b211c006c9b8962013",
+          "0xde3a0990e1c93b646703a8a721e40a51131cce4f94001891d4dcd9948208e9ca",
+          "0xb523b6457fdf579ff4c50b778f46d123e1fc759bbe4a9fbc074c54c07db2cc8a",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xABFB52f4CfAC3e6631c19a7e4Aa752110E1187B5": {
+        "index": 39,
+        "amount": "0xf9bf61c5ec9e03abc0",
+        "proof": [
+          "0x47ff3874f6fea8e63f7168ab5691ac871b16b9a6e1ba09a52b9d5f0d36789d69",
+          "0xa9c8b178786f4fb7f31658678377685391c50f735854f1e4359d1d59772a7ff7",
+          "0x0dc1b9aa4609e9857bfddc0ecb23563539cc224ad0c361e48376dd31ab6fa818",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xB62Fc1ADfFb2ab832041528C8178358338d85f76": {
+        "index": 40,
+        "amount": "0x138d6cf17891a01600",
+        "proof": [
+          "0x3beec9ffeb273c53da5794dd10402bc06133f1bdd40c81cb09cf4b83af6c1fe0",
+          "0x104bbeb2a661ac64ee3159b85723a714f76f3af66987c246307d0c46bee5cdb2",
+          "0xecc665a730332c9c6430af5a418f81c16a6b36e9859d5e87278cb0e4037186e5",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xB7a764884a2fBcfC7177b5c53A7797EE7fF4Bb39": {
+        "index": 41,
+        "amount": "0x0627676d14a9da1046d2",
+        "proof": [
+          "0x08fc1cf97638cd12f54526fcf919b0eef35631e394ff2e19cfceaf7209b1c0e8",
+          "0xde3a0990e1c93b646703a8a721e40a51131cce4f94001891d4dcd9948208e9ca",
+          "0xb523b6457fdf579ff4c50b778f46d123e1fc759bbe4a9fbc074c54c07db2cc8a",
+          "0x5f0ab7245945656f718cfe61736b72d5aed49e77a6042aa77fc2ce4a5bf377e1",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xB8A3AE209d153560993BFd8178E60F09B1c682E8": {
+        "index": 42,
+        "amount": "0x195864473f8eadcf6e10",
+        "proof": [
+          "0xf0da896064b13bcaa0b9d4ab0475a0065536e9e5bed90a83906bad2384959c72",
+          "0xd84d86d484e9c8b5729f8c83a6683b0230091c8e748077a12e8d7a0855754cb1",
+          "0xd335ef7fc9c55a4e46faff3012a6551cdbc2398b85d77dc8ef9b9a279d391ea6",
+          "0x0e52d034adf1017833c8af8bbd12d1cc862728e03bf88c0f774798d7976c02a9",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xBDE07f1cA107Ef319b0Bb26eBF1d0a5b4c97ffc1": {
+        "index": 43,
+        "amount": "0x053195194340b6df9ffb",
+        "proof": [
+          "0xa5502ef850cd3e22ee9cba79533026bc0323d06584711b57779de1471a7f9af9",
+          "0x55de412f39e50cafd013a95f5107164fd9f409a7714db2fa8e296a1a45afcce7",
+          "0x2e41a34af67544ec9e149177d772a192ca768132d8cfc1beae650fe8c99c8781",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xD52BfE62a163eB4eC8FC98f06eD3f02695ae491d": {
+        "index": 44,
+        "amount": "0xe8a1fe994038a5b97d",
+        "proof": [
+          "0x68e6456bd5d1563c4c38d344de4f47ab77670e8b97c7a6baad1a3590a2635cd9",
+          "0x9ce82ce583970c47b12c5fa7cffe55b4122b7b5917743636d8a21d112ddd2306",
+          "0x9db9105b545be02031098e8abfe95848aa386d4e6b130335df05a18c4a1e8e8a",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xE86181D6b672d78D33e83029fF3D0ef4A601B4C4": {
+        "index": 45,
+        "amount": "0x03d44c45348a719f51c2",
+        "proof": [
+          "0xc86adef4734c86405f482b6ca420bfc587f2bff0eabf23f418c81c44e486b051",
+          "0xe12f8dda5b421c44fb91895d8044d3e903ecc541924e7a5be04764d20dbed5b5",
+          "0x950994cc0ea73189376bc04c94002296bf9298c7c7a1c782f605cf4fea5731ae",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xF2f5E0a3365c385A3ADCA4F614eD0984dFff52a3": {
+        "index": 46,
+        "amount": "0x654065173a9bd44312",
+        "proof": [
+          "0x499871c42b7744d762a70dabd54176f80be016dd7a4b09f71a9369950401e977",
+          "0x1b429ab630c290ee7a841fc0d0fc89b16024b11bab100920c272ae12fb15c209",
+          "0x0dc1b9aa4609e9857bfddc0ecb23563539cc224ad0c361e48376dd31ab6fa818",
+          "0xa2079d31404dcadb6d5eaaa9c735d0194ff7d152687943fee8d08a271e565083",
+          "0x06fb01e57677777fa50ff47bb9a70971a1c0efb9a52512e00715d37e3fe4c903",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xF35343299a4f80Dd5D917bbe5ddd54eBB820eBd4": {
+        "index": 47,
+        "amount": "0x0e299a02bda9152f",
+        "proof": [
+          "0xfe7c659dd9ec88889d48371efe0d185541919dfd8cccf85f60c6d0bd56381c36",
+          "0x41734d6441b33d8f8a1bae50dc91a1e2ccf66b98cc421a165b3d37e41d6eac66",
+          "0x0e52d034adf1017833c8af8bbd12d1cc862728e03bf88c0f774798d7976c02a9",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xa39F6Ca62303229873D06395237307Cd59de806d": {
+        "index": 48,
+        "amount": "0x2bfa781257a67e51",
+        "proof": [
+          "0xa2a80660d5a24f0e77efa792da0b27c3495c6427c0a0698bd27f28f404fc3afd",
+          "0x55de412f39e50cafd013a95f5107164fd9f409a7714db2fa8e296a1a45afcce7",
+          "0x2e41a34af67544ec9e149177d772a192ca768132d8cfc1beae650fe8c99c8781",
+          "0xb7593542aa4b413c3516be95cb3c1de595ac1e75c011449156dcaba2169751ab",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xb7c561e2069aCaE2c4480111B1606790BB4E13fE": {
+        "index": 49,
+        "amount": "0x015493467bebe82dcd45",
+        "proof": [
+          "0x59dbf2b53c4ee40fb13c7fad166a3ce784ea4e5ce54f573bedaf0fe6a6463bf7",
+          "0x71ce86f3ccd06a3d54c9bd61c6b8e9191b12c3dee50c6b5dd1038f00a746bebb",
+          "0x337470bc0fb6f0ed5b0b436a26b735750d6b7378dd3b68097991c1e2ec870f0d",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xc5795fa1EADF77FCDa0C6D9F9B340D634C2ba546": {
+        "index": 50,
+        "amount": "0x030ea0461c604f4d7021",
+        "proof": [
+          "0x8cbe9e1f9f966829963b8d560fec45e7c9fd26b73b109f4142bf0621844945bf",
+          "0xf483139021e0d9cc1fc9fb511040caf4810bab49e82b836029e81910e6ff9ef9",
+          "0x4c303314619f8edbe6283233952869cfcb45c376b8af4122912056fe4290468a",
+          "0x50ad89a90ccc1d3757c997363706900aa6ad29e254735f41d6b63687bca8fef1",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      },
+      "0xd977144724Bc77FaeFAe219F958AE3947205d0b5": {
+        "index": 51,
+        "amount": "0x05d2209c423de845cd3a",
+        "proof": [
+          "0xd8ec7a1c33d5a12c24796ee1ccac4f0d71b4d5d63e59a4006ff7b00a29a4472c",
+          "0x8682e882537d2f6b6a7f2eb66418e1e6bf61a55a1a59fd0d1af5cc4abea7c4d7",
+          "0xeb1da996db12ac045aef6226b1e4332471f95854dc3354e1901dc7aa71987900",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xe26E2d93Bbc8fde0e1E3B290Fc927Fb374E7e34e": {
+        "index": 52,
+        "amount": "0x0131020ecdf455c780d4",
+        "proof": [
+          "0xe1369f4c7bfca2b169b0e6b2d8e28f07574a5d8e730d640d78939ec7706d6f59",
+          "0xcd3d25996bb2183a57ebcc38817811b1ea146c83b89da88255ca69f28e0c5af2",
+          "0xeb1da996db12ac045aef6226b1e4332471f95854dc3354e1901dc7aa71987900",
+          "0x47a1e159a85ddc28cf9ecbaabe3676a86431ca2a18260f019567f1209af8a312",
+          "0x41802c8e1c7ac104b315a5f7e69eae1bc5e036af5ed24ddbc2dc432396225649",
+          "0x5afde387f1de80c937445c32b50cbd44d47c9c949f5cd348eb651635e418be0f"
+        ]
+      },
+      "0xe3a2d16dA142E6B190A5d9F7e0C07cc460B58A5F": {
+        "index": 53,
+        "amount": "0x9f7121001fbbda3524",
+        "proof": [
+          "0x6408ffd0e1519b1445517300a66fa2312682c321d29ca15c0b2e9683eb277f77",
+          "0x4fdcaaed504ce00fc9517d4e22c658b13db521be99d695b1a3f9244e84be4b70",
+          "0x9db9105b545be02031098e8abfe95848aa386d4e6b130335df05a18c4a1e8e8a",
+          "0x3c61c8f4fa4f3ad21adcd02888e8371e56348f96fa56ed4af9126104b05f1d5e",
+          "0xa580680f59072bf42a829976bfa03301ee02c0d5ab9da85f202a367ee7285ad0",
+          "0xde6bf014f212c4ce6aaed53bd634d82544b766171eb6a97eb3a562ffaebe9376"
+        ]
+      }
+    }
   }
 }

--- a/solidity-v1/dashboard/src/utils/rewardsHelper.js
+++ b/solidity-v1/dashboard/src/utils/rewardsHelper.js
@@ -141,7 +141,12 @@ class ExtendedECDSARewards extends RewardsInterface {
         "0xdc8026bc52c1d200477e8aa8d374e934e57c79d1d0c9fa65d121a8f6607987b0",
     },
     // 2021-01-22 -> 2022-02-22
-    { start: 1642809600, end: 1645488000, merkleRoot: "" },
+    {
+      start: 1642809600,
+      end: 1645488000,
+      merkleRoot:
+        "0xa48918393536de2ba2dfb10b66ea91abb7f66352156d34f2f3ffcbb0b976ba2b",
+    },
     // 2021-02-22 -> 2022-03-22
     { start: 1645488000, end: 1647907200, merkleRoot: "" },
   ]


### PR DESCRIPTION
Backport of: #2843

Adding tBTC rewards merkle tree computed in https://github.com/keep-network/keep-ecdsa/pull/953 to KEEP Token Dashboard.