### PR TITLE
Reading dkg seed from the DKG library

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -979,13 +979,12 @@ contract WalletRegistry is
         return sortitionPool.isOperatorInPool(operator);
     }
 
-    /// @notice Selects a new group of operators based on the provided seed.
+    /// @notice Selects a new group of operators. Can only be called when DKG
+    ///         is in progress and the pool is locked.
     ///         At least one operator has to be registered in the pool,
     ///         otherwise the function fails reverting the transaction.
-    /// @param seed Number used to select operators to the group.
     /// @return IDs of selected group members.
-    function selectGroup(bytes32 seed) external view returns (uint32[] memory) {
-        // TODO: Read seed from DKG
-        return sortitionPool.selectGroup(DKG.groupSize, seed);
+    function selectGroup() external view returns (uint32[] memory) {
+        return sortitionPool.selectGroup(DKG.groupSize, bytes32(dkg.seed));
     }
 }

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -3455,7 +3455,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
     })
   })
 
-  describe.only("selectGroup", async () => {
+  describe("selectGroup", async () => {
     context("when dkg was not triggered", async () => {
       before(async () => {
         await createSnapshot()

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -3454,6 +3454,52 @@ describe("WalletRegistry - Wallet Creation", async () => {
       })
     })
   })
+
+  describe.only("selectGroup", async () => {
+    context("when dkg was not triggered", async () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(walletRegistry.selectGroup()).to.be.revertedWith(
+          "Sortition pool unlocked"
+        )
+      })
+    })
+
+    context("when dkg was triggered", async () => {
+      let dkgSeed: BigNumber
+
+      before(async () => {
+        await createSnapshot()
+        await walletRegistry.connect(walletOwner.wallet).requestNewWallet()
+        ;({ dkgSeed } = await submitRelayEntry(walletRegistry))
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should select a group", async () => {
+        const selectedGroup = await walletRegistry.selectGroup()
+        expect(selectedGroup.length).to.eq(constants.groupSize)
+      })
+
+      it("should be the same group as if called the sortition pool directly", async () => {
+        const exectedGroup = await sortitionPool.selectGroup(
+          constants.groupSize,
+          dkgSeed.toHexString()
+        )
+        const actualGroup = await walletRegistry.selectGroup()
+        expect(exectedGroup).to.be.deep.equal(actualGroup)
+      })
+    })
+  })
 })
 
 async function assertDkgResultCleanData(walletRegistry: WalletRegistryStub) {


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/2930

DKG seed can be read from the DKG library and there's no need passing it
as a parameter.