### PR TITLE
External tBTCv2 + SaddleV2 pool 

### DIFF
--- a/solidity-v1/dashboard/src/components/InactiveButExternalLiquidityRewardCard.jsx
+++ b/solidity-v1/dashboard/src/components/InactiveButExternalLiquidityRewardCard.jsx
@@ -1,0 +1,62 @@
+import React from "react"
+import LiquidityRewardCard from "./LiquidityRewardCard"
+import * as Icons from "./Icons"
+
+const InactiveButExternalLiquidityRewardCard = ({
+  poolId,
+  title,
+  MainIcon,
+  SecondaryIcon,
+  viewPoolLink,
+  // Current reward balance earned in `LPRewards` contract.
+  rewardBalance = "0",
+  // Balance of the wrapped token.
+  wrappedTokenBalance = "0",
+  // Balance of wrapped token deposited in the `LPRewards` contract.
+  lpBalance = "0",
+  isFetching,
+  wrapperClassName = "",
+  addLpTokens,
+  withdrawLiquidityRewards,
+  pool,
+  inactivePoolBannerProps = {
+    icon: Icons.Rewards,
+    title: "Incentives moved to T",
+    description:
+      "You can still withdraw rewards that you already earned. Click `Go to pool` and deposit your tokens in the Saddle dApp to earn incentives in multiple tokens.",
+    link: "https://forum.keep.network/t/repurpose-saddle-tbtc-pool-liquidity-incentives-and-move-incentives-to-t/404",
+    linkText: "More info",
+  },
+  children,
+}) => {
+  return (
+    <LiquidityRewardCard
+      title={title}
+      MainIcon={MainIcon}
+      SecondaryIcon={SecondaryIcon}
+      wrapperClassName={wrapperClassName}
+      isFetching={isFetching}
+      lpBalance={lpBalance}
+      wrappedTokenBalance={wrappedTokenBalance}
+      rewardBalance={rewardBalance}
+    >
+      <LiquidityRewardCard.Subtitle pool={pool} viewPoolLink={viewPoolLink} />
+      <LiquidityRewardCard.ActivePoolBanner
+        pool={pool}
+        viewPoolLink={viewPoolLink}
+        userInfoBannerProps={inactivePoolBannerProps}
+      />
+      {children}
+      <LiquidityRewardCard.Rewards />
+      <LiquidityRewardCard.GoToPoolButton viewPoolLink={viewPoolLink} />
+      <LiquidityRewardCard.ActionButtons
+        poolId={poolId}
+        incentivesRemoved={true}
+        addLpTokens={addLpTokens}
+        withdrawLiquidityRewards={withdrawLiquidityRewards}
+      />
+    </LiquidityRewardCard>
+  )
+}
+
+export default InactiveButExternalLiquidityRewardCard

--- a/solidity-v1/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity-v1/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -231,7 +231,7 @@ const LiquidityPage = ({ headerTitle }) => {
           <Banner.CloseIcon onClick={hideBanner} />
         </Banner>
       )}
-      <MasonryFlexContainer maxHeight={"2300px"}>
+      <MasonryFlexContainer maxHeight={"2100px"}>
         {cards.map(({ id, CardComponent, ...data }) => {
           return (
             <CardComponent

--- a/solidity-v1/dashboard/src/pages/liquidity/LiquidityPage.jsx
+++ b/solidity-v1/dashboard/src/pages/liquidity/LiquidityPage.jsx
@@ -16,16 +16,16 @@ import { useHideComponent } from "../../hooks/useHideComponent"
 import { gt } from "../../utils/arithmetics.utils"
 import MasonryFlexContainer from "../../components/MasonryFlexContainer"
 import KeepOnlyPoolCard from "../../components/liquidity/KeepOnlyPoolCard"
-import ActiveLiquidityRewardCard from "../../components/ActiveLiquidityRewardCard"
 import { LPTokenBalance } from "../../components/liquidity"
 import InactiveLiquidityRewardCard from "../../components/InactiveLiquidityRewardCard"
 import ExternalPoolLiquidityRewardCard from "../../components/ExternalPoolLiquidityRewardCard"
 import OnlyIf from "../../components/OnlyIf"
+import InactiveButExternalLiquidityRewardCard from "../../components/InactiveButExternalLiquidityRewardCard"
 
 const cards = [
   {
     id: "TBTCV2_SADDLE_META_V2",
-    CardComponent: ActiveLiquidityRewardCard,
+    CardComponent: InactiveButExternalLiquidityRewardCard,
     title: LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE_META_V2.label,
     liquidityPairContractName:
       LIQUIDITY_REWARD_PAIRS.TBTCV2_SADDLE_META_V2.contractName,


### PR DESCRIPTION
Changes:
- add banner with the information that rewards were moved to T, user can withdraw current rewards and he can deposit the tokens in Saddle dApp to earn incentives in multiple tokens
- add more info link that redirects to forum: https://forum.keep.network/t/repurpose-saddle-tbtc-pool-liquidity-incentives-and-move-incentives-to-t/404
- add Go to Pool button that redirects straight to the pool in Saddle dApp: https://saddle.exchange/#/pools/tbtcv2/deposit
- allow user to withdraw the incentives if he has any
- change column height in Masonry Layout for Liquidity Cards page to make TBTCv2 + mBTC pool land on top of the third column.

<p align="center">
<img width="397" alt="image" src="https://user-images.githubusercontent.com/40306834/159899088-b8e6b885-19a9-463c-a45d-2500f2c2a7eb.png">
</p>
