### PR TITLE
Use range in the t-network solidity-contracts dependency

### DIFF
--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -33,7 +33,7 @@
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
     "@openzeppelin/contracts": "^4.6.0",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": "development"
+    "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -969,7 +969,7 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@^1.2.0-dev.10":
+"@threshold-network/solidity-contracts@>1.2.0-dev <1.2.0-ropsten":
   version "1.2.0-dev.10"
   resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.10.tgz#a17391fec84b80dfd70e6b35bf2f71adb23f9d4f"
   integrity sha512-gVZYFWlet12iT3tOLjgmYkqrwcrWaKvISy6WLb0jVd3se5y8Il20mmivYjar6x+5AvapuXLVeKqQmsYtKhTvRg==


### PR DESCRIPTION
We tried using development tag to always point to the latest
development package, but that was causing An unexpected error
occurred: "expected manifest". error when running yarn upgrade
`@threshold-network/solidity-contracts`. So we're going back to using the
version range. We may use development tag in the future, once we
figure out the reason behind the error that we were getting.

It is possible that the error was related to this issue:
https://github.com/yarnpkg/yarn/issues/4731

See https://github.com/keep-network/keep-core/pull/2985 for ECDSA part.