### PR TITLE
Added padding for operator private keys shorter than 32 bytes

### DIFF
--- a/pkg/net/libp2p/key.go
+++ b/pkg/net/libp2p/key.go
@@ -27,10 +27,17 @@ func operatorPrivateKeyToNetworkKeyPair(operatorPrivateKey *operator.PrivateKey)
 		return nil, nil, fmt.Errorf("libp2p supports only secp256k1 operator keys")
 	}
 
+	operatorKeyBytes := operatorPrivateKey.D.Bytes()
+
+	// The length of operator private key bytes may be less than 32. In that
+	// case pad it with zeros to the length of 32 bytes.
+	paddedOperatorKeyBytes := make([]byte, 32)
+	copy(paddedOperatorKeyBytes[32 - len(operatorKeyBytes):], operatorKeyBytes)
+
 	// Note that `libp2pcrypto.UnmarshalSecp256k1PrivateKey` uses the secp256k1
 	// implementation provided by decred underneath
 	libp2pPrivateKey, err := libp2pcrypto.UnmarshalSecp256k1PrivateKey(
-		operatorPrivateKey.D.Bytes(),
+		paddedOperatorKeyBytes,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf(

--- a/pkg/net/libp2p/key.go
+++ b/pkg/net/libp2p/key.go
@@ -27,17 +27,24 @@ func operatorPrivateKeyToNetworkKeyPair(operatorPrivateKey *operator.PrivateKey)
 		return nil, nil, fmt.Errorf("libp2p supports only secp256k1 operator keys")
 	}
 
-	operatorKeyBytes := operatorPrivateKey.D.Bytes()
+	operatorPrivateKeyByteLength := 32
+
+	if len(operatorPrivateKey.D.Bytes()) > operatorPrivateKeyByteLength {
+		return nil, nil, fmt.Errorf(
+			"operator private key byte length is greater than %v bytes",
+			operatorPrivateKeyByteLength,
+		)
+	}
 
 	// The length of operator private key bytes may be less than 32. In that
 	// case pad it with zeros to the length of 32 bytes.
-	paddedOperatorKeyBytes := make([]byte, 32)
-	copy(paddedOperatorKeyBytes[32 - len(operatorKeyBytes):], operatorKeyBytes)
+	paddedOperatorPrivateKeyBytes := make([]byte, operatorPrivateKeyByteLength)
+	operatorPrivateKey.D.FillBytes(paddedOperatorPrivateKeyBytes)
 
 	// Note that `libp2pcrypto.UnmarshalSecp256k1PrivateKey` uses the secp256k1
 	// implementation provided by decred underneath
 	libp2pPrivateKey, err := libp2pcrypto.UnmarshalSecp256k1PrivateKey(
-		paddedOperatorKeyBytes,
+		paddedOperatorPrivateKeyBytes,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf(


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/3065.
This PR adds padding to operator private key bytes inside `operatorPrivateKeyToNetworkKeyPair` if the key's D parameter is shorter than 32 bytes.

It was tested by running `TestOperatorPrivateKeyToNetworkKeyPair` multiple times and on one run the generated operator private key was 31 bytes long:
```
=== RUN   TestOperatorPrivateKeyToNetworkKeyPair
len(operatorKeyBytes) 31
operatorKeyBytes [196 130 44 41 200 24 238 164 190 40 13 34 223 51 95 159 169 84 183 203 125 149 121 51 46 73 201 238 130 122 246]
len(paddedOperatorKeyBytes) 32
paddedOperatorKeyBytes [0 196 130 44 41 200 24 238 164 190 40 13 34 223 51 95 159 169 84 183 203 125 149 121 51 46 73 201 238 130 122 246]
--- PASS: TestOperatorPrivateKeyToNetworkKeyPair (0.00s)
```

(The logs of keys and their lengths were added only temporarily). 