### PR TITLE
Updated initial WalletRegistry parameters

### DIFF
--- a/solidity/ecdsa/README.adoc
+++ b/solidity/ecdsa/README.adoc
@@ -294,10 +294,16 @@ _90% of groupSize_
 |No
 |`65`
 
+|seedTimeout
+|Time in blocks for Random Beacon to provide group selection seed.
+|Yes
+d|`11_520 blocks` +
+_~48h assuming 15s block time_
+
 |resultChallengePeriodLength
 |Time in blocks during which the submitted DKG result can be challenged.
 |Yes
-d|`11520 blocks` +
+d|`11_520 blocks` +
 _~48h assuming 15s block time_
 
 |resultSubmissionTimeout
@@ -317,8 +323,8 @@ _100 members * 20 blocks = 2000 blocks_
 |maliciousDkgResultSlashingAmount
 |Slashing amount for submitting malicious DKG result.
 |Yes
-d|`50000e18` +
-_50 000 T_
+d|`400e18` +
+_400 T_
 
 |dkgMaliciousResultNotificationRewardMultiplier
 |Percentage of the staking contract malicious behavior notification reward which
@@ -339,17 +345,17 @@ inactive for other reasons.
 |Calculated gas cost for submitting a DKG result. This will be refunded as part
 of the DKG approval process.
 |Yes
-|`275000`
+|`275_000`
 
 |dkgResultApprovalGasOffset
 |Gas that is meant to balance the DKG result approval's overall cost.
 |Yes
-|`65000`
+|`65_000`
 
 |notifyOperatorInactivityGasOffset
 |Gas that is meant to balance the operator inactivity notification cost.
 |Yes
-|`85000`
+|`85_000`
 
 
 4+s|Authorization
@@ -358,15 +364,22 @@ of the DKG approval process.
 |The minimum authorization amount required so that operator can participate in
 the Random Beacon.
 |Yes
-d|`100000 * 1e18` +
-_100 000 T_
+d|`40_000 * 1e18` +
+_40 000 T_
 
 |authorizationDecreaseDelay
 |Delay in seconds that needs to pass between the time authorization decrease is
 requested and the time that request gets approved.
 |Yes
-d|`403200 blocks` +
-_~10 weeks assuming 15s block time_
+d|`3_888_000 seconds` +
+_45 days_
+
+|authorizationDecreaseChangePeriod
+|Time period in seconds before the authorization decrease delay end, during
+which the authorization decrease request can be overwritten.
+|Yes
+d|`3_888_000 seconds` +
+_45 days_
 
 4+s|Wallet Registry
 

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -2232,7 +2232,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   it("should emit DkgMaliciousResultSlashed event", async () => {
                     await expect(challengeTx)
                       .to.emit(walletRegistry, "DkgMaliciousResultSlashed")
-                      .withArgs(dkgResultHash, to1e18(50000), submitter.address)
+                      .withArgs(dkgResultHash, to1e18(400), submitter.address)
                   })
 
                   it("should reward the notifier", async () => {
@@ -2251,7 +2251,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                       )
                     await expect(slashingTx)
                       .to.emit(staking, "TokensSeized")
-                      .withArgs(stakingProvider, to1e18(50000), false)
+                      .withArgs(stakingProvider, to1e18(400), false)
                   })
                 })
               })
@@ -2306,7 +2306,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   it("should emit DkgMaliciousResultSlashed event", async () => {
                     await expect(challengeTx)
                       .to.emit(walletRegistry, "DkgMaliciousResultSlashed")
-                      .withArgs(dkgResultHash, to1e18(50000), submitter.address)
+                      .withArgs(dkgResultHash, to1e18(400), submitter.address)
                   })
 
                   it("should reward the notifier", async () => {
@@ -2325,7 +2325,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                       )
                     await expect(slashingTx)
                       .to.emit(staking, "TokensSeized")
-                      .withArgs(stakingProvider, to1e18(50000), false)
+                      .withArgs(stakingProvider, to1e18(400), false)
                   })
                 })
               })
@@ -2420,7 +2420,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                 it("should emit DkgMaliciousResultSlashed event", async () => {
                   await expect(challengeTx)
                     .to.emit(walletRegistry, "DkgMaliciousResultSlashed")
-                    .withArgs(dkgResultHash, to1e18(50000), submitter.address)
+                    .withArgs(dkgResultHash, to1e18(400), submitter.address)
                 })
 
                 it("should reward the notifier", async () => {
@@ -2439,7 +2439,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                     )
                   await expect(slashingTx)
                     .to.emit(staking, "TokensSeized")
-                    .withArgs(stakingProvider, to1e18(50000), false)
+                    .withArgs(stakingProvider, to1e18(400), false)
                 })
               }
             )
@@ -2675,7 +2675,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               it("should emit DkgMaliciousResultSlashed event", async () => {
                 await expect(challengeTx)
                   .to.emit(walletRegistry, "DkgMaliciousResultSlashed")
-                  .withArgs(dkgResultHash, to1e18(50000), submitter.address)
+                  .withArgs(dkgResultHash, to1e18(400), submitter.address)
               })
 
               it("should slash malicious result submitter", async () => {
@@ -2685,7 +2685,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   )
                 await expect(slashingTx)
                   .to.emit(staking, "TokensSeized")
-                  .withArgs(stakingProvider, to1e18(50000), false)
+                  .withArgs(stakingProvider, to1e18(400), false)
               })
             })
           })
@@ -2740,7 +2740,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
               it("should emit DkgMaliciousResultSlashed event", async () => {
                 await expect(challengeTx)
                   .to.emit(walletRegistry, "DkgMaliciousResultSlashed")
-                  .withArgs(dkgResultHash, to1e18(50000), submitter.address)
+                  .withArgs(dkgResultHash, to1e18(400), submitter.address)
               })
 
               it("should slash malicious result submitter", async () => {
@@ -2750,7 +2750,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   )
                 await expect(slashingTx)
                   .to.emit(staking, "TokensSeized")
-                  .withArgs(stakingProvider, to1e18(50000), false)
+                  .withArgs(stakingProvider, to1e18(400), false)
               })
             })
           })
@@ -2842,7 +2842,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
             it("should emit DkgMaliciousResultSlashed event", async () => {
               await expect(challengeTx)
                 .to.emit(walletRegistry, "DkgMaliciousResultSlashed")
-                .withArgs(dkgResultHash, to1e18(50000), submitter.address)
+                .withArgs(dkgResultHash, to1e18(400), submitter.address)
             })
 
             it("should slash malicious result submitter", async () => {
@@ -2852,7 +2852,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                 )
               await expect(slashingTx)
                 .to.emit(staking, "TokensSeized")
-                .withArgs(stakingProvider, to1e18(50000), false)
+                .withArgs(stakingProvider, to1e18(400), false)
             })
           }
         )

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -48,10 +48,10 @@ describe("WalletRegistryGovernance", async () => {
   let walletRegistryGovernance: WalletRegistryGovernance
   let thirdParty: SignerWithAddress
 
-  const initialMinimumAuthorization = to1e18(400000)
-  const initialAuthorizationDecreaseDelay = 5184000 // 60 days
-  const initialAuthorizationDecreaseChangePeriod = 5184000 // 60 days
-  const initialMaliciousDkgResultSlashingAmount = to1e18(50000)
+  const initialMinimumAuthorization = to1e18(40000)
+  const initialAuthorizationDecreaseDelay = 3888000 // 45 days
+  const initialAuthorizationDecreaseChangePeriod = 3888000 // 45 days
+  const initialMaliciousDkgResultSlashingAmount = to1e18(400)
   const initialMaliciousDkgResultNotificationRewardMultiplier = 100
   const initialDkgResultSubmissionGas = 275000
   const initialDkgResultApprovalGasOffset = 65000

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -36,9 +36,9 @@ export const dkgState = {
 }
 
 export const params = {
-  minimumAuthorization: to1e18(400000),
-  authorizationDecreaseDelay: 5184000,
-  authorizationDecreaseChangePeriod: 5184000,
+  minimumAuthorization: to1e18(40000),
+  authorizationDecreaseDelay: 3888000,
+  authorizationDecreaseChangePeriod: 3888000,
   dkgSeedTimeout: 8,
   dkgResultChallengePeriodLength: 10,
   dkgResultSubmissionTimeout: 30,


### PR DESCRIPTION
Closes: #2933 

All parameters set in the constructor are initial ones, used at the moment
contracts were deployed for the first time. Parameters are governable and values
assigned in the constructor do not need to reflect the current ones.

Minimum authorization is 40k T.

Authorization decrease delay is 45 days.

Authorization decrease change period is 45 days. It means pending authorization
decrease can be overwriten all the time.

Malicious DKG result slashing amount is set initially to 1% of the minimum
authorization (400 T). This values needs to be increased significantly once the
system is fully launched.

Reported of a malicious DKG result receives 100% of the notifier reward from the
staking contract.

Inactive operators are set as ineligible for rewards for 2 weeks.

DKG seed timeout is set to 48h assuming 15s block time. The same value is used
by the Random Beacon as a relay entry hard timeout.

DKG result challenge period length is set to 48h as well, assuming 15s block time.

DKG result submission timeout, gives each member 20 blocks to submit the result.
Assuming 15s block time, it is ~8h to submit the result in the pessimistic case.

The original DKG result submitter has 20 blocks to approve it before anyone else
can do that.

With these parameters, the happy path takes no more than 104 hours.
In practice, it should take about 48 hours (just the challenge time).