### PR TITLE
Remove functions from RandomBeaconStub

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -1009,7 +1009,7 @@ contract RandomBeacon is IRandomBeacon, Ownable {
     /// @notice Locks the state of group creation.
     /// @dev This function is meant to be used by test stubs which inherits
     ///      from this contract and needs to lock the DKG state arbitrarily.
-    function dkgLockState() internal {
+    function dkgLockState() external {
         dkg.lockState();
     }
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -1006,13 +1006,6 @@ contract RandomBeacon is IRandomBeacon, Ownable {
         tToken.safeTransfer(to, actualValue);
     }
 
-    /// @notice Locks the state of group creation.
-    /// @dev This function is meant to be used by test stubs which inherits
-    ///      from this contract and needs to lock the DKG state arbitrarily.
-    function dkgLockState() external {
-        dkg.lockState();
-    }
-
     /// @notice The minimum authorization amount required so that operator can
     ///         participate in the random beacon. This amount is required to
     ///         execute slashing for providing a malicious DKG result or when

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -20,8 +20,8 @@ contract RandomBeaconStub is RandomBeacon {
         return dkg;
     }
 
-    function getCallbackData() external view returns (Callback.Data memory) {
-        return callback;
+    function getCallbackContract() external view returns (address) {
+        return address(callback.callbackContract);
     }
 
     function roughlyAddGroup(
@@ -40,29 +40,9 @@ contract RandomBeaconStub is RandomBeacon {
         groups.groupsRegistry.push(groupPubKeyHash);
     }
 
-    function groupLifetimeOf(bytes32 groupPubKeyHash)
-        external
-        view
-        returns (uint256)
-    {
-        return
-            groups.groupsData[groupPubKeyHash].registrationBlockNumber +
-            groups.groupLifetime;
-    }
-
     function roughlyTerminateGroup(uint64 groupId) public {
         groups.groupsData[groups.groupsRegistry[groupId]].terminated = true;
         // just add groupId without sorting for simplicity
         groups.activeTerminatedGroups.push(groupId);
-    }
-
-    function isGroupTerminated(uint64 groupId) external view returns (bool) {
-        bytes32 groupPubKeyHash = groups.groupsRegistry[groupId];
-
-        return groups.groupsData[groupPubKeyHash].terminated;
-    }
-
-    function publicDkgLockState() external {
-        dkgLockState();
     }
 }

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -9,6 +9,8 @@ import {BeaconDkg as DKG} from "../libraries/BeaconDkg.sol";
 import {BeaconDkgValidator as DKGValidator} from "../BeaconDkgValidator.sol";
 
 contract RandomBeaconStub is RandomBeacon {
+    using DKG for DKG.Data;
+
     constructor(
         SortitionPool _sortitionPool,
         IERC20 _tToken,
@@ -44,5 +46,9 @@ contract RandomBeaconStub is RandomBeacon {
         groups.groupsData[groups.groupsRegistry[groupId]].terminated = true;
         // just add groupId without sorting for simplicity
         groups.activeTerminatedGroups.push(groupId);
+    }
+
+    function dkgLockState() external {
+        dkg.lockState();
     }
 }

--- a/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
+++ b/solidity/random-beacon/contracts/test/RandomBeaconStub.sol
@@ -10,6 +10,7 @@ import {BeaconDkgValidator as DKGValidator} from "../BeaconDkgValidator.sol";
 
 contract RandomBeaconStub is RandomBeacon {
     using DKG for DKG.Data;
+    using Groups for Groups.Data;
 
     constructor(
         SortitionPool _sortitionPool,
@@ -30,22 +31,11 @@ contract RandomBeaconStub is RandomBeacon {
         bytes calldata groupPubKey,
         bytes32 groupMembersHash
     ) external {
-        bytes32 groupPubKeyHash = keccak256(groupPubKey);
-
-        Groups.Group memory group;
-        group.groupPubKey = groupPubKey;
-        group.membersHash = groupMembersHash;
-        /* solhint-disable-next-line not-rely-on-time */
-        group.registrationBlockNumber = block.number;
-
-        groups.groupsData[groupPubKeyHash] = group;
-        groups.groupsRegistry.push(groupPubKeyHash);
+        groups.addGroup(groupPubKey, groupMembersHash);
     }
 
     function roughlyTerminateGroup(uint64 groupId) public {
-        groups.groupsData[groups.groupsRegistry[groupId]].terminated = true;
-        // just add groupId without sorting for simplicity
-        groups.activeTerminatedGroups.push(groupId);
+        groups.terminateGroup(groupId);
     }
 
     function dkgLockState() external {

--- a/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Callback.test.ts
@@ -84,9 +84,7 @@ describe("RandomBeacon - Callback", () => {
           .connect(requester)
           .requestRelayEntry(callbackContract.address)
 
-        const callbackData = await randomBeacon.getCallbackData()
-
-        await expect(callbackData.callbackContract).to.equal(
+        await expect(await randomBeacon.getCallbackContract()).to.equal(
           callbackContract.address
         )
 
@@ -108,8 +106,9 @@ describe("RandomBeacon - Callback", () => {
 
         await randomBeacon.connect(requester).requestRelayEntry(ZERO_ADDRESS)
 
-        const callbackData = await randomBeacon.getCallbackData()
-        await expect(callbackData.callbackContract).to.equal(ZERO_ADDRESS)
+        await expect(await randomBeacon.getCallbackContract()).to.equal(
+          ZERO_ADDRESS
+        )
 
         await restoreSnapshot()
       })
@@ -131,8 +130,7 @@ describe("RandomBeacon - Callback", () => {
           .connect(requester)
           .requestRelayEntry(callbackContract1.address)
 
-        const callbackData = await randomBeacon.getCallbackData()
-        await expect(callbackData.callbackContract).to.equal(
+        await expect(await randomBeacon.getCallbackContract()).to.equal(
           callbackContract1.address
         )
 

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -45,6 +45,12 @@ const { to1e18 } = helpers.number
 const ZERO_ADDRESS = ethers.constants.AddressZero
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
+// FIXME: As a workaround for a bug https://github.com/dethcrypto/TypeChain/issues/601
+// we declare a new type instead of using `RandomBeaconStub & RandomBeacon` intersection.
+type RandomBeaconTest = RandomBeacon & {
+  dkgLockState: () => Promise<ContractTransaction>
+}
+
 async function fixture() {
   const deployment = await randomBeaconDeployment()
 
@@ -62,7 +68,7 @@ async function fixture() {
   )
 
   return {
-    randomBeacon: deployment.randomBeacon as RandomBeacon,
+    randomBeacon: deployment.randomBeacon as RandomBeaconTest,
     randomBeaconGovernance:
       deployment.randomBeaconGovernance as RandomBeaconGovernance,
     sortitionPool: deployment.sortitionPool as SortitionPool,
@@ -83,7 +89,7 @@ describe("RandomBeacon - Relay", () => {
   let membersIDs: OperatorID[]
   let membersAddresses: Address[]
 
-  let randomBeacon: RandomBeacon
+  let randomBeacon: RandomBeaconTest
   let sortitionPool: SortitionPool
   let testToken: TestToken
   let staking: StakingStub


### PR DESCRIPTION
The functions are not necessary for the RandomBeaconStub as we can use
existing functions to obtain required data.