### PR TITLE
Adjusting RandomBeacon to Threshold IApplication rewards API

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -609,6 +609,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         require(operator != address(0), "Unknown operator");
         (, address beneficiary, ) = staking.rolesOf(stakingProvider);
         uint96 amount = sortitionPool.withdrawRewards(operator, beneficiary);
+        // slither-disable-next-line reentrancy-events
         emit RewardsWithdrawn(stakingProvider, amount);
     }
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -345,6 +345,8 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         address indexed operator
     );
 
+    event RewardsWithdrawn(address indexed stakingProvider, uint96 amount);
+
     /// @dev Assigns initial values to parameters to make the beacon work
     ///      safely. These parameters are just proposed defaults and they might
     ///      be updated with `update*` functions after the contract deployment
@@ -597,14 +599,17 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         emit RequesterAuthorizationUpdated(requester, isAuthorized);
     }
 
-    /// @notice Withdraw rewards for the given staking provider to their
-    ///         beneficiary address. Reverts if staking provider has not
-    ///         registered the operator address.
+    /// @notice Withdraws application rewards for the given staking provider.
+    ///         Rewards are withdrawn to the staking provider's beneficiary
+    ///         address set in the staking contract. Reverts if staking provider
+    ///         has not registered the operator address.
+    /// @dev Emits `RewardsWithdrawn` event.
     function withdrawRewards(address stakingProvider) external {
         address operator = stakingProviderToOperator(stakingProvider);
         require(operator != address(0), "Unknown operator");
         (, address beneficiary, ) = staking.rolesOf(stakingProvider);
-        sortitionPool.withdrawRewards(operator, beneficiary);
+        uint96 amount = sortitionPool.withdrawRewards(operator, beneficiary);
+        emit RewardsWithdrawn(stakingProvider, amount);
     }
 
     /// @notice Withdraws rewards belonging to operators marked as ineligible
@@ -1258,6 +1263,19 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         returns (uint96)
     {
         return authorization.eligibleStake(staking, stakingProvider);
+    }
+
+    /// @notice Returns the amount of rewards available for withdrawal for the
+    ///         given staking provider. Reverts if staking provider has not
+    ///         registered the operator address.
+    function availableRewards(address stakingProvider)
+        external
+        view
+        returns (uint96)
+    {
+        address operator = stakingProviderToOperator(stakingProvider);
+        require(operator != address(0), "Unknown operator");
+        return sortitionPool.getAvailableRewards(operator);
     }
 
     /// @notice Returns the amount of stake that is pending authorization

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -30,7 +30,7 @@
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts"
   },
   "dependencies": {
-    "@keep-network/sortition-pools": "^2.0.0-pre.7",
+    "@keep-network/sortition-pools": "^2.0.0-pre.9",
     "@openzeppelin/contracts": "^4.4.2",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
     "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten"

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -613,10 +613,10 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/sortition-pools@^2.0.0-pre.7":
-  version "2.0.0-pre.7"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.7.tgz#07ce8d645bbb45855718680b0679fc5dd329e34a"
-  integrity sha512-X5/QeEBAsz0v9QfBZ9YVgP/L5TkQHwW1fuyVIirVuR+Wf5zdsWopixk/yC5fL4BSapNaf4KJeIueMF7Eq8Kv/A==
+"@keep-network/sortition-pools@^2.0.0-pre.9":
+  version "2.0.0-pre.9"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.9.tgz#2525068532a9dcde7e86d55f239b32fdb8b92648"
+  integrity sha512-u09pSaxtvpm1B8Lu5EdLOUEKWyflE6C1saIm/hLW6dg8LzEHTr/bgfwH2ruqiia/akjZgiNENJp2VBYqs2IEbw==
   dependencies:
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"


### PR DESCRIPTION
~~Depends on #2952; Keeping it as a draft PR until #2952 is not merged.~~

Refs https://github.com/threshold-network/solidity-contracts/issues/89
Refs https://github.com/keep-network/keep-core/issues/2935

See https://github.com/threshold-network/solidity-contracts/pull/95
See https://github.com/keep-network/sortition-pools/pull/162
See https://github.com/keep-network/sortition-pools/pull/163

`RandomBeacon.withdrawRewards` emits `RewardsWithdrawn` event informing about
the amount of tokens withdrawn in the transaction.

`RandomBeacon.availableRewards` informs about the amount of reward tokens
available for withdrawal for the staking provider.
