### PR TITLE
WalletRegistry.seize function implemented

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -774,6 +774,58 @@ contract WalletRegistry is
         );
     }
 
+    /// @notice Allows the wallet owner to add all signing group members of the
+    ///         wallet with the given ID to the slashing queue of the staking .
+    ///         contract. The notifier will receive reward per each group member
+    ///         from the staking contract notifiers treasury. The reward is
+    ///         scaled by the `rewardMultiplier` provided as a parameter.
+    /// @param amount Amount of tokens to seize from each signing group member
+    /// @param rewardMultiplier Fraction of the staking contract notifiers
+    ///        reward the notifier should receive; should be between [0, 100]
+    /// @param notifier Address of the misbehavior notifier
+    /// @param walletID ID of the wallet
+    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    /// @dev Requirements:
+    ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
+    ///        be exactly the same as the hash stored under `membersIdsHash`
+    ///        for the given `walletID`. Those IDs are not directly stored
+    ///        in the contract for gas efficiency purposes but they can be
+    ///        read from appropriate `DkgResultSubmitted` and `DkgResultApproved`
+    ///        events.
+    ///      - `rewardMultiplier` must be between [0, 100]
+    function seize(
+        uint96 amount,
+        uint256 rewardMultiplier,
+        address notifier,
+        bytes32 walletID,
+        uint32[] calldata walletMembersIDs
+    ) external onlyWalletOwner {
+        bytes32 memberIdsHash = wallets.getWalletMembersIdsHash(walletID);
+        require(
+            memberIdsHash == keccak256(abi.encode(walletMembersIDs)),
+            "Invalid wallet members identifiers"
+        );
+
+        address[] memory groupMembersAddresses = sortitionPool.getIDOperators(
+            walletMembersIDs
+        );
+        address[] memory stakingProvidersAddresses = new address[](
+            walletMembersIDs.length
+        );
+        for (uint256 i = 0; i < groupMembersAddresses.length; i++) {
+            stakingProvidersAddresses[i] = operatorToStakingProvider(
+                groupMembersAddresses[i]
+            );
+        }
+
+        staking.seize(
+            amount,
+            rewardMultiplier,
+            notifier,
+            stakingProvidersAddresses
+        );
+    }
+
     /// @notice Checks if DKG result is valid for the current DKG.
     /// @param result DKG result.
     /// @return True if the result is valid. If the result is invalid it returns

--- a/solidity/ecdsa/test/WalletRegistry.Slashing.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Slashing.test.ts
@@ -1,0 +1,152 @@
+/* eslint-disable no-await-in-loop */
+import { helpers } from "hardhat"
+import { expect } from "chai"
+import { to1e18 } from "@keep-network/hardhat-helpers/dist/src/number"
+
+import ecdsaData from "./data/ecdsa"
+import { constants, walletRegistryFixture } from "./fixtures"
+import { createNewWallet } from "./utils/wallets"
+
+import type {
+  WalletRegistry,
+  IWalletOwner,
+  TokenStaking,
+  T,
+} from "../typechain"
+import type { FakeContract } from "@defi-wonderland/smock"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { Operator, OperatorID } from "./utils/operators"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("WalletRegistry - Slashing", () => {
+  let walletRegistry: WalletRegistry
+  let walletOwner: FakeContract<IWalletOwner>
+  let thirdParty: SignerWithAddress
+  let staking: TokenStaking
+  let tToken: T
+
+  let members: Operator[]
+  let membersIDs: OperatorID[]
+  let membersAddresses: string[]
+  let walletID: string
+
+  const walletPublicKey: string = ecdsaData.group1.publicKey
+  const amountToSlash = to1e18(1000)
+  const rewardMultiplier = 30
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ walletRegistry, walletOwner, thirdParty, staking, tToken } =
+      await walletRegistryFixture())
+    ;({ walletID, members } = await createNewWallet(
+      walletRegistry,
+      walletOwner.wallet,
+      walletPublicKey
+    ))
+
+    membersIDs = members.map((member) => member.id)
+    membersAddresses = members.map((member) => member.signer.address)
+  })
+
+  describe("seize", () => {
+    context("when called not by the wallet owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistry
+            .connect(thirdParty)
+            .seize(
+              amountToSlash,
+              rewardMultiplier,
+              thirdParty.address,
+              walletID,
+              membersIDs
+            )
+        ).to.be.revertedWith("Caller is not the Wallet Owner")
+      })
+    })
+
+    context("when called by the wallet owner", () => {
+      context("when the passed wallet members identifiers are invalid", () => {
+        it("should revert", async () => {
+          const corruptedMembersIDs = membersIDs.slice().reverse()
+          await expect(
+            walletRegistry
+              .connect(walletOwner.wallet)
+              .seize(
+                amountToSlash,
+                rewardMultiplier,
+                thirdParty.address,
+                walletID,
+                corruptedMembersIDs
+              )
+          ).to.be.revertedWith("Invalid wallet members identifiers")
+        })
+      })
+
+      context("when the passed wallet members identifiers are valid", () => {
+        let notifierBalanceBefore
+        let notifierBalanceAfter
+
+        before(async () => {
+          await createSnapshot()
+
+          notifierBalanceBefore = await tToken.balanceOf(thirdParty.address)
+          await walletRegistry
+            .connect(walletOwner.wallet)
+            .seize(
+              amountToSlash,
+              rewardMultiplier,
+              thirdParty.address,
+              walletID,
+              membersIDs
+            )
+          notifierBalanceAfter = await tToken.balanceOf(thirdParty.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should slash all group members", async () => {
+          expect(await staking.getSlashingQueueLength()).to.equal(
+            constants.groupSize
+          )
+        })
+
+        it("should slash with correct amounts", async () => {
+          for (let i = 0; i < constants.groupSize; i++) {
+            const slashing = await staking.slashingQueue(i)
+            expect(slashing.amount).to.equal(amountToSlash)
+          }
+        })
+
+        it("should slash correct staking providers", async () => {
+          for (let i = 0; i < constants.groupSize; i++) {
+            const slashing = await staking.slashingQueue(i)
+            const expectedStakingProvider =
+              await walletRegistry.operatorToStakingProvider(
+                membersAddresses[i]
+              )
+
+            expect(slashing.stakingProvider).to.equal(expectedStakingProvider)
+          }
+        })
+
+        it("should send correct reward to notifier", async () => {
+          // reward multiplier is in % so we first multiply and then divide by
+          // 100 to get the actual number
+          const perMemberReward = constants.tokenStakingNotificationReward
+            .mul(rewardMultiplier)
+            .div(100)
+
+          const receivedReward = notifierBalanceAfter.sub(notifierBalanceBefore)
+
+          expect(receivedReward).to.equal(
+            perMemberReward.mul(constants.groupSize)
+          )
+        })
+      })
+    })
+  })
+})

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -129,7 +129,9 @@ async function updateTokenStakingParams(
   staking: TokenStaking,
   deployer: SignerWithAddress
 ) {
-  const initialNotifierTreasury = to1e18(100000) // 100k T
+  const initialNotifierTreasury = constants.tokenStakingNotificationReward.mul(
+    constants.groupSize
+  )
   await tToken
     .connect(deployer)
     .approve(staking.address, initialNotifierTreasury)


### PR DESCRIPTION
Closes #2927

Allows the wallet owner to add all signing group members of the wallet with the given ID to the slashing queue of the staking contract. The notifier will receive reward per each group member from the staking contract notifiers treasury. The reward is scaled by the `rewardMultiplier` provided as a parameter.

This function will be used by tBTC Bridge contract to slash wallet signing group members.

TODO:
- [ ] Some time ago, hardhat gas reporter plugin stopped providing the report. For this reason, the gas cost of calling the new function is unknown at the moment.
- [ ] `@threshold-network/solidity-contracts` dependency should be updated to version `>1.2.0-dev <1.2.0-ropsten` to include the gas cost fix for `TokenStaking` from https://github.com/threshold-network/solidity-contracts/pull/87. This is blocked by a problem with running tests after the upgrade:
  ```
  Error: ERROR processing /Users/piotr/git/keep-network/keep-core/solidity/ecdsa/node_modules/@threshold-network/solidity-contracts/export/deploy/00_resolve_keep_registry.js:
  TypeError: Cannot read properties of undefined (reading 'length')
  ```