### PR TITLE
Replaced Random Beacon failed heartbeat with operator inactivity claim

### DIFF
--- a/solidity/random-beacon/README.adoc
+++ b/solidity/random-beacon/README.adoc
@@ -238,14 +238,14 @@ within the governable eligibility period, `(new_entry % group_size) + 1` and
 so on.
 
 If some group members are notoriously ignoring their duty, the group can vote on
-failed <<heartbeats,heartbeat>> notification for these operators.
+<<inactivity,inactivity>> notification for these operators.
 
 T rewards will be distributed continuously to all operators registered in the beacon
 sortition pool, excluding operators who were marked as ineligible for rewards
 due to failing the heartbeat.
 
-[[heartbeats]]
-=== Heartbeats
+[[inactivity]]
+=== Inactivity notification
 
 Off-chain clients are free to execute any heartbeat protocol they want to ensure
 group members are alive and nodes are operating properly.
@@ -256,27 +256,21 @@ nth blocks and first making sure the information cannot be used for
 `RandomBeacon.reportUnauthorizedSigning()`, that is, the signed information can
 not become `msg.sender` for `reportUnauthorizedSigning` call.
 
-Group members can agree upon members that failed the heartbeat and issue a
-heartbeat failure claim. If the required threshold of group members signed
-the heartbeat failure claim, they can submit it to
-`RandomBeacon.notifyFailedHeartbeat(Heartbeat.FailureClaim calldata claim, uint256 nonce)`
-function and have the group members who failed the heartbeat excluded from
+Group members can agree upon members who are permanently inactive and issue an
+operator inactivity claim. If the required threshold of group members signed
+the operator inactivity claim, they can submit it to
+`RandomBeacon.notifyOperatorInactivity(Inactivity.Claim calldata claim, uint256 nonce)`
+function and have the group members who are inactive excluded from
 the sortition pool rewards for a governable time period.
-
-The submitter of the failed heartbeat claim receives a reward from a separate
-notifier reward pool, funded by DAO for heartbeat failure claims specifically.
-This pool is expected to be funded by DAO with tokens saved from sortition pool
-rewards as a result of having operators marked as ineligible for rewards due to
-failing a heartbeat.
 
 This approach is theoretically susceptible to group members colluding together
 but because a reasonably high number of operators is needed to sign a claim and
 operators signing the claim other than the submitter receive nothing in return,
 we consider this approach safe and good enough. An important advantage of this
 approach is that honest players can decide off-chain when it makes sense to
-submit a heartbeat fail report and mark someone as ineligible for rewards. For
-example, marking an operator ineligible for rewards for the next two weeks have
-a higher impact than prolonging reward ineligibility for 10 minutes for an
+submit an operator inactivity claim and mark someone as ineligible for rewards.
+For example, marking an operator ineligible for rewards for the next two weeks
+have a higher impact than prolonging reward ineligibility for 10 minutes for an
 operator that was already marked as ineligible for rewards. This approach does
 not increase the gas cost of a happy path and leaves some freedom to group
 members. They may mark as ineligible operators who turned off their nodes,

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -20,7 +20,7 @@ import "./libraries/Groups.sol";
 import "./libraries/Relay.sol";
 import "./libraries/Groups.sol";
 import "./libraries/Callback.sol";
-import "./libraries/Heartbeat.sol";
+import "./libraries/Inactivity.sol";
 import {BeaconDkg as DKG} from "./libraries/BeaconDkg.sol";
 import {BeaconDkgValidator as DKGValidator} from "./BeaconDkgValidator.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
@@ -119,8 +119,9 @@ contract RandomBeacon is IRandomBeacon, Ownable {
     uint256 public unauthorizedSigningSlashingAmount;
 
     /// @notice Duration of the sortition pool rewards ban imposed on operators
-    ///         who missed their turn for relay entry / DKG result submission
-    ///         or operators who failed a heartbeat.
+    ///         who misbehaved during DKG by being inactive or disqualified and
+    ///         for operators that were identified by the rest of group members
+    ///         as inactive via `notifyOperatorInactivity`.
     uint256 public sortitionPoolRewardsBanDuration;
 
     /// @notice Percentage of the staking contract malicious behavior
@@ -152,10 +153,10 @@ contract RandomBeacon is IRandomBeacon, Ownable {
 
     // Other parameters
 
-    /// @notice Stores current failed heartbeat nonce for given group.
+    /// @notice Stores current operator inactivity claim nonce for given group.
     ///         Each claim is made with an unique nonce which protects
     ///         against claim replay.
-    mapping(uint64 => uint256) public failedHeartbeatNonce; // groupId -> nonce
+    mapping(uint64 => uint256) public inactivityClaimNonce; // groupId -> nonce
 
     // External dependencies
 
@@ -170,10 +171,6 @@ contract RandomBeacon is IRandomBeacon, Ownable {
     ///         rewards for actors approving DKG result or notifying about
     ///         DKG timeout.
     uint256 public dkgRewardsPool;
-    /// @notice Rewards pool for heartbeat notifiers. This pool is funded from
-    ///         external donates. Funds are used to cover rewards for actors
-    ///         notifying about failed heartbeats.
-    uint256 public heartbeatNotifierRewardsPool;
 
     // Libraries data storages
 
@@ -318,7 +315,7 @@ contract RandomBeacon is IRandomBeacon, Ownable {
 
     event CallbackFailed(uint256 entry, uint256 entrySubmittedBlock);
 
-    event HeartbeatFailed(uint64 groupId, uint256 nonce, address notifier);
+    event InactivityClaimed(uint64 groupId, uint256 nonce, address notifier);
 
     /// @dev Assigns initial values to parameters to make the beacon work
     ///      safely. These parameters are just proposed defaults and they might
@@ -938,30 +935,27 @@ contract RandomBeacon is IRandomBeacon, Ownable {
         }
     }
 
-    /// @notice Notifies about a failed group heartbeat. Using this function,
+    /// @notice Notifies about operators who are inactive. Using this function,
     ///         a majority of the group can decide about punishing specific
-    ///         group members who failed to provide a heartbeat. If provided
+    ///         group members who constantly fail doing their job. If the provided
     ///         claim is proved to be valid and signed by sufficient number
-    ///         of group members, operators of members deemed as failed are
+    ///         of group members, operators of members deemed as inactive are
     ///         banned for sortition pool rewards for duration specified by
     ///         `sortitionPoolRewardsBanDuration` parameter. The sender of
-    ///         the claim must be one of the claim signers. The sender is
-    ///         rewarded from `heartbeatNotifierRewardsPool`. Exact reward
-    ///         amount is multiplication of operators marked as ineligible
-    ///         and `ineligibleOperatorNotifierReward` factor. This function
+    ///         the claim must be one of the claim signers. This function
     ///         can be called only for active and non-terminated groups.
     /// @param claim Failure claim.
-    /// @param nonce Current failed heartbeat nonce for given group. Must
+    /// @param nonce Current inactivity claim nonce for the given group. Must
     ///        be the same as the stored one.
     /// @param groupMembers Identifiers of group members.
-    function notifyFailedHeartbeat(
-        Heartbeat.FailureClaim calldata claim,
+    function notifyOperatorInactivity(
+        Inactivity.Claim calldata claim,
         uint256 nonce,
         uint32[] calldata groupMembers
     ) external {
         uint64 groupId = claim.groupId;
 
-        require(nonce == failedHeartbeatNonce[groupId], "Invalid nonce");
+        require(nonce == inactivityClaimNonce[groupId], "Invalid nonce");
 
         require(
             groups.isGroupActive(groupId),
@@ -975,7 +969,7 @@ contract RandomBeacon is IRandomBeacon, Ownable {
             "Invalid group members"
         );
 
-        uint32[] memory ineligibleOperators = Heartbeat.verifyFailureClaim(
+        uint32[] memory ineligibleOperators = Inactivity.verifyClaim(
             sortitionPool,
             claim,
             group,
@@ -983,19 +977,14 @@ contract RandomBeacon is IRandomBeacon, Ownable {
             groupMembers
         );
 
-        failedHeartbeatNonce[groupId]++;
+        inactivityClaimNonce[groupId]++;
 
-        emit HeartbeatFailed(groupId, nonce, msg.sender);
+        emit InactivityClaimed(groupId, nonce, msg.sender);
 
         sortitionPool.setRewardIneligibility(
             ineligibleOperators,
             // solhint-disable-next-line not-rely-on-time
             block.timestamp + sortitionPoolRewardsBanDuration
-        );
-
-        transferHeartbeatNotifierRewards(
-            msg.sender,
-            ineligibleOperatorNotifierReward * ineligibleOperators.length
         );
     }
 
@@ -1008,34 +997,12 @@ contract RandomBeacon is IRandomBeacon, Ownable {
         tToken.safeTransferFrom(from, address(this), value);
     }
 
-    /// @notice Funds the heartbeat notifier rewards pool.
-    /// @param from Address of the funder. The funder must give a sufficient
-    ///        allowance for this contract to make a successful call.
-    /// @param value Token value transferred by the funder.
-    function fundHeartbeatNotifierRewardsPool(address from, uint256 value)
-        external
-    {
-        heartbeatNotifierRewardsPool += value;
-        tToken.safeTransferFrom(from, address(this), value);
-    }
-
     /// @notice Makes a transfer using DKG rewards pool.
     /// @param to Address of the recipient.
     /// @param value Token value transferred to the recipient.
     function transferDkgRewards(address to, uint256 value) internal {
         uint256 actualValue = Math.min(dkgRewardsPool, value);
         dkgRewardsPool -= actualValue;
-        tToken.safeTransfer(to, actualValue);
-    }
-
-    /// @notice Makes a transfer using heartbeat notifier rewards pool.
-    /// @param to Address of the recipient.
-    /// @param value Token value transferred to the recipient.
-    function transferHeartbeatNotifierRewards(address to, uint256 value)
-        internal
-    {
-        uint256 actualValue = Math.min(heartbeatNotifierRewardsPool, value);
-        heartbeatNotifierRewardsPool -= actualValue;
         tToken.safeTransfer(to, actualValue);
     }
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -20,7 +20,7 @@ import "./libraries/Groups.sol";
 import "./libraries/Relay.sol";
 import "./libraries/Groups.sol";
 import "./libraries/Callback.sol";
-import "./libraries/Inactivity.sol";
+import "./libraries/BeaconInactivity.sol";
 import {BeaconDkg as DKG} from "./libraries/BeaconDkg.sol";
 import {BeaconDkgValidator as DKGValidator} from "./BeaconDkgValidator.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
@@ -949,7 +949,7 @@ contract RandomBeacon is IRandomBeacon, Ownable {
     ///        be the same as the stored one.
     /// @param groupMembers Identifiers of group members.
     function notifyOperatorInactivity(
-        Inactivity.Claim calldata claim,
+        BeaconInactivity.Claim calldata claim,
         uint256 nonce,
         uint32[] calldata groupMembers
     ) external {
@@ -969,7 +969,7 @@ contract RandomBeacon is IRandomBeacon, Ownable {
             "Invalid group members"
         );
 
-        uint32[] memory ineligibleOperators = Inactivity.verifyClaim(
+        uint32[] memory ineligibleOperators = BeaconInactivity.verifyClaim(
             sortitionPool,
             claim,
             group,

--- a/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
@@ -19,7 +19,7 @@ import "./Groups.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 
-library Inactivity {
+library BeaconInactivity {
     using BytesLib for bytes;
     using ECDSA for bytes32;
 

--- a/solidity/random-beacon/contracts/libraries/Inactivity.sol
+++ b/solidity/random-beacon/contracts/libraries/Inactivity.sol
@@ -19,24 +19,24 @@ import "./Groups.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 
-library Heartbeat {
+library Inactivity {
     using BytesLib for bytes;
     using ECDSA for bytes32;
 
-    struct FailureClaim {
-        // ID of the group raising the claim.
+    struct Claim {
+        // ID of the group raising the inactivity claim.
         uint64 groupId;
-        // Indices of members accused of failed heartbeat. Indices must be in
+        // Indices of members accused of being inactive. Indices must be in
         // range [1, groupMembers.length], unique, and sorted in ascending order.
-        uint256[] failedMembersIndices;
+        uint256[] inactiveMembersIndices;
         // Concatenation of signatures from members supporting the claim.
-        // The message to be signed by each member is failed heartbeat nonce
-        // for given group, keccak256 hash of the group public key, and failed
-        // members indices. The calculated hash should be prefixed with
+        // The message to be signed by each member is inactivity claim nonce
+        // for the given group, keccak256 hash of the group public key, and
+        // inactive members indices. The calculated hash should be prefixed with
         // `\x19Ethereum signed message:\n` before signing, so the message
         // to sign is:
         // `\x19Ethereum signed message:\n${keccak256(
-        //    nonce, groupPubKey, failedMembersIndices
+        //    nonce, groupPubKey, inactiveMembersIndices
         // )}`
         bytes signatures;
         // Indices of members corresponding to each signature. Indices must be
@@ -46,36 +46,34 @@ library Heartbeat {
     }
 
     /// @notice The minimum number of group members needed to interact according
-    ///         to the protocol to produce a valid failure claim.
+    ///         to the protocol to produce a valid inactivity claim.
     uint256 public constant groupThreshold = 33;
 
     /// @notice Size in bytes of a single signature produced by member
-    ///         supporting the failure claim.
+    ///         supporting the inactivity claim.
     uint256 public constant signatureByteSize = 65;
 
-    /// @notice Verifies the failure claim according to rules mentioned in
-    ///         `FailureClaim` struct documentation. Reverts if verification
-    ///         fails.
+    /// @notice Verifies the inactivity claim according to rules mentioned in
+    ///         `Claim` struct documentation. Reverts if verification fails.
     /// @dev Group members hash is validated upstream in
-    ///      RandomBeacon.notifyFailedHeartbeat()
-    /// @param sortitionPool Sortition pool used by the application performing
-    ///        claim verification.
-    /// @param claim Failure claim.
+    ///      RandomBeacon.notifyOperatorInactivity()
+    /// @param sortitionPool Sortition pool reference.
+    /// @param claim Inactivity claim.
     /// @param group Group raising the claim.
     /// @param nonce Current nonce for group used in the claim.
     /// @param groupMembers Identifiers of group members.
-    /// @return failedMembers Identifiers of members who failed the heartbeat.
-    function verifyFailureClaim(
+    /// @return inactiveMembers Identifiers of members who are inactive.
+    function verifyClaim(
         SortitionPool sortitionPool,
-        FailureClaim calldata claim,
+        Claim calldata claim,
         Groups.Group storage group,
         uint256 nonce,
         uint32[] calldata groupMembers
-    ) external view returns (uint32[] memory failedMembers) {
-        // Validate failed members indices. Maximum indices count is equal to
+    ) external view returns (uint32[] memory inactiveMembers) {
+        // Validate inactive members indices. Maximum indices count is equal to
         // the group size and is not limited deliberately to leave a theoretical
         // possibility to accuse more members than `groupSize - groupThreshold`.
-        validateMembersIndices(claim.failedMembersIndices, groupMembers.length);
+        validateMembersIndices(claim.inactiveMembersIndices, groupMembers.length);
 
         // Validate signatures array is properly formed and number of
         // signatures and signers is correct.
@@ -101,14 +99,14 @@ library Heartbeat {
         );
 
         // Each signing member needs to sign the hash of packed `groupPubKey`
-        // and `failedMembersIndices` parameters. Usage of group public key
+        // and `inactiveMembersIndices` parameters. Usage of group public key
         // and not group ID is important because it provides uniqueness of
         // signed messages and prevent against reusing them in future.
         bytes32 signedMessageHash = keccak256(
             abi.encodePacked(
                 nonce,
                 group.groupPubKey,
-                claim.failedMembersIndices
+                claim.inactiveMembersIndices
             )
         ).toEthSignedMessageHash();
 
@@ -141,13 +139,13 @@ library Heartbeat {
 
         require(senderSignatureExists, "Sender must be claim signer");
 
-        failedMembers = new uint32[](claim.failedMembersIndices.length);
-        for (uint256 i = 0; i < claim.failedMembersIndices.length; i++) {
-            uint256 memberIndex = claim.failedMembersIndices[i];
-            failedMembers[i] = groupMembers[memberIndex - 1];
+        inactiveMembers = new uint32[](claim.inactiveMembersIndices.length);
+        for (uint256 i = 0; i < claim.inactiveMembersIndices.length; i++) {
+            uint256 memberIndex = claim.inactiveMembersIndices[i];
+            inactiveMembers[i] = groupMembers[memberIndex - 1];
         }
 
-        return failedMembers;
+        return inactiveMembers;
     }
 
     /// @notice Validates members indices array. Array is considered valid

--- a/solidity/random-beacon/contracts/libraries/Inactivity.sol
+++ b/solidity/random-beacon/contracts/libraries/Inactivity.sol
@@ -73,7 +73,10 @@ library Inactivity {
         // Validate inactive members indices. Maximum indices count is equal to
         // the group size and is not limited deliberately to leave a theoretical
         // possibility to accuse more members than `groupSize - groupThreshold`.
-        validateMembersIndices(claim.inactiveMembersIndices, groupMembers.length);
+        validateMembersIndices(
+            claim.inactiveMembersIndices,
+            groupMembers.length
+        );
 
         // Validate signatures array is properly formed and number of
         // signatures and signers is correct.

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -19,7 +19,7 @@ import {
   blsDeployment,
 } from "./fixtures"
 import { createGroup, hashUint32Array } from "./utils/groups"
-import { signHeartbeatFailureClaim } from "./utils/heartbeat"
+import { signOperatorInactivityClaim } from "./utils/inacvitity"
 import { registerOperators } from "./utils/operators"
 import { fakeTokenStaking } from "./mocks/staking"
 
@@ -1063,67 +1063,19 @@ describe("RandomBeacon - Relay", () => {
     )
   })
 
-  describe("fundHeartbeatNotifierRewardsPool", () => {
-    const amount = to1e18(1000)
-
-    let previousHeartbeatNotifierRewardsPoolBalance: BigNumber
-    let previousRandomBeaconBalance: BigNumber
-
-    before(async () => {
-      await createSnapshot()
-
-      previousHeartbeatNotifierRewardsPoolBalance =
-        await randomBeacon.heartbeatNotifierRewardsPool()
-      previousRandomBeaconBalance = await testToken.balanceOf(
-        randomBeacon.address
-      )
-
-      await testToken.mint(deployer.address, amount)
-      await testToken.connect(deployer).approve(randomBeacon.address, amount)
-
-      await randomBeacon.fundHeartbeatNotifierRewardsPool(
-        deployer.address,
-        amount
-      )
-    })
-
-    after(async () => {
-      await restoreSnapshot()
-    })
-
-    it("should increase the heartbeat notifier rewards pool balance", async () => {
-      const currentHeartbeatNotifierRewardsPoolBalance =
-        await randomBeacon.heartbeatNotifierRewardsPool()
-      expect(
-        currentHeartbeatNotifierRewardsPoolBalance.sub(
-          previousHeartbeatNotifierRewardsPoolBalance
-        )
-      ).to.be.equal(amount)
-    })
-
-    it("should transfer tokens to the random beacon contract", async () => {
-      const currentRandomBeaconBalance = await testToken.balanceOf(
-        randomBeacon.address
-      )
-      expect(
-        currentRandomBeaconBalance.sub(previousRandomBeaconBalance)
-      ).to.be.equal(amount)
-    })
-  })
-
-  describe("notifyFailedHeartbeat", () => {
+  describe("notifyOperatorInactivity", () => {
     const groupId = 0
     const stubSignatures = "0x00"
     const stubMembersIndices = []
-    // Use 31 element `failedMembersIndices` array to simulate the most gas
+    // Use 31 element `inactiveMembersIndices` array to simulate the most gas
     // expensive real-world case. If group size is 64, the required threshold
     // is 33 so we assume 31 operators at most will be marked as ineligible
-    // during a single `notifyFailedHeartbeat` call.
-    const subsequentFailedMembersIndices = Array.from(
+    // during a single `notifyOperatorInactivity` call.
+    const subsequentInactiveMembersIndices = Array.from(
       Array(31),
       (_, i) => i + 1
     )
-    const nonSubsequentFailedMembersIndices = [2, 5, 7, 23, 56]
+    const nonSubsequentInactiveMembersIndices = [2, 5, 7, 23, 56]
     const groupThreshold = 33
 
     let group
@@ -1141,13 +1093,13 @@ describe("RandomBeacon - Relay", () => {
 
     context("when passed nonce is valid", () => {
       context("when group is active and non-terminated", () => {
-        context("when failed members indices are correct", () => {
+        context("when inactive members indices are correct", () => {
           context("when signatures array is correct", () => {
             context("when signing members indices are correct", () => {
               context("when all signatures are correct", () => {
                 context("when claim sender signed the claim", () => {
-                  const assertNotifyFailedHeartbeatSucceed = async (
-                    failedMembersIndices: number[],
+                  const assertNotifyInactivitySucceed = async (
+                    inactiveMembersIndices: number[],
                     signaturesCount: number,
                     modifySignatures: (signatures: string) => string,
                     modifySigningMemberIndices: (
@@ -1156,8 +1108,6 @@ describe("RandomBeacon - Relay", () => {
                   ) => {
                     let tx: ContractTransaction
                     let initialNonce: BigNumber
-                    let initialNotifierBalance: BigNumber
-                    let initialHeartbeatNotifierRewardsPoolBalance: BigNumber
                     let claimSender: SignerWithAddress
 
                     before(async () => {
@@ -1166,38 +1116,25 @@ describe("RandomBeacon - Relay", () => {
                       // Assume claim sender is the first signing member.
                       claimSender = await ethers.getSigner(members[0].address)
 
-                      await fundHeartbeatNotifierRewardsPool(
-                        params.ineligibleOperatorNotifierReward.mul(
-                          failedMembersIndices.length
-                        )
-                      )
-
-                      initialNonce = await randomBeacon.failedHeartbeatNonce(
+                      initialNonce = await randomBeacon.inactivityClaimNonce(
                         groupId
                       )
 
-                      initialNotifierBalance = await testToken.balanceOf(
-                        claimSender.address
-                      )
-
-                      initialHeartbeatNotifierRewardsPoolBalance =
-                        await randomBeacon.heartbeatNotifierRewardsPool()
-
                       const { signatures, signingMembersIndices } =
-                        await signHeartbeatFailureClaim(
+                        await signOperatorInactivityClaim(
                           members,
                           0,
                           group.groupPubKey,
-                          failedMembersIndices,
+                          inactiveMembersIndices,
                           signaturesCount
                         )
 
                       tx = await randomBeacon
                         .connect(claimSender)
-                        .notifyFailedHeartbeat(
+                        .notifyOperatorInactivity(
                           {
                             groupId,
-                            failedMembersIndices,
+                            inactiveMembersIndices,
                             signatures: modifySignatures(signatures),
                             signingMembersIndices: modifySigningMemberIndices(
                               signingMembersIndices
@@ -1212,15 +1149,15 @@ describe("RandomBeacon - Relay", () => {
                       await restoreSnapshot()
                     })
 
-                    it("should increment failed heartbeat nonce for the group", async () => {
+                    it("should increment inactivity claim nonce for the group", async () => {
                       expect(
-                        await randomBeacon.failedHeartbeatNonce(groupId)
+                        await randomBeacon.inactivityClaimNonce(groupId)
                       ).to.be.equal(initialNonce.add(1))
                     })
 
-                    it("should emit HeartbeatFailed event", async () => {
+                    it("should emit InactivityClaimed event", async () => {
                       await expect(tx)
-                        .to.emit(randomBeacon, "HeartbeatFailed")
+                        .to.emit(randomBeacon, "InactivityClaimed")
                         .withArgs(
                           groupId,
                           initialNonce.toNumber(),
@@ -1228,47 +1165,25 @@ describe("RandomBeacon - Relay", () => {
                         )
                     })
 
-                    it("should ban sortition pool rewards for ineligible operators", async () => {
+                    it("should ban sortition pool rewards for inactive operators", async () => {
                       const now = await helpers.time.lastBlockTime()
                       const expectedUntil =
                         now + params.sortitionPoolRewardsBanDuration
 
                       const expectedIneligibleMembersIDs =
-                        failedMembersIndices.map((i) => membersIDs[i - 1])
+                        inactiveMembersIndices.map((i) => membersIDs[i - 1])
 
                       await expect(tx)
                         .to.emit(sortitionPool, "IneligibleForRewards")
                         .withArgs(expectedIneligibleMembersIDs, expectedUntil)
                     })
-
-                    it("should pay notifier reward from heartbeat notifier rewards pool", async () => {
-                      const expectedReward =
-                        params.ineligibleOperatorNotifierReward.mul(
-                          failedMembersIndices.length
-                        )
-
-                      const currentNotifierBalance = await testToken.balanceOf(
-                        claimSender.address
-                      )
-                      expect(
-                        currentNotifierBalance.sub(initialNotifierBalance)
-                      ).to.be.equal(expectedReward)
-
-                      const currentHeartbeatNotifierRewardsPoolBalance =
-                        await randomBeacon.heartbeatNotifierRewardsPool()
-                      expect(
-                        initialHeartbeatNotifierRewardsPoolBalance.sub(
-                          currentHeartbeatNotifierRewardsPoolBalance
-                        )
-                      ).to.be.equal(expectedReward)
-                    })
                   }
 
                   context(
-                    "when there are multiple subsequent failed members indices",
+                    "when there are multiple subsequent inactive members indices",
                     async () => {
-                      await assertNotifyFailedHeartbeatSucceed(
-                        subsequentFailedMembersIndices,
+                      await assertNotifyInactivitySucceed(
+                        subsequentInactiveMembersIndices,
                         groupThreshold,
                         (signatures) => signatures,
                         (signingMembersIndices) => signingMembersIndices
@@ -1277,9 +1192,9 @@ describe("RandomBeacon - Relay", () => {
                   )
 
                   context(
-                    "when there is only one failed members index",
+                    "when there is only one inactive member index",
                     async () => {
-                      await assertNotifyFailedHeartbeatSucceed(
+                      await assertNotifyInactivitySucceed(
                         [32],
                         groupThreshold,
                         (signatures) => signatures,
@@ -1289,10 +1204,10 @@ describe("RandomBeacon - Relay", () => {
                   )
 
                   context(
-                    "when there are multiple non-subsequent failed members indices",
+                    "when there are multiple non-subsequent inactive members indices",
                     async () => {
-                      await assertNotifyFailedHeartbeatSucceed(
-                        nonSubsequentFailedMembersIndices,
+                      await assertNotifyInactivitySucceed(
+                        nonSubsequentInactiveMembersIndices,
                         groupThreshold,
                         (signatures) => signatures,
                         (signingMembersIndices) => signingMembersIndices
@@ -1333,8 +1248,8 @@ describe("RandomBeacon - Relay", () => {
                         return newSignatures
                       }
 
-                      await assertNotifyFailedHeartbeatSucceed(
-                        subsequentFailedMembersIndices,
+                      await assertNotifyInactivitySucceed(
+                        subsequentInactiveMembersIndices,
                         // Make more signatures than needed to allow picking up
                         // arbitrary signatures.
                         64,
@@ -1350,11 +1265,11 @@ describe("RandomBeacon - Relay", () => {
                   async () => {
                     it("should revert", async () => {
                       const { signatures, signingMembersIndices } =
-                        await signHeartbeatFailureClaim(
+                        await signOperatorInactivityClaim(
                           members,
                           0,
                           group.groupPubKey,
-                          subsequentFailedMembersIndices,
+                          subsequentInactiveMembersIndices,
                           groupThreshold
                         )
 
@@ -1366,11 +1281,11 @@ describe("RandomBeacon - Relay", () => {
                       )
 
                       await expect(
-                        randomBeacon.connect(claimSender).notifyFailedHeartbeat(
+                        randomBeacon.connect(claimSender).notifyOperatorInactivity(
                           {
                             groupId,
-                            failedMembersIndices:
-                              subsequentFailedMembersIndices,
+                            inactiveMembersIndices:
+                              subsequentInactiveMembersIndices,
                             signatures,
                             signingMembersIndices,
                           },
@@ -1388,19 +1303,19 @@ describe("RandomBeacon - Relay", () => {
                   // The 32 signers sign correct parameters. Invalid signature
                   // is expected to be provided by signer 33.
                   const { signatures, signingMembersIndices } =
-                    await signHeartbeatFailureClaim(
+                    await signOperatorInactivityClaim(
                       members,
                       0,
                       group.groupPubKey,
-                      subsequentFailedMembersIndices,
+                      subsequentInactiveMembersIndices,
                       groupThreshold - 1
                     )
 
                   await expect(
-                    randomBeacon.notifyFailedHeartbeat(
+                    randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        failedMembersIndices: subsequentFailedMembersIndices,
+                        inactiveMembersIndices: subsequentInactiveMembersIndices,
                         // Slice removes `0x` prefix from wrong signature.
                         signatures: signatures + invalidSignature.slice(2),
                         signingMembersIndices: [...signingMembersIndices, 33],
@@ -1417,11 +1332,11 @@ describe("RandomBeacon - Relay", () => {
                     it("should revert", async () => {
                       // Signer 33 signs wrong nonce.
                       const invalidSignature = (
-                        await signHeartbeatFailureClaim(
+                        await signOperatorInactivityClaim(
                           [members[32]],
                           1,
                           group.groupPubKey,
-                          subsequentFailedMembersIndices,
+                          subsequentInactiveMembersIndices,
                           1
                         )
                       ).signatures
@@ -1437,11 +1352,11 @@ describe("RandomBeacon - Relay", () => {
                     it("should revert", async () => {
                       // Signer 33 signs wrong group public key.
                       const invalidSignature = (
-                        await signHeartbeatFailureClaim(
+                        await signOperatorInactivityClaim(
                           [members[32]],
                           0,
                           "0x010203",
-                          subsequentFailedMembersIndices,
+                          subsequentInactiveMembersIndices,
                           1
                         )
                       ).signatures
@@ -1452,12 +1367,12 @@ describe("RandomBeacon - Relay", () => {
                 )
 
                 context(
-                  "when one of the signatures signed the wrong failed group members indices",
+                  "when one of the signatures signed the wrong inactive group members indices",
                   () => {
                     it("should revert", async () => {
-                      // Signer 33 signs wrong failed group members indices.
+                      // Signer 33 signs wrong inactive group members indices.
                       const invalidSignature = (
-                        await signHeartbeatFailureClaim(
+                        await signOperatorInactivityClaim(
                           [members[32]],
                           0,
                           group.groupPubKey,
@@ -1479,19 +1394,19 @@ describe("RandomBeacon - Relay", () => {
                 () => {
                   it("should revert", async () => {
                     const { signatures, signingMembersIndices } =
-                      await signHeartbeatFailureClaim(
+                      await signOperatorInactivityClaim(
                         members,
                         0,
                         group.groupPubKey,
-                        subsequentFailedMembersIndices,
+                        subsequentInactiveMembersIndices,
                         groupThreshold
                       )
 
                     await expect(
-                      randomBeacon.notifyFailedHeartbeat(
+                      randomBeacon.notifyOperatorInactivity(
                         {
                           groupId,
-                          failedMembersIndices: subsequentFailedMembersIndices,
+                          inactiveMembersIndices: subsequentInactiveMembersIndices,
                           signatures,
                           // Remove the first signing member index
                           signingMembersIndices: signingMembersIndices.slice(1),
@@ -1507,21 +1422,21 @@ describe("RandomBeacon - Relay", () => {
               context("when first signing member index is zero", () => {
                 it("should revert", async () => {
                   const { signatures, signingMembersIndices } =
-                    await signHeartbeatFailureClaim(
+                    await signOperatorInactivityClaim(
                       members,
                       0,
                       group.groupPubKey,
-                      subsequentFailedMembersIndices,
+                      subsequentInactiveMembersIndices,
                       groupThreshold
                     )
 
                   signingMembersIndices[0] = 0
 
                   await expect(
-                    randomBeacon.notifyFailedHeartbeat(
+                    randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        failedMembersIndices: subsequentFailedMembersIndices,
+                        inactiveMembersIndices: subsequentInactiveMembersIndices,
                         signatures,
                         signingMembersIndices,
                       },
@@ -1537,21 +1452,21 @@ describe("RandomBeacon - Relay", () => {
                 () => {
                   it("should revert", async () => {
                     const { signatures, signingMembersIndices } =
-                      await signHeartbeatFailureClaim(
+                      await signOperatorInactivityClaim(
                         members,
                         0,
                         group.groupPubKey,
-                        subsequentFailedMembersIndices,
+                        subsequentInactiveMembersIndices,
                         groupThreshold
                       )
 
                     signingMembersIndices[signingMembersIndices.length - 1] = 65
 
                     await expect(
-                      randomBeacon.notifyFailedHeartbeat(
+                      randomBeacon.notifyOperatorInactivity(
                         {
                           groupId,
-                          failedMembersIndices: subsequentFailedMembersIndices,
+                          inactiveMembersIndices: subsequentInactiveMembersIndices,
                           signatures,
                           signingMembersIndices,
                         },
@@ -1568,11 +1483,11 @@ describe("RandomBeacon - Relay", () => {
                 () => {
                   it("should revert", async () => {
                     const { signatures, signingMembersIndices } =
-                      await signHeartbeatFailureClaim(
+                      await signOperatorInactivityClaim(
                         members,
                         0,
                         group.groupPubKey,
-                        subsequentFailedMembersIndices,
+                        subsequentInactiveMembersIndices,
                         groupThreshold
                       )
 
@@ -1580,10 +1495,10 @@ describe("RandomBeacon - Relay", () => {
                     signingMembersIndices[10] = signingMembersIndices[11]
 
                     await expect(
-                      randomBeacon.notifyFailedHeartbeat(
+                      randomBeacon.notifyOperatorInactivity(
                         {
                           groupId,
-                          failedMembersIndices: subsequentFailedMembersIndices,
+                          inactiveMembersIndices: subsequentInactiveMembersIndices,
                           signatures,
                           signingMembersIndices,
                         },
@@ -1603,10 +1518,10 @@ describe("RandomBeacon - Relay", () => {
                 const signatures = "0x"
 
                 await expect(
-                  randomBeacon.notifyFailedHeartbeat(
+                  randomBeacon.notifyOperatorInactivity(
                     {
                       groupId,
-                      failedMembersIndices: subsequentFailedMembersIndices,
+                      inactiveMembersIndices: subsequentInactiveMembersIndices,
                       signatures,
                       signingMembersIndices: stubMembersIndices,
                     },
@@ -1624,10 +1539,10 @@ describe("RandomBeacon - Relay", () => {
                   const signatures = "0x010203"
 
                   await expect(
-                    randomBeacon.notifyFailedHeartbeat(
+                    randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        failedMembersIndices: subsequentFailedMembersIndices,
+                        inactiveMembersIndices: subsequentInactiveMembersIndices,
                         signatures,
                         signingMembersIndices: stubMembersIndices,
                       },
@@ -1644,19 +1559,19 @@ describe("RandomBeacon - Relay", () => {
               () => {
                 it("should revert", async () => {
                   const { signatures, signingMembersIndices } =
-                    await signHeartbeatFailureClaim(
+                    await signOperatorInactivityClaim(
                       members,
                       0,
                       group.groupPubKey,
-                      subsequentFailedMembersIndices,
+                      subsequentInactiveMembersIndices,
                       groupThreshold
                     )
 
                   await expect(
-                    randomBeacon.notifyFailedHeartbeat(
+                    randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        failedMembersIndices: subsequentFailedMembersIndices,
+                        inactiveMembersIndices: subsequentInactiveMembersIndices,
                         // Remove the first signature to cause a mismatch with
                         // the signing members count.
                         signatures: `0x${signatures.slice(132)}`,
@@ -1675,20 +1590,20 @@ describe("RandomBeacon - Relay", () => {
               () => {
                 it("should revert", async () => {
                   const { signatures, signingMembersIndices } =
-                    await signHeartbeatFailureClaim(
+                    await signOperatorInactivityClaim(
                       members,
                       0,
                       group.groupPubKey,
-                      subsequentFailedMembersIndices,
+                      subsequentInactiveMembersIndices,
                       // Provide one signature too few.
                       groupThreshold - 1
                     )
 
                   await expect(
-                    randomBeacon.notifyFailedHeartbeat(
+                    randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        failedMembersIndices: subsequentFailedMembersIndices,
+                        inactiveMembersIndices: subsequentInactiveMembersIndices,
                         signatures,
                         signingMembersIndices,
                       },
@@ -1703,20 +1618,20 @@ describe("RandomBeacon - Relay", () => {
             context("when signatures count is bigger than group size", () => {
               it("should revert", async () => {
                 const { signatures, signingMembersIndices } =
-                  await signHeartbeatFailureClaim(
+                  await signOperatorInactivityClaim(
                     members,
                     0,
                     group.groupPubKey,
-                    subsequentFailedMembersIndices,
+                    subsequentInactiveMembersIndices,
                     // All group signs.
                     members.length
                   )
 
                 await expect(
-                  randomBeacon.notifyFailedHeartbeat(
+                  randomBeacon.notifyOperatorInactivity(
                     {
                       groupId,
-                      failedMembersIndices: subsequentFailedMembersIndices,
+                      inactiveMembersIndices: subsequentInactiveMembersIndices,
                       // Provide one signature too much.
                       signatures: signatures + signatures.slice(2, 132),
                       signingMembersIndices: [
@@ -1734,23 +1649,23 @@ describe("RandomBeacon - Relay", () => {
         })
 
         context("when failed members indices are incorrect", () => {
-          const assertFailedMembersIndicesCorrupted = async (
-            failedMembersIndices: number[]
+          const assertInactiveMembersIndicesCorrupted = async (
+            inactiveMembersIndices: number[]
           ) => {
             const { signatures, signingMembersIndices } =
-              await signHeartbeatFailureClaim(
+              await signOperatorInactivityClaim(
                 members,
                 0,
                 group.groupPubKey,
-                failedMembersIndices,
+                inactiveMembersIndices,
                 groupThreshold
               )
 
             await expect(
-              randomBeacon.notifyFailedHeartbeat(
+              randomBeacon.notifyOperatorInactivity(
                 {
                   groupId,
-                  failedMembersIndices,
+                  inactiveMembersIndices,
                   signatures,
                   signingMembersIndices,
                 },
@@ -1760,67 +1675,67 @@ describe("RandomBeacon - Relay", () => {
             ).to.be.revertedWith("Corrupted members indices")
           }
 
-          context("when failed members indices count is zero", () => {
+          context("when inactive members indices count is zero", () => {
             it("should revert", async () => {
-              const failedMembersIndices = []
+              const inactiveMembersIndices = []
 
-              await assertFailedMembersIndicesCorrupted(failedMembersIndices)
+              await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
             })
           })
 
           context(
-            "when failed members indices count is bigger than group size",
+            "when inactive members indices count is bigger than group size",
             () => {
               it("should revert", async () => {
-                const failedMembersIndices = Array.from(
+                const inactiveMembersIndices = Array.from(
                   Array(65),
                   (_, i) => i + 1
                 )
 
-                await assertFailedMembersIndicesCorrupted(failedMembersIndices)
+                await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
               })
             }
           )
 
           context("when first failed member index is zero", () => {
             it("should revert", async () => {
-              const failedMembersIndices = Array.from(
+              const inactiveMembersIndices = Array.from(
                 Array(64),
                 (_, i) => i + 1
               )
-              failedMembersIndices[0] = 0
+              inactiveMembersIndices[0] = 0
 
-              await assertFailedMembersIndicesCorrupted(failedMembersIndices)
+              await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
             })
           })
 
           context(
-            "when last failed member index is bigger than group size",
+            "when last inactive member index is bigger than group size",
             () => {
               it("should revert", async () => {
-                const failedMembersIndices = Array.from(
+                const inactiveMembersIndices = Array.from(
                   Array(64),
                   (_, i) => i + 1
                 )
-                failedMembersIndices[failedMembersIndices.length - 1] = 65
+                inactiveMembersIndices[inactiveMembersIndices.length - 1] = 65
 
-                await assertFailedMembersIndicesCorrupted(failedMembersIndices)
+                await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
               })
             }
           )
 
           context(
-            "when failed members indices are not ordered in ascending order",
+            "when inactive members indices are not ordered in ascending order",
             () => {
               it("should revert", async () => {
-                const failedMembersIndices = Array.from(
+                const inactiveMembersIndices = Array.from(
                   Array(64),
                   (_, i) => i + 1
                 )
                 // eslint-disable-next-line prefer-destructuring
-                failedMembersIndices[10] = failedMembersIndices[11]
+                inactiveMembersIndices[10] = inactiveMembersIndices[11]
 
-                await assertFailedMembersIndicesCorrupted(failedMembersIndices)
+                await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
               })
             }
           )
@@ -1843,10 +1758,10 @@ describe("RandomBeacon - Relay", () => {
 
         it("should revert", async () => {
           await expect(
-            randomBeacon.notifyFailedHeartbeat(
+            randomBeacon.notifyOperatorInactivity(
               {
                 groupId,
-                failedMembersIndices: stubMembersIndices,
+                inactiveMembersIndices: stubMembersIndices,
                 signatures: stubSignatures,
                 signingMembersIndices: stubMembersIndices,
               },
@@ -1878,10 +1793,10 @@ describe("RandomBeacon - Relay", () => {
 
         it("should revert", async () => {
           await expect(
-            randomBeacon.notifyFailedHeartbeat(
+            randomBeacon.notifyOperatorInactivity(
               {
                 groupId,
-                failedMembersIndices: stubMembersIndices,
+                inactiveMembersIndices: stubMembersIndices,
                 signatures: stubSignatures,
                 signingMembersIndices: stubMembersIndices,
               },
@@ -1896,10 +1811,10 @@ describe("RandomBeacon - Relay", () => {
     context("when passed nonce is invalid", () => {
       it("should revert", async () => {
         await expect(
-          randomBeacon.notifyFailedHeartbeat(
+          randomBeacon.notifyOperatorInactivity(
             {
               groupId,
-              failedMembersIndices: stubMembersIndices,
+              inactiveMembersIndices: stubMembersIndices,
               signatures: stubSignatures,
               signingMembersIndices: stubMembersIndices,
             },
@@ -1914,10 +1829,10 @@ describe("RandomBeacon - Relay", () => {
       it("should revert", async () => {
         const invalidMembersId = [0, 1, 42]
         await expect(
-          randomBeacon.notifyFailedHeartbeat(
+          randomBeacon.notifyOperatorInactivity(
             {
               groupId,
-              failedMembersIndices: stubMembersIndices,
+              inactiveMembersIndices: stubMembersIndices,
               signatures: stubSignatures,
               signingMembersIndices: stubMembersIndices,
             },
@@ -1934,17 +1849,5 @@ describe("RandomBeacon - Relay", () => {
     await testToken
       .connect(requester)
       .approve(randomBeacon.address, params.relayRequestFee)
-  }
-
-  async function fundHeartbeatNotifierRewardsPool(donateAmount: BigNumber) {
-    await testToken.mint(deployer.address, donateAmount)
-    await testToken
-      .connect(deployer)
-      .approve(randomBeacon.address, donateAmount)
-
-    await randomBeacon.fundHeartbeatNotifierRewardsPool(
-      deployer.address,
-      donateAmount
-    )
   }
 })

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -1281,17 +1281,19 @@ describe("RandomBeacon - Relay", () => {
                       )
 
                       await expect(
-                        randomBeacon.connect(claimSender).notifyOperatorInactivity(
-                          {
-                            groupId,
-                            inactiveMembersIndices:
-                              subsequentInactiveMembersIndices,
-                            signatures,
-                            signingMembersIndices,
-                          },
-                          0,
-                          membersIDs
-                        )
+                        randomBeacon
+                          .connect(claimSender)
+                          .notifyOperatorInactivity(
+                            {
+                              groupId,
+                              inactiveMembersIndices:
+                                subsequentInactiveMembersIndices,
+                              signatures,
+                              signingMembersIndices,
+                            },
+                            0,
+                            membersIDs
+                          )
                       ).to.be.revertedWith("Sender must be claim signer")
                     })
                   }
@@ -1315,7 +1317,8 @@ describe("RandomBeacon - Relay", () => {
                     randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        inactiveMembersIndices: subsequentInactiveMembersIndices,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
                         // Slice removes `0x` prefix from wrong signature.
                         signatures: signatures + invalidSignature.slice(2),
                         signingMembersIndices: [...signingMembersIndices, 33],
@@ -1406,7 +1409,8 @@ describe("RandomBeacon - Relay", () => {
                       randomBeacon.notifyOperatorInactivity(
                         {
                           groupId,
-                          inactiveMembersIndices: subsequentInactiveMembersIndices,
+                          inactiveMembersIndices:
+                            subsequentInactiveMembersIndices,
                           signatures,
                           // Remove the first signing member index
                           signingMembersIndices: signingMembersIndices.slice(1),
@@ -1436,7 +1440,8 @@ describe("RandomBeacon - Relay", () => {
                     randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        inactiveMembersIndices: subsequentInactiveMembersIndices,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
                         signatures,
                         signingMembersIndices,
                       },
@@ -1466,7 +1471,8 @@ describe("RandomBeacon - Relay", () => {
                       randomBeacon.notifyOperatorInactivity(
                         {
                           groupId,
-                          inactiveMembersIndices: subsequentInactiveMembersIndices,
+                          inactiveMembersIndices:
+                            subsequentInactiveMembersIndices,
                           signatures,
                           signingMembersIndices,
                         },
@@ -1498,7 +1504,8 @@ describe("RandomBeacon - Relay", () => {
                       randomBeacon.notifyOperatorInactivity(
                         {
                           groupId,
-                          inactiveMembersIndices: subsequentInactiveMembersIndices,
+                          inactiveMembersIndices:
+                            subsequentInactiveMembersIndices,
                           signatures,
                           signingMembersIndices,
                         },
@@ -1542,7 +1549,8 @@ describe("RandomBeacon - Relay", () => {
                     randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        inactiveMembersIndices: subsequentInactiveMembersIndices,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
                         signatures,
                         signingMembersIndices: stubMembersIndices,
                       },
@@ -1571,7 +1579,8 @@ describe("RandomBeacon - Relay", () => {
                     randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        inactiveMembersIndices: subsequentInactiveMembersIndices,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
                         // Remove the first signature to cause a mismatch with
                         // the signing members count.
                         signatures: `0x${signatures.slice(132)}`,
@@ -1603,7 +1612,8 @@ describe("RandomBeacon - Relay", () => {
                     randomBeacon.notifyOperatorInactivity(
                       {
                         groupId,
-                        inactiveMembersIndices: subsequentInactiveMembersIndices,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
                         signatures,
                         signingMembersIndices,
                       },
@@ -1679,7 +1689,9 @@ describe("RandomBeacon - Relay", () => {
             it("should revert", async () => {
               const inactiveMembersIndices = []
 
-              await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
+              await assertInactiveMembersIndicesCorrupted(
+                inactiveMembersIndices
+              )
             })
           })
 
@@ -1692,7 +1704,9 @@ describe("RandomBeacon - Relay", () => {
                   (_, i) => i + 1
                 )
 
-                await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
+                await assertInactiveMembersIndicesCorrupted(
+                  inactiveMembersIndices
+                )
               })
             }
           )
@@ -1705,7 +1719,9 @@ describe("RandomBeacon - Relay", () => {
               )
               inactiveMembersIndices[0] = 0
 
-              await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
+              await assertInactiveMembersIndicesCorrupted(
+                inactiveMembersIndices
+              )
             })
           })
 
@@ -1719,7 +1735,9 @@ describe("RandomBeacon - Relay", () => {
                 )
                 inactiveMembersIndices[inactiveMembersIndices.length - 1] = 65
 
-                await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
+                await assertInactiveMembersIndicesCorrupted(
+                  inactiveMembersIndices
+                )
               })
             }
           )
@@ -1735,7 +1753,9 @@ describe("RandomBeacon - Relay", () => {
                 // eslint-disable-next-line prefer-destructuring
                 inactiveMembersIndices[10] = inactiveMembersIndices[11]
 
-                await assertInactiveMembersIndicesCorrupted(inactiveMembersIndices)
+                await assertInactiveMembersIndicesCorrupted(
+                  inactiveMembersIndices
+                )
               })
             }
           )

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -112,9 +112,9 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
   const dkg = await BeaconDkg.deploy()
   await dkg.deployed()
 
-  const Heartbeat = await ethers.getContractFactory("Heartbeat")
-  const heartbeat = await Heartbeat.deploy()
-  await heartbeat.deployed()
+  const Inactivity = await ethers.getContractFactory("Inactivity")
+  const inactivity = await Inactivity.deploy()
+  await inactivity.deployed()
 
   const BeaconDkgValidator = await ethers.getContractFactory(
     "BeaconDkgValidator"
@@ -128,7 +128,7 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
     libraries: {
       BLS: (await blsDeployment()).bls.address,
       BeaconDkg: dkg.address,
-      Heartbeat: heartbeat.address,
+      Inactivity: inactivity.address,
     },
   })
   const randomBeacon: RandomBeaconStub = await RandomBeacon.deploy(

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -112,8 +112,8 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
   const dkg = await BeaconDkg.deploy()
   await dkg.deployed()
 
-  const Inactivity = await ethers.getContractFactory("Inactivity")
-  const inactivity = await Inactivity.deploy()
+  const BeaconInactivity = await ethers.getContractFactory("BeaconInactivity")
+  const inactivity = await BeaconInactivity.deploy()
   await inactivity.deployed()
 
   const BeaconDkgValidator = await ethers.getContractFactory(
@@ -128,7 +128,7 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
     libraries: {
       BLS: (await blsDeployment()).bls.address,
       BeaconDkg: dkg.address,
-      Inactivity: inactivity.address,
+      BeaconInactivity: inactivity.address,
     },
   })
   const randomBeacon: RandomBeaconStub = await RandomBeacon.deploy(

--- a/solidity/random-beacon/test/utils/inacvitity.ts
+++ b/solidity/random-beacon/test/utils/inacvitity.ts
@@ -3,11 +3,11 @@ import { ethers } from "hardhat"
 import type { Operator } from "./operators"
 
 // eslint-disable-next-line import/prefer-default-export
-export async function signHeartbeatFailureClaim(
+export async function signOperatorInactivityClaim(
   signers: Operator[],
   nonce: number,
   groupPubKey: string,
-  failedMembersIndices: number[],
+  inactiveMembersIndices: number[],
   numberOfSignatures: number
 ): Promise<{
   signatures: string
@@ -15,7 +15,7 @@ export async function signHeartbeatFailureClaim(
 }> {
   const messageHash = ethers.utils.solidityKeccak256(
     ["uint256", "bytes", "uint8[]"],
-    [nonce, groupPubKey, failedMembersIndices]
+    [nonce, groupPubKey, inactiveMembersIndices]
   )
 
   const signingMembersIndices: number[] = []


### PR DESCRIPTION
The goal of the inactivity claim is to have the group punish operators
who are constantly inactive and not contributing to the work by
excluding them from sortition pool rewards.

The goal of the wallet heartbeat failure - present only in ECDSA - is to
transfer funds to another wallet from the one who failed the heartbeat.

Inactivity claim in ECDSA will be only about excluding operators from
rewards and will not require moving funds.

For this reason, we need to keep these two actions separate and properly
named:
- inactivity claim: exclude operators from rewards
- heartbeat failure: move funds to another safe wallet (just ECDSA)

I went ahead and removed the logic for rewarding operators who
submitted the claim from a special pool of rewards. This action should
refund ETH to the submitter and this will be done in #2860. I did not
want to work on renaming something that soon will be removed anyway.