### PR TITLE
Remove Ownable from Reimbursable

### DIFF
--- a/solidity/random-beacon/contracts/Reimbursable.sol
+++ b/solidity/random-beacon/contracts/Reimbursable.sol
@@ -14,10 +14,9 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "./ReimbursementPool.sol";
 
-abstract contract Reimbursable is Ownable {
+abstract contract Reimbursable {
     ReimbursementPool public reimbursementPool;
 
     event ReimbursementPoolUpdated(address newReimbursementPool);
@@ -28,9 +27,13 @@ abstract contract Reimbursable is Ownable {
         reimbursementPool.refund(gasStart - gasleft(), receiver);
     }
 
+    modifier onlyReimbursableAdmin() virtual {
+        _;
+    }
+
     function updateReimbursementPool(ReimbursementPool _reimbursementPool)
         external
-        onlyOwner
+        onlyReimbursableAdmin
     {
         emit ReimbursementPoolUpdated(address(_reimbursementPool));
 

--- a/solidity/random-beacon/contracts/test/ReimbursableImplStub.sol
+++ b/solidity/random-beacon/contracts/test/ReimbursableImplStub.sol
@@ -1,8 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.6;
 
-import "../libraries/Relay.sol";
-import "../libraries/Groups.sol";
-import "../Reimbursable.sol";
+import {Reimbursable} from "../Reimbursable.sol";
 
-contract ReimbursableImplStub is Reimbursable {}
+contract ReimbursableImplStub is Reimbursable {
+    address public admin;
+
+    constructor(address _admin) {
+        admin = _admin;
+    }
+
+    modifier onlyReimbursableAdmin() override {
+        require(admin == msg.sender, "Caller is not the admin");
+        _;
+    }
+}


### PR DESCRIPTION
Reimbursable is an abstract contract with a function `updateReimbursementPool` that should be able to be executed only by a specific role. 

Using Ownable for this contract was not necessary, especially since this causes problems when using upgradable implementations, where we should use `OwnableUpgradable` instead of `Ownable`.

With the `onlyReimbursableAdmin` virtual modifier we leave it to the implementation to check the role according to their needs.