### PR TITLE
Update @threshold-network/solidity-contracts dependency in Beacon

### DIFF
--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -76,12 +76,17 @@ const config: HardhatUserConfig = {
           testConfig.nonStakingAccountsCount +
           testConfig.stakingRolesCount * testConfig.operatorsCount,
       },
-      tags: ["local"],
       // we use higher gas price for tests to obtain more realistic results
       // for gas refund tests than when the default hardhat ~1 gwei gas price is
       // used
       gasPrice: 200000000000, // 200 gwei
       allowUnlimitedContractSize: true,
+      tags: ["allowStubs"],
+    },
+    development: {
+      url: "http://localhost:8545",
+      chainId: 1101,
+      tags: ["allowStubs"],
     },
     ropsten: {
       url: process.env.CHAIN_API_URL || "",

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -34,7 +34,7 @@
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
     "@openzeppelin/contracts": "^4.6.0",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": ">1.2.0-dev <1.2.0-ropsten"
+    "@threshold-network/solidity-contracts": "development"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -992,10 +992,10 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@>1.2.0-dev <1.2.0-ropsten":
-  version "1.2.0-dev.10"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.10.tgz#a17391fec84b80dfd70e6b35bf2f71adb23f9d4f"
-  integrity sha512-gVZYFWlet12iT3tOLjgmYkqrwcrWaKvISy6WLb0jVd3se5y8Il20mmivYjar6x+5AvapuXLVeKqQmsYtKhTvRg==
+"@threshold-network/solidity-contracts@development":
+  version "1.2.0-dev.14"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.14.tgz#2e7104e41fdf261696aec8dc3a94de7c77be6a53"
+  integrity sha512-9OBoYMelzzVN1MKswRCtdTmwRuz3JvDHFRJo8jJuSiHeINHWbvAYQyz0KkF4qEhvLmbMxsRfO82jQcmN+LjqKg==
   dependencies:
     "@keep-network/keep-core" ">1.8.1-dev <1.8.1-pre"
     "@openzeppelin/contracts" "~4.5.0"


### PR DESCRIPTION
Updated @threshold-network/solidity-contracts dependency to the latest
published development package.