### PR TITLE
Add workflow publishing random-beacon contracts for dev env

### DIFF
--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -1,0 +1,48 @@
+name: NPM Random Beacon
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "solidity/random-beacon/contracts/**"
+      - "solidity/random-beacon/package.json"
+      - "solidity/random-beacon/yarn.lock"
+      - ".github/workflows/npm-random-beacon.yml"
+  workflow_dispatch:
+
+jobs:
+  npm-compile-publish-contracts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity/random-beacon
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+          cache: "yarn"
+          cache-dependency-path: solidity/random-beacon/yarn.lock
+
+      - name: Resolve latest contracts
+        run: yarn upgrade @keep-network/sortition-pools
+
+      - name: Compile contracts
+        run: yarn build
+
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          work-dir: ./solidity/random-beacon
+          environment: dev
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --tag=development


### PR DESCRIPTION
We're adding a workflow which will publish a package with compiled
`random-beacon` contracts. Package will be meant for development
purposes.

The `-dev` suffix will be used in the name of the published package.
The workflow will be triggered every time a change to contracts or
dependencies gets pushed to `main`. Also a change to the workflow file
will trigger the workflow.