### PR TITLE
Upgrading hardhat helpers to 0.6.0-pre.10

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.9",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.10",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-waffle": "^2.0.2",

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -617,10 +617,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.9":
-  version "0.6.0-pre.9"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.9.tgz#6277fcecfd7effbf6a6e7090b849593ffd23cc78"
-  integrity sha512-QXJ5sAa6sy2Y0DE4iMAelPW+guCh95SmWC/l52t6dz+AlLlke9jw/myWsQ/s5J4XQfIRwsfoRO36f6qSiIQjhg==
+"@keep-network/hardhat-helpers@^0.6.0-pre.10":
+  version "0.6.0-pre.10"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.10.tgz#e202e79bed99b6cbcd6e8ec13944d4bcdefbc443"
+  integrity sha512-qvSixo9bjG4vSMJjwn60DkhSpLqYI+zVf77wuEo62nXcw9nb87kcTp4VKvQhwDwCLJZCEZiDUEf8fkNeDswR7g==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"


### PR DESCRIPTION
We need the latest version of hardhat helpers so the external deployment script 03_deploy_wallet_registry.js can be executed. Without the upgrade it throws an error:

```
Error: cannot estimate gas; transaction may fail or may require manual gas limit (error={"name":"ProviderError","code":-32000,"_isProviderError":true}, method="call", transaction={"from":"0x407190f04d838Ec47dad4C0e0D2a9c49d7737479","to":"0x9E3991842f115f93D59cb92aE508242FE965A662","data":"0x204e1c7a0000000000000000000000009e500a116ea139c8e72af8f7953438ad0720cdcd","accessList":null}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.5.3)
```