### PR TITLE
Expand NPM workflow triggers

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "solidity/ecdsa/contracts/**"
       - "solidity/ecdsa/deploy/**"
+      - "solidity/ecdsa/hardhat.config.ts"
       - "solidity/ecdsa/package.json"
       - "solidity/ecdsa/yarn.lock"
       - ".github/workflows/npm-ecdsa.yml"

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "solidity/random-beacon/contracts/**"
+      - "solidity/random-beacon/hardhat.config.ts"
       - "solidity/random-beacon/package.json"
       - "solidity/random-beacon/yarn.lock"
       - ".github/workflows/npm-random-beacon.yml"


### PR DESCRIPTION
We want to publish the new NPM package tagged with `development` every
time changes affecting contracts get merged to `main`. We already
trigger the NPM workflows when changes are applied in couple of files,
but we missed the hardhat configuration in `hardhat.config.ts` which
can also affect the content of the exported package with the
contracts.

Similar changes in other projects:
https://github.com/keep-network/tbtc-v2/pull/230
https://github.com/keep-network/coverage-pools/pull/211