### PR TITLE
WalletRegistry and Reimbursable ownership/governance updates

### DIFF
--- a/solidity/ecdsa/contracts/Governable.sol
+++ b/solidity/ecdsa/contracts/Governable.sol
@@ -18,7 +18,7 @@ pragma solidity ^0.8.9;
 /// @dev A constructor is not defined, which makes the contract compatible with
 ///      upgradable proxies. This requires calling explicitly `_transferGovernance`
 ///      function in a child contract.
-contract Governable {
+abstract contract Governable {
     // Governance of the contract
     address public governance;
 

--- a/solidity/ecdsa/contracts/Governable.sol
+++ b/solidity/ecdsa/contracts/Governable.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+//
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+pragma solidity ^0.8.9;
+
+/// @notice Governable contract.
+/// @dev A constructor is not defined, which makes the contract compatible with
+///      upgradable proxies. This requires calling explicitly `_transferGovernance`
+///      function in a child contract.
+contract Governable {
+    // Governance of the contract
+    address public governance;
+
+    event GovernanceTransferred(address oldGovernance, address newGovernance);
+
+    modifier onlyGovernance() virtual {
+        require(governance == msg.sender, "Caller is not the governance");
+        _;
+    }
+
+    /// @notice Transfers governance of the contract to `newGovernance`.
+    function transferGovernance(address newGovernance)
+        external
+        virtual
+        onlyGovernance
+    {
+        require(
+            newGovernance != address(0),
+            "New governance is the zero address"
+        );
+        _transferGovernance(newGovernance);
+    }
+
+    function _transferGovernance(address newGovernance) internal virtual {
+        address oldGovernance = governance;
+        governance = newGovernance;
+        emit GovernanceTransferred(oldGovernance, newGovernance);
+    }
+}

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -239,6 +239,11 @@ contract WalletRegistry is
         _;
     }
 
+    modifier onlyReimbursableAdmin() override {
+        require(governance == msg.sender, "Caller is not the governance");
+        _;
+    }
+
     constructor(
         SortitionPool _sortitionPool,
         IStaking _staking,

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -288,10 +288,13 @@ contract WalletRegistry is
 
     /// @notice Withdraws rewards belonging to operators marked as ineligible
     ///         for sortition pool rewards.
-    /// @dev Can be called only by the contract owner, which should be the
+    /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract.
     /// @param recipient Recipient of withdrawn rewards.
-    function withdrawIneligibleRewards(address recipient) external onlyOwner {
+    function withdrawIneligibleRewards(address recipient)
+        external
+        onlyGovernance
+    {
         sortitionPool.withdrawIneligible(recipient);
     }
 

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -29,7 +29,7 @@ contract WalletRegistryGovernance is Ownable {
     uint256 public governanceDelayChangeInitiated;
 
     address public newWalletRegistryOwner;
-    uint256 public walletRegistryOwnershipTransferInitiated;
+    uint256 public walletRegistryGovernanceTransferInitiated;
 
     address public newWalletOwner;
     uint256 public walletOwnerChangeInitiated;
@@ -84,11 +84,11 @@ contract WalletRegistryGovernance is Ownable {
     );
     event GovernanceDelayUpdated(uint256 governanceDelay);
 
-    event WalletRegistryOwnershipTransferStarted(
+    event WalletRegistryGovernanceTransferStarted(
         address newWalletRegistryOwner,
         uint256 timestamp
     );
-    event WalletRegistryOwnershipTransferred(address newWalletRegistryOwner);
+    event WalletRegistryGovernanceTransferred(address newWalletRegistryOwner);
 
     event WalletOwnerUpdateStarted(address walletOwner, uint256 timestamp);
     event WalletOwnerUpdated(address walletOwner);
@@ -262,9 +262,9 @@ contract WalletRegistryGovernance is Ownable {
         newGovernanceDelay = 0;
     }
 
-    /// @notice Begins the wallet registry ownership transfer process.
+    /// @notice Begins the wallet registry governance transfer process.
     /// @dev Can be called only by the contract owner.
-    function beginWalletRegistryOwnershipTransfer(
+    function beginWalletRegistryGovernanceTransfer(
         address _newWalletRegistryOwner
     ) external onlyOwner {
         require(
@@ -273,26 +273,26 @@ contract WalletRegistryGovernance is Ownable {
         );
         newWalletRegistryOwner = _newWalletRegistryOwner;
         /* solhint-disable not-rely-on-time */
-        walletRegistryOwnershipTransferInitiated = block.timestamp;
-        emit WalletRegistryOwnershipTransferStarted(
+        walletRegistryGovernanceTransferInitiated = block.timestamp;
+        emit WalletRegistryGovernanceTransferStarted(
             _newWalletRegistryOwner,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
     }
 
-    /// @notice Finalizes the wallet registry ownership transfer process.
+    /// @notice Finalizes the wallet registry governance transfer process.
     /// @dev Can be called only by the contract owner, after the governance
     ///      delay elapses.
-    function finalizeWalletRegistryOwnershipTransfer()
+    function finalizeWalletRegistryGovernanceTransfer()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(walletRegistryOwnershipTransferInitiated)
+        onlyAfterGovernanceDelay(walletRegistryGovernanceTransferInitiated)
     {
-        emit WalletRegistryOwnershipTransferred(newWalletRegistryOwner);
+        emit WalletRegistryGovernanceTransferred(newWalletRegistryOwner);
         // slither-disable-next-line reentrancy-no-eth
-        walletRegistry.transferOwnership(newWalletRegistryOwner);
-        walletRegistryOwnershipTransferInitiated = 0;
+        walletRegistry.transferGovernance(newWalletRegistryOwner);
+        walletRegistryGovernanceTransferInitiated = 0;
         newWalletRegistryOwner = address(0);
     }
 
@@ -844,15 +844,16 @@ contract WalletRegistryGovernance is Ownable {
         return getRemainingChangeTime(governanceDelayChangeInitiated);
     }
 
-    /// @notice Get the time remaining until the wallet registry ownership can
+    /// @notice Get the time remaining until the wallet registry governance can
     ///         be transferred.
     /// @return Remaining time in seconds.
-    function getRemainingWalletRegistryOwnershipTransferDelayTime()
+    function getRemainingWalletRegistryGovernanceTransferDelayTime()
         external
         view
         returns (uint256)
     {
-        return getRemainingChangeTime(walletRegistryOwnershipTransferInitiated);
+        return
+            getRemainingChangeTime(walletRegistryGovernanceTransferInitiated);
     }
 
     /// @notice Get the time remaining until the minimum authorization amount

--- a/solidity/ecdsa/contracts/libraries/Wallets.sol
+++ b/solidity/ecdsa/contracts/libraries/Wallets.sol
@@ -14,8 +14,6 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-
 library Wallets {
     struct Wallet {
         // Keccak256 hash of group members identifiers array. Group members do not

--- a/solidity/ecdsa/contracts/test/GovernableImpl.sol
+++ b/solidity/ecdsa/contracts/test/GovernableImpl.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.8.9;
+
+import "../Governable.sol";
+
+contract GovernableImpl is Governable {
+    function _transferGovernanceExposed(address newGovernance) external {
+        _transferGovernance(newGovernance);
+    }
+}

--- a/solidity/ecdsa/deploy/08_transfer_governance.ts
+++ b/solidity/ecdsa/deploy/08_transfer_governance.ts
@@ -15,14 +15,15 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     deployer
   )
 
-  await helpers.ownable.transferOwnership(
+  await deployments.execute(
     "WalletRegistry",
-    WalletRegistryGovernance.address,
-    deployer
+    { from: deployer },
+    "transferGovernance",
+    WalletRegistryGovernance.address
   )
 }
 
 export default func
 
-func.tags = ["WalletRegistryTransferOwnership"]
+func.tags = ["WalletRegistryTransferGovernance"]
 func.dependencies = ["WalletRegistryGovernance"]

--- a/solidity/ecdsa/test/DKGValidator.test.ts
+++ b/solidity/ecdsa/test/DKGValidator.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { BigNumber } from "ethers"
-import { ethers, helpers, getUnnamedAccounts, waffle } from "hardhat"
+import { ethers, helpers } from "hardhat"
 import { expect } from "chai"
 
 import { constants, walletRegistryFixture } from "./fixtures"

--- a/solidity/ecdsa/test/Governable.test.ts
+++ b/solidity/ecdsa/test/Governable.test.ts
@@ -1,0 +1,177 @@
+/* eslint-disable no-underscore-dangle */
+import { expect } from "chai"
+import { ethers, helpers } from "hardhat"
+
+import type { ContractTransaction } from "ethers"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { GovernableImpl, GovernableImpl__factory } from "../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("Governable", () => {
+  let governable: GovernableImpl
+  let deployer: SignerWithAddress
+  let governance: SignerWithAddress
+  let thirdParty: SignerWithAddress
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ deployer, governance } = await ethers.getNamedSigners())
+    ;[thirdParty] = await ethers.getUnnamedSigners()
+
+    const GovernableFactory: GovernableImpl__factory =
+      await ethers.getContractFactory("GovernableImpl", deployer)
+    governable = await GovernableFactory.deploy()
+  })
+
+  describe("constructor", () => {
+    it("sets governance to default zero address", async () => {
+      expect(await governable.governance()).to.be.equal(
+        ethers.constants.AddressZero
+      )
+    })
+  })
+
+  describe("transferGovernance", () => {
+    describe("when governance was not initialized", () => {
+      describe("when called by the deployer", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(deployer)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when called by the governance", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(governance)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when called by a third party", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(thirdParty)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+    })
+
+    describe("when governance was initialized", () => {
+      before(async () => {
+        await governable._transferGovernanceExposed(governance.address)
+      })
+
+      describe("when called by the deployer", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(deployer)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when called by the governance", () => {
+        const newGovernance: string = ethers.Wallet.createRandom().address
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await governable
+            .connect(governance)
+            .transferGovernance(newGovernance)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("updates governance address", async () => {
+          expect(await governable.governance()).to.be.equal(newGovernance)
+        })
+
+        it("emits GovernanceTransferred event", async () => {
+          await expect(tx)
+            .to.emit(governable, "GovernanceTransferred")
+            .withArgs(governance.address, newGovernance)
+        })
+      })
+
+      describe("when called by a third party", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(thirdParty)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when new governance is zero address", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(governance)
+              .transferGovernance(ethers.constants.AddressZero)
+          ).to.be.revertedWith("New governance is the zero address")
+        })
+      })
+    })
+  })
+
+  describe("_transferGovernance", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    describe("when called by the deployer", () => {
+      it("succeeds", async () => {
+        const newGovernance = ethers.Wallet.createRandom().address
+
+        await governable
+          .connect(deployer)
+          ._transferGovernanceExposed(newGovernance)
+
+        expect(await governable.governance()).to.be.equal(newGovernance)
+      })
+    })
+
+    describe("when called by the governance", () => {
+      it("succeeds", async () => {
+        const newGovernance = ethers.Wallet.createRandom().address
+
+        await governable
+          .connect(governance)
+          ._transferGovernanceExposed(newGovernance)
+
+        expect(await governable.governance()).to.be.equal(newGovernance)
+      })
+    })
+
+    describe("when called by a third party", () => {
+      it("succeeds", async () => {
+        const newGovernance = ethers.Wallet.createRandom().address
+
+        await governable
+          .connect(thirdParty)
+          ._transferGovernanceExposed(newGovernance)
+
+        expect(await governable.governance()).to.be.equal(newGovernance)
+      })
+    })
+  })
+})

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -25,7 +25,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(deployer).updateAuthorizationParameters(1, 2)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -35,7 +35,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(walletOwner.wallet)
             .updateAuthorizationParameters(1, 2)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -43,7 +43,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(thirdParty).updateAuthorizationParameters(1, 2)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })
@@ -53,7 +53,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(deployer).updateDkgParameters(1, 2, 3, 4)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -63,7 +63,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(walletOwner.wallet)
             .updateDkgParameters(1, 2, 3, 4)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -71,7 +71,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(thirdParty).updateDkgParameters(1, 2, 3, 4)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })
@@ -81,7 +81,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(deployer).updateRewardParameters(1, 2)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -91,7 +91,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(walletOwner.wallet)
             .updateRewardParameters(1, 2)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -99,7 +99,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(thirdParty).updateRewardParameters(1, 2)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })
@@ -109,7 +109,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(deployer).updateSlashingParameters(1)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -117,7 +117,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(walletOwner.wallet).updateSlashingParameters(1)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -125,7 +125,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(thirdParty).updateSlashingParameters(1)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })
@@ -135,7 +135,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(deployer).updateWalletOwner(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -145,7 +145,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(walletOwner.wallet)
             .updateWalletOwner(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -155,7 +155,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(thirdParty)
             .updateWalletOwner(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })
@@ -165,7 +165,7 @@ describe("WalletRegistry - Parameters", async () => {
       it("should revert", async () => {
         await expect(
           walletRegistry.connect(deployer).updateGasParameters(4200, 4201, 4202)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -175,7 +175,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(walletOwner.wallet)
             .updateGasParameters(4200, 4201, 4202)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -185,7 +185,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(thirdParty)
             .updateGasParameters(4200, 4201, 4202)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })
@@ -197,7 +197,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(deployer)
             .upgradeRandomBeacon(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -207,7 +207,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(walletOwner.wallet)
             .upgradeRandomBeacon(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
@@ -217,7 +217,7 @@ describe("WalletRegistry - Parameters", async () => {
           walletRegistry
             .connect(thirdParty)
             .upgradeRandomBeacon(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
   })

--- a/solidity/ecdsa/test/WalletRegistry.Rewards.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Rewards.test.ts
@@ -113,7 +113,7 @@ describe("WalletRegistry - Rewards", () => {
           walletRegistry
             .connect(thirdParty)
             .withdrawIneligibleRewards(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -312,13 +312,13 @@ describe("WalletRegistryGovernance", async () => {
     )
   })
 
-  describe("beginWalletRegistryOwnershipTransfer", () => {
+  describe("beginWalletRegistryGovernanceTransfer", () => {
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
         await expect(
           walletRegistryGovernance
             .connect(thirdParty)
-            .beginWalletRegistryOwnershipTransfer(
+            .beginWalletRegistryGovernanceTransfer(
               "0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537"
             )
         ).to.be.revertedWith("Ownable: caller is not the owner")
@@ -333,7 +333,7 @@ describe("WalletRegistryGovernance", async () => {
 
         tx = await walletRegistryGovernance
           .connect(governance)
-          .beginWalletRegistryOwnershipTransfer(
+          .beginWalletRegistryGovernanceTransfer(
             "0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537"
           )
       })
@@ -347,7 +347,7 @@ describe("WalletRegistryGovernance", async () => {
           await expect(
             walletRegistryGovernance
               .connect(governance)
-              .beginWalletRegistryOwnershipTransfer(
+              .beginWalletRegistryGovernanceTransfer(
                 ethers.constants.AddressZero
               )
           ).to.be.revertedWith(
@@ -357,24 +357,24 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not transfer the ownership", async () => {
-        expect(await walletRegistry.owner()).to.be.equal(
+        expect(await walletRegistry.governance()).to.be.equal(
           walletRegistryGovernance.address
         )
       })
 
       it("should start the governance delay timer", async () => {
         expect(
-          await walletRegistryGovernance.getRemainingWalletRegistryOwnershipTransferDelayTime()
+          await walletRegistryGovernance.getRemainingWalletRegistryGovernanceTransferDelayTime()
         ).to.be.equal(constants.governanceDelay)
       })
 
-      it("should emit WalletRegistryOwnershipTransferStarted", async () => {
+      it("should emit WalletRegistryGovernanceTransferStarted", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
         await expect(tx)
           .to.emit(
             walletRegistryGovernance,
-            "WalletRegistryOwnershipTransferStarted"
+            "WalletRegistryGovernanceTransferStarted"
           )
           .withArgs(
             "0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537",
@@ -384,13 +384,13 @@ describe("WalletRegistryGovernance", async () => {
     })
   })
 
-  describe("finalizeWalletRegistryOwnershipTransfer", () => {
+  describe("finalizeWalletRegistryGovernanceTransfer", () => {
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
         await expect(
           walletRegistryGovernance
             .connect(thirdParty)
-            .finalizeWalletRegistryOwnershipTransfer()
+            .finalizeWalletRegistryGovernanceTransfer()
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -400,7 +400,7 @@ describe("WalletRegistryGovernance", async () => {
         await expect(
           walletRegistryGovernance
             .connect(governance)
-            .finalizeWalletRegistryOwnershipTransfer()
+            .finalizeWalletRegistryGovernanceTransfer()
         ).to.be.revertedWith("Change not initiated")
       })
     })
@@ -411,7 +411,7 @@ describe("WalletRegistryGovernance", async () => {
 
         await walletRegistryGovernance
           .connect(governance)
-          .beginWalletRegistryOwnershipTransfer(
+          .beginWalletRegistryGovernanceTransfer(
             "0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537"
           )
 
@@ -426,7 +426,7 @@ describe("WalletRegistryGovernance", async () => {
         await expect(
           walletRegistryGovernance
             .connect(governance)
-            .finalizeWalletRegistryOwnershipTransfer()
+            .finalizeWalletRegistryGovernanceTransfer()
         ).to.be.revertedWith("Governance delay has not elapsed")
       })
     })
@@ -441,7 +441,7 @@ describe("WalletRegistryGovernance", async () => {
 
           await walletRegistryGovernance
             .connect(governance)
-            .beginWalletRegistryOwnershipTransfer(
+            .beginWalletRegistryGovernanceTransfer(
               "0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537"
             )
 
@@ -449,7 +449,7 @@ describe("WalletRegistryGovernance", async () => {
 
           tx = await walletRegistryGovernance
             .connect(governance)
-            .finalizeWalletRegistryOwnershipTransfer()
+            .finalizeWalletRegistryGovernanceTransfer()
         })
 
         after(async () => {
@@ -457,23 +457,23 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should transfer wallet registry ownership", async () => {
-          expect(await walletRegistry.owner()).to.be.equal(
+          expect(await walletRegistry.governance()).to.be.equal(
             "0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537"
           )
         })
 
-        it("should emit WalletRegistryOwnershipTransferred event", async () => {
+        it("should emit WalletRegistryGovernanceTransferred event", async () => {
           await expect(tx)
             .to.emit(
               walletRegistryGovernance,
-              "WalletRegistryOwnershipTransferred"
+              "WalletRegistryGovernanceTransferred"
             )
             .withArgs("0x00Ea7D21bcCEeD400aCe08B583554aA619D3e537")
         })
 
         it("should reset the governance delay timer", async () => {
           await expect(
-            walletRegistryGovernance.getRemainingWalletRegistryOwnershipTransferDelayTime()
+            walletRegistryGovernance.getRemainingWalletRegistryGovernanceTransferDelayTime()
           ).to.be.revertedWith("Change not initiated")
         })
       }

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -1,4 +1,4 @@
-import { deployments, ethers, helpers, getUnnamedAccounts } from "hardhat"
+import { deployments, ethers, helpers } from "hardhat"
 import { smock } from "@defi-wonderland/smock"
 
 // eslint-disable-next-line import/no-cycle
@@ -79,11 +79,7 @@ export const walletRegistryFixture = deployments.createFixture(
       "governance"
     )
 
-    const thirdParty: SignerWithAddress = await ethers.getSigner(
-      (
-        await getUnnamedAccounts()
-      )[0]
-    )
+    const [thirdParty] = await ethers.getUnnamedSigners()
 
     // Accounts offset provided to slice getUnnamedAccounts have to include number
     // of unnamed accounts that were already used.

--- a/solidity/ecdsa/test/utils/governance.ts
+++ b/solidity/ecdsa/test/utils/governance.ts
@@ -10,7 +10,7 @@ export async function upgradeRandomBeacon(
   const walletRegistryGovernance: WalletRegistryGovernance =
     await ethers.getContractAt(
       "WalletRegistryGovernance",
-      await walletRegistry.owner()
+      await walletRegistry.governance()
     )
 
   const governance = await ethers.getNamedSigner("governance")

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -613,21 +613,14 @@
     openzeppelin-solidity "2.4.0"
 
 "@keep-network/random-beacon@development":
-  version "2.0.0-dev.3"
-  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.3.tgz#0aee6913ffde3806d3652297155fb2c1bbff6a50"
-  integrity sha512-cqpvGGOBoXqoUxVAqcF5rmlEg8lbmj+LRWzOYW4jaweWVxzRBG2DbaaZ7frHXfJHZ3sicr4cLhlhcqbIuiubYA==
+  version "2.0.0-dev.19"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.19.tgz#c30329d323a14cad1a6575d19a4f40e35c4e8dd4"
+  integrity sha512-ewuoFLCvCfVvKo8ryplAyNsf4Mv0DDk2vw4W00z3nFhrRRm3t7Acwk2EHyLefLV5IMyG7Wlpha61z/dbDzuvAw==
   dependencies:
-    "@keep-network/sortition-pools" "1.2.0-dev.24"
+    "@keep-network/sortition-pools" "^2.0.0-pre.7"
     "@openzeppelin/contracts" "^4.4.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-
-"@keep-network/sortition-pools@^2.0.0-pre.6":
-  version "2.0.0-pre.6"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.6.tgz#72ca66cc0c476a21644d9b2342f7136268c802eb"
-  integrity sha512-i+naD1W10pxCRjzJ63yeNJgpokpWzr7eTDI4TRCT1opIRyYCUPa6VNF+U3WGGToM5PtgrBHIe1TZbL7nx8LTSw==
-  dependencies:
-    "@openzeppelin/contracts" "^4.3.2"
-    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+    "@threshold-network/solidity-contracts" ">1.1.0-dev <1.1.0-ropsten"
 
 "@keep-network/sortition-pools@^2.0.0-pre.7":
   version "2.0.0-pre.7"
@@ -697,15 +690,15 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.1.tgz#dc354082460eb34f5833afdecfab46538b208c4f"
   integrity sha512-xcKycsSyFauIGMhSeeTJW/Jzz9jZUJdiFNP9Wo/9VhMhw8t5X0M92RY6x176VfcIWsxURMHFWOJVTlFA78HI/w==
 
-"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4", "@openzeppelin/contracts@^4.4.1":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
-  integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
-
-"@openzeppelin/contracts@^4.4.2":
+"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.4.2":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+
+"@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4", "@openzeppelin/contracts@^4.4.1":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
+  integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
 
 "@openzeppelin/upgrades@^2.7.2":
   version "2.8.0"


### PR DESCRIPTION
~~Depends on https://github.com/keep-network/keep-core/pull/2922~~

In this PR we modify the `WalletRegistry` to make it ready for becoming upgradable.

We removed `Ownable` with `Governable` which is a simpler solution and is consistent with `TokenStaking` contract from threshold-network.

Also, we implement `onlyReimbursableAdmin` from `Reimbursable` contract (https://github.com/keep-network/keep-core/pull/2922).