### PR TITLE
Prepare deployment artifacts for contracts packages publication

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -36,8 +36,10 @@ jobs:
             @keep-network/sortition-pools \
             @threshold-network/solidity-contracts
 
-      - name: Compile contracts
-        run: yarn build
+      # Deploy contracts to a local network to generate deployment artifacts that
+      # are required by dashboard and client compilation.
+      - name: Deploy contracts
+        run: yarn deploy --network hardhat --write true
 
       - name: Bump up package version
         id: npm-version-bump
@@ -52,7 +54,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --tag=development
+        run: npm publish --access=public --network=hardhat --tag=development
 
       - name: Publish package
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Resolve latest contracts
         run: yarn upgrade @keep-network/sortition-pools
 
-      - name: Compile contracts
-        run: yarn build
+      # Deploy contracts to a local network to generate deployment artifacts that
+      # are required by dashboard and client compilation.
+      - name: Deploy contracts
+        run: yarn deploy --network hardhat --write true
 
       - name: Bump up package version
         id: npm-version-bump
@@ -48,7 +50,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --tag=development
+        run: npm publish --access=public --network=hardhat --tag=development
 
       - name: Publish package
         if: github.ref != 'refs/heads/main'

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -28,11 +28,12 @@
     "build": "hardhat compile",
     "test": "TEST_USE_STUBS=true hardhat test",
     "deploy": "hardhat deploy --export export.json",
-    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts"
+    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts",
+    "prepublishOnly": "hardhat prepare-artifacts --network $npm_config_network"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.5",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.8",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-waffle": "^2.0.2",

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -591,10 +591,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.5":
-  version "0.6.0-pre.5"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.5.tgz#81cc010d1afac08ec29a09e5846c9f8da28173b6"
-  integrity sha512-hRgQmvhmcayL9kto8xcK3lsfyRMvq/XG+EfQjPM731DOwPJ79kFk6PK3UMw7I+uKIgnZEkh29B+JizDR80Vr2g==
+"@keep-network/hardhat-helpers@^0.6.0-pre.8":
+  version "0.6.0-pre.8"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.8.tgz#6e0722889a0132dabed5182fb32f6424ff4a77d0"
+  integrity sha512-51oLHceBubutBYxfVk2pLjgyhvpcDC1ahKM3V9lOiTa9lbWyY18Dza7rnM9V04kq+8DbweQRM0M9/f+K26nl9g==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -28,7 +28,8 @@
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix && prettier --write '**/*.sol'",
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
-    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts"
+    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts",
+    "prepublishOnly": "hardhat prepare-artifacts --network $npm_config_network"
   },
   "dependencies": {
     "@keep-network/sortition-pools": "^2.0.0-pre.9",
@@ -38,7 +39,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.7",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.8",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.0",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -933,10 +933,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.7":
-  version "0.6.0-pre.7"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.7.tgz#0b8fbc7c8ee7248f0babbfe4f2f957f5ef3f8507"
-  integrity sha512-6inPdST2lAwxYLGl619udVLJDoW41maQzxc2MD1YmvUDlkrHsI4GmSmqkj+mJPtLVVEbxqCjwQNjyDkSmIICvQ==
+"@keep-network/hardhat-helpers@^0.6.0-pre.8":
+  version "0.6.0-pre.8"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.8.tgz#6e0722889a0132dabed5182fb32f6424ff4a77d0"
+  integrity sha512-51oLHceBubutBYxfVk2pLjgyhvpcDC1ahKM3V9lOiTa9lbWyY18Dza7rnM9V04kq+8DbweQRM0M9/f+K26nl9g==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.0":
   version "0.1.0-pre.0"
@@ -947,9 +947,9 @@
     untildify "^4.0.0"
 
 "@keep-network/keep-core@>1.8.1-dev <1.8.1-pre":
-  version "1.8.1-dev.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.1-dev.0.tgz#d95864b25800214de43d8840376a68336cb12055"
-  integrity sha512-gFXkgN4PYOYCZ14AskL7fZHEFW5mu3BDd+TJKBuKZc1q9CgRMOK+dxpJnSctxmSH1tV+Ln9v9yqlSkfPCoiBHw==
+  version "1.8.1-goerli.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.1-goerli.0.tgz#238485aab51902021d42357bf59695225002f0ab"
+  integrity sha512-h3La/RqbyEZjBBPg8V+pcRFo3UpWZUF4CxWfXHZnUR4PnkZKnIDrTNFQPhpV2uYFZwrbJxTR9mzOq/DOAiXPwA==
   dependencies:
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"


### PR DESCRIPTION
The `hardhat-deploy` plugin outputs artifacts to `deployments/<network>` directory. For dApps and client builds we require the `artifcats` to be placed in the `artifacts/` directory.
Here we use a `prepare-artifacts` task that will copy the artifacts to the required dir.

The root cause of the problems we are solving here is a recent update to the `hardhat-deploy` plugin 
(https://github.com/wighawag/hardhat-deploy/issues/345).

The same change was introduced for `threshold-network/solidity-contracts` in https://github.com/threshold-network/solidity-contracts/pull/113/commits/0c843c620fa0d7e54474736933ad56d5aa3ba3ea
