### PR TITLE
Random Beacon: read DKG seed from chain instead of passing it

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -1404,13 +1404,12 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable, Reimbursable {
         return sortitionPool.isOperatorInPool(operator);
     }
 
-    /// @notice Selects a new group of operators based on the provided seed.
+    /// @notice Selects a new group of operators. Can only be called when DKG
+    ///         is in progress and the pool is locked.
     ///         At least one operator has to be registered in the pool,
     ///         otherwise the function fails reverting the transaction.
-    /// @param seed Number used to select operators to the group.
     /// @return IDs of selected group members.
-    function selectGroup(bytes32 seed) external view returns (uint32[] memory) {
-        // TODO: Read seed from RandomBeaconDkg
-        return sortitionPool.selectGroup(DKG.groupSize, seed);
+    function selectGroup() external view returns (uint32[] memory) {
+        return sortitionPool.selectGroup(DKG.groupSize, bytes32(dkg.seed));
     }
 }

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -2721,6 +2721,41 @@ describe("RandomBeacon - Group Creation", () => {
       await restoreSnapshot()
     })
   })
+
+  describe("selectGroup", async () => {
+    context("when dkg was not triggered", async () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(randomBeacon.selectGroup()).to.be.revertedWith(
+          "Sortition pool unlocked"
+        )
+      })
+    })
+
+    context("when dkg was triggered", async () => {
+      before(async () => {
+        await createSnapshot()
+
+        await genesis(randomBeacon)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should select a group", async () => {
+        const selectedGroup = await randomBeacon.selectGroup()
+        expect(selectedGroup.length).to.eq(constants.groupSize)
+      })
+    })
+  })
 })
 
 async function assertDkgResultCleanData(randomBeacon: {

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -2740,10 +2740,13 @@ describe("RandomBeacon - Group Creation", () => {
     })
 
     context("when dkg was triggered", async () => {
+      let genesisSeed: BigNumber
+
       before(async () => {
         await createSnapshot()
 
-        await genesis(randomBeacon)
+        const [, seed] = await genesis(randomBeacon)
+        genesisSeed = seed
       })
 
       after(async () => {
@@ -2753,6 +2756,15 @@ describe("RandomBeacon - Group Creation", () => {
       it("should select a group", async () => {
         const selectedGroup = await randomBeacon.selectGroup()
         expect(selectedGroup.length).to.eq(constants.groupSize)
+      })
+
+      it("should be the same group as if called the sortition pool directly", async () => {
+        const exectedGroup = await sortitionPool.selectGroup(
+          constants.groupSize,
+          genesisSeed.toHexString()
+        )
+        const actualGroup = await randomBeacon.selectGroup()
+        expect(exectedGroup).to.be.deep.equal(actualGroup)
       })
     })
   })


### PR DESCRIPTION
Closes #2929

Instead of requiring operators to pass the value that is already
available on-chain, we just read this value from DKG library storage.