### PR TITLE
Beacon: Use the same governance delay for all parameters

### DIFF
--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -1970,7 +1970,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
     //       await walletRegistryGovernance.beginDkgResultSubmissionRewardUpdate(
     //         dkgRewardsPoolBalance.mul(2)
     //       )
-    //       await helpers.time.increaseTime(12 * 60 * 60)
+    //       await helpers.time.increaseTime(params.governanceDelay)
     //       await walletRegistryGovernance.finalizeDkgResultSubmissionRewardUpdate()
 
     //       const [genesisTx, genesisSeed] = await genesis(walletRegistry)

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -89,38 +89,7 @@ contract RandomBeaconGovernance is Ownable {
 
     RandomBeacon public randomBeacon;
 
-    // Long governance delay used for critical parameters giving a chance for
-    // stakers to opt out before the change is finalized in case they do not
-    // agree with that change. The maximum group lifetime must not be longer
-    // than this delay.
-    //
-    // The full list of parameters protected by this delay:
-    // - relay entry hard timeout
-    // - callback gas limit
-    // - group lifetime
-    // - relay entry submission failure slashing amount
-    // - minimum authorization
-    // - authorization decrease delay
-    uint256 internal constant CRITICAL_PARAMETER_GOVERNANCE_DELAY = 2 weeks;
-
-    // Short governance delay for non-critical parameters. Honest stakers should
-    // not be severely affected by any change of these parameters.
-    //
-    // The full list of parameters protected by this delay:
-    // - relay request fee
-    // - group creation frequency
-    // - relay entry soft timeout
-    // - DKG result challenge period length
-    // - DKG result submission timeout
-    // - DKG submitter precedence period length
-    // - DKG result submission reward
-    // - sortition pool rewards ban duration
-    // - malicious DKG result slashing amount
-    // - sortition pool unlocking reward
-    // - ineligible operator notifier reward
-    // - relay entry timeout notification reward multiplier
-    // - DKG malicious result notification reward multiplier
-    uint256 internal constant STANDARD_PARAMETER_GOVERNANCE_DELAY = 12 hours;
+    uint256 public governanceDelay;
 
     event RelayRequestFeeUpdateStarted(
         uint256 relayRequestFee,
@@ -270,22 +239,20 @@ contract RandomBeaconGovernance is Ownable {
     /// @notice Reverts if called before the governance delay elapses.
     /// @param changeInitiatedTimestamp Timestamp indicating the beginning
     ///        of the change.
-    modifier onlyAfterGovernanceDelay(
-        uint256 changeInitiatedTimestamp,
-        uint256 delay
-    ) {
+    modifier onlyAfterGovernanceDelay(uint256 changeInitiatedTimestamp) {
         /* solhint-disable not-rely-on-time */
         require(changeInitiatedTimestamp > 0, "Change not initiated");
         require(
-            block.timestamp - changeInitiatedTimestamp >= delay,
+            block.timestamp - changeInitiatedTimestamp >= governanceDelay,
             "Governance delay has not elapsed"
         );
         _;
         /* solhint-enable not-rely-on-time */
     }
 
-    constructor(RandomBeacon _randomBeacon) {
+    constructor(RandomBeacon _randomBeacon, uint256 _governanceDelay) {
         randomBeacon = _randomBeacon;
+        governanceDelay = _governanceDelay;
     }
 
     /// @notice Begins the relay request fee update process.
@@ -308,10 +275,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeRelayRequestFeeUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            relayRequestFeeChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(relayRequestFeeChangeInitiated)
     {
         emit RelayRequestFeeUpdated(newRelayRequestFee);
         // slither-disable-next-line reentrancy-no-eth
@@ -352,10 +316,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeRelayEntrySoftTimeoutUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            relayEntrySoftTimeoutChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(relayEntrySoftTimeoutChangeInitiated)
     {
         emit RelayEntrySoftTimeoutUpdated(newRelayEntrySoftTimeout);
         // slither-disable-next-line reentrancy-no-eth
@@ -392,10 +353,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeRelayEntryHardTimeoutUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            relayEntryHardTimeoutChangeInitiated,
-            CRITICAL_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(relayEntryHardTimeoutChangeInitiated)
     {
         emit RelayEntryHardTimeoutUpdated(newRelayEntryHardTimeout);
         // slither-disable-next-line reentrancy-no-eth
@@ -437,10 +395,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeCallbackGasLimitUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            callbackGasLimitChangeInitiated,
-            CRITICAL_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(callbackGasLimitChangeInitiated)
     {
         emit CallbackGasLimitUpdated(newCallbackGasLimit);
         // slither-disable-next-line reentrancy-no-eth
@@ -480,10 +435,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeGroupCreationFrequencyUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            groupCreationFrequencyChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(groupCreationFrequencyChangeInitiated)
     {
         emit GroupCreationFrequencyUpdated(newGroupCreationFrequency);
         // slither-disable-next-line reentrancy-no-eth
@@ -519,10 +471,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeGroupLifetimeUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            groupLifetimeChangeInitiated,
-            CRITICAL_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(groupLifetimeChangeInitiated)
     {
         emit GroupLifetimeUpdated(newGroupLifetime);
         // slither-disable-next-line reentrancy-no-eth
@@ -561,10 +510,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeDkgResultChallengePeriodLengthUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            dkgResultChallengePeriodLengthChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(dkgResultChallengePeriodLengthChangeInitiated)
     {
         emit DkgResultChallengePeriodLengthUpdated(
             newDkgResultChallengePeriodLength
@@ -608,10 +554,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeDkgResultSubmissionTimeoutUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            dkgResultSubmissionTimeoutChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(dkgResultSubmissionTimeoutChangeInitiated)
     {
         emit DkgResultSubmissionTimeoutUpdated(newDkgResultSubmissionTimeout);
         // slither-disable-next-line reentrancy-no-eth
@@ -652,8 +595,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            dkgSubmitterPrecedencePeriodLengthChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            dkgSubmitterPrecedencePeriodLengthChangeInitiated
         )
     {
         emit DkgSubmitterPrecedencePeriodLengthUpdated(
@@ -691,10 +633,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeDkgResultSubmissionRewardUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            dkgResultSubmissionRewardChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(dkgResultSubmissionRewardChangeInitiated)
     {
         emit DkgResultSubmissionRewardUpdated(newDkgResultSubmissionReward);
         // slither-disable-next-line reentrancy-no-eth
@@ -733,10 +672,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeSortitionPoolUnlockingRewardUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            sortitionPoolUnlockingRewardChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(sortitionPoolUnlockingRewardChangeInitiated)
     {
         emit SortitionPoolUnlockingRewardUpdated(
             newSortitionPoolUnlockingReward
@@ -779,8 +715,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            ineligibleOperatorNotifierRewardChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            ineligibleOperatorNotifierRewardChangeInitiated
         )
     {
         emit IneligibleOperatorNotifierRewardUpdated(
@@ -823,10 +758,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeSortitionPoolRewardsBanDurationUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            sortitionPoolRewardsBanDurationChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(sortitionPoolRewardsBanDurationChangeInitiated)
     {
         emit SortitionPoolRewardsBanDurationUpdated(
             newSortitionPoolRewardsBanDuration
@@ -901,8 +833,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            unauthorizedSigningNotificationRewardMultiplierChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            unauthorizedSigningNotificationRewardMultiplierChangeInitiated
         )
     {
         emit UnauthorizedSigningNotificationRewardMultiplierUpdated(
@@ -930,8 +861,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            relayEntryTimeoutNotificationRewardMultiplierChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            relayEntryTimeoutNotificationRewardMultiplierChangeInitiated
         )
     {
         emit RelayEntryTimeoutNotificationRewardMultiplierUpdated(
@@ -983,8 +913,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            dkgMaliciousResultNotificationRewardMultiplierChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            dkgMaliciousResultNotificationRewardMultiplierChangeInitiated
         )
     {
         emit DkgMaliciousResultNotificationRewardMultiplierUpdated(
@@ -1031,8 +960,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            relayEntrySubmissionFailureSlashingAmountChangeInitiated,
-            CRITICAL_PARAMETER_GOVERNANCE_DELAY
+            relayEntrySubmissionFailureSlashingAmountChangeInitiated
         )
     {
         emit RelayEntrySubmissionFailureSlashingAmountUpdated(
@@ -1073,8 +1001,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            maliciousDkgResultSlashingAmountChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            maliciousDkgResultSlashingAmountChangeInitiated
         )
     {
         emit MaliciousDkgResultSlashingAmountUpdated(
@@ -1115,8 +1042,7 @@ contract RandomBeaconGovernance is Ownable {
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            unauthorizedSigningSlashingAmountChangeInitiated,
-            STANDARD_PARAMETER_GOVERNANCE_DELAY
+            unauthorizedSigningSlashingAmountChangeInitiated
         )
     {
         emit UnauthorizedSigningSlashingAmountUpdated(
@@ -1155,10 +1081,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeMinimumAuthorizationUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            minimumAuthorizationChangeInitiated,
-            CRITICAL_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(minimumAuthorizationChangeInitiated)
     {
         emit MinimumAuthorizationUpdated(newMinimumAuthorization);
         // slither-disable-next-line reentrancy-no-eth
@@ -1192,10 +1115,7 @@ contract RandomBeaconGovernance is Ownable {
     function finalizeAuthorizationDecreaseDelayUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(
-            authorizationDecreaseDelayChangeInitiated,
-            CRITICAL_PARAMETER_GOVERNANCE_DELAY
-        )
+        onlyAfterGovernanceDelay(authorizationDecreaseDelayChangeInitiated)
     {
         emit AuthorizationDecreaseDelayUpdated(newAuthorizationDecreaseDelay);
         // slither-disable-next-line reentrancy-no-eth
@@ -1223,11 +1143,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                relayRequestFeeChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(relayRequestFeeChangeInitiated);
     }
 
     /// @notice Get the time remaining until the relay entry submission soft
@@ -1238,11 +1154,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                relayEntrySoftTimeoutChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(relayEntrySoftTimeoutChangeInitiated);
     }
 
     /// @notice Get the time remaining until the relay entry hard timeout can be
@@ -1253,11 +1165,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                relayEntryHardTimeoutChangeInitiated,
-                CRITICAL_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(relayEntryHardTimeoutChangeInitiated);
     }
 
     /// @notice Get the time remaining until the callback gas limit can be
@@ -1268,11 +1176,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                callbackGasLimitChangeInitiated,
-                CRITICAL_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(callbackGasLimitChangeInitiated);
     }
 
     /// @notice Get the time remaining until the group creation frequency can be
@@ -1283,11 +1187,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                groupCreationFrequencyChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(groupCreationFrequencyChangeInitiated);
     }
 
     /// @notice Get the time remaining until the group lifetime can be updated.
@@ -1297,11 +1197,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                groupLifetimeChangeInitiated,
-                CRITICAL_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(groupLifetimeChangeInitiated);
     }
 
     /// @notice Get the time remaining until the DKG result challenge period
@@ -1314,8 +1210,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                dkgResultChallengePeriodLengthChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                dkgResultChallengePeriodLengthChangeInitiated
             );
     }
 
@@ -1328,10 +1223,7 @@ contract RandomBeaconGovernance is Ownable {
         returns (uint256)
     {
         return
-            getRemainingChangeTime(
-                dkgResultSubmissionTimeoutChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
-            );
+            getRemainingChangeTime(dkgResultSubmissionTimeoutChangeInitiated);
     }
 
     /// @notice Get the time remaining until the wallet owner can be updated.
@@ -1343,8 +1235,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                dkgSubmitterPrecedencePeriodLengthChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                dkgSubmitterPrecedencePeriodLengthChangeInitiated
             );
     }
 
@@ -1356,11 +1247,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                dkgResultSubmissionRewardChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(dkgResultSubmissionRewardChangeInitiated);
     }
 
     /// @notice Get the time remaining until the sortition pool unlocking reward
@@ -1372,10 +1259,7 @@ contract RandomBeaconGovernance is Ownable {
         returns (uint256)
     {
         return
-            getRemainingChangeTime(
-                sortitionPoolUnlockingRewardChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
-            );
+            getRemainingChangeTime(sortitionPoolUnlockingRewardChangeInitiated);
     }
 
     /// @notice Get the time remaining until the ineligible operator notifier
@@ -1388,8 +1272,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                ineligibleOperatorNotifierRewardChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                ineligibleOperatorNotifierRewardChangeInitiated
             );
     }
 
@@ -1403,8 +1286,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                relayEntrySubmissionFailureSlashingAmountChangeInitiated,
-                CRITICAL_PARAMETER_GOVERNANCE_DELAY
+                relayEntrySubmissionFailureSlashingAmountChangeInitiated
             );
     }
 
@@ -1418,8 +1300,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                maliciousDkgResultSlashingAmountChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                maliciousDkgResultSlashingAmountChangeInitiated
             );
     }
 
@@ -1433,8 +1314,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                unauthorizedSigningSlashingAmountChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                unauthorizedSigningSlashingAmountChangeInitiated
             );
     }
 
@@ -1446,11 +1326,7 @@ contract RandomBeaconGovernance is Ownable {
         view
         returns (uint256)
     {
-        return
-            getRemainingChangeTime(
-                minimumAuthorizationChangeInitiated,
-                CRITICAL_PARAMETER_GOVERNANCE_DELAY
-            );
+        return getRemainingChangeTime(minimumAuthorizationChangeInitiated);
     }
 
     function getRemainingAuthorizationDecreaseDelayUpdateTime()
@@ -1459,10 +1335,7 @@ contract RandomBeaconGovernance is Ownable {
         returns (uint256)
     {
         return
-            getRemainingChangeTime(
-                authorizationDecreaseDelayChangeInitiated,
-                CRITICAL_PARAMETER_GOVERNANCE_DELAY
-            );
+            getRemainingChangeTime(authorizationDecreaseDelayChangeInitiated);
     }
 
     /// @notice Get the time remaining until the sortition pool rewards ban
@@ -1475,8 +1348,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                sortitionPoolRewardsBanDurationChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                sortitionPoolRewardsBanDurationChangeInitiated
             );
     }
 
@@ -1490,8 +1362,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                relayEntryTimeoutNotificationRewardMultiplierChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                relayEntryTimeoutNotificationRewardMultiplierChangeInitiated
             );
     }
 
@@ -1505,8 +1376,7 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                unauthorizedSigningNotificationRewardMultiplierChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                unauthorizedSigningNotificationRewardMultiplierChangeInitiated
             );
     }
 
@@ -1520,17 +1390,15 @@ contract RandomBeaconGovernance is Ownable {
     {
         return
             getRemainingChangeTime(
-                dkgMaliciousResultNotificationRewardMultiplierChangeInitiated,
-                STANDARD_PARAMETER_GOVERNANCE_DELAY
+                dkgMaliciousResultNotificationRewardMultiplierChangeInitiated
             );
     }
 
     /// @notice Gets the time remaining until the governable parameter update
     ///         can be committed.
     /// @param changeTimestamp Timestamp indicating the beginning of the change.
-    /// @param delay Governance delay.
     /// @return Remaining time in seconds.
-    function getRemainingChangeTime(uint256 changeTimestamp, uint256 delay)
+    function getRemainingChangeTime(uint256 changeTimestamp)
         internal
         view
         returns (uint256)
@@ -1538,10 +1406,10 @@ contract RandomBeaconGovernance is Ownable {
         require(changeTimestamp > 0, "Change not initiated");
         /* solhint-disable-next-line not-rely-on-time */
         uint256 elapsed = block.timestamp - changeTimestamp;
-        if (elapsed >= delay) {
+        if (elapsed >= governanceDelay) {
             return 0;
         } else {
-            return delay - elapsed;
+            return governanceDelay - elapsed;
         }
     }
 }

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -1915,7 +1915,7 @@ describe("RandomBeacon - Group Creation", () => {
           await randomBeaconGovernance.beginDkgResultSubmissionRewardUpdate(
             dkgRewardsPoolBalance.mul(2)
           )
-          await helpers.time.increaseTime(12 * 60 * 60)
+          await helpers.time.increaseTime(params.governanceDelay)
           await randomBeaconGovernance.finalizeDkgResultSubmissionRewardUpdate()
 
           const [genesisTx, genesisSeed] = await genesis(randomBeacon)

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -14,6 +14,8 @@ describe("RandomBeaconGovernance", () => {
   let randomBeacon: RandomBeacon
   let randomBeaconGovernance: RandomBeaconGovernance
 
+  const governanceDelay = 604800 // 1 week
+
   const initialRelayRequestFee = 100000
   const initialRelayEntrySoftTimeout = 10
   const initialRelayEntryHardTimeout = 100
@@ -95,7 +97,7 @@ describe("RandomBeaconGovernance", () => {
       "RandomBeaconGovernance"
     )
     randomBeaconGovernance = await RandomBeaconGovernance.deploy(
-      randomBeacon.address
+      randomBeacon.address, governanceDelay
     )
     await randomBeaconGovernance.deployed()
     await randomBeacon.transferOwnership(randomBeaconGovernance.address)
@@ -136,7 +138,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingRelayRequestFeeUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the RelayRequestFeeUpdateStarted event", async () => {
@@ -178,7 +180,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginRelayRequestFeeUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60 - 10) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -202,7 +204,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginRelayRequestFeeUpdate(123)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -294,7 +296,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingRelayEntrySoftTimeoutUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the RelayEntrySoftTimeoutUpdateStarted event", async () => {
@@ -336,7 +338,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginRelayEntrySoftTimeoutUpdate(1)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -360,7 +362,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginRelayEntrySoftTimeoutUpdate(1)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -425,7 +427,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingRelayEntryHardTimeoutUpdateTime()
-        ).to.be.equal(14 * 24 * 60 * 60) // 2 weeks
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the RelayEntryHardTimeoutUpdateStarted event", async () => {
@@ -467,7 +469,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginRelayEntryHardTimeoutUpdate(123)
 
-        await helpers.time.increaseTime(13 * 24 * 60 * 60) // 13 days
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -491,7 +493,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginRelayEntryHardTimeoutUpdate(123)
 
-          await helpers.time.increaseTime(14 * 24 * 60 * 60) // 2 weeks
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -607,7 +609,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingCallbackGasLimitUpdateTime()
-        ).to.be.equal(14 * 24 * 60 * 60) // 2 weeks
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the CallbackGasLimitUpdateStarted event", async () => {
@@ -649,7 +651,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginCallbackGasLimitUpdate(123)
 
-        await helpers.time.increaseTime(13 * 24 * 60 * 60) // 13 days
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -673,7 +675,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginCallbackGasLimitUpdate(123)
 
-          await helpers.time.increaseTime(14 * 24 * 60 * 60) // 2 weeks
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -765,7 +767,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingGroupCreationFrequencyUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the GroupCreationFrequencyUpdateStarted event", async () => {
@@ -810,7 +812,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginGroupCreationFrequencyUpdate(1)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -834,7 +836,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginGroupCreationFrequencyUpdate(1)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -947,7 +949,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingGroupLifetimeUpdateTime()
-        ).to.be.equal(14 * 24 * 60 * 60) // 2 weeks
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the GroupLifetimeUpdateStarted event", async () => {
@@ -989,7 +991,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginGroupLifetimeUpdate(2 * 24 * 60 * 60) // 2 days
 
-        await helpers.time.increaseTime(13 * 24 * 60 * 60) // 13 days
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1013,7 +1015,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginGroupLifetimeUpdate(2 * 24 * 60 * 60) // 2 days
 
-          await helpers.time.increaseTime(14 * 24 * 60 * 60) // 2 weeks
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1107,7 +1109,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingDkgResultChallengePeriodLengthUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the DkgResultChallengePeriodLengthUpdateStarted event", async () => {
@@ -1152,7 +1154,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginDkgResultChallengePeriodLengthUpdate(11)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1176,7 +1178,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginDkgResultChallengePeriodLengthUpdate(11)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1273,7 +1275,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingDkgResultSubmissionTimeoutUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the DkgResultSubmissionTimeoutUpdateStarted event", async () => {
@@ -1318,7 +1320,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginDkgResultSubmissionTimeoutUpdate(1)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1343,7 +1345,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginDkgResultSubmissionTimeoutUpdate(newValue)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1445,7 +1447,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingDkgSubmitterPrecedencePeriodLengthUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the DkgSubmitterPrecedencePeriodLengthUpdateStarted event", async () => {
@@ -1490,7 +1492,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginDkgSubmitterPrecedencePeriodLengthUpdate(1)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1514,7 +1516,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginDkgSubmitterPrecedencePeriodLengthUpdate(1)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1584,7 +1586,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingDkgResultSubmissionRewardUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the DkgResultSubmissionRewardUpdateStarted event", async () => {
@@ -1629,7 +1631,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginDkgResultSubmissionRewardUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1653,7 +1655,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginDkgResultSubmissionRewardUpdate(123)
 
-          await helpers.time.increaseTime(24 * 60 * 60)
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1720,7 +1722,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingSortitionPoolUnlockingRewardUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the SortitionPoolUnlockingRewardUpdateStarted event", async () => {
@@ -1765,7 +1767,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginSortitionPoolUnlockingRewardUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1789,7 +1791,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginSortitionPoolUnlockingRewardUpdate(123)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1859,7 +1861,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingIneligibleOperatorNotifierRewardUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the IneligibleOperatorNotifierRewardUpdateStarted event", async () => {
@@ -1904,7 +1906,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginIneligibleOperatorNotifierRewardUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -1928,7 +1930,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginIneligibleOperatorNotifierRewardUpdate(123)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -1998,7 +2000,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingRelayEntrySubmissionFailureSlashingAmountUpdateTime()
-        ).to.be.equal(14 * 24 * 60 * 60) // 2 weeks
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the RelayEntrySubmissionFailureSlashingAmountUpdateStarted event", async () => {
@@ -2043,7 +2045,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginRelayEntrySubmissionFailureSlashingAmountUpdate(123)
 
-        await helpers.time.increaseTime(13 * 24 * 60 * 60) // 13 days
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2067,7 +2069,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginRelayEntrySubmissionFailureSlashingAmountUpdate(123)
 
-          await helpers.time.increaseTime(14 * 24 * 60 * 60) // 2 weeks
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2137,7 +2139,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingUnauthorizedSigningSlashingAmountUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the UnauthorizedSigningSlashingAmountUpdateStarted event", async () => {
@@ -2182,7 +2184,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginUnauthorizedSigningSlashingAmountUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2206,7 +2208,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginUnauthorizedSigningSlashingAmountUpdate(123)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2276,7 +2278,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingMaliciousDkgResultSlashingAmountUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the MaliciousDkgResultSlashingAmountUpdateStarted event", async () => {
@@ -2321,7 +2323,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginMaliciousDkgResultSlashingAmountUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2345,7 +2347,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginMaliciousDkgResultSlashingAmountUpdate(123)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2415,7 +2417,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingSortitionPoolRewardsBanDurationUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the SortitionPoolRewardsBanDurationUpdateStarted event", async () => {
@@ -2460,7 +2462,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginSortitionPoolRewardsBanDurationUpdate(123)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2484,7 +2486,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginSortitionPoolRewardsBanDurationUpdate(123)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2564,7 +2566,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingUnauthorizedSigningNotificationRewardMultiplierUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the UnauthorizedSigningNotificationRewardMultiplierUpdateStarted event", async () => {
@@ -2609,7 +2611,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginUnauthorizedSigningNotificationRewardMultiplierUpdate(100)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2633,7 +2635,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginUnauthorizedSigningNotificationRewardMultiplierUpdate(100)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2713,7 +2715,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingRelayEntryTimeoutNotificationRewardMultiplierUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the RelayEntryTimeoutNotificationRewardMultiplierUpdateStarted event", async () => {
@@ -2758,7 +2760,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginRelayEntryTimeoutNotificationRewardMultiplierUpdate(100)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2782,7 +2784,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginRelayEntryTimeoutNotificationRewardMultiplierUpdate(100)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2852,7 +2854,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingMimimumAuthorizationUpdateTime()
-        ).to.be.equal(24 * 14 * 60 * 60) // 2 weeks
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the MinimumAuthorizationUpdateStarted event", async () => {
@@ -2894,7 +2896,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginMinimumAuthorizationUpdate(123)
 
-        await helpers.time.increaseTime(13 * 24 * 60 * 60) // 13 days
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -2918,7 +2920,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginMinimumAuthorizationUpdate(123)
 
-          await helpers.time.increaseTime(24 * 14 * 60 * 60) // 2 weeks
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -2983,7 +2985,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingAuthorizationDecreaseDelayUpdateTime()
-        ).to.be.equal(24 * 14 * 60 * 60) // 2 weeks
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the AuthorizationDecreaseDelayUpdateStarted event", async () => {
@@ -3027,7 +3029,7 @@ describe("RandomBeaconGovernance", () => {
         await randomBeaconGovernance
           .connect(governance)
           .beginAuthorizationDecreaseDelayUpdate(123)
-        await helpers.time.increaseTime(13 * 24 * 60 * 60) // 13 days
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
         await expect(
           randomBeaconGovernance
             .connect(governance)
@@ -3050,7 +3052,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginAuthorizationDecreaseDelayUpdate(123)
 
-          await helpers.time.increaseTime(24 * 14 * 60 * 60) // 2 weeks
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)
@@ -3130,7 +3132,7 @@ describe("RandomBeaconGovernance", () => {
       it("should start the governance delay timer", async () => {
         expect(
           await randomBeaconGovernance.getRemainingDkgMaliciousResultNotificationRewardMultiplierUpdateTime()
-        ).to.be.equal(12 * 60 * 60) // 12 hours
+        ).to.be.equal(governanceDelay)
       })
 
       it("should emit the DkgMaliciousResultNotificationRewardMultiplierUpdateStarted event", async () => {
@@ -3175,7 +3177,7 @@ describe("RandomBeaconGovernance", () => {
           .connect(governance)
           .beginDkgMaliciousResultNotificationRewardMultiplierUpdate(100)
 
-        await helpers.time.increaseTime(11 * 60 * 60) // 11 hours
+        await helpers.time.increaseTime(governanceDelay - 60) // -1min
 
         await expect(
           randomBeaconGovernance
@@ -3199,7 +3201,7 @@ describe("RandomBeaconGovernance", () => {
             .connect(governance)
             .beginDkgMaliciousResultNotificationRewardMultiplierUpdate(100)
 
-          await helpers.time.increaseTime(12 * 60 * 60) // 12 hours
+          await helpers.time.increaseTime(governanceDelay)
 
           tx = await randomBeaconGovernance
             .connect(governance)

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -28,6 +28,7 @@ export const dkgState = {
 }
 
 export const params = {
+  governanceDelay: 604800, // 1 week
   relayRequestFee: to1e18(100),
   relayEntrySoftTimeout: 35,
   relayEntryHardTimeout: 100,
@@ -144,7 +145,10 @@ export async function testDeployment(): Promise<DeployedContracts> {
     "RandomBeaconGovernance"
   )
   const randomBeaconGovernance: RandomBeaconGovernance =
-    await RandomBeaconGovernance.deploy(contracts.randomBeacon.address)
+    await RandomBeaconGovernance.deploy(
+      contracts.randomBeacon.address,
+      params.governanceDelay
+    )
   await randomBeaconGovernance.deployed()
   await contracts.randomBeacon.transferOwnership(randomBeaconGovernance.address)
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2847
See https://github.com/keep-network/keep-core/pull/2862

2-week critical governance parameter dit not make sense for ECDSA `WalletRegistry`
given that wallets have to remain active for months. We could swallow it for
the `RandomBeacon` but it is handcuffing the governance - to make it work,
no group should live longer than 2 weeks. Given that ECDSA governance has only
one delay, beacon governance is updated for consistency.

Another option was to eliminate governance contracts completely and just deploy
`TimeLock` contract. However, `TimeLock` updates are more complex to set up than
simple calls to the existing governance contract, and the structure of `update*`
functions in `RandomBeacon` is more complicated.

Further work, outside of this PR to make the diff size sane:
- allow to update the governance delay
- allow transferring RandomBeacon ownership somewhere else