### PR TITLE
ECDSA Wallets: Store uncompressed public key

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install Slither
         env:
-          SLITHER_VERSION: 0.8.0
+          SLITHER_VERSION: 0.8.2
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
       - name: Install dependencies

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install Slither
         env:
-          SLITHER_VERSION: 0.8.0
+          SLITHER_VERSION: 0.8.2
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
       - name: Install dependencies

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -502,7 +502,7 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
         view
         returns (bytes memory)
     {
-        return wallets.registry[walletID].publicKey;
+        return wallets.getWalletPublicKey(walletID);
     }
 
     /// @notice Checks if a wallet with the given ID is registered.

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -107,7 +107,7 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     event DkgSeedTimedOut();
 
     event WalletCreated(
-        bytes32 indexed publicKeyHash,
+        bytes32 indexed walletID,
         bytes32 indexed dkgResultHash
     );
 
@@ -391,18 +391,19 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     function approveDkgResult(EcdsaDkg.Result calldata dkgResult) external {
         uint32[] memory misbehavedMembers = dkg.approveResult(dkgResult);
 
-        bytes32 publicKeyHash = keccak256(dkgResult.groupPubKey);
+        bytes32 walletID = wallets.addWallet(
+            dkgResult.membersHash,
+            dkgResult.groupPubKey
+        );
 
-        wallets.addWallet(dkgResult.membersHash, publicKeyHash);
-
-        emit WalletCreated(publicKeyHash, keccak256(abi.encode(dkgResult)));
+        emit WalletCreated(walletID, keccak256(abi.encode(dkgResult)));
 
         // TODO: Disable rewards for misbehavedMembers.
         //slither-disable-next-line redundant-statements
         misbehavedMembers;
 
         walletOwner.__ecdsaWalletCreatedCallback(
-            publicKeyHash,
+            walletID,
             dkgResult.groupPubKey
         );
 
@@ -483,24 +484,36 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
         return dkg.hasDkgTimedOut();
     }
 
-    function getWallet(bytes32 publicKeyHash)
+    function getWallet(bytes32 walletID)
         external
         view
         returns (Wallets.Wallet memory)
     {
-        return wallets.registry[publicKeyHash];
+        return wallets.registry[walletID];
     }
 
-    /// @notice Checks if a wallet with the given public key hash is registered.
-    /// @param publicKeyHash Wallet's public key hash.
-    /// @return True if wallet is registered, false otherwise.
-    function isWalletRegistered(bytes32 publicKeyHash)
+    /// @notice Gets public key of a wallet with a given wallet ID.
+    ///         The public key is returned in an uncompressed format as a 64-byte
+    ///         concatenation of X and Y coordinates.
+    /// @param walletID ID of the wallet.
+    /// @return Uncompressed public key of the wallet.
+    function getWalletPublicKey(bytes32 walletID)
         external
         view
-        returns (bool)
+        returns (bytes memory)
     {
-        return wallets.isWalletRegistered(publicKeyHash);
+        return wallets.registry[walletID].publicKey;
     }
+
+    /// @notice Checks if a wallet with the given ID is registered.
+    /// @param walletID Wallet's ID.
+    /// @return True if wallet is registered, false otherwise.
+    function isWalletRegistered(bytes32 walletID) external view returns (bool) {
+        return wallets.isWalletRegistered(walletID);
+    }
+
+    // TODO: Add function to close the Wallet so the members are notified that
+    // they no longer need to track the wallet.
 
     /// @notice Retrieves dkg parameters that were set in DKG library.
     function dkgParameters()

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -14,6 +14,7 @@
 
 pragma solidity ^0.8.9;
 
+import "./api/IWalletRegistry.sol";
 import "./api/IWalletOwner.sol";
 import "./libraries/EcdsaAuthorization.sol";
 import "./libraries/EcdsaDkg.sol";
@@ -40,7 +41,7 @@ interface IWalletStaking {
     ) external;
 }
 
-contract WalletRegistry is IRandomBeaconConsumer, Ownable {
+contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     using EcdsaAuthorization for EcdsaAuthorization.Data;
     using EcdsaDkg for EcdsaDkg.Data;
     using Wallets for Wallets.Data;

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -391,10 +391,8 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     function approveDkgResult(EcdsaDkg.Result calldata dkgResult) external {
         uint32[] memory misbehavedMembers = dkg.approveResult(dkgResult);
 
-        bytes32 walletID = wallets.addWallet(
-            dkgResult.membersHash,
-            dkgResult.groupPubKey
-        );
+        (bytes32 walletID, bytes32 publicKeyX, bytes32 publicKeyY) = wallets
+            .addWallet(dkgResult.membersHash, dkgResult.groupPubKey);
 
         emit WalletCreated(walletID, keccak256(abi.encode(dkgResult)));
 
@@ -404,7 +402,8 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
 
         walletOwner.__ecdsaWalletCreatedCallback(
             walletID,
-            dkgResult.groupPubKey
+            publicKeyX,
+            publicKeyY
         );
 
         dkg.complete();

--- a/solidity/ecdsa/contracts/api/IWalletOwner.sol
+++ b/solidity/ecdsa/contracts/api/IWalletOwner.sol
@@ -18,10 +18,11 @@ interface IWalletOwner {
     /// @notice Callback function executed once a new wallet is created.
     /// @dev Should be callable only by the Wallet Registry.
     /// @param walletID Wallet's unique identifier.
-    /// @param uncompressedPublicKey Wallet's uncompressed public key (64-byte)
-    ///        as a concatenation of X and Y coordinates.
+    /// @param publicKeyY Wallet's public key's X coordinate.
+    /// @param publicKeyY Wallet's public key's Y coordinate.
     function __ecdsaWalletCreatedCallback(
         bytes32 walletID,
-        bytes memory uncompressedPublicKey
+        bytes32 publicKeyX,
+        bytes32 publicKeyY
     ) external;
 }

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+//
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+pragma solidity ^0.8.9;
+
+interface IWalletRegistry {
+    /// @notice Requests a new wallet creation.
+    function requestNewWallet() external;
+
+    /// @notice Gets public key of a wallet with a given wallet ID.
+    ///         The public key is returned in an uncompressed format as a 64-byte
+    ///         concatenation of X and Y coordinates.
+    /// @param walletID ID of the wallet.
+    /// @return Uncompressed public key of the wallet.
+    function getWalletPublicKey(bytes32 walletID)
+        external
+        view
+        returns (bytes memory);
+}

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.8.9;
 
 interface IWalletRegistry {
     /// @notice Requests a new wallet creation.
+    /// @dev Only a Wallet Owner can call this function.
     function requestNewWallet() external;
 
     /// @notice Gets public key of a wallet with a given wallet ID.

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -63,10 +63,28 @@ library Wallets {
     /// @param walletID Wallet's ID.
     /// @return True if a wallet is registered, false otherwise.
     function isWalletRegistered(Data storage self, bytes32 walletID)
-        external
+        public
         view
         returns (bool)
     {
         return self.registry[walletID].publicKey.length > 0;
+    }
+
+    /// @notice Gets public key of a wallet with a given wallet ID.
+    ///         The public key is returned in an uncompressed format as a 64-byte
+    ///         concatenation of X and Y coordinates.
+    /// @param walletID ID of the wallet.
+    /// @return Uncompressed public key of the wallet.
+    function getWalletPublicKey(Data storage self, bytes32 walletID)
+        external
+        view
+        returns (bytes memory)
+    {
+        require(
+            isWalletRegistered(self, walletID),
+            "Wallet with given ID has not been registered"
+        );
+
+        return self.registry[walletID].publicKey;
     }
 }

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -39,13 +39,22 @@ library Wallets {
     /// @dev Uses a public key hash as a unique identifier of a wallet.
     /// @param membersIdsHash Keccak256 hash of group members identifiers array.
     /// @param publicKey Uncompressed public key.
-    /// @return Wallet's ID.
+    /// @return walletID Wallet's ID.
+    /// @return publicKeyX Wallet's public key's X coordinate.
+    /// @return publicKeyY Wallet's public key's Y coordinate.
     function addWallet(
         Data storage self,
         bytes32 membersIdsHash,
         bytes calldata publicKey
-    ) internal returns (bytes32) {
-        bytes32 walletID = keccak256(publicKey);
+    )
+        internal
+        returns (
+            bytes32 walletID,
+            bytes32 publicKeyX,
+            bytes32 publicKeyY
+        )
+    {
+        walletID = keccak256(publicKey);
 
         require(
             self.registry[walletID].publicKeyX == bytes32(0),
@@ -53,11 +62,12 @@ library Wallets {
         );
         require(publicKey.length == 64, "Invalid length of the public key");
 
-        self.registry[walletID].membersIdsHash = membersIdsHash;
-        self.registry[walletID].publicKeyX = bytes32(publicKey[:32]);
-        self.registry[walletID].publicKeyY = bytes32(publicKey[32:]);
+        publicKeyX = bytes32(publicKey[:32]);
+        publicKeyY = bytes32(publicKey[32:]);
 
-        return walletID;
+        self.registry[walletID].membersIdsHash = membersIdsHash;
+        self.registry[walletID].publicKeyX = publicKeyX;
+        self.registry[walletID].publicKeyY = publicKeyY;
     }
 
     /// @notice Checks if a wallet with the given ID is registered.

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -14,15 +14,12 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 // TODO: This contract is just a Stub implementation that was used for gas
 // comparisons for Wallets creation. It should be implemented according to the
 // Wallets' actual use case.
 library Wallets {
-    using ECDSA for bytes32;
-
     struct Wallet {
         // TODO: Verify if we want to store the whole public key or having
         // just the public key hash is enough.

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -40,7 +40,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
   const groupPublicKey: string = ethers.utils.hexValue(
     ecdsaData.group1.publicKey
   )
-  const groupPublicKeyHash: string = ethers.utils.keccak256(groupPublicKey)
+  const walletID: string = ethers.utils.keccak256(groupPublicKey)
 
   const stubDkgResult: DkgResult = {
     submitterMemberIndex: 1,
@@ -1529,9 +1529,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                 })
 
                 it("should register a new wallet", async () => {
-                  const wallet = await walletRegistry.getWallet(
-                    groupPublicKeyHash
-                  )
+                  const wallet = await walletRegistry.getWallet(walletID)
 
                   await expect(wallet.membersIdsHash).to.be.equal(
                     hashUint32Array(dkgResult.members)
@@ -1555,7 +1553,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                 it("should emit WalletCreated event", async () => {
                   await expect(tx)
                     .to.emit(walletRegistry, "WalletCreated")
-                    .withArgs(groupPublicKeyHash, dkgResultHash)
+                    .withArgs(walletID, dkgResultHash)
                 })
 
                 it("should unlock the sortition pool", async () => {
@@ -1750,9 +1748,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               })
 
               it("should register a new wallet", async () => {
-                const wallet = await walletRegistry.getWallet(
-                  groupPublicKeyHash
-                )
+                const wallet = await walletRegistry.getWallet(walletID)
 
                 await expect(wallet.membersIdsHash).to.be.equal(
                   hashUint32Array(dkgResult.members)
@@ -1776,7 +1772,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               it("should emit WalletCreated event", async () => {
                 await expect(tx)
                   .to.emit(walletRegistry, "WalletCreated")
-                  .withArgs(groupPublicKeyHash, dkgResultHash)
+                  .withArgs(walletID, dkgResultHash)
               })
 
               it("should unlock the sortition pool", async () => {
@@ -1869,8 +1865,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               expectedMembers.splice(58, 1) // index -6
 
               expect(
-                (await walletRegistry.getWallet(groupPublicKeyHash))
-                  .membersIdsHash
+                (await walletRegistry.getWallet(walletID)).membersIdsHash
               ).to.be.equal(hashUint32Array(expectedMembers))
             })
 
@@ -2026,20 +2021,18 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
     context("with wallet registered", async () => {
       const existingWalletPublicKey: string = ecdsaData.group1.publicKey
-      let existingWalletPublicKeyHash: string
+      let existingWalletID: string
 
       before("create a wallet", async () => {
         await createSnapshot()
-        ;({ publicKeyHash: existingWalletPublicKeyHash } =
-          await createNewWallet(
-            walletRegistry,
-            walletOwner.wallet,
-            existingWalletPublicKey
-          ))
+        ;({ walletID: existingWalletID } = await createNewWallet(
+          walletRegistry,
+          walletOwner.wallet,
+          existingWalletPublicKey
+        ))
 
-        await expect(
-          await walletRegistry.isWalletRegistered(existingWalletPublicKeyHash)
-        ).to.be.true
+        await expect(await walletRegistry.isWalletRegistered(existingWalletID))
+          .to.be.true
       })
 
       after(async () => {
@@ -2077,7 +2070,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
           let submitter: SignerWithAddress
 
           const newResultPublicKey = ecdsaData.group2.publicKey
-          const newResultPublicKeyHash = keccak256(newResultPublicKey)
+          const newWalletID = keccak256(newResultPublicKey)
           const newResultSubmitterIndex = 1
 
           before("submit dkg result", async () => {
@@ -2125,9 +2118,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
             })
 
             it("should register a new wallet", async () => {
-              const wallet = await walletRegistry.getWallet(
-                newResultPublicKeyHash
-              )
+              const wallet = await walletRegistry.getWallet(newWalletID)
 
               await expect(wallet.membersIdsHash).to.be.equal(
                 hashUint32Array(dkgResult.members)
@@ -2137,7 +2128,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
             it("should emit WalletCreated event", async () => {
               await expect(tx)
                 .to.emit(walletRegistry, "WalletCreated")
-                .withArgs(newResultPublicKeyHash, dkgResultHash)
+                .withArgs(newWalletID, dkgResultHash)
             })
 
             it("should unlock the sortition pool", async () => {

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -25,7 +25,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
   const groupPublicKey: string = ethers.utils.hexValue(
     ecdsaData.group1.publicKey
   )
-  const groupPublicKeyHash: string = ethers.utils.keccak256(groupPublicKey)
+  const walletID: string = ethers.utils.keccak256(groupPublicKey)
 
   let walletRegistry: WalletRegistryStub & WalletRegistry
   let walletOwner: FakeContract<IWalletOwner>
@@ -106,7 +106,7 @@ describe("WalletRegistry - Wallet Owner", async () => {
 
       it("should call wallet owner", async () => {
         await expect(walletOwner.__ecdsaWalletCreatedCallback).to.be.calledWith(
-          groupPublicKeyHash,
+          walletID,
           dkgResult.groupPubKey
         )
       })

--- a/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletOwner.test.ts
@@ -25,6 +25,12 @@ describe("WalletRegistry - Wallet Owner", async () => {
   const groupPublicKey: string = ethers.utils.hexValue(
     ecdsaData.group1.publicKey
   )
+  const groupPublicKeyX: string = ethers.utils.hexValue(
+    ecdsaData.group1.publicKeyX
+  )
+  const groupPublicKeyY: string = ethers.utils.hexValue(
+    ecdsaData.group1.publicKeyY
+  )
   const walletID: string = ethers.utils.keccak256(groupPublicKey)
 
   let walletRegistry: WalletRegistryStub & WalletRegistry
@@ -105,9 +111,12 @@ describe("WalletRegistry - Wallet Owner", async () => {
       })
 
       it("should call wallet owner", async () => {
+        await tx
+
         await expect(walletOwner.__ecdsaWalletCreatedCallback).to.be.calledWith(
           walletID,
-          dkgResult.groupPubKey
+          groupPublicKeyX,
+          groupPublicKeyY
         )
       })
     })

--- a/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
@@ -47,6 +47,13 @@ describe("WalletRegistry - Wallets", async () => {
             expectedWalletID:
               "0x525e77a3052a07734c5736074a94b71dd9149650ef6a4c57dac696a3e287d03c",
           },
+          {
+            context: "with zeros in the middle",
+            publicKey:
+              "0x9a0544440cc47779235ccb76d669590c2cd20c7e431f97e17a1093faf0320000000061a208a8a565ca1e384059bd2ff7ff6886df081ff1229250099d388c83df",
+            expectedWalletID:
+              "0xa8b7226c57b544536f7bf805ef75c7b831488398da117644839f650c5be6cbe0",
+          },
         ]
         testData.forEach((test) => {
           let walletID: string
@@ -73,9 +80,21 @@ describe("WalletRegistry - Wallets", async () => {
               "unexpected members ids hash"
             ).to.be.equal(hashUint32Array(dkgResult.members))
 
-            expect(wallet.publicKey, "unexpected public key").to.be.equal(
-              test.publicKey
+            expect(wallet.publicKeyX, "unexpected public key X").to.be.equal(
+              ethers.utils.hexDataSlice(test.publicKey, 0, 32)
             )
+            expect(wallet.publicKeyY, "unexpected public key Y").to.be.equal(
+              ethers.utils.hexDataSlice(test.publicKey, 32)
+            )
+          })
+
+          describe("getWalletPublicKey", async () => {
+            it("should return concatenated public key", async () => {
+              expect(
+                await walletRegistry.getWalletPublicKey(walletID),
+                "unexpected concatenated public key"
+              ).to.be.equal(test.publicKey)
+            })
           })
 
           it("should calculate wallet id", async () => {

--- a/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
@@ -32,11 +32,11 @@ describe("WalletRegistry - Wallets", async () => {
     })
 
     context("with wallet registered", async () => {
-      let publicKeyHash: string
+      let walletID: string
 
       before("create a wallet", async () => {
         await createSnapshot()
-        ;({ publicKeyHash } = await createNewWallet(
+        ;({ walletID } = await createNewWallet(
           walletRegistry,
           walletOwner.wallet
         ))
@@ -47,8 +47,8 @@ describe("WalletRegistry - Wallets", async () => {
       })
 
       it("should return true", async () => {
-        await expect(await walletRegistry.isWalletRegistered(publicKeyHash)).to
-          .be.true
+        await expect(await walletRegistry.isWalletRegistered(walletID)).to.be
+          .true
       })
     })
   })

--- a/solidity/ecdsa/test/data/ecdsa.ts
+++ b/solidity/ecdsa/test/data/ecdsa.ts
@@ -7,6 +7,10 @@ const ecdsaData = {
     // ecdsa public key
     publicKey:
       "0x9a0544440cc47779235ccb76d669590c2cd20c7e431f97e17a1093faf03291c473e661a208a8a565ca1e384059bd2ff7ff6886df081ff1229250099d388c83df",
+    publicKeyX:
+      "0x9a0544440cc47779235ccb76d669590c2cd20c7e431f97e17a1093faf03291c4",
+    publicKeyY:
+      "0x73e661a208a8a565ca1e384059bd2ff7ff6886df081ff1229250099d388c83df",
 
     // digest to sign
     digest1:

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -117,7 +117,7 @@ export const walletRegistryFixture = deployments.createFixture(
 export async function updateWalletRegistryParams(
   walletRegistryGovernance: WalletRegistryGovernance,
   governance: SignerWithAddress
-) {
+): Promise<void> {
   await walletRegistryGovernance
     .connect(governance)
     .beginMinimumAuthorizationUpdate(params.minimumAuthorization)

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -7,7 +7,7 @@ import { BigNumber } from "ethers"
 import { selectGroup } from "./groups"
 
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import type { BigNumberish, ContractTransaction } from "ethers"
+import type { BigNumberish, ContractTransaction, BytesLike } from "ethers"
 import type { SortitionPool, WalletRegistry } from "../../typechain"
 import type { Operator } from "./operators"
 import type {
@@ -17,7 +17,7 @@ import type {
 
 export interface DkgResult {
   submitterMemberIndex: number
-  groupPubKey: string
+  groupPubKey: BytesLike
   misbehavedMembersIndices: number[]
   signatures: string
   signingMembersIndices: number[]
@@ -46,7 +46,7 @@ export function calculateDkgSeed(
 // seed.
 export async function signAndSubmitCorrectDkgResult(
   walletRegistry: WalletRegistry,
-  groupPublicKey: string,
+  groupPublicKey: BytesLike,
   seed: BigNumber,
   startBlock: number,
   misbehavedIndices = noMisbehaved,
@@ -88,7 +88,7 @@ const DKG_RESULT_PARAMS_SIGNATURE =
 // for preparing invalid or malicious results for testing purposes.
 export async function signAndSubmitArbitraryDkgResult(
   walletRegistry: WalletRegistry,
-  groupPublicKey: string,
+  groupPublicKey: BytesLike,
   signers: Operator[],
   startBlock: number,
   misbehavedIndices: number[],
@@ -178,7 +178,7 @@ export async function signAndSubmitUnrecoverableDkgResult(
 
 export async function signDkgResult(
   signers: Operator[],
-  groupPublicKey: string,
+  groupPublicKey: BytesLike,
   misbehavedMembersIndices: number[],
   startBlock: number,
   submitterIndex = 1,

--- a/solidity/ecdsa/test/utils/wallets.ts
+++ b/solidity/ecdsa/test/utils/wallets.ts
@@ -20,7 +20,7 @@ export async function createNewWallet(
   publicKey = ecdsaData.group1.publicKey
 ): Promise<{
   members: Operator[]
-  publicKeyHash: string
+  walletID: string
 }> {
   const tx = await walletRegistry.connect(walletOwner).requestNewWallet()
 
@@ -51,5 +51,5 @@ export async function createNewWallet(
 
   await walletRegistry.connect(submitter).approveDkgResult(dkgResult)
 
-  return { members, publicKeyHash: keccak256(publicKey) }
+  return { members, walletID: keccak256(publicKey) }
 }


### PR DESCRIPTION
We want to store a public key of the wallet so it can be used by the wallet owner (Bridge) for transactions handling. The Bridge will use both compressed and uncompressed public keys. We store the longer one (uncompressed) that can be easily converted to the compressed format.

We also renamed `publicKeyHash` to walletID as this reflects better what this property is. Using the name `publicKeyHash` was confusing in the external owner contract as there may be another key hash in use, but this is an implementation detail of what hashing function we use for identification.

Please notice that gas costs went up:

BEFORE:
|  WalletRegistry.approveDkgResult | 210844 | 225949 | 214789 │

AFTER:
|  WalletRegistry.approveDkgResult | 257700 | 257940 | 257830 |

Depends on https://github.com/keep-network/keep-core/pull/2854
Refs: https://github.com/keep-network/tbtc-v2/pull/159