### PR TITLE
Configure git to don't use unauthenticated protocol

### DIFF
--- a/.github/workflows/dashboard-v1-format.yaml
+++ b/.github/workflows/dashboard-v1-format.yaml
@@ -45,6 +45,15 @@ jobs:
           cache: "npm"
           cache-dependency-path: solidity-v1/dashboard/package-lock.json
 
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `package-lock.json` refers to some package via `git://`. Using
+      # `git://` is no longer supported by GH. One of the `dashboard`
+      # dependencies by default uses `git://` and we needed to manually remove
+      # it every time it re-appeared in the lock file. Now even if it does,
+      # the `npm ci` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/dashboard-v1-mainnet.yml
+++ b/.github/workflows/dashboard-v1-mainnet.yml
@@ -61,6 +61,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `package-lock.json` refers to some package via `git://`. Using
+      # `git://` is no longer supported by GH. One of the `dashboard`
+      # dependencies by default uses `git://` and we needed to manually remove
+      # it every time it re-appeared in the lock file. Now even if it does,
+      # the `npm ci` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
       - run: npm ci
       #- run: npm run lint
       #- if: github.event_name == 'push' TODO uncomment when mainnet builds happen this way


### PR DESCRIPTION
This PR introduces a step to the dashboard workflows which
forces Git to download dependencies using `https://` protocol,
even if `package-lock.json` refers to some package via `git://`. Using
`git://` is no longer supported by GH. One of the `dashboard`
dependencies by default uses `git://` and we needed to manually remove
it every time it re-appeared in the lock file. Now even if it does,
the `npm ci` will not fail.

Similar change was already introduced to the `dashboard-v1-testnet.yml`
workflow in https://github.com/keep-network/keep-core/pull/2875