### PR TITLE
RandomBeacon: withdrawRewards

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -562,7 +562,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable {
     }
 
     /// @notice Withdraw rewards for the given staking provider to their
-    ///         beneficiary address Reverts if staking provider has not
+    ///         beneficiary address. Reverts if staking provider has not
     ///         registered the operator address.
     function withdrawRewards(address stakingProvider) external {
         address operator = stakingProviderToOperator(stakingProvider);

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -561,6 +561,16 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable {
         );
     }
 
+    /// @notice Withdraw rewards for the given staking provider to their
+    ///         beneficiary address Reverts if staking provider has not
+    ///         registered the operator address.
+    function withdrawRewards(address stakingProvider) external {
+        address operator = stakingProviderToOperator(stakingProvider);
+        require(operator != address(0), "Unknown operator");
+        (, address beneficiary, ) = staking.rolesOf(stakingProvider);
+        sortitionPool.withdrawRewards(operator, beneficiary);
+    }
+
     /// @notice Withdraws rewards belonging to operators marked as ineligible
     ///         for sortition pool rewards.
     /// @dev Can be called only by the contract owner, which should be the
@@ -1312,7 +1322,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable {
 
     /// @notice Returns operator registered for the given staking provider.
     function stakingProviderToOperator(address stakingProvider)
-        external
+        public
         view
         returns (address)
     {

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -84,6 +84,10 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 0, // take the first account as deployer
     },
+    governance: {
+      default: 1,
+      // mainnet: ""
+    },
   },
   external: {
     contracts: [

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -30,7 +30,7 @@
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts"
   },
   "dependencies": {
-    "@keep-network/sortition-pools": "^2.0.0-pre.6",
+    "@keep-network/sortition-pools": "^2.0.0-pre.7",
     "@openzeppelin/contracts": "^4.4.2",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
     "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten"

--- a/solidity/random-beacon/test/BeaconDkgValidator.test.ts
+++ b/solidity/random-beacon/test/BeaconDkgValidator.test.ts
@@ -21,7 +21,6 @@ import type {
   SortitionPool,
   BeaconDkgValidator as DKGValidator,
   BeaconDkg as DKG,
-  TokenStaking,
   T,
 } from "../typechain"
 
@@ -31,11 +30,9 @@ const { to1e18 } = helpers.number
 const fixture = async () => {
   await deployments.fixture(["TokenStaking"])
   const t: T = await ethers.getContract("T")
-  const staking: TokenStaking = await ethers.getContract("TokenStaking")
 
   const SortitionPool = await ethers.getContractFactory("SortitionPool")
   const sortitionPool = (await SortitionPool.deploy(
-    staking.address,
     t.address,
     constants.poolWeightDivisor
   )) as SortitionPool

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -1929,13 +1929,19 @@ describe("RandomBeacon - Group Creation", () => {
 
           dkgRewardsPoolBalance = await randomBeacon.dkgRewardsPool()
 
+          const governance: SignerWithAddress = await ethers.getNamedSigner(
+            "governance"
+          )
+
           // Set the DKG result submission reward to twice the amount of test
           // tokens in the DKG rewards pool
-          await randomBeaconGovernance.beginDkgResultSubmissionRewardUpdate(
-            dkgRewardsPoolBalance.mul(2)
-          )
+          await randomBeaconGovernance
+            .connect(governance)
+            .beginDkgResultSubmissionRewardUpdate(dkgRewardsPoolBalance.mul(2))
           await helpers.time.increaseTime(params.governanceDelay)
-          await randomBeaconGovernance.finalizeDkgResultSubmissionRewardUpdate()
+          await randomBeaconGovernance
+            .connect(governance)
+            .finalizeDkgResultSubmissionRewardUpdate()
 
           const [genesisTx, genesisSeed] = await genesis(randomBeacon)
           const startBlock: number = genesisTx.blockNumber

--- a/solidity/random-beacon/test/RandomBeacon.Rewards.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Rewards.test.ts
@@ -5,10 +5,18 @@ import { to1e18 } from "@keep-network/hardhat-helpers/dist/src/number"
 
 import { constants, testDeployment } from "./fixtures"
 import { registerOperators } from "./utils/operators"
+import { createGroup } from "./utils/groups"
+import { signOperatorInactivityClaim } from "./utils/inacvitity"
 
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { Operator } from "./utils/operators"
-import type { RandomBeacon, T, SortitionPool, TokenStaking } from "../typechain"
+import type {
+  RandomBeacon,
+  T,
+  SortitionPool,
+  TokenStaking,
+  RandomBeaconGovernance,
+} from "../typechain"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
@@ -17,7 +25,7 @@ const fixture = async () => {
 
   // Accounts offset provided to slice getUnnamedSigners have to include number
   // of unnamed accounts that were already used.
-  const signers = await registerOperators(
+  const operators = await registerOperators(
     contracts.randomBeacon as RandomBeacon,
     contracts.t as T,
     constants.groupSize,
@@ -25,24 +33,30 @@ const fixture = async () => {
   )
 
   const randomBeacon = contracts.randomBeacon as RandomBeacon
+  const randomBeaconGovernance =
+    contracts.randomBeaconGovernance as RandomBeaconGovernance
   const staking = contracts.staking as TokenStaking
   const sortitionPool = contracts.sortitionPool as SortitionPool
   const t = contracts.t as T
 
   return {
     randomBeacon,
+    randomBeaconGovernance,
     staking,
     sortitionPool,
     t,
-    signers,
+    operators,
   }
 }
 
 describe("RandomBeacon - Rewards", () => {
+  let deployer: SignerWithAddress
+  let governance: SignerWithAddress
   let thirdParty: SignerWithAddress
-  let signers: Operator[]
+  let operators: Operator[]
 
   let randomBeacon: RandomBeacon
+  let randomBeaconGovernance: RandomBeaconGovernance
   let staking: TokenStaking
   let sortitionPool: SortitionPool
   let t: T
@@ -50,16 +64,18 @@ describe("RandomBeacon - Rewards", () => {
   const rewardAmount = to1e18(100000)
 
   before(async () => {
-    ;({ randomBeacon, staking, sortitionPool, t, signers } =
-      await waffle.loadFixture(fixture))
+    ;({
+      randomBeacon,
+      randomBeaconGovernance,
+      staking,
+      sortitionPool,
+      t,
+      operators,
+    } = await waffle.loadFixture(fixture))
     ;[thirdParty] = await ethers.getUnnamedSigners()
-    const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
 
-    // Allocate sortition pool rewards
-    await t.connect(deployer).mint(deployer.address, rewardAmount)
-    await t
-      .connect(deployer)
-      .approveAndCall(sortitionPool.address, rewardAmount, [])
+    deployer = await ethers.getNamedSigner("deployer")
+    governance = await ethers.getNamedSigner("governance")
   })
 
   describe("withdrawRewards", () => {
@@ -74,6 +90,12 @@ describe("RandomBeacon - Rewards", () => {
     context("when called for a known operator", () => {
       before(async () => {
         await createSnapshot()
+
+        // Allocate sortition pool rewards
+        await t.connect(deployer).mint(deployer.address, rewardAmount)
+        await t
+          .connect(deployer)
+          .approveAndCall(sortitionPool.address, rewardAmount, [])
       })
 
       after(async () => {
@@ -81,7 +103,7 @@ describe("RandomBeacon - Rewards", () => {
       })
 
       it("should withdraw rewards", async () => {
-        const operator = signers[0].signer.address
+        const operator = operators[0].signer.address
         const stakingProvider = await randomBeacon.operatorToStakingProvider(
           operator
         )
@@ -90,6 +112,78 @@ describe("RandomBeacon - Rewards", () => {
         expect(await t.balanceOf(beneficiary)).to.equal(0)
         await randomBeacon.withdrawRewards(stakingProvider)
         expect(await t.balanceOf(beneficiary)).to.be.gt(0)
+      })
+    })
+  })
+
+  describe("withdrawIneligibleRewards", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          randomBeacon
+            .connect(thirdParty)
+            .withdrawIneligibleRewards(thirdParty.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      before(async () => {
+        await createSnapshot()
+
+        await createGroup(randomBeacon, operators)
+        const groupId = 0
+        const group = await randomBeacon["getGroup(uint64)"](groupId)
+
+        const inactiveMembersIndices = [1, 2, 3]
+
+        const { signatures, signingMembersIndices } =
+          await signOperatorInactivityClaim(
+            operators,
+            0,
+            group.groupPubKey,
+            inactiveMembersIndices,
+            33
+          )
+
+        const claimSender = operators[0].signer
+        await randomBeacon.connect(claimSender).notifyOperatorInactivity(
+          {
+            groupId,
+            inactiveMembersIndices,
+            signatures,
+            signingMembersIndices,
+          },
+          0,
+          operators.map((operator) => operator.id)
+        )
+
+        // Allocate sortition pool rewards
+        await t.connect(deployer).mint(deployer.address, rewardAmount)
+        await t
+          .connect(deployer)
+          .approveAndCall(sortitionPool.address, rewardAmount, [])
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should withdraw ineligible rewards", async () => {
+        // Withdraw rewards for ineligible operator. This action recalculates
+        // the balance of "ineligible rewards" available for withdrawal from
+        // the Sortition Pool
+        const operator = operators[0].signer.address
+        const stakingProvider = await randomBeacon.operatorToStakingProvider(
+          operator
+        )
+        await randomBeacon.withdrawRewards(stakingProvider)
+
+        expect(await t.balanceOf(thirdParty.address)).to.equal(0)
+        await randomBeaconGovernance
+          .connect(governance)
+          .withdrawIneligibleRewards(thirdParty.address)
+        expect(await t.balanceOf(thirdParty.address)).to.be.gt(0)
       })
     })
   })

--- a/solidity/random-beacon/test/RandomBeacon.Rewards.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Rewards.test.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-extra-semi */
+import { ethers, waffle, helpers } from "hardhat"
+import { expect } from "chai"
+import { to1e18 } from "@keep-network/hardhat-helpers/dist/src/number"
+
+import { constants, testDeployment } from "./fixtures"
+import { registerOperators } from "./utils/operators"
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { Operator } from "./utils/operators"
+import type { RandomBeacon, T, SortitionPool, TokenStaking } from "../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+const fixture = async () => {
+  const contracts = await testDeployment()
+
+  // Accounts offset provided to slice getUnnamedSigners have to include number
+  // of unnamed accounts that were already used.
+  const signers = await registerOperators(
+    contracts.randomBeacon as RandomBeacon,
+    contracts.t as T,
+    constants.groupSize,
+    1
+  )
+
+  const randomBeacon = contracts.randomBeacon as RandomBeacon
+  const staking = contracts.staking as TokenStaking
+  const sortitionPool = contracts.sortitionPool as SortitionPool
+  const t = contracts.t as T
+
+  return {
+    randomBeacon,
+    staking,
+    sortitionPool,
+    t,
+    signers,
+  }
+}
+
+describe("RandomBeacon - Rewards", () => {
+  let thirdParty: SignerWithAddress
+  let signers: Operator[]
+
+  let randomBeacon: RandomBeacon
+  let staking: TokenStaking
+  let sortitionPool: SortitionPool
+  let t: T
+
+  const rewardAmount = to1e18(100000)
+
+  before(async () => {
+    ;({ randomBeacon, staking, sortitionPool, t, signers } =
+      await waffle.loadFixture(fixture))
+    ;[thirdParty] = await ethers.getUnnamedSigners()
+    const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
+
+    // Allocate sortition pool rewards
+    await t.connect(deployer).mint(deployer.address, rewardAmount)
+    await t
+      .connect(deployer)
+      .approveAndCall(sortitionPool.address, rewardAmount, [])
+  })
+
+  describe("withdrawRewards", () => {
+    context("when called for an unknown operator", () => {
+      it("should revert", async () => {
+        await expect(
+          randomBeacon.withdrawRewards(thirdParty.address)
+        ).to.be.revertedWith("Unknown operator")
+      })
+    })
+
+    context("when called for a known operator", () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should withdraw rewards", async () => {
+        const operator = signers[0].signer.address
+        const stakingProvider = await randomBeacon.operatorToStakingProvider(
+          operator
+        )
+        const { beneficiary } = await staking.rolesOf(stakingProvider)
+
+        expect(await t.balanceOf(beneficiary)).to.equal(0)
+        await randomBeacon.withdrawRewards(stakingProvider)
+        expect(await t.balanceOf(beneficiary)).to.be.gt(0)
+      })
+    })
+  })
+})

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -12,99 +12,106 @@ import type {
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
+const governanceDelay = 604800 // 1 week
+
+const initialRelayRequestFee = 100000
+const initialRelayEntrySoftTimeout = 10
+const initialRelayEntryHardTimeout = 100
+const initialCallbackGasLimit = 900000
+const initialGroupCreationFrequency = 4
+const initialGroupLifeTime = 60 * 60 * 24 * 7
+const initialDkgResultChallengePeriodLength = 60
+const initialDkgResultSubmissionTimeout = 200
+const initialDkgSubmitterPrecedencePeriodLength = 180
+const initialDkgResultSubmissionReward = 500000
+const initialSortitionPoolUnlockingReward = 5000
+const initialIneligibleOperatorNotifierReward = 6000
+const initialRelayEntrySubmissionFailureSlashingAmount = 1000
+const initialMaliciousDkgResultSlashingAmount = 1000000000
+const initialUnauthorizedSigningSlashingAmount = 1000000000
+const initialSortitionPoolRewardsBanDuration = 1209600
+const initialRelayEntryTimeoutNotificationRewardMultiplier = 5
+const initialUnauthorizedSignatureNotificationRewardMultiplier = 5
+const initialMinimumAuthorization = 1000000
+const initialAuthorizationDecreaseDelay = 86400
+const initialDkgMaliciousResultNotificationRewardMultiplier = 5
+
+const fixture = async () => {
+  const governance = await ethers.getNamedSigner("deployer")
+
+  const contracts = await randomBeaconDeployment()
+
+  const randomBeacon = contracts.randomBeacon as RandomBeacon
+
+  await randomBeacon
+    .connect(governance)
+    .updateRelayEntryParameters(
+      initialRelayRequestFee,
+      initialRelayEntrySoftTimeout,
+      initialRelayEntryHardTimeout,
+      initialCallbackGasLimit
+    )
+  await randomBeacon
+    .connect(governance)
+    .updateGroupCreationParameters(
+      initialGroupCreationFrequency,
+      initialGroupLifeTime
+    )
+  await randomBeacon
+    .connect(governance)
+    .updateDkgParameters(
+      initialDkgResultChallengePeriodLength,
+      initialDkgResultSubmissionTimeout,
+      initialDkgSubmitterPrecedencePeriodLength
+    )
+  await randomBeacon
+    .connect(governance)
+    .updateRewardParameters(
+      initialDkgResultSubmissionReward,
+      initialSortitionPoolUnlockingReward,
+      initialIneligibleOperatorNotifierReward,
+      initialSortitionPoolRewardsBanDuration,
+      initialRelayEntryTimeoutNotificationRewardMultiplier,
+      initialUnauthorizedSignatureNotificationRewardMultiplier,
+      initialDkgMaliciousResultNotificationRewardMultiplier
+    )
+  await randomBeacon
+    .connect(governance)
+    .updateSlashingParameters(
+      initialRelayEntrySubmissionFailureSlashingAmount,
+      initialMaliciousDkgResultSlashingAmount,
+      initialUnauthorizedSigningSlashingAmount
+    )
+
+  await randomBeacon
+    .connect(governance)
+    .updateAuthorizationParameters(
+      initialMinimumAuthorization,
+      initialAuthorizationDecreaseDelay
+    )
+
+  const RandomBeaconGovernance =
+    await ethers.getContractFactory<RandomBeaconGovernance__factory>(
+      "RandomBeaconGovernance"
+    )
+  const randomBeaconGovernance: RandomBeaconGovernance =
+    await RandomBeaconGovernance.deploy(randomBeacon.address, governanceDelay)
+  await randomBeaconGovernance.deployed()
+  await randomBeacon.transferOwnership(randomBeaconGovernance.address)
+
+  return { governance, randomBeaconGovernance }
+}
+
 describe("RandomBeaconGovernance", () => {
   let governance: Signer
   let thirdParty: Signer
   let randomBeacon: RandomBeacon
   let randomBeaconGovernance: RandomBeaconGovernance
 
-  const governanceDelay = 604800 // 1 week
-
-  const initialRelayRequestFee = 100000
-  const initialRelayEntrySoftTimeout = 10
-  const initialRelayEntryHardTimeout = 100
-  const initialCallbackGasLimit = 900000
-  const initialGroupCreationFrequency = 4
-  const initialGroupLifeTime = 60 * 60 * 24 * 7
-  const initialDkgResultChallengePeriodLength = 60
-  const initialDkgResultSubmissionTimeout = 200
-  const initialDkgSubmitterPrecedencePeriodLength = 180
-  const initialDkgResultSubmissionReward = 500000
-  const initialSortitionPoolUnlockingReward = 5000
-  const initialIneligibleOperatorNotifierReward = 6000
-  const initialRelayEntrySubmissionFailureSlashingAmount = 1000
-  const initialMaliciousDkgResultSlashingAmount = 1000000000
-  const initialUnauthorizedSigningSlashingAmount = 1000000000
-  const initialSortitionPoolRewardsBanDuration = 1209600
-  const initialRelayEntryTimeoutNotificationRewardMultiplier = 5
-  const initialUnauthorizedSignatureNotificationRewardMultiplier = 5
-  const initialMinimumAuthorization = 1000000
-  const initialAuthorizationDecreaseDelay = 86400
-  const initialDkgMaliciousResultNotificationRewardMultiplier = 5
-
   // prettier-ignore
   before(async () => {
-    [governance, thirdParty] = await ethers.getSigners()
-
-    const contracts = await waffle.loadFixture(randomBeaconDeployment)
-
-    randomBeacon = contracts.randomBeacon as RandomBeacon
-
-    await randomBeacon
-      .connect(governance)
-      .updateRelayEntryParameters(
-        initialRelayRequestFee,
-        initialRelayEntrySoftTimeout,
-        initialRelayEntryHardTimeout,
-        initialCallbackGasLimit
-      )
-    await randomBeacon
-      .connect(governance)
-      .updateGroupCreationParameters(
-        initialGroupCreationFrequency,
-        initialGroupLifeTime
-      )
-    await randomBeacon
-      .connect(governance)
-      .updateDkgParameters(
-        initialDkgResultChallengePeriodLength,
-        initialDkgResultSubmissionTimeout,
-        initialDkgSubmitterPrecedencePeriodLength
-      )
-    await randomBeacon
-      .connect(governance)
-      .updateRewardParameters(
-        initialDkgResultSubmissionReward,
-        initialSortitionPoolUnlockingReward,
-        initialIneligibleOperatorNotifierReward,
-        initialSortitionPoolRewardsBanDuration,
-        initialRelayEntryTimeoutNotificationRewardMultiplier,
-        initialUnauthorizedSignatureNotificationRewardMultiplier,
-        initialDkgMaliciousResultNotificationRewardMultiplier
-      )
-    await randomBeacon
-      .connect(governance)
-      .updateSlashingParameters(
-        initialRelayEntrySubmissionFailureSlashingAmount,
-        initialMaliciousDkgResultSlashingAmount,
-        initialUnauthorizedSigningSlashingAmount
-      )
-
-    await randomBeacon
-      .connect(governance)
-      .updateAuthorizationParameters(
-        initialMinimumAuthorization,
-        initialAuthorizationDecreaseDelay
-      )
-
-    const RandomBeaconGovernance = await ethers.getContractFactory<RandomBeaconGovernance__factory>(
-      "RandomBeaconGovernance"
-    )
-    randomBeaconGovernance = await RandomBeaconGovernance.deploy(
-      randomBeacon.address, governanceDelay
-    )
-    await randomBeaconGovernance.deployed()
-    await randomBeacon.transferOwnership(randomBeaconGovernance.address)
+    [thirdParty] = await ethers.getUnnamedSigners()
+    ;({governance,randomBeaconGovernance} = await waffle.loadFixture(fixture))
   })
 
   describe("beginGovernanceDelayUpdate", () => {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -3,6 +3,7 @@ import { expect } from "chai"
 
 import { randomBeaconDeployment } from "./fixtures"
 
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { ContractTransaction, Signer } from "ethers"
 import type {
   RandomBeacon,
@@ -104,7 +105,7 @@ const fixture = async () => {
 
 describe("RandomBeaconGovernance", () => {
   let governance: Signer
-  let thirdParty: Signer
+  let thirdParty: SignerWithAddress
   let randomBeacon: RandomBeacon
   let randomBeaconGovernance: RandomBeaconGovernance
 
@@ -3544,5 +3545,19 @@ describe("RandomBeaconGovernance", () => {
         })
       }
     )
+  })
+
+  describe("withdrawIneligibleRewards", () => {
+    context("when caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          randomBeaconGovernance
+            .connect(thirdParty)
+            .withdrawIneligibleRewards(thirdParty.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    // The actual functionality is tested in RandomBeacon.Rewards.test.ts
   })
 })

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -99,7 +99,7 @@ const fixture = async () => {
   await randomBeaconGovernance.deployed()
   await randomBeacon.transferOwnership(randomBeaconGovernance.address)
 
-  return { governance, randomBeaconGovernance }
+  return { governance, randomBeaconGovernance, randomBeacon }
 }
 
 describe("RandomBeaconGovernance", () => {
@@ -111,7 +111,8 @@ describe("RandomBeaconGovernance", () => {
   // prettier-ignore
   before(async () => {
     [thirdParty] = await ethers.getUnnamedSigners()
-    ;({governance,randomBeaconGovernance} = await waffle.loadFixture(fixture))
+    ;({ governance, randomBeaconGovernance, randomBeacon } =
+      await waffle.loadFixture(fixture))
   })
 
   describe("beginGovernanceDelayUpdate", () => {

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -98,7 +98,6 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
 
   const SortitionPool = await ethers.getContractFactory("SortitionPool")
   const sortitionPool = (await SortitionPool.deploy(
-    staking.address,
     t.address,
     constants.poolWeightDivisor
   )) as SortitionPool

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -161,6 +161,11 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
 }
 
 export async function testDeployment(): Promise<DeployedContracts> {
+  const deployer: SignerWithAddress = await ethers.getNamedSigner("deployer")
+  const governance: SignerWithAddress = await ethers.getNamedSigner(
+    "governance"
+  )
+
   const contracts = await randomBeaconDeployment()
 
   const RandomBeaconGovernance =
@@ -173,7 +178,12 @@ export async function testDeployment(): Promise<DeployedContracts> {
       params.governanceDelay
     )
   await randomBeaconGovernance.deployed()
-  await contracts.randomBeacon.transferOwnership(randomBeaconGovernance.address)
+  await contracts.randomBeacon
+    .connect(deployer)
+    .transferOwnership(randomBeaconGovernance.address)
+  await randomBeaconGovernance
+    .connect(deployer)
+    .transferOwnership(governance.address)
 
   const newContracts = { randomBeaconGovernance }
 

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -613,10 +613,10 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/sortition-pools@^2.0.0-pre.6":
-  version "2.0.0-pre.6"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.6.tgz#72ca66cc0c476a21644d9b2342f7136268c802eb"
-  integrity sha512-i+naD1W10pxCRjzJ63yeNJgpokpWzr7eTDI4TRCT1opIRyYCUPa6VNF+U3WGGToM5PtgrBHIe1TZbL7nx8LTSw==
+"@keep-network/sortition-pools@^2.0.0-pre.7":
+  version "2.0.0-pre.7"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.7.tgz#07ce8d645bbb45855718680b0679fc5dd329e34a"
+  integrity sha512-X5/QeEBAsz0v9QfBZ9YVgP/L5TkQHwW1fuyVIirVuR+Wf5zdsWopixk/yC5fL4BSapNaf4KJeIueMF7Eq8Kv/A==
   dependencies:
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
@@ -7032,12 +7032,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
-
-minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
See https://github.com/keep-network/sortition-pools/pull/156

Previously, `SortitionPool.withdrawRewards` could be called directly and
the beneficiary address was fetched from the staking contract based on
the operator address.

This is no longer going to work - T `TokenStaking` contract does not store
operators but staking providers - operator is now a per-application role.

We now expect `SortitionPool.withdrawReward` call to be proxied through the
application `RandomBeacon` contract that will fetch the beneficiary address
from T `TokenStaking`.

This PR is also adding unit tests for `RandomBeacon.withdrawIneligibleRewards`.
This function was not covered with unit tests previously.