### PR TITLE
Expose `getWalletCreationState` function

### DIFF
--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -14,6 +14,8 @@
 
 pragma solidity ^0.8.9;
 
+import "../libraries/EcdsaDkg.sol";
+
 interface IWalletRegistry {
     /// @notice Requests a new wallet creation.
     /// @dev Only a Wallet Owner can call this function.
@@ -28,4 +30,7 @@ interface IWalletRegistry {
         external
         view
         returns (bytes memory);
+
+    /// @notice Check current wallet creation state.
+    function getWalletCreationState() external view returns (EcdsaDkg.State);
 }


### PR DESCRIPTION
This change expose `getWalletCreationState` function in `IWalletRegistry` interface. This function can help the wallet's owner to determine the moment when a new wallet can be created.