### PR TITLE
Configure ecdsa and random-beacon for local deploy

### DIFF
--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -143,16 +143,19 @@ const config: HardhatUserConfig = {
         deploy: "node_modules/@keep-network/random-beacon/export/deploy",
       },
     ],
-    // deployments: {
-    //   // For hardhat environment we can fork the mainnet, so we need to point it
-    //   // to the contract artifacts.
-    //   hardhat: process.env.FORKING_URL ? ["./external/mainnet"] : [],
-    //   // For development environment we expect the local dependencies to be linked
-    //   // with `yarn link` command.
-    //   development: ["node_modules/@keep-network/keep-core/artifacts"],
-    //   ropsten: ["node_modules/@keep-network/keep-core/artifacts"],
-    //   mainnet: ["./external/mainnet"],
-    // },
+    deployments: {
+      // For hardhat environment we can fork the mainnet, so we need to point it
+      // to the contract artifacts.
+      hardhat: process.env.FORKING_URL ? ["./external/mainnet"] : [],
+      // For development environment we expect the local dependencies to be linked
+      // with `yarn link` command.
+      development: [
+        "node_modules/@threshold-network/solidity-contracts/artifacts",
+        "node_modules/@keep-network/random-beacon",
+      ],
+      ropsten: ["node_modules/@keep-network/keep-core/artifacts"],
+      mainnet: ["./external/mainnet"],
+    },
   },
   dependencyCompiler:
     // As a workaround for a slither issue https://github.com/crytic/slither/issues/1140

--- a/solidity/ecdsa/scripts/prepare-artifacts.sh
+++ b/solidity/ecdsa/scripts/prepare-artifacts.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eo pipefail
+
+help() {
+  echo -e "\nUsage: $0 --network <network>"
+
+  echo -e "\nCommand line arguments:\n"
+  echo -e "\t--network: Ethereum network." \
+    "Available networks and settings are specified in 'hardhat.config.ts'"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--network") set -- "$@" "-n" ;;
+    "--help") set -- "$@" "-h" ;;
+    *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "n:h" opt; do
+  case "$opt" in
+    n) NETWORK="$OPTARG" ;;
+    h) help ;;
+    ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+[ -z "$NETWORK" ] && {
+  echo "--network option not provided" >&2
+  help
+  exit 1
+}
+
+echo "Copying deployments artifacts for network: $NETWORK"
+
+ROOT_DIR="$(realpath "$(dirname "$0")/..")"
+SOURCE_DEPLOYMENT_DIR="$(realpath "$ROOT_DIR/deployments/$NETWORK")"
+DESTINATION_ARTIFACTS_DIR="$(realpath "$ROOT_DIR/artifacts")"
+
+[ ! -d "${SOURCE_DEPLOYMENT_DIR}" ] && {
+  echo "$SOURCE_DEPLOYMENT_DIR does not exist" >&2
+  exit 1
+}
+
+rm -rf $DESTINATION_ARTIFACTS_DIR
+cp -r deployments/$NETWORK $DESTINATION_ARTIFACTS_DIR
+
+echo "Deployment artifacts copied to: $DESTINATION_ARTIFACTS_DIR"

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -124,16 +124,19 @@ const config: HardhatUserConfig = {
           "node_modules/@threshold-network/solidity-contracts/export/deploy",
       },
     ],
-    // deployments: {
-    //   // For hardhat environment we can fork the mainnet, so we need to point it
-    //   // to the contract artifacts.
-    //   hardhat: process.env.FORKING_URL ? ["./external/mainnet"] : [],
-    //   // For development environment we expect the local dependencies to be linked
-    //   // with `yarn link` command.
-    //   development: ["node_modules/@keep-network/keep-core/artifacts"],
-    //   ropsten: ["node_modules/@keep-network/keep-core/artifacts"],
-    //   mainnet: ["./external/mainnet"],
-    // },
+    deployments: {
+      // For hardhat environment we can fork the mainnet, so we need to point it
+      // to the contract artifacts.
+      hardhat: process.env.FORKING_URL ? ["./external/mainnet"] : [],
+      // For development environment we expect the local dependencies to be linked
+      // with `yarn link` command.
+      development: [
+        "node_modules/@keep-network/keep-core/artifacts",
+        "node_modules/@threshold-network/solidity-contracts",
+      ],
+      ropsten: ["node_modules/@keep-network/keep-core/artifacts"],
+      mainnet: ["./external/mainnet"],
+    },
   },
   dependencyCompiler: {
     paths: [

--- a/solidity/random-beacon/scripts/prepare-artifacts.sh
+++ b/solidity/random-beacon/scripts/prepare-artifacts.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eo pipefail
+
+help() {
+  echo -e "\nUsage: $0 --network <network>"
+
+  echo -e "\nCommand line arguments:\n"
+  echo -e "\t--network: Ethereum network." \
+    "Available networks and settings are specified in 'hardhat.config.ts'"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--network") set -- "$@" "-n" ;;
+    "--help") set -- "$@" "-h" ;;
+    *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "n:h" opt; do
+  case "$opt" in
+    n) NETWORK="$OPTARG" ;;
+    h) help ;;
+    ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+[ -z "$NETWORK" ] && {
+  echo "--network option not provided" >&2
+  help
+  exit 1
+}
+
+echo "Copying deployments artifacts for network: $NETWORK"
+
+ROOT_DIR="$(realpath "$(dirname "$0")/..")"
+SOURCE_DEPLOYMENT_DIR="$(realpath "$ROOT_DIR/deployments/$NETWORK")"
+DESTINATION_ARTIFACTS_DIR="$(realpath "$ROOT_DIR/artifacts")"
+
+[ ! -d "${SOURCE_DEPLOYMENT_DIR}" ] && {
+  echo "$SOURCE_DEPLOYMENT_DIR does not exist" >&2
+  exit 1
+}
+
+rm -rf $DESTINATION_ARTIFACTS_DIR
+cp -r deployments/$NETWORK $DESTINATION_ARTIFACTS_DIR
+
+echo "Deployment artifacts copied to: $DESTINATION_ARTIFACTS_DIR"


### PR DESCRIPTION
Configure hardhag.config file in `ecdsa` and `random-beacon` so it can be 
deployed locally with linked packages.

Also create `prepare-artifacts` scripst for both libs.