### PR TITLE
Use upgrade --exact for NPM package publication

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn upgrade \
+          yarn upgrade --exact \
             @keep-network/random-beacon \
             @keep-network/sortition-pools \
             @threshold-network/solidity-contracts

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn upgrade \
+          yarn upgrade --exact \
             @keep-network/sortition-pools \
             @threshold-network/solidity-contracts
 


### PR DESCRIPTION
We want to add `--exact` flag so the version of tagged package is
resolved to an exact value. Without this flag by default the version is
resolved by adding `^`, which can cause problems when resolving versions
with `-dev`, `-goerli`, `-mainnet` suffixes.