### PR TITLE
Adjusting WalletRegistry to Threshold IApplication rewards API

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -285,6 +285,7 @@ contract WalletRegistry is
         require(operator != address(0), "Unknown operator");
         (, address beneficiary, ) = staking.rolesOf(stakingProvider);
         uint96 amount = sortitionPool.withdrawRewards(operator, beneficiary);
+        // slither-disable-next-line reentrancy-events
         emit RewardsWithdrawn(stakingProvider, amount);
     }
 

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -221,6 +221,8 @@ contract WalletRegistry is
         address notifier
     );
 
+    event RewardsWithdrawn(address indexed stakingProvider, uint96 amount);
+
     modifier onlyStakingContract() {
         require(
             msg.sender == address(staking),
@@ -273,14 +275,17 @@ contract WalletRegistry is
         _transferGovernance(msg.sender);
     }
 
-    /// @notice Withdraw rewards for the given staking provider to their
-    ///         beneficiary address. Reverts if staking provider has not
-    ///         registered the operator address.
+    /// @notice Withdraws application rewards for the given staking provider.
+    ///         Rewards are withdrawn to the staking provider's beneficiary
+    ///         address set in the staking contract. Reverts if staking provider
+    ///         has not registered the operator address.
+    /// @dev Emits `RewardsWithdrawn` event.
     function withdrawRewards(address stakingProvider) external {
         address operator = stakingProviderToOperator(stakingProvider);
         require(operator != address(0), "Unknown operator");
         (, address beneficiary, ) = staking.rolesOf(stakingProvider);
-        sortitionPool.withdrawRewards(operator, beneficiary);
+        uint96 amount = sortitionPool.withdrawRewards(operator, beneficiary);
+        emit RewardsWithdrawn(stakingProvider, amount);
     }
 
     /// @notice Withdraws rewards belonging to operators marked as ineligible
@@ -966,6 +971,19 @@ contract WalletRegistry is
         returns (uint96)
     {
         return authorization.eligibleStake(staking, stakingProvider);
+    }
+
+    /// @notice Returns the amount of rewards available for withdrawal for the
+    ///         given staking provider. Reverts if staking provider has not
+    ///         registered the operator address.
+    function availableRewards(address stakingProvider)
+        external
+        view
+        returns (uint96)
+    {
+        address operator = stakingProviderToOperator(stakingProvider);
+        require(operator != address(0), "Unknown operator");
+        return sortitionPool.getAvailableRewards(operator);
     }
 
     /// @notice Returns the amount of stake that is pending authorization

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -221,8 +221,6 @@ contract WalletRegistry is
         address notifier
     );
 
-    event RewardsWithdrawn(address indexed stakingProvider, uint96 amount);
-
     modifier onlyStakingContract() {
         require(
             msg.sender == address(staking),

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@keep-network/random-beacon": "development",
-    "@keep-network/sortition-pools": "^2.0.0-pre.7",
+    "@keep-network/sortition-pools": "^2.0.0-pre.9",
     "@openzeppelin/contracts": "^4.4.1",
     "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
   },

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -630,6 +630,14 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
+"@keep-network/sortition-pools@^2.0.0-pre.9":
+  version "2.0.0-pre.9"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.9.tgz#2525068532a9dcde7e86d55f239b32fdb8b92648"
+  integrity sha512-u09pSaxtvpm1B8Lu5EdLOUEKWyflE6C1saIm/hLW6dg8LzEHTr/bgfwH2ruqiia/akjZgiNENJp2VBYqs2IEbw==
+  dependencies:
+    "@openzeppelin/contracts" "^4.3.2"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -613,22 +613,14 @@
     openzeppelin-solidity "2.4.0"
 
 "@keep-network/random-beacon@development":
-  version "2.0.0-dev.20"
-  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.20.tgz#79a852a2695fcd34d9aabe7223a23d7ac5cff6c4"
-  integrity sha512-vpdo+bEy37tsnIhX5vlpq/GtsDvjLPCKKnVpdWHnLBEt/wcR34YHc43O2szGYFURKAzeXgjyJ9wiIE84j4zbjg==
+  version "2.0.0-dev.25"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.25.tgz#41009e649db29a2bcf5c4e50e2cb874ebb7ebcfa"
+  integrity sha512-LdJ3ffFJdagycX47HYkDWRKCY0/uil8/DCj+grwjAcM2q9BYn9u9ofKY2fvXje/iK+ec6/2Cf6vbJ6BllIG0/A==
   dependencies:
-    "@keep-network/sortition-pools" "^2.0.0-pre.7"
+    "@keep-network/sortition-pools" "^2.0.0-pre.9"
     "@openzeppelin/contracts" "^4.4.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts" ">1.1.0-dev <1.1.0-ropsten"
-
-"@keep-network/sortition-pools@^2.0.0-pre.7":
-  version "2.0.0-pre.7"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.7.tgz#07ce8d645bbb45855718680b0679fc5dd329e34a"
-  integrity sha512-X5/QeEBAsz0v9QfBZ9YVgP/L5TkQHwW1fuyVIirVuR+Wf5zdsWopixk/yC5fL4BSapNaf4KJeIueMF7Eq8Kv/A==
-  dependencies:
-    "@openzeppelin/contracts" "^4.3.2"
-    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+    "@threshold-network/solidity-contracts" ">1.2.0-dev <1.2.0-ropsten"
 
 "@keep-network/sortition-pools@^2.0.0-pre.9":
   version "2.0.0-pre.9"
@@ -703,10 +695,15 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
-"@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4", "@openzeppelin/contracts@^4.4.1":
+"@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4.1":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
   integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
+
+"@openzeppelin/contracts@^4.5":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
+  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
 "@openzeppelin/upgrades@^2.7.2":
   version "2.8.0"
@@ -950,9 +947,9 @@
     "@openzeppelin/contracts" "^4.1.0"
 
 "@threshold-network/solidity-contracts@>1.2.0-dev <1.2.0-ropsten":
-  version "1.2.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.4.tgz#087d88f03a2d1bd07b64724eaf314f30cf9fa444"
-  integrity sha512-ud90FCblZPTz/62BWUusMZWIIC4dAuHGDbubyY7EmwEoC77YoVgG37X0qCuFE2tIkAImQOW6rcobA7JUNbz9bw==
+  version "1.2.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.5.tgz#270d5e6bf9b4b25c8fbf48ccfcce5f3ef3868d69"
+  integrity sha512-PxmSUw+mUmCCaWyHYvkd5lKzx7TcdC1NbZ1KjV7wfCPA02SHxS8HOjpEdrvQpXJOcdlwnvh1kfPSa9ZtWQ/Z9A==
   dependencies:
     "@keep-network/keep-core" ">1.8.0-dev <1.8.0-pre"
     "@openzeppelin/contracts" "^4.5"


### PR DESCRIPTION
~~Depends on #2953; Keeping it as a draft PR until #2953 is not merged.~~

Refs https://github.com/threshold-network/solidity-contracts/issues/89
Refs https://github.com/keep-network/keep-core/issues/2935

See https://github.com/threshold-network/solidity-contracts/pull/95
See https://github.com/keep-network/sortition-pools/pull/162
See https://github.com/keep-network/sortition-pools/pull/163

`WalletRegistry.withdrawRewards` emits `RewardsWithdrawn` event informing about
the amount of tokens withdrawn in the transaction.

`WalletRegistry.availableRewards` informs about the amount of reward tokens
available for withdrawal for the staking provider.