### PR TITLE
Restore unauthenticated git protocol fix

### DIFF
--- a/.github/workflows/dashboard-v1-testnet.yml
+++ b/.github/workflows/dashboard-v1-testnet.yml
@@ -66,6 +66,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: solidity-v1/dashboard/package-lock.json
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next steps has a dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       # We're not updating `coverage-pools` as we want to use a fixed version
       # (1.1.0-dev.2) specified in the `package.json`. That package is the last
       # one that successfully deployed AssetPool for KEEP token.

--- a/solidity-v1/dashboard/README.md
+++ b/solidity-v1/dashboard/README.md
@@ -61,6 +61,21 @@ truffle exec ./scripts/delegate-tokens.js
 
 - Use metamask with `localhost:8545` to use Ganache test network. Import your first Ganache test account into metamask and you should be able to see the demo data.
 
+### Troubleshooting
+
+The `dashboard` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package or
+update of its dependencies using NPM may result in `The unauthenticated git
+protocol on port 9418 is no longer supported` error.
+
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+```
+git config --global url."https://".insteadOf git://
+```
+
 ### Work with contracts deployed locally
 
 #### Prerequisite

--- a/solidity-v1/dashboard/README.md
+++ b/solidity-v1/dashboard/README.md
@@ -67,11 +67,11 @@ The `dashboard` package contains an indirect dependency to
 `@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
 via unathenticated `git://` protocol. That protocol is no longer supported by
 GitHub. This means that in certain situations installation of the package or
-update of its dependencies using NPM may result in `The unauthenticated git
-protocol on port 9418 is no longer supported` error.
+update of its dependencies using NPM may result in `The unauthenticated git protocol on port 9418 is no longer supported` error.
 
 As a workaround, we advise changing Git configuration to use `https://` protocol
 instead of `git://` by executing:
+
 ```
 git config --global url."https://".insteadOf git://
 ```

--- a/solidity-v1/dashboard/package-lock.json
+++ b/solidity-v1/dashboard/package-lock.json
@@ -2097,7 +2097,7 @@
       "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
       "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
       "requires": {
-        "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+        "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
         "bigi": "^1.1.0",
         "bignumber.js": "^9.0.0",
         "bip32": "2.0.5",
@@ -5087,8 +5087,8 @@
       }
     },
     "@umpirsky/country-list": {
-      "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-      "from": "git://github.com/umpirsky/country-list.git#05fda51"
+      "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+      "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
     },
     "@walletconnect/client": {
       "version": "1.3.6",


### PR DESCRIPTION
Restore fix for `The unauthenticated git protocol on port 9418 is no longer
supported.` that was overwritten.

The fix is described in #2683 