### PR TITLE
Lowering the size of RandomBeacon contract: parameter function refactoring

### DIFF
--- a/solidity/random-beacon/contracts/Governable.sol
+++ b/solidity/random-beacon/contracts/Governable.sol
@@ -20,6 +20,8 @@ pragma solidity ^0.8.9;
 ///      function in a child contract.
 abstract contract Governable {
     // Governance of the contract
+    // The variable should be initialized by the implementing contract.
+    // slither-disable-next-line uninitialized-state
     address public governance;
 
     event GovernanceTransferred(address oldGovernance, address newGovernance);

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -85,7 +85,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ///         who misbehaved during DKG by being inactive or disqualified and
     ///         for operators that were identified by the rest of group members
     ///         as inactive via `notifyOperatorInactivity`.
-    uint256 public sortitionPoolRewardsBanDuration;
+    uint256 internal _sortitionPoolRewardsBanDuration;
 
     /// @notice Percentage of the staking contract malicious behavior
     ///         notification reward which will be transferred to the notifier
@@ -94,7 +94,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ///         notification reward is 1000 and the value of the multiplier is
     ///         5, the notifier will receive: 5% of 1000 = 50 per each
     ///         operator affected.
-    uint256 public relayEntryTimeoutNotificationRewardMultiplier;
+    uint256 internal _relayEntryTimeoutNotificationRewardMultiplier;
 
     /// @notice Percentage of the staking contract malicious behavior
     ///         notification reward which will be transferred to the notifier
@@ -103,7 +103,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ///         notification reward is 1000 and the value of the multiplier is
     ///         5, the notifier will receive: 5% of 1000 = 50 per each
     ///         operator affected.
-    uint256 public unauthorizedSigningNotificationRewardMultiplier;
+    uint256 internal _unauthorizedSigningNotificationRewardMultiplier;
 
     /// @notice Percentage of the staking contract malicious behavior
     ///         notification reward which will be transferred to the notifier
@@ -112,7 +112,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ///         notification reward is 1000 and the value of the multiplier is
     ///         5, the notifier will receive: 5% of 1000 = 50 per each
     ///         operator affected.
-    uint256 public dkgMaliciousResultNotificationRewardMultiplier;
+    uint256 internal _dkgMaliciousResultNotificationRewardMultiplier;
 
     /// @notice Calculated gas cost for submitting a DKG result. This will
     ///         be refunded as part of the DKG approval process. It is in the
@@ -382,10 +382,10 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
 
         maliciousDkgResultSlashingAmount = 50000e18;
         unauthorizedSigningSlashingAmount = 100e3 * 1e18;
-        sortitionPoolRewardsBanDuration = 2 weeks;
-        relayEntryTimeoutNotificationRewardMultiplier = 40;
-        unauthorizedSigningNotificationRewardMultiplier = 50;
-        dkgMaliciousResultNotificationRewardMultiplier = 100;
+        _sortitionPoolRewardsBanDuration = 2 weeks;
+        _relayEntryTimeoutNotificationRewardMultiplier = 40;
+        _unauthorizedSigningNotificationRewardMultiplier = 50;
+        _dkgMaliciousResultNotificationRewardMultiplier = 100;
         // slither-disable-next-line too-many-digits
         authorization.setMinimumAuthorization(100000e18); // 100k T
         authorization.setAuthorizationDecreaseDelay(403200); // ~10 weeks assuming 15s block time
@@ -515,24 +515,24 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      random beacon governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _sortitionPoolRewardsBanDuration New sortition pool rewards
+    /// @param sortitionPoolRewardsBanDuration New sortition pool rewards
     ///        ban duration in seconds.
-    /// @param _relayEntryTimeoutNotificationRewardMultiplier New value of the
+    /// @param relayEntryTimeoutNotificationRewardMultiplier New value of the
     ///        relay entry timeout notification reward multiplier.
-    /// @param _unauthorizedSigningNotificationRewardMultiplier New value of the
+    /// @param unauthorizedSigningNotificationRewardMultiplier New value of the
     ///        unauthorized signing notification reward multiplier.
-    /// @param _dkgMaliciousResultNotificationRewardMultiplier New value of the
+    /// @param dkgMaliciousResultNotificationRewardMultiplier New value of the
     ///        DKG malicious result notification reward multiplier.
     function updateRewardParameters(
-        uint256 _sortitionPoolRewardsBanDuration,
-        uint256 _relayEntryTimeoutNotificationRewardMultiplier,
-        uint256 _unauthorizedSigningNotificationRewardMultiplier,
-        uint256 _dkgMaliciousResultNotificationRewardMultiplier
+        uint256 sortitionPoolRewardsBanDuration,
+        uint256 relayEntryTimeoutNotificationRewardMultiplier,
+        uint256 unauthorizedSigningNotificationRewardMultiplier,
+        uint256 dkgMaliciousResultNotificationRewardMultiplier
     ) external onlyGovernance {
-        sortitionPoolRewardsBanDuration = _sortitionPoolRewardsBanDuration;
-        relayEntryTimeoutNotificationRewardMultiplier = _relayEntryTimeoutNotificationRewardMultiplier;
-        unauthorizedSigningNotificationRewardMultiplier = _unauthorizedSigningNotificationRewardMultiplier;
-        dkgMaliciousResultNotificationRewardMultiplier = _dkgMaliciousResultNotificationRewardMultiplier;
+        _sortitionPoolRewardsBanDuration = sortitionPoolRewardsBanDuration;
+        _relayEntryTimeoutNotificationRewardMultiplier = relayEntryTimeoutNotificationRewardMultiplier;
+        _unauthorizedSigningNotificationRewardMultiplier = unauthorizedSigningNotificationRewardMultiplier;
+        _dkgMaliciousResultNotificationRewardMultiplier = dkgMaliciousResultNotificationRewardMultiplier;
         emit RewardParametersUpdated(
             sortitionPoolRewardsBanDuration,
             relayEntryTimeoutNotificationRewardMultiplier,
@@ -815,7 +815,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
             sortitionPool.setRewardIneligibility(
                 misbehavedMembers,
                 // solhint-disable-next-line not-rely-on-time
-                block.timestamp + sortitionPoolRewardsBanDuration
+                block.timestamp + _sortitionPoolRewardsBanDuration
             );
         }
 
@@ -853,7 +853,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         try
             staking.seize(
                 slashingAmount,
-                dkgMaliciousResultNotificationRewardMultiplier,
+                _dkgMaliciousResultNotificationRewardMultiplier,
                 msg.sender,
                 stakingProviderWrapper
             )
@@ -1064,7 +1064,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         try
             staking.seize(
                 slashingAmount,
-                relayEntryTimeoutNotificationRewardMultiplier,
+                _relayEntryTimeoutNotificationRewardMultiplier,
                 msg.sender,
                 stakingProvidersAddresses
             )
@@ -1157,7 +1157,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         try
             staking.seize(
                 unauthorizedSigningSlashingAmount,
-                unauthorizedSigningNotificationRewardMultiplier,
+                _unauthorizedSigningNotificationRewardMultiplier,
                 msg.sender,
                 stakingProvidersAddresses
             )
@@ -1186,7 +1186,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ///         claim is proved to be valid and signed by sufficient number
     ///         of group members, operators of members deemed as inactive are
     ///         banned for sortition pool rewards for duration specified by
-    ///         `sortitionPoolRewardsBanDuration` parameter. The sender of
+    ///         `_sortitionPoolRewardsBanDuration` parameter. The sender of
     ///         the claim must be one of the claim signers. This function can be
     ///         called only for active and non-terminated groups.
     /// @param claim Operator inactivity claim.
@@ -1230,7 +1230,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         sortitionPool.setRewardIneligibility(
             ineligibleOperators,
             // solhint-disable-next-line not-rely-on-time
-            block.timestamp + sortitionPoolRewardsBanDuration
+            block.timestamp + _sortitionPoolRewardsBanDuration
         );
 
         reimbursementPool.refund(
@@ -1415,6 +1415,51 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     /// @return IDs of selected group members.
     function selectGroup() external view returns (uint32[] memory) {
         return sortitionPool.selectGroup(DKG.groupSize, bytes32(dkg.seed));
+    }
+
+    /// @notice Returns reward-related parameters of the beacon.
+    /// @return sortitionPoolRewardsBanDuration Duration of the sortition pool
+    ///         rewards ban imposed on operators who misbehaved during DKG by
+    ///         being inactive or disqualified and for operators that were
+    ///         identified by the rest of group members as inactive via
+    ///         `notifyOperatorInactivity`.
+    /// @return relayEntryTimeoutNotificationRewardMultiplier Percentage of the
+    ///         staking contract malicious behavior notification reward which
+    ///         will be transferred to the notifier reporting about relay entry
+    ///         timeout. Notifiers are rewarded from a notifiers treasury pool.
+    ///         For example, if notification reward is 1000 and the value of the
+    ///         multiplier is 5, the notifier will receive: 5% of 1000 = 50 per
+    ///         each operator affected.
+    /// @return unauthorizedSigningNotificationRewardMultiplier Percentage of the
+    ///         staking contract malicious behavior notification reward which
+    ///         will be transferred to the notifier reporting about unauthorized
+    ///         signing. Notifiers are rewarded from a notifiers treasury pool.
+    ///         For example, if a notification reward is 1000 and the value of
+    ///         the multiplier is 5, the notifier will receive: 5% of 1000 = 50
+    ///         per each operator affected.
+    /// @return dkgMaliciousResultNotificationRewardMultiplier Percentage of the
+    ///         staking contract malicious behavior notification reward which
+    ///         will be transferred to the notifier reporting about a malicious
+    ///         DKG result. Notifiers are rewarded from a notifiers treasury
+    ///         pool. For example, if notification reward is 1000 and the value
+    ///         of the multiplier is 5, the notifier will receive:
+    ///         5% of 1000 = 50 per each operator affected.
+    function rewardParameters()
+        external
+        view
+        returns (
+            uint256 sortitionPoolRewardsBanDuration,
+            uint256 relayEntryTimeoutNotificationRewardMultiplier,
+            uint256 unauthorizedSigningNotificationRewardMultiplier,
+            uint256 dkgMaliciousResultNotificationRewardMultiplier
+        )
+    {
+        return (
+            _sortitionPoolRewardsBanDuration,
+            _relayEntryTimeoutNotificationRewardMultiplier,
+            _unauthorizedSigningNotificationRewardMultiplier,
+            _dkgMaliciousResultNotificationRewardMultiplier
+        );
     }
 
     /// @notice Returns gas-related parameters of the beacon.

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -685,12 +685,18 @@ contract RandomBeaconGovernance is Ownable {
         emit SortitionPoolRewardsBanDurationUpdated(
             newSortitionPoolRewardsBanDuration
         );
+        (
+            ,
+            uint256 relayEntryTimeoutNotificationRewardMultiplier,
+            uint256 unauthorizedSigningNotificationRewardMultiplier,
+            uint256 dkgMaliciousResultNotificationRewardMultiplier
+        ) = randomBeacon.rewardParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRewardParameters(
             newSortitionPoolRewardsBanDuration,
-            randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
-            randomBeacon.unauthorizedSigningNotificationRewardMultiplier(),
-            randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
+            relayEntryTimeoutNotificationRewardMultiplier,
+            unauthorizedSigningNotificationRewardMultiplier,
+            dkgMaliciousResultNotificationRewardMultiplier
         );
         sortitionPoolRewardsBanDurationChangeInitiated = 0;
         newSortitionPoolRewardsBanDuration = 0;
@@ -758,12 +764,18 @@ contract RandomBeaconGovernance is Ownable {
         emit UnauthorizedSigningNotificationRewardMultiplierUpdated(
             newUnauthorizedSigningNotificationRewardMultiplier
         );
+        (
+            uint256 sortitionPoolRewardsBanDuration,
+            uint256 relayEntryTimeoutNotificationRewardMultiplier,
+            ,
+            uint256 dkgMaliciousResultNotificationRewardMultiplier
+        ) = randomBeacon.rewardParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRewardParameters(
-            randomBeacon.sortitionPoolRewardsBanDuration(),
-            randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
+            sortitionPoolRewardsBanDuration,
+            relayEntryTimeoutNotificationRewardMultiplier,
             newUnauthorizedSigningNotificationRewardMultiplier,
-            randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
+            dkgMaliciousResultNotificationRewardMultiplier
         );
         unauthorizedSigningNotificationRewardMultiplierChangeInitiated = 0;
         newUnauthorizedSigningNotificationRewardMultiplier = 0;
@@ -783,12 +795,18 @@ contract RandomBeaconGovernance is Ownable {
         emit RelayEntryTimeoutNotificationRewardMultiplierUpdated(
             newRelayEntryTimeoutNotificationRewardMultiplier
         );
+        (
+            uint256 sortitionPoolRewardsBanDuration,
+            ,
+            uint256 unauthorizedSigningNotificationRewardMultiplier,
+            uint256 dkgMaliciousResultNotificationRewardMultiplier
+        ) = randomBeacon.rewardParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRewardParameters(
-            randomBeacon.sortitionPoolRewardsBanDuration(),
+            sortitionPoolRewardsBanDuration,
             newRelayEntryTimeoutNotificationRewardMultiplier,
-            randomBeacon.unauthorizedSigningNotificationRewardMultiplier(),
-            randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
+            unauthorizedSigningNotificationRewardMultiplier,
+            dkgMaliciousResultNotificationRewardMultiplier
         );
         relayEntryTimeoutNotificationRewardMultiplierChangeInitiated = 0;
         newRelayEntryTimeoutNotificationRewardMultiplier = 0;
@@ -832,11 +850,17 @@ contract RandomBeaconGovernance is Ownable {
         emit DkgMaliciousResultNotificationRewardMultiplierUpdated(
             newDkgMaliciousResultNotificationRewardMultiplier
         );
+        (
+            uint256 sortitionPoolRewardsBanDuration,
+            uint256 relayEntryTimeoutNotificationRewardMultiplier,
+            uint256 unauthorizedSigningNotificationRewardMultiplier,
+
+        ) = randomBeacon.rewardParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRewardParameters(
-            randomBeacon.sortitionPoolRewardsBanDuration(),
-            randomBeacon.relayEntryTimeoutNotificationRewardMultiplier(),
-            randomBeacon.unauthorizedSigningNotificationRewardMultiplier(),
+            sortitionPoolRewardsBanDuration,
+            relayEntryTimeoutNotificationRewardMultiplier,
+            unauthorizedSigningNotificationRewardMultiplier,
             newDkgMaliciousResultNotificationRewardMultiplier
         );
         dkgMaliciousResultNotificationRewardMultiplierChangeInitiated = 0;

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -911,12 +911,18 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(dkgResultSubmissionGasChangeInitiated)
     {
         emit DkgResultSubmissionGasUpdated(newDkgResultSubmissionGas);
+        (
+            ,
+            uint256 dkgResultApprovalGasOffset,
+            uint256 notifyOperatorInactivityGasOffset,
+            uint256 relayEntrySubmissionGasOffset
+        ) = randomBeacon.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateGasParameters(
             newDkgResultSubmissionGas,
-            randomBeacon.dkgResultApprovalGasOffset(),
-            randomBeacon.notifyOperatorInactivityGasOffset(),
-            randomBeacon.relayEntrySubmissionGasOffset()
+            dkgResultApprovalGasOffset,
+            notifyOperatorInactivityGasOffset,
+            relayEntrySubmissionGasOffset
         );
         dkgResultSubmissionGasChangeInitiated = 0;
         newDkgResultSubmissionGas = 0;
@@ -947,12 +953,18 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(dkgResultApprovalGasOffsetChangeInitiated)
     {
         emit DkgResultApprovalGasOffsetUpdated(newDkgResultApprovalGasOffset);
+        (
+            uint256 dkgResultSubmissionGas,
+            ,
+            uint256 notifyOperatorInactivityGasOffset,
+            uint256 relayEntrySubmissionGasOffset
+        ) = randomBeacon.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateGasParameters(
-            randomBeacon.dkgResultSubmissionGas(),
+            dkgResultSubmissionGas,
             newDkgResultApprovalGasOffset,
-            randomBeacon.notifyOperatorInactivityGasOffset(),
-            randomBeacon.relayEntrySubmissionGasOffset()
+            notifyOperatorInactivityGasOffset,
+            relayEntrySubmissionGasOffset
         );
         dkgResultApprovalGasOffsetChangeInitiated = 0;
         newDkgResultApprovalGasOffset = 0;
@@ -988,12 +1000,18 @@ contract RandomBeaconGovernance is Ownable {
         emit NotifyOperatorInactivityGasOffsetUpdated(
             newNotifyOperatorInactivityGasOffset
         );
+        (
+            uint256 dkgResultSubmissionGas,
+            uint256 dkgResultApprovalGasOffset,
+            ,
+            uint256 relayEntrySubmissionGasOffset
+        ) = randomBeacon.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateGasParameters(
-            randomBeacon.dkgResultSubmissionGas(),
-            randomBeacon.dkgResultApprovalGasOffset(),
+            dkgResultSubmissionGas,
+            dkgResultApprovalGasOffset,
             newNotifyOperatorInactivityGasOffset,
-            randomBeacon.relayEntrySubmissionGasOffset()
+            relayEntrySubmissionGasOffset
         );
         notifyOperatorInactivityGasOffsetChangeInitiated = 0;
         newNotifyOperatorInactivityGasOffset = 0;
@@ -1026,11 +1044,17 @@ contract RandomBeaconGovernance is Ownable {
         emit RelayEntrySubmissionGasOffsetUpdated(
             newRelayEntrySubmissionGasOffset
         );
+        (
+            uint256 dkgResultSubmissionGas,
+            uint256 dkgResultApprovalGasOffset,
+            uint256 notifyOperatorInactivityGasOffset,
+
+        ) = randomBeacon.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateGasParameters(
-            randomBeacon.dkgResultSubmissionGas(),
-            randomBeacon.dkgResultApprovalGasOffset(),
-            randomBeacon.notifyOperatorInactivityGasOffset(),
+            dkgResultSubmissionGas,
+            dkgResultApprovalGasOffset,
+            notifyOperatorInactivityGasOffset,
             newRelayEntrySubmissionGasOffset
         );
         relayEntrySubmissionGasOffsetChangeInitiated = 0;

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -368,11 +368,16 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(relayEntrySoftTimeoutChangeInitiated)
     {
         emit RelayEntrySoftTimeoutUpdated(newRelayEntrySoftTimeout);
+        (
+            ,
+            uint256 relayEntryHardTimeout,
+            uint256 callbackGasLimit
+        ) = randomBeacon.relayEntryParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRelayEntryParameters(
             newRelayEntrySoftTimeout,
-            randomBeacon.relayEntryHardTimeout(),
-            randomBeacon.callbackGasLimit()
+            relayEntryHardTimeout,
+            callbackGasLimit
         );
         relayEntrySoftTimeoutChangeInitiated = 0;
         newRelayEntrySoftTimeout = 0;
@@ -404,11 +409,16 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(relayEntryHardTimeoutChangeInitiated)
     {
         emit RelayEntryHardTimeoutUpdated(newRelayEntryHardTimeout);
+        (
+            uint256 relayEntrySoftTimeout,
+            ,
+            uint256 callbackGasLimit
+        ) = randomBeacon.relayEntryParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRelayEntryParameters(
-            randomBeacon.relayEntrySoftTimeout(),
+            relayEntrySoftTimeout,
             newRelayEntryHardTimeout,
-            randomBeacon.callbackGasLimit()
+            callbackGasLimit
         );
         relayEntryHardTimeoutChangeInitiated = 0;
         newRelayEntryHardTimeout = 0;
@@ -445,10 +455,15 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(callbackGasLimitChangeInitiated)
     {
         emit CallbackGasLimitUpdated(newCallbackGasLimit);
+        (
+            uint256 relayEntrySoftTimeout,
+            uint256 relayEntryHardTimeout,
+
+        ) = randomBeacon.relayEntryParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateRelayEntryParameters(
-            randomBeacon.relayEntrySoftTimeout(),
-            randomBeacon.relayEntryHardTimeout(),
+            relayEntrySoftTimeout,
+            relayEntryHardTimeout,
             newCallbackGasLimit
         );
         callbackGasLimitChangeInitiated = 0;

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -900,11 +900,16 @@ contract RandomBeaconGovernance is Ownable {
         emit RelayEntrySubmissionFailureSlashingAmountUpdated(
             newRelayEntrySubmissionFailureSlashingAmount
         );
+        (
+            ,
+            uint96 maliciousDkgResultSlashingAmount,
+            uint96 unauthorizedSigningSlashingAmount
+        ) = randomBeacon.slashingParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateSlashingParameters(
             newRelayEntrySubmissionFailureSlashingAmount,
-            randomBeacon.maliciousDkgResultSlashingAmount(),
-            randomBeacon.unauthorizedSigningSlashingAmount()
+            maliciousDkgResultSlashingAmount,
+            unauthorizedSigningSlashingAmount
         );
         relayEntrySubmissionFailureSlashingAmountChangeInitiated = 0;
         newRelayEntrySubmissionFailureSlashingAmount = 0;
@@ -1116,11 +1121,16 @@ contract RandomBeaconGovernance is Ownable {
         emit MaliciousDkgResultSlashingAmountUpdated(
             newMaliciousDkgResultSlashingAmount
         );
+        (
+            uint96 relayEntrySubmissionFailureSlashingAmount,
+            ,
+            uint96 unauthorizedSigningSlashingAmount
+        ) = randomBeacon.slashingParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateSlashingParameters(
-            randomBeacon.relayEntrySubmissionFailureSlashingAmount(),
+            relayEntrySubmissionFailureSlashingAmount,
             newMaliciousDkgResultSlashingAmount,
-            randomBeacon.unauthorizedSigningSlashingAmount()
+            unauthorizedSigningSlashingAmount
         );
         maliciousDkgResultSlashingAmountChangeInitiated = 0;
         newMaliciousDkgResultSlashingAmount = 0;
@@ -1157,10 +1167,15 @@ contract RandomBeaconGovernance is Ownable {
         emit UnauthorizedSigningSlashingAmountUpdated(
             newUnauthorizedSigningSlashingAmount
         );
+        (
+            uint96 relayEntrySubmissionFailureSlashingAmount,
+            uint96 maliciousDkgResultSlashingAmount,
+
+        ) = randomBeacon.slashingParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateSlashingParameters(
-            randomBeacon.relayEntrySubmissionFailureSlashingAmount(),
-            randomBeacon.maliciousDkgResultSlashingAmount(),
+            relayEntrySubmissionFailureSlashingAmount,
+            maliciousDkgResultSlashingAmount,
             newUnauthorizedSigningSlashingAmount
         );
         unauthorizedSigningSlashingAmountChangeInitiated = 0;

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -49,7 +49,7 @@ contract RandomBeaconGovernance is Ownable {
     uint256 public newDkgResultSubmissionTimeout;
     uint256 public dkgResultSubmissionTimeoutChangeInitiated;
 
-    uint256 public newSubmitterPrecedencePeriodLength;
+    uint256 public newDkgSubmitterPrecedencePeriodLength;
     uint256 public dkgSubmitterPrecedencePeriodLengthChangeInitiated;
 
     uint96 public newRelayEntrySubmissionFailureSlashingAmount;
@@ -668,20 +668,20 @@ contract RandomBeaconGovernance is Ownable {
 
     /// @notice Begins the DKG submitter precedence period length.
     /// @dev Can be called only by the contract owner.
-    /// @param _newSubmitterPrecedencePeriodLength New DKG submitter precedence
+    /// @param _newDkgSubmitterPrecedencePeriodLength New DKG submitter precedence
     ///        period length in blocks
     function beginDkgSubmitterPrecedencePeriodLengthUpdate(
-        uint256 _newSubmitterPrecedencePeriodLength
+        uint256 _newDkgSubmitterPrecedencePeriodLength
     ) external onlyOwner {
         /* solhint-disable not-rely-on-time */
         require(
-            _newSubmitterPrecedencePeriodLength > 0,
+            _newDkgSubmitterPrecedencePeriodLength > 0,
             "DKG submitter precedence period length must be > 0"
         );
-        newSubmitterPrecedencePeriodLength = _newSubmitterPrecedencePeriodLength;
+        newDkgSubmitterPrecedencePeriodLength = _newDkgSubmitterPrecedencePeriodLength;
         dkgSubmitterPrecedencePeriodLengthChangeInitiated = block.timestamp;
         emit DkgSubmitterPrecedencePeriodLengthUpdateStarted(
-            _newSubmitterPrecedencePeriodLength,
+            _newDkgSubmitterPrecedencePeriodLength,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
@@ -698,7 +698,7 @@ contract RandomBeaconGovernance is Ownable {
         )
     {
         emit DkgSubmitterPrecedencePeriodLengthUpdated(
-            newSubmitterPrecedencePeriodLength
+            newDkgSubmitterPrecedencePeriodLength
         );
         (
             uint256 groupCreationFrequency,
@@ -713,10 +713,10 @@ contract RandomBeaconGovernance is Ownable {
             groupLifetime,
             dkgResultChallengePeriodLength,
             dkgResultSubmissionTimeout,
-            newSubmitterPrecedencePeriodLength
+            newDkgSubmitterPrecedencePeriodLength
         );
         dkgSubmitterPrecedencePeriodLengthChangeInitiated = 0;
-        newSubmitterPrecedencePeriodLength = 0;
+        newDkgSubmitterPrecedencePeriodLength = 0;
     }
 
     /// @notice Begins the sortition pool rewards ban duration update process.

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -499,10 +499,20 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(groupCreationFrequencyChangeInitiated)
     {
         emit GroupCreationFrequencyUpdated(newGroupCreationFrequency);
+        (
+            ,
+            uint256 groupLifetime,
+            uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultSubmissionTimeout,
+            uint256 dkgSubmitterPrecedencePeriodLength
+        ) = randomBeacon.groupCreationParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateGroupCreationParameters(
             newGroupCreationFrequency,
-            randomBeacon.groupLifetime()
+            groupLifetime,
+            dkgResultChallengePeriodLength,
+            dkgResultSubmissionTimeout,
+            dkgSubmitterPrecedencePeriodLength
         );
         groupCreationFrequencyChangeInitiated = 0;
         newGroupCreationFrequency = 0;
@@ -535,10 +545,20 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(groupLifetimeChangeInitiated)
     {
         emit GroupLifetimeUpdated(newGroupLifetime);
+        (
+            uint256 groupCreationFrequency,
+            ,
+            uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultSubmissionTimeout,
+            uint256 dkgSubmitterPrecedencePeriodLength
+        ) = randomBeacon.groupCreationParameters();
         // slither-disable-next-line reentrancy-no-eth
         randomBeacon.updateGroupCreationParameters(
-            randomBeacon.groupCreationFrequency(),
-            newGroupLifetime
+            groupCreationFrequency,
+            newGroupLifetime,
+            dkgResultChallengePeriodLength,
+            dkgResultSubmissionTimeout,
+            dkgSubmitterPrecedencePeriodLength
         );
         groupLifetimeChangeInitiated = 0;
         newGroupLifetime = 0;
@@ -576,11 +596,20 @@ contract RandomBeaconGovernance is Ownable {
         emit DkgResultChallengePeriodLengthUpdated(
             newDkgResultChallengePeriodLength
         );
+        (
+            uint256 groupCreationFrequency,
+            uint256 groupLifetime,
+            ,
+            uint256 dkgResultSubmissionTimeout,
+            uint256 dkgSubmitterPrecedencePeriodLength
+        ) = randomBeacon.groupCreationParameters();
         // slither-disable-next-line reentrancy-no-eth
-        randomBeacon.updateDkgParameters(
+        randomBeacon.updateGroupCreationParameters(
+            groupCreationFrequency,
+            groupLifetime,
             newDkgResultChallengePeriodLength,
-            randomBeacon.dkgResultSubmissionTimeout(),
-            randomBeacon.dkgSubmitterPrecedencePeriodLength()
+            dkgResultSubmissionTimeout,
+            dkgSubmitterPrecedencePeriodLength
         );
         dkgResultChallengePeriodLengthChangeInitiated = 0;
         newDkgResultChallengePeriodLength = 0;
@@ -618,11 +647,20 @@ contract RandomBeaconGovernance is Ownable {
         onlyAfterGovernanceDelay(dkgResultSubmissionTimeoutChangeInitiated)
     {
         emit DkgResultSubmissionTimeoutUpdated(newDkgResultSubmissionTimeout);
+        (
+            uint256 groupCreationFrequency,
+            uint256 groupLifetime,
+            uint256 dkgResultChallengePeriodLength,
+            ,
+            uint256 dkgSubmitterPrecedencePeriodLength
+        ) = randomBeacon.groupCreationParameters();
         // slither-disable-next-line reentrancy-no-eth
-        randomBeacon.updateDkgParameters(
-            randomBeacon.dkgResultChallengePeriodLength(),
+        randomBeacon.updateGroupCreationParameters(
+            groupCreationFrequency,
+            groupLifetime,
+            dkgResultChallengePeriodLength,
             newDkgResultSubmissionTimeout,
-            randomBeacon.dkgSubmitterPrecedencePeriodLength()
+            dkgSubmitterPrecedencePeriodLength
         );
         dkgResultSubmissionTimeoutChangeInitiated = 0;
         newDkgResultSubmissionTimeout = 0;
@@ -662,10 +700,19 @@ contract RandomBeaconGovernance is Ownable {
         emit DkgSubmitterPrecedencePeriodLengthUpdated(
             newSubmitterPrecedencePeriodLength
         );
+        (
+            uint256 groupCreationFrequency,
+            uint256 groupLifetime,
+            uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultSubmissionTimeout,
+
+        ) = randomBeacon.groupCreationParameters();
         // slither-disable-next-line reentrancy-no-eth
-        randomBeacon.updateDkgParameters(
-            randomBeacon.dkgResultChallengePeriodLength(),
-            randomBeacon.dkgResultSubmissionTimeout(),
+        randomBeacon.updateGroupCreationParameters(
+            groupCreationFrequency,
+            groupLifetime,
+            dkgResultChallengePeriodLength,
+            dkgResultSubmissionTimeout,
             newSubmitterPrecedencePeriodLength
         );
         dkgSubmitterPrecedencePeriodLengthChangeInitiated = 0;

--- a/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
@@ -467,7 +467,7 @@ library BeaconDkg {
         require(
             newSubmitterPrecedencePeriodLength <
                 self.parameters.resultSubmissionTimeout,
-            "New value should be less than result submission timeout"
+            "Submitter precedence period length should be less than the result submission timeout"
         );
 
         self

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -147,8 +147,11 @@ describe("RandomBeacon - Parameters", () => {
   })
 
   describe("updateGroupCreationParameters", () => {
-    const groupCreationFrequency = 100
-    const groupLifetime = 200
+    const newGroupCreationFrequency = 100
+    const newGroupLifetime = 200
+    const newDkgResultChallengePeriodLength = 300
+    const newDkgResultSubmissionTimeout = 400
+    const newDkgSubmitterPrecedencePeriodLength = 200
 
     context("when the caller is not the governance", () => {
       it("should revert", async () => {
@@ -156,8 +159,11 @@ describe("RandomBeacon - Parameters", () => {
           randomBeacon
             .connect(thirdParty)
             .updateGroupCreationParameters(
-              groupCreationFrequency,
-              groupLifetime
+              newGroupCreationFrequency,
+              newGroupLifetime,
+              newDkgResultChallengePeriodLength,
+              newDkgResultSubmissionTimeout,
+              newDkgSubmitterPrecedencePeriodLength
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -171,7 +177,13 @@ describe("RandomBeacon - Parameters", () => {
 
         tx = await randomBeacon
           .connect(governance)
-          .updateGroupCreationParameters(groupCreationFrequency, groupLifetime)
+          .updateGroupCreationParameters(
+            newGroupCreationFrequency,
+            newGroupLifetime,
+            newDkgResultChallengePeriodLength,
+            newDkgResultSubmissionTimeout,
+            newDkgSubmitterPrecedencePeriodLength
+          )
       })
 
       after(async () => {
@@ -179,89 +191,50 @@ describe("RandomBeacon - Parameters", () => {
       })
 
       it("should update the group creation frequency", async () => {
-        expect(await randomBeacon.groupCreationFrequency()).to.be.equal(
-          groupCreationFrequency
-        )
+        const { groupCreationFrequency } =
+          await randomBeacon.groupCreationParameters()
+        expect(groupCreationFrequency).to.be.equal(groupCreationFrequency)
       })
 
       it("should update the group lifetime", async () => {
-        expect(await randomBeacon.groupLifetime()).to.be.equal(groupLifetime)
+        const { groupLifetime } = await randomBeacon.groupCreationParameters()
+        expect(groupLifetime).to.be.equal(newGroupLifetime)
+      })
+
+      it("should update the DKG result challenge period length", async () => {
+        const { dkgResultChallengePeriodLength } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgResultChallengePeriodLength).to.be.equal(
+          newDkgResultChallengePeriodLength
+        )
+      })
+
+      it("should update the DKG result submission timeout", async () => {
+        const { dkgResultSubmissionTimeout } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgResultSubmissionTimeout).to.be.equal(
+          newDkgResultSubmissionTimeout
+        )
+      })
+
+      it("should update the DKG submitter precedence period", async () => {
+        const { dkgSubmitterPrecedencePeriodLength } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgSubmitterPrecedencePeriodLength).to.be.equal(
+          newDkgSubmitterPrecedencePeriodLength
+        )
       })
 
       it("should emit the GroupCreationParametersUpdated event", async () => {
         await expect(tx)
           .to.emit(randomBeacon, "GroupCreationParametersUpdated")
-          .withArgs(groupCreationFrequency, groupLifetime)
-      })
-    })
-  })
-
-  describe("updateDkgParameters", () => {
-    const dkgResultChallengePeriodLength = 300
-    const dkgResultSubmissionTimeout = 400
-    const dkgSubmitterPrecedencePeriodLength = 200
-
-    context("when the caller is not the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          randomBeacon
-            .connect(thirdParty)
-            .updateDkgParameters(
-              dkgResultChallengePeriodLength,
-              dkgResultSubmissionTimeout,
-              dkgSubmitterPrecedencePeriodLength
-            )
-        ).to.be.revertedWith("Caller is not the governance")
-      })
-    })
-
-    context("when the caller is the governance", () => {
-      context("when values are valid", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          tx = await randomBeacon
-            .connect(governance)
-            .updateDkgParameters(
-              dkgResultChallengePeriodLength,
-              dkgResultSubmissionTimeout,
-              dkgSubmitterPrecedencePeriodLength
-            )
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should update the DKG result challenge period length", async () => {
-          expect(
-            await randomBeacon.dkgResultChallengePeriodLength()
-          ).to.be.equal(dkgResultChallengePeriodLength)
-        })
-
-        it("should update the DKG result submission timeout", async () => {
-          expect(await randomBeacon.dkgResultSubmissionTimeout()).to.be.equal(
-            dkgResultSubmissionTimeout
+          .withArgs(
+            newGroupCreationFrequency,
+            newGroupLifetime,
+            newDkgResultChallengePeriodLength,
+            newDkgResultSubmissionTimeout,
+            newDkgSubmitterPrecedencePeriodLength
           )
-        })
-
-        it("should update the DKG submitter precedence period", async () => {
-          expect(
-            await randomBeacon.dkgSubmitterPrecedencePeriodLength()
-          ).to.be.equal(dkgSubmitterPrecedencePeriodLength)
-        })
-
-        it("should emit the DkgParametersUpdated event", async () => {
-          await expect(tx)
-            .to.emit(randomBeacon, "DkgParametersUpdated")
-            .withArgs(
-              dkgResultChallengePeriodLength,
-              dkgResultSubmissionTimeout,
-              dkgSubmitterPrecedencePeriodLength
-            )
-        })
       })
 
       context("when values are invalid", () => {
@@ -270,18 +243,20 @@ describe("RandomBeacon - Parameters", () => {
           () => {
             it("should revert", async () => {
               const invalidDkgSubmitterPrecedencePeriodLength =
-                dkgResultSubmissionTimeout
+                newDkgResultSubmissionTimeout
 
               await expect(
                 randomBeacon
                   .connect(governance)
-                  .updateDkgParameters(
-                    dkgResultChallengePeriodLength,
-                    dkgResultSubmissionTimeout,
+                  .updateGroupCreationParameters(
+                    newGroupCreationFrequency,
+                    newGroupLifetime,
+                    newDkgResultChallengePeriodLength,
+                    newDkgResultSubmissionTimeout,
                     invalidDkgSubmitterPrecedencePeriodLength
                   )
               ).to.be.revertedWith(
-                "New value should be less than result submission timeout"
+                "Submitter precedence period length should be less than the result submission timeout"
               )
             })
           }
@@ -292,18 +267,20 @@ describe("RandomBeacon - Parameters", () => {
           () => {
             it("should revert", async () => {
               const invalidDkgSubmitterPrecedencePeriodLength =
-                dkgResultSubmissionTimeout + 1
+                newDkgResultSubmissionTimeout + 1
 
               await expect(
                 randomBeacon
                   .connect(governance)
-                  .updateDkgParameters(
-                    dkgResultChallengePeriodLength,
-                    dkgResultSubmissionTimeout,
+                  .updateGroupCreationParameters(
+                    newGroupCreationFrequency,
+                    newGroupLifetime,
+                    newDkgResultChallengePeriodLength,
+                    newDkgResultSubmissionTimeout,
                     invalidDkgSubmitterPrecedencePeriodLength
                   )
               ).to.be.revertedWith(
-                "New value should be less than result submission timeout"
+                "Submitter precedence period length should be less than the result submission timeout"
               )
             })
           }

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -314,10 +314,10 @@ describe("RandomBeacon - Parameters", () => {
   })
 
   describe("updateRewardParameters", () => {
-    const sortitionPoolRewardsBanDuration = 400
-    const relayEntryTimeoutNotificationRewardMultiplier = 10
-    const unauthorizedSigningNotificationRewardMultiplier = 10
-    const dkgMaliciousResultNotificationRewardMultiplier = 20
+    const newSortitionPoolRewardsBanDuration = 400
+    const newRelayEntryTimeoutNotificationRewardMultiplier = 10
+    const newUnauthorizedSigningNotificationRewardMultiplier = 10
+    const newDkgMaliciousResultNotificationRewardMultiplier = 20
 
     context("when the caller is not the governance", () => {
       it("should revert", async () => {
@@ -325,10 +325,10 @@ describe("RandomBeacon - Parameters", () => {
           randomBeacon
             .connect(thirdParty)
             .updateRewardParameters(
-              sortitionPoolRewardsBanDuration,
-              relayEntryTimeoutNotificationRewardMultiplier,
-              unauthorizedSigningNotificationRewardMultiplier,
-              dkgMaliciousResultNotificationRewardMultiplier
+              newSortitionPoolRewardsBanDuration,
+              newRelayEntryTimeoutNotificationRewardMultiplier,
+              newUnauthorizedSigningNotificationRewardMultiplier,
+              newDkgMaliciousResultNotificationRewardMultiplier
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -343,10 +343,10 @@ describe("RandomBeacon - Parameters", () => {
         tx = await randomBeacon
           .connect(governance)
           .updateRewardParameters(
-            sortitionPoolRewardsBanDuration,
-            relayEntryTimeoutNotificationRewardMultiplier,
-            unauthorizedSigningNotificationRewardMultiplier,
-            dkgMaliciousResultNotificationRewardMultiplier
+            newSortitionPoolRewardsBanDuration,
+            newRelayEntryTimeoutNotificationRewardMultiplier,
+            newUnauthorizedSigningNotificationRewardMultiplier,
+            newDkgMaliciousResultNotificationRewardMultiplier
           )
       })
 
@@ -355,31 +355,45 @@ describe("RandomBeacon - Parameters", () => {
       })
 
       it("should update the sortition pool rewards ban duration", async () => {
-        expect(
-          await randomBeacon.sortitionPoolRewardsBanDuration()
-        ).to.be.equal(sortitionPoolRewardsBanDuration)
+        const { sortitionPoolRewardsBanDuration } =
+          await randomBeacon.rewardParameters()
+        expect(sortitionPoolRewardsBanDuration).to.be.equal(
+          newSortitionPoolRewardsBanDuration
+        )
       })
 
       it("should update the relay entry timeout notification reward multiplier", async () => {
-        expect(
-          await randomBeacon.relayEntryTimeoutNotificationRewardMultiplier()
-        ).to.be.equal(relayEntryTimeoutNotificationRewardMultiplier)
+        const { relayEntryTimeoutNotificationRewardMultiplier } =
+          await randomBeacon.rewardParameters()
+        expect(relayEntryTimeoutNotificationRewardMultiplier).to.be.equal(
+          newRelayEntryTimeoutNotificationRewardMultiplier
+        )
+      })
+
+      it("should update the unauthorized signing notification reward multiplier", async () => {
+        const { unauthorizedSigningNotificationRewardMultiplier } =
+          await randomBeacon.rewardParameters()
+        expect(unauthorizedSigningNotificationRewardMultiplier).to.be.equal(
+          newUnauthorizedSigningNotificationRewardMultiplier
+        )
       })
 
       it("should update the DKG malicious result notification reward multiplier", async () => {
-        expect(
-          await randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
-        ).to.be.equal(dkgMaliciousResultNotificationRewardMultiplier)
+        const { dkgMaliciousResultNotificationRewardMultiplier } =
+          await randomBeacon.rewardParameters()
+        expect(dkgMaliciousResultNotificationRewardMultiplier).to.be.equal(
+          newDkgMaliciousResultNotificationRewardMultiplier
+        )
       })
 
       it("should emit the RewardParametersUpdated event", async () => {
         await expect(tx)
           .to.emit(randomBeacon, "RewardParametersUpdated")
           .withArgs(
-            sortitionPoolRewardsBanDuration,
-            relayEntryTimeoutNotificationRewardMultiplier,
-            unauthorizedSigningNotificationRewardMultiplier,
-            dkgMaliciousResultNotificationRewardMultiplier
+            newSortitionPoolRewardsBanDuration,
+            newRelayEntryTimeoutNotificationRewardMultiplier,
+            newUnauthorizedSigningNotificationRewardMultiplier,
+            newDkgMaliciousResultNotificationRewardMultiplier
           )
       })
     })

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -25,9 +25,9 @@ describe("RandomBeacon - Parameters", () => {
   })
 
   describe("updateRelayEntryParameters", () => {
-    const relayEntrySoftTimeout = 200
-    const relayEntryHardTimeout = 300
-    const callbackGasLimit = 400
+    const newRelayEntrySoftTimeout = 200
+    const newRelayEntryHardTimeout = 300
+    const newCallbackGasLimit = 400
 
     context("when the caller is not the governance", () => {
       it("should revert", async () => {
@@ -35,9 +35,9 @@ describe("RandomBeacon - Parameters", () => {
           randomBeacon
             .connect(thirdParty)
             .updateRelayEntryParameters(
-              relayEntrySoftTimeout,
-              relayEntryHardTimeout,
-              callbackGasLimit
+              newRelayEntrySoftTimeout,
+              newRelayEntryHardTimeout,
+              newCallbackGasLimit
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -52,9 +52,9 @@ describe("RandomBeacon - Parameters", () => {
         tx = await randomBeacon
           .connect(governance)
           .updateRelayEntryParameters(
-            relayEntrySoftTimeout,
-            relayEntryHardTimeout,
-            callbackGasLimit
+            newRelayEntrySoftTimeout,
+            newRelayEntryHardTimeout,
+            newCallbackGasLimit
           )
       })
 
@@ -63,30 +63,29 @@ describe("RandomBeacon - Parameters", () => {
       })
 
       it("should update the relay entry soft timeout", async () => {
-        expect(await randomBeacon.relayEntrySoftTimeout()).to.be.equal(
-          relayEntrySoftTimeout
-        )
+        const { relayEntrySoftTimeout } =
+          await randomBeacon.relayEntryParameters()
+        expect(relayEntrySoftTimeout).to.be.equal(newRelayEntrySoftTimeout)
       })
 
       it("should update the relay entry hard timeout", async () => {
-        expect(await randomBeacon.relayEntryHardTimeout()).to.be.equal(
-          relayEntryHardTimeout
-        )
+        const { relayEntryHardTimeout } =
+          await randomBeacon.relayEntryParameters()
+        expect(relayEntryHardTimeout).to.be.equal(newRelayEntryHardTimeout)
       })
 
       it("should update the callback gas limit", async () => {
-        expect(await randomBeacon.callbackGasLimit()).to.be.equal(
-          callbackGasLimit
-        )
+        const { callbackGasLimit } = await randomBeacon.relayEntryParameters()
+        expect(callbackGasLimit).to.be.equal(newCallbackGasLimit)
       })
 
       it("should emit the RelayEntryParametersUpdated event", async () => {
         await expect(tx)
           .to.emit(randomBeacon, "RelayEntryParametersUpdated")
           .withArgs(
-            relayEntrySoftTimeout,
-            relayEntryHardTimeout,
-            callbackGasLimit
+            newRelayEntrySoftTimeout,
+            newRelayEntryHardTimeout,
+            newCallbackGasLimit
           )
       })
     })

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -400,9 +400,9 @@ describe("RandomBeacon - Parameters", () => {
   })
 
   describe("updateSlashingParameters", () => {
-    const relayEntrySubmissionFailureSlashingAmount = 100
-    const maliciousDkgResultSlashingAmount = 200
-    const unauthorizedSigningSlashingAmount = 150
+    const newRelayEntrySubmissionFailureSlashingAmount = 100
+    const newMaliciousDkgResultSlashingAmount = 200
+    const newUnauthorizedSigningSlashingAmount = 150
 
     context("when the caller is not the governance", () => {
       it("should revert", async () => {
@@ -410,9 +410,9 @@ describe("RandomBeacon - Parameters", () => {
           randomBeacon
             .connect(thirdParty)
             .updateSlashingParameters(
-              relayEntrySubmissionFailureSlashingAmount,
-              maliciousDkgResultSlashingAmount,
-              unauthorizedSigningSlashingAmount
+              newRelayEntrySubmissionFailureSlashingAmount,
+              newMaliciousDkgResultSlashingAmount,
+              newUnauthorizedSigningSlashingAmount
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -427,9 +427,9 @@ describe("RandomBeacon - Parameters", () => {
         tx = await randomBeacon
           .connect(governance)
           .updateSlashingParameters(
-            relayEntrySubmissionFailureSlashingAmount,
-            maliciousDkgResultSlashingAmount,
-            unauthorizedSigningSlashingAmount
+            newRelayEntrySubmissionFailureSlashingAmount,
+            newMaliciousDkgResultSlashingAmount,
+            newUnauthorizedSigningSlashingAmount
           )
       })
 
@@ -438,30 +438,36 @@ describe("RandomBeacon - Parameters", () => {
       })
 
       it("should update the relay entry submission failure slashing amount", async () => {
-        expect(
-          await randomBeacon.relayEntrySubmissionFailureSlashingAmount()
-        ).to.be.equal(relayEntrySubmissionFailureSlashingAmount)
+        const { relayEntrySubmissionFailureSlashingAmount } =
+          await randomBeacon.slashingParameters()
+        expect(relayEntrySubmissionFailureSlashingAmount).to.be.equal(
+          newRelayEntrySubmissionFailureSlashingAmount
+        )
       })
 
       it("should update the malicious DKG result slashing amount", async () => {
-        expect(
-          await randomBeacon.maliciousDkgResultSlashingAmount()
-        ).to.be.equal(maliciousDkgResultSlashingAmount)
+        const { maliciousDkgResultSlashingAmount } =
+          await randomBeacon.slashingParameters()
+        expect(maliciousDkgResultSlashingAmount).to.be.equal(
+          newMaliciousDkgResultSlashingAmount
+        )
       })
 
       it("should update the unauthorized signing slashing amount", async () => {
-        expect(
-          await randomBeacon.unauthorizedSigningSlashingAmount()
-        ).to.be.equal(unauthorizedSigningSlashingAmount)
+        const { unauthorizedSigningSlashingAmount } =
+          await randomBeacon.slashingParameters()
+        expect(unauthorizedSigningSlashingAmount).to.be.equal(
+          newUnauthorizedSigningSlashingAmount
+        )
       })
 
       it("should emit the SlashingParametersUpdated event", async () => {
         await expect(tx)
           .to.emit(randomBeacon, "SlashingParametersUpdated")
           .withArgs(
-            relayEntrySubmissionFailureSlashingAmount,
-            maliciousDkgResultSlashingAmount,
-            unauthorizedSigningSlashingAmount
+            newRelayEntrySubmissionFailureSlashingAmount,
+            newMaliciousDkgResultSlashingAmount,
+            newUnauthorizedSigningSlashingAmount
           )
       })
     })

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -186,7 +186,13 @@ describe("RandomBeacon - Relay", () => {
                 // Force group creation on each relay entry.
                 await randomBeacon
                   .connect(deployer)
-                  .updateGroupCreationParameters(1, params.groupLifeTime)
+                  .updateGroupCreationParameters(
+                    1,
+                    params.groupLifeTime,
+                    params.dkgResultChallengePeriodLength,
+                    params.dkgResultSubmissionTimeout,
+                    params.dkgSubmitterPrecedencePeriodLength
+                  )
 
                 tx = await randomBeacon
                   .connect(requester)
@@ -1946,7 +1952,10 @@ describe("RandomBeacon - Relay", () => {
           const newGroupLifetime = 10
           await randomBeacon.updateGroupCreationParameters(
             params.groupCreationFrequency,
-            newGroupLifetime
+            newGroupLifetime,
+            params.dkgResultChallengePeriodLength,
+            params.dkgResultSubmissionTimeout,
+            params.dkgSubmitterPrecedencePeriodLength
           )
           // Simulate group was expired.
           await mineBlocks(newGroupLifetime)
@@ -2012,9 +2021,9 @@ describe("RandomBeacon - Relay", () => {
   async function groupLifetimeOf(groupID: BigNumberish): Promise<BigNumber> {
     const groupData = await randomBeacon.callStatic["getGroup(uint64)"](groupID)
 
-    const groupLifeTime = await randomBeacon.callStatic.groupLifetime()
+    const { groupLifetime } = await randomBeacon.groupCreationParameters()
 
-    return groupData.registrationBlockNumber.add(groupLifeTime)
+    return groupData.registrationBlockNumber.add(groupLifetime)
   }
 
   async function isGroupTerminated(groupID: BigNumberish): Promise<boolean> {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -3112,7 +3112,8 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update DKG result submission gas", async () => {
-        expect(await randomBeacon.dkgResultSubmissionGas()).to.be.equal(
+        const { dkgResultSubmissionGas } = await randomBeacon.gasParameters()
+        expect(dkgResultSubmissionGas).to.be.equal(
           initialDkgResultSubmissionGas
         )
       })
@@ -3201,7 +3202,8 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the DKG result submission gas", async () => {
-          expect(await randomBeacon.dkgResultSubmissionGas()).to.be.equal(1337)
+          const { dkgResultSubmissionGas } = await randomBeacon.gasParameters()
+          expect(dkgResultSubmissionGas).to.be.equal(1337)
         })
 
         it("should emit DkgResultSubmissionGasUpdated event", async () => {
@@ -3245,8 +3247,10 @@ describe("RandomBeaconGovernance", () => {
         await restoreSnapshot()
       })
 
-      it("should not update the DKG approval gas offset", async () => {
-        expect(await randomBeacon.dkgResultApprovalGasOffset()).to.be.equal(
+      it("should not update the DKG result approval gas offset", async () => {
+        const { dkgResultApprovalGasOffset } =
+          await randomBeacon.gasParameters()
+        expect(dkgResultApprovalGasOffset).to.be.equal(
           initialDkgResultApprovalGasOffset
         )
       })
@@ -3335,9 +3339,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the DKG result approval gas offset", async () => {
-          expect(await randomBeacon.dkgResultApprovalGasOffset()).to.be.equal(
-            7331
-          )
+          const { dkgResultApprovalGasOffset } =
+            await randomBeacon.gasParameters()
+          expect(dkgResultApprovalGasOffset).to.be.equal(7331)
         })
 
         it("should emit DkgResultApprovalGasOffsetUpdated event", async () => {
@@ -3384,10 +3388,12 @@ describe("RandomBeaconGovernance", () => {
         await restoreSnapshot()
       })
 
-      it("should not update the operator inactivity gas offset", async () => {
-        expect(
-          await randomBeacon.notifyOperatorInactivityGasOffset()
-        ).to.be.equal(initialNotifyOperatorInactivityGasOffset)
+      it("should not update the notify operator inactivity gas offset", async () => {
+        const { notifyOperatorInactivityGasOffset } =
+          await randomBeacon.gasParameters()
+        expect(notifyOperatorInactivityGasOffset).to.be.equal(
+          initialNotifyOperatorInactivityGasOffset
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -3473,10 +3479,10 @@ describe("RandomBeaconGovernance", () => {
           await restoreSnapshot()
         })
 
-        it("should update the operator inactivity gas offset", async () => {
-          expect(
-            await randomBeacon.notifyOperatorInactivityGasOffset()
-          ).to.be.equal(100)
+        it("should update the notify operator inactivity gas offset", async () => {
+          const { notifyOperatorInactivityGasOffset } =
+            await randomBeacon.gasParameters()
+          expect(notifyOperatorInactivityGasOffset).to.be.equal(100)
         })
 
         it("should emit NotifyOperatorInactivityGasOffsetUpdated event", async () => {
@@ -3524,7 +3530,9 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the relay entry submission gas offset", async () => {
-        expect(await randomBeacon.relayEntrySubmissionGasOffset()).to.be.equal(
+        const { relayEntrySubmissionGasOffset } =
+          await randomBeacon.gasParameters()
+        expect(relayEntrySubmissionGasOffset).to.be.equal(
           initialRelayEntrySubmissionGasOffset
         )
       })
@@ -3613,9 +3621,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the relay entry submission gas offset", async () => {
-          expect(
-            await randomBeacon.relayEntrySubmissionGasOffset()
-          ).to.be.equal(997)
+          const { relayEntrySubmissionGasOffset } =
+            await randomBeacon.gasParameters()
+          expect(relayEntrySubmissionGasOffset).to.be.equal(997)
         })
 
         it("should emit RelayEntrySubmissionGasOffsetUpdated event", async () => {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -506,9 +506,9 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the relay entry soft timeout", async () => {
-        expect(await randomBeacon.relayEntrySoftTimeout()).to.be.equal(
-          initialRelayEntrySoftTimeout
-        )
+        const { relayEntrySoftTimeout } =
+          await randomBeacon.relayEntryParameters()
+        expect(relayEntrySoftTimeout).to.be.equal(initialRelayEntrySoftTimeout)
       })
 
       it("should start the governance delay timer", async () => {
@@ -592,7 +592,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the relay entry soft timeout", async () => {
-          expect(await randomBeacon.relayEntrySoftTimeout()).to.be.equal(1)
+          const { relayEntrySoftTimeout } =
+            await randomBeacon.relayEntryParameters()
+          expect(relayEntrySoftTimeout).to.be.equal(1)
         })
 
         it("should emit RelayEntrySoftTimeoutUpdated event", async () => {
@@ -637,9 +639,9 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the relay entry hard timeout", async () => {
-        expect(await randomBeacon.relayEntryHardTimeout()).to.be.equal(
-          initialRelayEntryHardTimeout
-        )
+        const { relayEntryHardTimeout } =
+          await randomBeacon.relayEntryParameters()
+        expect(relayEntryHardTimeout).to.be.equal(initialRelayEntryHardTimeout)
       })
 
       it("should start the governance delay timer", async () => {
@@ -723,7 +725,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the relay entry hard timeout", async () => {
-          expect(await randomBeacon.relayEntryHardTimeout()).to.be.equal(123)
+          const { relayEntryHardTimeout } =
+            await randomBeacon.relayEntryParameters()
+          expect(relayEntryHardTimeout).to.be.equal(123)
         })
 
         it("should emit RelayEntryHardTimeoutUpdated event", async () => {
@@ -819,9 +823,8 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the callback gas limit", async () => {
-        expect(await randomBeacon.callbackGasLimit()).to.be.equal(
-          initialCallbackGasLimit
-        )
+        const { callbackGasLimit } = await randomBeacon.relayEntryParameters()
+        expect(callbackGasLimit).to.be.equal(initialCallbackGasLimit)
       })
 
       it("should start the governance delay timer", async () => {
@@ -905,7 +908,8 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the callback gas limit", async () => {
-          expect(await randomBeacon.callbackGasLimit()).to.be.equal(123)
+          const { callbackGasLimit } = await randomBeacon.relayEntryParameters()
+          expect(callbackGasLimit).to.be.equal(123)
         })
 
         it("should emit CallbackGasLimitUpdated event", async () => {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -2213,9 +2213,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the sortition pool rewards ban duration", async () => {
-        expect(
-          await randomBeacon.sortitionPoolRewardsBanDuration()
-        ).to.be.equal(initialSortitionPoolRewardsBanDuration)
+        const { sortitionPoolRewardsBanDuration } =
+          await randomBeacon.rewardParameters()
+        expect(sortitionPoolRewardsBanDuration).to.be.equal(
+          initialSortitionPoolRewardsBanDuration
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -2302,9 +2304,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the sortition pool rewards ban duration", async () => {
-          expect(
-            await randomBeacon.sortitionPoolRewardsBanDuration()
-          ).to.be.equal(123)
+          const { sortitionPoolRewardsBanDuration } =
+            await randomBeacon.rewardParameters()
+          expect(sortitionPoolRewardsBanDuration).to.be.equal(123)
         })
 
         it("should emit SortitionPoolRewardsBanDurationUpdated event", async () => {
@@ -2362,9 +2364,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the unauthorized signing notification reward multiplier", async () => {
-        expect(
-          await randomBeacon.unauthorizedSigningNotificationRewardMultiplier()
-        ).to.be.equal(initialUnauthorizedSignatureNotificationRewardMultiplier)
+        const { unauthorizedSigningNotificationRewardMultiplier } =
+          await randomBeacon.rewardParameters()
+        expect(unauthorizedSigningNotificationRewardMultiplier).to.be.equal(
+          initialUnauthorizedSignatureNotificationRewardMultiplier
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -2451,9 +2455,11 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the unauthorized signing notification reward multiplier", async () => {
-          expect(
-            await randomBeacon.unauthorizedSigningNotificationRewardMultiplier()
-          ).to.be.equal(100)
+          const { unauthorizedSigningNotificationRewardMultiplier } =
+            await randomBeacon.rewardParameters()
+          expect(unauthorizedSigningNotificationRewardMultiplier).to.be.equal(
+            100
+          )
         })
 
         it("should emit UnauthorizedSigningNotificationRewardMultiplierUpdated event", async () => {
@@ -2511,9 +2517,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the relay entry timeout notification reward multiplier", async () => {
-        expect(
-          await randomBeacon.relayEntryTimeoutNotificationRewardMultiplier()
-        ).to.be.equal(initialRelayEntryTimeoutNotificationRewardMultiplier)
+        const { relayEntryTimeoutNotificationRewardMultiplier } =
+          await randomBeacon.rewardParameters()
+        expect(relayEntryTimeoutNotificationRewardMultiplier).to.be.equal(
+          initialRelayEntryTimeoutNotificationRewardMultiplier
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -2600,9 +2608,10 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the relay entry timeout notification reward multiplier", async () => {
-          expect(
-            await randomBeacon.relayEntryTimeoutNotificationRewardMultiplier()
-          ).to.be.equal(100)
+          const { relayEntryTimeoutNotificationRewardMultiplier } =
+            await randomBeacon.rewardParameters()
+
+          expect(relayEntryTimeoutNotificationRewardMultiplier).to.be.equal(100)
         })
 
         it("should emit RelayEntryTimeoutNotificationRewardMultiplierUpdated event", async () => {
@@ -2973,9 +2982,12 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the DKG malicious result notification reward multiplier", async () => {
-        expect(
-          await randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
-        ).to.be.equal(initialDkgMaliciousResultNotificationRewardMultiplier)
+        const { dkgMaliciousResultNotificationRewardMultiplier } =
+          await randomBeacon.rewardParameters()
+
+        expect(dkgMaliciousResultNotificationRewardMultiplier).to.be.equal(
+          initialDkgMaliciousResultNotificationRewardMultiplier
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -3062,9 +3074,11 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the DKG malicious result notification reward multiplier", async () => {
-          expect(
-            await randomBeacon.dkgMaliciousResultNotificationRewardMultiplier()
-          ).to.be.equal(100)
+          const { dkgMaliciousResultNotificationRewardMultiplier } =
+            await randomBeacon.rewardParameters()
+          expect(dkgMaliciousResultNotificationRewardMultiplier).to.be.equal(
+            100
+          )
         })
 
         it("should emit DkgMaliciousResultNotificationRewardMultiplierUpdated event", async () => {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -1796,9 +1796,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the relay entry submission failure slashing amount", async () => {
-        expect(
-          await randomBeacon.relayEntrySubmissionFailureSlashingAmount()
-        ).to.be.equal(initialRelayEntrySubmissionFailureSlashingAmount)
+        const { relayEntrySubmissionFailureSlashingAmount } =
+          await randomBeacon.slashingParameters()
+        expect(relayEntrySubmissionFailureSlashingAmount).to.be.equal(
+          initialRelayEntrySubmissionFailureSlashingAmount
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -1885,9 +1887,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the relay entry submission failure slashing amount", async () => {
-          expect(
-            await randomBeacon.relayEntrySubmissionFailureSlashingAmount()
-          ).to.be.equal(123)
+          const { relayEntrySubmissionFailureSlashingAmount } =
+            await randomBeacon.slashingParameters()
+          expect(relayEntrySubmissionFailureSlashingAmount).to.be.equal(123)
         })
 
         it("should emit RelayEntrySubmissionFailureSlashingAmountUpdated event", async () => {
@@ -1935,9 +1937,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the unauthorized signing slashing amount", async () => {
-        expect(
-          await randomBeacon.unauthorizedSigningSlashingAmount()
-        ).to.be.equal(initialUnauthorizedSigningSlashingAmount)
+        const { unauthorizedSigningSlashingAmount } =
+          await randomBeacon.slashingParameters()
+        expect(unauthorizedSigningSlashingAmount).to.be.equal(
+          initialUnauthorizedSigningSlashingAmount
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -2024,9 +2028,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the unauthorized signing slashing amount", async () => {
-          expect(
-            await randomBeacon.unauthorizedSigningSlashingAmount()
-          ).to.be.equal(123)
+          const { unauthorizedSigningSlashingAmount } =
+            await randomBeacon.slashingParameters()
+          expect(unauthorizedSigningSlashingAmount).to.be.equal(123)
         })
 
         it("should emit UnauthorizedSigningSlashingAmountUpdated event", async () => {
@@ -2074,9 +2078,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the malicious DKG result slashing amount", async () => {
-        expect(
-          await randomBeacon.maliciousDkgResultSlashingAmount()
-        ).to.be.equal(initialMaliciousDkgResultSlashingAmount)
+        const { maliciousDkgResultSlashingAmount } =
+          await randomBeacon.slashingParameters()
+        expect(maliciousDkgResultSlashingAmount).to.be.equal(
+          initialMaliciousDkgResultSlashingAmount
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -2163,9 +2169,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the malicious DKG result slashing amount", async () => {
-          expect(
-            await randomBeacon.maliciousDkgResultSlashingAmount()
-          ).to.be.equal(123)
+          const { maliciousDkgResultSlashingAmount } =
+            await randomBeacon.slashingParameters()
+          expect(maliciousDkgResultSlashingAmount).to.be.equal(123)
         })
 
         it("should emit MaliciousDkgResultSlashingAmountUpdated event", async () => {

--- a/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
+++ b/solidity/random-beacon/test/RandomBeaconGovernance.test.ts
@@ -57,11 +57,7 @@ const fixture = async () => {
     .connect(governance)
     .updateGroupCreationParameters(
       initialGroupCreationFrequency,
-      initialGroupLifeTime
-    )
-  await randomBeacon
-    .connect(governance)
-    .updateDkgParameters(
+      initialGroupLifeTime,
       initialDkgResultChallengePeriodLength,
       initialDkgResultSubmissionTimeout,
       initialDkgSubmitterPrecedencePeriodLength
@@ -981,7 +977,9 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the group creation frequency timeout", async () => {
-        expect(await randomBeacon.groupCreationFrequency()).to.be.equal(
+        const { groupCreationFrequency } =
+          await randomBeacon.groupCreationParameters()
+        expect(groupCreationFrequency).to.be.equal(
           initialGroupCreationFrequency
         )
       })
@@ -1070,7 +1068,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the group creation frequency", async () => {
-          expect(await randomBeacon.groupCreationFrequency()).to.be.equal(1)
+          const { groupCreationFrequency } =
+            await randomBeacon.groupCreationParameters()
+          expect(groupCreationFrequency).to.be.equal(1)
         })
 
         it("should emit GroupCreationFrequencyUpdated event", async () => {
@@ -1163,9 +1163,8 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the group lifetime", async () => {
-        expect(await randomBeacon.groupLifetime()).to.be.equal(
-          initialGroupLifeTime
-        )
+        const { groupLifetime } = await randomBeacon.groupCreationParameters()
+        expect(groupLifetime).to.be.equal(initialGroupLifeTime)
       })
 
       it("should start the governance delay timer", async () => {
@@ -1249,9 +1248,8 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the group lifetime", async () => {
-          expect(await randomBeacon.groupLifetime()).to.be.equal(
-            2 * 24 * 60 * 60
-          )
+          const { groupLifetime } = await randomBeacon.groupCreationParameters()
+          expect(groupLifetime).to.be.equal(2 * 24 * 60 * 60)
         })
 
         it("should emit GroupLifetimeUpdated event", async () => {
@@ -1323,7 +1321,9 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the DKG result challenge period length", async () => {
-        expect(await randomBeacon.dkgResultChallengePeriodLength()).to.be.equal(
+        const { dkgResultChallengePeriodLength } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgResultChallengePeriodLength).to.be.equal(
           initialDkgResultChallengePeriodLength
         )
       })
@@ -1412,9 +1412,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the DKG result challenge period length", async () => {
-          expect(
-            await randomBeacon.dkgResultChallengePeriodLength()
-          ).to.be.equal(11)
+          const { dkgResultChallengePeriodLength } =
+            await randomBeacon.groupCreationParameters()
+          expect(dkgResultChallengePeriodLength).to.be.equal(11)
         })
 
         it("should emit DkgResultChallengePeriodLengthUpdated event", async () => {
@@ -1489,7 +1489,9 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the DKG result submission timeout", async () => {
-        expect(await randomBeacon.dkgResultSubmissionTimeout()).to.be.equal(
+        const { dkgResultSubmissionTimeout } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgResultSubmissionTimeout).to.be.equal(
           initialDkgResultSubmissionTimeout
         )
       })
@@ -1579,9 +1581,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the DKG result submission timeout", async () => {
-          expect(await randomBeacon.dkgResultSubmissionTimeout()).to.be.equal(
-            newValue
-          )
+          const { dkgResultSubmissionTimeout } =
+            await randomBeacon.groupCreationParameters()
+          expect(dkgResultSubmissionTimeout).to.be.equal(newValue)
         })
 
         it("should emit DkgResultSubmissionTimeoutUpdated event", async () => {
@@ -1661,9 +1663,11 @@ describe("RandomBeaconGovernance", () => {
       })
 
       it("should not update the DKG submitter precedence period length", async () => {
-        expect(
-          await randomBeacon.dkgSubmitterPrecedencePeriodLength()
-        ).to.be.equal(initialDkgSubmitterPrecedencePeriodLength)
+        const { dkgSubmitterPrecedencePeriodLength } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgSubmitterPrecedencePeriodLength).to.be.equal(
+          initialDkgSubmitterPrecedencePeriodLength
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -1750,9 +1754,9 @@ describe("RandomBeaconGovernance", () => {
         })
 
         it("should update the DKG submitter precedence period length", async () => {
-          expect(
-            await randomBeacon.dkgSubmitterPrecedencePeriodLength()
-          ).to.be.equal(1)
+          const { dkgSubmitterPrecedencePeriodLength } =
+            await randomBeacon.groupCreationParameters()
+          expect(dkgSubmitterPrecedencePeriodLength).to.be.equal(1)
         })
 
         it("should emit DkgSubmitterPrecedencePeriodLengthUpdated event", async () => {

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -239,10 +239,7 @@ async function setFixtureParameters(randomBeacon: RandomBeaconStub) {
 
   await randomBeacon.updateGroupCreationParameters(
     params.groupCreationFrequency,
-    params.groupLifeTime
-  )
-
-  await randomBeacon.updateDkgParameters(
+    params.groupLifeTime,
     params.dkgResultChallengePeriodLength,
     params.dkgResultSubmissionTimeout,
     params.dkgSubmitterPrecedencePeriodLength

--- a/solidity/random-beacon/test/system/e2e.test.ts
+++ b/solidity/random-beacon/test/system/e2e.test.ts
@@ -90,7 +90,13 @@ describe("System -- e2e", () => {
 
     await randomBeacon
       .connect(owner)
-      .updateGroupCreationParameters(groupCreationFrequency, groupLifetime)
+      .updateGroupCreationParameters(
+        groupCreationFrequency,
+        groupLifetime,
+        10, // dkgResultChallengePeriodLength, does not matter for this test
+        5, // dkgResultSubmissionTimeout, does not matter for this test
+        1 // dkgSubmitterPrecedencePeriodLength, does not matter for this test
+      )
 
     await randomBeacon
       .connect(owner)

--- a/solidity/random-beacon/test/system/e2e.test.ts
+++ b/solidity/random-beacon/test/system/e2e.test.ts
@@ -88,15 +88,13 @@ describe("System -- e2e", () => {
         callbackGasLimit
       )
 
-    await randomBeacon
-      .connect(owner)
-      .updateGroupCreationParameters(
-        groupCreationFrequency,
-        groupLifetime,
-        10, // dkgResultChallengePeriodLength, does not matter for this test
-        5, // dkgResultSubmissionTimeout, does not matter for this test
-        1 // dkgSubmitterPrecedencePeriodLength, does not matter for this test
-      )
+    await randomBeacon.connect(owner).updateGroupCreationParameters(
+      groupCreationFrequency,
+      groupLifetime,
+      10, // dkgResultChallengePeriodLength, does not matter for this test
+      5, // dkgResultSubmissionTimeout, does not matter for this test
+      1 // dkgSubmitterPrecedencePeriodLength, does not matter for this test
+    )
 
     await randomBeacon
       .connect(owner)


### PR DESCRIPTION
~~Depends on #2947. Keeping as a draft until #2947 is not merged but I plan no changes to the code so it is ready for review!~~

This PR allows to go down with `RandomBeacon` contract size from `24.333 KB` to `24.130 KB`.

This is cleaning up the structure but most importantly, should add enough space for some reward-related functions (to be done in a separate PR).

It is grouping parameters together so that instead of exposing them as separate view functions, they are grouped into:
- `relayEntryParameters()`
- `groupCreationParameters()`
- `rewardParameters()`
- `slashingParameters()`
- `gasParameters()`

No changes in the logic of how `RandomBeacon` works.

I recommend reviewing this PR commit-by-commit.