### PR TITLE
RandomBeacon contract switched to use Governable

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -25,8 +25,8 @@ contract RandomBeaconGovernance is Ownable {
     uint256 public newGovernanceDelay;
     uint256 public governanceDelayChangeInitiated;
 
-    address public newRandomBeaconOwner;
-    uint256 public randomBeaconOwnershipTransferInitiated;
+    address public newRandomBeaconGovernance;
+    uint256 public randomBeaconGovernanceTransferInitiated;
 
     uint256 public newRelayEntrySoftTimeout;
     uint256 public relayEntrySoftTimeoutChangeInitiated;
@@ -103,11 +103,11 @@ contract RandomBeaconGovernance is Ownable {
     );
     event GovernanceDelayUpdated(uint256 governanceDelay);
 
-    event RandomBeaconOwnershipTransferStarted(
-        address newRandomBeaconOwner,
+    event RandomBeaconGovernanceTransferStarted(
+        address newRandomBeaconGovernance,
         uint256 timestamp
     );
-    event RandomBeaconOwnershipTransferred(address newRandomBeaconOwner);
+    event RandomBeaconGovernanceTransferred(address newRandomBeaconGovernance);
 
     event RelayEntrySoftTimeoutUpdateStarted(
         uint256 relayEntrySoftTimeout,
@@ -304,39 +304,38 @@ contract RandomBeaconGovernance is Ownable {
         newGovernanceDelay = 0;
     }
 
-    /// @notice Begins the random beacon ownership transfer process.
-    /// @dev Can be called only by the contract owner.
-    function beginRandomBeaconOwnershipTransfer(address _newRandomBeaconOwner)
-        external
-        onlyOwner
-    {
+    /// @notice Begins the random beacon governance transfer process.
+    /// @dev Can be called only by the current contract governance.
+    function beginRandomBeaconGovernanceTransfer(
+        address _newRandomBeaconGovernance
+    ) external onlyOwner {
         require(
-            address(_newRandomBeaconOwner) != address(0),
-            "New random beacon owner address cannot be zero"
+            address(_newRandomBeaconGovernance) != address(0),
+            "New random beacon governance address cannot be zero"
         );
-        newRandomBeaconOwner = _newRandomBeaconOwner;
+        newRandomBeaconGovernance = _newRandomBeaconGovernance;
         /* solhint-disable not-rely-on-time */
-        randomBeaconOwnershipTransferInitiated = block.timestamp;
-        emit RandomBeaconOwnershipTransferStarted(
-            _newRandomBeaconOwner,
+        randomBeaconGovernanceTransferInitiated = block.timestamp;
+        emit RandomBeaconGovernanceTransferStarted(
+            _newRandomBeaconGovernance,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
     }
 
-    /// @notice Finalizes the random beacon ownership transfer process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
-    function finalizeRandomBeaconOwnershipTransfer()
+    /// @notice Finalizes the random beacon governance transfer process.
+    /// @dev Can be called only by the current contract governance, after the
+    ///      governance delay elapses.
+    function finalizeRandomBeaconGovernanceTransfer()
         external
         onlyOwner
-        onlyAfterGovernanceDelay(randomBeaconOwnershipTransferInitiated)
+        onlyAfterGovernanceDelay(randomBeaconGovernanceTransferInitiated)
     {
-        emit RandomBeaconOwnershipTransferred(newRandomBeaconOwner);
+        emit RandomBeaconGovernanceTransferred(newRandomBeaconGovernance);
         // slither-disable-next-line reentrancy-no-eth
-        randomBeacon.transferOwnership(newRandomBeaconOwner);
-        randomBeaconOwnershipTransferInitiated = 0;
-        newRandomBeaconOwner = address(0);
+        randomBeacon.transferGovernance(newRandomBeaconGovernance);
+        randomBeaconGovernanceTransferInitiated = 0;
+        newRandomBeaconGovernance = address(0);
     }
 
     /// @notice Begins the relay entry soft timeout update process.
@@ -1218,15 +1217,15 @@ contract RandomBeaconGovernance is Ownable {
         return getRemainingChangeTime(governanceDelayChangeInitiated);
     }
 
-    /// @notice Get the time remaining until the random beacon ownership can
+    /// @notice Get the time remaining until the random beacon governance can
     ///         be transferred.
     /// @return Remaining time in seconds.
-    function getRemainingRandomBeaconOwnershipTransferDelayTime()
+    function getRemainingRandomBeaconGovernanceTransferDelayTime()
         external
         view
         returns (uint256)
     {
-        return getRemainingChangeTime(randomBeaconOwnershipTransferInitiated);
+        return getRemainingChangeTime(randomBeaconGovernanceTransferInitiated);
     }
 
     /// @notice Get the time remaining until the relay entry submission soft

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -29,7 +29,7 @@ describe("RandomBeacon - Parameters", () => {
     const relayEntryHardTimeout = 300
     const callbackGasLimit = 400
 
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
@@ -39,11 +39,11 @@ describe("RandomBeacon - Parameters", () => {
               relayEntryHardTimeout,
               callbackGasLimit
             )
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       let tx: ContractTransaction
 
       before(async () => {
@@ -96,7 +96,7 @@ describe("RandomBeacon - Parameters", () => {
     const minimumAuthorization = 4200000
     const authorizationDecreaseDelay = 86400
 
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
@@ -105,11 +105,11 @@ describe("RandomBeacon - Parameters", () => {
               minimumAuthorization,
               authorizationDecreaseDelay
             )
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       let tx: ContractTransaction
 
       before(async () => {
@@ -151,7 +151,7 @@ describe("RandomBeacon - Parameters", () => {
     const groupCreationFrequency = 100
     const groupLifetime = 200
 
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
@@ -160,11 +160,11 @@ describe("RandomBeacon - Parameters", () => {
               groupCreationFrequency,
               groupLifetime
             )
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       let tx: ContractTransaction
 
       before(async () => {
@@ -202,7 +202,7 @@ describe("RandomBeacon - Parameters", () => {
     const dkgResultSubmissionTimeout = 400
     const dkgSubmitterPrecedencePeriodLength = 200
 
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
@@ -212,11 +212,11 @@ describe("RandomBeacon - Parameters", () => {
               dkgResultSubmissionTimeout,
               dkgSubmitterPrecedencePeriodLength
             )
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       context("when values are valid", () => {
         let tx: ContractTransaction
 
@@ -319,7 +319,7 @@ describe("RandomBeacon - Parameters", () => {
     const unauthorizedSigningNotificationRewardMultiplier = 10
     const dkgMaliciousResultNotificationRewardMultiplier = 20
 
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
@@ -330,11 +330,11 @@ describe("RandomBeacon - Parameters", () => {
               unauthorizedSigningNotificationRewardMultiplier,
               dkgMaliciousResultNotificationRewardMultiplier
             )
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       let tx: ContractTransaction
 
       before(async () => {
@@ -390,7 +390,7 @@ describe("RandomBeacon - Parameters", () => {
     const maliciousDkgResultSlashingAmount = 200
     const unauthorizedSigningSlashingAmount = 150
 
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
@@ -400,11 +400,11 @@ describe("RandomBeacon - Parameters", () => {
               maliciousDkgResultSlashingAmount,
               unauthorizedSigningSlashingAmount
             )
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       let tx: ContractTransaction
 
       before(async () => {
@@ -463,17 +463,17 @@ describe("RandomBeacon - Parameters", () => {
   })
 
   describe("setRequesterAuthorization", () => {
-    context("when the caller is not the owner", () => {
+    context("when the caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
           randomBeacon
             .connect(thirdParty)
             .setRequesterAuthorization(thirdPartyContract.address, true)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 
-    context("when the caller is the owner", () => {
+    context("when the caller is the governance", () => {
       context("when authorizing a contract", () => {
         let tx: ContractTransaction
 

--- a/solidity/random-beacon/test/RandomBeacon.Rewards.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Rewards.test.ts
@@ -123,7 +123,7 @@ describe("RandomBeacon - Rewards", () => {
           randomBeacon
             .connect(thirdParty)
             .withdrawIneligibleRewards(thirdParty.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
+        ).to.be.revertedWith("Caller is not the governance")
       })
     })
 

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -191,7 +191,7 @@ export async function testDeployment(): Promise<DeployedContracts> {
   await randomBeaconGovernance.deployed()
   await contracts.randomBeacon
     .connect(deployer)
-    .transferOwnership(randomBeaconGovernance.address)
+    .transferGovernance(randomBeaconGovernance.address)
   await randomBeaconGovernance
     .connect(deployer)
     .transferOwnership(governance.address)


### PR DESCRIPTION
~~Depends on #2946~~

`RandomBeacon` is now fully aligned with `WalletRegistry` when it comes to
how `Governable` and `Reimbursable` abstract contracts are used. This change
also allowed to reduce `RandomBeacon` contract size by a tiny bit.

Before/after:
```
 |  RandomBeacon   ·     24.352  │
 |  RandomBeacon   ·     24.333  │
```