### PR TITLE
ECDSA: withdraw sortition pool rewards

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -268,6 +268,16 @@ contract WalletRegistry is
         dkg.setSubmitterPrecedencePeriodLength(20);
     }
 
+    /// @notice Withdraw rewards for the given staking provider to their
+    ///         beneficiary address. Reverts if staking provider has not
+    ///         registered the operator address.
+    function withdrawRewards(address stakingProvider) external {
+        address operator = stakingProviderToOperator(stakingProvider);
+        require(operator != address(0), "Unknown operator");
+        (, address beneficiary, ) = staking.rolesOf(stakingProvider);
+        sortitionPool.withdrawRewards(operator, beneficiary);
+    }
+
     /// @notice Used by staking provider to set operator address that will
     ///         operate ECDSA node. The given staking provider can set operator
     ///         address only one time. The operator address can not be changed
@@ -875,7 +885,7 @@ contract WalletRegistry is
 
     /// @notice Returns operator registered for the given staking provider.
     function stakingProviderToOperator(address stakingProvider)
-        external
+        public
         view
         returns (address)
     {

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -278,6 +278,15 @@ contract WalletRegistry is
         sortitionPool.withdrawRewards(operator, beneficiary);
     }
 
+    /// @notice Withdraws rewards belonging to operators marked as ineligible
+    ///         for sortition pool rewards.
+    /// @dev Can be called only by the contract owner, which should be the
+    ///      wallet registry governance contract.
+    /// @param recipient Recipient of withdrawn rewards.
+    function withdrawIneligibleRewards(address recipient) external onlyOwner {
+        sortitionPool.withdrawIneligible(recipient);
+    }
+
     /// @notice Used by staking provider to set operator address that will
     ///         operate ECDSA node. The given staking provider can set operator
     ///         address only one time. The operator address can not be changed

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -834,6 +834,14 @@ contract WalletRegistryGovernance is Ownable {
         newSubmitterPrecedencePeriodLength = 0;
     }
 
+    /// @notice Withdraws rewards belonging to operators marked as ineligible
+    ///         for sortition pool rewards.
+    /// @dev Can be called only by the contract owner.
+    /// @param recipient Recipient of withdrawn rewards.
+    function withdrawIneligibleRewards(address recipient) external onlyOwner {
+        walletRegistry.withdrawIneligibleRewards(recipient);
+    }
+
     /// @notice Get the time remaining until the governance delay can be updated.
     /// @return Remaining time in seconds.
     function getRemainingGovernanceDelayUpdateTime()

--- a/solidity/ecdsa/deploy/01_deploy_sortition_pool.ts
+++ b/solidity/ecdsa/deploy/01_deploy_sortition_pool.ts
@@ -13,7 +13,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const SortitionPool = await deployments.deploy("SortitionPool", {
     from: deployer,
-    args: [TokenStaking.address, T.address, POOL_WEIGHT_DIVISOR],
+    args: [T.address, POOL_WEIGHT_DIVISOR],
     log: true,
   })
 

--- a/solidity/ecdsa/deploy/01_deploy_sortition_pool.ts
+++ b/solidity/ecdsa/deploy/01_deploy_sortition_pool.ts
@@ -8,7 +8,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const POOL_WEIGHT_DIVISOR = to1e18(1) // TODO: Update value
 
-  const TokenStaking = await deployments.get("TokenStaking")
   const T = await deployments.get("T")
 
   const SortitionPool = await deployments.deploy("SortitionPool", {

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@keep-network/random-beacon": "development",
-    "@keep-network/sortition-pools": "^2.0.0-pre.6",
+    "@keep-network/sortition-pools": "^2.0.0-pre.7",
     "@openzeppelin/contracts": "^4.4.1",
     "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten"
   },

--- a/solidity/ecdsa/test/WalletRegistry.Rewards.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Rewards.test.ts
@@ -1,0 +1,94 @@
+import { helpers } from "hardhat"
+import { expect } from "chai"
+
+import { walletRegistryFixture } from "./fixtures"
+import ecdsaData from "./data/ecdsa"
+import { createNewWallet } from "./utils/wallets"
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { FakeContract } from "@defi-wonderland/smock"
+import type { Operator, OperatorID } from "./utils/operators"
+import type {
+  SortitionPool,
+  WalletRegistry,
+  TokenStaking,
+  IWalletOwner,
+  T,
+} from "../typechain"
+
+const { to1e18 } = helpers.number
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("WalletRegistry - Rewards", () => {
+  let tToken: T
+  let walletRegistry: WalletRegistry
+  let staking: TokenStaking
+  let sortitionPool: SortitionPool
+  let walletOwner: FakeContract<IWalletOwner>
+
+  let deployer: SignerWithAddress
+  let thirdParty: SignerWithAddress
+
+  let members: Operator[]
+
+  const walletPublicKey: string = ecdsaData.group1.publicKey
+
+  const rewardAmount = to1e18(100000)
+
+  before("load test fixture", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      tToken,
+      walletRegistry,
+      staking,
+      sortitionPool,
+      walletOwner,
+      deployer,
+      thirdParty,
+    } = await walletRegistryFixture())
+    ;({ members } = await createNewWallet(
+      walletRegistry,
+      walletOwner.wallet,
+      walletPublicKey
+    ))
+  })
+
+  describe("withdrawRewards", () => {
+    context("when called for an unknown operator", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistry.withdrawRewards(thirdParty.address)
+        ).to.be.revertedWith("Unknown operator")
+      })
+    })
+
+    context("when called for a known operator", () => {
+      before(async () => {
+        await createSnapshot()
+
+        // Allocate sortition pool rewards
+        await tToken.connect(deployer).mint(deployer.address, rewardAmount)
+        await tToken
+          .connect(deployer)
+          .approveAndCall(sortitionPool.address, rewardAmount, [])
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should withdraw rewards", async () => {
+        const operator = members[0].signer.address
+        const stakingProvider = await walletRegistry.operatorToStakingProvider(
+          operator
+        )
+        const { beneficiary } = await staking.rolesOf(stakingProvider)
+
+        expect(await tToken.balanceOf(beneficiary)).to.equal(0)
+        await walletRegistry.withdrawRewards(stakingProvider)
+        expect(await tToken.balanceOf(beneficiary)).to.be.gt(0)
+      })
+    })
+  })
+})

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -2558,4 +2558,18 @@ describe("WalletRegistryGovernance", async () => {
       }
     )
   })
+
+  describe("withdrawIneligibleRewards", () => {
+    context("when caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(thirdParty)
+            .withdrawIneligibleRewards(thirdParty.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    // The actual functionality is tested in WalletRegistry.Rewards.test.ts
+  })
 })

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -47,6 +47,7 @@ export const params = {
 
 export const walletRegistryFixture = deployments.createFixture(
   async (): Promise<{
+    tToken: T
     walletRegistry: WalletRegistryStub & WalletRegistry
     walletRegistryGovernance: WalletRegistryGovernance
     sortitionPool: SortitionPool
@@ -108,6 +109,7 @@ export const walletRegistryFixture = deployments.createFixture(
     )
 
     return {
+      tToken,
       walletRegistry,
       sortitionPool,
       reimbursementPool,

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -617,15 +617,22 @@
   resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.3.tgz#0aee6913ffde3806d3652297155fb2c1bbff6a50"
   integrity sha512-cqpvGGOBoXqoUxVAqcF5rmlEg8lbmj+LRWzOYW4jaweWVxzRBG2DbaaZ7frHXfJHZ3sicr4cLhlhcqbIuiubYA==
   dependencies:
-    "@keep-network/sortition-pools" "^2.0.0-pre.6"
+    "@keep-network/sortition-pools" "1.2.0-dev.24"
     "@openzeppelin/contracts" "^4.4.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts" ">1.1.0-dev <1.1.0-ropsten"
 
 "@keep-network/sortition-pools@^2.0.0-pre.6":
   version "2.0.0-pre.6"
   resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.6.tgz#72ca66cc0c476a21644d9b2342f7136268c802eb"
   integrity sha512-i+naD1W10pxCRjzJ63yeNJgpokpWzr7eTDI4TRCT1opIRyYCUPa6VNF+U3WGGToM5PtgrBHIe1TZbL7nx8LTSw==
+  dependencies:
+    "@openzeppelin/contracts" "^4.3.2"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+
+"@keep-network/sortition-pools@^2.0.0-pre.7":
+  version "2.0.0-pre.7"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.7.tgz#07ce8d645bbb45855718680b0679fc5dd329e34a"
+  integrity sha512-X5/QeEBAsz0v9QfBZ9YVgP/L5TkQHwW1fuyVIirVuR+Wf5zdsWopixk/yC5fL4BSapNaf4KJeIueMF7Eq8Kv/A==
   dependencies:
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"


### PR DESCRIPTION
See https://github.com/keep-network/sortition-pools/pull/156

~~Depends on https://github.com/keep-network/keep-core/pull/2919; I am planning no more changes in the code but keeping it as a draft until #2919 is merged.~~

Previously, `SortitionPool.withdrawRewards` could be called directly and
the beneficiary address was fetched from the staking contract based on
the operator address.

This is no longer going to work - T `TokenStaking` contract does not store
operators but staking providers - operator is now a per-application role.

We now expect `SortitionPool.withdrawReward` call to be proxied through the
application `WalletRegistry` contract that will fetch the beneficiary address
from T `TokenStaking`.

This PR is also implementing `withdrawIneligibleRewards` function
on the `WalletRegistry`.

`SortitionPool` allows the owner to withdraw rewards that would normally
be allocated to operators in case these operators were marked as ineligible
for rewards. This needs to be called by the `SortitionPool` owner, which
here is the `WalletRegistry`.
