### PR TITLE
Use export-artifacts --including-no-public-functions

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -28,7 +28,7 @@
     "build": "hardhat compile",
     "test": "TEST_USE_STUBS=true hardhat test",
     "deploy": "hardhat deploy --export export.json",
-    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts"
+    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -28,7 +28,7 @@
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix && prettier --write '**/*.sol'",
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
-    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts"
+    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts"
   },
   "dependencies": {
     "@keep-network/sortition-pools": "^2.0.0-pre.9",


### PR DESCRIPTION
Some of the artifacts were not exported to `export/artifacts/contracts`
which caused a problems with deploying other projects, e.g. tbtc-v2
https://github.com/keep-network/tbtc-v2/pull/365#issuecomment-1172453165

With this change we expect artifacts for all contracts to be exported.