### PR TITLE
Random Beacon: restricted function mutability, added zero-address and zero-value checks to constructors

### DIFF
--- a/solidity/random-beacon/contracts/BeaconDkgValidator.sol
+++ b/solidity/random-beacon/contracts/BeaconDkgValidator.sol
@@ -56,6 +56,11 @@ contract BeaconDkgValidator {
     SortitionPool public sortitionPool;
 
     constructor(SortitionPool _sortitionPool) {
+        require(
+            address(_sortitionPool) != address(0),
+            "Zero-address reference"
+        );
+
         sortitionPool = _sortitionPool;
     }
 

--- a/solidity/random-beacon/contracts/BeaconDkgValidator.sol
+++ b/solidity/random-beacon/contracts/BeaconDkgValidator.sol
@@ -98,7 +98,7 @@ contract BeaconDkgValidator {
     /// @return errorMsg validation error message; empty for a valid result
     function validateFields(DKG.Result calldata result)
         public
-        view
+        pure
         returns (bool isValid, string memory errorMsg)
     {
         // Group public key needs to be 128 bytes long.
@@ -254,7 +254,7 @@ contract BeaconDkgValidator {
     ///         challenged.
     function validateMembersHash(DKG.Result calldata result)
         public
-        view
+        pure
         returns (bool)
     {
         if (result.misbehavedMembersIndices.length > 0) {

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -1404,13 +1404,12 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable, Reimbursable {
         return sortitionPool.isOperatorInPool(operator);
     }
 
-    /// @notice Selects a new group of operators based on the provided seed.
+    /// @notice Selects a new group of operators. Can only be called when DKG
+    ///         is in progress and the pool is locked.
     ///         At least one operator has to be registered in the pool,
     ///         otherwise the function fails reverting the transaction.
-    /// @param seed Number used to select operators to the group.
     /// @return IDs of selected group members.
-    function selectGroup(bytes32 seed) external view returns (uint32[] memory) {
-        // TODO: Read seed from RandomBeaconDkg
-        return sortitionPool.selectGroup(DKG.groupSize, seed);
+    function selectGroup() external view returns (uint32[] memory) {
+        return sortitionPool.selectGroup(DKG.groupSize, bytes32(dkg.seed));
     }
 }

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -369,6 +369,18 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable, Reimbursable {
         staking = _staking;
         reimbursementPool = _reimbursementPool;
 
+        require(
+            address(_sortitionPool) != address(0),
+            "Zero-address reference"
+        );
+        require(address(_tToken) != address(0), "Zero-address reference");
+        require(address(_staking) != address(0), "Zero-address reference");
+        require(address(_dkgValidator) != address(0), "Zero-address reference");
+        require(
+            address(_reimbursementPool) != address(0),
+            "Zero-address reference"
+        );
+
         // TODO: revisit all initial values
         callbackGasLimit = 56000;
         groupCreationFrequency = 5;

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -269,6 +269,9 @@ contract RandomBeaconGovernance is Ownable {
     }
 
     constructor(RandomBeacon _randomBeacon, uint256 _governanceDelay) {
+        require(address(_randomBeacon) != address(0), "Zero-address reference");
+        require(_governanceDelay != 0, "No governance delay");
+
         randomBeacon = _randomBeacon;
         governanceDelay = _governanceDelay;
     }

--- a/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
@@ -156,7 +156,7 @@ library BeaconInactivity {
     function validateMembersIndices(
         uint256[] calldata indices,
         uint256 groupSize
-    ) internal view {
+    ) internal pure {
         require(
             indices.length > 0 && indices.length <= groupSize,
             "Corrupted members indices"

--- a/solidity/random-beacon/test/RandomBeacon.Constructor.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Constructor.test.ts
@@ -6,7 +6,7 @@ import type { RandomBeacon__factory, SortitionPool } from "../typechain"
 
 const ZERO_ADDRESS = ethers.constants.AddressZero
 
-describe.only("RandomBeacon - Constructor", () => {
+describe("RandomBeacon - Constructor", () => {
   let sortitionPool: SortitionPool
   let tToken: string
   let staking: string

--- a/solidity/random-beacon/test/RandomBeacon.Constructor.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Constructor.test.ts
@@ -1,0 +1,145 @@
+import { ethers, getUnnamedAccounts } from "hardhat"
+import { expect } from "chai"
+import { to1e18 } from "@keep-network/hardhat-helpers/dist/src/number"
+
+import type { RandomBeacon__factory, SortitionPool } from "../typechain"
+
+const ZERO_ADDRESS = ethers.constants.AddressZero
+
+describe.only("RandomBeacon - Constructor", () => {
+  let sortitionPool: SortitionPool
+  let tToken: string
+  let staking: string
+  let dkgValidator: string
+  let reimbursementPool: string
+
+  let RandomBeacon: RandomBeacon__factory
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;[tToken, staking, dkgValidator, reimbursementPool] =
+      await getUnnamedAccounts()
+
+    // we need real SortitionPool contract instead of just string address
+    // because BeaconDkg.currentState() is called from the RandomBeacon
+    // constructor
+    const SortitionPool = await ethers.getContractFactory("SortitionPool")
+    sortitionPool = (await SortitionPool.deploy(
+      tToken,
+      to1e18(1)
+    )) as SortitionPool
+
+    const BLS = await ethers.getContractFactory("BLS")
+    const bls = await BLS.deploy()
+    await bls.deployed()
+
+    const Authorization = await ethers.getContractFactory("BeaconAuthorization")
+    const authorization = await Authorization.deploy()
+    await authorization.deployed()
+
+    const BeaconDkg = await ethers.getContractFactory("BeaconDkg")
+    const dkg = await BeaconDkg.deploy()
+    await dkg.deployed()
+
+    const BeaconInactivity = await ethers.getContractFactory("BeaconInactivity")
+    const inactivity = await BeaconInactivity.deploy()
+    await inactivity.deployed()
+
+    RandomBeacon = await ethers.getContractFactory<RandomBeacon__factory>(
+      "RandomBeacon",
+      {
+        libraries: {
+          BLS: bls.address,
+          BeaconAuthorization: authorization.address,
+          BeaconDkg: dkg.address,
+          BeaconInactivity: inactivity.address,
+        },
+      }
+    )
+  })
+
+  describe("constructor", () => {
+    context("when all passed addresses are valid", () => {
+      it("should work", async () => {
+        await RandomBeacon.deploy(
+          sortitionPool.address,
+          tToken,
+          staking,
+          dkgValidator,
+          reimbursementPool
+        )
+        // ok, did not revert
+      })
+    })
+
+    context("when sortition pool is 0-address", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeacon.deploy(
+            ZERO_ADDRESS,
+            tToken,
+            staking,
+            dkgValidator,
+            reimbursementPool
+          )
+        ).to.be.revertedWith("Zero-address reference")
+      })
+    })
+
+    context("when T token is 0-address", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeacon.deploy(
+            sortitionPool.address,
+            ZERO_ADDRESS,
+            staking,
+            dkgValidator,
+            reimbursementPool
+          )
+        ).to.be.revertedWith("Zero-address reference")
+      })
+    })
+
+    context("when token staking is 0-address", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeacon.deploy(
+            sortitionPool.address,
+            tToken,
+            ZERO_ADDRESS,
+            dkgValidator,
+            reimbursementPool
+          )
+        ).to.be.revertedWith("Zero-address reference")
+      })
+    })
+
+    context("when DKG validator is 0-address", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeacon.deploy(
+            sortitionPool.address,
+            tToken,
+            staking,
+            ZERO_ADDRESS,
+            reimbursementPool
+          )
+        ).to.be.revertedWith("Zero-address reference")
+      })
+    })
+
+    context("when reimbursement pool is 0-address", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeacon.deploy(
+            sortitionPool.address,
+            tToken,
+            staking,
+            dkgValidator,
+            ZERO_ADDRESS
+          )
+        ).to.be.revertedWith("Zero-address reference")
+      })
+    })
+  })
+})

--- a/solidity/random-beacon/test/RandomBeacon.Constructor.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Constructor.test.ts
@@ -61,14 +61,15 @@ describe("RandomBeacon - Constructor", () => {
   describe("constructor", () => {
     context("when all passed addresses are valid", () => {
       it("should work", async () => {
-        await RandomBeacon.deploy(
-          sortitionPool.address,
-          tToken,
-          staking,
-          dkgValidator,
-          reimbursementPool
-        )
-        // ok, did not revert
+        await expect(
+          RandomBeacon.deploy(
+            sortitionPool.address,
+            tToken,
+            staking,
+            dkgValidator,
+            reimbursementPool
+          )
+        ).not.to.be.reverted
       })
     })
 

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -2721,6 +2721,53 @@ describe("RandomBeacon - Group Creation", () => {
       await restoreSnapshot()
     })
   })
+
+  describe("selectGroup", async () => {
+    context("when dkg was not triggered", async () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(randomBeacon.selectGroup()).to.be.revertedWith(
+          "Sortition pool unlocked"
+        )
+      })
+    })
+
+    context("when dkg was triggered", async () => {
+      let genesisSeed: BigNumber
+
+      before(async () => {
+        await createSnapshot()
+
+        const [, seed] = await genesis(randomBeacon)
+        genesisSeed = seed
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should select a group", async () => {
+        const selectedGroup = await randomBeacon.selectGroup()
+        expect(selectedGroup.length).to.eq(constants.groupSize)
+      })
+
+      it("should be the same group as if called the sortition pool directly", async () => {
+        const exectedGroup = await sortitionPool.selectGroup(
+          constants.groupSize,
+          genesisSeed.toHexString()
+        )
+        const actualGroup = await randomBeacon.selectGroup()
+        expect(exectedGroup).to.be.deep.equal(actualGroup)
+      })
+    })
+  })
 })
 
 async function assertDkgResultCleanData(randomBeacon: {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -37,6 +37,8 @@ const initialDkgResultApprovalGasOffset = 43500
 const initialNotifyOperatorInactivityGasOffset = 54500
 const initialRelayEntrySubmissionGasOffset = 11500
 
+const ZERO_ADDRESS = ethers.constants.AddressZero
+
 const fixture = async () => {
   const governance = await ethers.getNamedSigner("deployer")
 
@@ -118,6 +120,33 @@ describe("RandomBeaconGovernance", () => {
     [thirdParty, thirdPartyContract] = await ethers.getUnnamedSigners()
     ;({ governance, randomBeaconGovernance, randomBeacon } =
       await waffle.loadFixture(fixture))
+  })
+
+  describe("constructor", () => {
+    let RandomBeaconGovernance: RandomBeaconGovernance__factory
+
+    before(async () => {
+      RandomBeaconGovernance =
+        await ethers.getContractFactory<RandomBeaconGovernance__factory>(
+          "RandomBeaconGovernance"
+        )
+    })
+
+    context("when random beacon is 0-address", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeaconGovernance.deploy(ZERO_ADDRESS, 1)
+        ).to.be.revertedWith("Zero-address reference")
+      })
+    })
+
+    context("when governance delay is 0", () => {
+      it("should revert", async () => {
+        await expect(
+          RandomBeaconGovernance.deploy(randomBeacon.address, 0)
+        ).to.be.revertedWith("No governance delay")
+      })
+    })
   })
 
   describe("beginGovernanceDelayUpdate", () => {


### PR DESCRIPTION
Restricted mutability of `validateFields` and `validateMembersHash` in
`BeaconDkgValidator` from `view` to `pure`.

Restricted mutability of `validateMembersIndices` in `BeaconInactivity` from
`view` to `pure`.

Added zero-address and zero-value checks to constructors.
