### PR TITLE
Use `development` tag to configure dependency between packages

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -48,6 +48,13 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Publish package
+        if: github.ref == 'main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public --tag=development
+
+      - name: Publish package
+        if: github.ref != 'main'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -43,6 +43,13 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Publish package
+        if: github.ref == 'main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public --tag=development
+
+      - name: Publish package
+        if: github.ref != 'main'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@keep-network/random-beacon": "../random-beacon",
+    "@keep-network/random-beacon": "development",
     "@keep-network/sortition-pools": "^2.0.0-dev.0",
     "@openzeppelin/contracts": "^4.4.1",
     "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten"

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -612,8 +612,10 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/random-beacon@../random-beacon":
-  version "2.0.0-dev"
+"@keep-network/random-beacon@development":
+  version "2.0.0-dev.3"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.3.tgz#0aee6913ffde3806d3652297155fb2c1bbff6a50"
+  integrity sha512-cqpvGGOBoXqoUxVAqcF5rmlEg8lbmj+LRWzOYW4jaweWVxzRBG2DbaaZ7frHXfJHZ3sicr4cLhlhcqbIuiubYA==
   dependencies:
     "@keep-network/sortition-pools" "1.2.0-dev.24"
     "@openzeppelin/contracts" "^4.4.2"


### PR DESCRIPTION
Some time ago we temporarily changed `@keep-network/random-beacon`
dependency in `solidity/ecdsa/package.json` from
`>2.0.0-dev <2.0.0-ropsten` to `../random-beacon`. This was only a
tempoorary change, to allow for passing of checks in PR2856. Now we want
to set the dependency to again point to the latest package meant for the
development environment. We discovered, that using
`>2.0.0-dev <2.0.0-ropsten` range to do that is not ideal (if one of the
packages in the range is tagged 'latest', but there are newer packages
which seem to fit the range, those newer packages won't be recognize as
fitting the range). As an alternative, we propose to refer to the latest
package by using following dependency configuration:
```
"@keep-network/random-beacon": "development"
```
This will always point us to the package tagged `deployment`. What we
also want to make sure, is to publish under this tag only the packages
which were built on the `main` branch.