### PR TITLE
Governable contract copied from ecdsa to random-beacon

### DIFF
--- a/solidity/random-beacon/contracts/Governable.sol
+++ b/solidity/random-beacon/contracts/Governable.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+//
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+pragma solidity ^0.8.9;
+
+/// @notice Governable contract.
+/// @dev A constructor is not defined, which makes the contract compatible with
+///      upgradable proxies. This requires calling explicitly `_transferGovernance`
+///      function in a child contract.
+abstract contract Governable {
+    // Governance of the contract
+    address public governance;
+
+    event GovernanceTransferred(address oldGovernance, address newGovernance);
+
+    modifier onlyGovernance() virtual {
+        require(governance == msg.sender, "Caller is not the governance");
+        _;
+    }
+
+    /// @notice Transfers governance of the contract to `newGovernance`.
+    function transferGovernance(address newGovernance)
+        external
+        virtual
+        onlyGovernance
+    {
+        require(
+            newGovernance != address(0),
+            "New governance is the zero address"
+        );
+        _transferGovernance(newGovernance);
+    }
+
+    function _transferGovernance(address newGovernance) internal virtual {
+        address oldGovernance = governance;
+        governance = newGovernance;
+        emit GovernanceTransferred(oldGovernance, newGovernance);
+    }
+}

--- a/solidity/random-beacon/contracts/test/GovernableImpl.sol
+++ b/solidity/random-beacon/contracts/test/GovernableImpl.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.8.9;
+
+import "../Governable.sol";
+
+contract GovernableImpl is Governable {
+    function _transferGovernanceExposed(address newGovernance) external {
+        _transferGovernance(newGovernance);
+    }
+}

--- a/solidity/random-beacon/test/Governable.test.ts
+++ b/solidity/random-beacon/test/Governable.test.ts
@@ -1,0 +1,177 @@
+/* eslint-disable no-underscore-dangle */
+import { expect } from "chai"
+import { ethers, helpers } from "hardhat"
+
+import type { ContractTransaction } from "ethers"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { GovernableImpl, GovernableImpl__factory } from "../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("Governable", () => {
+  let governable: GovernableImpl
+  let deployer: SignerWithAddress
+  let governance: SignerWithAddress
+  let thirdParty: SignerWithAddress
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ deployer, governance } = await ethers.getNamedSigners())
+    ;[thirdParty] = await ethers.getUnnamedSigners()
+
+    const GovernableFactory: GovernableImpl__factory =
+      await ethers.getContractFactory("GovernableImpl", deployer)
+    governable = await GovernableFactory.deploy()
+  })
+
+  describe("constructor", () => {
+    it("sets governance to default zero address", async () => {
+      expect(await governable.governance()).to.be.equal(
+        ethers.constants.AddressZero
+      )
+    })
+  })
+
+  describe("transferGovernance", () => {
+    describe("when governance was not initialized", () => {
+      describe("when called by the deployer", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(deployer)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when called by the governance", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(governance)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when called by a third party", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(thirdParty)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+    })
+
+    describe("when governance was initialized", () => {
+      before(async () => {
+        await governable._transferGovernanceExposed(governance.address)
+      })
+
+      describe("when called by the deployer", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(deployer)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when called by the governance", () => {
+        const newGovernance: string = ethers.Wallet.createRandom().address
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await governable
+            .connect(governance)
+            .transferGovernance(newGovernance)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("updates governance address", async () => {
+          expect(await governable.governance()).to.be.equal(newGovernance)
+        })
+
+        it("emits GovernanceTransferred event", async () => {
+          await expect(tx)
+            .to.emit(governable, "GovernanceTransferred")
+            .withArgs(governance.address, newGovernance)
+        })
+      })
+
+      describe("when called by a third party", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(thirdParty)
+              .transferGovernance(ethers.Wallet.createRandom().address)
+          ).to.be.revertedWith("Caller is not the governance")
+        })
+      })
+
+      describe("when new governance is zero address", () => {
+        it("reverts", async () => {
+          await expect(
+            governable
+              .connect(governance)
+              .transferGovernance(ethers.constants.AddressZero)
+          ).to.be.revertedWith("New governance is the zero address")
+        })
+      })
+    })
+  })
+
+  describe("_transferGovernance", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    describe("when called by the deployer", () => {
+      it("succeeds", async () => {
+        const newGovernance = ethers.Wallet.createRandom().address
+
+        await governable
+          .connect(deployer)
+          ._transferGovernanceExposed(newGovernance)
+
+        expect(await governable.governance()).to.be.equal(newGovernance)
+      })
+    })
+
+    describe("when called by the governance", () => {
+      it("succeeds", async () => {
+        const newGovernance = ethers.Wallet.createRandom().address
+
+        await governable
+          .connect(governance)
+          ._transferGovernanceExposed(newGovernance)
+
+        expect(await governable.governance()).to.be.equal(newGovernance)
+      })
+    })
+
+    describe("when called by a third party", () => {
+      it("succeeds", async () => {
+        const newGovernance = ethers.Wallet.createRandom().address
+
+        await governable
+          .connect(thirdParty)
+          ._transferGovernanceExposed(newGovernance)
+
+        expect(await governable.governance()).to.be.equal(newGovernance)
+      })
+    })
+  })
+})


### PR DESCRIPTION
See https://github.com/keep-network/keep-core/pull/2921/

This contract was originally implemented by @nkuba for ECDSA
`WalletRegistry` but we can use it also for `RandomBeacon`. First, for
consistency, second to decrease its size given we may need space for one
more function and event related to rewards.

Files are copied and not moved so that we can merge into `main`, have a
a new version of `@keep-network/random-beacon` pushed to NPM registry and
in a separate PR, import these contracts from `ecdsa` module and remove
them from there.

CONTRACTS AND TESTS WERE MOVED WITH NO CHANGES!