### PR TITLE
Grouped together functions to update parameters in beacon libraries

### DIFF
--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -386,15 +386,16 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         // slither-disable-next-line too-many-digits
         // Minimum authorization:         100k T
         // Authorization decrease delay:  ~10 weeks assuming 15s block time
-        authorization.updateParameters(100000e18, 403200);
+        authorization.setParameters(100000e18, 403200);
         dkg.init(_sortitionPool, _dkgValidator);
         dkg.setResultChallengePeriodLength(11520); // ~48h assuming 15s block time
         dkg.setResultSubmissionTimeout(1280); // 64 members * 20 blocks = 1280 blocks // TODO: Verify value
         dkg.setSubmitterPrecedencePeriodLength(20); // TODO: Verify value
 
         relay.initSeedEntry();
-        relay.setRelayEntrySoftTimeout(1280); // 64 members * 20 blocks = 1280 blocks
-        relay.setRelayEntryHardTimeout(5760); // ~24h assuming 15s block time
+        // Relay entry soft timeout: 64 members * 20 blocks = 1280 blocks
+        // Relay entry hard timeout:~ 24h assuming 15s block time
+        relay.setTimeouts(1280, 5760);
         relay.setRelayEntrySubmissionFailureSlashingAmount(1000e18);
 
         groups.setGroupLifetime(403200); // ~10 weeks assuming 15s block time
@@ -426,7 +427,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay
     ) external onlyGovernance {
-        authorization.updateParameters(
+        authorization.setParameters(
             _minimumAuthorization,
             _authorizationDecreaseDelay
         );
@@ -450,9 +451,7 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         uint256 callbackGasLimit
     ) external onlyGovernance {
         _callbackGasLimit = callbackGasLimit;
-
-        relay.setRelayEntrySoftTimeout(relayEntrySoftTimeout);
-        relay.setRelayEntryHardTimeout(relayEntryHardTimeout);
+        relay.setTimeouts(relayEntrySoftTimeout, relayEntryHardTimeout);
 
         emit RelayEntryParametersUpdated(
             relayEntrySoftTimeout,

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -383,9 +383,9 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         _relayEntryTimeoutNotificationRewardMultiplier = 40;
         _unauthorizedSigningNotificationRewardMultiplier = 50;
         _dkgMaliciousResultNotificationRewardMultiplier = 100;
-        // slither-disable-next-line too-many-digits
         // Minimum authorization:         100k T
         // Authorization decrease delay:  ~10 weeks assuming 15s block time
+        // slither-disable-next-line too-many-digits
         authorization.setParameters(100000e18, 403200);
         dkg.init(_sortitionPool, _dkgValidator);
         // DKG result challenge period length: ~48h assuming 15s block time

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -384,9 +384,9 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         _unauthorizedSigningNotificationRewardMultiplier = 50;
         _dkgMaliciousResultNotificationRewardMultiplier = 100;
         // slither-disable-next-line too-many-digits
-        authorization.setMinimumAuthorization(100000e18); // 100k T
-        authorization.setAuthorizationDecreaseDelay(403200); // ~10 weeks assuming 15s block time
-
+        // Minimum authorization:         100k T
+        // Authorization decrease delay:  ~10 weeks assuming 15s block time
+        authorization.updateParameters(100000e18, 403200);
         dkg.init(_sortitionPool, _dkgValidator);
         dkg.setResultChallengePeriodLength(11520); // ~48h assuming 15s block time
         dkg.setResultSubmissionTimeout(1280); // 64 members * 20 blocks = 1280 blocks // TODO: Verify value
@@ -426,8 +426,8 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay
     ) external onlyGovernance {
-        authorization.setMinimumAuthorization(_minimumAuthorization);
-        authorization.setAuthorizationDecreaseDelay(
+        authorization.updateParameters(
+            _minimumAuthorization,
             _authorizationDecreaseDelay
         );
 

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -388,9 +388,10 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
         // Authorization decrease delay:  ~10 weeks assuming 15s block time
         authorization.setParameters(100000e18, 403200);
         dkg.init(_sortitionPool, _dkgValidator);
-        dkg.setResultChallengePeriodLength(11520); // ~48h assuming 15s block time
-        dkg.setResultSubmissionTimeout(1280); // 64 members * 20 blocks = 1280 blocks // TODO: Verify value
-        dkg.setSubmitterPrecedencePeriodLength(20); // TODO: Verify value
+        // DKG result challenge period length: ~48h assuming 15s block time
+        // DKG result submission timeout: 64 members * 20 blocks = 1280 blocks
+        // DKG result submitter precedence period length: 20 blocks
+        dkg.setParameters(11520, 1280, 20);
 
         relay.initSeedEntry();
         // Relay entry soft timeout: 64 members * 20 blocks = 1280 blocks
@@ -480,9 +481,9 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ) external onlyGovernance {
         _groupCreationFrequency = groupCreationFrequency;
         groups.setGroupLifetime(groupLifetime);
-        dkg.setResultChallengePeriodLength(dkgResultChallengePeriodLength);
-        dkg.setResultSubmissionTimeout(dkgResultSubmissionTimeout);
-        dkg.setSubmitterPrecedencePeriodLength(
+        dkg.setParameters(
+            dkgResultChallengePeriodLength,
+            dkgResultSubmissionTimeout,
             dkgSubmitterPrecedencePeriodLength
         );
 

--- a/solidity/random-beacon/contracts/libraries/BeaconAuthorization.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconAuthorization.sol
@@ -92,24 +92,21 @@ library BeaconAuthorization {
         address indexed operator
     );
 
-    /// @notice Sets the minimum authorization for the beacon. Without
-    ///         at least the minimum authorization, staking provider is not
-    ///         eligible to join and operate in the network.
-    function setMinimumAuthorization(
+    /// @notice Updates authorization-related parameters.
+    /// @param _minimumAuthorization New value of the minimum authorization for
+    ///        the beacon. Without at least the minimum authorization, staking
+    ///        provider is not eligible to join and operate in the network.
+    /// @param _authorizationDecreaseDelay New value of the authorization
+    ///        decrease delay. It is the time in seconds that needs to pass
+    ///        between the time authorization decrease is requested and the time
+    ///        the authorization decrease can be approved, no matter the
+    ///        authorization decrease amount.
+    function updateParameters(
         Data storage self,
-        uint96 _minimumAuthorization
-    ) external {
-        self.parameters.minimumAuthorization = _minimumAuthorization;
-    }
-
-    /// @notice Sets the authorization decrease delay. It is the time in seconds
-    ///         that needs to pass between the time authorization decrease is
-    ///         requested and the time the authorization decrease can be
-    ///         approved, no matter the authorization decrease amount.
-    function setAuthorizationDecreaseDelay(
-        Data storage self,
+        uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay
     ) external {
+        self.parameters.minimumAuthorization = _minimumAuthorization;
         self
             .parameters
             .authorizationDecreaseDelay = _authorizationDecreaseDelay;

--- a/solidity/random-beacon/contracts/libraries/BeaconAuthorization.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconAuthorization.sol
@@ -101,7 +101,7 @@ library BeaconAuthorization {
     ///        between the time authorization decrease is requested and the time
     ///        the authorization decrease can be approved, no matter the
     ///        authorization decrease amount.
-    function updateParameters(
+    function setParameters(
         Data storage self,
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay

--- a/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
@@ -425,54 +425,44 @@ library BeaconDkg {
         return (maliciousResultHash, maliciousSubmitter);
     }
 
-    /// @notice Set resultChallengePeriodLength parameter.
-    function setResultChallengePeriodLength(
+    /// @notice Updates DKG-related parmaeters
+    /// @param _resultChallengePeriodLength New value of the result challenge
+    ///        period length. It is the number of blocks for which a DKG result
+    ///        can be challenged.
+    /// @param _resultSubmissionTimeout New value of the result submission
+    ///        timeout in seconds. It is a timeout for a group to provide a DKG
+    ///        result.
+    /// @param _submitterPrecedencePeriodLength New value of the submitter
+    ///        precedence period length in blocks. It is the time during which
+    ///        only the original DKG result submitter can approve it.
+    function setParameters(
         Data storage self,
-        uint256 newResultChallengePeriodLength
+        uint256 _resultChallengePeriodLength,
+        uint256 _resultSubmissionTimeout,
+        uint256 _submitterPrecedencePeriodLength
     ) internal {
         require(currentState(self) == State.IDLE, "Current state is not IDLE");
 
         require(
-            newResultChallengePeriodLength > 0,
-            "New value should be greater than zero"
+            _resultChallengePeriodLength > 0,
+            "Result challenge period length should be greater than zero"
         );
-
-        self
-            .parameters
-            .resultChallengePeriodLength = newResultChallengePeriodLength;
-    }
-
-    /// @notice Set resultSubmissionTimeout parameter.
-    function setResultSubmissionTimeout(
-        Data storage self,
-        uint256 newResultSubmissionTimeout
-    ) internal {
-        require(currentState(self) == State.IDLE, "Current state is not IDLE");
-
         require(
-            newResultSubmissionTimeout > 0,
-            "New value should be greater than zero"
+            _resultSubmissionTimeout > 0,
+            "Result submission timeout should be greater than zero"
         );
-
-        self.parameters.resultSubmissionTimeout = newResultSubmissionTimeout;
-    }
-
-    /// @notice Set submitterPrecedencePeriodLength parameter.
-    function setSubmitterPrecedencePeriodLength(
-        Data storage self,
-        uint256 newSubmitterPrecedencePeriodLength
-    ) internal {
-        require(currentState(self) == State.IDLE, "Current state is not IDLE");
-
         require(
-            newSubmitterPrecedencePeriodLength <
-                self.parameters.resultSubmissionTimeout,
+            _submitterPrecedencePeriodLength < _resultSubmissionTimeout,
             "Submitter precedence period length should be less than the result submission timeout"
         );
 
         self
             .parameters
-            .submitterPrecedencePeriodLength = newSubmitterPrecedencePeriodLength;
+            .resultChallengePeriodLength = _resultChallengePeriodLength;
+        self.parameters.resultSubmissionTimeout = _resultSubmissionTimeout;
+        self
+            .parameters
+            .submitterPrecedencePeriodLength = _submitterPrecedencePeriodLength;
     }
 
     /// @notice Completes DKG by cleaning up state.

--- a/solidity/random-beacon/contracts/libraries/Relay.sol
+++ b/solidity/random-beacon/contracts/libraries/Relay.sol
@@ -195,26 +195,22 @@ library Relay {
         return 0;
     }
 
-    /// @notice Set relayEntrySoftTimeout parameter.
-    /// @param newRelayEntrySoftTimeout New value of the parameter.
-    function setRelayEntrySoftTimeout(
+    /// @notice Updates relay-related parameters
+    /// @param _relayEntrySoftTimeout New relay entry soft timeout value.
+    ///        It is the time in blocks during which a result is expected to be
+    ///        submitted so that the group is not slashed.
+    /// @param _relayEntryHardTimeout New relay entry hard timeout value.
+    ///        It is the time in blocks for a group to submit the relay entry
+    ///        before slashing for the full slashing amount happens.
+    function setTimeouts(
         Data storage self,
-        uint256 newRelayEntrySoftTimeout
+        uint256 _relayEntrySoftTimeout,
+        uint256 _relayEntryHardTimeout
     ) internal {
         require(!isRequestInProgress(self), "Relay request in progress");
 
-        self.relayEntrySoftTimeout = uint32(newRelayEntrySoftTimeout);
-    }
-
-    /// @notice Set relayEntryHardTimeout parameter.
-    /// @param newRelayEntryHardTimeout New value of the parameter.
-    function setRelayEntryHardTimeout(
-        Data storage self,
-        uint256 newRelayEntryHardTimeout
-    ) internal {
-        require(!isRequestInProgress(self), "Relay request in progress");
-
-        self.relayEntryHardTimeout = uint32(newRelayEntryHardTimeout);
+        self.relayEntrySoftTimeout = uint32(_relayEntrySoftTimeout);
+        self.relayEntryHardTimeout = uint32(_relayEntryHardTimeout);
     }
 
     /// @notice Set relayEntrySubmissionFailureSlashingAmount parameter.

--- a/solidity/random-beacon/contracts/test/RelayStub.sol
+++ b/solidity/random-beacon/contracts/test/RelayStub.sol
@@ -13,8 +13,7 @@ contract RelayStub {
         uint256 relayEntrySoftTimeout,
         uint256 relayEntryHardTimeout
     ) public {
-        relay.setRelayEntrySoftTimeout(relayEntrySoftTimeout);
-        relay.setRelayEntryHardTimeout(relayEntryHardTimeout);
+        relay.setTimeouts(relayEntrySoftTimeout, relayEntryHardTimeout);
     }
 
     function setCurrentRequestStartBlock() external {


### PR DESCRIPTION
This PR does not change the functionality. It is squeezing the update code of libraries to save on bytecode in `RandomBeacon`. The bytecode freed will be needed for another authorization parameter (the next PR).

I suggest reviewing this PR commit-by-commit.