### PR TITLE
Fund ETH ReimbursementPool for ECDSA unit tests in fixture and fix hardhat gas reporter

### DIFF
--- a/solidity/ecdsa/deploy/02_deploy_reimbursement_pool.ts
+++ b/solidity/ecdsa/deploy/02_deploy_reimbursement_pool.ts
@@ -1,13 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { ethers } from "hardhat"
-
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
-  const deployerSigner = await ethers.getSigner(deployer)
 
   const staticGas = 40800 // gas amount consumed by the refund() + tx cost
   const maxGasPrice = 500000000000 // 500 gwei
@@ -17,13 +14,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     args: [staticGas, maxGasPrice],
     log: true,
   })
-
-  if (deployments.getNetworkName() === "hardhat") {
-    await deployerSigner.sendTransaction({
-      to: ReimbursementPool.address,
-      value: ethers.utils.parseEther("100.0"), // Send 100.0 ETH
-    })
-  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -102,6 +102,8 @@ export const walletRegistryFixture = deployments.createFixture(
     // Set parameters with tweaked values to reduce test execution time.
     await updateWalletRegistryParams(walletRegistryGovernance, governance)
 
+    await fundReimbursementPool(deployer, reimbursementPool)
+
     // Mock Wallet Owner contract.
     const walletOwner: FakeContract<IWalletOwner> = await initializeWalletOwner(
       walletRegistryGovernance,
@@ -229,4 +231,14 @@ export async function initializeWalletOwner(
     .initializeWalletOwner(walletOwner.address)
 
   return walletOwner
+}
+
+async function fundReimbursementPool(
+  deployer: SignerWithAddress,
+  reimbursementPool: ReimbursementPool
+) {
+  await deployer.sendTransaction({
+    to: reimbursementPool.address,
+    value: ethers.utils.parseEther("100.0"), // Send 100.0 ETH
+  })
 }


### PR DESCRIPTION
Instead of funding the pool in deployment scripts we fund it in the test fixture. After all, this funding is only for unit tests.

What is interesting, this change is fixing harhat gas reporter that is now displaying gas usage summary again at the end of `yarn test`.

The gas reporter worked fine at commit 7a476f4b2f709af696e7f9461314fbe4c1c56fdd and stopped working in the very next commit, c49d2300eac14cc2f9ce89810d500f0db154136f, where the change to deployment scripts funding the pool was introduced.