### PR TITLE
Rolled back the needed check during DKG submission

### DIFF
--- a/pkg/chain/ethereum/beacon.go
+++ b/pkg/chain/ethereum/beacon.go
@@ -510,6 +510,13 @@ func (mrb *mockRandomBeacon) SubmitDKGResult(
 	mrb.activeGroupMutex.Lock()
 	defer mrb.activeGroupMutex.Unlock()
 
+	// Abort if there is no DKG in progress. This check is needed to handle a
+	// situation in which two operators of the same client attempt to submit
+	// the DKG result.
+	if mrb.currentDkgStartBlock == nil {
+		return nil
+	}
+
 	blockNumber, err := mrb.blockCounter.CurrentBlock()
 	if err != nil {
 		return fmt.Errorf("failed to get the current block")


### PR DESCRIPTION
This PR rolls back the removal of a check that was removed in 7d3722f79dd2ae45df78a91a92814c7134eb52b0.
The check performed during DKG result submission is needed, as two operators that belong to the same client may submit a DKG result.