### PR TITLE
Merge gas-related updates into one function in WalletRegistry

### DIFF
--- a/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
+++ b/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
@@ -58,7 +58,6 @@ contract EcdsaDkgValidator {
 
     /// @dev Size in bytes of a public key produced by group members during the
     /// the DKG. The length assumes uncompressed ECDSA public key.
-    // TODO: Investigate if we could use compressed public keys of 33 bytes length.
     uint256 public constant publicKeyByteSize = 64;
 
     /// @dev Size in bytes of a single signature produced by operator supporting

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -723,9 +723,6 @@ contract WalletRegistry is
         return wallets.isWalletRegistered(walletID);
     }
 
-    // TODO: Add function to close the Wallet so the members are notified that
-    // they no longer need to track the wallet.
-
     /// @notice Retrieves dkg parameters that were set in DKG library.
     function dkgParameters()
         external

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -228,8 +228,8 @@ contract WalletRegistry is
         randomBeacon = _randomBeacon;
         reimbursementPool = _reimbursementPool;
 
-        // TODO: Implement governance for the parameters
         // TODO: revisit all initial values
+
         sortitionPoolRewardsBanDuration = 2 weeks;
 
         // slither-disable-next-line too-many-digits
@@ -240,10 +240,10 @@ contract WalletRegistry is
         maliciousDkgResultNotificationRewardMultiplier = 100;
 
         dkg.init(_sortitionPool, _ecdsaDkgValidator);
-        dkg.setSeedTimeout(1440); // ~6h assuming 15s block time // TODO: Verify value
+        dkg.setSeedTimeout(1440); // ~6h assuming 15s block time
         dkg.setResultChallengePeriodLength(11520); // ~48h assuming 15s block time
-        dkg.setResultSubmissionTimeout(100 * 20); // TODO: Verify value
-        dkg.setSubmitterPrecedencePeriodLength(20); // TODO: Verify value
+        dkg.setResultSubmissionTimeout(100 * 20);
+        dkg.setSubmitterPrecedencePeriodLength(20);
     }
 
     /// @notice Used by staking provider to set operator address that will

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -65,8 +65,8 @@ contract WalletRegistryGovernance is Ownable {
     uint256 public newDkgResultSubmissionGas;
     uint256 public dkgResultSubmissionGasChangeInitiated;
 
-    uint256 public newDkgApprovalGasOffset;
-    uint256 public dkgApprovalGasOffsetChangeInitiated;
+    uint256 public newDkgResultApprovalGasOffset;
+    uint256 public dkgResultApprovalGasOffsetChangeInitiated;
 
     address payable public newReimbursementPool;
     uint256 public reimbursementPoolChangeInitiated;
@@ -160,11 +160,11 @@ contract WalletRegistryGovernance is Ownable {
     );
     event DkgResultSubmissionGasUpdated(uint256 dkgResultSubmissionGas);
 
-    event DkgApprovalGasOffsetUpdateStarted(
+    event DkgResultApprovalGasOffsetUpdateStarted(
         uint256 dkgApprovalGasOffset,
         uint256 timestamp
     );
-    event DkgApprovalGasOffsetUpdated(uint256 dkgApprovalGasOffset);
+    event DkgResultApprovalGasOffsetUpdated(uint256 dkgResultApprovalGasOffset);
 
     event ReimbursementPoolUpdateStarted(
         address reimbursementPool,
@@ -499,7 +499,10 @@ contract WalletRegistryGovernance is Ownable {
     {
         emit DkgResultSubmissionGasUpdated(newDkgResultSubmissionGas);
         // slither-disable-next-line reentrancy-no-eth
-        walletRegistry.updateDkgResultSubmissionGas(newDkgResultSubmissionGas);
+        walletRegistry.updateGasParameters(
+            newDkgResultSubmissionGas,
+            walletRegistry.dkgResultApprovalGasOffset()
+        );
         dkgResultSubmissionGasChangeInitiated = 0;
         newDkgResultSubmissionGas = 0;
     }
@@ -544,34 +547,36 @@ contract WalletRegistryGovernance is Ownable {
 
     /// @notice Begins the dkg approval gas offset update process.
     /// @dev Can be called only by the contract owner.
-    /// @param _newDkgApprovalGasOffset New DKG result approval gas.
-    function beginDkgApprovalGasOffsetUpdate(uint256 _newDkgApprovalGasOffset)
-        external
-        onlyOwner
-    {
+    /// @param _newDkgResultApprovalGasOffset New DKG result approval gas.
+    function beginDkgResultApprovalGasOffsetUpdate(
+        uint256 _newDkgResultApprovalGasOffset
+    ) external onlyOwner {
         /* solhint-disable not-rely-on-time */
-        newDkgApprovalGasOffset = _newDkgApprovalGasOffset;
-        dkgApprovalGasOffsetChangeInitiated = block.timestamp;
-        emit DkgApprovalGasOffsetUpdateStarted(
-            _newDkgApprovalGasOffset,
+        newDkgResultApprovalGasOffset = _newDkgResultApprovalGasOffset;
+        dkgResultApprovalGasOffsetChangeInitiated = block.timestamp;
+        emit DkgResultApprovalGasOffsetUpdateStarted(
+            _newDkgResultApprovalGasOffset,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
     }
 
-    /// @notice Finalizes the dkg approval gas offset update process.
+    /// @notice Finalizes the dkg result approval gas offset update process.
     /// @dev Can be called only by the contract owner, after the governance
     ///      delay elapses.
-    function finalizeDkgApprovalGasOffsetUpdate()
+    function finalizeDkgResultApprovalGasOffsetUpdate()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(dkgApprovalGasOffsetChangeInitiated)
+        onlyAfterGovernanceDelay(dkgResultApprovalGasOffsetChangeInitiated)
     {
-        emit DkgApprovalGasOffsetUpdated(newDkgApprovalGasOffset);
+        emit DkgResultApprovalGasOffsetUpdated(newDkgResultApprovalGasOffset);
         // slither-disable-next-line reentrancy-no-eth
-        walletRegistry.updateDkgApprovalGasOffset(newDkgApprovalGasOffset);
-        dkgApprovalGasOffsetChangeInitiated = 0;
-        newDkgApprovalGasOffset = 0;
+        walletRegistry.updateGasParameters(
+            walletRegistry.dkgResultSubmissionGas(),
+            newDkgResultApprovalGasOffset
+        );
+        dkgResultApprovalGasOffsetChangeInitiated = 0;
+        newDkgResultApprovalGasOffset = 0;
     }
 
     /// @notice Begins the sortition pool rewards ban duration update process.
@@ -933,15 +938,16 @@ contract WalletRegistryGovernance is Ownable {
         return getRemainingChangeTime(dkgResultSubmissionGasChangeInitiated);
     }
 
-    /// @notice Get the time remaining until the dkg approval gas offset can
-    ///         be updated.
+    /// @notice Get the time remaining until the dkg result approval gas offset
+    ///         can be updated.
     /// @return Remaining time in seconds.
-    function getRemainingDkgApprovalGasOffsetUpdateTime()
+    function getRemainingDkgResultApprovalGasOffsetUpdateTime()
         external
         view
         returns (uint256)
     {
-        return getRemainingChangeTime(dkgApprovalGasOffsetChangeInitiated);
+        return
+            getRemainingChangeTime(dkgResultApprovalGasOffsetChangeInitiated);
     }
 
     /// @notice Get the time remaining until reimbursement pool can be updated.

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -16,9 +16,6 @@ pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-// TODO: This contract is just a Stub implementation that was used for gas
-// comparisons for Wallets creation. It should be implemented according to the
-// Wallets' actual use case.
 library Wallets {
     struct Wallet {
         // Keccak256 hash of group members identifiers array. Group members do not

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -160,11 +160,11 @@ describe("WalletRegistry - Parameters", async () => {
     })
   })
 
-  describe("updateDkgResultSubmissionGas", async () => {
+  describe("updateGasParameters", async () => {
     context("when called by the deployer", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(deployer).updateDkgResultSubmissionGas(4200)
+          walletRegistry.connect(deployer).updateGasParameters(4200, 4201)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -174,7 +174,7 @@ describe("WalletRegistry - Parameters", async () => {
         await expect(
           walletRegistry
             .connect(walletOwner.wallet)
-            .updateDkgResultSubmissionGas(4200)
+            .updateGasParameters(4200, 4201)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -182,35 +182,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by a third party", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(thirdParty).updateDkgResultSubmissionGas(4200)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-  })
-
-  describe("updateDkgApprovalGasOffset", async () => {
-    context("when called by the deployer", async () => {
-      it("should revert", async () => {
-        await expect(
-          walletRegistry.connect(deployer).updateDkgApprovalGasOffset(4200)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the wallet owner", async () => {
-      it("should revert", async () => {
-        await expect(
-          walletRegistry
-            .connect(walletOwner.wallet)
-            .updateDkgApprovalGasOffset(4200)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by a third party", async () => {
-      it("should revert", async () => {
-        await expect(
-          walletRegistry.connect(thirdParty).updateDkgApprovalGasOffset(4200)
+          walletRegistry.connect(thirdParty).updateGasParameters(4200, 4201)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -53,7 +53,7 @@ describe("WalletRegistryGovernance", async () => {
   const initialMaliciousDkgResultSlashingAmount = to1e18(50000)
   const initialMaliciousDkgResultNotificationRewardMultiplier = 100
   const initialDkgResultSubmissionGas = 300000
-  const initialDkgApprovalGasOffset = 65000
+  const initialDkgResultApprovalGasOffset = 65000
   const initialSortitionPoolRewardsBanDuration = 1209600 // 14 days
 
   before("load test fixture", async () => {
@@ -1166,13 +1166,13 @@ describe("WalletRegistryGovernance", async () => {
     )
   })
 
-  describe("beginDkgApprovalGasOffsetUpdate", () => {
+  describe("beginDkgResultApprovalGasOffsetUpdate", () => {
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
         await expect(
           walletRegistryGovernance
             .connect(thirdParty)
-            .beginDkgApprovalGasOffsetUpdate(100)
+            .beginDkgResultApprovalGasOffsetUpdate(100)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -1185,7 +1185,7 @@ describe("WalletRegistryGovernance", async () => {
 
         tx = await walletRegistryGovernance
           .connect(governance)
-          .beginDkgApprovalGasOffsetUpdate(100)
+          .beginDkgResultApprovalGasOffsetUpdate(100)
       })
 
       after(async () => {
@@ -1193,37 +1193,37 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the DKG approval gas offset", async () => {
-        expect(await walletRegistry.dkgApprovalGasOffset()).to.be.equal(
-          initialDkgApprovalGasOffset
+        expect(await walletRegistry.dkgResultApprovalGasOffset()).to.be.equal(
+          initialDkgResultApprovalGasOffset
         )
       })
 
       it("should start the governance delay timer", async () => {
         expect(
-          await walletRegistryGovernance.getRemainingDkgApprovalGasOffsetUpdateTime()
+          await walletRegistryGovernance.getRemainingDkgResultApprovalGasOffsetUpdateTime()
         ).to.be.equal(constants.governanceDelay)
       })
 
-      it("should emit the DkgApprovalGasOffsetUpdateStarted event", async () => {
+      it("should emit the DkgResultApprovalGasOffsetUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
         await expect(tx)
           .to.emit(
             walletRegistryGovernance,
-            "DkgApprovalGasOffsetUpdateStarted"
+            "DkgResultApprovalGasOffsetUpdateStarted"
           )
           .withArgs(100, blockTimestamp)
       })
     })
   })
 
-  describe("finalizeDkgApprovalGasOffsetUpdate", () => {
+  describe("finalizeDkgResultApprovalGasOffsetUpdate", () => {
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
         await expect(
           walletRegistryGovernance
             .connect(thirdParty)
-            .finalizeDkgApprovalGasOffsetUpdate()
+            .finalizeDkgResultApprovalGasOffsetUpdate()
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -1233,7 +1233,7 @@ describe("WalletRegistryGovernance", async () => {
         await expect(
           walletRegistryGovernance
             .connect(governance)
-            .finalizeDkgApprovalGasOffsetUpdate()
+            .finalizeDkgResultApprovalGasOffsetUpdate()
         ).to.be.revertedWith("Change not initiated")
       })
     })
@@ -1244,14 +1244,14 @@ describe("WalletRegistryGovernance", async () => {
 
         await walletRegistryGovernance
           .connect(governance)
-          .beginDkgApprovalGasOffsetUpdate(100)
+          .beginDkgResultApprovalGasOffsetUpdate(100)
 
         await helpers.time.increaseTime(constants.governanceDelay - 60) // -1min
 
         await expect(
           walletRegistryGovernance
             .connect(governance)
-            .finalizeDkgApprovalGasOffsetUpdate()
+            .finalizeDkgResultApprovalGasOffsetUpdate()
         ).to.be.revertedWith("Governance delay has not elapsed")
 
         await restoreSnapshot()
@@ -1268,13 +1268,13 @@ describe("WalletRegistryGovernance", async () => {
 
           await walletRegistryGovernance
             .connect(governance)
-            .beginDkgApprovalGasOffsetUpdate(100)
+            .beginDkgResultApprovalGasOffsetUpdate(100)
 
           await helpers.time.increaseTime(constants.governanceDelay)
 
           tx = await walletRegistryGovernance
             .connect(governance)
-            .finalizeDkgApprovalGasOffsetUpdate()
+            .finalizeDkgResultApprovalGasOffsetUpdate()
         })
 
         after(async () => {
@@ -1282,18 +1282,23 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the DKG result approval gas offset", async () => {
-          expect(await walletRegistry.dkgApprovalGasOffset()).to.be.equal(100)
+          expect(await walletRegistry.dkgResultApprovalGasOffset()).to.be.equal(
+            100
+          )
         })
 
-        it("should emit DkgApprovalGasOffsetUpdated event", async () => {
+        it("should emit DkgResultApprovalGasOffsetUpdated event", async () => {
           await expect(tx)
-            .to.emit(walletRegistryGovernance, "DkgApprovalGasOffsetUpdated")
+            .to.emit(
+              walletRegistryGovernance,
+              "DkgResultApprovalGasOffsetUpdated"
+            )
             .withArgs(100)
         })
 
         it("should reset the governance delay timer", async () => {
           await expect(
-            walletRegistryGovernance.getRemainingDkgApprovalGasOffsetUpdateTime()
+            walletRegistryGovernance.getRemainingDkgResultApprovalGasOffsetUpdateTime()
           ).to.be.revertedWith("Change not initiated")
         })
       }


### PR DESCRIPTION
Followup of #2880

Gas-related parameters are now updated using a single function on
`WalletRegistry`. This approach lets us save on the contract size and is
consistent with other functions updating various `WalletRegistry`
parameters.

I have also renamed `dkgApprovalGasOffset` to `dkgResultApprovalGasOffset`.
Given that the functions are `submitDkgResult` and  `approveDkgResult`.

I have also took an opportunity and cleaned up a bunch of TODOs that are
no longer valid