### PR TITLE
Pad seed with zeros in tests

### DIFF
--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -3551,7 +3551,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
       it("should be the same group as if called the sortition pool directly", async () => {
         const exectedGroup = await sortitionPool.selectGroup(
           constants.groupSize,
-          dkgSeed.toHexString()
+          ethers.utils.hexZeroPad(dkgSeed.toHexString(), 32)
         )
         const actualGroup = await walletRegistry.selectGroup()
         expect(exectedGroup).to.be.deep.equal(actualGroup)

--- a/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.GroupCreation.test.ts
@@ -2761,7 +2761,7 @@ describe("RandomBeacon - Group Creation", () => {
       it("should be the same group as if called the sortition pool directly", async () => {
         const exectedGroup = await sortitionPool.selectGroup(
           constants.groupSize,
-          genesisSeed.toHexString()
+          ethers.utils.hexZeroPad(genesisSeed.toHexString(), 32)
         )
         const actualGroup = await randomBeacon.selectGroup()
         expect(exectedGroup).to.be.deep.equal(actualGroup)

--- a/solidity/random-beacon/test/utils/groups.ts
+++ b/solidity/random-beacon/test/utils/groups.ts
@@ -40,7 +40,7 @@ export async function selectGroup(
 ): Promise<Operator[]> {
   const identifiers = await sortitionPool.selectGroup(
     constants.groupSize,
-    seed.toHexString()
+    ethers.utils.hexZeroPad(seed.toHexString(), 32)
   )
   const addresses = await sortitionPool.getIDOperators(identifiers)
 


### PR DESCRIPTION
When converting BigNumber seed for selectGroup we need to pad the hex
string with zeros to work with expected `bytes32` in
`sortitionPool.selectGroup`.