### PR TITLE
Fix for unicast channel related error

### DIFF
--- a/pkg/net/libp2p/unicast_channel_test.go
+++ b/pkg/net/libp2p/unicast_channel_test.go
@@ -63,6 +63,9 @@ func TestSendReceiveUnicastChannel(t *testing.T) {
 		}
 
 		// Peer 2 get the channel from cache.
+		// Wait for a moment until the messages sent by peer 1 are received by
+		// peer 2, so that the channel is opened and unmarshaller set.
+		time.Sleep(2 * time.Second)
 		peer2Channel, err := provider2.UnicastChannelWith(identity1.id)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3004.
This PR adds a fix for failing unit tests related to unicast channels.

Inside `TestSendReceiveUnicastChannel` we [send messages between peer 1 and peer 2](https://github.com/keep-network/keep-core/blob/333156b595e005322f06de2c8bda45cf822ff87a/pkg/net/libp2p/unicast_channel_test.go#L58).

Then [we retrieve the channel that should be created by the sent messages](https://github.com/keep-network/keep-core/blob/333156b595e005322f06de2c8bda45cf822ff87a/pkg/net/libp2p/unicast_channel_test.go#L66).

If the sent messages are received by peer 2 before the above call, it created the channel properly and sets the unmarshaller to handle the messages. In that case [the call](https://github.com/keep-network/keep-core/blob/333156b595e005322f06de2c8bda45cf822ff87a/pkg/net/libp2p/unicast_channel_test.go#L66) retrieves the channel and the test passes.

If the sent messages are received by peer 2 after the above call, the unmarshaller is not set and [the call](https://github.com/keep-network/keep-core/blob/333156b595e005322f06de2c8bda45cf822ff87a/pkg/net/libp2p/unicast_channel_test.go#L66) creates the channel instead of retrieving it and the channel has no unmarshaller set and the test fails.

The simplest solution is to wait for a moment before retrieving the channel inside `TestSendReceiveUnicastChannel`.