### PR TITLE
Callback for wallet's hearbeat failure

### DIFF
--- a/solidity/ecdsa/contracts/api/IWalletOwner.sol
+++ b/solidity/ecdsa/contracts/api/IWalletOwner.sol
@@ -25,4 +25,16 @@ interface IWalletOwner {
         bytes32 publicKeyX,
         bytes32 publicKeyY
     ) external;
+
+    /// @notice Callback function executed once a wallet heartbeat failure
+    ///         is detected.
+    /// @dev Should be callable only by the Wallet Registry.
+    /// @param walletID Wallet's unique identifier.
+    /// @param publicKeyY Wallet's public key's X coordinate.
+    /// @param publicKeyY Wallet's public key's Y coordinate.
+    function __ecdsaWalletHeartbeatFailedCallback(
+        bytes32 walletID,
+        bytes32 publicKeyX,
+        bytes32 publicKeyY
+    ) external;
 }


### PR DESCRIPTION
Refs: #2839
Refs: https://github.com/keep-network/tbtc-v2/issues/139

Here we expose `__ecdsaWalletHeartbeatFailedCallback` function in the `IWalletOwner` interface that will be used to notify the wallet owner about a heartbeat failure detected on a specific wallet.