### PR TITLE
ECDSA deployment updates

### DIFF
--- a/solidity/ecdsa/.gitignore
+++ b/solidity/ecdsa/.gitignore
@@ -1,6 +1,7 @@
 # Hardhat
 build/
 cache/
+deployments/hardhat/
 export/
 external/npm
 hardhat-dependency-compiler/

--- a/solidity/ecdsa/deploy/02_deploy_reimbursement_pool.ts
+++ b/solidity/ecdsa/deploy/02_deploy_reimbursement_pool.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 

--- a/solidity/ecdsa/deploy/10_deploy_proxy_admin_with_deputy.ts
+++ b/solidity/ecdsa/deploy/10_deploy_proxy_admin_with_deputy.ts
@@ -1,6 +1,5 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
-import type { ProxyAdmin } from "../typechain"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { ethers, getNamedAccounts, upgrades, deployments } = hre
@@ -18,7 +17,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const WalletRegistry = await deployments.get("WalletRegistry")
 
-  const proxyAdmin = (await upgrades.admin.getInstance()) as ProxyAdmin
+  const proxyAdmin = await upgrades.admin.getInstance()
 
   await proxyAdmin
     .connect(await ethers.getSigner(esdm))

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -14,6 +14,8 @@ import { TASK_TEST } from "hardhat/builtin-tasks/task-names"
 
 import type { HardhatUserConfig } from "hardhat/config"
 
+const TASK_CHECK_ACCOUNTS_COUNT = "check-accounts-count"
+
 // Configuration for testing environment.
 export const testConfig = {
   // How many accounts we expect to define for non-staking related signers, e.g.
@@ -164,6 +166,12 @@ const config: HardhatUserConfig = {
 }
 
 task(TASK_TEST, "Runs mocha tests").setAction(async (args, hre, runSuper) => {
+  await hre.run(TASK_CHECK_ACCOUNTS_COUNT)
+
+  return runSuper(args)
+})
+
+task(TASK_CHECK_ACCOUNTS_COUNT, "Checks accounts count").setAction(async () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
   const { constants } = require("./test/fixtures")
 
@@ -174,8 +182,6 @@ task(TASK_TEST, "Runs mocha tests").setAction(async (args, hre, runSuper) => {
         `number of predefined accounts: ${testConfig.operatorsCount}`
     )
   }
-
-  return runSuper(args)
 })
 
 export default config

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -54,7 +54,7 @@
     "hardhat-contract-sizer": "^2.3.0",
     "hardhat-dependency-compiler": "^1.1.2",
     "hardhat-deploy": "^0.9.27",
-    "hardhat-gas-reporter": "^1.0.6",
+    "hardhat-gas-reporter": "^1.0.8",
     "prettier": "^2.5.1",
     "prettier-plugin-sh": "^0.8.1",
     "prettier-plugin-solidity": "^1.0.0-beta.19",

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "0.5.0",
+    "@keep-network/hardhat-helpers": "^0.5.1",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers",
     "@nomiclabs/hardhat-waffle": "^2.0.2",

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -591,10 +591,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.5.0.tgz#9ff1849fc6786191e29e23751729fca34a8a7faa"
-  integrity sha512-okQ6Pa9Wz0cT6rKik3CVEkhTdmmDGJY3C0RjgjO9AePfy6tJpYinHxTkMJxErux+HeN8gUTTHa+j66/fyu+7Gg==
+"@keep-network/hardhat-helpers@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.5.1.tgz#de6363a5da367d01e3a338b3819dcede17737e2b"
+  integrity sha512-oL0LUgA2cYluewtqod6WBp8BI62YK2U+vzmP2FaBE4cTKYdryizupH9eMTAm2/PLNHnhdbhVBh6JEkx8vfTxow==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -5443,10 +5443,10 @@ hardhat-deploy@^0.9.27:
     murmur-128 "^0.2.1"
     qs "^6.9.4"
 
-hardhat-gas-reporter@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.7.tgz#b0e06a4f5a4da2369354991b6fa32ff002170573"
-  integrity sha512-calJH1rbhUFwCnw0odJb3Cw+mDmBIsHdVyutsHhA3RY6JELyFVaVxCnITYGr/crkmHqt4tQCYROy7ty6DTLkuA==
+hardhat-gas-reporter@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.8.tgz#93ce271358cd748d9c4185dbb9d1d5525ec145e0"
+  integrity sha512-1G5thPnnhcwLHsFnl759f2tgElvuwdkzxlI65fC9PwxYMEe9cmjkVAAWTf3/3y8uP6ZSPiUiOW8PgZnykmZe0g==
   dependencies:
     array-uniq "1.0.3"
     eth-gas-reporter "^0.2.24"


### PR DESCRIPTION
This PR includes some minor updates to the deployment scripts.
It also bumps up a version of @keep-network/hardhat-helpers to 0.5.1. Which adds more details to the WalletRegistry deployment artifact.