### PR TITLE
Expose initializeWalletOwner function

### DIFF
--- a/solidity/ecdsa/tasks/initialize-wallet-owner.ts
+++ b/solidity/ecdsa/tasks/initialize-wallet-owner.ts
@@ -1,28 +1,37 @@
 /* eslint-disable no-console */
 import { task } from "hardhat/config"
 
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
 task("initialize-wallet-owner", "Initializes Wallet Owner for Wallet Registry")
   .addParam("walletOwnerAddress", "The Wallet Owner's address")
   .setAction(async (args, hre) => {
-    const { getNamedAccounts, ethers, deployments } = hre
-    const { governance } = await getNamedAccounts()
-
     const { walletOwnerAddress } = args
 
-    if (!ethers.utils.isAddress(walletOwnerAddress)) {
-      throw Error(`invalid address: ${walletOwnerAddress}`)
-    }
-
-    const tx = await deployments.execute(
-      "WalletRegistryGovernance",
-      { from: governance },
-      "initializeWalletOwner",
-      walletOwnerAddress
-    )
-
-    console.log(
-      `Initialized Wallet Owner address: ${walletOwnerAddress} in transaction: ${tx.transactionHash}`
-    )
+    await initializeWalletOwner(hre, walletOwnerAddress)
   })
 
-export default {}
+async function initializeWalletOwner(
+  hre: HardhatRuntimeEnvironment,
+  walletOwnerAddress: string
+): Promise<void> {
+  const { getNamedAccounts, ethers, deployments } = hre
+  const { governance } = await getNamedAccounts()
+
+  if (!ethers.utils.isAddress(walletOwnerAddress)) {
+    throw Error(`invalid address: ${walletOwnerAddress}`)
+  }
+
+  const tx = await deployments.execute(
+    "WalletRegistryGovernance",
+    { from: governance },
+    "initializeWalletOwner",
+    walletOwnerAddress
+  )
+
+  console.log(
+    `Initialized Wallet Owner address: ${walletOwnerAddress} in transaction: ${tx.transactionHash}`
+  )
+}
+
+export default initializeWalletOwner


### PR DESCRIPTION
We wan to expose `initializeWalletOwner` function for tbtc-v2 to initialize the wallet owner after deploying the Bridge contract.

Refs https://github.com/keep-network/tbtc-v2/issues/250