### PR TITLE
Updated beacon `@threshold-network/solidity-contract` dependency

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -345,8 +345,6 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         address indexed operator
     );
 
-    event RewardsWithdrawn(address indexed stakingProvider, uint96 amount);
-
     /// @dev Assigns initial values to parameters to make the beacon work
     ///      safely. These parameters are just proposed defaults and they might
     ///      be updated with `update*` functions after the contract deployment

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -33,7 +33,7 @@
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
     "@openzeppelin/contracts": "^4.4.2",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten"
+    "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/solidity/random-beacon/test/RandomBeacon.Authorization.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Authorization.test.ts
@@ -1447,12 +1447,7 @@ describe("RandomBeacon - Authorization", () => {
             )
 
           const slashingTo = minimumAuthorization.sub(1)
-          // Note that we slash from the entire staked amount given that the
-          // initially authorized amount is less than staked amount and it is
-          // another application slashing. To go below the minimum stake, we need
-          // to start slashing from the entire staked amount, not just the
-          // one authorized for RandomBeacon.
-          const slashedAmount = stakedAmount.sub(slashingTo)
+          const slashedAmount = authorizedAmount.sub(slashingTo)
 
           await staking
             .connect(slasher.wallet)
@@ -2202,12 +2197,7 @@ describe("RandomBeacon - Authorization", () => {
             )
 
           const slashingTo = minimumAuthorization.sub(1)
-          // Note that we slash from the entire staked amount given that the
-          // initially authorized amount is less than staked amount and it is
-          // another application slashing. To go below the minimum stake, we need
-          // to start slashing from the entire staked amount, not just the
-          // one authorized for RandomBeacon.
-          const slashedAmount = stakedAmount.sub(slashingTo)
+          const slashedAmount = authorizedAmount.sub(slashingTo)
 
           await staking
             .connect(slasher.wallet)
@@ -2750,21 +2740,15 @@ describe("RandomBeacon - Authorization", () => {
         await createSnapshot()
 
         slashingTo = minimumAuthorization.sub(1)
-        // Note that we slash from the entire staked amount given that the
-        // initially authorized amount is less than staked amount and it is
-        // another application slashing. To go below the minimum stake, we need
-        // to start slashing from the entire staked amount, not just the
-        // one authorized for RandomBeacon.
-        const slashedAmount = stakedAmount.sub(slashingTo)
+        const slashedAmount = initialIncrease.sub(slashingTo)
 
         await staking
           .connect(slasher.wallet)
           .slash(slashedAmount, [stakingProvider.address])
         await staking.connect(thirdParty).processSlashing(1)
 
-        // Given that we slashed from the entire staked amount, we need to give
-        // the stake owner some more T and let them top-up the stake before they
-        // increase the authorization again.
+        // Give the stake owner some more T and let them top-up the stake before
+        // they increase the authorization again.
         secondIncrease = to1e18(10000)
         await t.connect(deployer).mint(owner.address, secondIncrease)
         await t.connect(owner).approve(staking.address, secondIncrease)
@@ -2819,10 +2803,7 @@ describe("RandomBeacon - Authorization", () => {
           .updateOperatorStatus(operator.address)
 
         slashingTo = initialIncrease.sub(to1e18(100))
-        // Note that we slash from the entire staked amount given that the
-        // initially authorized amount is less than staked amount and it is
-        // another application slashing.
-        const slashedAmount = stakedAmount.sub(slashingTo)
+        const slashedAmount = initialIncrease.sub(slashingTo)
 
         await staking
           .connect(slasher.wallet)
@@ -2866,10 +2847,7 @@ describe("RandomBeacon - Authorization", () => {
           .updateOperatorStatus(operator.address)
 
         slashingTo = initialIncrease.sub(to1e18(100))
-        // Note that we slash from the entire staked amount given that the
-        // initially authorized amount is less than staked amount and it is
-        // another application slashing.
-        const slashedAmount = stakedAmount.sub(slashingTo)
+        const slashedAmount = initialIncrease.sub(slashingTo)
 
         await staking
           .connect(slasher.wallet)
@@ -2919,10 +2897,9 @@ describe("RandomBeacon - Authorization", () => {
         await randomBeacon.approveAuthorizationDecrease(stakingProvider.address)
 
         slashingTo = initialIncrease.sub(to1e18(2500))
-        // Note that we slash from the entire staked amount given that the
-        // initially authorized amount is less than staked amount and it is
-        // another application slashing.
-        const slashedAmount = stakedAmount.sub(slashingTo)
+        const slashedAmount = initialIncrease
+          .sub(decreasedAmount)
+          .sub(slashingTo)
 
         await staking
           .connect(slasher.wallet)

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -676,7 +676,7 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@^4.4":
+"@openzeppelin/contracts-upgradeable@^4.5":
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
@@ -686,7 +686,7 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
   integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
 
-"@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4":
+"@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.5":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
@@ -937,14 +937,14 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@>1.1.0-dev <1.1.0-ropsten":
-  version "1.1.0-dev.8"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.1.0-dev.8.tgz#5c8ed6e9dab26823f25c319a5ade167c6bb8efa3"
-  integrity sha512-7xsjMIO3jtVDOB3X+tY6rEy9qViGHLwxyNEdgYH85BzpOdXvL3tlmwVnAn0k1fQyRhGLrUOtS56Z6fsDCxyRRg==
+"@threshold-network/solidity-contracts@>1.2.0-dev <1.2.0-ropsten":
+  version "1.2.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.5.tgz#270d5e6bf9b4b25c8fbf48ccfcce5f3ef3868d69"
+  integrity sha512-PxmSUw+mUmCCaWyHYvkd5lKzx7TcdC1NbZ1KjV7wfCPA02SHxS8HOjpEdrvQpXJOcdlwnvh1kfPSa9ZtWQ/Z9A==
   dependencies:
     "@keep-network/keep-core" ">1.8.0-dev <1.8.0-pre"
-    "@openzeppelin/contracts" "^4.4"
-    "@openzeppelin/contracts-upgradeable" "^4.4"
+    "@openzeppelin/contracts" "^4.5"
+    "@openzeppelin/contracts-upgradeable" "^4.5"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@tsconfig/node10@^1.0.7":


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/2935

Dependency updated to `>1.2.0-dev <1.2.0-ropsten`, with a fix on slashing
gas costs and changes to `IApplication` interface.

After upgrading the dependency, I had to fix the unit tests for `RandomBeacon`
authorizations to take into account the change of the behavior in the staking contract.
This was done in the commit 9d061aab160e93b7b0a5424b881a3b32ac54a102.

Note that the same fix was done for `WalletRegistry` in https://github.com/keep-network/keep-core/pull/2942.