### PR TITLE
Export WalletRegistryStub in the npm package

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -9,6 +9,7 @@
     "contracts/",
     "!contracts/hardhat-dependency-compiler",
     "!**/test/",
+    "contracts/test/WalletRegistryStub.sol",
     "deploy/",
     "export/",
     "export.json"


### PR DESCRIPTION
We don't export contracts from `contracts/test` directory, as those are
just stubs that are internal to the project. The exception is
WalletRegistryStub that we use in the deployment script on hardhat
network. We need to include this contract in the package, so the other
projects can use deployment scripts of WalletRegistry as a dependency.