### PR TITLE
Use immutable fields for SortitionPool

### DIFF
--- a/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
+++ b/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
@@ -64,7 +64,7 @@ contract EcdsaDkgValidator {
     ///      DKG result.
     uint256 public constant signatureByteSize = 65;
 
-    SortitionPool public sortitionPool;
+    SortitionPool public immutable sortitionPool;
 
     constructor(SortitionPool _sortitionPool) {
         sortitionPool = _sortitionPool;

--- a/solidity/random-beacon/contracts/BeaconDkgValidator.sol
+++ b/solidity/random-beacon/contracts/BeaconDkgValidator.sol
@@ -53,7 +53,7 @@ contract BeaconDkgValidator {
     ///      DKG result.
     uint256 public constant signatureByteSize = 65;
 
-    SortitionPool public sortitionPool;
+    SortitionPool public immutable sortitionPool;
 
     constructor(SortitionPool _sortitionPool) {
         require(


### PR DESCRIPTION
SortitionPool field in EcdsaDkgValidator and BeaconDkgValidator is set
only in constructor and never modified later. We can use immutable field
to save gas.