### PR TITLE
Random beacon no any

### DIFF
--- a/solidity/random-beacon/.eslintrc
+++ b/solidity/random-beacon/.eslintrc
@@ -7,6 +7,7 @@
       { "devDependencies": ["./test/**/*.ts", "hardhat.config.ts"] }
     ],
     "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "@typescript-eslint/consistent-type-imports": "warn",
     "import/order": [

--- a/solidity/random-beacon/.prettierignore
+++ b/solidity/random-beacon/.prettierignore
@@ -2,5 +2,6 @@ artifacts/
 build/
 cache/
 deployments/
-export.json
+hardhat-dependency-compiler/
 typechain/
+export.json

--- a/solidity/random-beacon/test/BeaconDkgValidator.test.ts
+++ b/solidity/random-beacon/test/BeaconDkgValidator.test.ts
@@ -15,6 +15,7 @@ import { constants } from "./fixtures"
 import { selectGroup, hashUint32Array } from "./utils/groups"
 import { signDkgResult, noMisbehaved, hashDKGMembers } from "./utils/dkg"
 
+import type { BigNumberish } from "ethers"
 import type { Operator } from "./utils/operators"
 import type {
   SortitionPool,
@@ -58,9 +59,18 @@ describe("BeaconDkgValidator", () => {
   const dkgStartBlock = 1337
   const groupPublicKey: string = ethers.utils.hexValue(blsData.groupPubKey)
 
-  let selectedOperators
+  let selectedOperators: Operator[]
 
-  let prepareDkgResult
+  let prepareDkgResult: (
+    _groupMembers: Operator[],
+    _signers: Operator[],
+    _groupPublicKey: string,
+    _misbehaved: number[],
+    _startBlock: number,
+    _numberOfSignatures?: number,
+    _submitterIndex?: number
+  ) => Promise<DKG.ResultStruct>
+
   let validator: DKGValidator
 
   before("load test fixture", async () => {
@@ -85,7 +95,7 @@ describe("BeaconDkgValidator", () => {
       _startBlock: number,
       _numberOfSignatures = 33,
       _submitterIndex = 1
-    ) => {
+    ): Promise<DKG.ResultStruct> => {
       const { signingMembersIndices, signaturesBytes } = await signDkgResult(
         _signers,
         _groupPublicKey,
@@ -113,10 +123,10 @@ describe("BeaconDkgValidator", () => {
 
   describe("validate", () => {
     const testValidate = async (
-      _groupMembers,
-      _signers,
-      _groupPublicKey,
-      _misbehaved,
+      _groupMembers: Operator[],
+      _signers: Operator[],
+      _groupPublicKey: string,
+      _misbehaved: number[],
       _membersHash?: string
     ) => {
       const dkgResult = await prepareDkgResult(
@@ -284,9 +294,9 @@ describe("BeaconDkgValidator", () => {
 
   describe("validateFields", () => {
     const testValidateFields = async (
-      _groupMembers,
-      _groupPublicKey,
-      _misbehaved,
+      _groupMembers: Operator[],
+      _groupPublicKey: string,
+      _misbehaved: number[],
       _numberOfSignatures = 33
     ) => {
       const dkgResult = await prepareDkgResult(
@@ -521,7 +531,9 @@ describe("BeaconDkgValidator", () => {
     })
 
     context("when signing members indices array is malformed", async () => {
-      const testSigningMembers = async (_signingMembersIndices) => {
+      const testSigningMembers = async (
+        _signingMembersIndices: BigNumberish[]
+      ) => {
         const dkgResult = await prepareDkgResult(
           selectedOperators,
           selectedOperators,
@@ -581,7 +593,7 @@ describe("BeaconDkgValidator", () => {
   })
 
   describe("validateGroupMembers", () => {
-    const testValidateGroupMembers = async (_groupMembers) => {
+    const testValidateGroupMembers = async (_groupMembers: Operator[]) => {
       const dkgResult = await prepareDkgResult(
         _groupMembers,
         _groupMembers,
@@ -611,7 +623,10 @@ describe("BeaconDkgValidator", () => {
   })
 
   describe("validateSignatures", () => {
-    const testValidateSignatures = async (_groupMembers, _signers) => {
+    const testValidateSignatures = async (
+      _groupMembers: Operator[],
+      _signers: Operator[]
+    ) => {
       const dkgResult = await prepareDkgResult(
         _groupMembers,
         _signers,

--- a/solidity/random-beacon/test/Groups.Expiration.test.ts
+++ b/solidity/random-beacon/test/Groups.Expiration.test.ts
@@ -5,6 +5,7 @@ import { expect } from "chai"
 
 import { noMisbehaved, hashDKGMembers } from "./utils/dkg"
 
+import type { BigNumberish } from "ethers"
 import type { GroupsStub, GroupsStub__factory } from "../typechain"
 
 const fixture = async () => {
@@ -290,7 +291,7 @@ describe("Groups", () => {
     })
   })
 
-  async function addGroups(firstGroup, numberOfGroups) {
+  async function addGroups(firstGroup: number, numberOfGroups: number) {
     for (let i = firstGroup; i < firstGroup + numberOfGroups; i++) {
       await groups.addGroup(
         ethers.utils.hexlify(i),
@@ -299,7 +300,7 @@ describe("Groups", () => {
     }
   }
 
-  async function expireGroup(groupId) {
+  async function expireGroup(groupId: BigNumberish) {
     const group = await groups.getGroupById(groupId)
     const registrationBlock = group.registrationBlockNumber
     const currentBlock = await ethers.provider.getBlock("latest")
@@ -314,8 +315,8 @@ describe("Groups", () => {
   }
 
   async function addTerminatedGroups(
-    firstGroupIdToTerminate,
-    numberOfTerminatedGroups
+    firstGroupIdToTerminate: number,
+    numberOfTerminatedGroups: number
   ) {
     for (
       let i = firstGroupIdToTerminate;
@@ -326,7 +327,11 @@ describe("Groups", () => {
     }
   }
 
-  async function runExpirationTest(numberOfGroups, expiredCount, beaconValue) {
+  async function runExpirationTest(
+    numberOfGroups: number,
+    expiredCount: number,
+    beaconValue: BigNumberish
+  ) {
     await addGroups(1, numberOfGroups)
     if (expiredCount > 0) {
       // expire group accepts group index, we need to subtract one from the

--- a/solidity/random-beacon/test/Groups.Termination.test.ts
+++ b/solidity/random-beacon/test/Groups.Termination.test.ts
@@ -5,6 +5,7 @@ import { expect } from "chai"
 
 import { noMisbehaved, hashDKGMembers } from "./utils/dkg"
 
+import type { BigNumberish } from "ethers"
 import type { GroupsStub, GroupsStub__factory } from "../typechain"
 
 const fixture = async () => {
@@ -242,7 +243,7 @@ describe("Groups", () => {
       })
     })
 
-    async function addGroups(start, numberOfGroups) {
+    async function addGroups(start: number, numberOfGroups: number) {
       for (let i = start; i <= numberOfGroups; i++) {
         await groups.addGroup(
           ethers.utils.hexlify(i),
@@ -252,10 +253,10 @@ describe("Groups", () => {
     }
 
     async function runTerminationTest(
-      groupsCount,
-      expiredCount,
-      terminatedGroups,
-      beaconValue
+      groupsCount: number,
+      expiredCount: number,
+      terminatedGroups: number[],
+      beaconValue: BigNumberish
     ) {
       await addGroups(1, expiredCount)
 

--- a/solidity/random-beacon/test/RandomBeacon.Authorization.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Authorization.test.ts
@@ -7,7 +7,7 @@ import { to1e18 } from "@keep-network/hardhat-helpers/dist/src/number"
 import { constants, params, testDeployment } from "./fixtures"
 
 import type { FakeContract } from "@defi-wonderland/smock"
-import type { BigNumber, ContractTransaction } from "ethers"
+import type { BigNumber, BigNumberish, ContractTransaction } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
   RandomBeacon,
@@ -40,7 +40,7 @@ describe("RandomBeacon - Authorization", () => {
   let thirdParty: SignerWithAddress
   let slasher: FakeContract<IApplication>
 
-  const stakedAmount = to1e18(1000000) // 1M T
+  const stakedAmount = to1e18(1_000_000) // 1MM T
   let minimumAuthorization: BigNumber
 
   before("load test fixture", async () => {
@@ -541,7 +541,7 @@ describe("RandomBeacon - Authorization", () => {
       context("when decreasing to zero", () => {
         let tx: ContractTransaction
         const decreasingTo = 0
-        let decreasingBy
+        let decreasingBy: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -592,8 +592,8 @@ describe("RandomBeacon - Authorization", () => {
 
       context("when decreasing to the minimum", () => {
         let tx: ContractTransaction
-        let decreasingTo
-        let decreasingBy
+        let decreasingTo: BigNumber
+        let decreasingBy: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -645,8 +645,8 @@ describe("RandomBeacon - Authorization", () => {
 
       context("when decreasing to a value above the minimum", () => {
         let tx: ContractTransaction
-        let decreasingTo
-        let decreasingBy
+        let decreasingTo: BigNumber
+        let decreasingBy: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -777,7 +777,7 @@ describe("RandomBeacon - Authorization", () => {
       context("when decreasing to zero", () => {
         let tx: ContractTransaction
         const decreasingTo = 0
-        let decreasingBy
+        let decreasingBy: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -827,8 +827,8 @@ describe("RandomBeacon - Authorization", () => {
 
       context("when decreasing to the minimum", () => {
         let tx: ContractTransaction
-        let decreasingTo
-        let decreasingBy
+        let decreasingTo: BigNumber
+        let decreasingBy: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -879,8 +879,8 @@ describe("RandomBeacon - Authorization", () => {
 
       context("when decreasing to a value above the minimum", () => {
         let tx: ContractTransaction
-        let decreasingTo
-        let decreasingBy
+        let decreasingTo: BigNumber
+        let decreasingBy: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -1517,7 +1517,7 @@ describe("RandomBeacon - Authorization", () => {
     context(
       "when the operator has more than the minimum stake authorized",
       () => {
-        let authorizedStake
+        let authorizedStake: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -1557,7 +1557,7 @@ describe("RandomBeacon - Authorization", () => {
     )
 
     context("when operator is in the process of deauthorizing", () => {
-      let deauthorizingTo
+      let deauthorizingTo: BigNumber
 
       before(async () => {
         await createSnapshot()
@@ -1616,7 +1616,7 @@ describe("RandomBeacon - Authorization", () => {
     context(
       "when operator is in the process of deauthorizing but also increased authorization in the meantime",
       () => {
-        let expectedAuthorizedStake
+        let expectedAuthorizedStake: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -1821,7 +1821,7 @@ describe("RandomBeacon - Authorization", () => {
 
       context("when the authorization increased", () => {
         let tx: ContractTransaction
-        let expectedWeight
+        let expectedWeight: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -1869,7 +1869,7 @@ describe("RandomBeacon - Authorization", () => {
         "when there was an authorization decrease request to non-zero",
         () => {
           let tx: ContractTransaction
-          let expectedWeight
+          let expectedWeight: BigNumber
 
           before(async () => {
             await createSnapshot()
@@ -1975,7 +1975,7 @@ describe("RandomBeacon - Authorization", () => {
         "when operator is in the process of deauthorizing but also increased authorization in the meantime",
         () => {
           let tx: ContractTransaction
-          let expectedWeight
+          let expectedWeight: BigNumber
 
           before(async () => {
             await createSnapshot()
@@ -2050,7 +2050,7 @@ describe("RandomBeacon - Authorization", () => {
     })
 
     context("when staking provider has stake authorized", () => {
-      let authorizedAmount
+      let authorizedAmount: BigNumber
 
       before(async () => {
         await createSnapshot()
@@ -2079,8 +2079,8 @@ describe("RandomBeacon - Authorization", () => {
     context(
       "when staking provider has some part of the stake deauthorizing",
       () => {
-        let authorizedAmount
-        let deauthorizingAmount
+        let authorizedAmount: BigNumber
+        let deauthorizingAmount: BigNumber
 
         before(async () => {
           await createSnapshot()
@@ -2526,7 +2526,7 @@ describe("RandomBeacon - Authorization", () => {
   // Testing final states for scenarios when functions are invoked one after
   // another. Operator is known and registered in the sortition pool.
   context("mixed interactions", () => {
-    let initialIncrease
+    let initialIncrease: BigNumber
 
     before(async () => {
       await createSnapshot()
@@ -2554,7 +2554,7 @@ describe("RandomBeacon - Authorization", () => {
 
     // Invoke `increaseAuthorization` after `increaseAuthorization`.
     describe("authorizationIncreased -> authorizationIncreased", () => {
-      let secondIncrease
+      let secondIncrease: BigNumberish
 
       before(async () => {
         await createSnapshot()
@@ -2592,8 +2592,8 @@ describe("RandomBeacon - Authorization", () => {
     // Invoke `increaseAuthorization` after `authorizationDecreaseRequested`.
     // The decrease is not yet approved when `increaseAuthorization` is called.
     describe("authorizationDecreaseRequested -> authorizationIncreased", () => {
-      let firstDecrease
-      let secondIncrease
+      let firstDecrease: BigNumberish
+      let secondIncrease: BigNumberish
 
       before(async () => {
         await createSnapshot()
@@ -2642,8 +2642,8 @@ describe("RandomBeacon - Authorization", () => {
     // Invoke `increaseAuthorization` after `approveAuthorizationDecrease`.
     // The decrease is approved when `increaseAuthorization` is called.
     describe("non-zero approveAuthorizationDecrease -> authorizationIncreased", () => {
-      let firstDecrease
-      let secondIncrease
+      let firstDecrease: BigNumber
+      let secondIncrease: BigNumber
 
       before(async () => {
         await createSnapshot()
@@ -2694,7 +2694,7 @@ describe("RandomBeacon - Authorization", () => {
 
     // Invoke `increaseAuthorization` after the authorization was decreased to 0.
     describe("to-zero approveAuthorizationDecrease -> authorizationIncreased", () => {
-      let secondIncrease
+      let secondIncrease: BigNumberish
 
       before(async () => {
         await createSnapshot()
@@ -2743,8 +2743,8 @@ describe("RandomBeacon - Authorization", () => {
     // Invoke `increaseAuthorization` after `involuntaryAuthorizationDecrease`
     // when the authorization amount dropped below the minimum authorization.
     describe("below-minimum involuntaryAuthorizationDecrease -> authorizationIncreased", () => {
-      let slashingTo
-      let secondIncrease
+      let slashingTo: BigNumber
+      let secondIncrease: BigNumber
 
       before(async () => {
         await createSnapshot()
@@ -2800,8 +2800,8 @@ describe("RandomBeacon - Authorization", () => {
     })
 
     describe("authorizationDecreaseRequested -> involuntaryAuthorizationDecrease", () => {
-      let decreasedAmount
-      let slashingTo
+      let decreasedAmount: BigNumber
+      let slashingTo: BigNumber
 
       before(async () => {
         await createSnapshot()
@@ -2847,8 +2847,8 @@ describe("RandomBeacon - Authorization", () => {
     })
 
     describe("authorizationDecreaseRequested -> involuntaryAuthorizationDecrease -> approveAuthorizationDecrease", () => {
-      let decreasedAmount
-      let slashingTo
+      let decreasedAmount: BigNumber
+      let slashingTo: BigNumber
 
       before(async () => {
         await createSnapshot()
@@ -2897,8 +2897,8 @@ describe("RandomBeacon - Authorization", () => {
     })
 
     describe("approveAuthorizationDecrease -> involuntaryAuthorizationDecrease", () => {
-      let decreasedAmount
-      let slashingTo
+      let decreasedAmount: BigNumberish
+      let slashingTo: BigNumberish
 
       before(async () => {
         await createSnapshot()

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -482,7 +482,7 @@ describe("RandomBeacon - Group Creation", () => {
 
     context("when genesis dkg started", async () => {
       let startBlock: number
-      let genesisSeed
+      let genesisSeed: BigNumber
 
       before("run genesis", async () => {
         await createSnapshot()
@@ -1785,8 +1785,8 @@ describe("RandomBeacon - Group Creation", () => {
       })
 
       context("with misbehaved operators", async () => {
-        const misbehavedIndices = [2, 9, 11, 30, 60, 64]
-        let misbehavedIds
+        const misbehavedIndices: number[] = [2, 9, 11, 30, 60, 64]
+        let misbehavedIds: number[]
         let tx: ContractTransaction
         let dkgResult: DKG.ResultStruct
 
@@ -2142,7 +2142,7 @@ describe("RandomBeacon - Group Creation", () => {
 
     context("with group creation in progress", async () => {
       let startBlock: number
-      let genesisSeed
+      let genesisSeed: BigNumber
 
       before("run genesis", async () => {
         await createSnapshot()

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai"
 
 import { randomBeaconDeployment } from "./fixtures"
 
-import type { Signer } from "ethers"
+import type { ContractTransaction, Signer } from "ethers"
 import type { RandomBeaconStub } from "../typechain"
 
 describe("RandomBeacon - Parameters", () => {
@@ -43,7 +43,7 @@ describe("RandomBeacon - Parameters", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
       beforeEach(async () => {
         tx = await randomBeacon
           .connect(governance)
@@ -110,7 +110,7 @@ describe("RandomBeacon - Parameters", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       beforeEach(async () => {
         tx = await randomBeacon
@@ -159,7 +159,7 @@ describe("RandomBeacon - Parameters", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
       beforeEach(async () => {
         tx = await randomBeacon
           .connect(governance)
@@ -205,7 +205,7 @@ describe("RandomBeacon - Parameters", () => {
 
     context("when the caller is the owner", () => {
       context("when values are valid", () => {
-        let tx
+        let tx: ContractTransaction
         beforeEach(async () => {
           tx = await randomBeacon
             .connect(governance)
@@ -321,7 +321,7 @@ describe("RandomBeacon - Parameters", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
       beforeEach(async () => {
         tx = await randomBeacon
           .connect(governance)
@@ -408,7 +408,7 @@ describe("RandomBeacon - Parameters", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
       beforeEach(async () => {
         tx = await randomBeacon
           .connect(governance)

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -417,7 +417,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -497,7 +497,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -575,7 +575,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -655,7 +655,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -706,7 +706,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -786,7 +786,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -888,7 +888,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -968,7 +968,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1046,7 +1046,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1129,7 +1129,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1228,7 +1228,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1308,7 +1308,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1388,7 +1388,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1471,7 +1471,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1554,7 +1554,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1638,7 +1638,7 @@ describe("RandomBeaconGovernance", () => {
       "when the update process is initialized and governance delay passed",
       () => {
         const newValue = 234
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1726,7 +1726,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1809,7 +1809,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1865,7 +1865,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1948,7 +1948,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2001,7 +2001,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2084,7 +2084,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2140,7 +2140,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2223,7 +2223,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2279,7 +2279,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2362,7 +2362,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2418,7 +2418,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2501,7 +2501,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2557,7 +2557,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2640,7 +2640,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2696,7 +2696,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2779,7 +2779,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2845,7 +2845,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner and value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2928,7 +2928,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2994,7 +2994,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner and value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -3077,7 +3077,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -3133,7 +3133,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -3213,7 +3213,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -3264,7 +3264,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -3345,7 +3345,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -3411,7 +3411,7 @@ describe("RandomBeaconGovernance", () => {
     })
 
     context("when the caller is the owner and value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -3494,7 +3494,7 @@ describe("RandomBeaconGovernance", () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()

--- a/solidity/random-beacon/test/system/e2e.test.ts
+++ b/solidity/random-beacon/test/system/e2e.test.ts
@@ -193,7 +193,7 @@ describe("System -- e2e", () => {
     })
   })
 
-  async function approveTokenForFee(_requester) {
+  async function approveTokenForFee(_requester: SignerWithAddress) {
     await t.mint(_requester.address, relayRequestFee)
     await t.connect(_requester).approve(randomBeacon.address, relayRequestFee)
   }

--- a/solidity/random-beacon/test/utils/dkg.test.ts
+++ b/solidity/random-beacon/test/utils/dkg.test.ts
@@ -4,11 +4,11 @@ import { expect } from "chai"
 import { hashDKGMembers } from "./dkg"
 
 describe("hashDKGMembers", () => {
-  const members = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
+  const members: number[] = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
 
   context("when there are no misbehaved members", () => {
     it("should hash all the members", () => {
-      const misbehavedMembers = []
+      const misbehavedMembers: number[] = []
       const expectedMembers = members
 
       const actualHash = hashDKGMembers(members, misbehavedMembers)

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -16,7 +16,7 @@ import type {
   DkgResultSubmittedEvent,
 } from "../../typechain/BeaconDkg"
 
-export const noMisbehaved = []
+export const noMisbehaved: number[] = []
 
 export async function genesis(
   randomBeacon: RandomBeacon

--- a/solidity/random-beacon/tsconfig.json
+++ b/solidity/random-beacon/tsconfig.json
@@ -2,6 +2,7 @@
   "files": ["./hardhat.config.ts"],
   "include": ["./deploy", "./test", "./typechain"],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
This PR updates configuration for typescript to require typings and discourage `any` usage.

See: 
- https://www.typescriptlang.org/tsconfig#noImplicitAny
- https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-explicit-any.md#no-explicit-any