### PR TITLE
Update threshold auth data after staking

### DIFF
--- a/solidity-v1/dashboard/src/actions/index.js
+++ b/solidity-v1/dashboard/src/actions/index.js
@@ -58,6 +58,8 @@ export const FETCH_THRESHOLD_AUTH_DATA_FAILURE =
   "threshold/fetch_auth_data_failure"
 export const THRESHOLD_AUTHORIZED = "threshold/contract_authorized"
 export const THRESHOLD_STAKED_TO_T = "threshold/staked_to_t"
+export const ADD_STAKE_TO_THRESHOLD_AUTH_DATA =
+  "threshold/add_stake_to_threshold_auth_data"
 export const REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA =
   "threshold/remove_stake_from_threshold_auth_data"
 

--- a/solidity-v1/dashboard/src/actions/keep-to-t-staking.js
+++ b/solidity-v1/dashboard/src/actions/keep-to-t-staking.js
@@ -1,8 +1,4 @@
-import {
-  REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
-  THRESHOLD_AUTHORIZED,
-  THRESHOLD_STAKED_TO_T,
-} from "./index"
+import { THRESHOLD_AUTHORIZED, THRESHOLD_STAKED_TO_T } from "./index"
 
 export const THRESHOLD_STAKE_KEEP_EVENT_EMITTED =
   "threshold/stake_keep_event_emitted"
@@ -36,12 +32,5 @@ export const stakeKeepToT = (data) => {
       operator: data.operatorAddress,
       isAuthorized: data.isAuthorized,
     },
-  }
-}
-
-export const removeStakeFromThresholdAuthData = (operatorAddress) => {
-  return {
-    type: REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
-    payload: { operatorAddress },
   }
 }

--- a/solidity-v1/dashboard/src/reducers/threshold-authorization.js
+++ b/solidity-v1/dashboard/src/reducers/threshold-authorization.js
@@ -139,7 +139,7 @@ const addStakeToAuthData = (
     },
     isStakedToT: false,
     isFromGrant: _isFromGrant,
-    canBeMovedToT: _isFromGrant,
+    canBeMovedToT: !_isFromGrant,
   }
 
   const updatedAuthData = [...authData, newStake]

--- a/solidity-v1/dashboard/src/reducers/threshold-authorization.js
+++ b/solidity-v1/dashboard/src/reducers/threshold-authorization.js
@@ -124,6 +124,8 @@ const addStakeToAuthData = (
     operatorContractAddress,
   }
 ) => {
+  const _isFromGrant = !!isFromGrant
+
   const newStake = {
     owner,
     authorizerAddress,
@@ -136,8 +138,8 @@ const addStakeToAuthData = (
       isAuthorized: false,
     },
     isStakedToT: false,
-    isFromGrant: isFromGrant ? isFromGrant : false,
-    canBeMovedToT: false,
+    isFromGrant: _isFromGrant,
+    canBeMovedToT: _isFromGrant,
   }
 
   const updatedAuthData = [...authData, newStake]

--- a/solidity-v1/dashboard/src/reducers/threshold-authorization.js
+++ b/solidity-v1/dashboard/src/reducers/threshold-authorization.js
@@ -5,9 +5,11 @@ import {
   THRESHOLD_AUTHORIZED,
   THRESHOLD_STAKED_TO_T,
   REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
+  ADD_STAKE_TO_THRESHOLD_AUTH_DATA,
 } from "../actions"
 import { findIndexAndObject, compareEthAddresses } from "../utils/array.utils"
 import { isSameEthAddress } from "../utils/general.utils"
+import { AUTH_CONTRACTS_LABEL } from "../constants/constants"
 
 const initialState = {
   authData: [],
@@ -47,6 +49,11 @@ const thresholdAuthorizationReducer = (state = initialState, action) => {
         authData: updateThresholdAuthData([...state.authData], {
           ...action.payload,
         }),
+      }
+    case ADD_STAKE_TO_THRESHOLD_AUTH_DATA:
+      return {
+        ...state,
+        authData: addStakeToAuthData([...state.authData], action.payload),
       }
     case REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA:
       return {
@@ -103,6 +110,38 @@ const updateThresholdAuthData = (authData, { operatorAddress }) => {
   }
 
   return updatedOperators
+}
+
+const addStakeToAuthData = (
+  authData,
+  {
+    owner,
+    authorizerAddress,
+    beneficiaryAddress,
+    operatorAddress,
+    amount,
+    isFromGrant,
+    operatorContractAddress,
+  }
+) => {
+  const newStake = {
+    owner,
+    authorizerAddress,
+    beneficiaryAddress,
+    operatorAddress,
+    stakeAmount: amount,
+    contract: {
+      contractName: AUTH_CONTRACTS_LABEL.THRESHOLD_TOKEN_STAKING,
+      operatorContractAddress: operatorContractAddress,
+      isAuthorized: false,
+    },
+    isStakedToT: false,
+    isFromGrant: isFromGrant,
+    canBeMovedToT: false,
+  }
+
+  const updatedAuthData = [...authData, newStake]
+  return updatedAuthData
 }
 
 const removeStakeFromAuthData = (authData, operatorAddress) => {

--- a/solidity-v1/dashboard/src/reducers/threshold-authorization.js
+++ b/solidity-v1/dashboard/src/reducers/threshold-authorization.js
@@ -117,9 +117,9 @@ const addStakeToAuthData = (
   {
     owner,
     authorizerAddress,
-    beneficiaryAddress,
+    beneficiary: beneficiaryAddress,
     operatorAddress,
-    amount,
+    amount: stakeAmount,
     isFromGrant,
     operatorContractAddress,
   }
@@ -129,14 +129,14 @@ const addStakeToAuthData = (
     authorizerAddress,
     beneficiaryAddress,
     operatorAddress,
-    stakeAmount: amount,
+    stakeAmount,
     contract: {
       contractName: AUTH_CONTRACTS_LABEL.THRESHOLD_TOKEN_STAKING,
       operatorContractAddress: operatorContractAddress,
       isAuthorized: false,
     },
     isStakedToT: false,
-    isFromGrant: isFromGrant,
+    isFromGrant: isFromGrant ? isFromGrant : false,
     canBeMovedToT: false,
   }
 

--- a/solidity-v1/dashboard/src/sagas/subscriptions.js
+++ b/solidity-v1/dashboard/src/sagas/subscriptions.js
@@ -227,14 +227,16 @@ function* observeStakedEvents() {
       }
 
       yield put({ type: "staking/add_delegation", payload: delegation })
-      yield put({
-        type: ADD_STAKE_TO_THRESHOLD_AUTH_DATA,
-        payload: {
-          ...delegation,
-          owner: yourAddress,
-          operatorContractAddress: Keep.thresholdStakingContract.address,
-        },
-      })
+      if (isSameEthAddress(yourAddress, authorizer)) {
+        yield put({
+          type: ADD_STAKE_TO_THRESHOLD_AUTH_DATA,
+          payload: {
+            ...delegation,
+            owner: yourAddress,
+            operatorContractAddress: Keep.thresholdStakingContract.address,
+          },
+        })
+      }
     } catch (error) {
       console.error(`Failed subscribing to StakeDelegated event`, error)
       contractEventCahnnel.close()

--- a/solidity-v1/dashboard/src/sagas/subscriptions.js
+++ b/solidity-v1/dashboard/src/sagas/subscriptions.js
@@ -20,6 +20,7 @@ import {
   FETCH_OPERATOR_DELEGATIONS_SUCCESS,
   tbtcV2Migration,
   REMOVE_STAKE_FROM_THRESHOLD_AUTH_DATA,
+  ADD_STAKE_TO_THRESHOLD_AUTH_DATA,
 } from "../actions"
 import {
   assetPoolDepositedEventEmitted,
@@ -226,6 +227,18 @@ function* observeStakedEvents() {
       }
 
       yield put({ type: "staking/add_delegation", payload: delegation })
+      yield put({
+        type: ADD_STAKE_TO_THRESHOLD_AUTH_DATA,
+        payload: {
+          owner: yourAddress,
+          authorizerAddress: delegation.authorizerAddress,
+          beneficiaryAddress: delegation.authorizerAddress,
+          operatorAddress: delegation.authorizerAddress,
+          amount: delegation.amount,
+          isFromGrant: delegation.isFromGrant,
+          operatorContractAddress: Keep.thresholdStakingContract.address,
+        },
+      })
     } catch (error) {
       console.error(`Failed subscribing to StakeDelegated event`, error)
       contractEventCahnnel.close()

--- a/solidity-v1/dashboard/src/sagas/subscriptions.js
+++ b/solidity-v1/dashboard/src/sagas/subscriptions.js
@@ -230,12 +230,8 @@ function* observeStakedEvents() {
       yield put({
         type: ADD_STAKE_TO_THRESHOLD_AUTH_DATA,
         payload: {
+          ...delegation,
           owner: yourAddress,
-          authorizerAddress: delegation.authorizerAddress,
-          beneficiaryAddress: delegation.authorizerAddress,
-          operatorAddress: delegation.authorizerAddress,
-          amount: delegation.amount,
-          isFromGrant: delegation.isFromGrant,
           operatorContractAddress: Keep.thresholdStakingContract.address,
         },
       })


### PR DESCRIPTION
Update threshold auth data after creating a delegation, so it updates 
immediately without refreshing