### PR TITLE
ECDSA Wallets: Use unique accounts for staking and operator registration roles in tests

### DIFF
--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -47,7 +47,9 @@ const config: HardhatUserConfig = {
           ? parseInt(process.env.FORKING_BLOCK, 10)
           : undefined,
       },
-      accounts: { count: 70 },
+      // We want to have 10 accounts for various tests and `5 * 100` accounts to use
+      // unique addresses in staking for each operator.
+      accounts: { count: 10 + 5 * 100 },
       tags: ["local"],
       // we use higher gas price for tests to obtain more realistic results
       // for gas refund tests than when the default hardhat ~1 gwei gas price is

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -91,12 +91,8 @@ export const walletRegistryFixture = deployments.createFixture(
     const operators: Operator[] = await registerOperators(
       walletRegistry,
       tToken,
-      (
-        await getUnnamedAccounts()
-      ).slice(
-        unnamedAccountsOffset,
-        unnamedAccountsOffset + constants.groupSize
-      )
+      constants.groupSize,
+      unnamedAccountsOffset
     )
 
     // Set up TokenStaking parameters

--- a/solidity/ecdsa/test/utils/operators.ts
+++ b/solidity/ecdsa/test/utils/operators.ts
@@ -5,10 +5,14 @@ import { ethers } from "hardhat"
 // eslint-disable-next-line import/no-cycle
 import { params } from "../fixtures"
 
-import type { Address } from "hardhat-deploy/types"
-import type { BigNumber } from "ethers"
+import type { BigNumber, BigNumberish } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import type { WalletRegistry, T } from "../../typechain"
+import type {
+  WalletRegistry,
+  T,
+  SortitionPool,
+  TokenStaking,
+} from "../../typechain"
 
 export type OperatorID = number
 export type Operator = {
@@ -18,55 +22,50 @@ export type Operator = {
 
 export async function registerOperators(
   walletRegistry: WalletRegistry,
-  tToken: T,
-  addresses: Address[],
+  t: T,
+  numberOfOperators: number,
+  unnamedSignersOffset = 0,
   stakeAmount: BigNumber = params.minimumAuthorization
 ): Promise<Operator[]> {
   const operators: Operator[] = []
 
-  const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
-
-  const sortitionPool = await ethers.getContractAt(
+  const sortitionPool: SortitionPool = await ethers.getContractAt(
     "SortitionPool",
     await walletRegistry.sortitionPool()
   )
 
-  const staking = await ethers.getContractAt(
+  const staking: TokenStaking = await ethers.getContractAt(
     "TokenStaking",
     await walletRegistry.staking()
   )
 
-  for (let i = 0; i < addresses.length; i++) {
-    const stakingProvider: SignerWithAddress = await ethers.getSigner(
-      addresses[i]
+  const signers = (await ethers.getUnnamedSigners()).slice(unnamedSignersOffset)
+
+  // We use unique accounts for each staking role for each operator.
+  if (signers.length < numberOfOperators * 5) {
+    throw new Error(
+      "not enough unnamed signers; update hardhat network's configuration account count"
     )
+  }
 
-    // TODO: Use unique addresses for each role.
-    const owner: SignerWithAddress = stakingProvider
-    const operator: SignerWithAddress = stakingProvider
-    const beneficiary: SignerWithAddress = stakingProvider
-    const authorizer: SignerWithAddress = stakingProvider
+  for (let i = 0; i < numberOfOperators; i++) {
+    const owner: SignerWithAddress = signers[i]
+    const stakingProvider: SignerWithAddress =
+      signers[1 * numberOfOperators + i]
+    const operator: SignerWithAddress = signers[2 * numberOfOperators + i]
+    const beneficiary: SignerWithAddress = signers[3 * numberOfOperators + i]
+    const authorizer: SignerWithAddress = signers[4 * numberOfOperators + i]
 
-    await tToken.connect(deployer).mint(operator.address, stakeAmount)
-
-    await tToken.connect(stakingProvider).approve(staking.address, stakeAmount)
-
-    await staking
-      .connect(owner)
-      .stake(
-        stakingProvider.address,
-        beneficiary.address,
-        authorizer.address,
-        stakeAmount
-      )
-
-    await staking
-      .connect(authorizer)
-      .increaseAuthorization(
-        stakingProvider.address,
-        walletRegistry.address,
-        stakeAmount
-      )
+    await stake(
+      t,
+      staking,
+      walletRegistry,
+      owner,
+      stakingProvider,
+      stakeAmount,
+      beneficiary,
+      authorizer
+    )
 
     await walletRegistry
       .connect(stakingProvider)
@@ -80,4 +79,37 @@ export async function registerOperators(
   }
 
   return operators
+}
+
+export async function stake(
+  t: T,
+  staking: TokenStaking,
+  randomBeacon: WalletRegistry,
+  owner: SignerWithAddress,
+  stakingProvider: SignerWithAddress,
+  stakeAmount: BigNumberish,
+  beneficiary = stakingProvider,
+  authorizer = stakingProvider
+): Promise<void> {
+  const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
+
+  await t.connect(deployer).mint(owner.address, stakeAmount)
+  await t.connect(owner).approve(staking.address, stakeAmount)
+
+  await staking
+    .connect(owner)
+    .stake(
+      stakingProvider.address,
+      beneficiary.address,
+      authorizer.address,
+      stakeAmount
+    )
+
+  await staking
+    .connect(authorizer)
+    .increaseAuthorization(
+      stakingProvider.address,
+      randomBeacon.address,
+      stakeAmount
+    )
 }


### PR DESCRIPTION
We need to make our tests more robust by using unique addresses for each role that is related to staking and operator registration. 
This requires configuring a hardhat network with more than 500 accounts so each address is unique and doesn't overlap.
Thanks to that the tests are more reliable and reduce the possibility to give false-positive results.

In the Random Beacon we introduce this change in https://github.com/keep-network/keep-core/pull/2903.