### PR TITLE
Workaround hardhat-gas-reporter bug with removing --deploy-fixture

### DIFF
--- a/solidity/ecdsa/README.adoc
+++ b/solidity/ecdsa/README.adoc
@@ -452,14 +452,6 @@ You can run them by doing:
 yarn test
 ```
 
-WARNING: Due to a link:https://github.com/cgewecke/hardhat-gas-reporter/issues/86[bug #86 in `hardhat-gas-reporter` plugin]
-we had to workaround deployment scripts to obtain gas usage report after test
-execution.
-We introduced an alternative deployment path as a workaround.
-To execute tests with the alternative deployment path run `yarn test:gas-reporter-workaround`.
-Please keep in mind that `yarn test` is preferred way for testing. Use alternative
-path only if you want to get the gas report.
-
 === Deploy contracts
 
 To deploy contract execute:

--- a/solidity/ecdsa/deploy/09_transfer_proxy_admin_ownership.ts
+++ b/solidity/ecdsa/deploy/09_transfer_proxy_admin_ownership.ts
@@ -21,7 +21,3 @@ export default func
 
 func.tags = ["TransferProxyAdminOwnership"]
 func.dependencies = ["WalletRegistry"]
-// FIXME: As a workaround for a bug in hardhat-gas-reporter #86 we need to provide
-// alternative deployment script to obtain a gas report.
-// #86: https://github.com/cgewecke/hardhat-gas-reporter/issues/86
-func.skip = async () => process.env.GAS_REPORTER_BUG_WORKAROUND === "true"

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -27,8 +27,7 @@
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
     "clean": "hardhat clean",
     "build": "hardhat compile",
-    "test": "hardhat test --deploy-fixture",
-    "test:gas-reporter-workaround": "GAS_REPORTER_BUG_WORKAROUND=true yarn test",
+    "test": "hardhat test",
     "deploy": "hardhat deploy --export export.json",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts"
   },

--- a/solidity/ecdsa/test/WalletRegistry.Deployment.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Deployment.test.ts
@@ -47,15 +47,7 @@ describe("WalletRegistry - Deployment", async () => {
         walletRegistry.address
       )
 
-    // FIXME: As a workaround for a bug in hardhat-gas-reporter #86 we need to provide
-    // alternative deployment script to obtain a gas report.
-    // Here we align tests to work with alternative deployment path.
-    // #86: https://github.com/cgewecke/hardhat-gas-reporter/issues/86
-    if (process.env.GAS_REPORTER_BUG_WORKAROUND === "true") {
-      proxyAdmin = (await ethers.getContract("DefaultProxyAdmin")) as ProxyAdmin
-    } else {
-      proxyAdmin = (await upgrades.admin.getInstance()) as ProxyAdmin
-    }
+    proxyAdmin = (await upgrades.admin.getInstance()) as ProxyAdmin
 
     expect(deployer.address, "deployer is the same as governance").not.equal(
       governance.address

--- a/solidity/ecdsa/test/WalletRegistry.Upgrade.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Upgrade.test.ts
@@ -24,13 +24,7 @@ describe("WalletRegistry - Upgrade", async () => {
   let proxyAdminOwner: SignerWithAddress
   let EcdsaInactivity: Contract
 
-  before(async function () {
-    // FIXME: As a workaround for a bug in hardhat-gas-reporter #86 we need to provide
-    // alternative deployment script to obtain a gas report.
-    // Here we ignore tests that are related to the original deployment script.
-    // #86: https://github.com/cgewecke/hardhat-gas-reporter/issues/86
-    if (process.env.GAS_REPORTER_BUG_WORKAROUND === "true") this.skip()
-
+  before(async () => {
     proxyAdminOwner = await ethers.getNamedSigner("esdm")
     EcdsaInactivity = await ethers.getContract("EcdsaInactivity")
   })

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -60,6 +60,10 @@ export const walletRegistryFixture = deployments.createFixture(
     operators: Operator[]
     reimbursementPool: ReimbursementPool
   }> => {
+    // Due to a [bug] in hardhat-gas-reporter plugin we avoid using `--deploy-fixture`
+    // flag of `hardhat-deploy` plugin. This requires us to load a global fixture
+    // (`deployments.fixture()`) instead of loading a specific tag (`deployments.fixture(<tag>)`.
+    // bug: https://github.com/cgewecke/hardhat-gas-reporter/issues/86
     await deployments.fixture()
 
     const walletRegistry: WalletRegistryStub & WalletRegistry =


### PR DESCRIPTION
In this PR we replace a previous workaround (https://github.com/keep-network/keep-core/pull/2970) for a bug in the `hardhat-gas-reporter` plugin (https://github.com/cgewecke/hardhat-gas-reporter/issues/86).

It turned out that there is a much simpler workaround, which is based on just removing `--deploy-fixture` flag. With the flag removed it is required that we load a global snapshot of the deployment (`deployments.fixture()`) instead of loading a specific tag (`deployments.fixture(<tag>)`. Which we do anyway after one of a recent code updates.

