### PR TITLE
ECDSA: Updated `@openzeppelin/contracts-upgradeable` to 4.6.0

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -32,9 +32,6 @@ import "@keep-network/random-beacon/contracts/Governable.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IApplication.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IStaking.sol";
 
-// TODO: We used RC version of @openzeppelin/contracts-upgradeable to use `reinitializer`
-// in upgrades. We should revisit this part before mainnet deployment and use
-// a final release package if it's ready.
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract WalletRegistry is

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -68,7 +68,6 @@
   "dependencies": {
     "@keep-network/random-beacon": "development",
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
-    "@openzeppelin/contracts": "~4.5.0",
     "@openzeppelin/contracts-upgradeable": "~4.6.0",
     "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
   },

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -69,7 +69,7 @@
     "@keep-network/random-beacon": "development",
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
     "@openzeppelin/contracts": "~4.5.0",
-    "@openzeppelin/contracts-upgradeable": "^4.6.0-rc.0",
+    "@openzeppelin/contracts-upgradeable": "~4.6.0",
     "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
   },
   "engines": {

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -695,7 +695,7 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0.tgz#1bf55f230f008554d4c6fe25eb165b85112108b0"
   integrity sha512-5OnVuO4HlkjSCJO165a4i2Pu1zQGzMs//o54LPrwUgxvEO2P3ax1QuaSI0cEHHTveA77guS0PnNugpR2JMsPfA==
 
-"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.4.2", "@openzeppelin/contracts@^4.5", "@openzeppelin/contracts@~4.5.0":
+"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.4.2", "@openzeppelin/contracts@^4.5":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
@@ -2027,10 +2027,6 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
   integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
-  dependencies:
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.26.2"

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -690,10 +690,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
 
-"@openzeppelin/contracts-upgradeable@^4.6.0-rc.0":
-  version "4.6.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0-rc.0.tgz#80b6dcff3167ab2f86f9d08e6bd60c0332a5fee5"
-  integrity sha512-IQo98b6AlCGqpdgW1pxsUucqMu8x6WFJmusKMS4qoaVm3cifA/aQM/klHIAdr3pmVeZRjIM1gywQU85jzWEnAA==
+"@openzeppelin/contracts-upgradeable@~4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0.tgz#1bf55f230f008554d4c6fe25eb165b85112108b0"
+  integrity sha512-5OnVuO4HlkjSCJO165a4i2Pu1zQGzMs//o54LPrwUgxvEO2P3ax1QuaSI0cEHHTveA77guS0PnNugpR2JMsPfA==
 
 "@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.4.2", "@openzeppelin/contracts@^4.5", "@openzeppelin/contracts@~4.5.0":
   version "4.5.0"


### PR DESCRIPTION
Non-RC version is now available. Updating from `4.6.0-rc.0` to `4.6.0`. Also, removed `@openzeppelin/contracts` dependency given we now use `@openzeppelin/contracts-upgradeable` in imports across ECDSA Solidity module code.

Refs https://github.com/keep-network/tbtc-v2/issues/152