### PR TITLE
Random Beacon genesis Hardhat task

### DIFF
--- a/solidity/random-beacon/tasks/genesis.ts
+++ b/solidity/random-beacon/tasks/genesis.ts
@@ -1,0 +1,21 @@
+import { task } from "hardhat/config"
+
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+task("genesis", "Triggers the Random Beacon genesis").setAction(
+  async (args, hre) => {
+    await genesis(hre)
+  }
+)
+
+async function genesis(hre: HardhatRuntimeEnvironment) {
+  const { helpers } = hre
+  const { governance } = await helpers.signers.getNamedSigners()
+
+  const randomBeacon = await helpers.contracts.getContract("RandomBeacon")
+
+  const genesisTx = await randomBeacon.connect(governance).genesis()
+  await genesisTx.wait()
+
+  console.log("Genesis was triggered successfully")
+}

--- a/solidity/random-beacon/tasks/index.ts
+++ b/solidity/random-beacon/tasks/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line global-require
 require("./unlock-eth-accounts")
 require("./stake")
+require("./genesis")


### PR DESCRIPTION
Here we introduce a Hardhat task that allows to trigger the Random Beacon's genesis. This task should facilitate testing on local Ethereum networks. In order to run it, move to the `solidity/random-beacon` directory and do:
```
npx hardhat genesis --network <network-name>
```