### PR TITLE
Authorization parameters for WalletRegistry contract

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -158,6 +158,9 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         // TODO: Implement governance for the parameters
         // TODO: revisit all initial values
 
+        // slither-disable-next-line too-many-digits
+        authorization.setMinimumAuthorization(400000e18); // 400k T
+        authorization.setAuthorizationDecreaseDelay(5184000); // 60 days
         maliciousDkgResultSlashingAmount = 50000e18;
         maliciousDkgResultNotificationRewardMultiplier = 100;
 

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -557,6 +557,9 @@ contract WalletRegistryGovernance is Ownable {
             );
     }
 
+    /// @notice Get the time remaining until the authorization decrease delay
+    ///         can be updated.
+    /// @return Remaining time in seconds.
     function getRemainingAuthorizationDecreaseDelayUpdateTime()
         external
         view

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -25,6 +25,12 @@ contract WalletRegistryGovernance is Ownable {
     address public newWalletOwner;
     uint256 public walletOwnerChangeInitiated;
 
+    uint96 public newMinimumAuthorization;
+    uint256 public minimumAuthorizationChangeInitiated;
+
+    uint64 public newAuthorizationDecreaseDelay;
+    uint256 public authorizationDecreaseDelayChangeInitiated;
+
     uint96 public newMaliciousDkgResultSlashingAmount;
     uint256 public maliciousDkgResultSlashingAmountChangeInitiated;
 
@@ -53,6 +59,8 @@ contract WalletRegistryGovernance is Ownable {
     //
     // The full list of parameters protected by this delay:
     // - wallet owner
+    // - minimum authorization
+    // - authorization decrease delay
     uint256 internal constant CRITICAL_PARAMETER_GOVERNANCE_DELAY = 2 weeks;
 
     // Short governance delay for non-critical parameters. Honest stakers should
@@ -69,6 +77,18 @@ contract WalletRegistryGovernance is Ownable {
 
     event WalletOwnerUpdateStarted(address walletOwner, uint256 timestamp);
     event WalletOwnerUpdated(address walletOwner);
+
+    event MinimumAuthorizationUpdateStarted(
+        uint96 minimumAuthorization,
+        uint256 timestamp
+    );
+    event MinimumAuthorizationUpdated(uint96 minimumAuthorization);
+
+    event AuthorizationDecreaseDelayUpdateStarted(
+        uint64 authorizationDecreaseDelay,
+        uint256 timestamp
+    );
+    event AuthorizationDecreaseDelayUpdated(uint64 authorizationDecreaseDelay);
 
     event MaliciousDkgResultSlashingAmountUpdateStarted(
         uint256 maliciousDkgResultSlashingAmount,
@@ -182,6 +202,81 @@ contract WalletRegistryGovernance is Ownable {
         walletRegistry.updateWalletOwner(newWalletOwner);
         walletOwnerChangeInitiated = 0;
         newWalletOwner = address(0);
+    }
+
+    /// @notice Begins the minimum authorization amount update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newMinimumAuthorization New minimum authorization amount.
+    function beginMinimumAuthorizationUpdate(uint96 _newMinimumAuthorization)
+        external
+        onlyOwner
+    {
+        /* solhint-disable not-rely-on-time */
+        newMinimumAuthorization = _newMinimumAuthorization;
+        minimumAuthorizationChangeInitiated = block.timestamp;
+        emit MinimumAuthorizationUpdateStarted(
+            _newMinimumAuthorization,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the minimum authorization amount update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeMinimumAuthorizationUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(
+            minimumAuthorizationChangeInitiated,
+            CRITICAL_PARAMETER_GOVERNANCE_DELAY
+        )
+    {
+        emit MinimumAuthorizationUpdated(newMinimumAuthorization);
+        // slither-disable-next-line reentrancy-no-eth
+        walletRegistry.updateAuthorizationParameters(
+            newMinimumAuthorization,
+            walletRegistry.authorizationDecreaseDelay()
+        );
+        minimumAuthorizationChangeInitiated = 0;
+        newMinimumAuthorization = 0;
+    }
+
+    /// @notice Begins the authorization decrease delay update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newAuthorizationDecreaseDelay New authorization decrease delay
+    function beginAuthorizationDecreaseDelayUpdate(
+        uint64 _newAuthorizationDecreaseDelay
+    ) external onlyOwner {
+        /* solhint-disable not-rely-on-time */
+        newAuthorizationDecreaseDelay = _newAuthorizationDecreaseDelay;
+        authorizationDecreaseDelayChangeInitiated = block.timestamp;
+        emit AuthorizationDecreaseDelayUpdateStarted(
+            _newAuthorizationDecreaseDelay,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the authorization decrease delay update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeAuthorizationDecreaseDelayUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(
+            authorizationDecreaseDelayChangeInitiated,
+            CRITICAL_PARAMETER_GOVERNANCE_DELAY
+        )
+    {
+        emit AuthorizationDecreaseDelayUpdated(newAuthorizationDecreaseDelay);
+        // slither-disable-next-line reentrancy-no-eth
+        walletRegistry.updateAuthorizationParameters(
+            walletRegistry.minimumAuthorization(),
+            newAuthorizationDecreaseDelay
+        );
+        authorizationDecreaseDelayChangeInitiated = 0;
+        newAuthorizationDecreaseDelay = 0;
     }
 
     /// @notice Begins the malicious DKG result slashing amount update process.
@@ -445,6 +540,33 @@ contract WalletRegistryGovernance is Ownable {
         );
         dkgSubmitterPrecedencePeriodLengthChangeInitiated = 0;
         newSubmitterPrecedencePeriodLength = 0;
+    }
+
+    /// @notice Get the time remaining until the minimum authorization amount
+    ///         can be updated.
+    /// @return Remaining time in seconds.
+    function getRemainingMimimumAuthorizationUpdateTime()
+        external
+        view
+        returns (uint256)
+    {
+        return
+            getRemainingChangeTime(
+                minimumAuthorizationChangeInitiated,
+                CRITICAL_PARAMETER_GOVERNANCE_DELAY
+            );
+    }
+
+    function getRemainingAuthorizationDecreaseDelayUpdateTime()
+        external
+        view
+        returns (uint256)
+    {
+        return
+            getRemainingChangeTime(
+                authorizationDecreaseDelayChangeInitiated,
+                CRITICAL_PARAMETER_GOVERNANCE_DELAY
+            );
     }
 
     /// @notice Get the time remaining until the malicious DKG result

--- a/solidity/ecdsa/contracts/libraries/EcdsaAuthorization.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaAuthorization.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+//
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//
+
+pragma solidity ^0.8.9;
+
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
+import "@threshold-network/solidity-contracts/contracts/staking/TokenStaking.sol";
+
+library EcdsaAuthorization {
+    struct Data {
+        uint96 minimumAuthorization;
+        uint64 authorizationDecreaseDelay;
+    }
+
+    function setMinimumAuthorization(
+        Data storage self,
+        uint96 _minimumAuthorization
+    ) internal {
+        self.minimumAuthorization = _minimumAuthorization;
+    }
+
+    function setAuthorizationDecreaseDelay(
+        Data storage self,
+        uint64 _authorizationDecreaseDelay
+    ) internal {
+        self.authorizationDecreaseDelay = _authorizationDecreaseDelay;
+    }
+}

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -106,6 +106,7 @@ const config: HardhatUserConfig = {
     disambiguatePaths: false,
     runOnCompile: true,
     strict: true,
+    except: ["TokenStaking$"],
   },
   mocha: {
     timeout: 60000,

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -55,7 +55,7 @@
     "@keep-network/random-beacon": "../random-beacon",
     "@keep-network/sortition-pools": "^2.0.0-dev.0",
     "@openzeppelin/contracts": "^4.4.1",
-    "@threshold-network/solidity-contracts": ">0.0.2-dev <0.0.2-ropsten"
+    "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -18,6 +18,34 @@ describe("WalletRegistry - Parameters", async () => {
       await walletRegistryFixture())
   })
 
+  describe("updateAuthorizationParameters", () => {
+    context("when called by the deployer", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistry.connect(deployer).updateAuthorizationParameters(1, 2)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the wallet owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistry
+            .connect(walletOwner)
+            .updateAuthorizationParameters(1, 2)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by a third party", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistry.connect(thirdParty).updateAuthorizationParameters(1, 2)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+  })
+
   describe("updateDkgParameters", async () => {
     context("when called by the deployer", async () => {
       it("should revert", async () => {

--- a/solidity/ecdsa/test/WalletRegistry.Pool.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Pool.test.ts
@@ -1,7 +1,7 @@
 import { deployments, ethers, getUnnamedAccounts, helpers } from "hardhat"
 import { expect } from "chai"
 
-import { constants } from "./fixtures"
+import { params } from "./fixtures"
 
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { WalletRegistry, SortitionPool, StakingStub } from "../typechain"
@@ -39,7 +39,7 @@ describe("WalletRegistry - Pool", () => {
         await staking.increaseAuthorization(
           stakingProvider.address,
           walletRegistry.address,
-          constants.minimumStake
+          params.minimumAuthorization
         )
       })
 
@@ -102,7 +102,7 @@ describe("WalletRegistry - Pool", () => {
         await staking.increaseAuthorization(
           stakingProvider.address,
           ethers.constants.AddressZero,
-          constants.minimumStake
+          params.minimumAuthorization
         )
         await walletRegistry.connect(operator).registerOperator()
       })

--- a/solidity/ecdsa/test/WalletRegistry.RandomBeacon.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.RandomBeacon.test.ts
@@ -175,8 +175,8 @@ describe("WalletRegistry - Random Beacon", async () => {
 
         // The exact value was noted from a test execution and is used as a reference
         // for all future executions.
-        it("should not exceed 77308", async () => {
-          const expectedGasEstimate = 77308
+        it("should not exceed 77330", async () => {
+          const expectedGasEstimate = 77330
 
           const gasEstimate = await walletRegistry
             .connect(randomBeaconFake.wallet)

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -2367,7 +2367,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               )
 
               context("with token staking seize call failure", async () => {
-                const slashingAmount = constants.minimumStake.add(1)
+                const slashingAmount = params.minimumAuthorization.add(1)
 
                 let tx: Promise<ContractTransaction>
 

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -17,8 +17,8 @@ describe("WalletRegistryGovernance", async () => {
   let thirdParty: SignerWithAddress
   let walletOwner: SignerWithAddress
 
-  const initialMinimumAuthorization = to1e18(100000)
-  const initialAuthorizationDecreaseDelay = 5260000 // 2 months
+  const initialMinimumAuthorization = to1e18(400000)
+  const initialAuthorizationDecreaseDelay = 5184000 // 60 days
   const initialMaliciousDkgResultSlashingAmount = to1e18(50000)
   const initialMaliciousDkgResultNotificationRewardMultiplier = 100
 

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -31,8 +31,8 @@ export const dkgState = {
 }
 
 export const params = {
-  minimumAuthorization: to1e18(100000),
-  authorizationDecreaseDelay: 5260000,
+  minimumAuthorization: to1e18(400000),
+  authorizationDecreaseDelay: 5184000,
   dkgSeedTimeout: 8,
   dkgResultChallengePeriodLength: 10,
   dkgResultSubmissionTimeout: 30,

--- a/solidity/ecdsa/test/utils/operators.ts
+++ b/solidity/ecdsa/test/utils/operators.ts
@@ -3,7 +3,7 @@
 import { ethers } from "hardhat"
 
 // eslint-disable-next-line import/no-cycle
-import { constants } from "../fixtures"
+import { params } from "../fixtures"
 
 import type { Address } from "hardhat-deploy/types"
 import type { BigNumber } from "ethers"
@@ -20,7 +20,7 @@ export async function registerOperators(
   walletRegistry: WalletRegistry,
   tToken: T,
   addresses: Address[],
-  stakeAmount: BigNumber = constants.minimumStake
+  stakeAmount: BigNumber = params.minimumAuthorization
 ): Promise<Operator[]> {
   const operators: Operator[] = []
 

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -604,7 +604,7 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
-"@keep-network/keep-core@>1.8.0-dev <1.8.0-ropsten":
+"@keep-network/keep-core@>1.8.0-dev <1.8.0-pre":
   version "1.8.0-dev.5"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz#8b4d08ec437f29c94723ee54fcf76456ba5408c3"
   integrity sha512-QVkpO5X28Vczj/xHezV0z2UuMw8QFaR3C8x/d6+3adedsL3nCxgveIGTUcXSuYpBqfx0v4/xT+9bIK7BwLkGPw==
@@ -616,7 +616,7 @@
   version "2.0.0-dev"
   dependencies:
     "@keep-network/sortition-pools" "1.2.0-dev.24"
-    "@openzeppelin/contracts" "^4.3.3"
+    "@openzeppelin/contracts" "^4.4.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/sortition-pools@1.2.0-dev.24":
@@ -690,12 +690,17 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.3.3", "@openzeppelin/contracts@^4.4", "@openzeppelin/contracts@^4.4.1":
+"@openzeppelin/contracts-upgradeable@^4.4":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.1.tgz#dc354082460eb34f5833afdecfab46538b208c4f"
+  integrity sha512-xcKycsSyFauIGMhSeeTJW/Jzz9jZUJdiFNP9Wo/9VhMhw8t5X0M92RY6x176VfcIWsxURMHFWOJVTlFA78HI/w==
+
+"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4", "@openzeppelin/contracts@^4.4.1":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
   integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
 
-"@openzeppelin/contracts@^4.3.3":
+"@openzeppelin/contracts@^4.4.2":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
@@ -941,13 +946,14 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@>0.0.2-dev <0.0.2-ropsten":
-  version "0.0.2-dev.18"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-0.0.2-dev.18.tgz#70ba580760b42765656c7675a936dc3813161eee"
-  integrity sha512-dS8iBkEraD2FpOCXymCg3FxVZqelR65SEjkkENNTbCLxxPQraKGVSU1BYs/tvX6cKvg0pcLfqXDwcEjxc4+rMQ==
+"@threshold-network/solidity-contracts@>1.1.0-dev <1.1.0-ropsten":
+  version "1.1.0-dev.8"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.1.0-dev.8.tgz#5c8ed6e9dab26823f25c319a5ade167c6bb8efa3"
+  integrity sha512-7xsjMIO3jtVDOB3X+tY6rEy9qViGHLwxyNEdgYH85BzpOdXvL3tlmwVnAn0k1fQyRhGLrUOtS56Z6fsDCxyRRg==
   dependencies:
-    "@keep-network/keep-core" ">1.8.0-dev <1.8.0-ropsten"
+    "@keep-network/keep-core" ">1.8.0-dev <1.8.0-pre"
     "@openzeppelin/contracts" "^4.4"
+    "@openzeppelin/contracts-upgradeable" "^4.4"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@tsconfig/node10@^1.0.7":


### PR DESCRIPTION
Refs: #2834 

Introduced two authorization-related parameters in the WalletRegistry contract:
- minimum authorization
- authorization decrease delay

`Authorization` library will be further developed to enable integration with Threshold `TokenStaking` contract. Changes introducing governable parameters are included separately in this PR to keep the diff size sane.

Side note: after looking at `WalletRegistryGovernance`, I've decided to open https://github.com/keep-network/keep-core/issues/2847 to improve how governance contract works for Random Beacon and ECDSA.