### PR TITLE
ECDSA Wallets: Callback to the Wallet Owner after wallet creation

### DIFF
--- a/solidity/ecdsa/.eslintrc
+++ b/solidity/ecdsa/.eslintrc
@@ -4,7 +4,13 @@
   "rules": {
     "import/no-extraneous-dependencies": [
       "error",
-      { "devDependencies": ["./test/**/*.ts", "hardhat.config.ts"] }
+      {
+        "devDependencies": [
+          "./test/**/*.ts",
+          "./tasks/**/*.ts",
+          "hardhat.config.ts"
+        ]
+      }
     ],
     "@typescript-eslint/no-use-before-define": "off",
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],

--- a/solidity/ecdsa/README.adoc
+++ b/solidity/ecdsa/README.adoc
@@ -58,3 +58,18 @@ You can run them by doing:
 ```sh
 yarn test
 ```
+
+=== Deploy contracts
+
+To deploy contract execute:
+
+```
+yarn deploy --network <NETWORK>
+```
+
+After the Bridge contract from tbtc-v2 is deployed it has to be set as the
+Wallet Owner in the `WalletRegistry`:
+
+```
+npx hardhat --network <NETWORK> initialize-wallet-owner --wallet-owner-address <BRIDGE_ADDRESS>
+```

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -398,7 +398,12 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         //slither-disable-next-line redundant-statements
         misbehavedMembers;
 
-        try walletOwner.notifyEcdsaWalletCreated(publicKeyHash) {} catch {
+        try
+            walletOwner.notifyEcdsaWalletCreated(
+                publicKeyHash,
+                dkgResult.groupPubKey
+            )
+        {} catch {
             // Should never happen but we want to ensure a non-critical path
             // failure from an external contract does not stop the DKG to complete.
             // slither-disable-next-line reentrancy-events

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -184,9 +184,12 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
     /// @param _randomBeacon Random Beacon address.
-    function upgradeRandomBeacon(address _randomBeacon) external onlyOwner {
-        randomBeacon = IRandomBeacon(_randomBeacon);
-        emit RandomBeaconUpgraded(_randomBeacon);
+    function upgradeRandomBeacon(IRandomBeacon _randomBeacon)
+        external
+        onlyOwner
+    {
+        randomBeacon = _randomBeacon;
+        emit RandomBeaconUpgraded(address(_randomBeacon));
     }
 
     /// @notice Updates the values of authorization parameters.
@@ -275,16 +278,17 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
     /// @notice Updates the values of the wallet parameters.
     /// @dev Can be called only by the contract owner, which should be the
     ///      wallet registry governance contract. The caller is responsible for
-    ///      validating parameters.
+    ///      validating parameters. The wallet owner has to implement `IWalletOwner`
+    ///      interface.
     /// @param _walletOwner New wallet owner address.
-    function updateWalletOwner(address _walletOwner) external onlyOwner {
+    function updateWalletOwner(IWalletOwner _walletOwner) external onlyOwner {
         require(
-            _walletOwner != address(0),
+            address(_walletOwner) != address(0),
             "Wallet owner address cannot be zero"
         );
 
-        walletOwner = IWalletOwner(_walletOwner);
-        emit WalletOwnerUpdated(_walletOwner);
+        walletOwner = _walletOwner;
+        emit WalletOwnerUpdated(address(_walletOwner));
     }
 
     /// @notice Registers the caller in the sortition pool.

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -110,8 +110,6 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         bytes32 indexed dkgResultHash
     );
 
-    event WalletOwnerNotificationFailed(bytes32 indexed publicKeyHash);
-
     event DkgMaliciousResultSlashed(
         bytes32 indexed resultHash,
         uint256 slashingAmount,
@@ -398,17 +396,10 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         //slither-disable-next-line redundant-statements
         misbehavedMembers;
 
-        try
-            walletOwner.__ecdsaWalletCreatedCallback(
-                publicKeyHash,
-                dkgResult.groupPubKey
-            )
-        {} catch {
-            // Should never happen but we want to ensure a non-critical path
-            // failure from an external contract does not stop the DKG to complete.
-            // slither-disable-next-line reentrancy-events
-            emit WalletOwnerNotificationFailed(publicKeyHash);
-        }
+        walletOwner.__ecdsaWalletCreatedCallback(
+            publicKeyHash,
+            dkgResult.groupPubKey
+        );
 
         dkg.complete();
     }

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -398,7 +398,7 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         //slither-disable-next-line redundant-statements
         misbehavedMembers;
 
-        try walletOwner.notifyWalletCreated(publicKeyHash) {} catch {
+        try walletOwner.notifyEcdsaWalletCreated(publicKeyHash) {} catch {
             // Should never happen but we want to ensure a non-critical path
             // failure from an external contract does not stop the DKG to complete.
             emit WalletOwnerNotificationFailed(publicKeyHash);

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -399,7 +399,7 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         misbehavedMembers;
 
         try
-            walletOwner.notifyEcdsaWalletCreated(
+            walletOwner.__ecdsaWalletCreatedCallback(
                 publicKeyHash,
                 dkgResult.groupPubKey
             )

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -401,6 +401,7 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         try walletOwner.notifyEcdsaWalletCreated(publicKeyHash) {} catch {
             // Should never happen but we want to ensure a non-critical path
             // failure from an external contract does not stop the DKG to complete.
+            // slither-disable-next-line reentrancy-events
             emit WalletOwnerNotificationFailed(publicKeyHash);
         }
 

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -150,13 +150,11 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         SortitionPool _sortitionPool,
         IWalletStaking _staking,
         EcdsaDkgValidator _ecdsaDkgValidator,
-        IRandomBeacon _randomBeacon,
-        address _walletOwner
+        IRandomBeacon _randomBeacon
     ) {
         sortitionPool = _sortitionPool;
         staking = _staking;
         randomBeacon = _randomBeacon;
-        walletOwner = _walletOwner;
 
         // TODO: Implement governance for the parameters
         // TODO: revisit all initial values

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -172,6 +172,15 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
         dkg.setSubmitterPrecedencePeriodLength(20); // TODO: Verify value
     }
 
+    /// @notice Reverts if called not by the Wallet Owner.
+    modifier onlyWalletOwner() {
+        require(
+            msg.sender == address(walletOwner),
+            "Caller is not the Wallet Owner"
+        );
+        _;
+    }
+
     /// @notice Updates address of the Random Beacon.
     /// @dev Can be called only by the contract owner, which should be the
     ///      wallet registry governance contract. The caller is responsible for
@@ -311,9 +320,7 @@ contract WalletRegistry is IRandomBeaconConsumer, Ownable {
     ///      It locks the DKG and request a new relay entry. It expects
     ///      that the DKG process will be started once a new relay entry
     ///      gets generated.
-    function requestNewWallet() external {
-        require(msg.sender == walletOwner, "Caller is not the Wallet Owner");
-
+    function requestNewWallet() external onlyWalletOwner {
         dkg.lockState();
 
         randomBeacon.requestRelayEntry(this);

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -168,6 +168,26 @@ contract WalletRegistryGovernance is Ownable {
         walletRegistry.upgradeRandomBeacon(_newRandomBeacon);
     }
 
+    /// @notice Initializes the Wallet Owner's address.
+    /// @dev Can be called only by the contract owner. It can be called only if
+    ///      walletOwner has not been set before. It doesn't enforce a governance
+    ///      delay for the initial update. Any subsequent updates should be performed
+    ///      with beginWalletOwnerUpdate/finalizeWalletOwnerUpdate with respect
+    ///      of a governance delay.
+    /// @param _walletOwner The Wallet Owner's address
+    function initializeWalletOwner(address _walletOwner) external onlyOwner {
+        require(
+            address(walletRegistry.walletOwner()) == address(0),
+            "Wallet Owner already initialized"
+        );
+        require(
+            _walletOwner != address(0),
+            "Wallet Owner address cannot be zero"
+        );
+
+        walletRegistry.updateWalletOwner(_walletOwner);
+    }
+
     /// @notice Begins the wallet owner update process.
     /// @dev Can be called only by the contract owner.
     /// @param _newWalletOwner New wallet owner address
@@ -176,7 +196,7 @@ contract WalletRegistryGovernance is Ownable {
         onlyOwner
     {
         require(
-            _newWalletOwner != address(0),
+            address(_newWalletOwner) != address(0),
             "New wallet owner address cannot be zero"
         );
         /* solhint-disable not-rely-on-time */
@@ -693,4 +713,6 @@ contract WalletRegistryGovernance is Ownable {
 
         return delay - elapsed;
     }
+
+    // TODO: Add function to transfer WalletRegistry ownership to another address.
 }

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -17,6 +17,9 @@ pragma solidity ^0.8.9;
 import "./WalletRegistry.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+import {IWalletOwner} from "./api/IWalletOwner.sol";
+import {IRandomBeacon} from "@keep-network/random-beacon/contracts/api/IRandomBeacon.sol";
+
 /// @title Wallet Registry Governance
 /// @notice Owns the `WalletRegistry` contract and is responsible for updating its
 ///         governable parameters in respect to governance delay individual
@@ -165,7 +168,7 @@ contract WalletRegistryGovernance is Ownable {
             "New random beacon address cannot be zero"
         );
 
-        walletRegistry.upgradeRandomBeacon(_newRandomBeacon);
+        walletRegistry.upgradeRandomBeacon(IRandomBeacon(_newRandomBeacon));
     }
 
     /// @notice Initializes the Wallet Owner's address.
@@ -185,7 +188,7 @@ contract WalletRegistryGovernance is Ownable {
             "Wallet Owner address cannot be zero"
         );
 
-        walletRegistry.updateWalletOwner(_walletOwner);
+        walletRegistry.updateWalletOwner(IWalletOwner(_walletOwner));
     }
 
     /// @notice Begins the wallet owner update process.
@@ -219,7 +222,7 @@ contract WalletRegistryGovernance is Ownable {
     {
         emit WalletOwnerUpdated(newWalletOwner);
         // slither-disable-next-line reentrancy-no-eth
-        walletRegistry.updateWalletOwner(newWalletOwner);
+        walletRegistry.updateWalletOwner(IWalletOwner(newWalletOwner));
         walletOwnerChangeInitiated = 0;
         newWalletOwner = address(0);
     }

--- a/solidity/ecdsa/contracts/api/IWalletOwner.sol
+++ b/solidity/ecdsa/contracts/api/IWalletOwner.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+//
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+pragma solidity ^0.8.9;
+
+interface IWalletOwner {
+    /// @notice Callback function executed once a new wallet is created.
+    /// @dev Should be callable only by the Wallet Registry.
+    /// @param publicKeyHash Keccak256 hash of the wallet's public key. It is
+    ///        considered an unique wallet identifier.
+    function notifyWalletCreated(bytes32 publicKeyHash) external;
+}

--- a/solidity/ecdsa/contracts/api/IWalletOwner.sol
+++ b/solidity/ecdsa/contracts/api/IWalletOwner.sol
@@ -20,7 +20,7 @@ interface IWalletOwner {
     /// @param walletID Wallet's unique identifier.
     /// @param uncompressedPublicKey Wallet's uncompressed public key (64-byte)
     ///        as a concatenation of X and Y coordinates.
-    function notifyEcdsaWalletCreated(
+    function __ecdsaWalletCreatedCallback(
         bytes32 walletID,
         bytes memory uncompressedPublicKey
     ) external;

--- a/solidity/ecdsa/contracts/api/IWalletOwner.sol
+++ b/solidity/ecdsa/contracts/api/IWalletOwner.sol
@@ -17,7 +17,11 @@ pragma solidity ^0.8.9;
 interface IWalletOwner {
     /// @notice Callback function executed once a new wallet is created.
     /// @dev Should be callable only by the Wallet Registry.
-    /// @param publicKeyHash Keccak256 hash of the wallet's public key. It is
-    ///        considered an unique wallet identifier.
-    function notifyEcdsaWalletCreated(bytes32 publicKeyHash) external;
+    /// @param walletID Wallet's unique identifier.
+    /// @param uncompressedPublicKey Wallet's uncompressed public key (64-byte)
+    ///        as a concatenation of X and Y coordinates.
+    function notifyEcdsaWalletCreated(
+        bytes32 walletID,
+        bytes memory uncompressedPublicKey
+    ) external;
 }

--- a/solidity/ecdsa/contracts/api/IWalletOwner.sol
+++ b/solidity/ecdsa/contracts/api/IWalletOwner.sol
@@ -19,5 +19,5 @@ interface IWalletOwner {
     /// @dev Should be callable only by the Wallet Registry.
     /// @param publicKeyHash Keccak256 hash of the wallet's public key. It is
     ///        considered an unique wallet identifier.
-    function notifyWalletCreated(bytes32 publicKeyHash) external;
+    function notifyEcdsaWalletCreated(bytes32 publicKeyHash) external;
 }

--- a/solidity/ecdsa/contracts/test/WalletRegistryStub.sol
+++ b/solidity/ecdsa/contracts/test/WalletRegistryStub.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.8.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
+import "../api/IWalletOwner.sol";
 import "../WalletRegistry.sol";
 import "../EcdsaDkgValidator.sol";
 import "../libraries/EcdsaDkg.sol";
@@ -12,17 +13,8 @@ contract WalletRegistryStub is WalletRegistry {
         SortitionPool _sortitionPool,
         IWalletStaking _staking,
         EcdsaDkgValidator _dkgValidator,
-        IRandomBeacon _randomBeacon,
-        address _walletOwner
-    )
-        WalletRegistry(
-            _sortitionPool,
-            _staking,
-            _dkgValidator,
-            _randomBeacon,
-            _walletOwner
-        )
-    {}
+        IRandomBeacon _randomBeacon
+    ) WalletRegistry(_sortitionPool, _staking, _dkgValidator, _randomBeacon) {}
 
     function getDkgData() external view returns (EcdsaDkg.Data memory) {
         return dkg;

--- a/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
@@ -3,7 +3,7 @@ import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, helpers } = hre
-  const { deployer, walletOwner } = await getNamedAccounts()
+  const { deployer } = await getNamedAccounts()
 
   const SortitionPool = await deployments.get("SortitionPool")
   let TokenStaking = await deployments.get("TokenStaking")
@@ -49,7 +49,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
       TokenStaking.address,
       EcdsaDkgValidator.address,
       RandomBeacon.address,
-      walletOwner,
     ],
     libraries: { EcdsaDkg: EcdsaDkg.address, Wallets: Wallets.address },
     log: true,

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -10,6 +10,8 @@ import "hardhat-gas-reporter"
 import "hardhat-contract-sizer"
 import "hardhat-dependency-compiler"
 
+import "./tasks"
+
 const config: HardhatUserConfig = {
   solidity: {
     compilers: [
@@ -48,6 +50,11 @@ const config: HardhatUserConfig = {
       accounts: { count: 70 },
       tags: ["local"],
     },
+    development: {
+      url: "http://localhost:8545",
+      chainId: 1101,
+      tags: ["local"],
+    },
     ropsten: {
       url: process.env.CHAIN_API_URL || "",
       chainId: 3,
@@ -66,12 +73,11 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1, // take the second account
+      // mainnet: ""
     },
     governance: {
       default: 2,
-    },
-    walletOwner: {
-      default: 3,
+      // mainnet: ""
     },
   },
   external: {

--- a/solidity/ecdsa/tasks/index.ts
+++ b/solidity/ecdsa/tasks/index.ts
@@ -1,0 +1,1 @@
+import "./initialize-wallet-owner"

--- a/solidity/ecdsa/tasks/initialize-wallet-owner.ts
+++ b/solidity/ecdsa/tasks/initialize-wallet-owner.ts
@@ -1,0 +1,28 @@
+/* eslint-disable no-console */
+import { task } from "hardhat/config"
+
+task("initialize-wallet-owner", "Initializes Wallet Owner for Wallet Registry")
+  .addParam("walletOwnerAddress", "The Wallet Owner's address")
+  .setAction(async (args, hre) => {
+    const { getNamedAccounts, ethers, deployments } = hre
+    const { governance } = await getNamedAccounts()
+
+    const { walletOwnerAddress } = args
+
+    if (!ethers.utils.isAddress(walletOwnerAddress)) {
+      throw Error(`invalid address: ${walletOwnerAddress}`)
+    }
+
+    const tx = await deployments.execute(
+      "WalletRegistryGovernance",
+      { from: governance },
+      "initializeWalletOwner",
+      walletOwnerAddress
+    )
+
+    console.log(
+      `Initialized Wallet Owner address: ${walletOwnerAddress} in transaction: ${tx.transactionHash}`
+    )
+  })
+
+export default {}

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -2,6 +2,8 @@ import { expect } from "chai"
 
 import { walletRegistryFixture } from "./fixtures"
 
+import type { IWalletOwner } from "../typechain/IWalletOwner"
+import type { FakeContract } from "@defi-wonderland/smock"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { WalletRegistry, WalletRegistryStub } from "../typechain"
 
@@ -9,7 +11,7 @@ describe("WalletRegistry - Parameters", async () => {
   let walletRegistry: WalletRegistryStub & WalletRegistry
 
   let deployer: SignerWithAddress
-  let walletOwner: SignerWithAddress
+  let walletOwner: FakeContract<IWalletOwner>
   let thirdParty: SignerWithAddress
 
   before("load test fixture", async () => {
@@ -58,7 +60,9 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by the wallet owner", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(walletOwner).updateDkgParameters(1, 2, 3, 4)
+          walletRegistry
+            .connect(walletOwner.wallet)
+            .updateDkgParameters(1, 2, 3, 4)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -84,7 +88,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by the wallet owner", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(walletOwner).updateRewardParameters(1)
+          walletRegistry.connect(walletOwner.wallet).updateRewardParameters(1)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -110,7 +114,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by the wallet owner", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(walletOwner).updateSlashingParameters(1)
+          walletRegistry.connect(walletOwner.wallet).updateSlashingParameters(1)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -137,7 +141,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry
-            .connect(walletOwner)
+            .connect(walletOwner.wallet)
             .updateWalletOwner(thirdParty.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
@@ -169,7 +173,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry
-            .connect(walletOwner)
+            .connect(walletOwner.wallet)
             .upgradeRandomBeacon(thirdParty.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -33,7 +33,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry
-            .connect(walletOwner)
+            .connect(walletOwner.wallet)
             .updateAuthorizationParameters(1, 2)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })

--- a/solidity/ecdsa/test/WalletRegistry.RandomBeacon.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.RandomBeacon.test.ts
@@ -7,6 +7,7 @@ import { dkgState, walletRegistryFixture } from "./fixtures"
 import { fakeRandomBeacon, resetMock } from "./utils/randomBeacon"
 import { upgradeRandomBeacon } from "./utils/governance"
 
+import type { IWalletOwner } from "../typechain/IWalletOwner"
 import type { MockContract, FakeContract } from "@defi-wonderland/smock"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
@@ -23,8 +24,7 @@ const { createSnapshot, restoreSnapshot } = helpers.snapshot
 describe("WalletRegistry - Random Beacon", async () => {
   let walletRegistry: WalletRegistryStub & WalletRegistry
   let randomBeaconFake: FakeContract<IRandomBeacon>
-
-  let walletOwner: SignerWithAddress
+  let walletOwner: FakeContract<IWalletOwner>
   let thirdParty: SignerWithAddress
 
   before("load test fixture", async () => {
@@ -46,7 +46,7 @@ describe("WalletRegistry - Random Beacon", async () => {
           "beacon internal error"
         )
 
-        tx = walletRegistry.connect(walletOwner).requestNewWallet()
+        tx = walletRegistry.connect(walletOwner.wallet).requestNewWallet()
       })
 
       after(async () => {
@@ -68,7 +68,7 @@ describe("WalletRegistry - Random Beacon", async () => {
       before(async () => {
         await createSnapshot()
 
-        tx = walletRegistry.connect(walletOwner).requestNewWallet()
+        tx = walletRegistry.connect(walletOwner.wallet).requestNewWallet()
       })
 
       after(async () => {
@@ -122,7 +122,7 @@ describe("WalletRegistry - Random Beacon", async () => {
         before(async () => {
           await createSnapshot()
 
-          await walletRegistry.connect(walletOwner).requestNewWallet()
+          await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
 
           tx = await walletRegistry
             .connect(randomBeaconFake.wallet)
@@ -166,7 +166,7 @@ describe("WalletRegistry - Random Beacon", async () => {
         before(async () => {
           await createSnapshot()
 
-          await walletRegistry.connect(walletOwner).requestNewWallet()
+          await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
         })
 
         after(async () => {
@@ -202,7 +202,7 @@ describe("WalletRegistry - Random Beacon", async () => {
 
           randomBeaconMock = await mockRandomBeacon(walletRegistry)
 
-          await walletRegistry.connect(walletOwner).requestNewWallet()
+          await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
         })
 
         after(async () => {

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -16,6 +16,7 @@ import { selectGroup, hashUint32Array } from "./utils/groups"
 import { createNewWallet } from "./utils/wallets"
 import { submitRelayEntry } from "./utils/randomBeacon"
 
+import type { IWalletOwner } from "../typechain/IWalletOwner"
 import type { BigNumber, ContractTransaction, Signer } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
@@ -26,6 +27,7 @@ import type {
 } from "../typechain"
 import type { DkgResult, DkgResultSubmittedEventArgs } from "./utils/dkg"
 import type { Operator } from "./utils/operators"
+import type { FakeContract } from "@defi-wonderland/smock"
 
 const { to1e18 } = helpers.number
 const { mineBlocks, mineBlocksTo } = helpers.time
@@ -53,9 +55,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
   let walletRegistry: WalletRegistryStub & WalletRegistry
   let sortitionPool: SortitionPool
   let staking: StakingStub
+  let walletOwner: FakeContract<IWalletOwner>
 
   let deployer: SignerWithAddress
-  let walletOwner: SignerWithAddress
   let thirdParty: SignerWithAddress
 
   let operators: Operator[]
@@ -96,7 +98,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
         before("start wallet creation", async () => {
           await createSnapshot()
-          tx = await walletRegistry.connect(walletOwner).requestNewWallet()
+          tx = await walletRegistry
+            .connect(walletOwner.wallet)
+            .requestNewWallet()
         })
 
         after(async () => {
@@ -136,7 +140,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
       context("with new wallet requested", async () => {
         before("request new wallet", async () => {
           await createSnapshot()
-          await walletRegistry.connect(walletOwner).requestNewWallet()
+          await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
         })
 
         after(async () => {
@@ -146,7 +150,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
         context("with relay entry not submitted", async () => {
           it("should revert with 'Current state is not IDLE' error", async () => {
             await expect(
-              walletRegistry.connect(walletOwner).requestNewWallet()
+              walletRegistry.connect(walletOwner.wallet).requestNewWallet()
             ).to.be.revertedWith("Current state is not IDLE")
           })
 
@@ -168,7 +172,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
             context("with dkg result not submitted", async () => {
               it("should revert with 'Current state is not IDLE' error", async () => {
                 await expect(
-                  walletRegistry.connect(walletOwner).requestNewWallet()
+                  walletRegistry.connect(walletOwner.wallet).requestNewWallet()
                 ).to.be.revertedWith("Current state is not IDLE")
               })
             })
@@ -196,7 +200,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
               context("with dkg result not approved", async () => {
                 it("should revert with 'current state is not IDLE' error", async () => {
                   await expect(
-                    walletRegistry.connect(walletOwner).requestNewWallet()
+                    walletRegistry
+                      .connect(walletOwner.wallet)
+                      .requestNewWallet()
                   ).to.be.revertedWith("Current state is not IDLE")
                 })
               })
@@ -218,7 +224,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
                 it("should succeed", async () => {
                   await expect(
-                    walletRegistry.connect(walletOwner).requestNewWallet()
+                    walletRegistry
+                      .connect(walletOwner.wallet)
+                      .requestNewWallet()
                   ).to.not.be.reverted
                 })
               })
@@ -256,7 +264,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
                 it("should revert", async () => {
                   await expect(
-                    walletRegistry.connect(walletOwner).requestNewWallet()
+                    walletRegistry
+                      .connect(walletOwner.wallet)
+                      .requestNewWallet()
                   ).to.be.revertedWith("Current state is not IDLE")
                 })
               })
@@ -277,7 +287,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
               it("should succeed", async () => {
                 await expect(
-                  walletRegistry.connect(walletOwner).requestNewWallet()
+                  walletRegistry.connect(walletOwner.wallet).requestNewWallet()
                 ).not.to.be.reverted
               })
             })
@@ -301,7 +311,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
     context("with new wallet requested", async () => {
       before("request new wallet", async () => {
         await createSnapshot()
-        await walletRegistry.connect(walletOwner).requestNewWallet()
+        await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
       })
 
       after(async () => {
@@ -478,7 +488,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
       before(async () => {
         await createSnapshot()
-        const tx = await walletRegistry.connect(walletOwner).requestNewWallet()
+        const tx = await walletRegistry
+          .connect(walletOwner.wallet)
+          .requestNewWallet()
 
         requestNewWalletStartBlock = tx.blockNumber
       })
@@ -805,7 +817,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
     context("with new wallet requested", async () => {
       before("request new wallet", async () => {
         await createSnapshot()
-        await walletRegistry.connect(walletOwner).requestNewWallet()
+        await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
       })
 
       after(async () => {
@@ -1375,7 +1387,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
     context("with new wallet requested", async () => {
       before("request new wallet", async () => {
         await createSnapshot()
-        await walletRegistry.connect(walletOwner).requestNewWallet()
+        await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
       })
 
       after(async () => {
@@ -2021,7 +2033,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
         ;({ publicKeyHash: existingWalletPublicKeyHash } =
           await createNewWallet(
             walletRegistry,
-            walletOwner,
+            walletOwner.wallet,
             existingWalletPublicKey
           ))
 
@@ -2042,7 +2054,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
           "request new wallet creation and submit relay entry",
           async () => {
             await createSnapshot()
-            await walletRegistry.connect(walletOwner).requestNewWallet()
+            await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
             ;({ startBlock, dkgSeed } = await submitRelayEntry(walletRegistry))
           }
         )
@@ -2148,7 +2160,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
       context("with new wallet requested", async () => {
         before("request new wallet", async () => {
           await createSnapshot()
-          await walletRegistry.connect(walletOwner).requestNewWallet()
+          await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
         })
 
         after(async () => {
@@ -2580,7 +2592,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
       before("create a wallet", async () => {
         await createSnapshot()
 
-        await createNewWallet(walletRegistry, walletOwner)
+        await createNewWallet(walletRegistry, walletOwner.wallet)
       })
 
       after(async () => {
@@ -2601,7 +2613,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
           "request new wallet creation and submit relay entry",
           async () => {
             await createSnapshot()
-            await walletRegistry.connect(walletOwner).requestNewWallet()
+            await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
             ;({ startBlock, dkgSeed } = await submitRelayEntry(walletRegistry))
           }
         )
@@ -2895,7 +2907,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
       it("should enforce submission start offset", async () => {
         let dkgResult: DkgResult
 
-        await walletRegistry.connect(walletOwner).requestNewWallet()
+        await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
         const { startBlock } = await submitRelayEntry(walletRegistry)
 
         // Submit result 1 at the beginning of the submission period
@@ -3032,7 +3044,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
       before("request new wallet creation and submit relay entry", async () => {
         await createSnapshot()
-        await walletRegistry.connect(walletOwner).requestNewWallet()
+        await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
         ;({ startBlock, dkgSeed } = await submitRelayEntry(walletRegistry))
       })
 
@@ -3098,7 +3110,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
       before(async () => {
         await createSnapshot()
-        const tx = await walletRegistry.connect(walletOwner).requestNewWallet()
+        const tx = await walletRegistry
+          .connect(walletOwner.wallet)
+          .requestNewWallet()
 
         requestNewWalletStartBlock = tx.blockNumber
       })
@@ -3191,7 +3205,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
       before(async () => {
         await createSnapshot()
-        const tx = await walletRegistry.connect(walletOwner).requestNewWallet()
+        const tx = await walletRegistry
+          .connect(walletOwner.wallet)
+          .requestNewWallet()
 
         requestNewWalletStartBlock = tx.blockNumber
       })
@@ -3312,7 +3328,9 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
       before(async () => {
         await createSnapshot()
-        const tx = await walletRegistry.connect(walletOwner).requestNewWallet()
+        const tx = await walletRegistry
+          .connect(walletOwner.wallet)
+          .requestNewWallet()
 
         requestNewWalletStartBlock = tx.blockNumber
       })

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -1,6 +1,5 @@
 import { ethers, helpers } from "hardhat"
 import { expect } from "chai"
-import { smock } from "@defi-wonderland/smock"
 
 import { params, walletRegistryFixture } from "./fixtures"
 import { submitRelayEntry } from "./utils/randomBeacon"
@@ -128,20 +127,3 @@ describe("WalletRegistry - Wallet Owner", async () => {
     })
   })
 })
-
-async function fakeWalletOwner(
-  walletRegistry: WalletRegistry
-): Promise<FakeContract<IWalletOwner>> {
-  const walletOwner = await smock.fake<IWalletOwner>("IWalletOwner", {
-    address: await walletRegistry.callStatic.walletOwner(),
-  })
-
-  await (
-    await ethers.getSigners()
-  )[0].sendTransaction({
-    to: walletOwner.address,
-    value: ethers.utils.parseEther("1"),
-  })
-
-  return walletOwner
-}

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -42,7 +42,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
     before(async () => {
       await createSnapshot()
 
-      await walletOwner.notifyWalletCreated.reverts(
+      await walletOwner.notifyEcdsaWalletCreated.reverts(
         "wallet owner internal error"
       )
 
@@ -62,16 +62,16 @@ describe("WalletRegistry - Wallet Owner", async () => {
     after(async () => {
       await restoreSnapshot()
 
-      await walletOwner.notifyWalletCreated.reset()
+      await walletOwner.notifyEcdsaWalletCreated.reset()
     })
 
-    context("when notifyWalletCreated reverts", async () => {
+    context("when notifyEcdsaWalletCreated reverts", async () => {
       let tx: Promise<ContractTransaction>
 
       before(async () => {
         await createSnapshot()
 
-        await walletOwner.notifyWalletCreated.reverts(
+        await walletOwner.notifyEcdsaWalletCreated.reverts(
           "wallet owner internal error"
         )
 
@@ -81,7 +81,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       after(async () => {
         await restoreSnapshot()
 
-        await walletOwner.notifyWalletCreated.reset()
+        await walletOwner.notifyEcdsaWalletCreated.reset()
       })
 
       it("should succeed", async () => {
@@ -89,7 +89,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
 
       it("should call random beacon", async () => {
-        await expect(walletOwner.notifyWalletCreated).to.be.calledWith(
+        await expect(walletOwner.notifyEcdsaWalletCreated).to.be.calledWith(
           groupPublicKeyHash
         )
       })
@@ -101,7 +101,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
     })
 
-    context("when notifyWalletCreated succeeds", async () => {
+    context("when notifyEcdsaWalletCreated succeeds", async () => {
       let tx: Promise<ContractTransaction>
 
       before(async () => {
@@ -119,7 +119,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
 
       it("should call wallet owner", async () => {
-        await expect(walletOwner.notifyWalletCreated).to.be.calledWith(
+        await expect(walletOwner.notifyEcdsaWalletCreated).to.be.calledWith(
           groupPublicKeyHash
         )
       })

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -71,7 +71,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       before(async () => {
         await createSnapshot()
 
-        await walletOwner.__ecdsaWalletCreatedCallback.reverts(
+        walletOwner.__ecdsaWalletCreatedCallback.reverts(
           "wallet owner internal error"
         )
 
@@ -84,8 +84,10 @@ describe("WalletRegistry - Wallet Owner", async () => {
         await walletOwner.__ecdsaWalletCreatedCallback.reset()
       })
 
-      it("should succeed", async () => {
-        await expect(tx).to.not.be.reverted
+      it("should revert", async () => {
+        // FIXME: For some reason this check doesn't work with the expected error message
+        // await expect(tx).to.be.revertedWith("wallet owner internal error")
+        await expect(tx).to.be.reverted
       })
 
       it("should call random beacon", async () => {
@@ -93,12 +95,6 @@ describe("WalletRegistry - Wallet Owner", async () => {
           groupPublicKeyHash,
           dkgResult.groupPubKey
         )
-      })
-
-      it("should emit WalletOwnerNotificationFailed", async () => {
-        await expect(tx)
-          .to.emit(walletRegistry, "WalletOwnerNotificationFailed")
-          .withArgs(groupPublicKeyHash)
       })
     })
 

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { ethers, helpers } from "hardhat"
 import { expect } from "chai"
 
@@ -41,7 +42,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
     before(async () => {
       await createSnapshot()
 
-      await walletOwner.notifyEcdsaWalletCreated.reverts(
+      await walletOwner.__ecdsaWalletCreatedCallback.reverts(
         "wallet owner internal error"
       )
 
@@ -61,16 +62,16 @@ describe("WalletRegistry - Wallet Owner", async () => {
     after(async () => {
       await restoreSnapshot()
 
-      await walletOwner.notifyEcdsaWalletCreated.reset()
+      await walletOwner.__ecdsaWalletCreatedCallback.reset()
     })
 
-    context("when notifyEcdsaWalletCreated reverts", async () => {
+    context("when __ecdsaWalletCreatedCallback reverts", async () => {
       let tx: Promise<ContractTransaction>
 
       before(async () => {
         await createSnapshot()
 
-        await walletOwner.notifyEcdsaWalletCreated.reverts(
+        await walletOwner.__ecdsaWalletCreatedCallback.reverts(
           "wallet owner internal error"
         )
 
@@ -80,7 +81,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       after(async () => {
         await restoreSnapshot()
 
-        await walletOwner.notifyEcdsaWalletCreated.reset()
+        await walletOwner.__ecdsaWalletCreatedCallback.reset()
       })
 
       it("should succeed", async () => {
@@ -88,7 +89,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
 
       it("should call random beacon", async () => {
-        await expect(walletOwner.notifyEcdsaWalletCreated).to.be.calledWith(
+        await expect(walletOwner.__ecdsaWalletCreatedCallback).to.be.calledWith(
           groupPublicKeyHash,
           dkgResult.groupPubKey
         )
@@ -101,7 +102,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
     })
 
-    context("when notifyEcdsaWalletCreated succeeds", async () => {
+    context("when __ecdsaWalletCreatedCallback succeeds", async () => {
       let tx: Promise<ContractTransaction>
 
       before(async () => {
@@ -119,7 +120,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
 
       it("should call wallet owner", async () => {
-        await expect(walletOwner.notifyEcdsaWalletCreated).to.be.calledWith(
+        await expect(walletOwner.__ecdsaWalletCreatedCallback).to.be.calledWith(
           groupPublicKeyHash,
           dkgResult.groupPubKey
         )

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -1,0 +1,145 @@
+import { ethers, helpers } from "hardhat"
+import { expect } from "chai"
+import { smock } from "@defi-wonderland/smock"
+
+import { params, walletRegistryFixture } from "./fixtures"
+import { submitRelayEntry } from "./utils/randomBeacon"
+import { signAndSubmitCorrectDkgResult } from "./utils/dkg"
+import ecdsaData from "./data/ecdsa"
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { DkgResult } from "./utils/dkg"
+import type { FakeContract } from "@defi-wonderland/smock"
+import type {
+  IWalletOwner,
+  WalletRegistry,
+  WalletRegistryStub,
+} from "../typechain"
+import type { ContractTransaction } from "ethers"
+
+const { mineBlocks } = helpers.time
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("WalletRegistry - Wallet Owner", async () => {
+  const groupPublicKey: string = ethers.utils.hexValue(
+    ecdsaData.group1.publicKey
+  )
+  const groupPublicKeyHash: string = ethers.utils.keccak256(groupPublicKey)
+
+  let walletRegistry: WalletRegistryStub & WalletRegistry
+  let walletOwner: FakeContract<IWalletOwner>
+
+  before("load test fixture", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ walletRegistry, walletOwner } = await walletRegistryFixture())
+  })
+
+  describe("approveDkgResult", async () => {
+    let dkgResult: DkgResult
+    let submitter: SignerWithAddress
+
+    before(async () => {
+      await createSnapshot()
+
+      await walletOwner.notifyWalletCreated.reverts(
+        "wallet owner internal error"
+      )
+
+      await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
+      const { startBlock, dkgSeed } = await submitRelayEntry(walletRegistry)
+
+      ;({ dkgResult, submitter } = await signAndSubmitCorrectDkgResult(
+        walletRegistry,
+        groupPublicKey,
+        dkgSeed,
+        startBlock
+      ))
+
+      await mineBlocks(params.dkgResultChallengePeriodLength)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+
+      await walletOwner.notifyWalletCreated.reset()
+    })
+
+    context("when notifyWalletCreated reverts", async () => {
+      let tx: Promise<ContractTransaction>
+
+      before(async () => {
+        await createSnapshot()
+
+        await walletOwner.notifyWalletCreated.reverts(
+          "wallet owner internal error"
+        )
+
+        tx = walletRegistry.connect(submitter).approveDkgResult(dkgResult)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+
+        await walletOwner.notifyWalletCreated.reset()
+      })
+
+      it("should succeed", async () => {
+        await expect(tx).to.not.be.reverted
+      })
+
+      it("should call random beacon", async () => {
+        await expect(walletOwner.notifyWalletCreated).to.be.calledWith(
+          groupPublicKeyHash
+        )
+      })
+
+      it("should emit WalletOwnerNotificationFailed", async () => {
+        await expect(tx)
+          .to.emit(walletRegistry, "WalletOwnerNotificationFailed")
+          .withArgs(groupPublicKeyHash)
+      })
+    })
+
+    context("when notifyWalletCreated succeeds", async () => {
+      let tx: Promise<ContractTransaction>
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = walletRegistry.connect(submitter).approveDkgResult(dkgResult)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should succeed", async () => {
+        await expect(tx).to.not.be.reverted
+      })
+
+      it("should call wallet owner", async () => {
+        await expect(walletOwner.notifyWalletCreated).to.be.calledWith(
+          groupPublicKeyHash
+        )
+      })
+    })
+  })
+})
+
+async function fakeWalletOwner(
+  walletRegistry: WalletRegistry
+): Promise<FakeContract<IWalletOwner>> {
+  const walletOwner = await smock.fake<IWalletOwner>("IWalletOwner", {
+    address: await walletRegistry.callStatic.walletOwner(),
+  })
+
+  await (
+    await ethers.getSigners()
+  )[0].sendTransaction({
+    to: walletOwner.address,
+    value: ethers.utils.parseEther("1"),
+  })
+
+  return walletOwner
+}

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -90,7 +90,8 @@ describe("WalletRegistry - Wallet Owner", async () => {
 
       it("should call random beacon", async () => {
         await expect(walletOwner.notifyEcdsaWalletCreated).to.be.calledWith(
-          groupPublicKeyHash
+          groupPublicKeyHash,
+          dkgResult.groupPubKey
         )
       })
 
@@ -120,7 +121,8 @@ describe("WalletRegistry - Wallet Owner", async () => {
 
       it("should call wallet owner", async () => {
         await expect(walletOwner.notifyEcdsaWalletCreated).to.be.calledWith(
-          groupPublicKeyHash
+          groupPublicKeyHash,
+          dkgResult.groupPubKey
         )
       })
     })

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -85,13 +85,6 @@ describe("WalletRegistry - Wallet Owner", async () => {
         // await expect(tx).to.be.revertedWith("wallet owner internal error")
         await expect(tx).to.be.reverted
       })
-
-      it("should call random beacon", async () => {
-        await expect(walletOwner.__ecdsaWalletCreatedCallback).to.be.calledWith(
-          groupPublicKeyHash,
-          dkgResult.groupPubKey
-        )
-      })
     })
 
     context("when __ecdsaWalletCreatedCallback succeeds", async () => {

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -42,10 +42,6 @@ describe("WalletRegistry - Wallet Owner", async () => {
     before(async () => {
       await createSnapshot()
 
-      await walletOwner.__ecdsaWalletCreatedCallback.reverts(
-        "wallet owner internal error"
-      )
-
       await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
       const { startBlock, dkgSeed } = await submitRelayEntry(walletRegistry)
 

--- a/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
@@ -1,18 +1,19 @@
-import { waffle, helpers } from "hardhat"
+import { helpers } from "hardhat"
 import { expect } from "chai"
 import { formatBytes32String } from "ethers/lib/utils"
 
 import { walletRegistryFixture } from "./fixtures"
 import { createNewWallet } from "./utils/wallets"
 
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { IWalletOwner } from "../typechain/IWalletOwner"
 import type { WalletRegistry, WalletRegistryStub } from "../typechain"
+import type { FakeContract } from "@defi-wonderland/smock"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
 describe("WalletRegistry - Wallets", async () => {
   let walletRegistry: WalletRegistryStub & WalletRegistry
-  let walletOwner: SignerWithAddress
+  let walletOwner: FakeContract<IWalletOwner>
 
   before("load test fixture", async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -37,7 +38,7 @@ describe("WalletRegistry - Wallets", async () => {
         await createSnapshot()
         ;({ publicKeyHash } = await createNewWallet(
           walletRegistry,
-          walletOwner
+          walletOwner.wallet
         ))
       })
 

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -1,7 +1,7 @@
 import { deployments, ethers, helpers, getUnnamedAccounts } from "hardhat"
 import { expect } from "chai"
 
-import { params, updateWalletDkgRegistryParams } from "./fixtures"
+import { params, updateWalletRegistryParams } from "./fixtures"
 
 import type { ContractTransaction } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
@@ -32,7 +32,7 @@ const fixture = deployments.createFixture(async () => {
     )[0]
   )
 
-  await updateWalletDkgRegistryParams(walletRegistryGovernance, governance)
+  await updateWalletRegistryParams(walletRegistryGovernance, governance)
 
   return {
     walletRegistry,

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -1,21 +1,52 @@
-import { ethers, helpers } from "hardhat"
+import { deployments, ethers, helpers, getUnnamedAccounts } from "hardhat"
 import { expect } from "chai"
 
-import { walletRegistryFixture, params } from "./fixtures"
+import { params, updateWalletDkgRegistryParams } from "./fixtures"
 
 import type { ContractTransaction } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import type { WalletRegistry, WalletRegistryGovernance } from "../typechain"
+import type {
+  WalletRegistry,
+  WalletRegistryStub,
+  WalletRegistryGovernance,
+} from "../typechain"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 const { to1e18 } = helpers.number
+
+const fixture = deployments.createFixture(async () => {
+  await deployments.fixture(["WalletRegistry"])
+
+  const walletRegistry: WalletRegistryStub & WalletRegistry =
+    await ethers.getContract("WalletRegistry")
+  const walletRegistryGovernance: WalletRegistryGovernance =
+    await ethers.getContract("WalletRegistryGovernance")
+
+  const governance: SignerWithAddress = await ethers.getNamedSigner(
+    "governance"
+  )
+
+  const thirdParty: SignerWithAddress = await ethers.getSigner(
+    (
+      await getUnnamedAccounts()
+    )[0]
+  )
+
+  await updateWalletDkgRegistryParams(walletRegistryGovernance, governance)
+
+  return {
+    walletRegistry,
+    walletRegistryGovernance,
+    governance,
+    thirdParty,
+  }
+})
 
 describe("WalletRegistryGovernance", async () => {
   let governance: SignerWithAddress
   let walletRegistry: WalletRegistry
   let walletRegistryGovernance: WalletRegistryGovernance
   let thirdParty: SignerWithAddress
-  let walletOwner: SignerWithAddress
 
   const initialMinimumAuthorization = to1e18(400000)
   const initialAuthorizationDecreaseDelay = 5184000 // 60 days
@@ -24,13 +55,8 @@ describe("WalletRegistryGovernance", async () => {
 
   before("load test fixture", async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;({
-      walletRegistry,
-      walletRegistryGovernance,
-      governance,
-      thirdParty,
-      walletOwner,
-    } = await walletRegistryFixture())
+    ;({ walletRegistry, walletRegistryGovernance, governance, thirdParty } =
+      await fixture())
   })
 
   describe("upgradeRandomBeacon", () => {
@@ -85,6 +111,66 @@ describe("WalletRegistryGovernance", async () => {
     })
   })
 
+  describe("initializeWalletOwner", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(thirdParty)
+            .initializeWalletOwner(thirdParty.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the caller is the owner", () => {
+      let tx: ContractTransaction
+
+      context("when new address is zero", () => {
+        it("should revert when a new address is zero", async () => {
+          await expect(
+            walletRegistryGovernance
+              .connect(governance)
+              .initializeWalletOwner(ethers.constants.AddressZero)
+          ).to.be.revertedWith("Wallet Owner address cannot be zero")
+        })
+      })
+
+      context("when new address is not zero", () => {
+        before(async () => {
+          await createSnapshot()
+
+          tx = await walletRegistryGovernance
+            .connect(governance)
+            .initializeWalletOwner(thirdParty.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the wallet owner", async () => {
+          expect(await walletRegistry.walletOwner()).to.be.equal(
+            thirdParty.address
+          )
+        })
+
+        it("should emit WalletOwnerUpdated event", async () => {
+          await expect(tx)
+            .to.emit(walletRegistry, "WalletOwnerUpdated")
+            .withArgs(thirdParty.address)
+        })
+
+        it("should revert when called for the second time", async () => {
+          await expect(
+            walletRegistryGovernance
+              .connect(governance)
+              .initializeWalletOwner(thirdParty.address)
+          ).to.be.revertedWith("Wallet Owner already initialized")
+        })
+      })
+    })
+  })
+
   describe("beginWalletOwnerUpdate", () => {
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
@@ -123,7 +209,7 @@ describe("WalletRegistryGovernance", async () => {
 
       it("should not update the wallet owner", async () => {
         expect(await walletRegistry.walletOwner()).to.be.equal(
-          walletOwner.address
+          ethers.constants.AddressZero
         )
       })
 

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -1,8 +1,10 @@
 import { deployments, ethers, helpers, getUnnamedAccounts } from "hardhat"
+import { smock } from "@defi-wonderland/smock"
 
 // eslint-disable-next-line import/no-cycle
 import { registerOperators } from "../utils/operators"
 
+import type { IWalletOwner } from "../../typechain/IWalletOwner"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { Operator } from "../utils/operators"
 import type {
@@ -13,6 +15,7 @@ import type {
   WalletRegistryGovernance,
   T,
 } from "../../typechain"
+import type { FakeContract } from "@defi-wonderland/smock"
 
 const { to1e18 } = helpers.number
 
@@ -39,59 +42,79 @@ export const params = {
   dkgSubmitterPrecedencePeriodLength: 5,
 }
 
-export const walletRegistryFixture = deployments.createFixture(async () => {
-  await deployments.fixture(["WalletRegistry"])
+export const walletRegistryFixture = deployments.createFixture(
+  async (): Promise<{
+    walletRegistry: WalletRegistryStub & WalletRegistry
+    walletRegistryGovernance: WalletRegistryGovernance
+    sortitionPool: SortitionPool
+    staking: StakingStub
+    walletOwner: FakeContract<IWalletOwner>
+    deployer: SignerWithAddress
+    governance: SignerWithAddress
+    thirdParty: SignerWithAddress
+    operators: Operator[]
+  }> => {
+    await deployments.fixture(["WalletRegistry"])
 
-  const walletRegistry: WalletRegistryStub & WalletRegistry =
-    await ethers.getContract("WalletRegistry")
-  const walletRegistryGovernance: WalletRegistryGovernance =
-    await ethers.getContract("WalletRegistryGovernance")
-  const sortitionPool: SortitionPool = await ethers.getContract("SortitionPool")
-  const tToken: T = await ethers.getContract("T")
-  const staking: StakingStub = await ethers.getContract("StakingStub")
+    const walletRegistry: WalletRegistryStub & WalletRegistry =
+      await ethers.getContract("WalletRegistry")
+    const walletRegistryGovernance: WalletRegistryGovernance =
+      await ethers.getContract("WalletRegistryGovernance")
+    const sortitionPool: SortitionPool = await ethers.getContract(
+      "SortitionPool"
+    )
+    const tToken: T = await ethers.getContract("T")
+    const staking: StakingStub = await ethers.getContract("StakingStub")
 
-  const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
-  const governance: SignerWithAddress = await ethers.getNamedSigner(
-    "governance"
-  )
-  const walletOwner: SignerWithAddress = await ethers.getNamedSigner(
-    "walletOwner"
-  )
+    const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
+    const governance: SignerWithAddress = await ethers.getNamedSigner(
+      "governance"
+    )
 
-  const thirdParty: SignerWithAddress = await ethers.getSigner(
-    (
-      await getUnnamedAccounts()
-    )[0]
-  )
+    const thirdParty: SignerWithAddress = await ethers.getSigner(
+      (
+        await getUnnamedAccounts()
+      )[0]
+    )
 
-  // Accounts offset provided to slice getUnnamedAccounts have to include number
-  // of unnamed accounts that were already used.
-  const unnamedAccountsOffset = 1
-  const operators: Operator[] = await registerOperators(
-    walletRegistry,
-    tToken,
-    (
-      await getUnnamedAccounts()
-    ).slice(unnamedAccountsOffset, unnamedAccountsOffset + constants.groupSize)
-  )
+    // Accounts offset provided to slice getUnnamedAccounts have to include number
+    // of unnamed accounts that were already used.
+    const unnamedAccountsOffset = 1
+    const operators: Operator[] = await registerOperators(
+      walletRegistry,
+      tToken,
+      (
+        await getUnnamedAccounts()
+      ).slice(
+        unnamedAccountsOffset,
+        unnamedAccountsOffset + constants.groupSize
+      )
+    )
 
-  // Set parameters with tweaked values to reduce test execution time.
-  await updateWalletRegistryParams(walletRegistryGovernance, governance)
+    // Set parameters with tweaked values to reduce test execution time.
+    await updateWalletRegistryParams(walletRegistryGovernance, governance)
 
-  return {
-    walletRegistry,
-    sortitionPool,
-    walletOwner,
-    deployer,
-    governance,
-    thirdParty,
-    operators,
-    staking,
-    walletRegistryGovernance,
+    // Mock Wallet Owner contract.
+    const walletOwner: FakeContract<IWalletOwner> = await initializeWalletOwner(
+      walletRegistryGovernance,
+      governance
+    )
+
+    return {
+      walletRegistry,
+      sortitionPool,
+      walletOwner,
+      deployer,
+      governance,
+      thirdParty,
+      operators,
+      staking,
+      walletRegistryGovernance,
+    }
   }
-})
+)
 
-async function updateWalletRegistryParams(
+export async function updateWalletRegistryParams(
   walletRegistryGovernance: WalletRegistryGovernance,
   governance: SignerWithAddress
 ) {
@@ -148,4 +171,25 @@ async function updateWalletRegistryParams(
   await walletRegistryGovernance
     .connect(governance)
     .finalizeDkgSubmitterPrecedencePeriodLengthUpdate()
+}
+
+async function initializeWalletOwner(
+  walletRegistryGovernance: WalletRegistryGovernance,
+  governance: SignerWithAddress
+): Promise<FakeContract<IWalletOwner>> {
+  const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
+
+  const walletOwner: FakeContract<IWalletOwner> =
+    await smock.fake<IWalletOwner>("IWalletOwner")
+
+  await deployer.sendTransaction({
+    to: walletOwner.address,
+    value: ethers.utils.parseEther("1"),
+  })
+
+  await walletRegistryGovernance
+    .connect(governance)
+    .initializeWalletOwner(walletOwner.address)
+
+  return walletOwner
 }

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -49,7 +49,7 @@ export async function signAndSubmitCorrectDkgResult(
   groupPublicKey: string,
   seed: BigNumber,
   startBlock: number,
-  misbehavedIndices: number[],
+  misbehavedIndices = noMisbehaved,
   submitterIndex = 1,
   numberOfSignatures = 51
 ): Promise<{

--- a/solidity/ecdsa/test/utils/wallets.ts
+++ b/solidity/ecdsa/test/utils/wallets.ts
@@ -7,8 +7,8 @@ import { noMisbehaved, signAndSubmitCorrectDkgResult } from "./dkg"
 import { fakeRandomBeacon } from "./randomBeacon"
 
 import type { WalletRegistry } from "../../typechain"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { Operator } from "./operators"
+import type { Signer } from "ethers"
 
 const { mineBlocks } = helpers.time
 const { keccak256 } = ethers.utils
@@ -16,7 +16,7 @@ const { keccak256 } = ethers.utils
 // eslint-disable-next-line import/prefer-default-export
 export async function createNewWallet(
   walletRegistry: WalletRegistry,
-  walletOwner: SignerWithAddress,
+  walletOwner: Signer,
   publicKey = ecdsaData.group1.publicKey
 ): Promise<{
   members: Operator[]

--- a/solidity/ecdsa/tsconfig.json
+++ b/solidity/ecdsa/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "files": ["./hardhat.config.ts"],
-  "include": ["./deploy", "./test", "./typechain"],
+  "include": ["./deploy", "./tasks", "./test", "./typechain"],
   "compilerOptions": {
     "downlevelIteration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Wallet Owner has to be notified when a requested wallet gets created. We handle this with a callback function that submits to the Wallet Owner a keccak256 hash of the wallet's public key. 

It is required that the Wallet Owner contract implements IWalletOwner interface:
```solidity
interface IWalletOwner {
    /// @notice Callback function executed once a new wallet is created.
    /// @dev Should be callable only by the Wallet Registry.
    /// @param publicKeyHash Keccak256 hash of the wallet's public key. It is
    ///        considered an unique wallet identifier.
    function __notifyWalletCreated(bytes32 publicKeyHash) external;
}
```

Refs https://github.com/keep-network/keep-core/issues/2833