### PR TITLE
Fix the tagging of `random-beacon` and `ecdsa` packages

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -48,13 +48,13 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Publish package
-        if: github.ref == 'main'
+        if: github.ref == 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public --tag=development
 
       - name: Publish package
-        if: github.ref != 'main'
+        if: github.ref != 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -43,13 +43,13 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Publish package
-        if: github.ref == 'main'
+        if: github.ref == 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public --tag=development
 
       - name: Publish package
-        if: github.ref != 'main'
+        if: github.ref != 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public


### PR DESCRIPTION
Our intention is to tag the published NPM packages with `development`
tag when changes to the contract and configuration related files get
modified and those changes land on `main` branch. The configuration of
the steps in the `npm-....yml` workflows responsible for that was wrong.
The format of the `github.ref` variable for the `main` branch is
`refs/heads/main`, not `main`.