### PR TITLE
Ignore slither unitialized variable error for reimbursementPool

### DIFF
--- a/solidity/random-beacon/contracts/Reimbursable.sol
+++ b/solidity/random-beacon/contracts/Reimbursable.sol
@@ -17,6 +17,8 @@ pragma solidity ^0.8.9;
 import "./ReimbursementPool.sol";
 
 abstract contract Reimbursable {
+    // The variable should be initialized by the implementing contract.
+    // slither-disable-next-line uninitialized-state
     ReimbursementPool public reimbursementPool;
 
     event ReimbursementPoolUpdated(address newReimbursementPool);


### PR DESCRIPTION
It is expected that `reimbursementPool` is initialized by the
implementing contract right after deployment. We could add a constructor
to set the variable to initial value, but we want to have upgradable
contract anyway so we would have to remove the constructor.

Unblocks https://github.com/keep-network/keep-core/pull/2947