### PR TITLE
ECDSA: unlink the libraries

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -73,7 +73,7 @@ contract WalletRegistry is
     ///         submitter's interest to not skip his priority turn on the approval,
     ///         otherwise the refund of the DKG submission will be refunded to
     ///         other member that will call the DKG approve function.
-    uint256 public dkgResultSubmissionGas = 300000;
+    uint256 public dkgResultSubmissionGas = 275000;
 
     // @notice Gas meant to balance the DKG approval's overall cost. Can be updated
     //         by the governace based on the current market conditions.

--- a/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
@@ -230,7 +230,7 @@ library EcdsaDkg {
     ///         a chance to challenge the result as invalid one. Submitter of
     ///         the result needs to be in the sortition pool and if the result
     ///         gets challenged, the submitter will get slashed.
-    function submitResult(Data storage self, Result calldata result) external {
+    function submitResult(Data storage self, Result calldata result) internal {
         require(
             currentState(self) == State.AWAITING_RESULT,
             "Current state is not AWAITING_RESULT"
@@ -311,7 +311,7 @@ library EcdsaDkg {
     ///        during `submitResult`.
     /// @return misbehavedMembers Identifiers of members who misbehaved during DKG.
     function approveResult(Data storage self, Result calldata result)
-        external
+        internal
         returns (uint32[] memory misbehavedMembers)
     {
         require(
@@ -372,7 +372,7 @@ library EcdsaDkg {
     /// @return maliciousResultHash Hash of the malicious result.
     /// @return maliciousSubmitter Identifier of the malicious submitter.
     function challengeResult(Data storage self, Result calldata result)
-        external
+        internal
         returns (bytes32 maliciousResultHash, uint32 maliciousSubmitter)
     {
         require(
@@ -438,7 +438,7 @@ library EcdsaDkg {
     /// @return True if the result is valid. If the result is invalid it returns
     ///         false and an error message.
     function isResultValid(Data storage self, Result calldata result)
-        external
+        internal
         view
         returns (bool, string memory)
     {

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -74,7 +74,7 @@ library Wallets {
     /// @param walletID Wallet's ID.
     /// @return True if a wallet is registered, false otherwise.
     function isWalletRegistered(Data storage self, bytes32 walletID)
-        public
+        internal
         view
         returns (bool)
     {
@@ -87,7 +87,7 @@ library Wallets {
     /// @param walletID ID of the wallet.
     /// @return Uncompressed public key of the wallet.
     function getWalletPublicKey(Data storage self, bytes32 walletID)
-        external
+        internal
         view
         returns (bytes memory)
     {

--- a/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
@@ -24,11 +24,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
   })
 
-  const Wallets = await deployments.deploy("Wallets", {
-    from: deployer,
-    log: true,
-  })
-
   const WalletRegistry = await deployments.deploy("WalletRegistry", {
     contract:
       deployments.getNetworkName() === "hardhat"
@@ -42,7 +37,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
       RandomBeacon.address,
       ReimbursementPool.address,
     ],
-    libraries: { EcdsaDkg: EcdsaDkg.address, Wallets: Wallets.address },
+    libraries: { EcdsaDkg: EcdsaDkg.address },
     log: true,
   })
 

--- a/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
@@ -19,11 +19,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
   })
 
-  const EcdsaDkg = await deployments.deploy("EcdsaDkg", {
-    from: deployer,
-    log: true,
-  })
-
   const WalletRegistry = await deployments.deploy("WalletRegistry", {
     contract:
       deployments.getNetworkName() === "hardhat"
@@ -37,7 +32,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
       RandomBeacon.address,
       ReimbursementPool.address,
     ],
-    libraries: { EcdsaDkg: EcdsaDkg.address },
     log: true,
   })
 

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -52,7 +52,7 @@ describe("WalletRegistryGovernance", async () => {
   const initialAuthorizationDecreaseDelay = 5184000 // 60 days
   const initialMaliciousDkgResultSlashingAmount = to1e18(50000)
   const initialMaliciousDkgResultNotificationRewardMultiplier = 100
-  const initialDkgResultSubmissionGas = 300000
+  const initialDkgResultSubmissionGas = 275000
   const initialDkgApprovalGasOffset = 65000
   const initialSortitionPoolRewardsBanDuration = 1209600 // 14 days
 


### PR DESCRIPTION
The contract size increased from 16.859 to 19.181 which should still be enough for adding the remaining functionality (inactivity, heartbeats, closing wallet) but the gas cost of DKG dropped by ~20k units of gas.

Before vs after comparison:
```
submitDkgResult     ·     269513  ·     305282  ·     297796   │
submitDkgResult     ·     253126  ·     282468  ·     276413   │

approveDkgResult    ·     281679  ·     345023  ·     290260   │
approveDkgResult    ·     260958  ·     322070  ·     269305   |

challengeDkgResult  ·     352034  ·    1823098  ·    1356153   │
challengeDkgResult  ·     328853  ·    1802020  ·    1334557   │
```

Individual comparisons for inlined `Wallets` and `EcdsaDkg` libraries are available in commit descriptions.