### PR TITLE
Align `WalletRegistry` parameter view functions with `RandomBeacon` approach

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -887,80 +887,6 @@ contract WalletRegistry is
         return wallets.isWalletRegistered(walletID);
     }
 
-    /// @notice Retrieves dkg parameters that were set in DKG library.
-    function dkgParameters() external view returns (DKG.Parameters memory) {
-        return dkg.parameters;
-    }
-
-    /// @notice Retrieves reward-related parameters.
-    /// @return maliciousDkgResultNotificationRewardMultiplier Percentage of the
-    ///         staking contract malicious behavior notification reward which
-    ///         will be transferred to the notifier reporting about a malicious
-    ///         DKG result. Notifiers are rewarded from a notifiers treasury
-    ///         pool. For example, if notification reward is 1000 and the value
-    ///         of the multiplier is 5, the notifier will receive:
-    ///         5% of 1000 = 50 per each operator affected.
-    /// @return sortitionPoolRewardsBanDuration Duration of the sortition pool
-    ///         rewards ban imposed on operators who missed their turn for DKG
-    ///         result submission or who failed a heartbeat.
-    function rewardParameters()
-        external
-        view
-        returns (
-            uint256 maliciousDkgResultNotificationRewardMultiplier,
-            uint256 sortitionPoolRewardsBanDuration
-        )
-    {
-        return (
-            _maliciousDkgResultNotificationRewardMultiplier,
-            _sortitionPoolRewardsBanDuration
-        );
-    }
-
-    /// @notice Retrieves slashing-related parameters.
-    /// @return maliciousDkgResultSlashingAmount Slashing amount for submitting
-    ///         a malicious DKG result. Every DKG result submitted can be
-    ///         challenged for the time of `dkg.resultChallengePeriodLength`.
-    ///         If the DKG result submitted is challenged and proven to be
-    ///         malicious, the operator who submitted the malicious result is
-    ///         slashed for `_maliciousDkgResultSlashingAmount`.
-    function slashingParameters()
-        external
-        view
-        returns (uint96 maliciousDkgResultSlashingAmount)
-    {
-        return _maliciousDkgResultSlashingAmount;
-    }
-
-    /// @notice Retrieves gas-related parameters.
-    /// @return dkgResultSubmissionGas Calculated max gas cost for submitting
-    ///         a DKG result. This will be refunded as part of the DKG approval
-    ///         process. It is in the submitter's interest to not skip his
-    ///         priority turn on the approval, otherwise the refund of the DKG
-    ///         submission will be refunded to another group member that will
-    ///         call the DKG approve function.
-    /// @return dkgResultApprovalGasOffset Gas that is meant to balance the DKG
-    ///         result approval's overall cost. It can be updated by the
-    ///         governace based on the current market conditions.
-    /// @return notifyOperatorInactivityGasOffset Gas that is meant to balance
-    ///         the notification of an operator inactivity. It can be updated by
-    ///         the governace based on the current market conditions.
-    function gasParameters()
-        external
-        view
-        returns (
-            uint256 dkgResultSubmissionGas,
-            uint256 dkgResultApprovalGasOffset,
-            uint256 notifyOperatorInactivityGasOffset
-        )
-    {
-        return (
-            _dkgResultSubmissionGas,
-            _dkgResultApprovalGasOffset,
-            _notifyOperatorInactivityGasOffset
-        );
-    }
-
     /// @notice The minimum authorization amount required so that operator can
     ///         participate in ECDSA Wallet operations.
     function minimumAuthorization() external view returns (uint96) {
@@ -1053,5 +979,79 @@ contract WalletRegistry is
     /// @return IDs of selected group members.
     function selectGroup() external view returns (uint32[] memory) {
         return sortitionPool.selectGroup(DKG.groupSize, bytes32(dkg.seed));
+    }
+
+    /// @notice Retrieves dkg parameters that were set in DKG library.
+    function dkgParameters() external view returns (DKG.Parameters memory) {
+        return dkg.parameters;
+    }
+
+    /// @notice Retrieves reward-related parameters.
+    /// @return maliciousDkgResultNotificationRewardMultiplier Percentage of the
+    ///         staking contract malicious behavior notification reward which
+    ///         will be transferred to the notifier reporting about a malicious
+    ///         DKG result. Notifiers are rewarded from a notifiers treasury
+    ///         pool. For example, if notification reward is 1000 and the value
+    ///         of the multiplier is 5, the notifier will receive:
+    ///         5% of 1000 = 50 per each operator affected.
+    /// @return sortitionPoolRewardsBanDuration Duration of the sortition pool
+    ///         rewards ban imposed on operators who missed their turn for DKG
+    ///         result submission or who failed a heartbeat.
+    function rewardParameters()
+        external
+        view
+        returns (
+            uint256 maliciousDkgResultNotificationRewardMultiplier,
+            uint256 sortitionPoolRewardsBanDuration
+        )
+    {
+        return (
+            _maliciousDkgResultNotificationRewardMultiplier,
+            _sortitionPoolRewardsBanDuration
+        );
+    }
+
+    /// @notice Retrieves slashing-related parameters.
+    /// @return maliciousDkgResultSlashingAmount Slashing amount for submitting
+    ///         a malicious DKG result. Every DKG result submitted can be
+    ///         challenged for the time of `dkg.resultChallengePeriodLength`.
+    ///         If the DKG result submitted is challenged and proven to be
+    ///         malicious, the operator who submitted the malicious result is
+    ///         slashed for `_maliciousDkgResultSlashingAmount`.
+    function slashingParameters()
+        external
+        view
+        returns (uint96 maliciousDkgResultSlashingAmount)
+    {
+        return _maliciousDkgResultSlashingAmount;
+    }
+
+    /// @notice Retrieves gas-related parameters.
+    /// @return dkgResultSubmissionGas Calculated max gas cost for submitting
+    ///         a DKG result. This will be refunded as part of the DKG approval
+    ///         process. It is in the submitter's interest to not skip his
+    ///         priority turn on the approval, otherwise the refund of the DKG
+    ///         submission will be refunded to another group member that will
+    ///         call the DKG approve function.
+    /// @return dkgResultApprovalGasOffset Gas that is meant to balance the DKG
+    ///         result approval's overall cost. It can be updated by the
+    ///         governace based on the current market conditions.
+    /// @return notifyOperatorInactivityGasOffset Gas that is meant to balance
+    ///         the notification of an operator inactivity. It can be updated by
+    ///         the governace based on the current market conditions.
+    function gasParameters()
+        external
+        view
+        returns (
+            uint256 dkgResultSubmissionGas,
+            uint256 dkgResultApprovalGasOffset,
+            uint256 notifyOperatorInactivityGasOffset
+        )
+    {
+        return (
+            _dkgResultSubmissionGas,
+            _dkgResultApprovalGasOffset,
+            _notifyOperatorInactivityGasOffset
+        );
     }
 }

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -477,10 +477,12 @@ contract WalletRegistryGovernance is Ownable {
         emit MaliciousDkgResultNotificationRewardMultiplierUpdated(
             newMaliciousDkgResultNotificationRewardMultiplier
         );
+        (, uint256 sortitionPoolRewardsBanDuration) = walletRegistry
+            .rewardParameters();
         // slither-disable-next-line reentrancy-no-eth
         walletRegistry.updateRewardParameters(
             newMaliciousDkgResultNotificationRewardMultiplier,
-            walletRegistry.sortitionPoolRewardsBanDuration()
+            sortitionPoolRewardsBanDuration
         );
         maliciousDkgResultNotificationRewardMultiplierChangeInitiated = 0;
         newMaliciousDkgResultNotificationRewardMultiplier = 0;
@@ -677,9 +679,13 @@ contract WalletRegistryGovernance is Ownable {
         emit SortitionPoolRewardsBanDurationUpdated(
             newSortitionPoolRewardsBanDuration
         );
+        (
+            uint256 maliciousDkgResultNotificationRewardMultiplier,
+
+        ) = walletRegistry.rewardParameters();
         // slither-disable-next-line reentrancy-no-eth
         walletRegistry.updateRewardParameters(
-            walletRegistry.maliciousDkgResultNotificationRewardMultiplier(),
+            maliciousDkgResultNotificationRewardMultiplier,
             newSortitionPoolRewardsBanDuration
         );
         sortitionPoolRewardsBanDurationChangeInitiated = 0;

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -511,11 +511,16 @@ contract WalletRegistryGovernance is Ownable {
         onlyAfterGovernanceDelay(dkgResultSubmissionGasChangeInitiated)
     {
         emit DkgResultSubmissionGasUpdated(newDkgResultSubmissionGas);
+        (
+            ,
+            uint256 dkgResultApprovalGasOffset,
+            uint256 notifyOperatorInactivityGasOffset
+        ) = walletRegistry.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         walletRegistry.updateGasParameters(
             newDkgResultSubmissionGas,
-            walletRegistry.dkgResultApprovalGasOffset(),
-            walletRegistry.notifyOperatorInactivityGasOffset()
+            dkgResultApprovalGasOffset,
+            notifyOperatorInactivityGasOffset
         );
         dkgResultSubmissionGasChangeInitiated = 0;
         newDkgResultSubmissionGas = 0;
@@ -546,11 +551,16 @@ contract WalletRegistryGovernance is Ownable {
         onlyAfterGovernanceDelay(dkgResultApprovalGasOffsetChangeInitiated)
     {
         emit DkgResultApprovalGasOffsetUpdated(newDkgResultApprovalGasOffset);
+        (
+            uint256 dkgResultSubmissionGas,
+            ,
+            uint256 notifyOperatorInactivityGasOffset
+        ) = walletRegistry.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         walletRegistry.updateGasParameters(
-            walletRegistry.dkgResultSubmissionGas(),
+            dkgResultSubmissionGas,
             newDkgResultApprovalGasOffset,
-            walletRegistry.notifyOperatorInactivityGasOffset()
+            notifyOperatorInactivityGasOffset
         );
         dkgResultApprovalGasOffsetChangeInitiated = 0;
         newDkgResultApprovalGasOffset = 0;
@@ -586,10 +596,15 @@ contract WalletRegistryGovernance is Ownable {
         emit NotifyOperatorInactivityGasOffsetUpdated(
             newNotifyOperatorInactivityGasOffset
         );
+        (
+            uint256 dkgResultSubmissionGas,
+            uint256 dkgResultApprovalGasOffset,
+
+        ) = walletRegistry.gasParameters();
         // slither-disable-next-line reentrancy-no-eth
         walletRegistry.updateGasParameters(
-            walletRegistry.dkgResultSubmissionGas(),
-            walletRegistry.dkgResultApprovalGasOffset(),
+            dkgResultSubmissionGas,
+            dkgResultApprovalGasOffset,
             newNotifyOperatorInactivityGasOffset
         );
         notifyOperatorInactivityGasOffsetChangeInitiated = 0;

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -1624,9 +1624,11 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   it("should refund ETH to a third party caller", async () => {
                     const postDkgResultApprovalThirdPartyInitialBalance =
                       await provider.getBalance(await thirdParty.getAddress())
-                    const feeForDkgSubmission = (
-                      await walletRegistry.dkgResultSubmissionGas()
-                    ).mul(tx.gasPrice)
+                    const { dkgResultSubmissionGas } =
+                      await walletRegistry.gasParameters()
+                    const feeForDkgSubmission = dkgResultSubmissionGas.mul(
+                      tx.gasPrice
+                    )
                     // submission part was done by someone else and this is why
                     // we add submission dkg fee to the initial balance
                     const diff =
@@ -1768,9 +1770,11 @@ describe("WalletRegistry - Wallet Creation", async () => {
               it("should refund ETH to a submitter", async () => {
                 const postDkgResultApprovalAnotherSubmitterInitialBalance =
                   await provider.getBalance(await anotherSubmitter.getAddress())
-                const feeForDkgSubmission = (
-                  await walletRegistry.dkgResultSubmissionGas()
-                ).mul(tx.gasPrice)
+                const { dkgResultSubmissionGas } =
+                  await walletRegistry.gasParameters()
+                const feeForDkgSubmission = dkgResultSubmissionGas.mul(
+                  tx.gasPrice
+                )
                 // submission part was done by someone else and this is why
                 // we add submission dkg fee to the initial balance
                 const diff =

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -1060,7 +1060,8 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the DKG submission result gas", async () => {
-        expect(await walletRegistry.dkgResultSubmissionGas()).to.be.equal(
+        const { dkgResultSubmissionGas } = await walletRegistry.gasParameters()
+        expect(dkgResultSubmissionGas).to.be.equal(
           initialDkgResultSubmissionGas
         )
       })
@@ -1149,7 +1150,9 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the DKG result submission gas", async () => {
-          expect(await walletRegistry.dkgResultSubmissionGas()).to.be.equal(100)
+          const { dkgResultSubmissionGas } =
+            await walletRegistry.gasParameters()
+          expect(dkgResultSubmissionGas).to.be.equal(100)
         })
 
         it("should emit DkgResultSubmissionGasUpdated event", async () => {
@@ -1194,7 +1197,9 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the DKG approval gas offset", async () => {
-        expect(await walletRegistry.dkgResultApprovalGasOffset()).to.be.equal(
+        const { dkgResultApprovalGasOffset } =
+          await walletRegistry.gasParameters()
+        expect(dkgResultApprovalGasOffset).to.be.equal(
           initialDkgResultApprovalGasOffset
         )
       })
@@ -1283,9 +1288,9 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the DKG result approval gas offset", async () => {
-          expect(await walletRegistry.dkgResultApprovalGasOffset()).to.be.equal(
-            100
-          )
+          const { dkgResultApprovalGasOffset } =
+            await walletRegistry.gasParameters()
+          expect(dkgResultApprovalGasOffset).to.be.equal(100)
         })
 
         it("should emit DkgResultApprovalGasOffsetUpdated event", async () => {
@@ -2445,9 +2450,11 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the operator inactivity gas offset", async () => {
-        expect(
-          await walletRegistry.notifyOperatorInactivityGasOffset()
-        ).to.be.equal(initialNotifyOperatorInactivityGasOffset)
+        const { notifyOperatorInactivityGasOffset } =
+          await walletRegistry.gasParameters()
+        expect(notifyOperatorInactivityGasOffset).to.be.equal(
+          initialNotifyOperatorInactivityGasOffset
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -2534,9 +2541,9 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the operator inactivity gas offset", async () => {
-          expect(
-            await walletRegistry.notifyOperatorInactivityGasOffset()
-          ).to.be.equal(100)
+          const { notifyOperatorInactivityGasOffset } =
+            await walletRegistry.gasParameters()
+          expect(notifyOperatorInactivityGasOffset).to.be.equal(100)
         })
 
         it("should emit NotifyOperatorInactivityGasOffsetUpdated event", async () => {

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -921,9 +921,11 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the malicious DKG result slashing amount", async () => {
-        expect(
-          await walletRegistry.maliciousDkgResultSlashingAmount()
-        ).to.be.equal(initialMaliciousDkgResultSlashingAmount)
+        const maliciousDkgResultSlashingAmount =
+          await walletRegistry.slashingParameters()
+        expect(maliciousDkgResultSlashingAmount).to.be.equal(
+          initialMaliciousDkgResultSlashingAmount
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -1010,9 +1012,9 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the malicious DKG result slashing amount", async () => {
-          expect(
-            await walletRegistry.maliciousDkgResultSlashingAmount()
-          ).to.be.equal(123)
+          const maliciousDkgResultSlashingAmount =
+            await walletRegistry.slashingParameters()
+          expect(maliciousDkgResultSlashingAmount).to.be.equal(123)
         })
 
         it("should emit MaliciousDkgResultSlashingAmountUpdated event", async () => {

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -1348,9 +1348,11 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the DKG malicious result notification reward multiplier", async () => {
-        expect(
-          await walletRegistry.maliciousDkgResultNotificationRewardMultiplier()
-        ).to.be.equal(initialMaliciousDkgResultNotificationRewardMultiplier)
+        const { maliciousDkgResultNotificationRewardMultiplier } =
+          await walletRegistry.rewardParameters()
+        expect(maliciousDkgResultNotificationRewardMultiplier).to.be.equal(
+          initialMaliciousDkgResultNotificationRewardMultiplier
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -1437,9 +1439,11 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the DKG malicious result notification reward multiplier", async () => {
-          expect(
-            await walletRegistry.maliciousDkgResultNotificationRewardMultiplier()
-          ).to.be.equal(100)
+          const { maliciousDkgResultNotificationRewardMultiplier } =
+            await walletRegistry.rewardParameters()
+          expect(maliciousDkgResultNotificationRewardMultiplier).to.be.equal(
+            100
+          )
         })
 
         it("should emit MaliciousDkgResultNotificationRewardMultiplierUpdated event", async () => {
@@ -1487,9 +1491,11 @@ describe("WalletRegistryGovernance", async () => {
       })
 
       it("should not update the sortition pool rewards ban duration", async () => {
-        expect(
-          await walletRegistry.sortitionPoolRewardsBanDuration()
-        ).to.be.equal(initialSortitionPoolRewardsBanDuration)
+        const { sortitionPoolRewardsBanDuration } =
+          await walletRegistry.rewardParameters()
+        expect(sortitionPoolRewardsBanDuration).to.be.equal(
+          initialSortitionPoolRewardsBanDuration
+        )
       })
 
       it("should start the governance delay timer", async () => {
@@ -1576,9 +1582,9 @@ describe("WalletRegistryGovernance", async () => {
         })
 
         it("should update the sortition pool rewards ban duration", async () => {
-          expect(
-            await walletRegistry.sortitionPoolRewardsBanDuration()
-          ).to.be.equal(86400)
+          const { sortitionPoolRewardsBanDuration } =
+            await walletRegistry.rewardParameters()
+          expect(sortitionPoolRewardsBanDuration).to.be.equal(86400)
         })
 
         it("should emit SortitionPoolRewardsBanDurationUpdated event", async () => {


### PR DESCRIPTION
Depends on #2951; Keeping as a draft until #2951 is not merged.

Aligned `WalletRegistry` with `RandomBeacon` changes from #2951. Parameters are grouped together and exposed in view functions:
- `dkgParameters()` - this one was already there
- `rewardParameters()`
-  `slashingParameters()`
- `gasParameters()`

This change allowed to reduce the size of `WalletRegistry`. Before/after:
```
|  WalletRegistry            ·     21.948  │
|  WalletRegistry            ·     21.903  │
```