### PR TITLE
IsOperatorUpToDate and UpdateOperatorStatus functions added to sortition Chain

### DIFF
--- a/pkg/chain/ethereum/beacon.go
+++ b/pkg/chain/ethereum/beacon.go
@@ -162,3 +162,10 @@ func (bc *BeaconChain) JoinSortitionPool() error {
 	_, err := bc.randomBeacon.JoinSortitionPool()
 	return err
 }
+
+// UpdateOperatorStatus executes a transaction to update the current
+// operator's state in the sortition pool.
+func (bc *BeaconChain) UpdateOperatorStatus() error {
+	_, err := bc.randomBeacon.UpdateOperatorStatus(bc.key.Address)
+	return err
+}

--- a/pkg/chain/ethereum/beacon.go
+++ b/pkg/chain/ethereum/beacon.go
@@ -146,6 +146,16 @@ func (bc *BeaconChain) IsOperatorInPool() (bool, error) {
 	return bc.randomBeacon.IsOperatorInPool(bc.key.Address)
 }
 
+// IsOperatorUpToDate checks if the operator's authorized stake is in sync
+// with operator's weight in the sortition pool.
+// If the operator's authorized stake is not in sync with sortition pool
+// weight, function returns false.
+// If the operator is not in the sortition pool and their authorized stake
+// is non-zero, function returns false.
+func (bc *BeaconChain) IsOperatorUpToDate() (bool, error) {
+	return bc.randomBeacon.IsOperatorUpToDate(bc.key.Address)
+}
+
 // JoinSortitionPool executes a transaction to have the current operator join
 // the sortition pool.
 func (bc *BeaconChain) JoinSortitionPool() error {

--- a/pkg/sortition/chain.go
+++ b/pkg/sortition/chain.go
@@ -42,4 +42,8 @@ type Chain interface {
 	// JoinSortitionPool executes a transaction to have the current operator
 	// join the sortition pool.
 	JoinSortitionPool() error
+
+	// UpdateOperatorStatus executes a transaction to update the current
+	// operator's state in the sortition pool.
+	UpdateOperatorStatus() error
 }

--- a/pkg/sortition/chain.go
+++ b/pkg/sortition/chain.go
@@ -31,6 +31,14 @@ type Chain interface {
 	// the sortition pool.
 	IsOperatorInPool() (bool, error)
 
+	// IsOperatorUpToDate checks if the operator's authorized stake is in sync
+	// with operator's weight in the sortition pool.
+	// If the operator's authorized stake is not in sync with sortition pool
+	// weight, function returns false.
+	// If the operator is not in the sortition pool and their authorized stake
+	// is non-zero, function returns false.
+	IsOperatorUpToDate() (bool, error)
+
 	// JoinSortitionPool executes a transaction to have the current operator
 	// join the sortition pool.
 	JoinSortitionPool() error

--- a/pkg/sortition/internal/local.go
+++ b/pkg/sortition/internal/local.go
@@ -136,3 +136,21 @@ func (lc *localChain) JoinSortitionPool() error {
 
 	return nil
 }
+
+func (lc *localChain) UpdateOperatorStatus() error {
+	lc.eligibleStakeMutex.RLock()
+	defer lc.eligibleStakeMutex.RUnlock()
+
+	lc.sortitionPoolMutex.Lock()
+	defer lc.sortitionPoolMutex.Unlock()
+
+	stakingProvider, isRegistered := lc.operatorToStakingProvider[lc.operatorAddress]
+	if !isRegistered {
+		return errOperatorUnknown
+	}
+
+	eligibleStake := lc.eligibleStake[stakingProvider]
+	lc.sortitionPool[lc.operatorAddress] = eligibleStake
+
+	return nil
+}

--- a/pkg/sortition/internal/local_test.go
+++ b/pkg/sortition/internal/local_test.go
@@ -202,3 +202,41 @@ func TestJoinSortitionPool_OperatorAlreadyInPool(t *testing.T) {
 	err = localChain.JoinSortitionPool()
 	testutils.AssertErrorsEqual(t, errOperatorAlreadyRegisteredInPool, err)
 }
+
+func TestUpdateOperatorStatus_NotRegisteredOperator(t *testing.T) {
+	localChain := connectLocal(testOperatorAddress)
+
+	err := localChain.UpdateOperatorStatus()
+	testutils.AssertErrorsEqual(t, errOperatorUnknown, err)
+}
+
+func TestUpdateOperatorStatus(t *testing.T) {
+	localChain := connectLocal(testOperatorAddress)
+	localChain.registerOperator(testStakingProviderAddress, testOperatorAddress)
+	localChain.setEligibleStake(testStakingProviderAddress, big.NewInt(100))
+	err := localChain.JoinSortitionPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	localChain.setEligibleStake(testStakingProviderAddress, big.NewInt(101))
+
+	isUpToDate, err := localChain.IsOperatorUpToDate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isUpToDate {
+		t.Fatal("expected the operator not to be up to date")
+	}
+
+	localChain.UpdateOperatorStatus()
+
+	isUpToDate, err = localChain.IsOperatorUpToDate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isUpToDate {
+		t.Fatal("expected the operator to be up to date")
+	}
+}


### PR DESCRIPTION
Refs #3006 

`IsOperatorUpToDate` and `UpdateOperatorStatus` functions added to sortition `Chain` and implemented for the local and Ethereum chain.

`IsOperatorUpToDate` and `UpdateOperatorStatus` are needed to monitor the status of the operator in the sortition pool. The local Go implementation mirrors the behavior of `BeaconAuthorization` Solidity library.