### PR TITLE
Dashboard docker image build updates

### DIFF
--- a/.github/workflows/dashboard-v1-mainnet.yml
+++ b/.github/workflows/dashboard-v1-mainnet.yml
@@ -2,9 +2,9 @@ name: Token Dashboard / Mainnet
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - solidity-v1/dashboard/**
+      - solidity-v1/dashboard/**
 
 # For pull_request_target:
 #  - Checkout with repository set to PR repo, ref same (see
@@ -12,6 +12,38 @@ on:
 #  - Trigger from issue comment?
 
 jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker Build Image
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - # Temp fix - move cache instead of copying (added below step and
+        # modified value of `cache-to`).
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        # Without the change some jobs were failing with `no space left on device`
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
   build-and-deploy:
     runs-on: ubuntu-latest
 
@@ -24,48 +56,48 @@ jobs:
       run:
         working-directory: solidity-v1/dashboard
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    #- run: npm run lint
-    #- if: github.event_name == 'push' TODO uncomment when mainnet builds happen this way
-    #  run: npm run build --if-present
-    - if: github.event_name == 'pull_request'
-      run: npm run build
-      env:
-        PUBLIC_URL: /${{ github.head_ref }}
-    # A push event is a main merge; deploy to primary bucket.
-    # TODO uncomment when mainnet builds happen this way
-    #- if: github.event_name == 'push'
-    #  name: Deploy Main to GCP
-    #  uses: thesis/gcp-storage-bucket-action@v3.1.0
-    #  with:
-    #    service-key: ${{ secrets.KEEP_DASHBOARD_UPLOADER_SERVICE_KEY_JSON }}
-    #    project: keep-prd-210b
-    #    bucket-name: dashboard.keep.network
-    #    build-folder: solidity-v1/dashboard/build
-    # A pull_request event is a PR; deploy to preview bucket.
-    - if: github.event_name == 'pull_request'
-      name: Deploy PR preview to GCP
-      uses: thesis/gcp-storage-bucket-action@v3.1.0
-      with:
-        service-key: ${{ secrets.KEEP_DASHBOARD_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
-        project: keep-prd-210b
-        bucket-name: preview.dashboard.keep.network
-        bucket-path: ${{ github.head_ref }}
-        build-folder: solidity-v1/dashboard/build
-    # A pull_request event is a PR; leave a comment with the preview URL.
-    - if: github.event_name == 'pull_request'
-      name: Post preview URL to PR
-      uses: actions/github-script@v5
-      with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'Preview uploaded to https://preview.dashboard.keep.network/${{ github.head_ref }}/.'
-          })
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      #- run: npm run lint
+      #- if: github.event_name == 'push' TODO uncomment when mainnet builds happen this way
+      #  run: npm run build --if-present
+      - if: github.event_name == 'pull_request'
+        run: npm run build
+        env:
+          PUBLIC_URL: /${{ github.head_ref }}
+      # A push event is a main merge; deploy to primary bucket.
+      # TODO uncomment when mainnet builds happen this way
+      #- if: github.event_name == 'push'
+      #  name: Deploy Main to GCP
+      #  uses: thesis/gcp-storage-bucket-action@v3.1.0
+      #  with:
+      #    service-key: ${{ secrets.KEEP_DASHBOARD_UPLOADER_SERVICE_KEY_JSON }}
+      #    project: keep-prd-210b
+      #    bucket-name: dashboard.keep.network
+      #    build-folder: solidity-v1/dashboard/build
+      # A pull_request event is a PR; deploy to preview bucket.
+      - if: github.event_name == 'pull_request'
+        name: Deploy PR preview to GCP
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        with:
+          service-key: ${{ secrets.KEEP_DASHBOARD_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: keep-prd-210b
+          bucket-name: preview.dashboard.keep.network
+          bucket-path: ${{ github.head_ref }}
+          build-folder: solidity-v1/dashboard/build
+      # A pull_request event is a PR; leave a comment with the preview URL.
+      - if: github.event_name == 'pull_request'
+        name: Post preview URL to PR
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Preview uploaded to https://preview.dashboard.keep.network/${{ github.head_ref }}/.'
+            })

--- a/solidity-v1/dashboard/Dockerfile
+++ b/solidity-v1/dashboard/Dockerfile
@@ -15,7 +15,7 @@ COPY package-lock.json /app/package-lock.json
 COPY .env* /app/
 
 # Install from lockfile.
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY src /app/src
 COPY public /app/public


### PR DESCRIPTION
This PR changes docker image build process for Token Dashboard that came up during the v1.17.0 release.

`@threshold-network/solidity-contracts` dependency has `postinstall` script that works perfectly fine locally but fails inside a docker image building. We don't need to execute this script in docker as it's used for the deployment of contracts, but here we are expecting final artifacts to be provided. This is a solution proposed by @r-czajkowski 🙇🏻‍♂️ 

Another change we add here is docker image build executed as part of GitHub actions, to confirm that the build works and won't surprise us on mainnet release.