### PR TITLE
Update openzeppelin contracts to ^4.6.0

### DIFF
--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -144,7 +144,6 @@ const config: HardhatUserConfig = {
           paths: [
             "@threshold-network/solidity-contracts/contracts/token/T.sol",
             "@threshold-network/solidity-contracts/contracts/staking/TokenStaking.sol",
-            "@threshold-network/solidity-contracts/contracts/governance/ProxyAdminWithDeputy.sol",
             "@keep-network/random-beacon/contracts/api/IRandomBeacon.sol",
             "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol",
           ],

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -68,8 +68,8 @@
   "dependencies": {
     "@keep-network/random-beacon": "development",
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
-    "@openzeppelin/contracts": "~4.5.0",
-    "@openzeppelin/contracts-upgradeable": "~4.6.0",
+    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts-upgradeable": "^4.6.0",
     "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
   },
   "engines": {

--- a/solidity/ecdsa/test/WalletRegistry.Deployment.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Deployment.test.ts
@@ -3,12 +3,9 @@ import { deployments, ethers, upgrades } from "hardhat"
 import chai, { expect } from "chai"
 import chaiAsPromised from "chai-as-promised"
 
+import type { Contract } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import type {
-  ProxyAdmin,
-  WalletRegistry,
-  WalletRegistryGovernance,
-} from "../typechain"
+import type { WalletRegistry, WalletRegistryGovernance } from "../typechain"
 import type { TransparentUpgradeableProxy } from "../typechain/TransparentUpgradeableProxy"
 
 chai.use(chaiAsPromised)
@@ -23,7 +20,7 @@ describe("WalletRegistry - Deployment", async () => {
   let walletRegistry: WalletRegistry
   let walletRegistryGovernance: WalletRegistryGovernance
   let walletRegistryProxy: TransparentUpgradeableProxy
-  let proxyAdmin: ProxyAdmin
+  let proxyAdmin: Contract
   let walletRegistryImplementationAddress: string
 
   before(async () => {
@@ -47,7 +44,7 @@ describe("WalletRegistry - Deployment", async () => {
         walletRegistry.address
       )
 
-    proxyAdmin = (await upgrades.admin.getInstance()) as ProxyAdmin
+    proxyAdmin = await upgrades.admin.getInstance()
 
     expect(deployer.address, "deployer is the same as governance").not.equal(
       governance.address

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -685,15 +685,15 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0.tgz#1bf55f230f008554d4c6fe25eb165b85112108b0"
+  integrity sha512-5OnVuO4HlkjSCJO165a4i2Pu1zQGzMs//o54LPrwUgxvEO2P3ax1QuaSI0cEHHTveA77guS0PnNugpR2JMsPfA==
+
 "@openzeppelin/contracts-upgradeable@~4.5.2":
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
-
-"@openzeppelin/contracts-upgradeable@~4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0.tgz#1bf55f230f008554d4c6fe25eb165b85112108b0"
-  integrity sha512-5OnVuO4HlkjSCJO165a4i2Pu1zQGzMs//o54LPrwUgxvEO2P3ax1QuaSI0cEHHTveA77guS0PnNugpR2JMsPfA==
 
 "@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.6.0":
   version "4.6.0"


### PR DESCRIPTION
Seting both `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradeable`
dependency versions to `^4.6.0`. This version of `@openzeppelin/contracts` is
aligned with what we use in `solidity/random-beacon`.

To make this change possible, I removed `ProxyAdminWithDeputy.sol` imported from
`@threshold-network/solidity-contracts` from the list of contracts compiled by
the hardhat dependency compiler. `ProxyAdminWithDeputy` is used only in
deployment scripts and does not need to be compiled. Without this change, we
would have to pin `@openzeppelin/contracts` to version `4.5.0` given some
changes in `@openzeppelin/contracts` version `4.6.0` stops
`@threshold-network/solidity-contracts` from compiling. See
https://github.com/threshold-network/solidity-contracts/pull/97
Additionally, I had to replace `ProxyAdmin` type import in deployment scripts
with a generic `Contract` type import. `ProxyAdmin` was available in `typescript`
bindings only because `ProxyAdminWithDeputy` was compiled.