### PR TITLE
 #3012 Add LoadBalancer with static IP

### DIFF
--- a/infrastructure/kube/keep-test/geth-node/eth-goerli-node.yaml
+++ b/infrastructure/kube/keep-test/geth-node/eth-goerli-node.yaml
@@ -79,3 +79,5 @@ spec:
       targetPort: 30303
       name: udp-30303
       protocol: UDP
+  type: LoadBalancer
+  loadBalancerIP: "35.238.111.174"


### PR DESCRIPTION
 - added `type` to `spec` section in service of kubernetes defining kind of service
 - added LoadBalancer IP which was previously reserved using gcloud command as regional IP