### PR TITLE
[Backport] Fix displaying undelegated stakes in app->threshold

### DIFF
--- a/solidity-v1/dashboard/src/actions/index.js
+++ b/solidity-v1/dashboard/src/actions/index.js
@@ -58,6 +58,8 @@ export const FETCH_THRESHOLD_AUTH_DATA_FAILURE =
   "threshold/fetch_auth_data_failure"
 export const THRESHOLD_AUTHORIZED = "threshold/contract_authorized"
 export const THRESHOLD_STAKED_TO_T = "threshold/staked_to_t"
+export const REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA =
+  "threshold/remove_stake_from_threshold_auth_data"
 
 export const tbtcV2Migration = {
   ...TBTCV2MigrationActions,

--- a/solidity-v1/dashboard/src/actions/keep-to-t-staking.js
+++ b/solidity-v1/dashboard/src/actions/keep-to-t-staking.js
@@ -1,4 +1,8 @@
-import { THRESHOLD_AUTHORIZED, THRESHOLD_STAKED_TO_T } from "./index"
+import {
+  REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
+  THRESHOLD_AUTHORIZED,
+  THRESHOLD_STAKED_TO_T,
+} from "./index"
 
 export const THRESHOLD_STAKE_KEEP_EVENT_EMITTED =
   "threshold/stake_keep_event_emitted"
@@ -32,5 +36,12 @@ export const stakeKeepToT = (data) => {
       operator: data.operatorAddress,
       isAuthorized: data.isAuthorized,
     },
+  }
+}
+
+export const removeStakeFromThresholdAuthData = (operatorAddress) => {
+  return {
+    type: REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
+    payload: { operatorAddress },
   }
 }

--- a/solidity-v1/dashboard/src/reducers/threshold-authorization.js
+++ b/solidity-v1/dashboard/src/reducers/threshold-authorization.js
@@ -4,8 +4,10 @@ import {
   FETCH_THRESHOLD_AUTH_DATA_FAILURE,
   THRESHOLD_AUTHORIZED,
   THRESHOLD_STAKED_TO_T,
+  REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
 } from "../actions"
 import { findIndexAndObject, compareEthAddresses } from "../utils/array.utils"
+import { isSameEthAddress } from "../utils/general.utils"
 
 const initialState = {
   authData: [],
@@ -45,6 +47,11 @@ const thresholdAuthorizationReducer = (state = initialState, action) => {
         authData: updateThresholdAuthData([...state.authData], {
           ...action.payload,
         }),
+      }
+    case REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA:
+      return {
+        ...state,
+        authData: removeStakeFromAuthData([...state.authData], action.payload),
       }
     default:
       return state
@@ -96,6 +103,12 @@ const updateThresholdAuthData = (authData, { operatorAddress }) => {
   }
 
   return updatedOperators
+}
+
+const removeStakeFromAuthData = (authData, operatorAddress) => {
+  return authData.filter((stake) => {
+    return !isSameEthAddress(stake.operatorAddress, operatorAddress)
+  })
 }
 
 export default thresholdAuthorizationReducer

--- a/solidity-v1/dashboard/src/sagas/subscriptions.js
+++ b/solidity-v1/dashboard/src/sagas/subscriptions.js
@@ -19,6 +19,7 @@ import {
   OPERATOR_DELEGATION_UNDELEGATED,
   FETCH_OPERATOR_DELEGATIONS_SUCCESS,
   tbtcV2Migration,
+  REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
 } from "../actions"
 import {
   assetPoolDepositedEventEmitted,
@@ -303,6 +304,10 @@ function* observeUndelegatedEvent() {
 
       yield put({ type: "staking/remove_delegation", payload: operator })
       yield put({ type: "staking/add_undelegation", payload: undelegation })
+      yield put({
+        type: REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
+        payload: operator,
+      })
     } catch (error) {
       console.error(`Failed subscribing to Undelegated event`, error)
       contractEventCahnnel.close()

--- a/solidity-v1/dashboard/src/services/threshold-authorization.service.js
+++ b/solidity-v1/dashboard/src/services/threshold-authorization.service.js
@@ -10,7 +10,6 @@ import {
   TOKEN_GRANT_CONTRACT_NAME,
 } from "../constants/constants"
 import { Keep } from "../contracts"
-import { gt } from "../utils/arithmetics.utils"
 
 const fetchThresholdAuthorizationData = async (address) => {
   if (!address) {
@@ -61,7 +60,7 @@ const fetchThresholdAuthorizationData = async (address) => {
 
     // If stake is undelegated we won't display it, because undelegated stakes
     // can't be staked to Threshold
-    if (undelegatedAt !== "0" && gt(stakeAmount, 0)) continue
+    if (undelegatedAt !== "0") continue
 
     const isThresholdTokenStakingContractAuthorized =
       await stakingContract.methods


### PR DESCRIPTION
Backport of: https://github.com/keep-network/keep-core/pull/2846

There was a bug when the stake that was undelegated and recovered displayed in
the tables in Applications->Threshold page. This PR fixes that.

Main changes:
- fixed a bug that caused undelegated and recovered stakes to be displayed in
Application -> Threshold page
- updates the threshold auth data after doing an undelegation so this way user
don't have to refresh the page to see the actual changes