### PR TITLE
Check wallet membership

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -775,8 +775,10 @@ contract WalletRegistry is
     /// @notice Checks whether the given operator is a member of the given
     ///         wallet signing group.
     /// @param walletID ID of the wallet
-    /// @param operator Address of the checked operator
     /// @param walletMembersIDs Identifiers of the wallet signing group members
+    /// @param operator Address of the checked operator
+    /// @param walletMemberIndex Position of the operator in the wallet signing
+    ///        group members list
     /// @return True - if the operator is a member of the given wallet signing
     ///         group. False - otherwise.
     /// @dev Requirements:
@@ -784,10 +786,12 @@ contract WalletRegistry is
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
     ///        for the given `walletID`.
+    ///      - The `walletMemberIndex` must be in range [0, walletMembersIDs.length-1]
     function isWalletMember(
         bytes32 walletID,
+        uint32[] calldata walletMembersIDs,
         address operator,
-        uint32[] calldata walletMembersIDs
+        uint256 walletMemberIndex
     ) external view returns (bool) {
         uint32 operatorID = sortitionPool.getOperatorID(operator);
 
@@ -800,13 +804,13 @@ contract WalletRegistry is
             "Invalid wallet members identifiers"
         );
 
-        for (uint256 i = 0; i < walletMembersIDs.length; i++) {
-            if (walletMembersIDs[i] == operatorID) {
-                return true;
-            }
-        }
+        require(
+            0 <= walletMemberIndex &&
+                walletMemberIndex <= walletMembersIDs.length - 1,
+            "Wallet member index is out of range"
+        );
 
-        return false;
+        return walletMembersIDs[walletMemberIndex] == operatorID;
     }
 
     /// @notice Checks if awaiting seed timed out.

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -785,7 +785,10 @@ contract WalletRegistry is
     ///      - The `operator` parameter must be an actual sortition pool operator.
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
-    ///        for the given `walletID`.
+    ///        for the given `walletID`. Those IDs are not directly stored
+    ///        in the contract for gas efficiency purposes but they can be
+    ///        read from appropriate `DkgResultSubmitted` and `DkgResultApproved`
+    ///        events.
     ///      - The `walletMemberIndex` must be in range [1, walletMembersIDs.length]
     function isWalletMember(
         bytes32 walletID,

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -786,7 +786,7 @@ contract WalletRegistry is
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
     ///        for the given `walletID`.
-    ///      - The `walletMemberIndex` must be in range [0, walletMembersIDs.length-1]
+    ///      - The `walletMemberIndex` must be in range [1, walletMembersIDs.length]
     function isWalletMember(
         bytes32 walletID,
         uint32[] calldata walletMembersIDs,
@@ -805,12 +805,12 @@ contract WalletRegistry is
         );
 
         require(
-            0 <= walletMemberIndex &&
-                walletMemberIndex <= walletMembersIDs.length - 1,
+            1 <= walletMemberIndex &&
+                walletMemberIndex <= walletMembersIDs.length,
             "Wallet member index is out of range"
         );
 
-        return walletMembersIDs[walletMemberIndex] == operatorID;
+        return walletMembersIDs[walletMemberIndex - 1] == operatorID;
     }
 
     /// @notice Checks if awaiting seed timed out.

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -772,6 +772,43 @@ contract WalletRegistry is
         return dkg.currentState();
     }
 
+    /// @notice Checks whether the given operator is a member of the given
+    ///         wallet signing group.
+    /// @param walletID ID of the wallet
+    /// @param operator Address of the checked operator
+    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    /// @return True - if the operator is a member of the given wallet signing
+    ///         group. False - otherwise.
+    /// @dev Requirements:
+    ///      - The `operator` parameter must be an actual sortition pool operator.
+    ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
+    ///        be exactly the same as the hash stored under `membersIdsHash`
+    ///        for the given `walletID`.
+    function isWalletMember(
+        bytes32 walletID,
+        address operator,
+        uint32[] calldata walletMembersIDs
+    ) external view returns (bool) {
+        uint32 operatorID = sortitionPool.getOperatorID(operator);
+
+        require(operatorID != 0, "Not a sortition pool operator");
+
+        bytes32 memberIdsHash = wallets.getWalletMembersIdsHash(walletID);
+
+        require(
+            memberIdsHash == keccak256(abi.encode(walletMembersIDs)),
+            "Invalid wallet members identifiers"
+        );
+
+        for (uint256 i = 0; i < walletMembersIDs.length; i++) {
+            if (walletMembersIDs[i] == operatorID) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// @notice Checks if awaiting seed timed out.
     /// @return True if awaiting seed timed out, false otherwise.
     function hasSeedTimedOut() external view returns (bool) {

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -53,7 +53,7 @@ interface IWalletRegistry {
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
     ///        for the given `walletID`.
-    ///      - The `walletMemberIndex` must be in range [0, walletMembersIDs.length-1]
+    ///      - The `walletMemberIndex` must be in range [1, walletMembersIDs.length]
     function isWalletMember(
         bytes32 walletID,
         uint32[] calldata walletMembersIDs,

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -42,8 +42,10 @@ interface IWalletRegistry {
     /// @notice Checks whether the given operator is a member of the given
     ///         wallet signing group.
     /// @param walletID ID of the wallet
-    /// @param operator Address of the checked operator
     /// @param walletMembersIDs Identifiers of the wallet signing group members
+    /// @param operator Address of the checked operator
+    /// @param walletMemberIndex Position of the operator in the wallet signing
+    ///        group members list
     /// @return True - if the operator is a member of the given wallet signing
     ///         group. False - otherwise.
     /// @dev Requirements:
@@ -51,9 +53,11 @@ interface IWalletRegistry {
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
     ///        for the given `walletID`.
+    ///      - The `walletMemberIndex` must be in range [0, walletMembersIDs.length-1]
     function isWalletMember(
         bytes32 walletID,
+        uint32[] calldata walletMembersIDs,
         address operator,
-        uint32[] calldata walletMembersIDs
+        uint256 walletMemberIndex
     ) external view returns (bool);
 }

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -52,7 +52,10 @@ interface IWalletRegistry {
     ///      - The `operator` parameter must be an actual sortition pool operator.
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
-    ///        for the given `walletID`.
+    ///        for the given `walletID`. Those IDs are not directly stored
+    ///        in the contract for gas efficiency purposes but they can be
+    ///        read from appropriate `DkgResultSubmitted` and `DkgResultApproved`
+    ///        events.
     ///      - The `walletMemberIndex` must be in range [1, walletMembersIDs.length]
     function isWalletMember(
         bytes32 walletID,

--- a/solidity/ecdsa/contracts/api/IWalletRegistry.sol
+++ b/solidity/ecdsa/contracts/api/IWalletRegistry.sol
@@ -38,4 +38,22 @@ interface IWalletRegistry {
 
     /// @notice Check current wallet creation state.
     function getWalletCreationState() external view returns (EcdsaDkg.State);
+
+    /// @notice Checks whether the given operator is a member of the given
+    ///         wallet signing group.
+    /// @param walletID ID of the wallet
+    /// @param operator Address of the checked operator
+    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    /// @return True - if the operator is a member of the given wallet signing
+    ///         group. False - otherwise.
+    /// @dev Requirements:
+    ///      - The `operator` parameter must be an actual sortition pool operator.
+    ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
+    ///        be exactly the same as the hash stored under `membersIdsHash`
+    ///        for the given `walletID`.
+    function isWalletMember(
+        bytes32 walletID,
+        address operator,
+        uint32[] calldata walletMembersIDs
+    ) external view returns (bool);
 }

--- a/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
@@ -396,7 +396,7 @@ describe("WalletRegistry - Wallets", async () => {
         context("when the passed wallet members identifiers are valid", () => {
           context("when the wallet member index is in correct range", () => {
             context(
-              "when the given operator is the member of the wallet signing group at given position",
+              "when the given operator is the member of the wallet signing group at the given position",
               () => {
                 it("should return true", async () => {
                   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -405,7 +405,7 @@ describe("WalletRegistry - Wallets", async () => {
                       walletID,
                       walletMembersIDs,
                       walletMembersAddresses[5],
-                      5
+                      6
                     )
                   ).to.be.true
                 })
@@ -413,7 +413,7 @@ describe("WalletRegistry - Wallets", async () => {
             )
 
             context(
-              "when the given operator is not the member of the wallet signing group at given position",
+              "when the given operator is not the member of the wallet signing group at the given position",
               () => {
                 it("should return false", async () => {
                   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -422,7 +422,7 @@ describe("WalletRegistry - Wallets", async () => {
                       walletID,
                       walletMembersIDs,
                       walletMembersAddresses[5],
-                      6
+                      7
                     )
                   ).to.be.false
                 })
@@ -431,17 +431,39 @@ describe("WalletRegistry - Wallets", async () => {
           })
 
           context("when the wallet member index is out of range", () => {
-            it("should revert", async () => {
-              // Max proper value is `walletMembersIDs.length-1`.
-              await expect(
-                walletRegistry.isWalletMember(
-                  walletID,
-                  walletMembersIDs,
-                  walletMembersAddresses[0],
-                  walletMembersIDs.length
-                )
-              ).to.be.revertedWith("Wallet member index is out of range")
-            })
+            context(
+              "when the wallet member index is lesser than the minimum proper value",
+              () => {
+                it("should revert", async () => {
+                  // Min proper value is `1`.
+                  await expect(
+                    walletRegistry.isWalletMember(
+                      walletID,
+                      walletMembersIDs,
+                      walletMembersAddresses[0],
+                      0
+                    )
+                  ).to.be.revertedWith("Wallet member index is out of range")
+                })
+              }
+            )
+
+            context(
+              "when the wallet member index is greater than the maximum proper value",
+              () => {
+                it("should revert", async () => {
+                  // Max proper value is `walletMembersIDs.length`.
+                  await expect(
+                    walletRegistry.isWalletMember(
+                      walletID,
+                      walletMembersIDs,
+                      walletMembersAddresses[0],
+                      walletMembersIDs.length + 1
+                    )
+                  ).to.be.revertedWith("Wallet member index is out of range")
+                })
+              }
+            )
           })
         })
 

--- a/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Wallets.test.ts
@@ -7,11 +7,15 @@ import { createNewWallet } from "./utils/wallets"
 import ecdsaData from "./data/ecdsa"
 import { hashUint32Array } from "./utils/groups"
 
+import type { Operator } from "./utils/operators"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { ContractTransaction } from "ethers"
 import type { DkgResult } from "./utils/dkg"
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { WalletRegistry, WalletRegistryStub } from "../typechain"
+import type {
+  IWalletOwner,
+  WalletRegistry,
+  WalletRegistryStub,
+} from "../typechain"
 import type { FakeContract } from "@defi-wonderland/smock"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
@@ -362,5 +366,124 @@ describe("WalletRegistry - Wallets", async () => {
         }
       )
     })
+  })
+
+  describe("isWalletMember", () => {
+    let walletID: string
+    let walletMembersIDs: number[]
+    let walletMembersAddresses: string[]
+
+    before("create a wallet", async () => {
+      await createSnapshot()
+
+      let members: Operator[]
+      ;({ walletID, members } = await createNewWallet(
+        walletRegistry,
+        walletOwner.wallet
+      ))
+
+      walletMembersIDs = members.map((member) => member.id)
+      walletMembersAddresses = members.map((member) => member.signer.address)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context(
+      "when the given operator address is an actual sortition pool operator",
+      () => {
+        context("when the passed wallet members identifiers are valid", () => {
+          context("when the wallet member index is in correct range", () => {
+            context(
+              "when the given operator is the member of the wallet signing group at given position",
+              () => {
+                it("should return true", async () => {
+                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                  expect(
+                    await walletRegistry.isWalletMember(
+                      walletID,
+                      walletMembersIDs,
+                      walletMembersAddresses[5],
+                      5
+                    )
+                  ).to.be.true
+                })
+              }
+            )
+
+            context(
+              "when the given operator is not the member of the wallet signing group at given position",
+              () => {
+                it("should return false", async () => {
+                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                  expect(
+                    await walletRegistry.isWalletMember(
+                      walletID,
+                      walletMembersIDs,
+                      walletMembersAddresses[5],
+                      6
+                    )
+                  ).to.be.false
+                })
+              }
+            )
+          })
+
+          context("when the wallet member index is out of range", () => {
+            it("should revert", async () => {
+              // Max proper value is `walletMembersIDs.length-1`.
+              await expect(
+                walletRegistry.isWalletMember(
+                  walletID,
+                  walletMembersIDs,
+                  walletMembersAddresses[0],
+                  walletMembersIDs.length
+                )
+              ).to.be.revertedWith("Wallet member index is out of range")
+            })
+          })
+        })
+
+        context(
+          "when the passed wallet members identifiers are invalid",
+          () => {
+            it("should revert", async () => {
+              const corruptedWalletMembersIDs = walletMembersIDs.reverse()
+
+              await expect(
+                walletRegistry.isWalletMember(
+                  walletID,
+                  corruptedWalletMembersIDs,
+                  walletMembersAddresses[0],
+                  0
+                )
+              ).to.be.revertedWith("Invalid wallet members identifiers")
+            })
+          }
+        )
+      }
+    )
+
+    context(
+      "when the given operator address is not an actual sortition pool operator",
+      () => {
+        it("should revert", async () => {
+          // To test this scenario, we need an address that is not a
+          // sortition pool operator for sure. The address of the wallet
+          // registry itself seems to be a good candidate.
+          const operator = walletRegistry.address
+
+          await expect(
+            walletRegistry.isWalletMember(
+              walletID,
+              walletMembersIDs,
+              operator,
+              0
+            )
+          ).to.be.revertedWith("Not a sortition pool operator")
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
This change adds `isWalletMember` function to the ECDSA wallet registry. That function allows checking whether the given operator is a member of the given wallet signing group. In order to make a successful check, the tested operator address must actually belong to a sortition pool operator, and the passed wallet members identifiers must be equal to the hashed identifiers held by the contract.

This feature is required by the tBTC v2 wallet moving funds process. Specifically, the `Bridge` contract must make sure the moving funds commitment is made by an actual wallet member.