### PR TITLE
Implemented `WalletRegistry.closeWallet` logic

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -127,6 +127,8 @@ contract WalletRegistry is
         bytes32 indexed dkgResultHash
     );
 
+    event WalletClosed(bytes32 indexed walletID);
+
     event DkgMaliciousResultSlashed(
         bytes32 indexed resultHash,
         uint256 slashingAmount,
@@ -523,11 +525,13 @@ contract WalletRegistry is
         randomBeacon.requestRelayEntry(this);
     }
 
-    /// @notice Closes an existing wallet.
+    /// @notice Closes an existing wallet. Reverts if wallet with the given ID
+    ///         does not exist or if it has already been closed.
     /// @param walletID ID of the wallet.
     /// @dev Only a Wallet Owner can call this function.
     function closeWallet(bytes32 walletID) external onlyWalletOwner {
-        // TODO: Implementation.
+        wallets.deleteWallet(walletID);
+        emit WalletClosed(walletID);
     }
 
     /// @notice A callback that is executed once a new relay entry gets

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -67,6 +67,18 @@ library Wallets {
         self.registry[walletID].publicKeyY = publicKeyY;
     }
 
+    /// @notice Deletes wallet with the given ID from the registry. Reverts
+    ///         if wallet with the given ID has not been registered or if it
+    ///         has already been closed.
+    function deleteWallet(Data storage self, bytes32 walletID) internal {
+        require(
+            isWalletRegistered(self, walletID),
+            "Wallet with the given ID has not been registered"
+        );
+
+        delete self.registry[walletID];
+    }
+
     /// @notice Checks if a wallet with the given ID is registered.
     /// @param walletID Wallet's ID
     /// @return True if a wallet is registered, false otherwise
@@ -88,6 +100,11 @@ library Wallets {
         view
         returns (bytes32)
     {
+        require(
+            isWalletRegistered(self, walletID),
+            "Wallet with the given ID has not been registered"
+        );
+
         return self.registry[walletID].membersIdsHash;
     }
 
@@ -103,7 +120,7 @@ library Wallets {
     {
         require(
             isWalletRegistered(self, walletID),
-            "Wallet with given ID has not been registered"
+            "Wallet with the given ID has not been registered"
         );
 
         return

--- a/solidity/ecdsa/test/WalletRegistry.Inactivity.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Inactivity.ts
@@ -780,7 +780,46 @@ describe("WalletRegistry - Inactivity", () => {
               0,
               membersIDs
             )
-          ).to.be.revertedWith("Wallet with given ID has not been registered")
+          ).to.be.revertedWith(
+            "Wallet with the given ID has not been registered"
+          )
+        })
+      })
+
+      context("when wallet has been closed", async () => {
+        before("close the wallet", async () => {
+          await createSnapshot()
+          await walletRegistry.connect(walletOwner.wallet).closeWallet(walletID)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          const { signatures, signingMembersIndices } =
+            await signOperatorInactivityClaim(
+              members,
+              0,
+              walletPublicKey,
+              subsequentInactiveMembersIndices,
+              groupThreshold
+            )
+
+          await expect(
+            walletRegistry.notifyOperatorInactivity(
+              {
+                walletID,
+                inactiveMembersIndices: subsequentInactiveMembersIndices,
+                signatures,
+                signingMembersIndices,
+              },
+              0,
+              membersIDs
+            )
+          ).to.be.revertedWith(
+            "Wallet with the given ID has not been registered"
+          )
         })
       })
     })


### PR DESCRIPTION
Closes #2864
Depends on #2905; Keeping it as a draft until #2905 is merged.

So far this function was just a stub and now the implementation is there. The
logic is pretty simple - we emit an event and remove the wallet from the
registry.

The idea behind removing the wallet from the registry is that we do not want to
allow reporting inactivity for a closed wallet and at the same time, we do not
want to maintain separate wallet states in `WalletRegistry` - it's happening
already in tBTCv2 `Bridge` contract.