### PR TITLE
[Backport] Config git to use `https://` instead of `git://`

### DIFF
--- a/solidity-v1/dashboard/Dockerfile
+++ b/solidity-v1/dashboard/Dockerfile
@@ -14,6 +14,9 @@ COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 COPY .env* /app/
 
+# Use `https://` instead of unauthenticated `git://` protocol
+RUN git config --global url."https://".insteadOf git://
+
 # Install from lockfile.
 RUN npm ci --ignore-scripts
 


### PR DESCRIPTION
Backport of https://github.com/keep-network/keep-core/pull/3001

The `git://` protocol is no longer supported by Github. This means that in
certain situations installation of the package or update of its dependencies
using NPM may result in errors like `fatal: unable to connect to github.com`.
That is what happenning after executing the Dockerfile and installing some
dependencies of the token dashboard.

As a workaround, we're adding step to the Dockerfile, which configures Git to
use `https://` protocol instead of `git://` when downloading files.