### PR TITLE
Allow to update delay in RandomBeaconGovernance

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -22,6 +22,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 ///         governable parameters in respect to governance delay individual
 ///         for each parameter.
 contract RandomBeaconGovernance is Ownable {
+    uint256 public newGovernanceDelay;
+    uint256 public governanceDelayChangeInitiated;
+
     uint256 public newRelayRequestFee;
     uint256 public relayRequestFeeChangeInitiated;
 
@@ -90,6 +93,12 @@ contract RandomBeaconGovernance is Ownable {
     RandomBeacon public randomBeacon;
 
     uint256 public governanceDelay;
+
+    event GovernanceDelayUpdateStarted(
+        uint256 governanceDelay,
+        uint256 timestamp
+    );
+    event GovernanceDelayUpdated(uint256 governanceDelay);
 
     event RelayRequestFeeUpdateStarted(
         uint256 relayRequestFee,
@@ -253,6 +262,34 @@ contract RandomBeaconGovernance is Ownable {
     constructor(RandomBeacon _randomBeacon, uint256 _governanceDelay) {
         randomBeacon = _randomBeacon;
         governanceDelay = _governanceDelay;
+    }
+
+    /// @notice Begins the governance delay update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newGovernanceDelay New governance delay
+    function beginGovernanceDelayUpdate(uint256 _newGovernanceDelay)
+        external
+        onlyOwner
+    {
+        newGovernanceDelay = _newGovernanceDelay;
+        /* solhint-disable not-rely-on-time */
+        governanceDelayChangeInitiated = block.timestamp;
+        emit GovernanceDelayUpdateStarted(_newGovernanceDelay, block.timestamp);
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the governance delay update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeGovernanceDelayUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(governanceDelayChangeInitiated)
+    {
+        emit GovernanceDelayUpdated(newGovernanceDelay);
+        governanceDelay = newGovernanceDelay;
+        governanceDelayChangeInitiated = 0;
+        newGovernanceDelay = 0;
     }
 
     /// @notice Begins the relay request fee update process.
@@ -1133,6 +1170,16 @@ contract RandomBeaconGovernance is Ownable {
     /// @param recipient Recipient of withdrawn rewards.
     function withdrawIneligibleRewards(address recipient) external onlyOwner {
         randomBeacon.withdrawIneligibleRewards(recipient);
+    }
+
+    /// @notice Get the time remaining until the governance delay can be updated.
+    /// @return Remaining time in seconds.
+    function getRemainingGovernanceDelayUpdateTime()
+        external
+        view
+        returns (uint256)
+    {
+        return getRemainingChangeTime(governanceDelayChangeInitiated);
     }
 
     /// @notice Get the time remaining until the relay request fee can be


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2847
See https://github.com/keep-network/keep-core/pull/2862

Depends on #2865; Keeping as a draft until #2865 is merged.

There is one governance delay for all governable parameters and now, this delay
can be updated by governance contract owner. The same rules apply as for other
parameters: start the update process, wait for the delay period, finalize the
update.

It is possible that two updates can happen at the same time. If one of these
updates is governance delay, it is possible that the finalization of another update
may take longer than initially expected. This is acceptable - governance needs
to take it into account. What is more, the contract guarantees the change does
not happen earlier than the delay but it does not guarantee the change will
be applied as soon as the delay ends.