### PR TITLE
Update expected artifacts for generation

### DIFF
--- a/pkg/chain/common/gen/Makefile
+++ b/pkg/chain/common/gen/Makefile
@@ -7,7 +7,7 @@ ifndef npm_package_tag
 endif
 
 contracts_dir =_contracts
-artifacts_dir = $(realpath ${contracts_dir}/package/export/artifacts)
+artifacts_dir = $(realpath ${contracts_dir}/package/artifacts)
 
 # Go bindings generated for the solidity contracts.
 contract_files = $(addprefix contract/,$(addsuffix .go,${required_contracts}))

--- a/pkg/chain/ecdsa/gen/Makefile
+++ b/pkg/chain/ecdsa/gen/Makefile
@@ -1,6 +1,6 @@
 npm_package_name=@keep-network/ecdsa
 
 # Contracts for which the bindings should be generated.
-required_contracts := WalletRegistry SortitionPool
+required_contracts := WalletRegistry EcdsaSortitionPool
 
 include ../../common/gen/Makefile

--- a/pkg/chain/ecdsa/gen/abi/EcdsaSortitionPool.go
+++ b/pkg/chain/ecdsa/gen/abi/EcdsaSortitionPool.go
@@ -28,113 +28,113 @@ var (
 	_ = event.NewSubscription
 )
 
-// SortitionPoolMetaData contains all meta data concerning the SortitionPool contract.
-var SortitionPoolMetaData = &bind.MetaData{
+// EcdsaSortitionPoolMetaData contains all meta data concerning the EcdsaSortitionPool contract.
+var EcdsaSortitionPoolMetaData = &bind.MetaData{
 	ABI: "[{\"inputs\":[{\"internalType\":\"contractIERC20WithPermit\",\"name\":\"_rewardToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_poolWeightDivisor\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32[]\",\"name\":\"ids\",\"type\":\"uint32[]\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"until\",\"type\":\"uint256\"}],\"name\":\"IneligibleForRewards\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"id\",\"type\":\"uint32\"}],\"name\":\"RewardEligibilityRestored\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"operator\",\"type\":\"uint32\"}],\"name\":\"canRestoreRewardEligibility\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getAvailableRewards\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"id\",\"type\":\"uint32\"}],\"name\":\"getIDOperator\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32[]\",\"name\":\"ids\",\"type\":\"uint32[]\"}],\"name\":\"getIDOperators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getOperatorID\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getPoolWeight\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ineligibleEarnedRewards\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"authorizedStake\",\"type\":\"uint256\"}],\"name\":\"insertOperator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"operator\",\"type\":\"uint32\"}],\"name\":\"isEligibleForRewards\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"isLocked\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isOperatorInPool\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isOperatorRegistered\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"authorizedStake\",\"type\":\"uint256\"}],\"name\":\"isOperatorUpToDate\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"lock\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"operatorsInPool\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"poolWeightDivisor\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"receiveApproval\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"restoreRewardEligibility\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"rewardToken\",\"outputs\":[{\"internalType\":\"contractIERC20WithPermit\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"operator\",\"type\":\"uint32\"}],\"name\":\"rewardsEligibilityRestorableAt\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"groupSize\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"seed\",\"type\":\"bytes32\"}],\"name\":\"selectGroup\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"\",\"type\":\"uint32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32[]\",\"name\":\"operators\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256\",\"name\":\"until\",\"type\":\"uint256\"}],\"name\":\"setRewardIneligibility\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalWeight\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unlock\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"authorizedStake\",\"type\":\"uint256\"}],\"name\":\"updateOperatorStatus\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"withdrawIneligible\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"beneficiary\",\"type\":\"address\"}],\"name\":\"withdrawRewards\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
-// SortitionPoolABI is the input ABI used to generate the binding from.
-// Deprecated: Use SortitionPoolMetaData.ABI instead.
-var SortitionPoolABI = SortitionPoolMetaData.ABI
+// EcdsaSortitionPoolABI is the input ABI used to generate the binding from.
+// Deprecated: Use EcdsaSortitionPoolMetaData.ABI instead.
+var EcdsaSortitionPoolABI = EcdsaSortitionPoolMetaData.ABI
 
-// SortitionPool is an auto generated Go binding around an Ethereum contract.
-type SortitionPool struct {
-	SortitionPoolCaller     // Read-only binding to the contract
-	SortitionPoolTransactor // Write-only binding to the contract
-	SortitionPoolFilterer   // Log filterer for contract events
+// EcdsaSortitionPool is an auto generated Go binding around an Ethereum contract.
+type EcdsaSortitionPool struct {
+	EcdsaSortitionPoolCaller     // Read-only binding to the contract
+	EcdsaSortitionPoolTransactor // Write-only binding to the contract
+	EcdsaSortitionPoolFilterer   // Log filterer for contract events
 }
 
-// SortitionPoolCaller is an auto generated read-only Go binding around an Ethereum contract.
-type SortitionPoolCaller struct {
+// EcdsaSortitionPoolCaller is an auto generated read-only Go binding around an Ethereum contract.
+type EcdsaSortitionPoolCaller struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// SortitionPoolTransactor is an auto generated write-only Go binding around an Ethereum contract.
-type SortitionPoolTransactor struct {
+// EcdsaSortitionPoolTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type EcdsaSortitionPoolTransactor struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// SortitionPoolFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
-type SortitionPoolFilterer struct {
+// EcdsaSortitionPoolFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type EcdsaSortitionPoolFilterer struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// SortitionPoolSession is an auto generated Go binding around an Ethereum contract,
+// EcdsaSortitionPoolSession is an auto generated Go binding around an Ethereum contract,
 // with pre-set call and transact options.
-type SortitionPoolSession struct {
-	Contract     *SortitionPool    // Generic contract binding to set the session for
-	CallOpts     bind.CallOpts     // Call options to use throughout this session
-	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+type EcdsaSortitionPoolSession struct {
+	Contract     *EcdsaSortitionPool // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
 }
 
-// SortitionPoolCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// EcdsaSortitionPoolCallerSession is an auto generated read-only Go binding around an Ethereum contract,
 // with pre-set call options.
-type SortitionPoolCallerSession struct {
-	Contract *SortitionPoolCaller // Generic contract caller binding to set the session for
-	CallOpts bind.CallOpts        // Call options to use throughout this session
+type EcdsaSortitionPoolCallerSession struct {
+	Contract *EcdsaSortitionPoolCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
 }
 
-// SortitionPoolTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// EcdsaSortitionPoolTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
 // with pre-set transact options.
-type SortitionPoolTransactorSession struct {
-	Contract     *SortitionPoolTransactor // Generic contract transactor binding to set the session for
-	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+type EcdsaSortitionPoolTransactorSession struct {
+	Contract     *EcdsaSortitionPoolTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
 }
 
-// SortitionPoolRaw is an auto generated low-level Go binding around an Ethereum contract.
-type SortitionPoolRaw struct {
-	Contract *SortitionPool // Generic contract binding to access the raw methods on
+// EcdsaSortitionPoolRaw is an auto generated low-level Go binding around an Ethereum contract.
+type EcdsaSortitionPoolRaw struct {
+	Contract *EcdsaSortitionPool // Generic contract binding to access the raw methods on
 }
 
-// SortitionPoolCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
-type SortitionPoolCallerRaw struct {
-	Contract *SortitionPoolCaller // Generic read-only contract binding to access the raw methods on
+// EcdsaSortitionPoolCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type EcdsaSortitionPoolCallerRaw struct {
+	Contract *EcdsaSortitionPoolCaller // Generic read-only contract binding to access the raw methods on
 }
 
-// SortitionPoolTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
-type SortitionPoolTransactorRaw struct {
-	Contract *SortitionPoolTransactor // Generic write-only contract binding to access the raw methods on
+// EcdsaSortitionPoolTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type EcdsaSortitionPoolTransactorRaw struct {
+	Contract *EcdsaSortitionPoolTransactor // Generic write-only contract binding to access the raw methods on
 }
 
-// NewSortitionPool creates a new instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPool(address common.Address, backend bind.ContractBackend) (*SortitionPool, error) {
-	contract, err := bindSortitionPool(address, backend, backend, backend)
+// NewEcdsaSortitionPool creates a new instance of EcdsaSortitionPool, bound to a specific deployed contract.
+func NewEcdsaSortitionPool(address common.Address, backend bind.ContractBackend) (*EcdsaSortitionPool, error) {
+	contract, err := bindEcdsaSortitionPool(address, backend, backend, backend)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPool{SortitionPoolCaller: SortitionPoolCaller{contract: contract}, SortitionPoolTransactor: SortitionPoolTransactor{contract: contract}, SortitionPoolFilterer: SortitionPoolFilterer{contract: contract}}, nil
+	return &EcdsaSortitionPool{EcdsaSortitionPoolCaller: EcdsaSortitionPoolCaller{contract: contract}, EcdsaSortitionPoolTransactor: EcdsaSortitionPoolTransactor{contract: contract}, EcdsaSortitionPoolFilterer: EcdsaSortitionPoolFilterer{contract: contract}}, nil
 }
 
-// NewSortitionPoolCaller creates a new read-only instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPoolCaller(address common.Address, caller bind.ContractCaller) (*SortitionPoolCaller, error) {
-	contract, err := bindSortitionPool(address, caller, nil, nil)
+// NewEcdsaSortitionPoolCaller creates a new read-only instance of EcdsaSortitionPool, bound to a specific deployed contract.
+func NewEcdsaSortitionPoolCaller(address common.Address, caller bind.ContractCaller) (*EcdsaSortitionPoolCaller, error) {
+	contract, err := bindEcdsaSortitionPool(address, caller, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolCaller{contract: contract}, nil
+	return &EcdsaSortitionPoolCaller{contract: contract}, nil
 }
 
-// NewSortitionPoolTransactor creates a new write-only instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPoolTransactor(address common.Address, transactor bind.ContractTransactor) (*SortitionPoolTransactor, error) {
-	contract, err := bindSortitionPool(address, nil, transactor, nil)
+// NewEcdsaSortitionPoolTransactor creates a new write-only instance of EcdsaSortitionPool, bound to a specific deployed contract.
+func NewEcdsaSortitionPoolTransactor(address common.Address, transactor bind.ContractTransactor) (*EcdsaSortitionPoolTransactor, error) {
+	contract, err := bindEcdsaSortitionPool(address, nil, transactor, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolTransactor{contract: contract}, nil
+	return &EcdsaSortitionPoolTransactor{contract: contract}, nil
 }
 
-// NewSortitionPoolFilterer creates a new log filterer instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPoolFilterer(address common.Address, filterer bind.ContractFilterer) (*SortitionPoolFilterer, error) {
-	contract, err := bindSortitionPool(address, nil, nil, filterer)
+// NewEcdsaSortitionPoolFilterer creates a new log filterer instance of EcdsaSortitionPool, bound to a specific deployed contract.
+func NewEcdsaSortitionPoolFilterer(address common.Address, filterer bind.ContractFilterer) (*EcdsaSortitionPoolFilterer, error) {
+	contract, err := bindEcdsaSortitionPool(address, nil, nil, filterer)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolFilterer{contract: contract}, nil
+	return &EcdsaSortitionPoolFilterer{contract: contract}, nil
 }
 
-// bindSortitionPool binds a generic wrapper to an already deployed contract.
-func bindSortitionPool(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(SortitionPoolABI))
+// bindEcdsaSortitionPool binds a generic wrapper to an already deployed contract.
+func bindEcdsaSortitionPool(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(EcdsaSortitionPoolABI))
 	if err != nil {
 		return nil, err
 	}
@@ -145,46 +145,46 @@ func bindSortitionPool(address common.Address, caller bind.ContractCaller, trans
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_SortitionPool *SortitionPoolRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _SortitionPool.Contract.SortitionPoolCaller.contract.Call(opts, result, method, params...)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _EcdsaSortitionPool.Contract.EcdsaSortitionPoolCaller.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_SortitionPool *SortitionPoolRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SortitionPoolTransactor.contract.Transfer(opts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.EcdsaSortitionPoolTransactor.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_SortitionPool *SortitionPoolRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SortitionPoolTransactor.contract.Transact(opts, method, params...)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.EcdsaSortitionPoolTransactor.contract.Transact(opts, method, params...)
 }
 
 // Call invokes the (constant) contract method with params as input values and
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_SortitionPool *SortitionPoolCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _SortitionPool.Contract.contract.Call(opts, result, method, params...)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _EcdsaSortitionPool.Contract.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_SortitionPool *SortitionPoolTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.Contract.contract.Transfer(opts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_SortitionPool *SortitionPoolTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _SortitionPool.Contract.contract.Transact(opts, method, params...)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.contract.Transact(opts, method, params...)
 }
 
 // CanRestoreRewardEligibility is a free data retrieval call binding the contract method 0x69ba3c33.
 //
 // Solidity: function canRestoreRewardEligibility(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) CanRestoreRewardEligibility(opts *bind.CallOpts, operator uint32) (bool, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) CanRestoreRewardEligibility(opts *bind.CallOpts, operator uint32) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "canRestoreRewardEligibility", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "canRestoreRewardEligibility", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -199,23 +199,23 @@ func (_SortitionPool *SortitionPoolCaller) CanRestoreRewardEligibility(opts *bin
 // CanRestoreRewardEligibility is a free data retrieval call binding the contract method 0x69ba3c33.
 //
 // Solidity: function canRestoreRewardEligibility(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.CanRestoreRewardEligibility(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
+	return _EcdsaSortitionPool.Contract.CanRestoreRewardEligibility(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // CanRestoreRewardEligibility is a free data retrieval call binding the contract method 0x69ba3c33.
 //
 // Solidity: function canRestoreRewardEligibility(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.CanRestoreRewardEligibility(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
+	return _EcdsaSortitionPool.Contract.CanRestoreRewardEligibility(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // GetAvailableRewards is a free data retrieval call binding the contract method 0x873e31fa.
 //
 // Solidity: function getAvailableRewards(address operator) view returns(uint96)
-func (_SortitionPool *SortitionPoolCaller) GetAvailableRewards(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) GetAvailableRewards(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getAvailableRewards", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "getAvailableRewards", operator)
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -230,23 +230,23 @@ func (_SortitionPool *SortitionPoolCaller) GetAvailableRewards(opts *bind.CallOp
 // GetAvailableRewards is a free data retrieval call binding the contract method 0x873e31fa.
 //
 // Solidity: function getAvailableRewards(address operator) view returns(uint96)
-func (_SortitionPool *SortitionPoolSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetAvailableRewards(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.GetAvailableRewards(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // GetAvailableRewards is a free data retrieval call binding the contract method 0x873e31fa.
 //
 // Solidity: function getAvailableRewards(address operator) view returns(uint96)
-func (_SortitionPool *SortitionPoolCallerSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetAvailableRewards(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.GetAvailableRewards(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // GetIDOperator is a free data retrieval call binding the contract method 0x8871ca5d.
 //
 // Solidity: function getIDOperator(uint32 id) view returns(address)
-func (_SortitionPool *SortitionPoolCaller) GetIDOperator(opts *bind.CallOpts, id uint32) (common.Address, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) GetIDOperator(opts *bind.CallOpts, id uint32) (common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getIDOperator", id)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "getIDOperator", id)
 
 	if err != nil {
 		return *new(common.Address), err
@@ -261,23 +261,23 @@ func (_SortitionPool *SortitionPoolCaller) GetIDOperator(opts *bind.CallOpts, id
 // GetIDOperator is a free data retrieval call binding the contract method 0x8871ca5d.
 //
 // Solidity: function getIDOperator(uint32 id) view returns(address)
-func (_SortitionPool *SortitionPoolSession) GetIDOperator(id uint32) (common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperator(&_SortitionPool.CallOpts, id)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) GetIDOperator(id uint32) (common.Address, error) {
+	return _EcdsaSortitionPool.Contract.GetIDOperator(&_EcdsaSortitionPool.CallOpts, id)
 }
 
 // GetIDOperator is a free data retrieval call binding the contract method 0x8871ca5d.
 //
 // Solidity: function getIDOperator(uint32 id) view returns(address)
-func (_SortitionPool *SortitionPoolCallerSession) GetIDOperator(id uint32) (common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperator(&_SortitionPool.CallOpts, id)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) GetIDOperator(id uint32) (common.Address, error) {
+	return _EcdsaSortitionPool.Contract.GetIDOperator(&_EcdsaSortitionPool.CallOpts, id)
 }
 
 // GetIDOperators is a free data retrieval call binding the contract method 0xf7f9a8fa.
 //
 // Solidity: function getIDOperators(uint32[] ids) view returns(address[])
-func (_SortitionPool *SortitionPoolCaller) GetIDOperators(opts *bind.CallOpts, ids []uint32) ([]common.Address, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) GetIDOperators(opts *bind.CallOpts, ids []uint32) ([]common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getIDOperators", ids)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "getIDOperators", ids)
 
 	if err != nil {
 		return *new([]common.Address), err
@@ -292,23 +292,23 @@ func (_SortitionPool *SortitionPoolCaller) GetIDOperators(opts *bind.CallOpts, i
 // GetIDOperators is a free data retrieval call binding the contract method 0xf7f9a8fa.
 //
 // Solidity: function getIDOperators(uint32[] ids) view returns(address[])
-func (_SortitionPool *SortitionPoolSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperators(&_SortitionPool.CallOpts, ids)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
+	return _EcdsaSortitionPool.Contract.GetIDOperators(&_EcdsaSortitionPool.CallOpts, ids)
 }
 
 // GetIDOperators is a free data retrieval call binding the contract method 0xf7f9a8fa.
 //
 // Solidity: function getIDOperators(uint32[] ids) view returns(address[])
-func (_SortitionPool *SortitionPoolCallerSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperators(&_SortitionPool.CallOpts, ids)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
+	return _EcdsaSortitionPool.Contract.GetIDOperators(&_EcdsaSortitionPool.CallOpts, ids)
 }
 
 // GetOperatorID is a free data retrieval call binding the contract method 0x5a48b46b.
 //
 // Solidity: function getOperatorID(address operator) view returns(uint32)
-func (_SortitionPool *SortitionPoolCaller) GetOperatorID(opts *bind.CallOpts, operator common.Address) (uint32, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) GetOperatorID(opts *bind.CallOpts, operator common.Address) (uint32, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getOperatorID", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "getOperatorID", operator)
 
 	if err != nil {
 		return *new(uint32), err
@@ -323,23 +323,23 @@ func (_SortitionPool *SortitionPoolCaller) GetOperatorID(opts *bind.CallOpts, op
 // GetOperatorID is a free data retrieval call binding the contract method 0x5a48b46b.
 //
 // Solidity: function getOperatorID(address operator) view returns(uint32)
-func (_SortitionPool *SortitionPoolSession) GetOperatorID(operator common.Address) (uint32, error) {
-	return _SortitionPool.Contract.GetOperatorID(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) GetOperatorID(operator common.Address) (uint32, error) {
+	return _EcdsaSortitionPool.Contract.GetOperatorID(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // GetOperatorID is a free data retrieval call binding the contract method 0x5a48b46b.
 //
 // Solidity: function getOperatorID(address operator) view returns(uint32)
-func (_SortitionPool *SortitionPoolCallerSession) GetOperatorID(operator common.Address) (uint32, error) {
-	return _SortitionPool.Contract.GetOperatorID(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) GetOperatorID(operator common.Address) (uint32, error) {
+	return _EcdsaSortitionPool.Contract.GetOperatorID(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // GetPoolWeight is a free data retrieval call binding the contract method 0x5757ed5b.
 //
 // Solidity: function getPoolWeight(address operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) GetPoolWeight(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) GetPoolWeight(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getPoolWeight", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "getPoolWeight", operator)
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -354,23 +354,23 @@ func (_SortitionPool *SortitionPoolCaller) GetPoolWeight(opts *bind.CallOpts, op
 // GetPoolWeight is a free data retrieval call binding the contract method 0x5757ed5b.
 //
 // Solidity: function getPoolWeight(address operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetPoolWeight(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.GetPoolWeight(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // GetPoolWeight is a free data retrieval call binding the contract method 0x5757ed5b.
 //
 // Solidity: function getPoolWeight(address operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetPoolWeight(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.GetPoolWeight(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IneligibleEarnedRewards is a free data retrieval call binding the contract method 0xa7a7d391.
 //
 // Solidity: function ineligibleEarnedRewards() view returns(uint96)
-func (_SortitionPool *SortitionPoolCaller) IneligibleEarnedRewards(opts *bind.CallOpts) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) IneligibleEarnedRewards(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "ineligibleEarnedRewards")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "ineligibleEarnedRewards")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -385,23 +385,23 @@ func (_SortitionPool *SortitionPoolCaller) IneligibleEarnedRewards(opts *bind.Ca
 // IneligibleEarnedRewards is a free data retrieval call binding the contract method 0xa7a7d391.
 //
 // Solidity: function ineligibleEarnedRewards() view returns(uint96)
-func (_SortitionPool *SortitionPoolSession) IneligibleEarnedRewards() (*big.Int, error) {
-	return _SortitionPool.Contract.IneligibleEarnedRewards(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) IneligibleEarnedRewards() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.IneligibleEarnedRewards(&_EcdsaSortitionPool.CallOpts)
 }
 
 // IneligibleEarnedRewards is a free data retrieval call binding the contract method 0xa7a7d391.
 //
 // Solidity: function ineligibleEarnedRewards() view returns(uint96)
-func (_SortitionPool *SortitionPoolCallerSession) IneligibleEarnedRewards() (*big.Int, error) {
-	return _SortitionPool.Contract.IneligibleEarnedRewards(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) IneligibleEarnedRewards() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.IneligibleEarnedRewards(&_EcdsaSortitionPool.CallOpts)
 }
 
 // IsEligibleForRewards is a free data retrieval call binding the contract method 0x5222580a.
 //
 // Solidity: function isEligibleForRewards(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsEligibleForRewards(opts *bind.CallOpts, operator uint32) (bool, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) IsEligibleForRewards(opts *bind.CallOpts, operator uint32) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isEligibleForRewards", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "isEligibleForRewards", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -416,23 +416,23 @@ func (_SortitionPool *SortitionPoolCaller) IsEligibleForRewards(opts *bind.CallO
 // IsEligibleForRewards is a free data retrieval call binding the contract method 0x5222580a.
 //
 // Solidity: function isEligibleForRewards(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsEligibleForRewards(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.IsEligibleForRewards(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) IsEligibleForRewards(operator uint32) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsEligibleForRewards(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IsEligibleForRewards is a free data retrieval call binding the contract method 0x5222580a.
 //
 // Solidity: function isEligibleForRewards(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsEligibleForRewards(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.IsEligibleForRewards(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) IsEligibleForRewards(operator uint32) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsEligibleForRewards(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IsLocked is a free data retrieval call binding the contract method 0xa4e2d634.
 //
 // Solidity: function isLocked() view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsLocked(opts *bind.CallOpts) (bool, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) IsLocked(opts *bind.CallOpts) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isLocked")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "isLocked")
 
 	if err != nil {
 		return *new(bool), err
@@ -447,23 +447,23 @@ func (_SortitionPool *SortitionPoolCaller) IsLocked(opts *bind.CallOpts) (bool, 
 // IsLocked is a free data retrieval call binding the contract method 0xa4e2d634.
 //
 // Solidity: function isLocked() view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsLocked() (bool, error) {
-	return _SortitionPool.Contract.IsLocked(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) IsLocked() (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsLocked(&_EcdsaSortitionPool.CallOpts)
 }
 
 // IsLocked is a free data retrieval call binding the contract method 0xa4e2d634.
 //
 // Solidity: function isLocked() view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsLocked() (bool, error) {
-	return _SortitionPool.Contract.IsLocked(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) IsLocked() (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsLocked(&_EcdsaSortitionPool.CallOpts)
 }
 
 // IsOperatorInPool is a free data retrieval call binding the contract method 0xf7186ce0.
 //
 // Solidity: function isOperatorInPool(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsOperatorInPool(opts *bind.CallOpts, operator common.Address) (bool, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) IsOperatorInPool(opts *bind.CallOpts, operator common.Address) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isOperatorInPool", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "isOperatorInPool", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -478,23 +478,23 @@ func (_SortitionPool *SortitionPoolCaller) IsOperatorInPool(opts *bind.CallOpts,
 // IsOperatorInPool is a free data retrieval call binding the contract method 0xf7186ce0.
 //
 // Solidity: function isOperatorInPool(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsOperatorInPool(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorInPool(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) IsOperatorInPool(operator common.Address) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsOperatorInPool(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorInPool is a free data retrieval call binding the contract method 0xf7186ce0.
 //
 // Solidity: function isOperatorInPool(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsOperatorInPool(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorInPool(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) IsOperatorInPool(operator common.Address) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsOperatorInPool(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorRegistered is a free data retrieval call binding the contract method 0x6b1906f8.
 //
 // Solidity: function isOperatorRegistered(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsOperatorRegistered(opts *bind.CallOpts, operator common.Address) (bool, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) IsOperatorRegistered(opts *bind.CallOpts, operator common.Address) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isOperatorRegistered", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "isOperatorRegistered", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -509,23 +509,23 @@ func (_SortitionPool *SortitionPoolCaller) IsOperatorRegistered(opts *bind.CallO
 // IsOperatorRegistered is a free data retrieval call binding the contract method 0x6b1906f8.
 //
 // Solidity: function isOperatorRegistered(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsOperatorRegistered(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorRegistered(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) IsOperatorRegistered(operator common.Address) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsOperatorRegistered(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorRegistered is a free data retrieval call binding the contract method 0x6b1906f8.
 //
 // Solidity: function isOperatorRegistered(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsOperatorRegistered(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorRegistered(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) IsOperatorRegistered(operator common.Address) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsOperatorRegistered(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorUpToDate is a free data retrieval call binding the contract method 0x4de824f0.
 //
 // Solidity: function isOperatorUpToDate(address operator, uint256 authorizedStake) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsOperatorUpToDate(opts *bind.CallOpts, operator common.Address, authorizedStake *big.Int) (bool, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) IsOperatorUpToDate(opts *bind.CallOpts, operator common.Address, authorizedStake *big.Int) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isOperatorUpToDate", operator, authorizedStake)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "isOperatorUpToDate", operator, authorizedStake)
 
 	if err != nil {
 		return *new(bool), err
@@ -540,23 +540,23 @@ func (_SortitionPool *SortitionPoolCaller) IsOperatorUpToDate(opts *bind.CallOpt
 // IsOperatorUpToDate is a free data retrieval call binding the contract method 0x4de824f0.
 //
 // Solidity: function isOperatorUpToDate(address operator, uint256 authorizedStake) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorUpToDate(&_SortitionPool.CallOpts, operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsOperatorUpToDate(&_EcdsaSortitionPool.CallOpts, operator, authorizedStake)
 }
 
 // IsOperatorUpToDate is a free data retrieval call binding the contract method 0x4de824f0.
 //
 // Solidity: function isOperatorUpToDate(address operator, uint256 authorizedStake) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorUpToDate(&_SortitionPool.CallOpts, operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
+	return _EcdsaSortitionPool.Contract.IsOperatorUpToDate(&_EcdsaSortitionPool.CallOpts, operator, authorizedStake)
 }
 
 // OperatorsInPool is a free data retrieval call binding the contract method 0xe7bfd899.
 //
 // Solidity: function operatorsInPool() view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) OperatorsInPool(opts *bind.CallOpts) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) OperatorsInPool(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "operatorsInPool")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "operatorsInPool")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -571,23 +571,23 @@ func (_SortitionPool *SortitionPoolCaller) OperatorsInPool(opts *bind.CallOpts) 
 // OperatorsInPool is a free data retrieval call binding the contract method 0xe7bfd899.
 //
 // Solidity: function operatorsInPool() view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) OperatorsInPool() (*big.Int, error) {
-	return _SortitionPool.Contract.OperatorsInPool(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) OperatorsInPool() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.OperatorsInPool(&_EcdsaSortitionPool.CallOpts)
 }
 
 // OperatorsInPool is a free data retrieval call binding the contract method 0xe7bfd899.
 //
 // Solidity: function operatorsInPool() view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) OperatorsInPool() (*big.Int, error) {
-	return _SortitionPool.Contract.OperatorsInPool(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) OperatorsInPool() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.OperatorsInPool(&_EcdsaSortitionPool.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_SortitionPool *SortitionPoolCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "owner")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "owner")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -602,23 +602,23 @@ func (_SortitionPool *SortitionPoolCaller) Owner(opts *bind.CallOpts) (common.Ad
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_SortitionPool *SortitionPoolSession) Owner() (common.Address, error) {
-	return _SortitionPool.Contract.Owner(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) Owner() (common.Address, error) {
+	return _EcdsaSortitionPool.Contract.Owner(&_EcdsaSortitionPool.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_SortitionPool *SortitionPoolCallerSession) Owner() (common.Address, error) {
-	return _SortitionPool.Contract.Owner(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) Owner() (common.Address, error) {
+	return _EcdsaSortitionPool.Contract.Owner(&_EcdsaSortitionPool.CallOpts)
 }
 
 // PoolWeightDivisor is a free data retrieval call binding the contract method 0x43a3db30.
 //
 // Solidity: function poolWeightDivisor() view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) PoolWeightDivisor(opts *bind.CallOpts) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) PoolWeightDivisor(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "poolWeightDivisor")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "poolWeightDivisor")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -633,23 +633,23 @@ func (_SortitionPool *SortitionPoolCaller) PoolWeightDivisor(opts *bind.CallOpts
 // PoolWeightDivisor is a free data retrieval call binding the contract method 0x43a3db30.
 //
 // Solidity: function poolWeightDivisor() view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) PoolWeightDivisor() (*big.Int, error) {
-	return _SortitionPool.Contract.PoolWeightDivisor(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) PoolWeightDivisor() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.PoolWeightDivisor(&_EcdsaSortitionPool.CallOpts)
 }
 
 // PoolWeightDivisor is a free data retrieval call binding the contract method 0x43a3db30.
 //
 // Solidity: function poolWeightDivisor() view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) PoolWeightDivisor() (*big.Int, error) {
-	return _SortitionPool.Contract.PoolWeightDivisor(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) PoolWeightDivisor() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.PoolWeightDivisor(&_EcdsaSortitionPool.CallOpts)
 }
 
 // RewardToken is a free data retrieval call binding the contract method 0xf7c618c1.
 //
 // Solidity: function rewardToken() view returns(address)
-func (_SortitionPool *SortitionPoolCaller) RewardToken(opts *bind.CallOpts) (common.Address, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) RewardToken(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "rewardToken")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "rewardToken")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -664,23 +664,23 @@ func (_SortitionPool *SortitionPoolCaller) RewardToken(opts *bind.CallOpts) (com
 // RewardToken is a free data retrieval call binding the contract method 0xf7c618c1.
 //
 // Solidity: function rewardToken() view returns(address)
-func (_SortitionPool *SortitionPoolSession) RewardToken() (common.Address, error) {
-	return _SortitionPool.Contract.RewardToken(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) RewardToken() (common.Address, error) {
+	return _EcdsaSortitionPool.Contract.RewardToken(&_EcdsaSortitionPool.CallOpts)
 }
 
 // RewardToken is a free data retrieval call binding the contract method 0xf7c618c1.
 //
 // Solidity: function rewardToken() view returns(address)
-func (_SortitionPool *SortitionPoolCallerSession) RewardToken() (common.Address, error) {
-	return _SortitionPool.Contract.RewardToken(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) RewardToken() (common.Address, error) {
+	return _EcdsaSortitionPool.Contract.RewardToken(&_EcdsaSortitionPool.CallOpts)
 }
 
 // RewardsEligibilityRestorableAt is a free data retrieval call binding the contract method 0xbe51fb4a.
 //
 // Solidity: function rewardsEligibilityRestorableAt(uint32 operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) RewardsEligibilityRestorableAt(opts *bind.CallOpts, operator uint32) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) RewardsEligibilityRestorableAt(opts *bind.CallOpts, operator uint32) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "rewardsEligibilityRestorableAt", operator)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "rewardsEligibilityRestorableAt", operator)
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -695,23 +695,23 @@ func (_SortitionPool *SortitionPoolCaller) RewardsEligibilityRestorableAt(opts *
 // RewardsEligibilityRestorableAt is a free data retrieval call binding the contract method 0xbe51fb4a.
 //
 // Solidity: function rewardsEligibilityRestorableAt(uint32 operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
-	return _SortitionPool.Contract.RewardsEligibilityRestorableAt(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.RewardsEligibilityRestorableAt(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // RewardsEligibilityRestorableAt is a free data retrieval call binding the contract method 0xbe51fb4a.
 //
 // Solidity: function rewardsEligibilityRestorableAt(uint32 operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
-	return _SortitionPool.Contract.RewardsEligibilityRestorableAt(&_SortitionPool.CallOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.RewardsEligibilityRestorableAt(&_EcdsaSortitionPool.CallOpts, operator)
 }
 
 // SelectGroup is a free data retrieval call binding the contract method 0x6c2530b9.
 //
 // Solidity: function selectGroup(uint256 groupSize, bytes32 seed) view returns(uint32[])
-func (_SortitionPool *SortitionPoolCaller) SelectGroup(opts *bind.CallOpts, groupSize *big.Int, seed [32]byte) ([]uint32, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) SelectGroup(opts *bind.CallOpts, groupSize *big.Int, seed [32]byte) ([]uint32, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "selectGroup", groupSize, seed)
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "selectGroup", groupSize, seed)
 
 	if err != nil {
 		return *new([]uint32), err
@@ -726,23 +726,23 @@ func (_SortitionPool *SortitionPoolCaller) SelectGroup(opts *bind.CallOpts, grou
 // SelectGroup is a free data retrieval call binding the contract method 0x6c2530b9.
 //
 // Solidity: function selectGroup(uint256 groupSize, bytes32 seed) view returns(uint32[])
-func (_SortitionPool *SortitionPoolSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
-	return _SortitionPool.Contract.SelectGroup(&_SortitionPool.CallOpts, groupSize, seed)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
+	return _EcdsaSortitionPool.Contract.SelectGroup(&_EcdsaSortitionPool.CallOpts, groupSize, seed)
 }
 
 // SelectGroup is a free data retrieval call binding the contract method 0x6c2530b9.
 //
 // Solidity: function selectGroup(uint256 groupSize, bytes32 seed) view returns(uint32[])
-func (_SortitionPool *SortitionPoolCallerSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
-	return _SortitionPool.Contract.SelectGroup(&_SortitionPool.CallOpts, groupSize, seed)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
+	return _EcdsaSortitionPool.Contract.SelectGroup(&_EcdsaSortitionPool.CallOpts, groupSize, seed)
 }
 
 // TotalWeight is a free data retrieval call binding the contract method 0x96c82e57.
 //
 // Solidity: function totalWeight() view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) TotalWeight(opts *bind.CallOpts) (*big.Int, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCaller) TotalWeight(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "totalWeight")
+	err := _EcdsaSortitionPool.contract.Call(opts, &out, "totalWeight")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -757,251 +757,251 @@ func (_SortitionPool *SortitionPoolCaller) TotalWeight(opts *bind.CallOpts) (*bi
 // TotalWeight is a free data retrieval call binding the contract method 0x96c82e57.
 //
 // Solidity: function totalWeight() view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) TotalWeight() (*big.Int, error) {
-	return _SortitionPool.Contract.TotalWeight(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) TotalWeight() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.TotalWeight(&_EcdsaSortitionPool.CallOpts)
 }
 
 // TotalWeight is a free data retrieval call binding the contract method 0x96c82e57.
 //
 // Solidity: function totalWeight() view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) TotalWeight() (*big.Int, error) {
-	return _SortitionPool.Contract.TotalWeight(&_SortitionPool.CallOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolCallerSession) TotalWeight() (*big.Int, error) {
+	return _EcdsaSortitionPool.Contract.TotalWeight(&_EcdsaSortitionPool.CallOpts)
 }
 
 // InsertOperator is a paid mutator transaction binding the contract method 0x241a4188.
 //
 // Solidity: function insertOperator(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactor) InsertOperator(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "insertOperator", operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) InsertOperator(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "insertOperator", operator, authorizedStake)
 }
 
 // InsertOperator is a paid mutator transaction binding the contract method 0x241a4188.
 //
 // Solidity: function insertOperator(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.InsertOperator(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.InsertOperator(&_EcdsaSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // InsertOperator is a paid mutator transaction binding the contract method 0x241a4188.
 //
 // Solidity: function insertOperator(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.InsertOperator(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.InsertOperator(&_EcdsaSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // Lock is a paid mutator transaction binding the contract method 0xf83d08ba.
 //
 // Solidity: function lock() returns()
-func (_SortitionPool *SortitionPoolTransactor) Lock(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "lock")
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) Lock(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "lock")
 }
 
 // Lock is a paid mutator transaction binding the contract method 0xf83d08ba.
 //
 // Solidity: function lock() returns()
-func (_SortitionPool *SortitionPoolSession) Lock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Lock(&_SortitionPool.TransactOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) Lock() (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.Lock(&_EcdsaSortitionPool.TransactOpts)
 }
 
 // Lock is a paid mutator transaction binding the contract method 0xf83d08ba.
 //
 // Solidity: function lock() returns()
-func (_SortitionPool *SortitionPoolTransactorSession) Lock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Lock(&_SortitionPool.TransactOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) Lock() (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.Lock(&_EcdsaSortitionPool.TransactOpts)
 }
 
 // ReceiveApproval is a paid mutator transaction binding the contract method 0x8f4ffcb1.
 //
 // Solidity: function receiveApproval(address sender, uint256 amount, address token, bytes ) returns()
-func (_SortitionPool *SortitionPoolTransactor) ReceiveApproval(opts *bind.TransactOpts, sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "receiveApproval", sender, amount, token, arg3)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) ReceiveApproval(opts *bind.TransactOpts, sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "receiveApproval", sender, amount, token, arg3)
 }
 
 // ReceiveApproval is a paid mutator transaction binding the contract method 0x8f4ffcb1.
 //
 // Solidity: function receiveApproval(address sender, uint256 amount, address token, bytes ) returns()
-func (_SortitionPool *SortitionPoolSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
-	return _SortitionPool.Contract.ReceiveApproval(&_SortitionPool.TransactOpts, sender, amount, token, arg3)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.ReceiveApproval(&_EcdsaSortitionPool.TransactOpts, sender, amount, token, arg3)
 }
 
 // ReceiveApproval is a paid mutator transaction binding the contract method 0x8f4ffcb1.
 //
 // Solidity: function receiveApproval(address sender, uint256 amount, address token, bytes ) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
-	return _SortitionPool.Contract.ReceiveApproval(&_SortitionPool.TransactOpts, sender, amount, token, arg3)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.ReceiveApproval(&_EcdsaSortitionPool.TransactOpts, sender, amount, token, arg3)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_SortitionPool *SortitionPoolTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "renounceOwnership")
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "renounceOwnership")
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_SortitionPool *SortitionPoolSession) RenounceOwnership() (*types.Transaction, error) {
-	return _SortitionPool.Contract.RenounceOwnership(&_SortitionPool.TransactOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) RenounceOwnership() (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.RenounceOwnership(&_EcdsaSortitionPool.TransactOpts)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_SortitionPool *SortitionPoolTransactorSession) RenounceOwnership() (*types.Transaction, error) {
-	return _SortitionPool.Contract.RenounceOwnership(&_SortitionPool.TransactOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.RenounceOwnership(&_EcdsaSortitionPool.TransactOpts)
 }
 
 // RestoreRewardEligibility is a paid mutator transaction binding the contract method 0xb2f3db4d.
 //
 // Solidity: function restoreRewardEligibility(address operator) returns()
-func (_SortitionPool *SortitionPoolTransactor) RestoreRewardEligibility(opts *bind.TransactOpts, operator common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "restoreRewardEligibility", operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) RestoreRewardEligibility(opts *bind.TransactOpts, operator common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "restoreRewardEligibility", operator)
 }
 
 // RestoreRewardEligibility is a paid mutator transaction binding the contract method 0xb2f3db4d.
 //
 // Solidity: function restoreRewardEligibility(address operator) returns()
-func (_SortitionPool *SortitionPoolSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.RestoreRewardEligibility(&_SortitionPool.TransactOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.RestoreRewardEligibility(&_EcdsaSortitionPool.TransactOpts, operator)
 }
 
 // RestoreRewardEligibility is a paid mutator transaction binding the contract method 0xb2f3db4d.
 //
 // Solidity: function restoreRewardEligibility(address operator) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.RestoreRewardEligibility(&_SortitionPool.TransactOpts, operator)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.RestoreRewardEligibility(&_EcdsaSortitionPool.TransactOpts, operator)
 }
 
 // SetRewardIneligibility is a paid mutator transaction binding the contract method 0x942f6892.
 //
 // Solidity: function setRewardIneligibility(uint32[] operators, uint256 until) returns()
-func (_SortitionPool *SortitionPoolTransactor) SetRewardIneligibility(opts *bind.TransactOpts, operators []uint32, until *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "setRewardIneligibility", operators, until)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) SetRewardIneligibility(opts *bind.TransactOpts, operators []uint32, until *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "setRewardIneligibility", operators, until)
 }
 
 // SetRewardIneligibility is a paid mutator transaction binding the contract method 0x942f6892.
 //
 // Solidity: function setRewardIneligibility(uint32[] operators, uint256 until) returns()
-func (_SortitionPool *SortitionPoolSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SetRewardIneligibility(&_SortitionPool.TransactOpts, operators, until)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.SetRewardIneligibility(&_EcdsaSortitionPool.TransactOpts, operators, until)
 }
 
 // SetRewardIneligibility is a paid mutator transaction binding the contract method 0x942f6892.
 //
 // Solidity: function setRewardIneligibility(uint32[] operators, uint256 until) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SetRewardIneligibility(&_SortitionPool.TransactOpts, operators, until)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.SetRewardIneligibility(&_EcdsaSortitionPool.TransactOpts, operators, until)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_SortitionPool *SortitionPoolTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "transferOwnership", newOwner)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "transferOwnership", newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_SortitionPool *SortitionPoolSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.TransferOwnership(&_SortitionPool.TransactOpts, newOwner)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.TransferOwnership(&_EcdsaSortitionPool.TransactOpts, newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.TransferOwnership(&_SortitionPool.TransactOpts, newOwner)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.TransferOwnership(&_EcdsaSortitionPool.TransactOpts, newOwner)
 }
 
 // Unlock is a paid mutator transaction binding the contract method 0xa69df4b5.
 //
 // Solidity: function unlock() returns()
-func (_SortitionPool *SortitionPoolTransactor) Unlock(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "unlock")
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) Unlock(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "unlock")
 }
 
 // Unlock is a paid mutator transaction binding the contract method 0xa69df4b5.
 //
 // Solidity: function unlock() returns()
-func (_SortitionPool *SortitionPoolSession) Unlock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Unlock(&_SortitionPool.TransactOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) Unlock() (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.Unlock(&_EcdsaSortitionPool.TransactOpts)
 }
 
 // Unlock is a paid mutator transaction binding the contract method 0xa69df4b5.
 //
 // Solidity: function unlock() returns()
-func (_SortitionPool *SortitionPoolTransactorSession) Unlock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Unlock(&_SortitionPool.TransactOpts)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) Unlock() (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.Unlock(&_EcdsaSortitionPool.TransactOpts)
 }
 
 // UpdateOperatorStatus is a paid mutator transaction binding the contract method 0xdc7520c5.
 //
 // Solidity: function updateOperatorStatus(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactor) UpdateOperatorStatus(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "updateOperatorStatus", operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) UpdateOperatorStatus(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "updateOperatorStatus", operator, authorizedStake)
 }
 
 // UpdateOperatorStatus is a paid mutator transaction binding the contract method 0xdc7520c5.
 //
 // Solidity: function updateOperatorStatus(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.UpdateOperatorStatus(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.UpdateOperatorStatus(&_EcdsaSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // UpdateOperatorStatus is a paid mutator transaction binding the contract method 0xdc7520c5.
 //
 // Solidity: function updateOperatorStatus(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.UpdateOperatorStatus(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.UpdateOperatorStatus(&_EcdsaSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // WithdrawIneligible is a paid mutator transaction binding the contract method 0xa9649414.
 //
 // Solidity: function withdrawIneligible(address recipient) returns()
-func (_SortitionPool *SortitionPoolTransactor) WithdrawIneligible(opts *bind.TransactOpts, recipient common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "withdrawIneligible", recipient)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) WithdrawIneligible(opts *bind.TransactOpts, recipient common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "withdrawIneligible", recipient)
 }
 
 // WithdrawIneligible is a paid mutator transaction binding the contract method 0xa9649414.
 //
 // Solidity: function withdrawIneligible(address recipient) returns()
-func (_SortitionPool *SortitionPoolSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawIneligible(&_SortitionPool.TransactOpts, recipient)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.WithdrawIneligible(&_EcdsaSortitionPool.TransactOpts, recipient)
 }
 
 // WithdrawIneligible is a paid mutator transaction binding the contract method 0xa9649414.
 //
 // Solidity: function withdrawIneligible(address recipient) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawIneligible(&_SortitionPool.TransactOpts, recipient)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.WithdrawIneligible(&_EcdsaSortitionPool.TransactOpts, recipient)
 }
 
 // WithdrawRewards is a paid mutator transaction binding the contract method 0xe20981ca.
 //
 // Solidity: function withdrawRewards(address operator, address beneficiary) returns(uint96)
-func (_SortitionPool *SortitionPoolTransactor) WithdrawRewards(opts *bind.TransactOpts, operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "withdrawRewards", operator, beneficiary)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactor) WithdrawRewards(opts *bind.TransactOpts, operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.contract.Transact(opts, "withdrawRewards", operator, beneficiary)
 }
 
 // WithdrawRewards is a paid mutator transaction binding the contract method 0xe20981ca.
 //
 // Solidity: function withdrawRewards(address operator, address beneficiary) returns(uint96)
-func (_SortitionPool *SortitionPoolSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawRewards(&_SortitionPool.TransactOpts, operator, beneficiary)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.WithdrawRewards(&_EcdsaSortitionPool.TransactOpts, operator, beneficiary)
 }
 
 // WithdrawRewards is a paid mutator transaction binding the contract method 0xe20981ca.
 //
 // Solidity: function withdrawRewards(address operator, address beneficiary) returns(uint96)
-func (_SortitionPool *SortitionPoolTransactorSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawRewards(&_SortitionPool.TransactOpts, operator, beneficiary)
+func (_EcdsaSortitionPool *EcdsaSortitionPoolTransactorSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
+	return _EcdsaSortitionPool.Contract.WithdrawRewards(&_EcdsaSortitionPool.TransactOpts, operator, beneficiary)
 }
 
-// SortitionPoolIneligibleForRewardsIterator is returned from FilterIneligibleForRewards and is used to iterate over the raw logs and unpacked data for IneligibleForRewards events raised by the SortitionPool contract.
-type SortitionPoolIneligibleForRewardsIterator struct {
-	Event *SortitionPoolIneligibleForRewards // Event containing the contract specifics and raw log
+// EcdsaSortitionPoolIneligibleForRewardsIterator is returned from FilterIneligibleForRewards and is used to iterate over the raw logs and unpacked data for IneligibleForRewards events raised by the EcdsaSortitionPool contract.
+type EcdsaSortitionPoolIneligibleForRewardsIterator struct {
+	Event *EcdsaSortitionPoolIneligibleForRewards // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1015,7 +1015,7 @@ type SortitionPoolIneligibleForRewardsIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
+func (it *EcdsaSortitionPoolIneligibleForRewardsIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1024,7 +1024,7 @@ func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SortitionPoolIneligibleForRewards)
+			it.Event = new(EcdsaSortitionPoolIneligibleForRewards)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1039,7 +1039,7 @@ func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SortitionPoolIneligibleForRewards)
+		it.Event = new(EcdsaSortitionPoolIneligibleForRewards)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1055,19 +1055,19 @@ func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SortitionPoolIneligibleForRewardsIterator) Error() error {
+func (it *EcdsaSortitionPoolIneligibleForRewardsIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SortitionPoolIneligibleForRewardsIterator) Close() error {
+func (it *EcdsaSortitionPoolIneligibleForRewardsIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SortitionPoolIneligibleForRewards represents a IneligibleForRewards event raised by the SortitionPool contract.
-type SortitionPoolIneligibleForRewards struct {
+// EcdsaSortitionPoolIneligibleForRewards represents a IneligibleForRewards event raised by the EcdsaSortitionPool contract.
+type EcdsaSortitionPoolIneligibleForRewards struct {
 	Ids   []uint32
 	Until *big.Int
 	Raw   types.Log // Blockchain specific contextual infos
@@ -1076,21 +1076,21 @@ type SortitionPoolIneligibleForRewards struct {
 // FilterIneligibleForRewards is a free log retrieval operation binding the contract event 0x01f5838e3dde8cf4817b958fe95be92bdfeccb34317e1d9f58d1cfe5230de231.
 //
 // Solidity: event IneligibleForRewards(uint32[] ids, uint256 until)
-func (_SortitionPool *SortitionPoolFilterer) FilterIneligibleForRewards(opts *bind.FilterOpts) (*SortitionPoolIneligibleForRewardsIterator, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) FilterIneligibleForRewards(opts *bind.FilterOpts) (*EcdsaSortitionPoolIneligibleForRewardsIterator, error) {
 
-	logs, sub, err := _SortitionPool.contract.FilterLogs(opts, "IneligibleForRewards")
+	logs, sub, err := _EcdsaSortitionPool.contract.FilterLogs(opts, "IneligibleForRewards")
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolIneligibleForRewardsIterator{contract: _SortitionPool.contract, event: "IneligibleForRewards", logs: logs, sub: sub}, nil
+	return &EcdsaSortitionPoolIneligibleForRewardsIterator{contract: _EcdsaSortitionPool.contract, event: "IneligibleForRewards", logs: logs, sub: sub}, nil
 }
 
 // WatchIneligibleForRewards is a free log subscription operation binding the contract event 0x01f5838e3dde8cf4817b958fe95be92bdfeccb34317e1d9f58d1cfe5230de231.
 //
 // Solidity: event IneligibleForRewards(uint32[] ids, uint256 until)
-func (_SortitionPool *SortitionPoolFilterer) WatchIneligibleForRewards(opts *bind.WatchOpts, sink chan<- *SortitionPoolIneligibleForRewards) (event.Subscription, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) WatchIneligibleForRewards(opts *bind.WatchOpts, sink chan<- *EcdsaSortitionPoolIneligibleForRewards) (event.Subscription, error) {
 
-	logs, sub, err := _SortitionPool.contract.WatchLogs(opts, "IneligibleForRewards")
+	logs, sub, err := _EcdsaSortitionPool.contract.WatchLogs(opts, "IneligibleForRewards")
 	if err != nil {
 		return nil, err
 	}
@@ -1100,8 +1100,8 @@ func (_SortitionPool *SortitionPoolFilterer) WatchIneligibleForRewards(opts *bin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SortitionPoolIneligibleForRewards)
-				if err := _SortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
+				event := new(EcdsaSortitionPoolIneligibleForRewards)
+				if err := _EcdsaSortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1125,18 +1125,18 @@ func (_SortitionPool *SortitionPoolFilterer) WatchIneligibleForRewards(opts *bin
 // ParseIneligibleForRewards is a log parse operation binding the contract event 0x01f5838e3dde8cf4817b958fe95be92bdfeccb34317e1d9f58d1cfe5230de231.
 //
 // Solidity: event IneligibleForRewards(uint32[] ids, uint256 until)
-func (_SortitionPool *SortitionPoolFilterer) ParseIneligibleForRewards(log types.Log) (*SortitionPoolIneligibleForRewards, error) {
-	event := new(SortitionPoolIneligibleForRewards)
-	if err := _SortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) ParseIneligibleForRewards(log types.Log) (*EcdsaSortitionPoolIneligibleForRewards, error) {
+	event := new(EcdsaSortitionPoolIneligibleForRewards)
+	if err := _EcdsaSortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// SortitionPoolOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the SortitionPool contract.
-type SortitionPoolOwnershipTransferredIterator struct {
-	Event *SortitionPoolOwnershipTransferred // Event containing the contract specifics and raw log
+// EcdsaSortitionPoolOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the EcdsaSortitionPool contract.
+type EcdsaSortitionPoolOwnershipTransferredIterator struct {
+	Event *EcdsaSortitionPoolOwnershipTransferred // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1150,7 +1150,7 @@ type SortitionPoolOwnershipTransferredIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
+func (it *EcdsaSortitionPoolOwnershipTransferredIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1159,7 +1159,7 @@ func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SortitionPoolOwnershipTransferred)
+			it.Event = new(EcdsaSortitionPoolOwnershipTransferred)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1174,7 +1174,7 @@ func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SortitionPoolOwnershipTransferred)
+		it.Event = new(EcdsaSortitionPoolOwnershipTransferred)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1190,19 +1190,19 @@ func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SortitionPoolOwnershipTransferredIterator) Error() error {
+func (it *EcdsaSortitionPoolOwnershipTransferredIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SortitionPoolOwnershipTransferredIterator) Close() error {
+func (it *EcdsaSortitionPoolOwnershipTransferredIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SortitionPoolOwnershipTransferred represents a OwnershipTransferred event raised by the SortitionPool contract.
-type SortitionPoolOwnershipTransferred struct {
+// EcdsaSortitionPoolOwnershipTransferred represents a OwnershipTransferred event raised by the EcdsaSortitionPool contract.
+type EcdsaSortitionPoolOwnershipTransferred struct {
 	PreviousOwner common.Address
 	NewOwner      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -1211,7 +1211,7 @@ type SortitionPoolOwnershipTransferred struct {
 // FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_SortitionPool *SortitionPoolFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*SortitionPoolOwnershipTransferredIterator, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*EcdsaSortitionPoolOwnershipTransferredIterator, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -1222,17 +1222,17 @@ func (_SortitionPool *SortitionPoolFilterer) FilterOwnershipTransferred(opts *bi
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _EcdsaSortitionPool.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolOwnershipTransferredIterator{contract: _SortitionPool.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+	return &EcdsaSortitionPoolOwnershipTransferredIterator{contract: _EcdsaSortitionPool.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
 }
 
 // WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *SortitionPoolOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *EcdsaSortitionPoolOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -1243,7 +1243,7 @@ func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bin
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _EcdsaSortitionPool.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,8 +1253,8 @@ func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SortitionPoolOwnershipTransferred)
-				if err := _SortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+				event := new(EcdsaSortitionPoolOwnershipTransferred)
+				if err := _EcdsaSortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1278,18 +1278,18 @@ func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bin
 // ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_SortitionPool *SortitionPoolFilterer) ParseOwnershipTransferred(log types.Log) (*SortitionPoolOwnershipTransferred, error) {
-	event := new(SortitionPoolOwnershipTransferred)
-	if err := _SortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) ParseOwnershipTransferred(log types.Log) (*EcdsaSortitionPoolOwnershipTransferred, error) {
+	event := new(EcdsaSortitionPoolOwnershipTransferred)
+	if err := _EcdsaSortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// SortitionPoolRewardEligibilityRestoredIterator is returned from FilterRewardEligibilityRestored and is used to iterate over the raw logs and unpacked data for RewardEligibilityRestored events raised by the SortitionPool contract.
-type SortitionPoolRewardEligibilityRestoredIterator struct {
-	Event *SortitionPoolRewardEligibilityRestored // Event containing the contract specifics and raw log
+// EcdsaSortitionPoolRewardEligibilityRestoredIterator is returned from FilterRewardEligibilityRestored and is used to iterate over the raw logs and unpacked data for RewardEligibilityRestored events raised by the EcdsaSortitionPool contract.
+type EcdsaSortitionPoolRewardEligibilityRestoredIterator struct {
+	Event *EcdsaSortitionPoolRewardEligibilityRestored // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1303,7 +1303,7 @@ type SortitionPoolRewardEligibilityRestoredIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
+func (it *EcdsaSortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1312,7 +1312,7 @@ func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SortitionPoolRewardEligibilityRestored)
+			it.Event = new(EcdsaSortitionPoolRewardEligibilityRestored)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1327,7 +1327,7 @@ func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SortitionPoolRewardEligibilityRestored)
+		it.Event = new(EcdsaSortitionPoolRewardEligibilityRestored)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1343,19 +1343,19 @@ func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SortitionPoolRewardEligibilityRestoredIterator) Error() error {
+func (it *EcdsaSortitionPoolRewardEligibilityRestoredIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SortitionPoolRewardEligibilityRestoredIterator) Close() error {
+func (it *EcdsaSortitionPoolRewardEligibilityRestoredIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SortitionPoolRewardEligibilityRestored represents a RewardEligibilityRestored event raised by the SortitionPool contract.
-type SortitionPoolRewardEligibilityRestored struct {
+// EcdsaSortitionPoolRewardEligibilityRestored represents a RewardEligibilityRestored event raised by the EcdsaSortitionPool contract.
+type EcdsaSortitionPoolRewardEligibilityRestored struct {
 	Operator common.Address
 	Id       uint32
 	Raw      types.Log // Blockchain specific contextual infos
@@ -1364,7 +1364,7 @@ type SortitionPoolRewardEligibilityRestored struct {
 // FilterRewardEligibilityRestored is a free log retrieval operation binding the contract event 0xe61e9f0f049b3bfae1ae903a5e3018c02a008aa0d238ffddf23a4fb4c0278536.
 //
 // Solidity: event RewardEligibilityRestored(address indexed operator, uint32 indexed id)
-func (_SortitionPool *SortitionPoolFilterer) FilterRewardEligibilityRestored(opts *bind.FilterOpts, operator []common.Address, id []uint32) (*SortitionPoolRewardEligibilityRestoredIterator, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) FilterRewardEligibilityRestored(opts *bind.FilterOpts, operator []common.Address, id []uint32) (*EcdsaSortitionPoolRewardEligibilityRestoredIterator, error) {
 
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
@@ -1375,17 +1375,17 @@ func (_SortitionPool *SortitionPoolFilterer) FilterRewardEligibilityRestored(opt
 		idRule = append(idRule, idItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.FilterLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
+	logs, sub, err := _EcdsaSortitionPool.contract.FilterLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolRewardEligibilityRestoredIterator{contract: _SortitionPool.contract, event: "RewardEligibilityRestored", logs: logs, sub: sub}, nil
+	return &EcdsaSortitionPoolRewardEligibilityRestoredIterator{contract: _EcdsaSortitionPool.contract, event: "RewardEligibilityRestored", logs: logs, sub: sub}, nil
 }
 
 // WatchRewardEligibilityRestored is a free log subscription operation binding the contract event 0xe61e9f0f049b3bfae1ae903a5e3018c02a008aa0d238ffddf23a4fb4c0278536.
 //
 // Solidity: event RewardEligibilityRestored(address indexed operator, uint32 indexed id)
-func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts *bind.WatchOpts, sink chan<- *SortitionPoolRewardEligibilityRestored, operator []common.Address, id []uint32) (event.Subscription, error) {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) WatchRewardEligibilityRestored(opts *bind.WatchOpts, sink chan<- *EcdsaSortitionPoolRewardEligibilityRestored, operator []common.Address, id []uint32) (event.Subscription, error) {
 
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
@@ -1396,7 +1396,7 @@ func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts
 		idRule = append(idRule, idItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.WatchLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
+	logs, sub, err := _EcdsaSortitionPool.contract.WatchLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1406,8 +1406,8 @@ func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SortitionPoolRewardEligibilityRestored)
-				if err := _SortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
+				event := new(EcdsaSortitionPoolRewardEligibilityRestored)
+				if err := _EcdsaSortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1431,9 +1431,9 @@ func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts
 // ParseRewardEligibilityRestored is a log parse operation binding the contract event 0xe61e9f0f049b3bfae1ae903a5e3018c02a008aa0d238ffddf23a4fb4c0278536.
 //
 // Solidity: event RewardEligibilityRestored(address indexed operator, uint32 indexed id)
-func (_SortitionPool *SortitionPoolFilterer) ParseRewardEligibilityRestored(log types.Log) (*SortitionPoolRewardEligibilityRestored, error) {
-	event := new(SortitionPoolRewardEligibilityRestored)
-	if err := _SortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
+func (_EcdsaSortitionPool *EcdsaSortitionPoolFilterer) ParseRewardEligibilityRestored(log types.Log) (*EcdsaSortitionPoolRewardEligibilityRestored, error) {
+	event := new(EcdsaSortitionPoolRewardEligibilityRestored)
+	if err := _EcdsaSortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/pkg/chain/ecdsa/gen/cmd/EcdsaSortitionPool.go
+++ b/pkg/chain/ecdsa/gen/cmd/EcdsaSortitionPool.go
@@ -21,9 +21,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-var SortitionPoolCommand cli.Command
+var EcdsaSortitionPoolCommand cli.Command
 
-var sortitionPoolDescription = `The sortition-pool command allows calling the SortitionPool contract on an
+var ecdsaSortitionPoolDescription = `The ecdsa-sortition-pool command allows calling the EcdsaSortitionPool contract on an
 	ETH-like network. It has subcommands corresponding to each contract method,
 	which respectively each take parameters based on the contract method's
 	parameters.
@@ -48,168 +48,168 @@ var sortitionPoolDescription = `The sortition-pool command allows calling the So
 
 func init() {
 	AvailableCommands = append(AvailableCommands, cli.Command{
-		Name:        "sortition-pool",
-		Usage:       `Provides access to the SortitionPool contract.`,
-		Description: sortitionPoolDescription,
+		Name:        "ecdsa-sortition-pool",
+		Usage:       `Provides access to the EcdsaSortitionPool contract.`,
+		Description: ecdsaSortitionPoolDescription,
 		Subcommands: []cli.Command{{
 			Name:      "get-available-rewards",
-			Usage:     "Calls the view method getAvailableRewards on the SortitionPool contract.",
+			Usage:     "Calls the view method getAvailableRewards on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spGetAvailableRewards,
+			Action:    espGetAvailableRewards,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "get-operator-i-d",
-			Usage:     "Calls the view method getOperatorID on the SortitionPool contract.",
+			Usage:     "Calls the view method getOperatorID on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spGetOperatorID,
+			Action:    espGetOperatorID,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "get-pool-weight",
-			Usage:     "Calls the view method getPoolWeight on the SortitionPool contract.",
+			Usage:     "Calls the view method getPoolWeight on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spGetPoolWeight,
+			Action:    espGetPoolWeight,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "ineligible-earned-rewards",
-			Usage:     "Calls the view method ineligibleEarnedRewards on the SortitionPool contract.",
+			Usage:     "Calls the view method ineligibleEarnedRewards on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spIneligibleEarnedRewards,
+			Action:    espIneligibleEarnedRewards,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-locked",
-			Usage:     "Calls the view method isLocked on the SortitionPool contract.",
+			Usage:     "Calls the view method isLocked on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spIsLocked,
+			Action:    espIsLocked,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-operator-in-pool",
-			Usage:     "Calls the view method isOperatorInPool on the SortitionPool contract.",
+			Usage:     "Calls the view method isOperatorInPool on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spIsOperatorInPool,
+			Action:    espIsOperatorInPool,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-operator-registered",
-			Usage:     "Calls the view method isOperatorRegistered on the SortitionPool contract.",
+			Usage:     "Calls the view method isOperatorRegistered on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spIsOperatorRegistered,
+			Action:    espIsOperatorRegistered,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-operator-up-to-date",
-			Usage:     "Calls the view method isOperatorUpToDate on the SortitionPool contract.",
+			Usage:     "Calls the view method isOperatorUpToDate on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_authorizedStake] ",
-			Action:    spIsOperatorUpToDate,
+			Action:    espIsOperatorUpToDate,
 			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "operators-in-pool",
-			Usage:     "Calls the view method operatorsInPool on the SortitionPool contract.",
+			Usage:     "Calls the view method operatorsInPool on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spOperatorsInPool,
+			Action:    espOperatorsInPool,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "owner",
-			Usage:     "Calls the view method owner on the SortitionPool contract.",
+			Usage:     "Calls the view method owner on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spOwner,
+			Action:    espOwner,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "pool-weight-divisor",
-			Usage:     "Calls the view method poolWeightDivisor on the SortitionPool contract.",
+			Usage:     "Calls the view method poolWeightDivisor on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spPoolWeightDivisor,
+			Action:    espPoolWeightDivisor,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "reward-token",
-			Usage:     "Calls the view method rewardToken on the SortitionPool contract.",
+			Usage:     "Calls the view method rewardToken on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spRewardToken,
+			Action:    espRewardToken,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "total-weight",
-			Usage:     "Calls the view method totalWeight on the SortitionPool contract.",
+			Usage:     "Calls the view method totalWeight on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spTotalWeight,
+			Action:    espTotalWeight,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "insert-operator",
-			Usage:     "Calls the nonpayable method insertOperator on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method insertOperator on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_authorizedStake] ",
-			Action:    spInsertOperator,
+			Action:    espInsertOperator,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "lock",
-			Usage:     "Calls the nonpayable method lock on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method lock on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spLock,
+			Action:    espLock,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "receive-approval",
-			Usage:     "Calls the nonpayable method receiveApproval on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method receiveApproval on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_sender] [arg_amount] [arg_token] [arg3] ",
-			Action:    spReceiveApproval,
+			Action:    espReceiveApproval,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "renounce-ownership",
-			Usage:     "Calls the nonpayable method renounceOwnership on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method renounceOwnership on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spRenounceOwnership,
+			Action:    espRenounceOwnership,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "restore-reward-eligibility",
-			Usage:     "Calls the nonpayable method restoreRewardEligibility on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method restoreRewardEligibility on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spRestoreRewardEligibility,
+			Action:    espRestoreRewardEligibility,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "transfer-ownership",
-			Usage:     "Calls the nonpayable method transferOwnership on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method transferOwnership on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_newOwner] ",
-			Action:    spTransferOwnership,
+			Action:    espTransferOwnership,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "unlock",
-			Usage:     "Calls the nonpayable method unlock on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method unlock on the EcdsaSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spUnlock,
+			Action:    espUnlock,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "update-operator-status",
-			Usage:     "Calls the nonpayable method updateOperatorStatus on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method updateOperatorStatus on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_authorizedStake] ",
-			Action:    spUpdateOperatorStatus,
+			Action:    espUpdateOperatorStatus,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "withdraw-ineligible",
-			Usage:     "Calls the nonpayable method withdrawIneligible on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method withdrawIneligible on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_recipient] ",
-			Action:    spWithdrawIneligible,
+			Action:    espWithdrawIneligible,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "withdraw-rewards",
-			Usage:     "Calls the nonpayable method withdrawRewards on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method withdrawRewards on the EcdsaSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_beneficiary] ",
-			Action:    spWithdrawRewards,
+			Action:    espWithdrawRewards,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}},
@@ -218,8 +218,8 @@ func init() {
 
 /// ------------------- Const methods -------------------
 
-func spGetAvailableRewards(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espGetAvailableRewards(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -246,8 +246,8 @@ func spGetAvailableRewards(c *cli.Context) error {
 	return nil
 }
 
-func spGetOperatorID(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espGetOperatorID(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -274,8 +274,8 @@ func spGetOperatorID(c *cli.Context) error {
 	return nil
 }
 
-func spGetPoolWeight(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espGetPoolWeight(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -302,8 +302,8 @@ func spGetPoolWeight(c *cli.Context) error {
 	return nil
 }
 
-func spIneligibleEarnedRewards(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espIneligibleEarnedRewards(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -322,8 +322,8 @@ func spIneligibleEarnedRewards(c *cli.Context) error {
 	return nil
 }
 
-func spIsLocked(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espIsLocked(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -342,8 +342,8 @@ func spIsLocked(c *cli.Context) error {
 	return nil
 }
 
-func spIsOperatorInPool(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espIsOperatorInPool(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -370,8 +370,8 @@ func spIsOperatorInPool(c *cli.Context) error {
 	return nil
 }
 
-func spIsOperatorRegistered(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espIsOperatorRegistered(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -398,8 +398,8 @@ func spIsOperatorRegistered(c *cli.Context) error {
 	return nil
 }
 
-func spIsOperatorUpToDate(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espIsOperatorUpToDate(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -435,8 +435,8 @@ func spIsOperatorUpToDate(c *cli.Context) error {
 	return nil
 }
 
-func spOperatorsInPool(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espOperatorsInPool(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -455,8 +455,8 @@ func spOperatorsInPool(c *cli.Context) error {
 	return nil
 }
 
-func spOwner(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espOwner(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -475,8 +475,8 @@ func spOwner(c *cli.Context) error {
 	return nil
 }
 
-func spPoolWeightDivisor(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espPoolWeightDivisor(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -495,8 +495,8 @@ func spPoolWeightDivisor(c *cli.Context) error {
 	return nil
 }
 
-func spRewardToken(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espRewardToken(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -515,8 +515,8 @@ func spRewardToken(c *cli.Context) error {
 	return nil
 }
 
-func spTotalWeight(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espTotalWeight(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -537,8 +537,8 @@ func spTotalWeight(c *cli.Context) error {
 
 /// ------------------- Non-const methods -------------------
 
-func spInsertOperator(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espInsertOperator(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -591,8 +591,8 @@ func spInsertOperator(c *cli.Context) error {
 	return nil
 }
 
-func spLock(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espLock(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -624,8 +624,8 @@ func spLock(c *cli.Context) error {
 	return nil
 }
 
-func spReceiveApproval(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espReceiveApproval(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -698,8 +698,8 @@ func spReceiveApproval(c *cli.Context) error {
 	return nil
 }
 
-func spRenounceOwnership(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espRenounceOwnership(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -731,8 +731,8 @@ func spRenounceOwnership(c *cli.Context) error {
 	return nil
 }
 
-func spRestoreRewardEligibility(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espRestoreRewardEligibility(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -775,8 +775,8 @@ func spRestoreRewardEligibility(c *cli.Context) error {
 	return nil
 }
 
-func spTransferOwnership(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espTransferOwnership(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -819,8 +819,8 @@ func spTransferOwnership(c *cli.Context) error {
 	return nil
 }
 
-func spUnlock(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espUnlock(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -852,8 +852,8 @@ func spUnlock(c *cli.Context) error {
 	return nil
 }
 
-func spUpdateOperatorStatus(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espUpdateOperatorStatus(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -906,8 +906,8 @@ func spUpdateOperatorStatus(c *cli.Context) error {
 	return nil
 }
 
-func spWithdrawIneligible(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espWithdrawIneligible(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -950,8 +950,8 @@ func spWithdrawIneligible(c *cli.Context) error {
 	return nil
 }
 
-func spWithdrawRewards(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func espWithdrawRewards(c *cli.Context) error {
+	contract, err := initializeEcdsaSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -1007,7 +1007,7 @@ func spWithdrawRewards(c *cli.Context) error {
 
 /// ------------------- Initialization -------------------
 
-func initializeSortitionPool(c *cli.Context) (*contract.SortitionPool, error) {
+func initializeEcdsaSortitionPool(c *cli.Context) (*contract.EcdsaSortitionPool, error) {
 	config, err := config.ReadEthereumConfig(c.GlobalString("config"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading config from file: [%v]", err)
@@ -1048,9 +1048,9 @@ func initializeSortitionPool(c *cli.Context) (*contract.SortitionPool, error) {
 		)
 	}
 
-	address := common.HexToAddress(config.ContractAddresses["SortitionPool"])
+	address := common.HexToAddress(config.ContractAddresses["EcdsaSortitionPool"])
 
-	return contract.NewSortitionPool(
+	return contract.NewEcdsaSortitionPool(
 		address,
 		chainID,
 		key,

--- a/pkg/chain/ethereum/beacon.go
+++ b/pkg/chain/ethereum/beacon.go
@@ -21,7 +21,7 @@ type BeaconChain struct {
 	*Chain
 
 	randomBeacon  *contract.RandomBeacon
-	sortitionPool *contract.SortitionPool
+	sortitionPool *contract.BeaconSortitionPool
 }
 
 // newBeaconChain construct a new instance of the beacon-specific Ethereum
@@ -66,7 +66,7 @@ func newBeaconChain(
 	}
 
 	sortitionPool, err :=
-		contract.NewSortitionPool(
+		contract.NewBeaconSortitionPool(
 			sortitionPoolAddress,
 			baseChain.chainID,
 			baseChain.key,

--- a/pkg/chain/ethereum/beacon.go
+++ b/pkg/chain/ethereum/beacon.go
@@ -78,7 +78,7 @@ func newBeaconChain(
 		)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to attach to SortitionPool contract: [%v]",
+			"failed to attach to BeaconSortitionPool contract: [%v]",
 			err,
 		)
 	}

--- a/pkg/chain/random-beacon/gen/Makefile
+++ b/pkg/chain/random-beacon/gen/Makefile
@@ -1,6 +1,6 @@
 npm_package_name=@keep-network/random-beacon
 
 # Contracts for which the bindings should be generated.
-required_contracts := RandomBeacon SortitionPool
+required_contracts := RandomBeacon BeaconSortitionPool
 
 include ../../common/gen/Makefile

--- a/pkg/chain/random-beacon/gen/abi/BeaconSortitionPool.go
+++ b/pkg/chain/random-beacon/gen/abi/BeaconSortitionPool.go
@@ -28,113 +28,113 @@ var (
 	_ = event.NewSubscription
 )
 
-// SortitionPoolMetaData contains all meta data concerning the SortitionPool contract.
-var SortitionPoolMetaData = &bind.MetaData{
+// BeaconSortitionPoolMetaData contains all meta data concerning the BeaconSortitionPool contract.
+var BeaconSortitionPoolMetaData = &bind.MetaData{
 	ABI: "[{\"inputs\":[{\"internalType\":\"contractIERC20WithPermit\",\"name\":\"_rewardToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_poolWeightDivisor\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32[]\",\"name\":\"ids\",\"type\":\"uint32[]\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"until\",\"type\":\"uint256\"}],\"name\":\"IneligibleForRewards\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"id\",\"type\":\"uint32\"}],\"name\":\"RewardEligibilityRestored\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"operator\",\"type\":\"uint32\"}],\"name\":\"canRestoreRewardEligibility\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getAvailableRewards\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"id\",\"type\":\"uint32\"}],\"name\":\"getIDOperator\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32[]\",\"name\":\"ids\",\"type\":\"uint32[]\"}],\"name\":\"getIDOperators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getOperatorID\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getPoolWeight\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ineligibleEarnedRewards\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"authorizedStake\",\"type\":\"uint256\"}],\"name\":\"insertOperator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"operator\",\"type\":\"uint32\"}],\"name\":\"isEligibleForRewards\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"isLocked\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isOperatorInPool\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isOperatorRegistered\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"authorizedStake\",\"type\":\"uint256\"}],\"name\":\"isOperatorUpToDate\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"lock\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"operatorsInPool\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"poolWeightDivisor\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"receiveApproval\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"restoreRewardEligibility\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"rewardToken\",\"outputs\":[{\"internalType\":\"contractIERC20WithPermit\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"operator\",\"type\":\"uint32\"}],\"name\":\"rewardsEligibilityRestorableAt\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"groupSize\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"seed\",\"type\":\"bytes32\"}],\"name\":\"selectGroup\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"\",\"type\":\"uint32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32[]\",\"name\":\"operators\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256\",\"name\":\"until\",\"type\":\"uint256\"}],\"name\":\"setRewardIneligibility\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalWeight\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unlock\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"authorizedStake\",\"type\":\"uint256\"}],\"name\":\"updateOperatorStatus\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"withdrawIneligible\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"beneficiary\",\"type\":\"address\"}],\"name\":\"withdrawRewards\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
-// SortitionPoolABI is the input ABI used to generate the binding from.
-// Deprecated: Use SortitionPoolMetaData.ABI instead.
-var SortitionPoolABI = SortitionPoolMetaData.ABI
+// BeaconSortitionPoolABI is the input ABI used to generate the binding from.
+// Deprecated: Use BeaconSortitionPoolMetaData.ABI instead.
+var BeaconSortitionPoolABI = BeaconSortitionPoolMetaData.ABI
 
-// SortitionPool is an auto generated Go binding around an Ethereum contract.
-type SortitionPool struct {
-	SortitionPoolCaller     // Read-only binding to the contract
-	SortitionPoolTransactor // Write-only binding to the contract
-	SortitionPoolFilterer   // Log filterer for contract events
+// BeaconSortitionPool is an auto generated Go binding around an Ethereum contract.
+type BeaconSortitionPool struct {
+	BeaconSortitionPoolCaller     // Read-only binding to the contract
+	BeaconSortitionPoolTransactor // Write-only binding to the contract
+	BeaconSortitionPoolFilterer   // Log filterer for contract events
 }
 
-// SortitionPoolCaller is an auto generated read-only Go binding around an Ethereum contract.
-type SortitionPoolCaller struct {
+// BeaconSortitionPoolCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BeaconSortitionPoolCaller struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// SortitionPoolTransactor is an auto generated write-only Go binding around an Ethereum contract.
-type SortitionPoolTransactor struct {
+// BeaconSortitionPoolTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BeaconSortitionPoolTransactor struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// SortitionPoolFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
-type SortitionPoolFilterer struct {
+// BeaconSortitionPoolFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BeaconSortitionPoolFilterer struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// SortitionPoolSession is an auto generated Go binding around an Ethereum contract,
+// BeaconSortitionPoolSession is an auto generated Go binding around an Ethereum contract,
 // with pre-set call and transact options.
-type SortitionPoolSession struct {
-	Contract     *SortitionPool    // Generic contract binding to set the session for
-	CallOpts     bind.CallOpts     // Call options to use throughout this session
-	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+type BeaconSortitionPoolSession struct {
+	Contract     *BeaconSortitionPool // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts        // Call options to use throughout this session
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
 }
 
-// SortitionPoolCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// BeaconSortitionPoolCallerSession is an auto generated read-only Go binding around an Ethereum contract,
 // with pre-set call options.
-type SortitionPoolCallerSession struct {
-	Contract *SortitionPoolCaller // Generic contract caller binding to set the session for
-	CallOpts bind.CallOpts        // Call options to use throughout this session
+type BeaconSortitionPoolCallerSession struct {
+	Contract *BeaconSortitionPoolCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts              // Call options to use throughout this session
 }
 
-// SortitionPoolTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// BeaconSortitionPoolTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
 // with pre-set transact options.
-type SortitionPoolTransactorSession struct {
-	Contract     *SortitionPoolTransactor // Generic contract transactor binding to set the session for
-	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+type BeaconSortitionPoolTransactorSession struct {
+	Contract     *BeaconSortitionPoolTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts              // Transaction auth options to use throughout this session
 }
 
-// SortitionPoolRaw is an auto generated low-level Go binding around an Ethereum contract.
-type SortitionPoolRaw struct {
-	Contract *SortitionPool // Generic contract binding to access the raw methods on
+// BeaconSortitionPoolRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BeaconSortitionPoolRaw struct {
+	Contract *BeaconSortitionPool // Generic contract binding to access the raw methods on
 }
 
-// SortitionPoolCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
-type SortitionPoolCallerRaw struct {
-	Contract *SortitionPoolCaller // Generic read-only contract binding to access the raw methods on
+// BeaconSortitionPoolCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BeaconSortitionPoolCallerRaw struct {
+	Contract *BeaconSortitionPoolCaller // Generic read-only contract binding to access the raw methods on
 }
 
-// SortitionPoolTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
-type SortitionPoolTransactorRaw struct {
-	Contract *SortitionPoolTransactor // Generic write-only contract binding to access the raw methods on
+// BeaconSortitionPoolTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BeaconSortitionPoolTransactorRaw struct {
+	Contract *BeaconSortitionPoolTransactor // Generic write-only contract binding to access the raw methods on
 }
 
-// NewSortitionPool creates a new instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPool(address common.Address, backend bind.ContractBackend) (*SortitionPool, error) {
-	contract, err := bindSortitionPool(address, backend, backend, backend)
+// NewBeaconSortitionPool creates a new instance of BeaconSortitionPool, bound to a specific deployed contract.
+func NewBeaconSortitionPool(address common.Address, backend bind.ContractBackend) (*BeaconSortitionPool, error) {
+	contract, err := bindBeaconSortitionPool(address, backend, backend, backend)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPool{SortitionPoolCaller: SortitionPoolCaller{contract: contract}, SortitionPoolTransactor: SortitionPoolTransactor{contract: contract}, SortitionPoolFilterer: SortitionPoolFilterer{contract: contract}}, nil
+	return &BeaconSortitionPool{BeaconSortitionPoolCaller: BeaconSortitionPoolCaller{contract: contract}, BeaconSortitionPoolTransactor: BeaconSortitionPoolTransactor{contract: contract}, BeaconSortitionPoolFilterer: BeaconSortitionPoolFilterer{contract: contract}}, nil
 }
 
-// NewSortitionPoolCaller creates a new read-only instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPoolCaller(address common.Address, caller bind.ContractCaller) (*SortitionPoolCaller, error) {
-	contract, err := bindSortitionPool(address, caller, nil, nil)
+// NewBeaconSortitionPoolCaller creates a new read-only instance of BeaconSortitionPool, bound to a specific deployed contract.
+func NewBeaconSortitionPoolCaller(address common.Address, caller bind.ContractCaller) (*BeaconSortitionPoolCaller, error) {
+	contract, err := bindBeaconSortitionPool(address, caller, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolCaller{contract: contract}, nil
+	return &BeaconSortitionPoolCaller{contract: contract}, nil
 }
 
-// NewSortitionPoolTransactor creates a new write-only instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPoolTransactor(address common.Address, transactor bind.ContractTransactor) (*SortitionPoolTransactor, error) {
-	contract, err := bindSortitionPool(address, nil, transactor, nil)
+// NewBeaconSortitionPoolTransactor creates a new write-only instance of BeaconSortitionPool, bound to a specific deployed contract.
+func NewBeaconSortitionPoolTransactor(address common.Address, transactor bind.ContractTransactor) (*BeaconSortitionPoolTransactor, error) {
+	contract, err := bindBeaconSortitionPool(address, nil, transactor, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolTransactor{contract: contract}, nil
+	return &BeaconSortitionPoolTransactor{contract: contract}, nil
 }
 
-// NewSortitionPoolFilterer creates a new log filterer instance of SortitionPool, bound to a specific deployed contract.
-func NewSortitionPoolFilterer(address common.Address, filterer bind.ContractFilterer) (*SortitionPoolFilterer, error) {
-	contract, err := bindSortitionPool(address, nil, nil, filterer)
+// NewBeaconSortitionPoolFilterer creates a new log filterer instance of BeaconSortitionPool, bound to a specific deployed contract.
+func NewBeaconSortitionPoolFilterer(address common.Address, filterer bind.ContractFilterer) (*BeaconSortitionPoolFilterer, error) {
+	contract, err := bindBeaconSortitionPool(address, nil, nil, filterer)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolFilterer{contract: contract}, nil
+	return &BeaconSortitionPoolFilterer{contract: contract}, nil
 }
 
-// bindSortitionPool binds a generic wrapper to an already deployed contract.
-func bindSortitionPool(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(SortitionPoolABI))
+// bindBeaconSortitionPool binds a generic wrapper to an already deployed contract.
+func bindBeaconSortitionPool(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(BeaconSortitionPoolABI))
 	if err != nil {
 		return nil, err
 	}
@@ -145,46 +145,46 @@ func bindSortitionPool(address common.Address, caller bind.ContractCaller, trans
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_SortitionPool *SortitionPoolRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _SortitionPool.Contract.SortitionPoolCaller.contract.Call(opts, result, method, params...)
+func (_BeaconSortitionPool *BeaconSortitionPoolRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BeaconSortitionPool.Contract.BeaconSortitionPoolCaller.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_SortitionPool *SortitionPoolRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SortitionPoolTransactor.contract.Transfer(opts)
+func (_BeaconSortitionPool *BeaconSortitionPoolRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.BeaconSortitionPoolTransactor.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_SortitionPool *SortitionPoolRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SortitionPoolTransactor.contract.Transact(opts, method, params...)
+func (_BeaconSortitionPool *BeaconSortitionPoolRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.BeaconSortitionPoolTransactor.contract.Transact(opts, method, params...)
 }
 
 // Call invokes the (constant) contract method with params as input values and
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_SortitionPool *SortitionPoolCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _SortitionPool.Contract.contract.Call(opts, result, method, params...)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BeaconSortitionPool.Contract.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_SortitionPool *SortitionPoolTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.Contract.contract.Transfer(opts)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_SortitionPool *SortitionPoolTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _SortitionPool.Contract.contract.Transact(opts, method, params...)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.contract.Transact(opts, method, params...)
 }
 
 // CanRestoreRewardEligibility is a free data retrieval call binding the contract method 0x69ba3c33.
 //
 // Solidity: function canRestoreRewardEligibility(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) CanRestoreRewardEligibility(opts *bind.CallOpts, operator uint32) (bool, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) CanRestoreRewardEligibility(opts *bind.CallOpts, operator uint32) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "canRestoreRewardEligibility", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "canRestoreRewardEligibility", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -199,23 +199,23 @@ func (_SortitionPool *SortitionPoolCaller) CanRestoreRewardEligibility(opts *bin
 // CanRestoreRewardEligibility is a free data retrieval call binding the contract method 0x69ba3c33.
 //
 // Solidity: function canRestoreRewardEligibility(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.CanRestoreRewardEligibility(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
+	return _BeaconSortitionPool.Contract.CanRestoreRewardEligibility(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // CanRestoreRewardEligibility is a free data retrieval call binding the contract method 0x69ba3c33.
 //
 // Solidity: function canRestoreRewardEligibility(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.CanRestoreRewardEligibility(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) CanRestoreRewardEligibility(operator uint32) (bool, error) {
+	return _BeaconSortitionPool.Contract.CanRestoreRewardEligibility(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // GetAvailableRewards is a free data retrieval call binding the contract method 0x873e31fa.
 //
 // Solidity: function getAvailableRewards(address operator) view returns(uint96)
-func (_SortitionPool *SortitionPoolCaller) GetAvailableRewards(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) GetAvailableRewards(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getAvailableRewards", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "getAvailableRewards", operator)
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -230,23 +230,23 @@ func (_SortitionPool *SortitionPoolCaller) GetAvailableRewards(opts *bind.CallOp
 // GetAvailableRewards is a free data retrieval call binding the contract method 0x873e31fa.
 //
 // Solidity: function getAvailableRewards(address operator) view returns(uint96)
-func (_SortitionPool *SortitionPoolSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetAvailableRewards(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.GetAvailableRewards(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // GetAvailableRewards is a free data retrieval call binding the contract method 0x873e31fa.
 //
 // Solidity: function getAvailableRewards(address operator) view returns(uint96)
-func (_SortitionPool *SortitionPoolCallerSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetAvailableRewards(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) GetAvailableRewards(operator common.Address) (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.GetAvailableRewards(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // GetIDOperator is a free data retrieval call binding the contract method 0x8871ca5d.
 //
 // Solidity: function getIDOperator(uint32 id) view returns(address)
-func (_SortitionPool *SortitionPoolCaller) GetIDOperator(opts *bind.CallOpts, id uint32) (common.Address, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) GetIDOperator(opts *bind.CallOpts, id uint32) (common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getIDOperator", id)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "getIDOperator", id)
 
 	if err != nil {
 		return *new(common.Address), err
@@ -261,23 +261,23 @@ func (_SortitionPool *SortitionPoolCaller) GetIDOperator(opts *bind.CallOpts, id
 // GetIDOperator is a free data retrieval call binding the contract method 0x8871ca5d.
 //
 // Solidity: function getIDOperator(uint32 id) view returns(address)
-func (_SortitionPool *SortitionPoolSession) GetIDOperator(id uint32) (common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperator(&_SortitionPool.CallOpts, id)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) GetIDOperator(id uint32) (common.Address, error) {
+	return _BeaconSortitionPool.Contract.GetIDOperator(&_BeaconSortitionPool.CallOpts, id)
 }
 
 // GetIDOperator is a free data retrieval call binding the contract method 0x8871ca5d.
 //
 // Solidity: function getIDOperator(uint32 id) view returns(address)
-func (_SortitionPool *SortitionPoolCallerSession) GetIDOperator(id uint32) (common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperator(&_SortitionPool.CallOpts, id)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) GetIDOperator(id uint32) (common.Address, error) {
+	return _BeaconSortitionPool.Contract.GetIDOperator(&_BeaconSortitionPool.CallOpts, id)
 }
 
 // GetIDOperators is a free data retrieval call binding the contract method 0xf7f9a8fa.
 //
 // Solidity: function getIDOperators(uint32[] ids) view returns(address[])
-func (_SortitionPool *SortitionPoolCaller) GetIDOperators(opts *bind.CallOpts, ids []uint32) ([]common.Address, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) GetIDOperators(opts *bind.CallOpts, ids []uint32) ([]common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getIDOperators", ids)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "getIDOperators", ids)
 
 	if err != nil {
 		return *new([]common.Address), err
@@ -292,23 +292,23 @@ func (_SortitionPool *SortitionPoolCaller) GetIDOperators(opts *bind.CallOpts, i
 // GetIDOperators is a free data retrieval call binding the contract method 0xf7f9a8fa.
 //
 // Solidity: function getIDOperators(uint32[] ids) view returns(address[])
-func (_SortitionPool *SortitionPoolSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperators(&_SortitionPool.CallOpts, ids)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
+	return _BeaconSortitionPool.Contract.GetIDOperators(&_BeaconSortitionPool.CallOpts, ids)
 }
 
 // GetIDOperators is a free data retrieval call binding the contract method 0xf7f9a8fa.
 //
 // Solidity: function getIDOperators(uint32[] ids) view returns(address[])
-func (_SortitionPool *SortitionPoolCallerSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
-	return _SortitionPool.Contract.GetIDOperators(&_SortitionPool.CallOpts, ids)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) GetIDOperators(ids []uint32) ([]common.Address, error) {
+	return _BeaconSortitionPool.Contract.GetIDOperators(&_BeaconSortitionPool.CallOpts, ids)
 }
 
 // GetOperatorID is a free data retrieval call binding the contract method 0x5a48b46b.
 //
 // Solidity: function getOperatorID(address operator) view returns(uint32)
-func (_SortitionPool *SortitionPoolCaller) GetOperatorID(opts *bind.CallOpts, operator common.Address) (uint32, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) GetOperatorID(opts *bind.CallOpts, operator common.Address) (uint32, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getOperatorID", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "getOperatorID", operator)
 
 	if err != nil {
 		return *new(uint32), err
@@ -323,23 +323,23 @@ func (_SortitionPool *SortitionPoolCaller) GetOperatorID(opts *bind.CallOpts, op
 // GetOperatorID is a free data retrieval call binding the contract method 0x5a48b46b.
 //
 // Solidity: function getOperatorID(address operator) view returns(uint32)
-func (_SortitionPool *SortitionPoolSession) GetOperatorID(operator common.Address) (uint32, error) {
-	return _SortitionPool.Contract.GetOperatorID(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) GetOperatorID(operator common.Address) (uint32, error) {
+	return _BeaconSortitionPool.Contract.GetOperatorID(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // GetOperatorID is a free data retrieval call binding the contract method 0x5a48b46b.
 //
 // Solidity: function getOperatorID(address operator) view returns(uint32)
-func (_SortitionPool *SortitionPoolCallerSession) GetOperatorID(operator common.Address) (uint32, error) {
-	return _SortitionPool.Contract.GetOperatorID(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) GetOperatorID(operator common.Address) (uint32, error) {
+	return _BeaconSortitionPool.Contract.GetOperatorID(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // GetPoolWeight is a free data retrieval call binding the contract method 0x5757ed5b.
 //
 // Solidity: function getPoolWeight(address operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) GetPoolWeight(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) GetPoolWeight(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "getPoolWeight", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "getPoolWeight", operator)
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -354,23 +354,23 @@ func (_SortitionPool *SortitionPoolCaller) GetPoolWeight(opts *bind.CallOpts, op
 // GetPoolWeight is a free data retrieval call binding the contract method 0x5757ed5b.
 //
 // Solidity: function getPoolWeight(address operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetPoolWeight(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.GetPoolWeight(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // GetPoolWeight is a free data retrieval call binding the contract method 0x5757ed5b.
 //
 // Solidity: function getPoolWeight(address operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
-	return _SortitionPool.Contract.GetPoolWeight(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) GetPoolWeight(operator common.Address) (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.GetPoolWeight(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IneligibleEarnedRewards is a free data retrieval call binding the contract method 0xa7a7d391.
 //
 // Solidity: function ineligibleEarnedRewards() view returns(uint96)
-func (_SortitionPool *SortitionPoolCaller) IneligibleEarnedRewards(opts *bind.CallOpts) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) IneligibleEarnedRewards(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "ineligibleEarnedRewards")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "ineligibleEarnedRewards")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -385,23 +385,23 @@ func (_SortitionPool *SortitionPoolCaller) IneligibleEarnedRewards(opts *bind.Ca
 // IneligibleEarnedRewards is a free data retrieval call binding the contract method 0xa7a7d391.
 //
 // Solidity: function ineligibleEarnedRewards() view returns(uint96)
-func (_SortitionPool *SortitionPoolSession) IneligibleEarnedRewards() (*big.Int, error) {
-	return _SortitionPool.Contract.IneligibleEarnedRewards(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) IneligibleEarnedRewards() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.IneligibleEarnedRewards(&_BeaconSortitionPool.CallOpts)
 }
 
 // IneligibleEarnedRewards is a free data retrieval call binding the contract method 0xa7a7d391.
 //
 // Solidity: function ineligibleEarnedRewards() view returns(uint96)
-func (_SortitionPool *SortitionPoolCallerSession) IneligibleEarnedRewards() (*big.Int, error) {
-	return _SortitionPool.Contract.IneligibleEarnedRewards(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) IneligibleEarnedRewards() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.IneligibleEarnedRewards(&_BeaconSortitionPool.CallOpts)
 }
 
 // IsEligibleForRewards is a free data retrieval call binding the contract method 0x5222580a.
 //
 // Solidity: function isEligibleForRewards(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsEligibleForRewards(opts *bind.CallOpts, operator uint32) (bool, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) IsEligibleForRewards(opts *bind.CallOpts, operator uint32) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isEligibleForRewards", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "isEligibleForRewards", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -416,23 +416,23 @@ func (_SortitionPool *SortitionPoolCaller) IsEligibleForRewards(opts *bind.CallO
 // IsEligibleForRewards is a free data retrieval call binding the contract method 0x5222580a.
 //
 // Solidity: function isEligibleForRewards(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsEligibleForRewards(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.IsEligibleForRewards(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) IsEligibleForRewards(operator uint32) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsEligibleForRewards(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IsEligibleForRewards is a free data retrieval call binding the contract method 0x5222580a.
 //
 // Solidity: function isEligibleForRewards(uint32 operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsEligibleForRewards(operator uint32) (bool, error) {
-	return _SortitionPool.Contract.IsEligibleForRewards(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) IsEligibleForRewards(operator uint32) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsEligibleForRewards(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IsLocked is a free data retrieval call binding the contract method 0xa4e2d634.
 //
 // Solidity: function isLocked() view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsLocked(opts *bind.CallOpts) (bool, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) IsLocked(opts *bind.CallOpts) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isLocked")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "isLocked")
 
 	if err != nil {
 		return *new(bool), err
@@ -447,23 +447,23 @@ func (_SortitionPool *SortitionPoolCaller) IsLocked(opts *bind.CallOpts) (bool, 
 // IsLocked is a free data retrieval call binding the contract method 0xa4e2d634.
 //
 // Solidity: function isLocked() view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsLocked() (bool, error) {
-	return _SortitionPool.Contract.IsLocked(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) IsLocked() (bool, error) {
+	return _BeaconSortitionPool.Contract.IsLocked(&_BeaconSortitionPool.CallOpts)
 }
 
 // IsLocked is a free data retrieval call binding the contract method 0xa4e2d634.
 //
 // Solidity: function isLocked() view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsLocked() (bool, error) {
-	return _SortitionPool.Contract.IsLocked(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) IsLocked() (bool, error) {
+	return _BeaconSortitionPool.Contract.IsLocked(&_BeaconSortitionPool.CallOpts)
 }
 
 // IsOperatorInPool is a free data retrieval call binding the contract method 0xf7186ce0.
 //
 // Solidity: function isOperatorInPool(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsOperatorInPool(opts *bind.CallOpts, operator common.Address) (bool, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) IsOperatorInPool(opts *bind.CallOpts, operator common.Address) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isOperatorInPool", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "isOperatorInPool", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -478,23 +478,23 @@ func (_SortitionPool *SortitionPoolCaller) IsOperatorInPool(opts *bind.CallOpts,
 // IsOperatorInPool is a free data retrieval call binding the contract method 0xf7186ce0.
 //
 // Solidity: function isOperatorInPool(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsOperatorInPool(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorInPool(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) IsOperatorInPool(operator common.Address) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsOperatorInPool(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorInPool is a free data retrieval call binding the contract method 0xf7186ce0.
 //
 // Solidity: function isOperatorInPool(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsOperatorInPool(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorInPool(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) IsOperatorInPool(operator common.Address) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsOperatorInPool(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorRegistered is a free data retrieval call binding the contract method 0x6b1906f8.
 //
 // Solidity: function isOperatorRegistered(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsOperatorRegistered(opts *bind.CallOpts, operator common.Address) (bool, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) IsOperatorRegistered(opts *bind.CallOpts, operator common.Address) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isOperatorRegistered", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "isOperatorRegistered", operator)
 
 	if err != nil {
 		return *new(bool), err
@@ -509,23 +509,23 @@ func (_SortitionPool *SortitionPoolCaller) IsOperatorRegistered(opts *bind.CallO
 // IsOperatorRegistered is a free data retrieval call binding the contract method 0x6b1906f8.
 //
 // Solidity: function isOperatorRegistered(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsOperatorRegistered(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorRegistered(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) IsOperatorRegistered(operator common.Address) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsOperatorRegistered(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorRegistered is a free data retrieval call binding the contract method 0x6b1906f8.
 //
 // Solidity: function isOperatorRegistered(address operator) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsOperatorRegistered(operator common.Address) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorRegistered(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) IsOperatorRegistered(operator common.Address) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsOperatorRegistered(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // IsOperatorUpToDate is a free data retrieval call binding the contract method 0x4de824f0.
 //
 // Solidity: function isOperatorUpToDate(address operator, uint256 authorizedStake) view returns(bool)
-func (_SortitionPool *SortitionPoolCaller) IsOperatorUpToDate(opts *bind.CallOpts, operator common.Address, authorizedStake *big.Int) (bool, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) IsOperatorUpToDate(opts *bind.CallOpts, operator common.Address, authorizedStake *big.Int) (bool, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "isOperatorUpToDate", operator, authorizedStake)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "isOperatorUpToDate", operator, authorizedStake)
 
 	if err != nil {
 		return *new(bool), err
@@ -540,23 +540,23 @@ func (_SortitionPool *SortitionPoolCaller) IsOperatorUpToDate(opts *bind.CallOpt
 // IsOperatorUpToDate is a free data retrieval call binding the contract method 0x4de824f0.
 //
 // Solidity: function isOperatorUpToDate(address operator, uint256 authorizedStake) view returns(bool)
-func (_SortitionPool *SortitionPoolSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorUpToDate(&_SortitionPool.CallOpts, operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsOperatorUpToDate(&_BeaconSortitionPool.CallOpts, operator, authorizedStake)
 }
 
 // IsOperatorUpToDate is a free data retrieval call binding the contract method 0x4de824f0.
 //
 // Solidity: function isOperatorUpToDate(address operator, uint256 authorizedStake) view returns(bool)
-func (_SortitionPool *SortitionPoolCallerSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
-	return _SortitionPool.Contract.IsOperatorUpToDate(&_SortitionPool.CallOpts, operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) IsOperatorUpToDate(operator common.Address, authorizedStake *big.Int) (bool, error) {
+	return _BeaconSortitionPool.Contract.IsOperatorUpToDate(&_BeaconSortitionPool.CallOpts, operator, authorizedStake)
 }
 
 // OperatorsInPool is a free data retrieval call binding the contract method 0xe7bfd899.
 //
 // Solidity: function operatorsInPool() view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) OperatorsInPool(opts *bind.CallOpts) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) OperatorsInPool(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "operatorsInPool")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "operatorsInPool")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -571,23 +571,23 @@ func (_SortitionPool *SortitionPoolCaller) OperatorsInPool(opts *bind.CallOpts) 
 // OperatorsInPool is a free data retrieval call binding the contract method 0xe7bfd899.
 //
 // Solidity: function operatorsInPool() view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) OperatorsInPool() (*big.Int, error) {
-	return _SortitionPool.Contract.OperatorsInPool(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) OperatorsInPool() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.OperatorsInPool(&_BeaconSortitionPool.CallOpts)
 }
 
 // OperatorsInPool is a free data retrieval call binding the contract method 0xe7bfd899.
 //
 // Solidity: function operatorsInPool() view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) OperatorsInPool() (*big.Int, error) {
-	return _SortitionPool.Contract.OperatorsInPool(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) OperatorsInPool() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.OperatorsInPool(&_BeaconSortitionPool.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_SortitionPool *SortitionPoolCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "owner")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "owner")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -602,23 +602,23 @@ func (_SortitionPool *SortitionPoolCaller) Owner(opts *bind.CallOpts) (common.Ad
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_SortitionPool *SortitionPoolSession) Owner() (common.Address, error) {
-	return _SortitionPool.Contract.Owner(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) Owner() (common.Address, error) {
+	return _BeaconSortitionPool.Contract.Owner(&_BeaconSortitionPool.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_SortitionPool *SortitionPoolCallerSession) Owner() (common.Address, error) {
-	return _SortitionPool.Contract.Owner(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) Owner() (common.Address, error) {
+	return _BeaconSortitionPool.Contract.Owner(&_BeaconSortitionPool.CallOpts)
 }
 
 // PoolWeightDivisor is a free data retrieval call binding the contract method 0x43a3db30.
 //
 // Solidity: function poolWeightDivisor() view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) PoolWeightDivisor(opts *bind.CallOpts) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) PoolWeightDivisor(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "poolWeightDivisor")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "poolWeightDivisor")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -633,23 +633,23 @@ func (_SortitionPool *SortitionPoolCaller) PoolWeightDivisor(opts *bind.CallOpts
 // PoolWeightDivisor is a free data retrieval call binding the contract method 0x43a3db30.
 //
 // Solidity: function poolWeightDivisor() view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) PoolWeightDivisor() (*big.Int, error) {
-	return _SortitionPool.Contract.PoolWeightDivisor(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) PoolWeightDivisor() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.PoolWeightDivisor(&_BeaconSortitionPool.CallOpts)
 }
 
 // PoolWeightDivisor is a free data retrieval call binding the contract method 0x43a3db30.
 //
 // Solidity: function poolWeightDivisor() view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) PoolWeightDivisor() (*big.Int, error) {
-	return _SortitionPool.Contract.PoolWeightDivisor(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) PoolWeightDivisor() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.PoolWeightDivisor(&_BeaconSortitionPool.CallOpts)
 }
 
 // RewardToken is a free data retrieval call binding the contract method 0xf7c618c1.
 //
 // Solidity: function rewardToken() view returns(address)
-func (_SortitionPool *SortitionPoolCaller) RewardToken(opts *bind.CallOpts) (common.Address, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) RewardToken(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "rewardToken")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "rewardToken")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -664,23 +664,23 @@ func (_SortitionPool *SortitionPoolCaller) RewardToken(opts *bind.CallOpts) (com
 // RewardToken is a free data retrieval call binding the contract method 0xf7c618c1.
 //
 // Solidity: function rewardToken() view returns(address)
-func (_SortitionPool *SortitionPoolSession) RewardToken() (common.Address, error) {
-	return _SortitionPool.Contract.RewardToken(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) RewardToken() (common.Address, error) {
+	return _BeaconSortitionPool.Contract.RewardToken(&_BeaconSortitionPool.CallOpts)
 }
 
 // RewardToken is a free data retrieval call binding the contract method 0xf7c618c1.
 //
 // Solidity: function rewardToken() view returns(address)
-func (_SortitionPool *SortitionPoolCallerSession) RewardToken() (common.Address, error) {
-	return _SortitionPool.Contract.RewardToken(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) RewardToken() (common.Address, error) {
+	return _BeaconSortitionPool.Contract.RewardToken(&_BeaconSortitionPool.CallOpts)
 }
 
 // RewardsEligibilityRestorableAt is a free data retrieval call binding the contract method 0xbe51fb4a.
 //
 // Solidity: function rewardsEligibilityRestorableAt(uint32 operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) RewardsEligibilityRestorableAt(opts *bind.CallOpts, operator uint32) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) RewardsEligibilityRestorableAt(opts *bind.CallOpts, operator uint32) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "rewardsEligibilityRestorableAt", operator)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "rewardsEligibilityRestorableAt", operator)
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -695,23 +695,23 @@ func (_SortitionPool *SortitionPoolCaller) RewardsEligibilityRestorableAt(opts *
 // RewardsEligibilityRestorableAt is a free data retrieval call binding the contract method 0xbe51fb4a.
 //
 // Solidity: function rewardsEligibilityRestorableAt(uint32 operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
-	return _SortitionPool.Contract.RewardsEligibilityRestorableAt(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.RewardsEligibilityRestorableAt(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // RewardsEligibilityRestorableAt is a free data retrieval call binding the contract method 0xbe51fb4a.
 //
 // Solidity: function rewardsEligibilityRestorableAt(uint32 operator) view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
-	return _SortitionPool.Contract.RewardsEligibilityRestorableAt(&_SortitionPool.CallOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) RewardsEligibilityRestorableAt(operator uint32) (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.RewardsEligibilityRestorableAt(&_BeaconSortitionPool.CallOpts, operator)
 }
 
 // SelectGroup is a free data retrieval call binding the contract method 0x6c2530b9.
 //
 // Solidity: function selectGroup(uint256 groupSize, bytes32 seed) view returns(uint32[])
-func (_SortitionPool *SortitionPoolCaller) SelectGroup(opts *bind.CallOpts, groupSize *big.Int, seed [32]byte) ([]uint32, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) SelectGroup(opts *bind.CallOpts, groupSize *big.Int, seed [32]byte) ([]uint32, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "selectGroup", groupSize, seed)
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "selectGroup", groupSize, seed)
 
 	if err != nil {
 		return *new([]uint32), err
@@ -726,23 +726,23 @@ func (_SortitionPool *SortitionPoolCaller) SelectGroup(opts *bind.CallOpts, grou
 // SelectGroup is a free data retrieval call binding the contract method 0x6c2530b9.
 //
 // Solidity: function selectGroup(uint256 groupSize, bytes32 seed) view returns(uint32[])
-func (_SortitionPool *SortitionPoolSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
-	return _SortitionPool.Contract.SelectGroup(&_SortitionPool.CallOpts, groupSize, seed)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
+	return _BeaconSortitionPool.Contract.SelectGroup(&_BeaconSortitionPool.CallOpts, groupSize, seed)
 }
 
 // SelectGroup is a free data retrieval call binding the contract method 0x6c2530b9.
 //
 // Solidity: function selectGroup(uint256 groupSize, bytes32 seed) view returns(uint32[])
-func (_SortitionPool *SortitionPoolCallerSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
-	return _SortitionPool.Contract.SelectGroup(&_SortitionPool.CallOpts, groupSize, seed)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) SelectGroup(groupSize *big.Int, seed [32]byte) ([]uint32, error) {
+	return _BeaconSortitionPool.Contract.SelectGroup(&_BeaconSortitionPool.CallOpts, groupSize, seed)
 }
 
 // TotalWeight is a free data retrieval call binding the contract method 0x96c82e57.
 //
 // Solidity: function totalWeight() view returns(uint256)
-func (_SortitionPool *SortitionPoolCaller) TotalWeight(opts *bind.CallOpts) (*big.Int, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolCaller) TotalWeight(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _SortitionPool.contract.Call(opts, &out, "totalWeight")
+	err := _BeaconSortitionPool.contract.Call(opts, &out, "totalWeight")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -757,251 +757,251 @@ func (_SortitionPool *SortitionPoolCaller) TotalWeight(opts *bind.CallOpts) (*bi
 // TotalWeight is a free data retrieval call binding the contract method 0x96c82e57.
 //
 // Solidity: function totalWeight() view returns(uint256)
-func (_SortitionPool *SortitionPoolSession) TotalWeight() (*big.Int, error) {
-	return _SortitionPool.Contract.TotalWeight(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) TotalWeight() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.TotalWeight(&_BeaconSortitionPool.CallOpts)
 }
 
 // TotalWeight is a free data retrieval call binding the contract method 0x96c82e57.
 //
 // Solidity: function totalWeight() view returns(uint256)
-func (_SortitionPool *SortitionPoolCallerSession) TotalWeight() (*big.Int, error) {
-	return _SortitionPool.Contract.TotalWeight(&_SortitionPool.CallOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolCallerSession) TotalWeight() (*big.Int, error) {
+	return _BeaconSortitionPool.Contract.TotalWeight(&_BeaconSortitionPool.CallOpts)
 }
 
 // InsertOperator is a paid mutator transaction binding the contract method 0x241a4188.
 //
 // Solidity: function insertOperator(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactor) InsertOperator(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "insertOperator", operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) InsertOperator(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "insertOperator", operator, authorizedStake)
 }
 
 // InsertOperator is a paid mutator transaction binding the contract method 0x241a4188.
 //
 // Solidity: function insertOperator(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.InsertOperator(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.InsertOperator(&_BeaconSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // InsertOperator is a paid mutator transaction binding the contract method 0x241a4188.
 //
 // Solidity: function insertOperator(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.InsertOperator(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) InsertOperator(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.InsertOperator(&_BeaconSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // Lock is a paid mutator transaction binding the contract method 0xf83d08ba.
 //
 // Solidity: function lock() returns()
-func (_SortitionPool *SortitionPoolTransactor) Lock(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "lock")
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) Lock(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "lock")
 }
 
 // Lock is a paid mutator transaction binding the contract method 0xf83d08ba.
 //
 // Solidity: function lock() returns()
-func (_SortitionPool *SortitionPoolSession) Lock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Lock(&_SortitionPool.TransactOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) Lock() (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.Lock(&_BeaconSortitionPool.TransactOpts)
 }
 
 // Lock is a paid mutator transaction binding the contract method 0xf83d08ba.
 //
 // Solidity: function lock() returns()
-func (_SortitionPool *SortitionPoolTransactorSession) Lock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Lock(&_SortitionPool.TransactOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) Lock() (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.Lock(&_BeaconSortitionPool.TransactOpts)
 }
 
 // ReceiveApproval is a paid mutator transaction binding the contract method 0x8f4ffcb1.
 //
 // Solidity: function receiveApproval(address sender, uint256 amount, address token, bytes ) returns()
-func (_SortitionPool *SortitionPoolTransactor) ReceiveApproval(opts *bind.TransactOpts, sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "receiveApproval", sender, amount, token, arg3)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) ReceiveApproval(opts *bind.TransactOpts, sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "receiveApproval", sender, amount, token, arg3)
 }
 
 // ReceiveApproval is a paid mutator transaction binding the contract method 0x8f4ffcb1.
 //
 // Solidity: function receiveApproval(address sender, uint256 amount, address token, bytes ) returns()
-func (_SortitionPool *SortitionPoolSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
-	return _SortitionPool.Contract.ReceiveApproval(&_SortitionPool.TransactOpts, sender, amount, token, arg3)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.ReceiveApproval(&_BeaconSortitionPool.TransactOpts, sender, amount, token, arg3)
 }
 
 // ReceiveApproval is a paid mutator transaction binding the contract method 0x8f4ffcb1.
 //
 // Solidity: function receiveApproval(address sender, uint256 amount, address token, bytes ) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
-	return _SortitionPool.Contract.ReceiveApproval(&_SortitionPool.TransactOpts, sender, amount, token, arg3)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) ReceiveApproval(sender common.Address, amount *big.Int, token common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.ReceiveApproval(&_BeaconSortitionPool.TransactOpts, sender, amount, token, arg3)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_SortitionPool *SortitionPoolTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "renounceOwnership")
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "renounceOwnership")
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_SortitionPool *SortitionPoolSession) RenounceOwnership() (*types.Transaction, error) {
-	return _SortitionPool.Contract.RenounceOwnership(&_SortitionPool.TransactOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.RenounceOwnership(&_BeaconSortitionPool.TransactOpts)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_SortitionPool *SortitionPoolTransactorSession) RenounceOwnership() (*types.Transaction, error) {
-	return _SortitionPool.Contract.RenounceOwnership(&_SortitionPool.TransactOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.RenounceOwnership(&_BeaconSortitionPool.TransactOpts)
 }
 
 // RestoreRewardEligibility is a paid mutator transaction binding the contract method 0xb2f3db4d.
 //
 // Solidity: function restoreRewardEligibility(address operator) returns()
-func (_SortitionPool *SortitionPoolTransactor) RestoreRewardEligibility(opts *bind.TransactOpts, operator common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "restoreRewardEligibility", operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) RestoreRewardEligibility(opts *bind.TransactOpts, operator common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "restoreRewardEligibility", operator)
 }
 
 // RestoreRewardEligibility is a paid mutator transaction binding the contract method 0xb2f3db4d.
 //
 // Solidity: function restoreRewardEligibility(address operator) returns()
-func (_SortitionPool *SortitionPoolSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.RestoreRewardEligibility(&_SortitionPool.TransactOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.RestoreRewardEligibility(&_BeaconSortitionPool.TransactOpts, operator)
 }
 
 // RestoreRewardEligibility is a paid mutator transaction binding the contract method 0xb2f3db4d.
 //
 // Solidity: function restoreRewardEligibility(address operator) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.RestoreRewardEligibility(&_SortitionPool.TransactOpts, operator)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) RestoreRewardEligibility(operator common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.RestoreRewardEligibility(&_BeaconSortitionPool.TransactOpts, operator)
 }
 
 // SetRewardIneligibility is a paid mutator transaction binding the contract method 0x942f6892.
 //
 // Solidity: function setRewardIneligibility(uint32[] operators, uint256 until) returns()
-func (_SortitionPool *SortitionPoolTransactor) SetRewardIneligibility(opts *bind.TransactOpts, operators []uint32, until *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "setRewardIneligibility", operators, until)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) SetRewardIneligibility(opts *bind.TransactOpts, operators []uint32, until *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "setRewardIneligibility", operators, until)
 }
 
 // SetRewardIneligibility is a paid mutator transaction binding the contract method 0x942f6892.
 //
 // Solidity: function setRewardIneligibility(uint32[] operators, uint256 until) returns()
-func (_SortitionPool *SortitionPoolSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SetRewardIneligibility(&_SortitionPool.TransactOpts, operators, until)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.SetRewardIneligibility(&_BeaconSortitionPool.TransactOpts, operators, until)
 }
 
 // SetRewardIneligibility is a paid mutator transaction binding the contract method 0x942f6892.
 //
 // Solidity: function setRewardIneligibility(uint32[] operators, uint256 until) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.SetRewardIneligibility(&_SortitionPool.TransactOpts, operators, until)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) SetRewardIneligibility(operators []uint32, until *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.SetRewardIneligibility(&_BeaconSortitionPool.TransactOpts, operators, until)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_SortitionPool *SortitionPoolTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "transferOwnership", newOwner)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "transferOwnership", newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_SortitionPool *SortitionPoolSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.TransferOwnership(&_SortitionPool.TransactOpts, newOwner)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.TransferOwnership(&_BeaconSortitionPool.TransactOpts, newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.TransferOwnership(&_SortitionPool.TransactOpts, newOwner)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.TransferOwnership(&_BeaconSortitionPool.TransactOpts, newOwner)
 }
 
 // Unlock is a paid mutator transaction binding the contract method 0xa69df4b5.
 //
 // Solidity: function unlock() returns()
-func (_SortitionPool *SortitionPoolTransactor) Unlock(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "unlock")
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) Unlock(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "unlock")
 }
 
 // Unlock is a paid mutator transaction binding the contract method 0xa69df4b5.
 //
 // Solidity: function unlock() returns()
-func (_SortitionPool *SortitionPoolSession) Unlock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Unlock(&_SortitionPool.TransactOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) Unlock() (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.Unlock(&_BeaconSortitionPool.TransactOpts)
 }
 
 // Unlock is a paid mutator transaction binding the contract method 0xa69df4b5.
 //
 // Solidity: function unlock() returns()
-func (_SortitionPool *SortitionPoolTransactorSession) Unlock() (*types.Transaction, error) {
-	return _SortitionPool.Contract.Unlock(&_SortitionPool.TransactOpts)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) Unlock() (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.Unlock(&_BeaconSortitionPool.TransactOpts)
 }
 
 // UpdateOperatorStatus is a paid mutator transaction binding the contract method 0xdc7520c5.
 //
 // Solidity: function updateOperatorStatus(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactor) UpdateOperatorStatus(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "updateOperatorStatus", operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) UpdateOperatorStatus(opts *bind.TransactOpts, operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "updateOperatorStatus", operator, authorizedStake)
 }
 
 // UpdateOperatorStatus is a paid mutator transaction binding the contract method 0xdc7520c5.
 //
 // Solidity: function updateOperatorStatus(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.UpdateOperatorStatus(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.UpdateOperatorStatus(&_BeaconSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // UpdateOperatorStatus is a paid mutator transaction binding the contract method 0xdc7520c5.
 //
 // Solidity: function updateOperatorStatus(address operator, uint256 authorizedStake) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
-	return _SortitionPool.Contract.UpdateOperatorStatus(&_SortitionPool.TransactOpts, operator, authorizedStake)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) UpdateOperatorStatus(operator common.Address, authorizedStake *big.Int) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.UpdateOperatorStatus(&_BeaconSortitionPool.TransactOpts, operator, authorizedStake)
 }
 
 // WithdrawIneligible is a paid mutator transaction binding the contract method 0xa9649414.
 //
 // Solidity: function withdrawIneligible(address recipient) returns()
-func (_SortitionPool *SortitionPoolTransactor) WithdrawIneligible(opts *bind.TransactOpts, recipient common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "withdrawIneligible", recipient)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) WithdrawIneligible(opts *bind.TransactOpts, recipient common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "withdrawIneligible", recipient)
 }
 
 // WithdrawIneligible is a paid mutator transaction binding the contract method 0xa9649414.
 //
 // Solidity: function withdrawIneligible(address recipient) returns()
-func (_SortitionPool *SortitionPoolSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawIneligible(&_SortitionPool.TransactOpts, recipient)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.WithdrawIneligible(&_BeaconSortitionPool.TransactOpts, recipient)
 }
 
 // WithdrawIneligible is a paid mutator transaction binding the contract method 0xa9649414.
 //
 // Solidity: function withdrawIneligible(address recipient) returns()
-func (_SortitionPool *SortitionPoolTransactorSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawIneligible(&_SortitionPool.TransactOpts, recipient)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) WithdrawIneligible(recipient common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.WithdrawIneligible(&_BeaconSortitionPool.TransactOpts, recipient)
 }
 
 // WithdrawRewards is a paid mutator transaction binding the contract method 0xe20981ca.
 //
 // Solidity: function withdrawRewards(address operator, address beneficiary) returns(uint96)
-func (_SortitionPool *SortitionPoolTransactor) WithdrawRewards(opts *bind.TransactOpts, operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
-	return _SortitionPool.contract.Transact(opts, "withdrawRewards", operator, beneficiary)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactor) WithdrawRewards(opts *bind.TransactOpts, operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.contract.Transact(opts, "withdrawRewards", operator, beneficiary)
 }
 
 // WithdrawRewards is a paid mutator transaction binding the contract method 0xe20981ca.
 //
 // Solidity: function withdrawRewards(address operator, address beneficiary) returns(uint96)
-func (_SortitionPool *SortitionPoolSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawRewards(&_SortitionPool.TransactOpts, operator, beneficiary)
+func (_BeaconSortitionPool *BeaconSortitionPoolSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.WithdrawRewards(&_BeaconSortitionPool.TransactOpts, operator, beneficiary)
 }
 
 // WithdrawRewards is a paid mutator transaction binding the contract method 0xe20981ca.
 //
 // Solidity: function withdrawRewards(address operator, address beneficiary) returns(uint96)
-func (_SortitionPool *SortitionPoolTransactorSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
-	return _SortitionPool.Contract.WithdrawRewards(&_SortitionPool.TransactOpts, operator, beneficiary)
+func (_BeaconSortitionPool *BeaconSortitionPoolTransactorSession) WithdrawRewards(operator common.Address, beneficiary common.Address) (*types.Transaction, error) {
+	return _BeaconSortitionPool.Contract.WithdrawRewards(&_BeaconSortitionPool.TransactOpts, operator, beneficiary)
 }
 
-// SortitionPoolIneligibleForRewardsIterator is returned from FilterIneligibleForRewards and is used to iterate over the raw logs and unpacked data for IneligibleForRewards events raised by the SortitionPool contract.
-type SortitionPoolIneligibleForRewardsIterator struct {
-	Event *SortitionPoolIneligibleForRewards // Event containing the contract specifics and raw log
+// BeaconSortitionPoolIneligibleForRewardsIterator is returned from FilterIneligibleForRewards and is used to iterate over the raw logs and unpacked data for IneligibleForRewards events raised by the BeaconSortitionPool contract.
+type BeaconSortitionPoolIneligibleForRewardsIterator struct {
+	Event *BeaconSortitionPoolIneligibleForRewards // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1015,7 +1015,7 @@ type SortitionPoolIneligibleForRewardsIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
+func (it *BeaconSortitionPoolIneligibleForRewardsIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1024,7 +1024,7 @@ func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SortitionPoolIneligibleForRewards)
+			it.Event = new(BeaconSortitionPoolIneligibleForRewards)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1039,7 +1039,7 @@ func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SortitionPoolIneligibleForRewards)
+		it.Event = new(BeaconSortitionPoolIneligibleForRewards)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1055,19 +1055,19 @@ func (it *SortitionPoolIneligibleForRewardsIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SortitionPoolIneligibleForRewardsIterator) Error() error {
+func (it *BeaconSortitionPoolIneligibleForRewardsIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SortitionPoolIneligibleForRewardsIterator) Close() error {
+func (it *BeaconSortitionPoolIneligibleForRewardsIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SortitionPoolIneligibleForRewards represents a IneligibleForRewards event raised by the SortitionPool contract.
-type SortitionPoolIneligibleForRewards struct {
+// BeaconSortitionPoolIneligibleForRewards represents a IneligibleForRewards event raised by the BeaconSortitionPool contract.
+type BeaconSortitionPoolIneligibleForRewards struct {
 	Ids   []uint32
 	Until *big.Int
 	Raw   types.Log // Blockchain specific contextual infos
@@ -1076,21 +1076,21 @@ type SortitionPoolIneligibleForRewards struct {
 // FilterIneligibleForRewards is a free log retrieval operation binding the contract event 0x01f5838e3dde8cf4817b958fe95be92bdfeccb34317e1d9f58d1cfe5230de231.
 //
 // Solidity: event IneligibleForRewards(uint32[] ids, uint256 until)
-func (_SortitionPool *SortitionPoolFilterer) FilterIneligibleForRewards(opts *bind.FilterOpts) (*SortitionPoolIneligibleForRewardsIterator, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) FilterIneligibleForRewards(opts *bind.FilterOpts) (*BeaconSortitionPoolIneligibleForRewardsIterator, error) {
 
-	logs, sub, err := _SortitionPool.contract.FilterLogs(opts, "IneligibleForRewards")
+	logs, sub, err := _BeaconSortitionPool.contract.FilterLogs(opts, "IneligibleForRewards")
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolIneligibleForRewardsIterator{contract: _SortitionPool.contract, event: "IneligibleForRewards", logs: logs, sub: sub}, nil
+	return &BeaconSortitionPoolIneligibleForRewardsIterator{contract: _BeaconSortitionPool.contract, event: "IneligibleForRewards", logs: logs, sub: sub}, nil
 }
 
 // WatchIneligibleForRewards is a free log subscription operation binding the contract event 0x01f5838e3dde8cf4817b958fe95be92bdfeccb34317e1d9f58d1cfe5230de231.
 //
 // Solidity: event IneligibleForRewards(uint32[] ids, uint256 until)
-func (_SortitionPool *SortitionPoolFilterer) WatchIneligibleForRewards(opts *bind.WatchOpts, sink chan<- *SortitionPoolIneligibleForRewards) (event.Subscription, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) WatchIneligibleForRewards(opts *bind.WatchOpts, sink chan<- *BeaconSortitionPoolIneligibleForRewards) (event.Subscription, error) {
 
-	logs, sub, err := _SortitionPool.contract.WatchLogs(opts, "IneligibleForRewards")
+	logs, sub, err := _BeaconSortitionPool.contract.WatchLogs(opts, "IneligibleForRewards")
 	if err != nil {
 		return nil, err
 	}
@@ -1100,8 +1100,8 @@ func (_SortitionPool *SortitionPoolFilterer) WatchIneligibleForRewards(opts *bin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SortitionPoolIneligibleForRewards)
-				if err := _SortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
+				event := new(BeaconSortitionPoolIneligibleForRewards)
+				if err := _BeaconSortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1125,18 +1125,18 @@ func (_SortitionPool *SortitionPoolFilterer) WatchIneligibleForRewards(opts *bin
 // ParseIneligibleForRewards is a log parse operation binding the contract event 0x01f5838e3dde8cf4817b958fe95be92bdfeccb34317e1d9f58d1cfe5230de231.
 //
 // Solidity: event IneligibleForRewards(uint32[] ids, uint256 until)
-func (_SortitionPool *SortitionPoolFilterer) ParseIneligibleForRewards(log types.Log) (*SortitionPoolIneligibleForRewards, error) {
-	event := new(SortitionPoolIneligibleForRewards)
-	if err := _SortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) ParseIneligibleForRewards(log types.Log) (*BeaconSortitionPoolIneligibleForRewards, error) {
+	event := new(BeaconSortitionPoolIneligibleForRewards)
+	if err := _BeaconSortitionPool.contract.UnpackLog(event, "IneligibleForRewards", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// SortitionPoolOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the SortitionPool contract.
-type SortitionPoolOwnershipTransferredIterator struct {
-	Event *SortitionPoolOwnershipTransferred // Event containing the contract specifics and raw log
+// BeaconSortitionPoolOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BeaconSortitionPool contract.
+type BeaconSortitionPoolOwnershipTransferredIterator struct {
+	Event *BeaconSortitionPoolOwnershipTransferred // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1150,7 +1150,7 @@ type SortitionPoolOwnershipTransferredIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
+func (it *BeaconSortitionPoolOwnershipTransferredIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1159,7 +1159,7 @@ func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SortitionPoolOwnershipTransferred)
+			it.Event = new(BeaconSortitionPoolOwnershipTransferred)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1174,7 +1174,7 @@ func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SortitionPoolOwnershipTransferred)
+		it.Event = new(BeaconSortitionPoolOwnershipTransferred)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1190,19 +1190,19 @@ func (it *SortitionPoolOwnershipTransferredIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SortitionPoolOwnershipTransferredIterator) Error() error {
+func (it *BeaconSortitionPoolOwnershipTransferredIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SortitionPoolOwnershipTransferredIterator) Close() error {
+func (it *BeaconSortitionPoolOwnershipTransferredIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SortitionPoolOwnershipTransferred represents a OwnershipTransferred event raised by the SortitionPool contract.
-type SortitionPoolOwnershipTransferred struct {
+// BeaconSortitionPoolOwnershipTransferred represents a OwnershipTransferred event raised by the BeaconSortitionPool contract.
+type BeaconSortitionPoolOwnershipTransferred struct {
 	PreviousOwner common.Address
 	NewOwner      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -1211,7 +1211,7 @@ type SortitionPoolOwnershipTransferred struct {
 // FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_SortitionPool *SortitionPoolFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*SortitionPoolOwnershipTransferredIterator, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BeaconSortitionPoolOwnershipTransferredIterator, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -1222,17 +1222,17 @@ func (_SortitionPool *SortitionPoolFilterer) FilterOwnershipTransferred(opts *bi
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _BeaconSortitionPool.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolOwnershipTransferredIterator{contract: _SortitionPool.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+	return &BeaconSortitionPoolOwnershipTransferredIterator{contract: _BeaconSortitionPool.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
 }
 
 // WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *SortitionPoolOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BeaconSortitionPoolOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -1243,7 +1243,7 @@ func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bin
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _BeaconSortitionPool.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,8 +1253,8 @@ func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SortitionPoolOwnershipTransferred)
-				if err := _SortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+				event := new(BeaconSortitionPoolOwnershipTransferred)
+				if err := _BeaconSortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1278,18 +1278,18 @@ func (_SortitionPool *SortitionPoolFilterer) WatchOwnershipTransferred(opts *bin
 // ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_SortitionPool *SortitionPoolFilterer) ParseOwnershipTransferred(log types.Log) (*SortitionPoolOwnershipTransferred, error) {
-	event := new(SortitionPoolOwnershipTransferred)
-	if err := _SortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) ParseOwnershipTransferred(log types.Log) (*BeaconSortitionPoolOwnershipTransferred, error) {
+	event := new(BeaconSortitionPoolOwnershipTransferred)
+	if err := _BeaconSortitionPool.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// SortitionPoolRewardEligibilityRestoredIterator is returned from FilterRewardEligibilityRestored and is used to iterate over the raw logs and unpacked data for RewardEligibilityRestored events raised by the SortitionPool contract.
-type SortitionPoolRewardEligibilityRestoredIterator struct {
-	Event *SortitionPoolRewardEligibilityRestored // Event containing the contract specifics and raw log
+// BeaconSortitionPoolRewardEligibilityRestoredIterator is returned from FilterRewardEligibilityRestored and is used to iterate over the raw logs and unpacked data for RewardEligibilityRestored events raised by the BeaconSortitionPool contract.
+type BeaconSortitionPoolRewardEligibilityRestoredIterator struct {
+	Event *BeaconSortitionPoolRewardEligibilityRestored // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1303,7 +1303,7 @@ type SortitionPoolRewardEligibilityRestoredIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
+func (it *BeaconSortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1312,7 +1312,7 @@ func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SortitionPoolRewardEligibilityRestored)
+			it.Event = new(BeaconSortitionPoolRewardEligibilityRestored)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1327,7 +1327,7 @@ func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SortitionPoolRewardEligibilityRestored)
+		it.Event = new(BeaconSortitionPoolRewardEligibilityRestored)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1343,19 +1343,19 @@ func (it *SortitionPoolRewardEligibilityRestoredIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SortitionPoolRewardEligibilityRestoredIterator) Error() error {
+func (it *BeaconSortitionPoolRewardEligibilityRestoredIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SortitionPoolRewardEligibilityRestoredIterator) Close() error {
+func (it *BeaconSortitionPoolRewardEligibilityRestoredIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SortitionPoolRewardEligibilityRestored represents a RewardEligibilityRestored event raised by the SortitionPool contract.
-type SortitionPoolRewardEligibilityRestored struct {
+// BeaconSortitionPoolRewardEligibilityRestored represents a RewardEligibilityRestored event raised by the BeaconSortitionPool contract.
+type BeaconSortitionPoolRewardEligibilityRestored struct {
 	Operator common.Address
 	Id       uint32
 	Raw      types.Log // Blockchain specific contextual infos
@@ -1364,7 +1364,7 @@ type SortitionPoolRewardEligibilityRestored struct {
 // FilterRewardEligibilityRestored is a free log retrieval operation binding the contract event 0xe61e9f0f049b3bfae1ae903a5e3018c02a008aa0d238ffddf23a4fb4c0278536.
 //
 // Solidity: event RewardEligibilityRestored(address indexed operator, uint32 indexed id)
-func (_SortitionPool *SortitionPoolFilterer) FilterRewardEligibilityRestored(opts *bind.FilterOpts, operator []common.Address, id []uint32) (*SortitionPoolRewardEligibilityRestoredIterator, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) FilterRewardEligibilityRestored(opts *bind.FilterOpts, operator []common.Address, id []uint32) (*BeaconSortitionPoolRewardEligibilityRestoredIterator, error) {
 
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
@@ -1375,17 +1375,17 @@ func (_SortitionPool *SortitionPoolFilterer) FilterRewardEligibilityRestored(opt
 		idRule = append(idRule, idItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.FilterLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
+	logs, sub, err := _BeaconSortitionPool.contract.FilterLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
 	if err != nil {
 		return nil, err
 	}
-	return &SortitionPoolRewardEligibilityRestoredIterator{contract: _SortitionPool.contract, event: "RewardEligibilityRestored", logs: logs, sub: sub}, nil
+	return &BeaconSortitionPoolRewardEligibilityRestoredIterator{contract: _BeaconSortitionPool.contract, event: "RewardEligibilityRestored", logs: logs, sub: sub}, nil
 }
 
 // WatchRewardEligibilityRestored is a free log subscription operation binding the contract event 0xe61e9f0f049b3bfae1ae903a5e3018c02a008aa0d238ffddf23a4fb4c0278536.
 //
 // Solidity: event RewardEligibilityRestored(address indexed operator, uint32 indexed id)
-func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts *bind.WatchOpts, sink chan<- *SortitionPoolRewardEligibilityRestored, operator []common.Address, id []uint32) (event.Subscription, error) {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) WatchRewardEligibilityRestored(opts *bind.WatchOpts, sink chan<- *BeaconSortitionPoolRewardEligibilityRestored, operator []common.Address, id []uint32) (event.Subscription, error) {
 
 	var operatorRule []interface{}
 	for _, operatorItem := range operator {
@@ -1396,7 +1396,7 @@ func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts
 		idRule = append(idRule, idItem)
 	}
 
-	logs, sub, err := _SortitionPool.contract.WatchLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
+	logs, sub, err := _BeaconSortitionPool.contract.WatchLogs(opts, "RewardEligibilityRestored", operatorRule, idRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1406,8 +1406,8 @@ func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SortitionPoolRewardEligibilityRestored)
-				if err := _SortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
+				event := new(BeaconSortitionPoolRewardEligibilityRestored)
+				if err := _BeaconSortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1431,9 +1431,9 @@ func (_SortitionPool *SortitionPoolFilterer) WatchRewardEligibilityRestored(opts
 // ParseRewardEligibilityRestored is a log parse operation binding the contract event 0xe61e9f0f049b3bfae1ae903a5e3018c02a008aa0d238ffddf23a4fb4c0278536.
 //
 // Solidity: event RewardEligibilityRestored(address indexed operator, uint32 indexed id)
-func (_SortitionPool *SortitionPoolFilterer) ParseRewardEligibilityRestored(log types.Log) (*SortitionPoolRewardEligibilityRestored, error) {
-	event := new(SortitionPoolRewardEligibilityRestored)
-	if err := _SortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
+func (_BeaconSortitionPool *BeaconSortitionPoolFilterer) ParseRewardEligibilityRestored(log types.Log) (*BeaconSortitionPoolRewardEligibilityRestored, error) {
+	event := new(BeaconSortitionPoolRewardEligibilityRestored)
+	if err := _BeaconSortitionPool.contract.UnpackLog(event, "RewardEligibilityRestored", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/pkg/chain/random-beacon/gen/cmd/BeaconSortitionPool.go
+++ b/pkg/chain/random-beacon/gen/cmd/BeaconSortitionPool.go
@@ -21,9 +21,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-var SortitionPoolCommand cli.Command
+var BeaconSortitionPoolCommand cli.Command
 
-var sortitionPoolDescription = `The sortition-pool command allows calling the SortitionPool contract on an
+var beaconSortitionPoolDescription = `The beacon-sortition-pool command allows calling the BeaconSortitionPool contract on an
 	ETH-like network. It has subcommands corresponding to each contract method,
 	which respectively each take parameters based on the contract method's
 	parameters.
@@ -48,168 +48,168 @@ var sortitionPoolDescription = `The sortition-pool command allows calling the So
 
 func init() {
 	AvailableCommands = append(AvailableCommands, cli.Command{
-		Name:        "sortition-pool",
-		Usage:       `Provides access to the SortitionPool contract.`,
-		Description: sortitionPoolDescription,
+		Name:        "beacon-sortition-pool",
+		Usage:       `Provides access to the BeaconSortitionPool contract.`,
+		Description: beaconSortitionPoolDescription,
 		Subcommands: []cli.Command{{
 			Name:      "get-available-rewards",
-			Usage:     "Calls the view method getAvailableRewards on the SortitionPool contract.",
+			Usage:     "Calls the view method getAvailableRewards on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spGetAvailableRewards,
+			Action:    bspGetAvailableRewards,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "get-operator-i-d",
-			Usage:     "Calls the view method getOperatorID on the SortitionPool contract.",
+			Usage:     "Calls the view method getOperatorID on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spGetOperatorID,
+			Action:    bspGetOperatorID,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "get-pool-weight",
-			Usage:     "Calls the view method getPoolWeight on the SortitionPool contract.",
+			Usage:     "Calls the view method getPoolWeight on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spGetPoolWeight,
+			Action:    bspGetPoolWeight,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "ineligible-earned-rewards",
-			Usage:     "Calls the view method ineligibleEarnedRewards on the SortitionPool contract.",
+			Usage:     "Calls the view method ineligibleEarnedRewards on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spIneligibleEarnedRewards,
+			Action:    bspIneligibleEarnedRewards,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-locked",
-			Usage:     "Calls the view method isLocked on the SortitionPool contract.",
+			Usage:     "Calls the view method isLocked on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spIsLocked,
+			Action:    bspIsLocked,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-operator-in-pool",
-			Usage:     "Calls the view method isOperatorInPool on the SortitionPool contract.",
+			Usage:     "Calls the view method isOperatorInPool on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spIsOperatorInPool,
+			Action:    bspIsOperatorInPool,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-operator-registered",
-			Usage:     "Calls the view method isOperatorRegistered on the SortitionPool contract.",
+			Usage:     "Calls the view method isOperatorRegistered on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spIsOperatorRegistered,
+			Action:    bspIsOperatorRegistered,
 			Before:    cmd.ArgCountChecker(1),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "is-operator-up-to-date",
-			Usage:     "Calls the view method isOperatorUpToDate on the SortitionPool contract.",
+			Usage:     "Calls the view method isOperatorUpToDate on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_authorizedStake] ",
-			Action:    spIsOperatorUpToDate,
+			Action:    bspIsOperatorUpToDate,
 			Before:    cmd.ArgCountChecker(2),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "operators-in-pool",
-			Usage:     "Calls the view method operatorsInPool on the SortitionPool contract.",
+			Usage:     "Calls the view method operatorsInPool on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spOperatorsInPool,
+			Action:    bspOperatorsInPool,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "owner",
-			Usage:     "Calls the view method owner on the SortitionPool contract.",
+			Usage:     "Calls the view method owner on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spOwner,
+			Action:    bspOwner,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "pool-weight-divisor",
-			Usage:     "Calls the view method poolWeightDivisor on the SortitionPool contract.",
+			Usage:     "Calls the view method poolWeightDivisor on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spPoolWeightDivisor,
+			Action:    bspPoolWeightDivisor,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "reward-token",
-			Usage:     "Calls the view method rewardToken on the SortitionPool contract.",
+			Usage:     "Calls the view method rewardToken on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spRewardToken,
+			Action:    bspRewardToken,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "total-weight",
-			Usage:     "Calls the view method totalWeight on the SortitionPool contract.",
+			Usage:     "Calls the view method totalWeight on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spTotalWeight,
+			Action:    bspTotalWeight,
 			Before:    cmd.ArgCountChecker(0),
 			Flags:     cmd.ConstFlags,
 		}, {
 			Name:      "insert-operator",
-			Usage:     "Calls the nonpayable method insertOperator on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method insertOperator on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_authorizedStake] ",
-			Action:    spInsertOperator,
+			Action:    bspInsertOperator,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "lock",
-			Usage:     "Calls the nonpayable method lock on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method lock on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spLock,
+			Action:    bspLock,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "receive-approval",
-			Usage:     "Calls the nonpayable method receiveApproval on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method receiveApproval on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_sender] [arg_amount] [arg_token] [arg3] ",
-			Action:    spReceiveApproval,
+			Action:    bspReceiveApproval,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(4))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "renounce-ownership",
-			Usage:     "Calls the nonpayable method renounceOwnership on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method renounceOwnership on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spRenounceOwnership,
+			Action:    bspRenounceOwnership,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "restore-reward-eligibility",
-			Usage:     "Calls the nonpayable method restoreRewardEligibility on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method restoreRewardEligibility on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] ",
-			Action:    spRestoreRewardEligibility,
+			Action:    bspRestoreRewardEligibility,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "transfer-ownership",
-			Usage:     "Calls the nonpayable method transferOwnership on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method transferOwnership on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_newOwner] ",
-			Action:    spTransferOwnership,
+			Action:    bspTransferOwnership,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "unlock",
-			Usage:     "Calls the nonpayable method unlock on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method unlock on the BeaconSortitionPool contract.",
 			ArgsUsage: "",
-			Action:    spUnlock,
+			Action:    bspUnlock,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(0))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "update-operator-status",
-			Usage:     "Calls the nonpayable method updateOperatorStatus on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method updateOperatorStatus on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_authorizedStake] ",
-			Action:    spUpdateOperatorStatus,
+			Action:    bspUpdateOperatorStatus,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "withdraw-ineligible",
-			Usage:     "Calls the nonpayable method withdrawIneligible on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method withdrawIneligible on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_recipient] ",
-			Action:    spWithdrawIneligible,
+			Action:    bspWithdrawIneligible,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(1))),
 			Flags:     cmd.NonConstFlags,
 		}, {
 			Name:      "withdraw-rewards",
-			Usage:     "Calls the nonpayable method withdrawRewards on the SortitionPool contract.",
+			Usage:     "Calls the nonpayable method withdrawRewards on the BeaconSortitionPool contract.",
 			ArgsUsage: "[arg_operator] [arg_beneficiary] ",
-			Action:    spWithdrawRewards,
+			Action:    bspWithdrawRewards,
 			Before:    cli.BeforeFunc(cmd.NonConstArgsChecker.AndThen(cmd.ArgCountChecker(2))),
 			Flags:     cmd.NonConstFlags,
 		}},
@@ -218,8 +218,8 @@ func init() {
 
 /// ------------------- Const methods -------------------
 
-func spGetAvailableRewards(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspGetAvailableRewards(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -246,8 +246,8 @@ func spGetAvailableRewards(c *cli.Context) error {
 	return nil
 }
 
-func spGetOperatorID(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspGetOperatorID(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -274,8 +274,8 @@ func spGetOperatorID(c *cli.Context) error {
 	return nil
 }
 
-func spGetPoolWeight(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspGetPoolWeight(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -302,8 +302,8 @@ func spGetPoolWeight(c *cli.Context) error {
 	return nil
 }
 
-func spIneligibleEarnedRewards(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspIneligibleEarnedRewards(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -322,8 +322,8 @@ func spIneligibleEarnedRewards(c *cli.Context) error {
 	return nil
 }
 
-func spIsLocked(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspIsLocked(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -342,8 +342,8 @@ func spIsLocked(c *cli.Context) error {
 	return nil
 }
 
-func spIsOperatorInPool(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspIsOperatorInPool(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -370,8 +370,8 @@ func spIsOperatorInPool(c *cli.Context) error {
 	return nil
 }
 
-func spIsOperatorRegistered(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspIsOperatorRegistered(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -398,8 +398,8 @@ func spIsOperatorRegistered(c *cli.Context) error {
 	return nil
 }
 
-func spIsOperatorUpToDate(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspIsOperatorUpToDate(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -435,8 +435,8 @@ func spIsOperatorUpToDate(c *cli.Context) error {
 	return nil
 }
 
-func spOperatorsInPool(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspOperatorsInPool(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -455,8 +455,8 @@ func spOperatorsInPool(c *cli.Context) error {
 	return nil
 }
 
-func spOwner(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspOwner(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -475,8 +475,8 @@ func spOwner(c *cli.Context) error {
 	return nil
 }
 
-func spPoolWeightDivisor(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspPoolWeightDivisor(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -495,8 +495,8 @@ func spPoolWeightDivisor(c *cli.Context) error {
 	return nil
 }
 
-func spRewardToken(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspRewardToken(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -515,8 +515,8 @@ func spRewardToken(c *cli.Context) error {
 	return nil
 }
 
-func spTotalWeight(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspTotalWeight(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -537,8 +537,8 @@ func spTotalWeight(c *cli.Context) error {
 
 /// ------------------- Non-const methods -------------------
 
-func spInsertOperator(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspInsertOperator(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -591,8 +591,8 @@ func spInsertOperator(c *cli.Context) error {
 	return nil
 }
 
-func spLock(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspLock(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -624,8 +624,8 @@ func spLock(c *cli.Context) error {
 	return nil
 }
 
-func spReceiveApproval(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspReceiveApproval(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -698,8 +698,8 @@ func spReceiveApproval(c *cli.Context) error {
 	return nil
 }
 
-func spRenounceOwnership(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspRenounceOwnership(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -731,8 +731,8 @@ func spRenounceOwnership(c *cli.Context) error {
 	return nil
 }
 
-func spRestoreRewardEligibility(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspRestoreRewardEligibility(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -775,8 +775,8 @@ func spRestoreRewardEligibility(c *cli.Context) error {
 	return nil
 }
 
-func spTransferOwnership(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspTransferOwnership(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -819,8 +819,8 @@ func spTransferOwnership(c *cli.Context) error {
 	return nil
 }
 
-func spUnlock(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspUnlock(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -852,8 +852,8 @@ func spUnlock(c *cli.Context) error {
 	return nil
 }
 
-func spUpdateOperatorStatus(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspUpdateOperatorStatus(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -906,8 +906,8 @@ func spUpdateOperatorStatus(c *cli.Context) error {
 	return nil
 }
 
-func spWithdrawIneligible(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspWithdrawIneligible(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -950,8 +950,8 @@ func spWithdrawIneligible(c *cli.Context) error {
 	return nil
 }
 
-func spWithdrawRewards(c *cli.Context) error {
-	contract, err := initializeSortitionPool(c)
+func bspWithdrawRewards(c *cli.Context) error {
+	contract, err := initializeBeaconSortitionPool(c)
 	if err != nil {
 		return err
 	}
@@ -1007,7 +1007,7 @@ func spWithdrawRewards(c *cli.Context) error {
 
 /// ------------------- Initialization -------------------
 
-func initializeSortitionPool(c *cli.Context) (*contract.SortitionPool, error) {
+func initializeBeaconSortitionPool(c *cli.Context) (*contract.BeaconSortitionPool, error) {
 	config, err := config.ReadEthereumConfig(c.GlobalString("config"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading config from file: [%v]", err)
@@ -1048,9 +1048,9 @@ func initializeSortitionPool(c *cli.Context) (*contract.SortitionPool, error) {
 		)
 	}
 
-	address := common.HexToAddress(config.ContractAddresses["SortitionPool"])
+	address := common.HexToAddress(config.ContractAddresses["BeaconSortitionPool"])
 
-	return contract.NewSortitionPool(
+	return contract.NewBeaconSortitionPool(
 		address,
 		chainID,
 		key,

--- a/pkg/chain/random-beacon/gen/contract/BeaconSortitionPool.go
+++ b/pkg/chain/random-beacon/gen/contract/BeaconSortitionPool.go
@@ -29,10 +29,10 @@ import (
 // Create a package-level logger for this contract. The logger exists at
 // package level so that the logger is registered at startup and can be
 // included or excluded from logging at startup by name.
-var spLogger = log.Logger("keep-contract-SortitionPool")
+var bspLogger = log.Logger("keep-contract-BeaconSortitionPool")
 
-type SortitionPool struct {
-	contract          *abi.SortitionPool
+type BeaconSortitionPool struct {
+	contract          *abi.BeaconSortitionPool
 	contractAddress   common.Address
 	contractABI       *hostchainabi.ABI
 	caller            bind.ContractCaller
@@ -47,7 +47,7 @@ type SortitionPool struct {
 	transactionMutex *sync.Mutex
 }
 
-func NewSortitionPool(
+func NewBeaconSortitionPool(
 	contractAddress common.Address,
 	chainId *big.Int,
 	accountKey *keystore.Key,
@@ -56,7 +56,7 @@ func NewSortitionPool(
 	miningWaiter *chainutil.MiningWaiter,
 	blockCounter *ethlike.BlockCounter,
 	transactionMutex *sync.Mutex,
-) (*SortitionPool, error) {
+) (*BeaconSortitionPool, error) {
 	callerOptions := &bind.CallOpts{
 		From: accountKey.Address,
 	}
@@ -72,7 +72,7 @@ func NewSortitionPool(
 		return nil, fmt.Errorf("failed to instantiate transactor: [%v]", err)
 	}
 
-	contract, err := abi.NewSortitionPool(
+	contract, err := abi.NewBeaconSortitionPool(
 		contractAddress,
 		backend,
 	)
@@ -84,12 +84,12 @@ func NewSortitionPool(
 		)
 	}
 
-	contractABI, err := hostchainabi.JSON(strings.NewReader(abi.SortitionPoolABI))
+	contractABI, err := hostchainabi.JSON(strings.NewReader(abi.BeaconSortitionPoolABI))
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate ABI: [%v]", err)
 	}
 
-	return &SortitionPool{
+	return &BeaconSortitionPool{
 		contract:          contract,
 		contractAddress:   contractAddress,
 		contractABI:       &contractABI,
@@ -108,13 +108,13 @@ func NewSortitionPool(
 // ----- Non-const Methods ------
 
 // Transaction submission.
-func (sp *SortitionPool) InsertOperator(
+func (bsp *BeaconSortitionPool) InsertOperator(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction insertOperator",
 		" params: ",
 		fmt.Sprint(
@@ -123,12 +123,12 @@ func (sp *SortitionPool) InsertOperator(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -138,22 +138,22 @@ func (sp *SortitionPool) InsertOperator(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.InsertOperator(
+	transaction, err := bsp.contract.InsertOperator(
 		transactorOptions,
 		arg_operator,
 		arg_authorizedStake,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"insertOperator",
 			arg_operator,
@@ -161,13 +161,13 @@ func (sp *SortitionPool) InsertOperator(
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction insertOperator with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -181,15 +181,15 @@ func (sp *SortitionPool) InsertOperator(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.InsertOperator(
+			transaction, err := bsp.contract.InsertOperator(
 				newTransactorOptions,
 				arg_operator,
 				arg_authorizedStake,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"insertOperator",
 					arg_operator,
@@ -197,7 +197,7 @@ func (sp *SortitionPool) InsertOperator(
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction insertOperator with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -207,13 +207,13 @@ func (sp *SortitionPool) InsertOperator(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallInsertOperator(
+func (bsp *BeaconSortitionPool) CallInsertOperator(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 	blockNumber *big.Int,
@@ -221,12 +221,12 @@ func (sp *SortitionPool) CallInsertOperator(
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"insertOperator",
 		&result,
 		arg_operator,
@@ -236,18 +236,18 @@ func (sp *SortitionPool) CallInsertOperator(
 	return err
 }
 
-func (sp *SortitionPool) InsertOperatorGasEstimate(
+func (bsp *BeaconSortitionPool) InsertOperatorGasEstimate(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"insertOperator",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_operator,
 		arg_authorizedStake,
 	)
@@ -256,20 +256,20 @@ func (sp *SortitionPool) InsertOperatorGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) Lock(
+func (bsp *BeaconSortitionPool) Lock(
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction lock",
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -279,32 +279,32 @@ func (sp *SortitionPool) Lock(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.Lock(
+	transaction, err := bsp.contract.Lock(
 		transactorOptions,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"lock",
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction lock with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -318,19 +318,19 @@ func (sp *SortitionPool) Lock(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.Lock(
+			transaction, err := bsp.contract.Lock(
 				newTransactorOptions,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"lock",
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction lock with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -340,24 +340,24 @@ func (sp *SortitionPool) Lock(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallLock(
+func (bsp *BeaconSortitionPool) CallLock(
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"lock",
 		&result,
 	)
@@ -365,22 +365,22 @@ func (sp *SortitionPool) CallLock(
 	return err
 }
 
-func (sp *SortitionPool) LockGasEstimate() (uint64, error) {
+func (bsp *BeaconSortitionPool) LockGasEstimate() (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"lock",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 	)
 
 	return result, err
 }
 
 // Transaction submission.
-func (sp *SortitionPool) ReceiveApproval(
+func (bsp *BeaconSortitionPool) ReceiveApproval(
 	arg_sender common.Address,
 	arg_amount *big.Int,
 	arg_token common.Address,
@@ -388,7 +388,7 @@ func (sp *SortitionPool) ReceiveApproval(
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction receiveApproval",
 		" params: ",
 		fmt.Sprint(
@@ -399,12 +399,12 @@ func (sp *SortitionPool) ReceiveApproval(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -414,14 +414,14 @@ func (sp *SortitionPool) ReceiveApproval(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.ReceiveApproval(
+	transaction, err := bsp.contract.ReceiveApproval(
 		transactorOptions,
 		arg_sender,
 		arg_amount,
@@ -429,9 +429,9 @@ func (sp *SortitionPool) ReceiveApproval(
 		arg3,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"receiveApproval",
 			arg_sender,
@@ -441,13 +441,13 @@ func (sp *SortitionPool) ReceiveApproval(
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction receiveApproval with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -461,7 +461,7 @@ func (sp *SortitionPool) ReceiveApproval(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.ReceiveApproval(
+			transaction, err := bsp.contract.ReceiveApproval(
 				newTransactorOptions,
 				arg_sender,
 				arg_amount,
@@ -469,9 +469,9 @@ func (sp *SortitionPool) ReceiveApproval(
 				arg3,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"receiveApproval",
 					arg_sender,
@@ -481,7 +481,7 @@ func (sp *SortitionPool) ReceiveApproval(
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction receiveApproval with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -491,13 +491,13 @@ func (sp *SortitionPool) ReceiveApproval(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallReceiveApproval(
+func (bsp *BeaconSortitionPool) CallReceiveApproval(
 	arg_sender common.Address,
 	arg_amount *big.Int,
 	arg_token common.Address,
@@ -507,12 +507,12 @@ func (sp *SortitionPool) CallReceiveApproval(
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"receiveApproval",
 		&result,
 		arg_sender,
@@ -524,7 +524,7 @@ func (sp *SortitionPool) CallReceiveApproval(
 	return err
 }
 
-func (sp *SortitionPool) ReceiveApprovalGasEstimate(
+func (bsp *BeaconSortitionPool) ReceiveApprovalGasEstimate(
 	arg_sender common.Address,
 	arg_amount *big.Int,
 	arg_token common.Address,
@@ -533,11 +533,11 @@ func (sp *SortitionPool) ReceiveApprovalGasEstimate(
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"receiveApproval",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_sender,
 		arg_amount,
 		arg_token,
@@ -548,20 +548,20 @@ func (sp *SortitionPool) ReceiveApprovalGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) RenounceOwnership(
+func (bsp *BeaconSortitionPool) RenounceOwnership(
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction renounceOwnership",
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -571,32 +571,32 @@ func (sp *SortitionPool) RenounceOwnership(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.RenounceOwnership(
+	transaction, err := bsp.contract.RenounceOwnership(
 		transactorOptions,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"renounceOwnership",
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction renounceOwnership with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -610,19 +610,19 @@ func (sp *SortitionPool) RenounceOwnership(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.RenounceOwnership(
+			transaction, err := bsp.contract.RenounceOwnership(
 				newTransactorOptions,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"renounceOwnership",
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction renounceOwnership with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -632,24 +632,24 @@ func (sp *SortitionPool) RenounceOwnership(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallRenounceOwnership(
+func (bsp *BeaconSortitionPool) CallRenounceOwnership(
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"renounceOwnership",
 		&result,
 	)
@@ -657,27 +657,27 @@ func (sp *SortitionPool) CallRenounceOwnership(
 	return err
 }
 
-func (sp *SortitionPool) RenounceOwnershipGasEstimate() (uint64, error) {
+func (bsp *BeaconSortitionPool) RenounceOwnershipGasEstimate() (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"renounceOwnership",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 	)
 
 	return result, err
 }
 
 // Transaction submission.
-func (sp *SortitionPool) RestoreRewardEligibility(
+func (bsp *BeaconSortitionPool) RestoreRewardEligibility(
 	arg_operator common.Address,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction restoreRewardEligibility",
 		" params: ",
 		fmt.Sprint(
@@ -685,12 +685,12 @@ func (sp *SortitionPool) RestoreRewardEligibility(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -700,34 +700,34 @@ func (sp *SortitionPool) RestoreRewardEligibility(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.RestoreRewardEligibility(
+	transaction, err := bsp.contract.RestoreRewardEligibility(
 		transactorOptions,
 		arg_operator,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"restoreRewardEligibility",
 			arg_operator,
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction restoreRewardEligibility with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -741,21 +741,21 @@ func (sp *SortitionPool) RestoreRewardEligibility(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.RestoreRewardEligibility(
+			transaction, err := bsp.contract.RestoreRewardEligibility(
 				newTransactorOptions,
 				arg_operator,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"restoreRewardEligibility",
 					arg_operator,
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction restoreRewardEligibility with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -765,25 +765,25 @@ func (sp *SortitionPool) RestoreRewardEligibility(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallRestoreRewardEligibility(
+func (bsp *BeaconSortitionPool) CallRestoreRewardEligibility(
 	arg_operator common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"restoreRewardEligibility",
 		&result,
 		arg_operator,
@@ -792,17 +792,17 @@ func (sp *SortitionPool) CallRestoreRewardEligibility(
 	return err
 }
 
-func (sp *SortitionPool) RestoreRewardEligibilityGasEstimate(
+func (bsp *BeaconSortitionPool) RestoreRewardEligibilityGasEstimate(
 	arg_operator common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"restoreRewardEligibility",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_operator,
 	)
 
@@ -810,13 +810,13 @@ func (sp *SortitionPool) RestoreRewardEligibilityGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) SetRewardIneligibility(
+func (bsp *BeaconSortitionPool) SetRewardIneligibility(
 	arg_operators []uint32,
 	arg_until *big.Int,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction setRewardIneligibility",
 		" params: ",
 		fmt.Sprint(
@@ -825,12 +825,12 @@ func (sp *SortitionPool) SetRewardIneligibility(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -840,22 +840,22 @@ func (sp *SortitionPool) SetRewardIneligibility(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.SetRewardIneligibility(
+	transaction, err := bsp.contract.SetRewardIneligibility(
 		transactorOptions,
 		arg_operators,
 		arg_until,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"setRewardIneligibility",
 			arg_operators,
@@ -863,13 +863,13 @@ func (sp *SortitionPool) SetRewardIneligibility(
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction setRewardIneligibility with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -883,15 +883,15 @@ func (sp *SortitionPool) SetRewardIneligibility(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.SetRewardIneligibility(
+			transaction, err := bsp.contract.SetRewardIneligibility(
 				newTransactorOptions,
 				arg_operators,
 				arg_until,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"setRewardIneligibility",
 					arg_operators,
@@ -899,7 +899,7 @@ func (sp *SortitionPool) SetRewardIneligibility(
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction setRewardIneligibility with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -909,13 +909,13 @@ func (sp *SortitionPool) SetRewardIneligibility(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallSetRewardIneligibility(
+func (bsp *BeaconSortitionPool) CallSetRewardIneligibility(
 	arg_operators []uint32,
 	arg_until *big.Int,
 	blockNumber *big.Int,
@@ -923,12 +923,12 @@ func (sp *SortitionPool) CallSetRewardIneligibility(
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"setRewardIneligibility",
 		&result,
 		arg_operators,
@@ -938,18 +938,18 @@ func (sp *SortitionPool) CallSetRewardIneligibility(
 	return err
 }
 
-func (sp *SortitionPool) SetRewardIneligibilityGasEstimate(
+func (bsp *BeaconSortitionPool) SetRewardIneligibilityGasEstimate(
 	arg_operators []uint32,
 	arg_until *big.Int,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"setRewardIneligibility",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_operators,
 		arg_until,
 	)
@@ -958,12 +958,12 @@ func (sp *SortitionPool) SetRewardIneligibilityGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) TransferOwnership(
+func (bsp *BeaconSortitionPool) TransferOwnership(
 	arg_newOwner common.Address,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction transferOwnership",
 		" params: ",
 		fmt.Sprint(
@@ -971,12 +971,12 @@ func (sp *SortitionPool) TransferOwnership(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -986,34 +986,34 @@ func (sp *SortitionPool) TransferOwnership(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.TransferOwnership(
+	transaction, err := bsp.contract.TransferOwnership(
 		transactorOptions,
 		arg_newOwner,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"transferOwnership",
 			arg_newOwner,
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction transferOwnership with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -1027,21 +1027,21 @@ func (sp *SortitionPool) TransferOwnership(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.TransferOwnership(
+			transaction, err := bsp.contract.TransferOwnership(
 				newTransactorOptions,
 				arg_newOwner,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"transferOwnership",
 					arg_newOwner,
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction transferOwnership with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -1051,25 +1051,25 @@ func (sp *SortitionPool) TransferOwnership(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallTransferOwnership(
+func (bsp *BeaconSortitionPool) CallTransferOwnership(
 	arg_newOwner common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"transferOwnership",
 		&result,
 		arg_newOwner,
@@ -1078,17 +1078,17 @@ func (sp *SortitionPool) CallTransferOwnership(
 	return err
 }
 
-func (sp *SortitionPool) TransferOwnershipGasEstimate(
+func (bsp *BeaconSortitionPool) TransferOwnershipGasEstimate(
 	arg_newOwner common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"transferOwnership",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_newOwner,
 	)
 
@@ -1096,20 +1096,20 @@ func (sp *SortitionPool) TransferOwnershipGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) Unlock(
+func (bsp *BeaconSortitionPool) Unlock(
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction unlock",
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -1119,32 +1119,32 @@ func (sp *SortitionPool) Unlock(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.Unlock(
+	transaction, err := bsp.contract.Unlock(
 		transactorOptions,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"unlock",
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction unlock with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -1158,19 +1158,19 @@ func (sp *SortitionPool) Unlock(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.Unlock(
+			transaction, err := bsp.contract.Unlock(
 				newTransactorOptions,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"unlock",
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction unlock with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -1180,24 +1180,24 @@ func (sp *SortitionPool) Unlock(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallUnlock(
+func (bsp *BeaconSortitionPool) CallUnlock(
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"unlock",
 		&result,
 	)
@@ -1205,28 +1205,28 @@ func (sp *SortitionPool) CallUnlock(
 	return err
 }
 
-func (sp *SortitionPool) UnlockGasEstimate() (uint64, error) {
+func (bsp *BeaconSortitionPool) UnlockGasEstimate() (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"unlock",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 	)
 
 	return result, err
 }
 
 // Transaction submission.
-func (sp *SortitionPool) UpdateOperatorStatus(
+func (bsp *BeaconSortitionPool) UpdateOperatorStatus(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction updateOperatorStatus",
 		" params: ",
 		fmt.Sprint(
@@ -1235,12 +1235,12 @@ func (sp *SortitionPool) UpdateOperatorStatus(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -1250,22 +1250,22 @@ func (sp *SortitionPool) UpdateOperatorStatus(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.UpdateOperatorStatus(
+	transaction, err := bsp.contract.UpdateOperatorStatus(
 		transactorOptions,
 		arg_operator,
 		arg_authorizedStake,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"updateOperatorStatus",
 			arg_operator,
@@ -1273,13 +1273,13 @@ func (sp *SortitionPool) UpdateOperatorStatus(
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction updateOperatorStatus with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -1293,15 +1293,15 @@ func (sp *SortitionPool) UpdateOperatorStatus(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.UpdateOperatorStatus(
+			transaction, err := bsp.contract.UpdateOperatorStatus(
 				newTransactorOptions,
 				arg_operator,
 				arg_authorizedStake,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"updateOperatorStatus",
 					arg_operator,
@@ -1309,7 +1309,7 @@ func (sp *SortitionPool) UpdateOperatorStatus(
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction updateOperatorStatus with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -1319,13 +1319,13 @@ func (sp *SortitionPool) UpdateOperatorStatus(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallUpdateOperatorStatus(
+func (bsp *BeaconSortitionPool) CallUpdateOperatorStatus(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 	blockNumber *big.Int,
@@ -1333,12 +1333,12 @@ func (sp *SortitionPool) CallUpdateOperatorStatus(
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"updateOperatorStatus",
 		&result,
 		arg_operator,
@@ -1348,18 +1348,18 @@ func (sp *SortitionPool) CallUpdateOperatorStatus(
 	return err
 }
 
-func (sp *SortitionPool) UpdateOperatorStatusGasEstimate(
+func (bsp *BeaconSortitionPool) UpdateOperatorStatusGasEstimate(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"updateOperatorStatus",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_operator,
 		arg_authorizedStake,
 	)
@@ -1368,12 +1368,12 @@ func (sp *SortitionPool) UpdateOperatorStatusGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) WithdrawIneligible(
+func (bsp *BeaconSortitionPool) WithdrawIneligible(
 	arg_recipient common.Address,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction withdrawIneligible",
 		" params: ",
 		fmt.Sprint(
@@ -1381,12 +1381,12 @@ func (sp *SortitionPool) WithdrawIneligible(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -1396,34 +1396,34 @@ func (sp *SortitionPool) WithdrawIneligible(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.WithdrawIneligible(
+	transaction, err := bsp.contract.WithdrawIneligible(
 		transactorOptions,
 		arg_recipient,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"withdrawIneligible",
 			arg_recipient,
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction withdrawIneligible with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -1437,21 +1437,21 @@ func (sp *SortitionPool) WithdrawIneligible(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.WithdrawIneligible(
+			transaction, err := bsp.contract.WithdrawIneligible(
 				newTransactorOptions,
 				arg_recipient,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"withdrawIneligible",
 					arg_recipient,
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction withdrawIneligible with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -1461,25 +1461,25 @@ func (sp *SortitionPool) WithdrawIneligible(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallWithdrawIneligible(
+func (bsp *BeaconSortitionPool) CallWithdrawIneligible(
 	arg_recipient common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"withdrawIneligible",
 		&result,
 		arg_recipient,
@@ -1488,17 +1488,17 @@ func (sp *SortitionPool) CallWithdrawIneligible(
 	return err
 }
 
-func (sp *SortitionPool) WithdrawIneligibleGasEstimate(
+func (bsp *BeaconSortitionPool) WithdrawIneligibleGasEstimate(
 	arg_recipient common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"withdrawIneligible",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_recipient,
 	)
 
@@ -1506,13 +1506,13 @@ func (sp *SortitionPool) WithdrawIneligibleGasEstimate(
 }
 
 // Transaction submission.
-func (sp *SortitionPool) WithdrawRewards(
+func (bsp *BeaconSortitionPool) WithdrawRewards(
 	arg_operator common.Address,
 	arg_beneficiary common.Address,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
-	spLogger.Debug(
+	bspLogger.Debug(
 		"submitting transaction withdrawRewards",
 		" params: ",
 		fmt.Sprint(
@@ -1521,12 +1521,12 @@ func (sp *SortitionPool) WithdrawRewards(
 		),
 	)
 
-	sp.transactionMutex.Lock()
-	defer sp.transactionMutex.Unlock()
+	bsp.transactionMutex.Lock()
+	defer bsp.transactionMutex.Unlock()
 
 	// create a copy
 	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *sp.transactorOptions
+	*transactorOptions = *bsp.transactorOptions
 
 	if len(transactionOptions) > 1 {
 		return nil, fmt.Errorf(
@@ -1536,22 +1536,22 @@ func (sp *SortitionPool) WithdrawRewards(
 		transactionOptions[0].Apply(transactorOptions)
 	}
 
-	nonce, err := sp.nonceManager.CurrentNonce()
+	nonce, err := bsp.nonceManager.CurrentNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
 	}
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := sp.contract.WithdrawRewards(
+	transaction, err := bsp.contract.WithdrawRewards(
 		transactorOptions,
 		arg_operator,
 		arg_beneficiary,
 	)
 	if err != nil {
-		return transaction, sp.errorResolver.ResolveError(
+		return transaction, bsp.errorResolver.ResolveError(
 			err,
-			sp.transactorOptions.From,
+			bsp.transactorOptions.From,
 			nil,
 			"withdrawRewards",
 			arg_operator,
@@ -1559,13 +1559,13 @@ func (sp *SortitionPool) WithdrawRewards(
 		)
 	}
 
-	spLogger.Infof(
+	bspLogger.Infof(
 		"submitted transaction withdrawRewards with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
 
-	go sp.miningWaiter.ForceMining(
+	go bsp.miningWaiter.ForceMining(
 		transaction,
 		transactorOptions,
 		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
@@ -1579,15 +1579,15 @@ func (sp *SortitionPool) WithdrawRewards(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := sp.contract.WithdrawRewards(
+			transaction, err := bsp.contract.WithdrawRewards(
 				newTransactorOptions,
 				arg_operator,
 				arg_beneficiary,
 			)
 			if err != nil {
-				return nil, sp.errorResolver.ResolveError(
+				return nil, bsp.errorResolver.ResolveError(
 					err,
-					sp.transactorOptions.From,
+					bsp.transactorOptions.From,
 					nil,
 					"withdrawRewards",
 					arg_operator,
@@ -1595,7 +1595,7 @@ func (sp *SortitionPool) WithdrawRewards(
 				)
 			}
 
-			spLogger.Infof(
+			bspLogger.Infof(
 				"submitted transaction withdrawRewards with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
@@ -1605,13 +1605,13 @@ func (sp *SortitionPool) WithdrawRewards(
 		},
 	)
 
-	sp.nonceManager.IncrementNonce()
+	bsp.nonceManager.IncrementNonce()
 
 	return transaction, err
 }
 
 // Non-mutating call, not a transaction submission.
-func (sp *SortitionPool) CallWithdrawRewards(
+func (bsp *BeaconSortitionPool) CallWithdrawRewards(
 	arg_operator common.Address,
 	arg_beneficiary common.Address,
 	blockNumber *big.Int,
@@ -1619,12 +1619,12 @@ func (sp *SortitionPool) CallWithdrawRewards(
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.transactorOptions.From,
+		bsp.transactorOptions.From,
 		blockNumber, nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"withdrawRewards",
 		&result,
 		arg_operator,
@@ -1634,18 +1634,18 @@ func (sp *SortitionPool) CallWithdrawRewards(
 	return result, err
 }
 
-func (sp *SortitionPool) WithdrawRewardsGasEstimate(
+func (bsp *BeaconSortitionPool) WithdrawRewardsGasEstimate(
 	arg_operator common.Address,
 	arg_beneficiary common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
-		sp.callerOptions.From,
-		sp.contractAddress,
+		bsp.callerOptions.From,
+		bsp.contractAddress,
 		"withdrawRewards",
-		sp.contractABI,
-		sp.transactor,
+		bsp.contractABI,
+		bsp.transactor,
 		arg_operator,
 		arg_beneficiary,
 	)
@@ -1655,18 +1655,18 @@ func (sp *SortitionPool) WithdrawRewardsGasEstimate(
 
 // ----- Const Methods ------
 
-func (sp *SortitionPool) CanRestoreRewardEligibility(
+func (bsp *BeaconSortitionPool) CanRestoreRewardEligibility(
 	arg_operator uint32,
 ) (bool, error) {
-	result, err := sp.contract.CanRestoreRewardEligibility(
-		sp.callerOptions,
+	result, err := bsp.contract.CanRestoreRewardEligibility(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"canRestoreRewardEligibility",
 			arg_operator,
@@ -1676,20 +1676,20 @@ func (sp *SortitionPool) CanRestoreRewardEligibility(
 	return result, err
 }
 
-func (sp *SortitionPool) CanRestoreRewardEligibilityAtBlock(
+func (bsp *BeaconSortitionPool) CanRestoreRewardEligibilityAtBlock(
 	arg_operator uint32,
 	blockNumber *big.Int,
 ) (bool, error) {
 	var result bool
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"canRestoreRewardEligibility",
 		&result,
 		arg_operator,
@@ -1698,18 +1698,18 @@ func (sp *SortitionPool) CanRestoreRewardEligibilityAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) GetAvailableRewards(
+func (bsp *BeaconSortitionPool) GetAvailableRewards(
 	arg_operator common.Address,
 ) (*big.Int, error) {
-	result, err := sp.contract.GetAvailableRewards(
-		sp.callerOptions,
+	result, err := bsp.contract.GetAvailableRewards(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"getAvailableRewards",
 			arg_operator,
@@ -1719,20 +1719,20 @@ func (sp *SortitionPool) GetAvailableRewards(
 	return result, err
 }
 
-func (sp *SortitionPool) GetAvailableRewardsAtBlock(
+func (bsp *BeaconSortitionPool) GetAvailableRewardsAtBlock(
 	arg_operator common.Address,
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"getAvailableRewards",
 		&result,
 		arg_operator,
@@ -1741,18 +1741,18 @@ func (sp *SortitionPool) GetAvailableRewardsAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) GetIDOperator(
+func (bsp *BeaconSortitionPool) GetIDOperator(
 	arg_id uint32,
 ) (common.Address, error) {
-	result, err := sp.contract.GetIDOperator(
-		sp.callerOptions,
+	result, err := bsp.contract.GetIDOperator(
+		bsp.callerOptions,
 		arg_id,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"getIDOperator",
 			arg_id,
@@ -1762,20 +1762,20 @@ func (sp *SortitionPool) GetIDOperator(
 	return result, err
 }
 
-func (sp *SortitionPool) GetIDOperatorAtBlock(
+func (bsp *BeaconSortitionPool) GetIDOperatorAtBlock(
 	arg_id uint32,
 	blockNumber *big.Int,
 ) (common.Address, error) {
 	var result common.Address
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"getIDOperator",
 		&result,
 		arg_id,
@@ -1784,18 +1784,18 @@ func (sp *SortitionPool) GetIDOperatorAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) GetIDOperators(
+func (bsp *BeaconSortitionPool) GetIDOperators(
 	arg_ids []uint32,
 ) ([]common.Address, error) {
-	result, err := sp.contract.GetIDOperators(
-		sp.callerOptions,
+	result, err := bsp.contract.GetIDOperators(
+		bsp.callerOptions,
 		arg_ids,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"getIDOperators",
 			arg_ids,
@@ -1805,20 +1805,20 @@ func (sp *SortitionPool) GetIDOperators(
 	return result, err
 }
 
-func (sp *SortitionPool) GetIDOperatorsAtBlock(
+func (bsp *BeaconSortitionPool) GetIDOperatorsAtBlock(
 	arg_ids []uint32,
 	blockNumber *big.Int,
 ) ([]common.Address, error) {
 	var result []common.Address
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"getIDOperators",
 		&result,
 		arg_ids,
@@ -1827,18 +1827,18 @@ func (sp *SortitionPool) GetIDOperatorsAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) GetOperatorID(
+func (bsp *BeaconSortitionPool) GetOperatorID(
 	arg_operator common.Address,
 ) (uint32, error) {
-	result, err := sp.contract.GetOperatorID(
-		sp.callerOptions,
+	result, err := bsp.contract.GetOperatorID(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"getOperatorID",
 			arg_operator,
@@ -1848,20 +1848,20 @@ func (sp *SortitionPool) GetOperatorID(
 	return result, err
 }
 
-func (sp *SortitionPool) GetOperatorIDAtBlock(
+func (bsp *BeaconSortitionPool) GetOperatorIDAtBlock(
 	arg_operator common.Address,
 	blockNumber *big.Int,
 ) (uint32, error) {
 	var result uint32
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"getOperatorID",
 		&result,
 		arg_operator,
@@ -1870,18 +1870,18 @@ func (sp *SortitionPool) GetOperatorIDAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) GetPoolWeight(
+func (bsp *BeaconSortitionPool) GetPoolWeight(
 	arg_operator common.Address,
 ) (*big.Int, error) {
-	result, err := sp.contract.GetPoolWeight(
-		sp.callerOptions,
+	result, err := bsp.contract.GetPoolWeight(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"getPoolWeight",
 			arg_operator,
@@ -1891,20 +1891,20 @@ func (sp *SortitionPool) GetPoolWeight(
 	return result, err
 }
 
-func (sp *SortitionPool) GetPoolWeightAtBlock(
+func (bsp *BeaconSortitionPool) GetPoolWeightAtBlock(
 	arg_operator common.Address,
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"getPoolWeight",
 		&result,
 		arg_operator,
@@ -1913,15 +1913,15 @@ func (sp *SortitionPool) GetPoolWeightAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) IneligibleEarnedRewards() (*big.Int, error) {
-	result, err := sp.contract.IneligibleEarnedRewards(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) IneligibleEarnedRewards() (*big.Int, error) {
+	result, err := bsp.contract.IneligibleEarnedRewards(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"ineligibleEarnedRewards",
 		)
@@ -1930,19 +1930,19 @@ func (sp *SortitionPool) IneligibleEarnedRewards() (*big.Int, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) IneligibleEarnedRewardsAtBlock(
+func (bsp *BeaconSortitionPool) IneligibleEarnedRewardsAtBlock(
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"ineligibleEarnedRewards",
 		&result,
 	)
@@ -1950,18 +1950,18 @@ func (sp *SortitionPool) IneligibleEarnedRewardsAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) IsEligibleForRewards(
+func (bsp *BeaconSortitionPool) IsEligibleForRewards(
 	arg_operator uint32,
 ) (bool, error) {
-	result, err := sp.contract.IsEligibleForRewards(
-		sp.callerOptions,
+	result, err := bsp.contract.IsEligibleForRewards(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"isEligibleForRewards",
 			arg_operator,
@@ -1971,20 +1971,20 @@ func (sp *SortitionPool) IsEligibleForRewards(
 	return result, err
 }
 
-func (sp *SortitionPool) IsEligibleForRewardsAtBlock(
+func (bsp *BeaconSortitionPool) IsEligibleForRewardsAtBlock(
 	arg_operator uint32,
 	blockNumber *big.Int,
 ) (bool, error) {
 	var result bool
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"isEligibleForRewards",
 		&result,
 		arg_operator,
@@ -1993,15 +1993,15 @@ func (sp *SortitionPool) IsEligibleForRewardsAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) IsLocked() (bool, error) {
-	result, err := sp.contract.IsLocked(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) IsLocked() (bool, error) {
+	result, err := bsp.contract.IsLocked(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"isLocked",
 		)
@@ -2010,19 +2010,19 @@ func (sp *SortitionPool) IsLocked() (bool, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) IsLockedAtBlock(
+func (bsp *BeaconSortitionPool) IsLockedAtBlock(
 	blockNumber *big.Int,
 ) (bool, error) {
 	var result bool
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"isLocked",
 		&result,
 	)
@@ -2030,18 +2030,18 @@ func (sp *SortitionPool) IsLockedAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) IsOperatorInPool(
+func (bsp *BeaconSortitionPool) IsOperatorInPool(
 	arg_operator common.Address,
 ) (bool, error) {
-	result, err := sp.contract.IsOperatorInPool(
-		sp.callerOptions,
+	result, err := bsp.contract.IsOperatorInPool(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"isOperatorInPool",
 			arg_operator,
@@ -2051,20 +2051,20 @@ func (sp *SortitionPool) IsOperatorInPool(
 	return result, err
 }
 
-func (sp *SortitionPool) IsOperatorInPoolAtBlock(
+func (bsp *BeaconSortitionPool) IsOperatorInPoolAtBlock(
 	arg_operator common.Address,
 	blockNumber *big.Int,
 ) (bool, error) {
 	var result bool
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"isOperatorInPool",
 		&result,
 		arg_operator,
@@ -2073,18 +2073,18 @@ func (sp *SortitionPool) IsOperatorInPoolAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) IsOperatorRegistered(
+func (bsp *BeaconSortitionPool) IsOperatorRegistered(
 	arg_operator common.Address,
 ) (bool, error) {
-	result, err := sp.contract.IsOperatorRegistered(
-		sp.callerOptions,
+	result, err := bsp.contract.IsOperatorRegistered(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"isOperatorRegistered",
 			arg_operator,
@@ -2094,20 +2094,20 @@ func (sp *SortitionPool) IsOperatorRegistered(
 	return result, err
 }
 
-func (sp *SortitionPool) IsOperatorRegisteredAtBlock(
+func (bsp *BeaconSortitionPool) IsOperatorRegisteredAtBlock(
 	arg_operator common.Address,
 	blockNumber *big.Int,
 ) (bool, error) {
 	var result bool
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"isOperatorRegistered",
 		&result,
 		arg_operator,
@@ -2116,20 +2116,20 @@ func (sp *SortitionPool) IsOperatorRegisteredAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) IsOperatorUpToDate(
+func (bsp *BeaconSortitionPool) IsOperatorUpToDate(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 ) (bool, error) {
-	result, err := sp.contract.IsOperatorUpToDate(
-		sp.callerOptions,
+	result, err := bsp.contract.IsOperatorUpToDate(
+		bsp.callerOptions,
 		arg_operator,
 		arg_authorizedStake,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"isOperatorUpToDate",
 			arg_operator,
@@ -2140,7 +2140,7 @@ func (sp *SortitionPool) IsOperatorUpToDate(
 	return result, err
 }
 
-func (sp *SortitionPool) IsOperatorUpToDateAtBlock(
+func (bsp *BeaconSortitionPool) IsOperatorUpToDateAtBlock(
 	arg_operator common.Address,
 	arg_authorizedStake *big.Int,
 	blockNumber *big.Int,
@@ -2148,13 +2148,13 @@ func (sp *SortitionPool) IsOperatorUpToDateAtBlock(
 	var result bool
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"isOperatorUpToDate",
 		&result,
 		arg_operator,
@@ -2164,15 +2164,15 @@ func (sp *SortitionPool) IsOperatorUpToDateAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) OperatorsInPool() (*big.Int, error) {
-	result, err := sp.contract.OperatorsInPool(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) OperatorsInPool() (*big.Int, error) {
+	result, err := bsp.contract.OperatorsInPool(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"operatorsInPool",
 		)
@@ -2181,19 +2181,19 @@ func (sp *SortitionPool) OperatorsInPool() (*big.Int, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) OperatorsInPoolAtBlock(
+func (bsp *BeaconSortitionPool) OperatorsInPoolAtBlock(
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"operatorsInPool",
 		&result,
 	)
@@ -2201,15 +2201,15 @@ func (sp *SortitionPool) OperatorsInPoolAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) Owner() (common.Address, error) {
-	result, err := sp.contract.Owner(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) Owner() (common.Address, error) {
+	result, err := bsp.contract.Owner(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"owner",
 		)
@@ -2218,19 +2218,19 @@ func (sp *SortitionPool) Owner() (common.Address, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) OwnerAtBlock(
+func (bsp *BeaconSortitionPool) OwnerAtBlock(
 	blockNumber *big.Int,
 ) (common.Address, error) {
 	var result common.Address
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"owner",
 		&result,
 	)
@@ -2238,15 +2238,15 @@ func (sp *SortitionPool) OwnerAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) PoolWeightDivisor() (*big.Int, error) {
-	result, err := sp.contract.PoolWeightDivisor(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) PoolWeightDivisor() (*big.Int, error) {
+	result, err := bsp.contract.PoolWeightDivisor(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"poolWeightDivisor",
 		)
@@ -2255,19 +2255,19 @@ func (sp *SortitionPool) PoolWeightDivisor() (*big.Int, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) PoolWeightDivisorAtBlock(
+func (bsp *BeaconSortitionPool) PoolWeightDivisorAtBlock(
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"poolWeightDivisor",
 		&result,
 	)
@@ -2275,15 +2275,15 @@ func (sp *SortitionPool) PoolWeightDivisorAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) RewardToken() (common.Address, error) {
-	result, err := sp.contract.RewardToken(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) RewardToken() (common.Address, error) {
+	result, err := bsp.contract.RewardToken(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"rewardToken",
 		)
@@ -2292,19 +2292,19 @@ func (sp *SortitionPool) RewardToken() (common.Address, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) RewardTokenAtBlock(
+func (bsp *BeaconSortitionPool) RewardTokenAtBlock(
 	blockNumber *big.Int,
 ) (common.Address, error) {
 	var result common.Address
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"rewardToken",
 		&result,
 	)
@@ -2312,18 +2312,18 @@ func (sp *SortitionPool) RewardTokenAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) RewardsEligibilityRestorableAt(
+func (bsp *BeaconSortitionPool) RewardsEligibilityRestorableAt(
 	arg_operator uint32,
 ) (*big.Int, error) {
-	result, err := sp.contract.RewardsEligibilityRestorableAt(
-		sp.callerOptions,
+	result, err := bsp.contract.RewardsEligibilityRestorableAt(
+		bsp.callerOptions,
 		arg_operator,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"rewardsEligibilityRestorableAt",
 			arg_operator,
@@ -2333,20 +2333,20 @@ func (sp *SortitionPool) RewardsEligibilityRestorableAt(
 	return result, err
 }
 
-func (sp *SortitionPool) RewardsEligibilityRestorableAtAtBlock(
+func (bsp *BeaconSortitionPool) RewardsEligibilityRestorableAtAtBlock(
 	arg_operator uint32,
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"rewardsEligibilityRestorableAt",
 		&result,
 		arg_operator,
@@ -2355,20 +2355,20 @@ func (sp *SortitionPool) RewardsEligibilityRestorableAtAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) SelectGroup(
+func (bsp *BeaconSortitionPool) SelectGroup(
 	arg_groupSize *big.Int,
 	arg_seed [32]byte,
 ) ([]uint32, error) {
-	result, err := sp.contract.SelectGroup(
-		sp.callerOptions,
+	result, err := bsp.contract.SelectGroup(
+		bsp.callerOptions,
 		arg_groupSize,
 		arg_seed,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"selectGroup",
 			arg_groupSize,
@@ -2379,7 +2379,7 @@ func (sp *SortitionPool) SelectGroup(
 	return result, err
 }
 
-func (sp *SortitionPool) SelectGroupAtBlock(
+func (bsp *BeaconSortitionPool) SelectGroupAtBlock(
 	arg_groupSize *big.Int,
 	arg_seed [32]byte,
 	blockNumber *big.Int,
@@ -2387,13 +2387,13 @@ func (sp *SortitionPool) SelectGroupAtBlock(
 	var result []uint32
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"selectGroup",
 		&result,
 		arg_groupSize,
@@ -2403,15 +2403,15 @@ func (sp *SortitionPool) SelectGroupAtBlock(
 	return result, err
 }
 
-func (sp *SortitionPool) TotalWeight() (*big.Int, error) {
-	result, err := sp.contract.TotalWeight(
-		sp.callerOptions,
+func (bsp *BeaconSortitionPool) TotalWeight() (*big.Int, error) {
+	result, err := bsp.contract.TotalWeight(
+		bsp.callerOptions,
 	)
 
 	if err != nil {
-		return result, sp.errorResolver.ResolveError(
+		return result, bsp.errorResolver.ResolveError(
 			err,
-			sp.callerOptions.From,
+			bsp.callerOptions.From,
 			nil,
 			"totalWeight",
 		)
@@ -2420,19 +2420,19 @@ func (sp *SortitionPool) TotalWeight() (*big.Int, error) {
 	return result, err
 }
 
-func (sp *SortitionPool) TotalWeightAtBlock(
+func (bsp *BeaconSortitionPool) TotalWeightAtBlock(
 	blockNumber *big.Int,
 ) (*big.Int, error) {
 	var result *big.Int
 
 	err := chainutil.CallAtBlock(
-		sp.callerOptions.From,
+		bsp.callerOptions.From,
 		blockNumber,
 		nil,
-		sp.contractABI,
-		sp.caller,
-		sp.errorResolver,
-		sp.contractAddress,
+		bsp.contractABI,
+		bsp.caller,
+		bsp.errorResolver,
+		bsp.contractAddress,
 		"totalWeight",
 		&result,
 	)
@@ -2442,9 +2442,9 @@ func (sp *SortitionPool) TotalWeightAtBlock(
 
 // ------ Events -------
 
-func (sp *SortitionPool) IneligibleForRewardsEvent(
+func (bsp *BeaconSortitionPool) IneligibleForRewardsEvent(
 	opts *ethlike.SubscribeOpts,
-) *SpIneligibleForRewardsSubscription {
+) *BspIneligibleForRewardsSubscription {
 	if opts == nil {
 		opts = new(ethlike.SubscribeOpts)
 	}
@@ -2455,27 +2455,27 @@ func (sp *SortitionPool) IneligibleForRewardsEvent(
 		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &SpIneligibleForRewardsSubscription{
-		sp,
+	return &BspIneligibleForRewardsSubscription{
+		bsp,
 		opts,
 	}
 }
 
-type SpIneligibleForRewardsSubscription struct {
-	contract *SortitionPool
+type BspIneligibleForRewardsSubscription struct {
+	contract *BeaconSortitionPool
 	opts     *ethlike.SubscribeOpts
 }
 
-type sortitionPoolIneligibleForRewardsFunc func(
+type beaconSortitionPoolIneligibleForRewardsFunc func(
 	Ids []uint32,
 	Until *big.Int,
 	blockNumber uint64,
 )
 
-func (ifrs *SpIneligibleForRewardsSubscription) OnEvent(
-	handler sortitionPoolIneligibleForRewardsFunc,
+func (ifrs *BspIneligibleForRewardsSubscription) OnEvent(
+	handler beaconSortitionPoolIneligibleForRewardsFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.SortitionPoolIneligibleForRewards)
+	eventChan := make(chan *abi.BeaconSortitionPoolIneligibleForRewards)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -2500,8 +2500,8 @@ func (ifrs *SpIneligibleForRewardsSubscription) OnEvent(
 	})
 }
 
-func (ifrs *SpIneligibleForRewardsSubscription) Pipe(
-	sink chan *abi.SortitionPoolIneligibleForRewards,
+func (ifrs *BspIneligibleForRewardsSubscription) Pipe(
+	sink chan *abi.BeaconSortitionPoolIneligibleForRewards,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
@@ -2514,14 +2514,14 @@ func (ifrs *SpIneligibleForRewardsSubscription) Pipe(
 			case <-ticker.C:
 				lastBlock, err := ifrs.contract.blockCounter.CurrentBlock()
 				if err != nil {
-					spLogger.Errorf(
+					bspLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
 				fromBlock := lastBlock - ifrs.opts.PastBlocks
 
-				spLogger.Infof(
+				bspLogger.Infof(
 					"subscription monitoring fetching past IneligibleForRewards events "+
 						"starting from block [%v]",
 					fromBlock,
@@ -2531,13 +2531,13 @@ func (ifrs *SpIneligibleForRewardsSubscription) Pipe(
 					nil,
 				)
 				if err != nil {
-					spLogger.Errorf(
+					bspLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 					continue
 				}
-				spLogger.Infof(
+				bspLogger.Infof(
 					"subscription monitoring fetched [%v] past IneligibleForRewards events",
 					len(events),
 				)
@@ -2559,18 +2559,18 @@ func (ifrs *SpIneligibleForRewardsSubscription) Pipe(
 	})
 }
 
-func (sp *SortitionPool) watchIneligibleForRewards(
-	sink chan *abi.SortitionPoolIneligibleForRewards,
+func (bsp *BeaconSortitionPool) watchIneligibleForRewards(
+	sink chan *abi.BeaconSortitionPoolIneligibleForRewards,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return sp.contract.WatchIneligibleForRewards(
+		return bsp.contract.WatchIneligibleForRewards(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 		)
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		spLogger.Errorf(
+		bspLogger.Errorf(
 			"subscription to event IneligibleForRewards had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2579,7 +2579,7 @@ func (sp *SortitionPool) watchIneligibleForRewards(
 	}
 
 	subscriptionFailedFn := func(err error) {
-		spLogger.Errorf(
+		bspLogger.Errorf(
 			"subscription to event IneligibleForRewards failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
@@ -2596,11 +2596,11 @@ func (sp *SortitionPool) watchIneligibleForRewards(
 	)
 }
 
-func (sp *SortitionPool) PastIneligibleForRewardsEvents(
+func (bsp *BeaconSortitionPool) PastIneligibleForRewardsEvents(
 	startBlock uint64,
 	endBlock *uint64,
-) ([]*abi.SortitionPoolIneligibleForRewards, error) {
-	iterator, err := sp.contract.FilterIneligibleForRewards(
+) ([]*abi.BeaconSortitionPoolIneligibleForRewards, error) {
+	iterator, err := bsp.contract.FilterIneligibleForRewards(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
@@ -2613,7 +2613,7 @@ func (sp *SortitionPool) PastIneligibleForRewardsEvents(
 		)
 	}
 
-	events := make([]*abi.SortitionPoolIneligibleForRewards, 0)
+	events := make([]*abi.BeaconSortitionPoolIneligibleForRewards, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -2623,11 +2623,11 @@ func (sp *SortitionPool) PastIneligibleForRewardsEvents(
 	return events, nil
 }
 
-func (sp *SortitionPool) OwnershipTransferredEvent(
+func (bsp *BeaconSortitionPool) OwnershipTransferredEvent(
 	opts *ethlike.SubscribeOpts,
 	previousOwnerFilter []common.Address,
 	newOwnerFilter []common.Address,
-) *SpOwnershipTransferredSubscription {
+) *BspOwnershipTransferredSubscription {
 	if opts == nil {
 		opts = new(ethlike.SubscribeOpts)
 	}
@@ -2638,31 +2638,31 @@ func (sp *SortitionPool) OwnershipTransferredEvent(
 		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &SpOwnershipTransferredSubscription{
-		sp,
+	return &BspOwnershipTransferredSubscription{
+		bsp,
 		opts,
 		previousOwnerFilter,
 		newOwnerFilter,
 	}
 }
 
-type SpOwnershipTransferredSubscription struct {
-	contract            *SortitionPool
+type BspOwnershipTransferredSubscription struct {
+	contract            *BeaconSortitionPool
 	opts                *ethlike.SubscribeOpts
 	previousOwnerFilter []common.Address
 	newOwnerFilter      []common.Address
 }
 
-type sortitionPoolOwnershipTransferredFunc func(
+type beaconSortitionPoolOwnershipTransferredFunc func(
 	PreviousOwner common.Address,
 	NewOwner common.Address,
 	blockNumber uint64,
 )
 
-func (ots *SpOwnershipTransferredSubscription) OnEvent(
-	handler sortitionPoolOwnershipTransferredFunc,
+func (ots *BspOwnershipTransferredSubscription) OnEvent(
+	handler beaconSortitionPoolOwnershipTransferredFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.SortitionPoolOwnershipTransferred)
+	eventChan := make(chan *abi.BeaconSortitionPoolOwnershipTransferred)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -2687,8 +2687,8 @@ func (ots *SpOwnershipTransferredSubscription) OnEvent(
 	})
 }
 
-func (ots *SpOwnershipTransferredSubscription) Pipe(
-	sink chan *abi.SortitionPoolOwnershipTransferred,
+func (ots *BspOwnershipTransferredSubscription) Pipe(
+	sink chan *abi.BeaconSortitionPoolOwnershipTransferred,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
@@ -2701,14 +2701,14 @@ func (ots *SpOwnershipTransferredSubscription) Pipe(
 			case <-ticker.C:
 				lastBlock, err := ots.contract.blockCounter.CurrentBlock()
 				if err != nil {
-					spLogger.Errorf(
+					bspLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
 				fromBlock := lastBlock - ots.opts.PastBlocks
 
-				spLogger.Infof(
+				bspLogger.Infof(
 					"subscription monitoring fetching past OwnershipTransferred events "+
 						"starting from block [%v]",
 					fromBlock,
@@ -2720,13 +2720,13 @@ func (ots *SpOwnershipTransferredSubscription) Pipe(
 					ots.newOwnerFilter,
 				)
 				if err != nil {
-					spLogger.Errorf(
+					bspLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 					continue
 				}
-				spLogger.Infof(
+				bspLogger.Infof(
 					"subscription monitoring fetched [%v] past OwnershipTransferred events",
 					len(events),
 				)
@@ -2750,13 +2750,13 @@ func (ots *SpOwnershipTransferredSubscription) Pipe(
 	})
 }
 
-func (sp *SortitionPool) watchOwnershipTransferred(
-	sink chan *abi.SortitionPoolOwnershipTransferred,
+func (bsp *BeaconSortitionPool) watchOwnershipTransferred(
+	sink chan *abi.BeaconSortitionPoolOwnershipTransferred,
 	previousOwnerFilter []common.Address,
 	newOwnerFilter []common.Address,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return sp.contract.WatchOwnershipTransferred(
+		return bsp.contract.WatchOwnershipTransferred(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 			previousOwnerFilter,
@@ -2765,7 +2765,7 @@ func (sp *SortitionPool) watchOwnershipTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		spLogger.Errorf(
+		bspLogger.Errorf(
 			"subscription to event OwnershipTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2774,7 +2774,7 @@ func (sp *SortitionPool) watchOwnershipTransferred(
 	}
 
 	subscriptionFailedFn := func(err error) {
-		spLogger.Errorf(
+		bspLogger.Errorf(
 			"subscription to event OwnershipTransferred failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
@@ -2791,13 +2791,13 @@ func (sp *SortitionPool) watchOwnershipTransferred(
 	)
 }
 
-func (sp *SortitionPool) PastOwnershipTransferredEvents(
+func (bsp *BeaconSortitionPool) PastOwnershipTransferredEvents(
 	startBlock uint64,
 	endBlock *uint64,
 	previousOwnerFilter []common.Address,
 	newOwnerFilter []common.Address,
-) ([]*abi.SortitionPoolOwnershipTransferred, error) {
-	iterator, err := sp.contract.FilterOwnershipTransferred(
+) ([]*abi.BeaconSortitionPoolOwnershipTransferred, error) {
+	iterator, err := bsp.contract.FilterOwnershipTransferred(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
@@ -2812,7 +2812,7 @@ func (sp *SortitionPool) PastOwnershipTransferredEvents(
 		)
 	}
 
-	events := make([]*abi.SortitionPoolOwnershipTransferred, 0)
+	events := make([]*abi.BeaconSortitionPoolOwnershipTransferred, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -2822,11 +2822,11 @@ func (sp *SortitionPool) PastOwnershipTransferredEvents(
 	return events, nil
 }
 
-func (sp *SortitionPool) RewardEligibilityRestoredEvent(
+func (bsp *BeaconSortitionPool) RewardEligibilityRestoredEvent(
 	opts *ethlike.SubscribeOpts,
 	operatorFilter []common.Address,
 	idFilter []uint32,
-) *SpRewardEligibilityRestoredSubscription {
+) *BspRewardEligibilityRestoredSubscription {
 	if opts == nil {
 		opts = new(ethlike.SubscribeOpts)
 	}
@@ -2837,31 +2837,31 @@ func (sp *SortitionPool) RewardEligibilityRestoredEvent(
 		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &SpRewardEligibilityRestoredSubscription{
-		sp,
+	return &BspRewardEligibilityRestoredSubscription{
+		bsp,
 		opts,
 		operatorFilter,
 		idFilter,
 	}
 }
 
-type SpRewardEligibilityRestoredSubscription struct {
-	contract       *SortitionPool
+type BspRewardEligibilityRestoredSubscription struct {
+	contract       *BeaconSortitionPool
 	opts           *ethlike.SubscribeOpts
 	operatorFilter []common.Address
 	idFilter       []uint32
 }
 
-type sortitionPoolRewardEligibilityRestoredFunc func(
+type beaconSortitionPoolRewardEligibilityRestoredFunc func(
 	Operator common.Address,
 	Id uint32,
 	blockNumber uint64,
 )
 
-func (rers *SpRewardEligibilityRestoredSubscription) OnEvent(
-	handler sortitionPoolRewardEligibilityRestoredFunc,
+func (rers *BspRewardEligibilityRestoredSubscription) OnEvent(
+	handler beaconSortitionPoolRewardEligibilityRestoredFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.SortitionPoolRewardEligibilityRestored)
+	eventChan := make(chan *abi.BeaconSortitionPoolRewardEligibilityRestored)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -2886,8 +2886,8 @@ func (rers *SpRewardEligibilityRestoredSubscription) OnEvent(
 	})
 }
 
-func (rers *SpRewardEligibilityRestoredSubscription) Pipe(
-	sink chan *abi.SortitionPoolRewardEligibilityRestored,
+func (rers *BspRewardEligibilityRestoredSubscription) Pipe(
+	sink chan *abi.BeaconSortitionPoolRewardEligibilityRestored,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
@@ -2900,14 +2900,14 @@ func (rers *SpRewardEligibilityRestoredSubscription) Pipe(
 			case <-ticker.C:
 				lastBlock, err := rers.contract.blockCounter.CurrentBlock()
 				if err != nil {
-					spLogger.Errorf(
+					bspLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
 				fromBlock := lastBlock - rers.opts.PastBlocks
 
-				spLogger.Infof(
+				bspLogger.Infof(
 					"subscription monitoring fetching past RewardEligibilityRestored events "+
 						"starting from block [%v]",
 					fromBlock,
@@ -2919,13 +2919,13 @@ func (rers *SpRewardEligibilityRestoredSubscription) Pipe(
 					rers.idFilter,
 				)
 				if err != nil {
-					spLogger.Errorf(
+					bspLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 					continue
 				}
-				spLogger.Infof(
+				bspLogger.Infof(
 					"subscription monitoring fetched [%v] past RewardEligibilityRestored events",
 					len(events),
 				)
@@ -2949,13 +2949,13 @@ func (rers *SpRewardEligibilityRestoredSubscription) Pipe(
 	})
 }
 
-func (sp *SortitionPool) watchRewardEligibilityRestored(
-	sink chan *abi.SortitionPoolRewardEligibilityRestored,
+func (bsp *BeaconSortitionPool) watchRewardEligibilityRestored(
+	sink chan *abi.BeaconSortitionPoolRewardEligibilityRestored,
 	operatorFilter []common.Address,
 	idFilter []uint32,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return sp.contract.WatchRewardEligibilityRestored(
+		return bsp.contract.WatchRewardEligibilityRestored(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 			operatorFilter,
@@ -2964,7 +2964,7 @@ func (sp *SortitionPool) watchRewardEligibilityRestored(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		spLogger.Errorf(
+		bspLogger.Errorf(
 			"subscription to event RewardEligibilityRestored had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2973,7 +2973,7 @@ func (sp *SortitionPool) watchRewardEligibilityRestored(
 	}
 
 	subscriptionFailedFn := func(err error) {
-		spLogger.Errorf(
+		bspLogger.Errorf(
 			"subscription to event RewardEligibilityRestored failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
@@ -2990,13 +2990,13 @@ func (sp *SortitionPool) watchRewardEligibilityRestored(
 	)
 }
 
-func (sp *SortitionPool) PastRewardEligibilityRestoredEvents(
+func (bsp *BeaconSortitionPool) PastRewardEligibilityRestoredEvents(
 	startBlock uint64,
 	endBlock *uint64,
 	operatorFilter []common.Address,
 	idFilter []uint32,
-) ([]*abi.SortitionPoolRewardEligibilityRestored, error) {
-	iterator, err := sp.contract.FilterRewardEligibilityRestored(
+) ([]*abi.BeaconSortitionPoolRewardEligibilityRestored, error) {
+	iterator, err := bsp.contract.FilterRewardEligibilityRestored(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
@@ -3011,7 +3011,7 @@ func (sp *SortitionPool) PastRewardEligibilityRestoredEvents(
 		)
 	}
 
-	events := make([]*abi.SortitionPoolRewardEligibilityRestored, 0)
+	events := make([]*abi.BeaconSortitionPoolRewardEligibilityRestored, 0)
 
 	for iterator.Next() {
 		event := iterator.Event


### PR DESCRIPTION
We update the expected path where artifacts should be placed in the contract package. With the recent changes to the contracts packages exports, we expect them to be placed in `artifacts` directory in a flat directory structure.

Also for the `@keep-network/random-beacon` and `@keep-network/ecdsa` the artifact names have changed from `SortitionPool` to `BeaconSortitionPool` and `EcdsaSortitionPool`.