### PR TITLE
Update sortition pools unlocks and DKG complete for notifySeedTimeout

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -650,13 +650,11 @@ contract WalletRegistry is
     ///         callback function.
     function notifySeedTimeout() external refundable(msg.sender) {
         dkg.notifySeedTimeout();
-        dkg.complete();
     }
 
     /// @notice Notifies about DKG timeout.
     function notifyDkgTimeout() external refundable(msg.sender) {
         dkg.notifyDkgTimeout();
-        dkg.complete();
     }
 
     /// @notice Challenges DKG result. If the submitted result is proved to be

--- a/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
@@ -289,6 +289,8 @@ library EcdsaDkg {
         require(hasSeedTimedOut(self), "Awaiting seed has not timed out");
 
         emit DkgSeedTimedOut();
+
+        complete(self);
     }
 
     /// @notice Notifies about DKG timeout.
@@ -296,6 +298,8 @@ library EcdsaDkg {
         require(hasDkgTimedOut(self), "DKG has not timed out");
 
         emit DkgTimedOut();
+
+        complete(self);
     }
 
     /// @notice Approves DKG result. Can be called when the challenge period for

--- a/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
@@ -289,8 +289,6 @@ library EcdsaDkg {
         require(hasSeedTimedOut(self), "Awaiting seed has not timed out");
 
         emit DkgSeedTimedOut();
-
-        self.sortitionPool.unlock();
     }
 
     /// @notice Notifies about DKG timeout.

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -1085,6 +1085,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable, Reimbursable {
             // avoid blocking the future group creation.
             if (dkg.currentState() == DKG.State.AWAITING_SEED) {
                 dkg.notifySeedTimedOut();
+                dkg.complete();
             }
         }
     }

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -777,7 +777,6 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable, Reimbursable {
     /// @notice Notifies about DKG timeout.
     function notifyDkgTimeout() external refundable(msg.sender) {
         dkg.notifyTimeout();
-        dkg.complete();
     }
 
     /// @notice Approves DKG result. Can be called when the challenge period for
@@ -1085,7 +1084,6 @@ contract RandomBeacon is IRandomBeacon, IApplication, Ownable, Reimbursable {
             // avoid blocking the future group creation.
             if (dkg.currentState() == DKG.State.AWAITING_SEED) {
                 dkg.notifySeedTimedOut();
-                dkg.complete();
             }
         }
     }

--- a/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
@@ -272,6 +272,8 @@ library BeaconDkg {
         require(hasDkgTimedOut(self), "DKG has not timed out");
 
         emit DkgTimedOut();
+
+        complete(self);
     }
 
     /// @notice Notifies about the seed was not delivered and restores the
@@ -283,6 +285,8 @@ library BeaconDkg {
         );
 
         emit DkgSeedTimedOut();
+
+        complete(self);
     }
 
     /// @notice Approves DKG result. Can be called when the challenge period for

--- a/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
@@ -283,8 +283,6 @@ library BeaconDkg {
         );
 
         emit DkgSeedTimedOut();
-
-        self.sortitionPool.unlock();
     }
 
     /// @notice Approves DKG result. Can be called when the challenge period for


### PR DESCRIPTION
After `notifySeedTimeout` is called we want to unlock the sortition pool and cleanup DKG state. In this PR we make it consistent for both ECDSA and Random Beacon.

`sortitionPool.unlock()` is called as part of `dkg.complete` function.