### PR TITLE
Mark operators misbehaving during ECDSA DKG as ineligible for rewards

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -163,10 +163,12 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
 
         // TODO: Implement governance for the parameters
         // TODO: revisit all initial values
+        sortitionPoolRewardsBanDuration = 2 weeks;
 
         // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(400000e18); // 400k T
         authorization.setAuthorizationDecreaseDelay(5184000); // 60 days
+        
         maliciousDkgResultSlashingAmount = 50000e18;
         maliciousDkgResultNotificationRewardMultiplier = 100;
 

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -72,6 +72,11 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     ///         operator affected.
     uint256 public maliciousDkgResultNotificationRewardMultiplier;
 
+    /// @notice Duration of the sortition pool rewards ban imposed on operators
+    ///         who missed their turn for DKG result submission or who failed
+    ///         a heartbeat.
+    uint256 public sortitionPoolRewardsBanDuration;
+
     // External dependencies
 
     SortitionPool public immutable sortitionPool;
@@ -129,7 +134,8 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     );
 
     event RewardParametersUpdated(
-        uint256 maliciousDkgResultNotificationRewardMultiplier
+        uint256 maliciousDkgResultNotificationRewardMultiplier,
+        uint256 sortitionPoolRewardsBanDuration
     );
 
     event SlashingParametersUpdated(uint256 maliciousDkgResultSlashingAmount);
@@ -253,12 +259,17 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
     ///      validating parameters.
     /// @param _maliciousDkgResultNotificationRewardMultiplier New value of the
     ///        DKG malicious result notification reward multiplier.
+    /// @param _sortitionPoolRewardsBanDuration New sortition pool rewards
+    ///        ban duration in seconds.
     function updateRewardParameters(
-        uint256 _maliciousDkgResultNotificationRewardMultiplier
+        uint256 _maliciousDkgResultNotificationRewardMultiplier,
+        uint256 _sortitionPoolRewardsBanDuration
     ) external onlyOwner {
         maliciousDkgResultNotificationRewardMultiplier = _maliciousDkgResultNotificationRewardMultiplier;
+        sortitionPoolRewardsBanDuration = _sortitionPoolRewardsBanDuration;
         emit RewardParametersUpdated(
-            maliciousDkgResultNotificationRewardMultiplier
+            _maliciousDkgResultNotificationRewardMultiplier,
+            _sortitionPoolRewardsBanDuration
         );
     }
 
@@ -273,7 +284,7 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
         onlyOwner
     {
         maliciousDkgResultSlashingAmount = _maliciousDkgResultSlashingAmount;
-        emit SlashingParametersUpdated(maliciousDkgResultSlashingAmount);
+        emit SlashingParametersUpdated(_maliciousDkgResultSlashingAmount);
     }
 
     /// @notice Updates the values of the wallet parameters.

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -168,7 +168,7 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
         // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(400000e18); // 400k T
         authorization.setAuthorizationDecreaseDelay(5184000); // 60 days
-        
+
         maliciousDkgResultSlashingAmount = 50000e18;
         maliciousDkgResultNotificationRewardMultiplier = 100;
 

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -407,9 +407,13 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
 
         emit WalletCreated(walletID, keccak256(abi.encode(dkgResult)));
 
-        // TODO: Disable rewards for misbehavedMembers.
-        //slither-disable-next-line redundant-statements
-        misbehavedMembers;
+        if (misbehavedMembers.length > 0) {
+            sortitionPool.setRewardIneligibility(
+                misbehavedMembers,
+                // solhint-disable-next-line not-rely-on-time
+                block.timestamp + sortitionPoolRewardsBanDuration
+            );
+        }
 
         walletOwner.__ecdsaWalletCreatedCallback(
             walletID,

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -46,6 +46,9 @@ contract WalletRegistryGovernance is Ownable {
     uint256
         public maliciousDkgResultNotificationRewardMultiplierChangeInitiated;
 
+    uint256 public newSortitionPoolRewardsBanDuration;
+    uint256 public sortitionPoolRewardsBanDurationChangeInitiated;
+
     uint256 public newDkgSeedTimeout;
     uint256 public dkgSeedTimeoutChangeInitiated;
 
@@ -103,6 +106,14 @@ contract WalletRegistryGovernance is Ownable {
     );
     event MaliciousDkgResultNotificationRewardMultiplierUpdated(
         uint256 maliciousDkgResultNotificationRewardMultiplier
+    );
+
+    event SortitionPoolRewardsBanDurationUpdateStarted(
+        uint256 sortitionPoolRewardsBanDuration,
+        uint256 timestamp
+    );
+    event SortitionPoolRewardsBanDurationUpdated(
+        uint256 sortitionPoolRewardsBanDuration
     );
 
     event DkgSeedTimeoutUpdateStarted(
@@ -427,10 +438,48 @@ contract WalletRegistryGovernance is Ownable {
         );
         // slither-disable-next-line reentrancy-no-eth
         walletRegistry.updateRewardParameters(
-            newMaliciousDkgResultNotificationRewardMultiplier
+            newMaliciousDkgResultNotificationRewardMultiplier,
+            walletRegistry.sortitionPoolRewardsBanDuration()
         );
         maliciousDkgResultNotificationRewardMultiplierChangeInitiated = 0;
         newMaliciousDkgResultNotificationRewardMultiplier = 0;
+    }
+
+    /// @notice Begins the sortition pool rewards ban duration update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newSortitionPoolRewardsBanDuration New sortition pool rewards
+    ///        ban duration.
+    function beginSortitionPoolRewardsBanDurationUpdate(
+        uint256 _newSortitionPoolRewardsBanDuration
+    ) external onlyOwner {
+        /* solhint-disable not-rely-on-time */
+        newSortitionPoolRewardsBanDuration = _newSortitionPoolRewardsBanDuration;
+        sortitionPoolRewardsBanDurationChangeInitiated = block.timestamp;
+        emit SortitionPoolRewardsBanDurationUpdateStarted(
+            _newSortitionPoolRewardsBanDuration,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the sortition pool rewards ban duration update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeSortitionPoolRewardsBanDurationUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(sortitionPoolRewardsBanDurationChangeInitiated)
+    {
+        emit SortitionPoolRewardsBanDurationUpdated(
+            newSortitionPoolRewardsBanDuration
+        );
+        // slither-disable-next-line reentrancy-no-eth
+        walletRegistry.updateRewardParameters(
+            walletRegistry.maliciousDkgResultNotificationRewardMultiplier(),
+            newSortitionPoolRewardsBanDuration
+        );
+        sortitionPoolRewardsBanDurationChangeInitiated = 0;
+        newSortitionPoolRewardsBanDuration = 0;
     }
 
     /// @notice Begins the DKG seed timeout update process.
@@ -668,6 +717,20 @@ contract WalletRegistryGovernance is Ownable {
         return
             getRemainingChangeTime(
                 maliciousDkgResultNotificationRewardMultiplierChangeInitiated
+            );
+    }
+
+    /// @notice Get the time remaining until the sortition pool rewards ban
+    ///         duration can be updated.
+    /// @return Remaining time in seconds.
+    function getRemainingSortitionPoolRewardsBanDurationUpdateTime()
+        external
+        view
+        returns (uint256)
+    {
+        return
+            getRemainingChangeTime(
+                sortitionPoolRewardsBanDurationChangeInitiated
             );
     }
 

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -80,7 +80,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by the deployer", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(deployer).updateRewardParameters(1)
+          walletRegistry.connect(deployer).updateRewardParameters(1, 2)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -88,7 +88,9 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by the wallet owner", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(walletOwner.wallet).updateRewardParameters(1)
+          walletRegistry
+            .connect(walletOwner.wallet)
+            .updateRewardParameters(1, 2)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -96,7 +98,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by a third party", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(thirdParty).updateRewardParameters(1)
+          walletRegistry.connect(thirdParty).updateRewardParameters(1, 2)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -1847,16 +1847,17 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
               let members: number[]
               let submitter: SignerWithAddress
-              ;({ dkgResult, members, submitter } =
-                await signAndSubmitCorrectDkgResult(
-                  walletRegistry,
-                  groupPublicKey,
-                  dkgSeed,
-                  startBlock,
-                  misbehavedIndices
-                ))
+              ;({ dkgResult, submitter } = await signAndSubmitCorrectDkgResult(
+                walletRegistry,
+                groupPublicKey,
+                dkgSeed,
+                startBlock,
+                misbehavedIndices
+              ))
 
-              misbehavedIds = misbehavedIndices.map((i) => members[i - 1])
+              misbehavedIds = misbehavedIndices.map(
+                (i) => dkgResult.members[i - 1]
+              )
 
               await mineBlocks(params.dkgResultChallengePeriodLength)
               tx = await walletRegistry

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -1559,6 +1559,15 @@ describe("WalletRegistry - Wallet Creation", async () => {
                 it("should unlock the sortition pool", async () => {
                   await expect(await sortitionPool.isLocked()).to.be.false
                 })
+
+                // there are no misbehaving group members in the result,
+                // everyone should be eligible for rewards
+                it("should not mark properly behaving operators as ineligible for rewards", async () => {
+                  await expect(tx).not.to.emit(
+                    sortitionPool,
+                    "IneligibleForRewards"
+                  )
+                })
               })
 
               context("when called by a third party", async () => {
@@ -1924,6 +1933,8 @@ describe("WalletRegistry - Wallet Creation", async () => {
             }
           )
 
+          // This case shouldn't happen in real life. When a result is submitted
+          // with invalid order of misbehaved operators it should be challenged.
           context("when misbehaved members contains duplicates", async () => {
             const misbehavedIndices = [2, 9, 9, 10]
 

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -1836,7 +1836,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
           context("with misbehaved operators", async () => {
             const misbehavedIndices = [2, 9, 11, 30, 60, 64]
-            let misbehavedIds
+            let misbehavedIds: number[]
             let tx: ContractTransaction
             let dkgResult: DkgResult
 
@@ -1845,7 +1845,6 @@ describe("WalletRegistry - Wallet Creation", async () => {
 
               await mineBlocksTo(startBlock + dkgTimeout - 1)
 
-              let members: number[]
               let submitter: SignerWithAddress
               ;({ dkgResult, submitter } = await signAndSubmitCorrectDkgResult(
                 walletRegistry,

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -52,7 +52,7 @@ describe("WalletRegistryGovernance", async () => {
   const initialAuthorizationDecreaseDelay = 5184000 // 60 days
   const initialMaliciousDkgResultSlashingAmount = to1e18(50000)
   const initialMaliciousDkgResultNotificationRewardMultiplier = 100
-  const initialSortitionPoolRewardsBanDuration = 604800 // 7 days
+  const initialSortitionPoolRewardsBanDuration = 1209600 // 14 days
 
   before("load test fixture", async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -52,6 +52,7 @@ describe("WalletRegistryGovernance", async () => {
   const initialAuthorizationDecreaseDelay = 5184000 // 60 days
   const initialMaliciousDkgResultSlashingAmount = to1e18(50000)
   const initialMaliciousDkgResultNotificationRewardMultiplier = 100
+  const initialSortitionPoolRewardsBanDuration = 604800 // 7 days
 
   before("load test fixture", async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -1172,6 +1173,145 @@ describe("WalletRegistryGovernance", async () => {
         it("should reset the governance delay timer", async () => {
           await expect(
             walletRegistryGovernance.getRemainingMaliciousDkgResultNotificationRewardMultiplierUpdateTime()
+          ).to.be.revertedWith("Change not initiated")
+        })
+      }
+    )
+  })
+
+  describe("beginSortitionPoolRewardsBanDurationUpdate", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(thirdParty)
+            .beginSortitionPoolRewardsBanDurationUpdate(86400)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the caller is the owner", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await walletRegistryGovernance
+          .connect(governance)
+          .beginSortitionPoolRewardsBanDurationUpdate(86400)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should not update the sortition pool rewards ban duration", async () => {
+        expect(
+          await walletRegistry.sortitionPoolRewardsBanDuration()
+        ).to.be.equal(initialSortitionPoolRewardsBanDuration)
+      })
+
+      it("should start the governance delay timer", async () => {
+        expect(
+          await walletRegistryGovernance.getRemainingSortitionPoolRewardsBanDurationUpdateTime()
+        ).to.be.equal(constants.governanceDelay)
+      })
+
+      it("should emit the SortitionPoolRewardsBanDurationUpdateStarted event", async () => {
+        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
+          .timestamp
+        await expect(tx)
+          .to.emit(
+            walletRegistryGovernance,
+            "SortitionPoolRewardsBanDurationUpdateStarted"
+          )
+          .withArgs(86400, blockTimestamp)
+      })
+    })
+  })
+
+  describe("finalizeSortitionPoolRewardsBanDurationUpdate", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(thirdParty)
+            .finalizeSortitionPoolRewardsBanDurationUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initialized", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(governance)
+            .finalizeSortitionPoolRewardsBanDurationUpdate()
+        ).to.be.revertedWith("Change not initiated")
+      })
+    })
+
+    context("when the governance delay has not passed", () => {
+      it("should revert", async () => {
+        await createSnapshot()
+
+        await walletRegistryGovernance
+          .connect(governance)
+          .beginSortitionPoolRewardsBanDurationUpdate(86400)
+
+        await helpers.time.increaseTime(constants.governanceDelay - 60) // -1min
+
+        await expect(
+          walletRegistryGovernance
+            .connect(governance)
+            .finalizeSortitionPoolRewardsBanDurationUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+
+        await restoreSnapshot()
+      })
+    })
+
+    context(
+      "when the update process is initialized and governance delay passed",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await walletRegistryGovernance
+            .connect(governance)
+            .beginSortitionPoolRewardsBanDurationUpdate(86400)
+
+          await helpers.time.increaseTime(constants.governanceDelay)
+
+          tx = await walletRegistryGovernance
+            .connect(governance)
+            .finalizeSortitionPoolRewardsBanDurationUpdate()
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the sortition pool rewards ban duration", async () => {
+          expect(
+            await walletRegistry.sortitionPoolRewardsBanDuration()
+          ).to.be.equal(86400)
+        })
+
+        it("should emit SortitionPoolRewardsBanDurationUpdated event", async () => {
+          await expect(tx)
+            .to.emit(
+              walletRegistryGovernance,
+              "SortitionPoolRewardsBanDurationUpdated"
+            )
+            .withArgs(86400)
+        })
+
+        it("should reset the governance delay timer", async () => {
+          await expect(
+            walletRegistryGovernance.getRemainingSortitionPoolRewardsBanDurationUpdateTime()
           ).to.be.revertedWith("Change not initiated")
         })
       }

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -40,7 +40,7 @@ export const params = {
   dkgResultChallengePeriodLength: 10,
   dkgResultSubmissionTimeout: 30,
   dkgSubmitterPrecedencePeriodLength: 5,
-  sortitionPoolRewardsBanDuration: 604800, // 7 days
+  sortitionPoolRewardsBanDuration: 1209600, // 14 days
 }
 
 export const walletRegistryFixture = deployments.createFixture(

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -40,6 +40,7 @@ export const params = {
   dkgResultChallengePeriodLength: 10,
   dkgResultSubmissionTimeout: 30,
   dkgSubmitterPrecedencePeriodLength: 5,
+  sortitionPoolRewardsBanDuration: 604800, // 7 days
 }
 
 export const walletRegistryFixture = deployments.createFixture(
@@ -146,6 +147,12 @@ export async function updateWalletRegistryParams(
       params.dkgSubmitterPrecedencePeriodLength
     )
 
+  await walletRegistryGovernance
+    .connect(governance)
+    .beginSortitionPoolRewardsBanDurationUpdate(
+      params.sortitionPoolRewardsBanDuration
+    )
+
   await helpers.time.increaseTime(constants.governanceDelay)
 
   await walletRegistryGovernance
@@ -171,6 +178,10 @@ export async function updateWalletRegistryParams(
   await walletRegistryGovernance
     .connect(governance)
     .finalizeDkgSubmitterPrecedencePeriodLengthUpdate()
+
+  await walletRegistryGovernance
+    .connect(governance)
+    .finalizeSortitionPoolRewardsBanDurationUpdate()
 }
 
 async function initializeWalletOwner(

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -56,6 +56,7 @@ export async function signAndSubmitCorrectDkgResult(
   signers: Operator[]
   dkgResult: DkgResult
   dkgResultHash: string
+  members: number[]
   submitter: SignerWithAddress
   transaction: ContractTransaction
 }> {
@@ -97,10 +98,11 @@ export async function signAndSubmitArbitraryDkgResult(
 ): Promise<{
   dkgResult: DkgResult
   dkgResultHash: string
+  members: number[]
   submitter: SignerWithAddress
   transaction: ContractTransaction
 }> {
-  const { dkgResult } = await signDkgResult(
+  const { dkgResult, members } = await signDkgResult(
     signers,
     groupPublicKey,
     misbehavedIndices,
@@ -121,6 +123,7 @@ export async function signAndSubmitArbitraryDkgResult(
   return {
     dkgResult,
     dkgResultHash,
+    members,
     submitter,
     ...(await submitDkgResult(walletRegistry, dkgResult, submitter)),
   }
@@ -187,6 +190,7 @@ export async function signDkgResult(
   dkgResult: DkgResult
   signingMembersIndices: number[]
   signaturesBytes: string
+  members: number[]
 }> {
   const resultHash = ethers.utils.solidityKeccak256(
     ["bytes", "uint8[]", "uint256"],
@@ -228,7 +232,7 @@ export async function signDkgResult(
     membersHash: hashDKGMembers(members, misbehavedMembersIndices),
   }
 
-  return { dkgResult, signingMembersIndices, signaturesBytes }
+  return { dkgResult, signingMembersIndices, signaturesBytes, members }
 }
 
 export async function submitDkgResult(

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -56,7 +56,6 @@ export async function signAndSubmitCorrectDkgResult(
   signers: Operator[]
   dkgResult: DkgResult
   dkgResultHash: string
-  members: number[]
   submitter: SignerWithAddress
   transaction: ContractTransaction
 }> {
@@ -98,11 +97,10 @@ export async function signAndSubmitArbitraryDkgResult(
 ): Promise<{
   dkgResult: DkgResult
   dkgResultHash: string
-  members: number[]
   submitter: SignerWithAddress
   transaction: ContractTransaction
 }> {
-  const { dkgResult, members } = await signDkgResult(
+  const { dkgResult } = await signDkgResult(
     signers,
     groupPublicKey,
     misbehavedIndices,
@@ -123,7 +121,6 @@ export async function signAndSubmitArbitraryDkgResult(
   return {
     dkgResult,
     dkgResultHash,
-    members,
     submitter,
     ...(await submitDkgResult(walletRegistry, dkgResult, submitter)),
   }
@@ -190,7 +187,6 @@ export async function signDkgResult(
   dkgResult: DkgResult
   signingMembersIndices: number[]
   signaturesBytes: string
-  members: number[]
 }> {
   const resultHash = ethers.utils.solidityKeccak256(
     ["bytes", "uint8[]", "uint256"],
@@ -232,7 +228,7 @@ export async function signDkgResult(
     membersHash: hashDKGMembers(members, misbehavedMembersIndices),
   }
 
-  return { dkgResult, signingMembersIndices, signaturesBytes, members }
+  return { dkgResult, signingMembersIndices, signaturesBytes }
 }
 
 export async function submitDkgResult(

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -119,7 +119,8 @@ contract RandomBeacon is IRandomBeacon, Ownable {
     uint256 public unauthorizedSigningSlashingAmount;
 
     /// @notice Duration of the sortition pool rewards ban imposed on operators
-    ///         who missed their turn for relay entry or DKG result submission.
+    ///         who missed their turn for relay entry / DKG result submission
+    ///         or operators who failed a heartbeat.
     uint256 public sortitionPoolRewardsBanDuration;
 
     /// @notice Percentage of the staking contract malicious behavior


### PR DESCRIPTION
Closes #2857

Group members who were misbehaving during DKG (inactive or disqualified) are marked as ineligible for rewards for a certain, governable, period of time.

Added governable parameter to `WalletRegistry` indicating that time. The new governable parameter will also be used for reward ineligibility period for operators who missed their turn during DKG result submission or that failed a heartbeat (this is covered in https://github.com/keep-network/keep-core/issues/2839).