### PR TITLE
Closing wallets on ECDSA registry side

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -329,6 +329,13 @@ contract WalletRegistry is IRandomBeaconConsumer, IWalletRegistry, Ownable {
         randomBeacon.requestRelayEntry(this);
     }
 
+    /// @notice Closes an existing wallet.
+    /// @param walletID ID of the wallet.
+    /// @dev Only a Wallet Owner can call this function.
+    function closeWallet(bytes32 walletID) external onlyWalletOwner {
+        // TODO: Implementation.
+    }
+
     /// @notice A callback that is executed once a new relay entry gets
     ///         generated. It starts the DKG process.
     /// @dev Can be called only by the random beacon contract.

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -21,6 +21,11 @@ interface IWalletRegistry {
     /// @dev Only a Wallet Owner can call this function.
     function requestNewWallet() external;
 
+    /// @notice Closes an existing wallet.
+    /// @param walletID ID of the wallet.
+    /// @dev Only a Wallet Owner can call this function.
+    function closeWallet(bytes32 walletID) external;
+
     /// @notice Gets public key of a wallet with a given wallet ID.
     ///         The public key is returned in an uncompressed format as a 64-byte
     ///         concatenation of X and Y coordinates.


### PR DESCRIPTION
Refs: #2864 

This change exposes `closeWallet` function that allows the wallet owner to send a signal about wallet closure to the ECDSA registry. The scope of this change is just about exposing the function to unblock the work on the `Bridge` side. Actual implementation should be provided by a follow-up PR.