### PR TITLE
Update @keep-network/hardhat-helpers version

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.8",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.9",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-waffle": "^2.0.2",

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -617,10 +617,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.8":
-  version "0.6.0-pre.8"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.8.tgz#6e0722889a0132dabed5182fb32f6424ff4a77d0"
-  integrity sha512-51oLHceBubutBYxfVk2pLjgyhvpcDC1ahKM3V9lOiTa9lbWyY18Dza7rnM9V04kq+8DbweQRM0M9/f+K26nl9g==
+"@keep-network/hardhat-helpers@^0.6.0-pre.9":
+  version "0.6.0-pre.9"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.9.tgz#6277fcecfd7effbf6a6e7090b849593ffd23cc78"
+  integrity sha512-QXJ5sAa6sy2Y0DE4iMAelPW+guCh95SmWC/l52t6dz+AlLlke9jw/myWsQ/s5J4XQfIRwsfoRO36f6qSiIQjhg==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"


### PR DESCRIPTION
We update @keep-network/hardhat-helpers version to 0.6.0-pre.9 as it
contains improvements introduced in https://github.com/keep-network/hardhat-helpers/pull/27
that will modify the artifact exported for proxy contracts. The new
artifact matches the artifacts produced for contracts deployed non-proxy
way, which is important for Go code generator.