### PR TITLE
Clarify test accounts configuration

### DIFF
--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -1,5 +1,3 @@
-import type { HardhatUserConfig } from "hardhat/config"
-
 import "@keep-network/hardhat-helpers"
 import "@keep-network/hardhat-local-networks-config"
 import "@nomiclabs/hardhat-waffle"
@@ -11,6 +9,25 @@ import "hardhat-contract-sizer"
 import "hardhat-dependency-compiler"
 
 import "./tasks"
+import { task } from "hardhat/config"
+import { TASK_TEST } from "hardhat/builtin-tasks/task-names"
+
+import type { HardhatUserConfig } from "hardhat/config"
+
+// Configuration for testing environment.
+export const testConfig = {
+  // How many accounts we expect to define for non-staking related signers, e.g.
+  // deployer, thirdParty, governance.
+  // It is used as an offset for getting accounts for operators and stakes registration.
+  nonStakingAccountsCount: 10,
+
+  // How many roles do we need to define for staking, i.e. stakeOwner, stakingProvider,
+  // operator, beneficiary, authorizer.
+  stakingRolesCount: 5,
+
+  // Number of operators to register. Should be at least the same as group size.
+  operatorsCount: 100,
+}
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -47,9 +64,12 @@ const config: HardhatUserConfig = {
           ? parseInt(process.env.FORKING_BLOCK, 10)
           : undefined,
       },
-      // We want to have 10 accounts for various tests and `5 * 100` accounts to use
-      // unique addresses in staking for each operator.
-      accounts: { count: 10 + 5 * 100 },
+      accounts: {
+        // Number of accounts that should be predefined on the testing environment.
+        count:
+          testConfig.nonStakingAccountsCount +
+          testConfig.stakingRolesCount * testConfig.operatorsCount,
+      },
       tags: ["local"],
       // we use higher gas price for tests to obtain more realistic results
       // for gas refund tests than when the default hardhat ~1 gwei gas price is
@@ -128,5 +148,20 @@ const config: HardhatUserConfig = {
     outDir: "typechain",
   },
 }
+
+task(TASK_TEST, "Runs mocha tests").setAction(async (args, hre, runSuper) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
+  const { constants } = require("./test/fixtures")
+
+  if (testConfig.operatorsCount < constants.groupSize) {
+    throw new Error(
+      "not enough accounts predefined for configured group size: " +
+        `expected group size: ${constants.groupSize} ` +
+        `number of predefined accounts: ${testConfig.operatorsCount}`
+    )
+  }
+
+  return runSuper(args)
+})
 
 export default config

--- a/solidity/ecdsa/test/utils/operators.ts
+++ b/solidity/ecdsa/test/utils/operators.ts
@@ -4,6 +4,7 @@ import { ethers } from "hardhat"
 
 // eslint-disable-next-line import/no-cycle
 import { params } from "../fixtures"
+import { testConfig } from "../../hardhat.config"
 
 import type { BigNumber, BigNumberish } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
@@ -23,8 +24,8 @@ export type Operator = {
 export async function registerOperators(
   walletRegistry: WalletRegistry,
   t: T,
-  numberOfOperators: number,
-  unnamedSignersOffset = 0,
+  numberOfOperators = testConfig.operatorsCount,
+  unnamedSignersOffset = testConfig.nonStakingAccountsCount,
   stakeAmount: BigNumber = params.minimumAuthorization
 ): Promise<Operator[]> {
   const operators: Operator[] = []


### PR DESCRIPTION
To be more clear about accounts configuration for tests we defined
testConfig object that holds the config and those config are reused in
operators registration. Additionally we validate on hardhat test start
if the parameters are configured properly.

This is a follow-up for https://github.com/keep-network/keep-core/pull/2909#discussion_r839449135