### PR TITLE
Follow-up: Notify operator inactivity refund

### DIFF
--- a/solidity/ecdsa/deploy/02_deploy_reimbursement_pool.ts
+++ b/solidity/ecdsa/deploy/02_deploy_reimbursement_pool.ts
@@ -18,10 +18,12 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
   })
 
-  await deployerSigner.sendTransaction({
-    to: ReimbursementPool.address,
-    value: ethers.utils.parseEther("100.0"), // Send 100.0 ETH
-  })
+  if (deployments.getNetworkName() === "hardhat") {
+    await deployerSigner.sendTransaction({
+      to: ReimbursementPool.address,
+      value: ethers.utils.parseEther("100.0"), // Send 100.0 ETH
+    })
+  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -1044,7 +1044,7 @@ describe("WalletRegistryGovernance", async () => {
       })
     })
 
-    context("when the caller is the owner and value is correct", () => {
+    context("when the caller is the owner", () => {
       let tx
 
       before(async () => {
@@ -1178,7 +1178,7 @@ describe("WalletRegistryGovernance", async () => {
       })
     })
 
-    context("when the caller is the owner and value is correct", () => {
+    context("when the caller is the owner", () => {
       let tx
 
       before(async () => {
@@ -1642,7 +1642,7 @@ describe("WalletRegistryGovernance", async () => {
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the owner and the value is correct", () => {
       let tx
 
       before(async () => {
@@ -1805,7 +1805,7 @@ describe("WalletRegistryGovernance", async () => {
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the owner and the value is correct", () => {
       let tx
 
       before(async () => {
@@ -2145,7 +2145,7 @@ describe("WalletRegistryGovernance", async () => {
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the owner and the value is correct", () => {
       let tx
 
       before(async () => {
@@ -2431,7 +2431,7 @@ describe("WalletRegistryGovernance", async () => {
       })
     })
 
-    context("when the caller is the owner and value is correct", () => {
+    context("when the caller is the owner", () => {
       let tx
 
       before(async () => {


### PR DESCRIPTION
This PR is a follow-up of review comments to #2795:
- [Reordered inactive operators gas offsets in ECDSA governance contract](https://github.com/keep-network/keep-core/commit/2817ffed2d23919ef8bb2ff312cc8a037b28adac): Reordered fields, events, and functions with no single change in the logic so that gas offset info is next to each other.
- [Send 100 ETH to reimbursement pool only for hardhat tests](https://github.com/keep-network/keep-core/commit/bb9005443dc2b6aef9ce869977a843d99785caeb): Deployment scripts are used for testing and for real deployment. We do not want to send any ETH from deployer account when deploying to mainnet. This is needed only for tests.
- [Improved test names for wallet registry governance](https://github.com/keep-network/keep-core/commit/e6e9ae03c37c10d6eac28a5e5afc16331660088c): For functions where the value is not validated at all, we should not say "... and value is correct" in test. For functions when we do the validation and the test structure does not already make it clear the correct value is used, we should add "... and value is correct".