### PR TITLE
WalletRegistry authentication unit test improvements

### DIFF
--- a/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
@@ -213,6 +213,11 @@ describe("WalletRegistry - Authorization", () => {
           .to.emit(walletRegistry, "OperatorRegistered")
           .withArgs(stakingProvider.address, operator.address)
       })
+
+      it("should not register operator in the pool", async () => {
+        expect(await walletRegistry.isOperatorInPool(operator.address)).to.be
+          .false
+      })
     })
 
     // It is possible to approve authorization decrease request immediately

--- a/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
@@ -1452,6 +1452,52 @@ describe("WalletRegistry - Authorization", () => {
       })
     })
 
+    // The only option for it to happen is when there was a slashing.
+    context(
+      "when the authorization dropped below the minimum but is still non-zero",
+      () => {
+        before(async () => {
+          await createSnapshot()
+
+          await walletRegistry
+            .connect(stakingProvider)
+            .registerOperator(operator.address)
+
+          const authorizedAmount = minimumAuthorization
+          await staking
+            .connect(authorizer)
+            .increaseAuthorization(
+              stakingProvider.address,
+              walletRegistry.address,
+              authorizedAmount
+            )
+
+          const slashingTo = minimumAuthorization.sub(1)
+          // Note that we slash from the entire staked amount given that the
+          // initially authorized amount is less than staked amount and it is
+          // another application slashing. To go below the minimum stake, we need
+          // to start slashing from the entire staked amount, not just the
+          // one authorized for WalletRegistry.
+          const slashedAmount = stakedAmount.sub(slashingTo)
+
+          await staking
+            .connect(slasher.wallet)
+            .slash(slashedAmount, [stakingProvider.address])
+          await staking.connect(thirdParty).processSlashing(1)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            walletRegistry.connect(operator).joinSortitionPool()
+          ).to.be.revertedWith("Authorization below the minimum")
+        })
+      }
+    )
+
     context("when the operator has the minimum stake authorized", () => {
       let tx: ContractTransaction
 


### PR DESCRIPTION
This PR is a follow-up to the comments from #2850.

Added two unit tests:
- Make sure `WalletRegistry.registerOperator` does not add operator into the sortition pool.
- Make sure `WalletRegistry.joinSortitionPool` reverts for stake below the minimum. Note that the only situation possible when such a scenario occurs is when there was a slashing in the meantime and the authorization that was previously above the minimum dropped.