### PR TITLE
`notifyOperatorInactivity` for Wallet Registry

### DIFF
--- a/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+//
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import "@keep-network/random-beacon/contracts/libraries/BytesLib.sol";
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
+
+import "./Wallets.sol";
+
+library EcdsaInactivity {
+    using BytesLib for bytes;
+    using ECDSA for bytes32;
+
+    struct Claim {
+        // ID of the wallet whose signing group is raising the inactivity claim.
+        bytes32 walletID;
+        // Indices of group members accused of being inactive. Indices must be in
+        // range [1, groupMembers.length], unique, and sorted in ascending order.
+        uint256[] inactiveMembersIndices;
+        // Concatenation of signatures from members supporting the claim.
+        // The message to be signed by each member is keccak256 hash of the
+        // concatenation of inactivity claim nonce for the given wallet, wallet
+        // public key, and inactive members indices. The calculated hash should
+        // be prefixed with `\x19Ethereum signed message:\n` before signing, so
+        // the message to sign is:
+        // `\x19Ethereum signed message:\n${keccak256(
+        //    nonce | walletPubKey | inactiveMembersIndices
+        // )}`
+        bytes signatures;
+        // Indices of members corresponding to each signature. Indices must be
+        // in range [1, groupMembers.length], unique, and sorted in ascending
+        // order.
+        uint256[] signingMembersIndices;
+    }
+
+    /// @notice The minimum number of wallet signing group members needed to
+    ///         interact according to the protocol to produce a valid inactivity
+    ///         claim.
+    uint256 public constant groupThreshold = 51;
+
+    /// @notice Size in bytes of a single signature produced by member
+    ///         supporting the inactivity claim.
+    uint256 public constant signatureByteSize = 65;
+
+    /// @notice Verifies the inactivity claim according to the rules defined in
+    ///         `Claim` struct documentation. Reverts if verification fails.
+    /// @dev Wallet signing group members hash is validated upstream in
+    ///      `WalletRegistry.notifyOperatorInactivity()`
+    /// @param sortitionPool Sortition pool reference
+    /// @param claim Inactivity claim
+    /// @param walletPubKey Public key of the wallet
+    /// @param nonce Current inactivity nonce for wallet used in the claim
+    /// @param groupMembers Identifiers of group members
+    /// @return inactiveMembers Identifiers of members who are inactive
+    function verifyClaim(
+        SortitionPool sortitionPool,
+        Claim calldata claim,
+        bytes memory walletPubKey,
+        uint256 nonce,
+        uint32[] calldata groupMembers
+    ) external view returns (uint32[] memory inactiveMembers) {
+        // Validate inactive members indices. Maximum indices count is equal to
+        // the group size and is not limited deliberately to leave a theoretical
+        // possibility to accuse more members than `groupSize - groupThreshold`.
+        validateMembersIndices(
+            claim.inactiveMembersIndices,
+            groupMembers.length
+        );
+
+        // Validate signatures array is properly formed and number of
+        // signatures and signers is correct.
+        uint256 signaturesCount = claim.signatures.length / signatureByteSize;
+        require(claim.signatures.length != 0, "No signatures provided");
+        require(
+            claim.signatures.length % signatureByteSize == 0,
+            "Malformed signatures array"
+        );
+        require(
+            signaturesCount == claim.signingMembersIndices.length,
+            "Unexpected signatures count"
+        );
+        require(signaturesCount >= groupThreshold, "Too few signatures");
+        require(signaturesCount <= groupMembers.length, "Too many signatures");
+
+        // Validate signing members indices. Note that `signingMembersIndices`
+        // were already partially validated during `signatures` parameter
+        // validation.
+        validateMembersIndices(
+            claim.signingMembersIndices,
+            groupMembers.length
+        );
+
+        bytes32 signedMessageHash = keccak256(
+            abi.encodePacked(nonce, walletPubKey, claim.inactiveMembersIndices)
+        ).toEthSignedMessageHash();
+
+        address[] memory groupMembersAddresses = sortitionPool.getIDOperators(
+            groupMembers
+        );
+
+        // Verify each signature.
+        bytes memory checkedSignature;
+        bool senderSignatureExists = false;
+        for (uint256 i = 0; i < signaturesCount; i++) {
+            uint256 memberIndex = claim.signingMembersIndices[i];
+            checkedSignature = claim.signatures.slice(
+                signatureByteSize * i,
+                signatureByteSize
+            );
+            address recoveredAddress = signedMessageHash.recover(
+                checkedSignature
+            );
+
+            require(
+                groupMembersAddresses[memberIndex - 1] == recoveredAddress,
+                "Invalid signature"
+            );
+
+            if (!senderSignatureExists && msg.sender == recoveredAddress) {
+                senderSignatureExists = true;
+            }
+        }
+
+        require(senderSignatureExists, "Sender must be claim signer");
+
+        inactiveMembers = new uint32[](claim.inactiveMembersIndices.length);
+        for (uint256 i = 0; i < claim.inactiveMembersIndices.length; i++) {
+            uint256 memberIndex = claim.inactiveMembersIndices[i];
+            inactiveMembers[i] = groupMembers[memberIndex - 1];
+        }
+
+        return inactiveMembers;
+    }
+
+    /// @notice Validates members indices array. Array is considered valid
+    ///         if its size and each single index are in [1, groupSize] range,
+    ///         indexes are unique, and sorted in an ascending order.
+    ///         Reverts if validation fails.
+    /// @param indices Array to validate.
+    /// @param groupSize Group size used as reference.
+    function validateMembersIndices(
+        uint256[] calldata indices,
+        uint256 groupSize
+    ) internal view {
+        require(
+            indices.length > 0 && indices.length <= groupSize,
+            "Corrupted members indices"
+        );
+
+        // Check if first and last indices are in range [1, groupSize].
+        // This check combined with the loop below makes sure every single
+        // index is in the correct range.
+        require(
+            indices[0] > 0 && indices[indices.length - 1] <= groupSize,
+            "Corrupted members indices"
+        );
+
+        for (uint256 i = 0; i < indices.length - 1; i++) {
+            // Check whether given index is smaller than the next one. This
+            // way we are sure indexes are ordered in the ascending order
+            // and there are no duplicates.
+            require(indices[i] < indices[i + 1], "Corrupted members indices");
+        }
+    }
+}

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -37,11 +37,11 @@ library Wallets {
 
     /// @notice Registers a new wallet.
     /// @dev Uses a public key hash as a unique identifier of a wallet.
-    /// @param membersIdsHash Keccak256 hash of group members identifiers array.
-    /// @param publicKey Uncompressed public key.
-    /// @return walletID Wallet's ID.
-    /// @return publicKeyX Wallet's public key's X coordinate.
-    /// @return publicKeyY Wallet's public key's Y coordinate.
+    /// @param membersIdsHash Keccak256 hash of group members identifiers array
+    /// @param publicKey Uncompressed public key
+    /// @return walletID Wallet's ID
+    /// @return publicKeyX Wallet's public key's X coordinate
+    /// @return publicKeyY Wallet's public key's Y coordinate
     function addWallet(
         Data storage self,
         bytes32 membersIdsHash,
@@ -71,8 +71,8 @@ library Wallets {
     }
 
     /// @notice Checks if a wallet with the given ID is registered.
-    /// @param walletID Wallet's ID.
-    /// @return True if a wallet is registered, false otherwise.
+    /// @param walletID Wallet's ID
+    /// @return True if a wallet is registered, false otherwise
     function isWalletRegistered(Data storage self, bytes32 walletID)
         public
         view
@@ -81,11 +81,24 @@ library Wallets {
         return self.registry[walletID].publicKeyX != bytes32(0);
     }
 
+    /// @notice Returns Keccak256 hash of the wallet signing group members
+    ///         identifiers array. Group members do not include operators
+    ///         selected by the sortition pool that misbehaved during DKG.
+    /// @param walletID ID of the wallet
+    /// @return Wallet signing group members hash
+    function getWalletMembersIdsHash(Data storage self, bytes32 walletID)
+        external
+        view
+        returns (bytes32)
+    {
+        return self.registry[walletID].membersIdsHash;
+    }
+
     /// @notice Gets public key of a wallet with a given wallet ID.
     ///         The public key is returned in an uncompressed format as a 64-byte
     ///         concatenation of X and Y coordinates.
-    /// @param walletID ID of the wallet.
-    /// @return Uncompressed public key of the wallet.
+    /// @param walletID ID of the wallet
+    /// @return Uncompressed public key of the wallet
     function getWalletPublicKey(Data storage self, bytes32 walletID)
         external
         view

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -84,7 +84,7 @@ library Wallets {
     /// @param walletID ID of the wallet
     /// @return Wallet signing group members hash
     function getWalletMembersIdsHash(Data storage self, bytes32 walletID)
-        external
+        internal
         view
         returns (bytes32)
     {

--- a/solidity/ecdsa/contracts/test/WalletRegistryStub.sol
+++ b/solidity/ecdsa/contracts/test/WalletRegistryStub.sol
@@ -1,12 +1,10 @@
-pragma solidity ^0.8.6;
+pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
 import "@keep-network/random-beacon/contracts/ReimbursementPool.sol";
 import "../WalletRegistry.sol";
 import "../EcdsaDkgValidator.sol";
-import "../libraries/EcdsaDkg.sol";
-import "../libraries/Wallets.sol";
 
 contract WalletRegistryStub is WalletRegistry {
     constructor(

--- a/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
@@ -38,7 +38,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
       ReimbursementPool.address,
     ],
     libraries: {
-      EcdsaInactivity: EcdsaInactivity.address
+      EcdsaInactivity: EcdsaInactivity.address,
     },
     log: true,
   })

--- a/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/04_deploy_wallet_registry.ts
@@ -29,6 +29,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
   })
 
+  const EcdsaInactivity = await deployments.deploy("EcdsaInactivity", {
+    from: deployer,
+    log: true,
+  })
+
   const WalletRegistry = await deployments.deploy("WalletRegistry", {
     contract:
       deployments.getNetworkName() === "hardhat"
@@ -42,7 +47,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
       RandomBeacon.address,
       ReimbursementPool.address,
     ],
-    libraries: { EcdsaDkg: EcdsaDkg.address, Wallets: Wallets.address },
+    libraries: {
+      EcdsaDkg: EcdsaDkg.address,
+      Wallets: Wallets.address,
+      EcdsaInactivity: EcdsaInactivity.address,
+    },
     log: true,
   })
 

--- a/solidity/ecdsa/test/WalletRegistry.Inactivity.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Inactivity.ts
@@ -1,0 +1,823 @@
+import { ethers, helpers } from "hardhat"
+import { expect } from "chai"
+
+import ecdsaData from "./data/ecdsa"
+import { params, walletRegistryFixture } from "./fixtures"
+import { createNewWallet } from "./utils/wallets"
+import { signOperatorInactivityClaim } from "./utils/inactivity"
+
+import type { BigNumber, ContractTransaction } from "ethers"
+import type { FakeContract } from "@defi-wonderland/smock"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { SortitionPool, WalletRegistry, IWalletOwner } from "../typechain"
+import type { Operator, OperatorID } from "./utils/operators"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe.only("WalletRegistry - Inactivity", () => {
+  const walletPublicKey: string = ecdsaData.group1.publicKey
+
+  let walletRegistry: WalletRegistry
+  let sortitionPool: SortitionPool
+  let walletOwner: FakeContract<IWalletOwner>
+
+  let thirdParty: SignerWithAddress
+
+  let members: Operator[]
+  let membersIDs: OperatorID[]
+  let walletID: string
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ walletRegistry, sortitionPool, walletOwner, thirdParty } =
+      await walletRegistryFixture())
+    ;({ members, walletID } = await createNewWallet(
+      walletRegistry,
+      walletOwner.wallet,
+      walletPublicKey
+    ))
+
+    membersIDs = members.map((member) => member.id)
+  })
+
+  describe("notifyOperatorInactivity", () => {
+    const emptyMembersIndices = []
+
+    // Use 49 element `inactiveMembersIndices` array to simulate the most gas
+    // expensive real-world case. If group size is 100, the required threshold
+    // is 51 so we assume 49 operators at most will be marked as ineligible
+    // during a single `notifyOperatorInactivity` call.
+    const subsequentInactiveMembersIndices = Array.from(
+      Array(49),
+      (_, i) => i + 1
+    )
+    const nonSubsequentInactiveMembersIndices = [2, 5, 7, 23, 56]
+    const groupThreshold = 51
+
+    context("when passed nonce is valid", () => {
+      context("when wallet is known", () => {
+        context("when inactive members indices are correct", () => {
+          context("when signatures array is correct", () => {
+            context("when signing members indices are correct", () => {
+              context("when all signatures are correct", () => {
+                context("when claim sender signed the claim", () => {
+                  const assertNotifyInactivitySucceed = async (
+                    inactiveMembersIndices: number[],
+                    signaturesCount: number,
+                    modifySignatures: (signatures: string) => string,
+                    modifySigningMemberIndices: (
+                      signingMemberIndices: number[]
+                    ) => number[]
+                  ) => {
+                    let tx: ContractTransaction
+                    let initialNonce: BigNumber
+                    let claimSender: SignerWithAddress
+
+                    before(async () => {
+                      await createSnapshot()
+
+                      // Assume claim sender is the first signing member.
+                      claimSender = members[0].signer
+
+                      initialNonce = await walletRegistry.inactivityClaimNonce(
+                        walletID
+                      )
+
+                      const { signatures, signingMembersIndices } =
+                        await signOperatorInactivityClaim(
+                          members,
+                          0,
+                          walletPublicKey,
+                          inactiveMembersIndices,
+                          signaturesCount
+                        )
+
+                      tx = await walletRegistry
+                        .connect(claimSender)
+                        .notifyOperatorInactivity(
+                          {
+                            walletID,
+                            inactiveMembersIndices,
+                            signatures: modifySignatures(signatures),
+                            signingMembersIndices: modifySigningMemberIndices(
+                              signingMembersIndices
+                            ),
+                          },
+                          0,
+                          membersIDs
+                        )
+                    })
+
+                    after(async () => {
+                      await restoreSnapshot()
+                    })
+
+                    it("should increment inactivity claim nonce for the group", async () => {
+                      expect(
+                        await walletRegistry.inactivityClaimNonce(walletID)
+                      ).to.be.equal(initialNonce.add(1))
+                    })
+
+                    it("should emit InactivityClaimed event", async () => {
+                      await expect(tx)
+                        .to.emit(walletRegistry, "InactivityClaimed")
+                        .withArgs(
+                          walletID,
+                          initialNonce.toNumber(),
+                          claimSender.address
+                        )
+                    })
+
+                    it("should ban sortition pool rewards for inactive operators", async () => {
+                      const now = await helpers.time.lastBlockTime()
+                      const expectedUntil =
+                        now + params.sortitionPoolRewardsBanDuration
+
+                      const expectedIneligibleMembersIDs =
+                        inactiveMembersIndices.map((i) => membersIDs[i - 1])
+
+                      await expect(tx)
+                        .to.emit(sortitionPool, "IneligibleForRewards")
+                        .withArgs(expectedIneligibleMembersIDs, expectedUntil)
+                    })
+                  }
+
+                  context(
+                    "when there are multiple subsequent inactive members indices",
+                    async () => {
+                      await assertNotifyInactivitySucceed(
+                        subsequentInactiveMembersIndices,
+                        groupThreshold,
+                        (signatures) => signatures,
+                        (signingMembersIndices) => signingMembersIndices
+                      )
+                    }
+                  )
+
+                  context(
+                    "when there is only one inactive member index",
+                    async () => {
+                      await assertNotifyInactivitySucceed(
+                        [32],
+                        groupThreshold,
+                        (signatures) => signatures,
+                        (signingMembersIndices) => signingMembersIndices
+                      )
+                    }
+                  )
+
+                  context(
+                    "when there are multiple non-subsequent inactive members indices",
+                    async () => {
+                      await assertNotifyInactivitySucceed(
+                        nonSubsequentInactiveMembersIndices,
+                        groupThreshold,
+                        (signatures) => signatures,
+                        (signingMembersIndices) => signingMembersIndices
+                      )
+                    }
+                  )
+
+                  context(
+                    "when there are multiple non-subsequent signing members indices",
+                    async () => {
+                      const newSigningMembersIndices = [
+                        1, 5, 8, 11, 14, 15, 18, 20, 22, 24, 25, 27, 29, 30, 31,
+                        33, 38, 39, 41, 42, 44, 47, 48, 49, 51, 53, 55, 56, 57,
+                        59, 61, 62, 64, 65, 66, 67, 69, 71, 73, 75, 76, 78, 79,
+                        80, 82, 83, 84, 86, 88, 90, 99,
+                      ]
+
+                      // we cut the first 2 characters to get rid of "0x" and
+                      // then return signature on arbitrary position - each
+                      // signature has 65 bytes so 130 characters
+                      const getSignature = (signatures, index) =>
+                        signatures
+                          .slice(2)
+                          .slice(130 * index, 130 * index + 130)
+
+                      const modifySignatures = (signatures) => {
+                        let newSignatures = "0x"
+
+                        for (
+                          let i = 0;
+                          i < newSigningMembersIndices.length;
+                          i++
+                        ) {
+                          const newSigningMemberIndex =
+                            newSigningMembersIndices[i]
+                          newSignatures += getSignature(
+                            signatures,
+                            newSigningMemberIndex - 1
+                          )
+                        }
+
+                        return newSignatures
+                      }
+
+                      await assertNotifyInactivitySucceed(
+                        subsequentInactiveMembersIndices,
+                        // Make more signatures than needed to allow picking up
+                        // arbitrary signatures.
+                        100,
+                        modifySignatures,
+                        () => newSigningMembersIndices
+                      )
+                    }
+                  )
+                })
+
+                context(
+                  "when claim sender did not sign the claim",
+                  async () => {
+                    it("should revert", async () => {
+                      const { signatures, signingMembersIndices } =
+                        await signOperatorInactivityClaim(
+                          members,
+                          0,
+                          walletPublicKey,
+                          subsequentInactiveMembersIndices,
+                          groupThreshold
+                        )
+
+                      const claimSender = thirdParty
+
+                      await expect(
+                        walletRegistry
+                          .connect(claimSender)
+                          .notifyOperatorInactivity(
+                            {
+                              walletID,
+                              inactiveMembersIndices:
+                                subsequentInactiveMembersIndices,
+                              signatures,
+                              signingMembersIndices,
+                            },
+                            0,
+                            membersIDs
+                          )
+                      ).to.be.revertedWith("Sender must be claim signer")
+                    })
+                  }
+                )
+              })
+
+              context("when one of the signatures is incorrect", () => {
+                const assertInvalidSignature = async (invalidSignature) => {
+                  // The 50 signers sign correct parameters. Invalid signature
+                  // is expected to be provided by signer 51.
+                  const { signatures, signingMembersIndices } =
+                    await signOperatorInactivityClaim(
+                      members,
+                      0,
+                      walletPublicKey,
+                      subsequentInactiveMembersIndices,
+                      groupThreshold - 1
+                    )
+
+                  await expect(
+                    walletRegistry.notifyOperatorInactivity(
+                      {
+                        walletID,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
+                        // Slice removes `0x` prefix from wrong signature.
+                        signatures: signatures + invalidSignature.slice(2),
+                        signingMembersIndices: [...signingMembersIndices, 51],
+                      },
+                      0,
+                      membersIDs
+                    )
+                  ).to.be.revertedWith("Invalid signature")
+                }
+
+                context(
+                  "when one of the signatures signed the wrong nonce",
+                  () => {
+                    it("should revert", async () => {
+                      // Signer 51 signs wrong nonce.
+                      const invalidSignature = (
+                        await signOperatorInactivityClaim(
+                          [members[50]],
+                          1,
+                          walletPublicKey,
+                          subsequentInactiveMembersIndices,
+                          1
+                        )
+                      ).signatures
+
+                      await assertInvalidSignature(invalidSignature)
+                    })
+                  }
+                )
+
+                context(
+                  "when one of the signatures signed the wrong group public key",
+                  () => {
+                    it("should revert", async () => {
+                      // Signer 51 signs wrong group public key.
+                      const invalidSignature = (
+                        await signOperatorInactivityClaim(
+                          [members[50]],
+                          0,
+                          "0x010203",
+                          subsequentInactiveMembersIndices,
+                          1
+                        )
+                      ).signatures
+
+                      await assertInvalidSignature(invalidSignature)
+                    })
+                  }
+                )
+
+                context(
+                  "when one of the signatures signed the wrong inactive group members indices",
+                  () => {
+                    it("should revert", async () => {
+                      // Signer 51 signs wrong inactive group members indices.
+                      const invalidSignature = (
+                        await signOperatorInactivityClaim(
+                          [members[50]],
+                          0,
+                          walletPublicKey,
+                          [1, 2, 3, 4, 5, 6, 7, 8],
+                          1
+                        )
+                      ).signatures
+
+                      await assertInvalidSignature(invalidSignature)
+                    })
+                  }
+                )
+              })
+            })
+
+            context("when signing members indices are incorrect", () => {
+              context(
+                "when signing members indices count is different than signatures count",
+                () => {
+                  it("should revert", async () => {
+                    const { signatures, signingMembersIndices } =
+                      await signOperatorInactivityClaim(
+                        members,
+                        0,
+                        walletPublicKey,
+                        subsequentInactiveMembersIndices,
+                        groupThreshold
+                      )
+
+                    await expect(
+                      walletRegistry.notifyOperatorInactivity(
+                        {
+                          walletID,
+                          inactiveMembersIndices:
+                            subsequentInactiveMembersIndices,
+                          signatures,
+                          // Remove the first signing member index
+                          signingMembersIndices: signingMembersIndices.slice(1),
+                        },
+                        0,
+                        membersIDs
+                      )
+                    ).to.be.revertedWith("Unexpected signatures count")
+                  })
+                }
+              )
+
+              context("when first signing member index is zero", () => {
+                it("should revert", async () => {
+                  const { signatures, signingMembersIndices } =
+                    await signOperatorInactivityClaim(
+                      members,
+                      0,
+                      walletPublicKey,
+                      subsequentInactiveMembersIndices,
+                      groupThreshold
+                    )
+
+                  signingMembersIndices[0] = 0
+
+                  await expect(
+                    walletRegistry.notifyOperatorInactivity(
+                      {
+                        walletID,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
+                        signatures,
+                        signingMembersIndices,
+                      },
+                      0,
+                      membersIDs
+                    )
+                  ).to.be.revertedWith("Corrupted members indices")
+                })
+              })
+
+              context(
+                "when last signing member index is bigger than group size",
+                () => {
+                  it("should revert", async () => {
+                    const { signatures, signingMembersIndices } =
+                      await signOperatorInactivityClaim(
+                        members,
+                        0,
+                        walletPublicKey,
+                        subsequentInactiveMembersIndices,
+                        groupThreshold
+                      )
+
+                    signingMembersIndices[
+                      signingMembersIndices.length - 1
+                    ] = 101
+
+                    await expect(
+                      walletRegistry.notifyOperatorInactivity(
+                        {
+                          walletID,
+                          inactiveMembersIndices:
+                            subsequentInactiveMembersIndices,
+                          signatures,
+                          signingMembersIndices,
+                        },
+                        0,
+                        membersIDs
+                      )
+                    ).to.be.revertedWith("Corrupted members indices")
+                  })
+                }
+              )
+
+              context(
+                "when signing members indices are not ordered in ascending order",
+                () => {
+                  it("should revert", async () => {
+                    const { signatures, signingMembersIndices } =
+                      await signOperatorInactivityClaim(
+                        members,
+                        0,
+                        walletPublicKey,
+                        subsequentInactiveMembersIndices,
+                        groupThreshold
+                      )
+
+                    // eslint-disable-next-line prefer-destructuring
+                    signingMembersIndices[10] = signingMembersIndices[11]
+
+                    await expect(
+                      walletRegistry.notifyOperatorInactivity(
+                        {
+                          walletID,
+                          inactiveMembersIndices:
+                            subsequentInactiveMembersIndices,
+                          signatures,
+                          signingMembersIndices,
+                        },
+                        0,
+                        membersIDs
+                      )
+                    ).to.be.revertedWith("Corrupted members indices")
+                  })
+                }
+              )
+            })
+          })
+
+          context("when signatures array is incorrect", () => {
+            context("when signatures count is zero", () => {
+              it("should revert", async () => {
+                const signatures = "0x"
+
+                await expect(
+                  walletRegistry.notifyOperatorInactivity(
+                    {
+                      walletID,
+                      inactiveMembersIndices: subsequentInactiveMembersIndices,
+                      signatures,
+                      signingMembersIndices: emptyMembersIndices,
+                    },
+                    0,
+                    membersIDs
+                  )
+                ).to.be.revertedWith("No signatures provided")
+              })
+            })
+
+            context(
+              "when signatures count is not divisible by signature byte size",
+              () => {
+                it("should revert", async () => {
+                  const signatures = "0x010203"
+
+                  await expect(
+                    walletRegistry.notifyOperatorInactivity(
+                      {
+                        walletID,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
+                        signatures,
+                        signingMembersIndices: emptyMembersIndices,
+                      },
+                      0,
+                      membersIDs
+                    )
+                  ).to.be.revertedWith("Malformed signatures array")
+                })
+              }
+            )
+
+            context(
+              "when signatures count is different than signing members count",
+              () => {
+                it("should revert", async () => {
+                  const { signatures, signingMembersIndices } =
+                    await signOperatorInactivityClaim(
+                      members,
+                      0,
+                      walletPublicKey,
+                      subsequentInactiveMembersIndices,
+                      groupThreshold
+                    )
+
+                  await expect(
+                    walletRegistry.notifyOperatorInactivity(
+                      {
+                        walletID,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
+                        // Remove the first signature to cause a mismatch with
+                        // the signing members count.
+                        signatures: `0x${signatures.slice(132)}`,
+                        signingMembersIndices,
+                      },
+                      0,
+                      membersIDs
+                    )
+                  ).to.be.revertedWith("Unexpected signatures count")
+                })
+              }
+            )
+
+            context(
+              "when signatures count is less than group threshold",
+              () => {
+                it("should revert", async () => {
+                  const { signatures, signingMembersIndices } =
+                    await signOperatorInactivityClaim(
+                      members,
+                      0,
+                      walletPublicKey,
+                      subsequentInactiveMembersIndices,
+                      // Provide one few signature
+                      groupThreshold - 1
+                    )
+
+                  await expect(
+                    walletRegistry.notifyOperatorInactivity(
+                      {
+                        walletID,
+                        inactiveMembersIndices:
+                          subsequentInactiveMembersIndices,
+                        signatures,
+                        signingMembersIndices,
+                      },
+                      0,
+                      membersIDs
+                    )
+                  ).to.be.revertedWith("Too few signatures")
+                })
+              }
+            )
+
+            context("when signatures count is bigger than group size", () => {
+              it("should revert", async () => {
+                const { signatures, signingMembersIndices } =
+                  await signOperatorInactivityClaim(
+                    members,
+                    0,
+                    walletPublicKey,
+                    subsequentInactiveMembersIndices,
+                    // All group signs.
+                    members.length
+                  )
+
+                await expect(
+                  walletRegistry.notifyOperatorInactivity(
+                    {
+                      walletID,
+                      inactiveMembersIndices: subsequentInactiveMembersIndices,
+                      // Provide one more signature
+                      // 2 to cut initial '0x' and 132 because signature length
+                      // is 130 bytes, so 2+132 = 132
+                      signatures: signatures + signatures.slice(2, 132),
+                      signingMembersIndices: [
+                        ...signingMembersIndices,
+                        signingMembersIndices[0],
+                      ],
+                    },
+                    0,
+                    membersIDs
+                  )
+                ).to.be.revertedWith("Too many signatures")
+              })
+            })
+          })
+        })
+
+        context("when inactive members indices are incorrect", () => {
+          const assertInactiveMembersIndicesCorrupted = async (
+            inactiveMembersIndices: number[]
+          ) => {
+            const { signatures, signingMembersIndices } =
+              await signOperatorInactivityClaim(
+                members,
+                0,
+                walletPublicKey,
+                inactiveMembersIndices,
+                groupThreshold
+              )
+
+            await expect(
+              walletRegistry.notifyOperatorInactivity(
+                {
+                  walletID,
+                  inactiveMembersIndices,
+                  signatures,
+                  signingMembersIndices,
+                },
+                0,
+                membersIDs
+              )
+            ).to.be.revertedWith("Corrupted members indices")
+          }
+
+          context("when inactive members indices count is zero", () => {
+            it("should revert", async () => {
+              const inactiveMembersIndices = []
+
+              await assertInactiveMembersIndicesCorrupted(
+                inactiveMembersIndices
+              )
+            })
+          })
+
+          context(
+            "when inactive members indices count is bigger than group size",
+            () => {
+              it("should revert", async () => {
+                const inactiveMembersIndices = Array.from(
+                  Array(101),
+                  (_, i) => i + 1
+                )
+
+                await assertInactiveMembersIndicesCorrupted(
+                  inactiveMembersIndices
+                )
+              })
+            }
+          )
+
+          context("when first inactive member index is zero", () => {
+            it("should revert", async () => {
+              const inactiveMembersIndices = Array.from(
+                Array(100),
+                (_, i) => i + 1
+              )
+              inactiveMembersIndices[0] = 0
+
+              await assertInactiveMembersIndicesCorrupted(
+                inactiveMembersIndices
+              )
+            })
+          })
+
+          context(
+            "when last inactive member index is bigger than group size",
+            () => {
+              it("should revert", async () => {
+                const inactiveMembersIndices = Array.from(
+                  Array(100),
+                  (_, i) => i + 1
+                )
+                inactiveMembersIndices[inactiveMembersIndices.length - 1] = 101
+
+                await assertInactiveMembersIndicesCorrupted(
+                  inactiveMembersIndices
+                )
+              })
+            }
+          )
+
+          context(
+            "when inactive members indices are not ordered in ascending order",
+            () => {
+              it("should revert", async () => {
+                const inactiveMembersIndices = Array.from(
+                  Array(100),
+                  (_, i) => i + 1
+                )
+                // eslint-disable-next-line prefer-destructuring
+                inactiveMembersIndices[10] = inactiveMembersIndices[11]
+
+                await assertInactiveMembersIndicesCorrupted(
+                  inactiveMembersIndices
+                )
+              })
+            }
+          )
+        })
+      })
+
+      context("when wallet public key is unknown", async () => {
+        const unknownWalletPublicKey: string = ecdsaData.group2.publicKey
+
+        it("should revert", async () => {
+          const { signatures, signingMembersIndices } =
+            await signOperatorInactivityClaim(
+              members,
+              0,
+              unknownWalletPublicKey,
+              subsequentInactiveMembersIndices,
+              groupThreshold
+            )
+
+          await expect(
+            walletRegistry.notifyOperatorInactivity(
+              {
+                walletID,
+                inactiveMembersIndices: subsequentInactiveMembersIndices,
+                signatures,
+                signingMembersIndices,
+              },
+              0,
+              membersIDs
+            )
+          ).to.be.revertedWith("Invalid signature")
+        })
+      })
+
+      context("when wallet ID is unknown", async () => {
+        it("should revert", async () => {
+          const unknownWalletID: string = ethers.utils.keccak256(walletID)
+
+          const { signatures, signingMembersIndices } =
+            await signOperatorInactivityClaim(
+              members,
+              0,
+              walletPublicKey,
+              subsequentInactiveMembersIndices,
+              groupThreshold
+            )
+
+          await expect(
+            walletRegistry.notifyOperatorInactivity(
+              {
+                walletID: unknownWalletID,
+                inactiveMembersIndices: subsequentInactiveMembersIndices,
+                signatures,
+                signingMembersIndices,
+              },
+              0,
+              membersIDs
+            )
+          ).to.be.revertedWith("Wallet with given ID has not been registered")
+        })
+      })
+    })
+
+    context("when passed nonce is invalid", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistry.notifyOperatorInactivity(
+            {
+              walletID,
+              inactiveMembersIndices: emptyMembersIndices,
+              signatures: "0x",
+              signingMembersIndices: emptyMembersIndices,
+            },
+            1,
+            membersIDs
+          ) // Initial nonce is `0`.
+        ).to.be.revertedWith("Invalid nonce")
+      })
+    })
+
+    context("when group members are invalid", () => {
+      it("should revert", async () => {
+        const invalidMembersId = [0, 1, 42]
+        await expect(
+          walletRegistry.notifyOperatorInactivity(
+            {
+              walletID,
+              inactiveMembersIndices: emptyMembersIndices,
+              signatures: "0x",
+              signingMembersIndices: emptyMembersIndices,
+            },
+            0,
+            invalidMembersId
+          )
+        ).to.be.revertedWith("Invalid group members")
+      })
+    })
+  })
+})

--- a/solidity/ecdsa/test/WalletRegistry.Inactivity.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Inactivity.ts
@@ -14,7 +14,7 @@ import type { Operator, OperatorID } from "./utils/operators"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
-describe.only("WalletRegistry - Inactivity", () => {
+describe("WalletRegistry - Inactivity", () => {
   const walletPublicKey: string = ecdsaData.group1.publicKey
 
   let walletRegistry: WalletRegistry

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -3302,7 +3302,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               )
               expect(diff).to.be.gt(0)
               expect(diff).to.be.lt(
-                ethers.utils.parseUnits("31000", "gwei") // 0,000031 ETH
+                ethers.utils.parseUnits("100000", "gwei") // 0,0001 ETH
               )
             })
           })

--- a/solidity/ecdsa/test/utils/inactivity.ts
+++ b/solidity/ecdsa/test/utils/inactivity.ts
@@ -1,0 +1,46 @@
+import { ethers } from "hardhat"
+
+import type { Operator } from "./operators"
+
+// eslint-disable-next-line import/prefer-default-export
+export async function signOperatorInactivityClaim(
+  signers: Operator[],
+  nonce: number,
+  groupPubKey: string,
+  inactiveMembersIndices: number[],
+  numberOfSignatures: number
+): Promise<{
+  signatures: string
+  signingMembersIndices: number[]
+}> {
+  const messageHash = ethers.utils.solidityKeccak256(
+    ["uint256", "bytes", "uint8[]"],
+    [nonce, groupPubKey, inactiveMembersIndices]
+  )
+
+  const signingMembersIndices: number[] = []
+  const signatures: string[] = []
+
+  for (let i = 0; i < signers.length; i++) {
+    if (signatures.length === numberOfSignatures) {
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
+    const signerIndex: number = i + 1
+
+    signingMembersIndices.push(signerIndex)
+
+    // eslint-disable-next-line no-await-in-loop
+    const signature = await signers[i].signer.signMessage(
+      ethers.utils.arrayify(messageHash)
+    )
+
+    signatures.push(signature)
+  }
+
+  return {
+    signatures: ethers.utils.hexConcat(signatures),
+    signingMembersIndices,
+  }
+}

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -315,7 +315,11 @@ contract RandomBeacon is IRandomBeacon, Ownable {
 
     event CallbackFailed(uint256 entry, uint256 entrySubmittedBlock);
 
-    event InactivityClaimed(uint64 groupId, uint256 nonce, address notifier);
+    event InactivityClaimed(
+        uint64 indexed groupId,
+        uint256 nonce,
+        address notifier
+    );
 
     /// @dev Assigns initial values to parameters to make the beacon work
     ///      safely. These parameters are just proposed defaults and they might

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -948,7 +948,7 @@ contract RandomBeacon is IRandomBeacon, Ownable {
     ///         `sortitionPoolRewardsBanDuration` parameter. The sender of
     ///         the claim must be one of the claim signers. This function
     ///         can be called only for active and non-terminated groups.
-    /// @param claim Failure claim.
+    /// @param claim Operator inactivity claim.
     /// @param nonce Current inactivity claim nonce for the given group. Must
     ///        be the same as the stored one.
     /// @param groupMembers Identifiers of group members.

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -79,6 +79,7 @@ describe("RandomBeacon - Relay", () => {
   let requester: SignerWithAddress
   let notifier: SignerWithAddress
   let submitter: SignerWithAddress
+  let thirdParty: SignerWithAddress
   let members: Operator[]
   let membersIDs: OperatorID[]
   let membersAddresses: Address[]
@@ -92,6 +93,7 @@ describe("RandomBeacon - Relay", () => {
 
   before(async () => {
     deployer = await ethers.getSigner((await getNamedAccounts()).deployer)
+    thirdParty = await ethers.getSigner((await getNamedAccounts()).thirdParty)
     requester = await ethers.getSigner((await getUnnamedAccounts())[1])
     notifier = await ethers.getSigner((await getUnnamedAccounts())[2])
     submitter = await ethers.getSigner((await getUnnamedAccounts())[3])
@@ -1065,8 +1067,8 @@ describe("RandomBeacon - Relay", () => {
 
   describe("notifyOperatorInactivity", () => {
     const groupId = 0
-    const stubSignatures = "0x00"
-    const stubMembersIndices = []
+    const emptySignatures = "0x00"
+    const emptyMemberIndices = []
     // Use 31 element `inactiveMembersIndices` array to simulate the most gas
     // expensive real-world case. If group size is 64, the required threshold
     // is 33 so we assume 31 operators at most will be marked as ineligible
@@ -1224,6 +1226,9 @@ describe("RandomBeacon - Relay", () => {
                         59, 61, 62, 64,
                       ]
 
+                      // we cut the first 2 characters to get rid of "0x" and
+                      // then return signature on arbitrary position - each
+                      // signature has 65 bytes so 130 characters
                       const getSignature = (signatures, index) =>
                         signatures
                           .slice(2)
@@ -1273,12 +1278,7 @@ describe("RandomBeacon - Relay", () => {
                           groupThreshold
                         )
 
-                      // Assume claim sender is member `34` - the first member
-                      // who did not sign the claim. We take index `33` since
-                      // `members` array is zero-based.
-                      const claimSender = await ethers.getSigner(
-                        members[33].address
-                      )
+                      const claimSender = thirdParty
 
                       await expect(
                         randomBeacon
@@ -1530,7 +1530,7 @@ describe("RandomBeacon - Relay", () => {
                       groupId,
                       inactiveMembersIndices: subsequentInactiveMembersIndices,
                       signatures,
-                      signingMembersIndices: stubMembersIndices,
+                      signingMembersIndices: emptyMemberIndices,
                     },
                     0,
                     membersIDs
@@ -1552,7 +1552,7 @@ describe("RandomBeacon - Relay", () => {
                         inactiveMembersIndices:
                           subsequentInactiveMembersIndices,
                         signatures,
-                        signingMembersIndices: stubMembersIndices,
+                        signingMembersIndices: emptyMemberIndices,
                       },
                       0,
                       membersIDs
@@ -1658,7 +1658,7 @@ describe("RandomBeacon - Relay", () => {
           })
         })
 
-        context("when failed members indices are incorrect", () => {
+        context("when inactive members indices are incorrect", () => {
           const assertInactiveMembersIndicesCorrupted = async (
             inactiveMembersIndices: number[]
           ) => {
@@ -1711,7 +1711,7 @@ describe("RandomBeacon - Relay", () => {
             }
           )
 
-          context("when first failed member index is zero", () => {
+          context("when first inactive member index is zero", () => {
             it("should revert", async () => {
               const inactiveMembersIndices = Array.from(
                 Array(64),
@@ -1781,9 +1781,9 @@ describe("RandomBeacon - Relay", () => {
             randomBeacon.notifyOperatorInactivity(
               {
                 groupId,
-                inactiveMembersIndices: stubMembersIndices,
-                signatures: stubSignatures,
-                signingMembersIndices: stubMembersIndices,
+                inactiveMembersIndices: emptyMemberIndices,
+                signatures: emptySignatures,
+                signingMembersIndices: emptyMemberIndices,
               },
               0,
               membersIDs
@@ -1816,9 +1816,9 @@ describe("RandomBeacon - Relay", () => {
             randomBeacon.notifyOperatorInactivity(
               {
                 groupId,
-                inactiveMembersIndices: stubMembersIndices,
-                signatures: stubSignatures,
-                signingMembersIndices: stubMembersIndices,
+                inactiveMembersIndices: emptyMemberIndices,
+                signatures: emptySignatures,
+                signingMembersIndices: emptyMemberIndices,
               },
               0,
               membersIDs
@@ -1834,9 +1834,9 @@ describe("RandomBeacon - Relay", () => {
           randomBeacon.notifyOperatorInactivity(
             {
               groupId,
-              inactiveMembersIndices: stubMembersIndices,
-              signatures: stubSignatures,
-              signingMembersIndices: stubMembersIndices,
+              inactiveMembersIndices: emptyMemberIndices,
+              signatures: emptySignatures,
+              signingMembersIndices: emptyMemberIndices,
             },
             1,
             membersIDs
@@ -1852,9 +1852,9 @@ describe("RandomBeacon - Relay", () => {
           randomBeacon.notifyOperatorInactivity(
             {
               groupId,
-              inactiveMembersIndices: stubMembersIndices,
-              signatures: stubSignatures,
-              signingMembersIndices: stubMembersIndices,
+              inactiveMembersIndices: emptyMemberIndices,
+              signatures: emptySignatures,
+              signingMembersIndices: emptyMemberIndices,
             },
             0,
             invalidMembersId


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2839

The function lets the wallet signing group operators notify about operators who are
inactive in the group. Using this function, a majority of the wallet signing
group can decide about punishing specific group members who constantly fail
to do their job. If the provided claim is proved to be valid and signed by
a sufficient number of group members, operators of members deemed as inactive are
banned from sortition pool rewards for the duration specified by
`sortitionPoolRewardsBanDuration` parameter. The sender of the claim must be one
of the claim signers. This function can be called only for registered wallets.

TODO (in a separate PR):
- [ ] ETH reimbursement for `notifyOperatorInactivity`