### PR TITLE
Ledger packages migration

### DIFF
--- a/solidity-v1/dashboard/package-lock.json
+++ b/solidity-v1/dashboard/package-lock.json
@@ -2884,6 +2884,76 @@
         }
       }
     },
+    "@ledgerhq/hw-transport-webusb": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.24.1.tgz",
+      "integrity": "sha512-+bAkVF/5MbbGIXobtmc5st/gFEjSRqACk+UPJGSxT21Z2SVm+FgG0Bui5wy24H+Ts/tC4IA3Mff8cz4PGbZhPA==",
+      "requires": {
+        "@ledgerhq/devices": "^6.24.1",
+        "@ledgerhq/errors": "^6.10.0",
+        "@ledgerhq/hw-transport": "^6.24.1",
+        "@ledgerhq/logs": "^6.10.0"
+      },
+      "dependencies": {
+        "@ledgerhq/devices": {
+          "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.24.1.tgz",
+          "integrity": "sha512-6SNXWXxojUF6WKXMVIbRs15Mveg+9k0RKJK/PKlwZh929Lnr/NcbONWdwPjWKZAp1g82eEPT4jIkG6qc4QXlcA==",
+          "requires": {
+            "@ledgerhq/errors": "^6.10.0",
+            "@ledgerhq/logs": "^6.10.0",
+            "rxjs": "6",
+            "semver": "^7.3.5"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.0.tgz",
+          "integrity": "sha512-fQFnl2VIXh9Yd41lGjReCeK+Q2hwxQJvLZfqHnKqWapTz68NHOv5QcI0OHuZVNEbv0xhgdLhi5b65kgYeQSUVg=="
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.24.1.tgz",
+          "integrity": "sha512-cOhxkQJrN7DvPFLLXAS2nqAZ7NIDaFqnbgu9ugTccgbJm2/z7ClRZX/uQoI4FscswZ47MuJQdXqz4nK48phteQ==",
+          "requires": {
+            "@ledgerhq/devices": "^6.24.1",
+            "@ledgerhq/errors": "^6.10.0",
+            "events": "^3.3.0"
+          }
+        },
+        "@ledgerhq/logs": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.0.tgz",
+          "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw=="
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "@ledgerhq/logs": {
       "version": "4.72.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-4.72.0.tgz",

--- a/solidity-v1/dashboard/package-lock.json
+++ b/solidity-v1/dashboard/package-lock.json
@@ -2635,7 +2635,8 @@
         "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
         "@openzeppelin/contracts": "^4.3",
         "@tenderly/hardhat-tenderly": "^1.0.12",
-        "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
+        "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
+        "@threshold-network/solidity-contracts": "github:threshold-network/solidity-contracts#6664c73"
       },
       "dependencies": {
         "@openzeppelin/contracts": {
@@ -2648,6 +2649,23 @@
           "from": "github:thesis/solidity-contracts#4985bcf",
           "requires": {
             "@openzeppelin/contracts": "^4.1.0"
+          }
+        },
+        "@threshold-network/solidity-contracts": {
+          "version": "github:threshold-network/solidity-contracts#6664c738660f79de3add7fdff735fcb19d5165ad",
+          "from": "github:threshold-network/solidity-contracts#6664c73",
+          "requires": {
+            "@openzeppelin/contracts": "^4.3",
+            "@thesis/solidity-contracts": "github:thesis/solidity-contracts#507c647"
+          },
+          "dependencies": {
+            "@thesis/solidity-contracts": {
+              "version": "github:thesis/solidity-contracts#507c64759a2783196b505365e0cb4bf13c1ad1fa",
+              "from": "github:thesis/solidity-contracts#507c647",
+              "requires": {
+                "@openzeppelin/contracts": "^4.1.0"
+              }
+            }
           }
         }
       }
@@ -2839,49 +2857,6 @@
         "@ledgerhq/hw-transport": "^4.78.0",
         "@ledgerhq/logs": "^4.72.0",
         "node-hid": "^0.7.9"
-      }
-    },
-    "@ledgerhq/hw-transport-u2f": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.17.0.tgz",
-      "integrity": "sha512-xnyJYZpi5UB+ZBMwlViFAd5A/StojA0OQIYmp+Vcf9ytoU51BaGV4GjAyN6vWsv2ZClGIOK0gTdD/qnUNIqWiQ==",
-      "requires": {
-        "@ledgerhq/errors": "^5.17.0",
-        "@ledgerhq/hw-transport": "^5.17.0",
-        "@ledgerhq/logs": "^5.17.0",
-        "u2f-api": "0.2.7"
-      },
-      "dependencies": {
-        "@ledgerhq/devices": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.17.0.tgz",
-          "integrity": "sha512-GBog+x/vkyt/RB722rm7VW7GMW0nHpOeFSJBad6padjAXkPQZr0LD34yTrIuZjA7y9aGjOB/RK9CjnVDyWODGQ==",
-          "requires": {
-            "@ledgerhq/errors": "^5.17.0",
-            "@ledgerhq/logs": "^5.17.0",
-            "rxjs": "^6.5.5"
-          }
-        },
-        "@ledgerhq/errors": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.17.0.tgz",
-          "integrity": "sha512-m+es6OwqqhHPFGnSZOxGgn7kucWNS6Ep/khCS/avYx/LNz+SRZVRvHT4GuH9Qy6sB9Lg0W7ZEJpKqEzvLGvNoQ=="
-        },
-        "@ledgerhq/hw-transport": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.17.0.tgz",
-          "integrity": "sha512-Z+9D1WHGBxMv1lwOYS9R4NmdlCFECwbUy/Zwc56uKGnk6r59MBwjS2yuIV2zEw4p602xeP2X76+k9c55JM2o5g==",
-          "requires": {
-            "@ledgerhq/devices": "^5.17.0",
-            "@ledgerhq/errors": "^5.17.0",
-            "events": "^3.1.0"
-          }
-        },
-        "@ledgerhq/logs": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.17.0.tgz",
-          "integrity": "sha512-cY3aL9hLdQONFJihQDaO3szmyo53nLdMYisVLfjxJ2SBH5SOyoAtg6Utwz4u6Y3Cf464BJ0wZu3/SlVO0kboBQ=="
-        }
       }
     },
     "@ledgerhq/hw-transport-webusb": {
@@ -11945,6 +11920,17 @@
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
               "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
             }
+          }
+        },
+        "ajv": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-errors": {

--- a/solidity-v1/dashboard/package-lock.json
+++ b/solidity-v1/dashboard/package-lock.json
@@ -31745,6 +31745,14 @@
         }
       }
     },
+    "react-device-detect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.1.2.tgz",
+      "integrity": "sha512-N42xttwez3ECgu4KpOL2ICesdfoz8NCBfmc1rH9FRYSjH7NmMyANPSrQ3EvAtJyj/6TzJNhrANSO38iXjCB2Ug==",
+      "requires": {
+        "ua-parser-js": "^0.7.30"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -34650,6 +34658,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-0.2.7.tgz",
       "integrity": "sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg=="
+    },
+    "ua-parser-js": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
     },
     "ultron": {
       "version": "1.1.1",

--- a/solidity-v1/dashboard/package.json
+++ b/solidity-v1/dashboard/package.json
@@ -12,7 +12,6 @@
     "@keep-network/tbtc-v2": ">0.1.1-dev <0.1.1-ropsten",
     "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten",
     "@ledgerhq/hw-app-eth": "^5.13.0",
-    "@ledgerhq/hw-transport-u2f": "^5.13.0",
     "@ledgerhq/hw-transport-webusb": "^6.24.1",
     "@walletconnect/web3-subprovider": "^1.3.6",
     "axios": "^0.21.1",

--- a/solidity-v1/dashboard/package.json
+++ b/solidity-v1/dashboard/package.json
@@ -13,6 +13,7 @@
     "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten",
     "@ledgerhq/hw-app-eth": "^5.13.0",
     "@ledgerhq/hw-transport-u2f": "^5.13.0",
+    "@ledgerhq/hw-transport-webusb": "^6.24.1",
     "@walletconnect/web3-subprovider": "^1.3.6",
     "axios": "^0.21.1",
     "bignumber.js": "9.0.0",

--- a/solidity-v1/dashboard/package.json
+++ b/solidity-v1/dashboard/package.json
@@ -27,6 +27,7 @@
     "react": "^16.13.1",
     "react-accessible-accordion": "^4.0.0",
     "react-countup": "^4.3.3",
+    "react-device-detect": "^2.1.2",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.1.2",

--- a/solidity-v1/dashboard/src/components/modal/wallets/LedgerModal.jsx
+++ b/solidity-v1/dashboard/src/components/modal/wallets/LedgerModal.jsx
@@ -4,6 +4,8 @@ import { ModalHeader } from "../Modal"
 import * as Icons from "../../Icons"
 import Button from "../../Button"
 import { withBaseModal } from "../withBaseModal"
+import { isBrowser, isChrome } from "react-device-detect"
+import OnlyIf from "../../OnlyIf"
 
 const LedgerModalBase = ({ connector, connectAppWithWallet, onClose }) => {
   const [ledgerVersion, setLedgerVersion] = useState("")
@@ -30,7 +32,11 @@ const LedgerModalBase = ({ connector, connectAppWithWallet, onClose }) => {
         icon={<Icons.Ledger className="ledger-logo ledger-logo--black" />}
         walletName="Ledger"
         descriptionIcon={<Icons.LedgerDevice />}
-        description="Plug in Ledger device and unlock."
+        description={
+          isBrowser && isChrome
+            ? "Plug in Ledger device and unlock."
+            : "Connecting to Ledger is currently supported only on Google Chrome browser. Please open the dashboard on Chrome and try again or use Ledger Live Bridge through MetaMask."
+        }
         connector={connector[ledgerVersion]}
         connectAppWithWallet={connectAppWithWallet}
         closeModal={onClose}
@@ -38,7 +44,7 @@ const LedgerModalBase = ({ connector, connectAppWithWallet, onClose }) => {
         numberOfAccounts={5}
         withAccountPagination={true}
       >
-        <>
+        <OnlyIf condition={isBrowser && isChrome}>
           <div
             className="flex column mt-1"
             style={{
@@ -59,7 +65,7 @@ const LedgerModalBase = ({ connector, connectAppWithWallet, onClose }) => {
               ledger legacy
             </Button>
           </div>
-        </>
+        </OnlyIf>
       </SelectedWalletModal>
     </>
   )

--- a/solidity-v1/dashboard/src/connectors/ledger.js
+++ b/solidity-v1/dashboard/src/connectors/ledger.js
@@ -1,6 +1,6 @@
 import { LedgerSubprovider } from "@0x/subproviders"
-import TransportU2F from "@ledgerhq/hw-transport-u2f"
 import AppEth from "@ledgerhq/hw-app-eth"
+import TransportWebUSB from "@ledgerhq/hw-transport-webusb"
 import { AbstractHardwareWalletConnector } from "./abstract-connector"
 import { getChainIdFromV, getEthereumTxObj, getChainId } from "./utils"
 import web3Utils from "web3-utils"
@@ -20,7 +20,7 @@ export class LedgerConnector extends AbstractHardwareWalletConnector {
 
 const LEDGER_EXCHANGE_TIMEOUT = 100000
 const ledgerEthereumClientFactoryAsync = async () => {
-  const ledgerConnection = await TransportU2F.create()
+  const ledgerConnection = await TransportWebUSB.create()
   ledgerConnection.setExchangeTimeout(LEDGER_EXCHANGE_TIMEOUT)
   const ledgerEthClient = new AppEth(ledgerConnection)
 


### PR DESCRIPTION
The package that we use for Ledger - `@ledgerhq/hw-transport-u2f` have been deprecated.

We migrate from `@ledgerhq/hw-transport-u2f` to the newer and safer `@ledgerhq/hw-transport-webusb`

Mozilla Firefox does not support WebUSB at this moment so we remove the possibility to log in directly from Ledger Live on Firefox (and other browsers expect Chrome).

More info: [https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_webusb.md](https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_webusb.md)

Main changes:
- install `@ledgerhq/hw-transport-webusb` and uninstall deprecated `@ledgerhq/hw-transport-u2f` package
- install `react-device-detect` library which help with detecting what device and what browser does user use
- display proper message in Ledger Login window, that informs user that are viewing the dashboard from different browser than Chrome, that it's impossible to login straight from Ledger and that they should either use Chrome or log in through Ledger Live Bridge on MetaMask

Ledger login modal on Firefox:
<img width="556" alt="image" src="https://user-images.githubusercontent.com/40306834/160172153-f7a2718b-f046-4dfb-a4e2-25b4e0d6894e.png">

Testing:

To test the Ledger log in locally install packages from mainnet and run the dashboard with HTTP=true flag:
`HTTPS=true npm start`
