### PR TITLE
Start keep-core 1.9.0-dev package version

### DIFF
--- a/solidity-v1/package-lock.json
+++ b/solidity-v1/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0-dev",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity-v1/package-lock.json
+++ b/solidity-v1/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0",
+  "version": "1.9.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity-v1/package.json
+++ b/solidity-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0-dev",
+  "version": "1.8.0",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",

--- a/solidity-v1/package.json
+++ b/solidity-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-core",
-  "version": "1.8.0",
+  "version": "1.9.0-dev",
   "description": "Smart Contracts for the Keep Network Core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR bumps version of keep-core V1 to 1.9.0-dev after we deployed 1.8.0