### PR TITLE
Fix challengeDkgResult gas usage assertion

### DIFF
--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -2279,7 +2279,7 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   })
 
                   it("should use close to 1 820 000 gas", async () => {
-                    await assertGasUsed(challengeTx, 1_820_000, 30_000)
+                    await assertGasUsed(challengeTx, 1_820_000, 40_000)
                   })
                 })
               })


### PR DESCRIPTION
Several times the test checking gas usage for `challengeDkgResult` have
failed due to less gas used than expected (around 1785k gas was used).
Adjusting the gas usage margin to allow for such values.

Sample failing workflow: https://github.com/keep-network/keep-core/runs/6853425591?check_suite_focus=true.