### PR TITLE
One More Once: Keygen Retry Algorithm

### DIFF
--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -94,7 +94,9 @@ func EvaluateRetryParticipantsForSigning(
 // sending corrupted information, either on purpose or accidentally, we keep
 // trying to find a subset of `groupMembers` that is as large as possible by
 // first excluding single operators, then pairs of operators, then triplets of
-// operators.
+// operators. We use the `seed` param to generate randomness to shuffle the
+// singles/pairs/triplets of operators to exclude and then use the `retryCount`
+// param to select which single/pair/triplet to exclude.
 //
 // The `seed` param needs to vary on a per-message basis but must be the same
 // seed between all operators for each invocation. This can be the hash of the
@@ -120,7 +122,10 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	}
 	operatorToSeatCount := calculateSeatCount(groupMembers)
 	// #nosec G404 (insecure random number source (rand))
-	// Shuffling operators for retries does not require secure randomness.
+	// Shuffling operators for retries does not require secure randomness. Unlike
+	// EvaluateRetryParticipantsForSigning above, we only want to use the seed as
+	// a source of randomness. The `retryCount` is used to select which operators
+	// to exclude after we shuffle them.
 	rng := rand.New(rand.NewSource(seed))
 
 	operators := make([]chain.Address, 0, len(operatorToSeatCount))

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -130,6 +130,8 @@ func EvaluateRetryParticipantsForKeyGeneration(
 
 	operators := make([]chain.Address, 0, len(operatorToSeatCount))
 	for operator := range operatorToSeatCount {
+		// Only include the operators that have few enough seats such that if they
+		// were excluded we still have at least `retryParticipantsCount` seats.
 		if len(groupMembers)-int(operatorToSeatCount[operator]) >= int(retryParticipantsCount) {
 			operators = append(operators, operator)
 		}
@@ -221,10 +223,13 @@ func excludeOperatorPairs(
 		for j := i + 1; j < len(operators); j++ {
 			leftOperator := operators[i]
 			rightOperator := operators[j]
+
+			// Only include the operators pairs that have few enough seats such that
+			// if they were excluded we still have at least `retryParticipantsCount`
+			// seats.
 			count := len(groupMembers) -
 				int(operatorToSeatCount[leftOperator]) -
 				int(operatorToSeatCount[rightOperator])
-
 			if count >= int(retryParticipantsCount) {
 				pairIndexes = append(pairIndexes, [2]int{i, j})
 			}
@@ -264,11 +269,14 @@ func excludeOperatorTriplets(
 				leftOperator := operators[i]
 				middleOperator := operators[j]
 				rightOperator := operators[j]
+
+				// Only include the operators triples that have few enough seats such
+				// that if they were excluded we still have at least
+				// `retryParticipantsCount` seats.
 				count := len(groupMembers) -
 					int(operatorToSeatCount[leftOperator]) -
 					int(operatorToSeatCount[middleOperator]) -
 					int(operatorToSeatCount[rightOperator])
-
 				if count >= int(retryParticipantsCount) {
 					tripletIndexes = append(tripletIndexes, [3]int{i, j, k})
 				}

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -186,6 +186,17 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	}
 }
 
+// excludeSingleOperator randomly excludes all of an operator's seats from a
+// given `groupMembers`. It needs a pre-seeded random generator `rng`, and an
+// `index`, which is expected to be inferred from a `retryCount`.
+//
+// It does this by shuffling a list of eligible-for-exclusion operators
+// according to `rng`, selecting the operator according to `index`, and then
+// filtering that operator out of `groupMembers`.
+//
+// In the case that `index` is larger than the number of eligible operators, it
+// skips shuffling and returns the number of eligible operators, which is
+// useful for determining the index of the operator pair to ignore.
 func excludeSingleOperator(
 	rng *rand.Rand,
 	groupMembers []chain.Address,
@@ -210,6 +221,18 @@ func excludeSingleOperator(
 	}
 }
 
+// excludeOperatorPairs randomly excludes all of a pair of operator's seats from a
+// given `groupMembers`. It needs a pre-seeded random generator `rng`, and an
+// `index`, which is expected to be inferred from a `retryCount`.
+//
+// It does this by shuffling a list of eligable-for-exclusion operators
+// according to `rng`, selecting the operator according to `index`, and then
+// filtering that operator pair out of `groupMembers`.
+//
+// In the case that `index` is larger than the number of eligible operator
+// pairs, it skips shuffling and returns the number of eligible operators
+// pairs, which is useful for determining the index of the operator triplet to
+// ignore.
 func excludeOperatorPairs(
 	rng *rand.Rand,
 	groupMembers []chain.Address,
@@ -254,6 +277,17 @@ func excludeOperatorPairs(
 	}
 }
 
+// excludeOperatorTriplets randomly excludes all of a triplet of operator's seats from a
+// given `groupMembers`. It needs a pre-seeded random generator `rng`, and an
+// `index`, which is expected to be inferred from a `retryCount`.
+//
+// It does this by shuffling a list of eligable-for-exclusion operators
+// according to `rng`, selecting the operator according to `index`, and then
+// filtering that operator triplet out of `groupMembers`.
+//
+// In the case that `index` is larger than the number of eligible operator
+// triplets, it skips shuffling and returns the number of eligible operators
+// triplets, which is useful for logging errors.
 func excludeOperatorTriplets(
 	rng *rand.Rand,
 	groupMembers []chain.Address,

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -109,7 +109,7 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	retryCount uint,
 	retryParticipantsCount uint,
 ) ([]chain.Address, error) {
-	originalRetryCount := retryCount
+	remainingTries := retryCount
 	if int(retryParticipantsCount) > len(groupMembers) {
 		return nil, fmt.Errorf(
 			"asked for too many seats. [%d] seats were requested, "+
@@ -135,20 +135,20 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	usedOperators, tries, ok := excludeSingleOperator(
 		rng,
 		groupMembers,
-		int(retryCount),
+		int(remainingTries),
 		operatorToSeatCount,
 		operators,
 	)
 	if ok {
 		return usedOperators, nil
 	} else {
-		retryCount -= uint(tries)
+		remainingTries -= uint(tries)
 	}
 
 	usedOperators, tries, ok = excludeOperatorPairs(
 		rng,
 		groupMembers,
-		int(retryCount),
+		int(remainingTries),
 		operatorToSeatCount,
 		operators,
 		int(retryParticipantsCount),
@@ -156,13 +156,13 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	if ok {
 		return usedOperators, nil
 	} else {
-		retryCount -= uint(tries)
+		remainingTries -= uint(tries)
 	}
 
 	usedOperators, tries, ok = excludeOperatorTriplets(
 		rng,
 		groupMembers,
-		int(retryCount),
+		int(remainingTries),
 		operatorToSeatCount,
 		operators,
 		int(retryParticipantsCount),
@@ -170,12 +170,12 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	if ok {
 		return usedOperators, nil
 	} else {
-		retryCount -= uint(tries)
+		remainingTries -= uint(tries)
 		return nil, fmt.Errorf(
 			"the retry count [%d] was too large to handle! "+
 				"Tried every single, pair, and triplet, but still needed [%d] more.",
-			originalRetryCount,
 			retryCount,
+			remainingTries,
 		)
 	}
 }

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -231,6 +231,8 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	}
 	operatorToSeatCount := calculateSeatCount(groupMembers)
 	source := rand.NewSource(seed)
+	// #nosec G404 (insecure random number source (rand))
+	// Shuffling operators for retries does not require secure randomness.
 	rng := rand.New(source)
 
 	operators := make([]chain.Address, 0, len(operatorToSeatCount))

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -132,6 +132,7 @@ func EvaluateRetryParticipantsForKeyGeneration(
 		operators[i], operators[j] = operators[j], operators[i]
 	})
 
+	// Try excluding one operator at a time from the operator set.
 	if int(retryCount) < len(operators) {
 		removedOperator := operators[retryCount]
 		usedOperators := make([]chain.Address, 0, len(groupMembers))
@@ -143,6 +144,8 @@ func EvaluateRetryParticipantsForKeyGeneration(
 		return usedOperators, nil
 	} else {
 		retryCount -= uint(len(operators))
+		// Since we're still getting failures after excluding all of the operators
+		// individually, try excluding the pairs of operators.
 		pairIndexes := make([][2]int, 0, len(operators)*len(operators))
 		for i := 0; i < len(operators)-1; i++ {
 			for j := i + 1; j < len(operators); j++ {
@@ -173,6 +176,8 @@ func EvaluateRetryParticipantsForKeyGeneration(
 			return usedOperators, nil
 		} else {
 			retryCount -= uint(len(pairIndexes))
+			// Since we're still getting failures after excluding all of the pairs of
+			// operators, try excluding the triplets of operators.
 			tripletIndexes := make([][3]int, 0, len(operators)*len(operators)*len(operators))
 			for i := 0; i < len(operators)-2; i++ {
 				for j := i + 1; i < len(operators)-1; j++ {

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -48,7 +48,7 @@ func EvaluateRetryParticipantsForSigning(
 ) ([]chain.Address, error) {
 	if int(retryParticipantsCount) > len(groupMembers) {
 		return nil, fmt.Errorf(
-			"asked for too many seats. [%d] seats were requested, but there are only [%d] available.",
+			"asked for too many seats; [%d] seats were requested, but there are only [%d] available.",
 			retryParticipantsCount,
 			len(groupMembers),
 		)
@@ -112,7 +112,7 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	remainingTries := retryCount
 	if int(retryParticipantsCount) > len(groupMembers) {
 		return nil, fmt.Errorf(
-			"asked for too many seats. [%d] seats were requested, "+
+			"asked for too many seats; [%d] seats were requested, "+
 				"but there are only [%d] available.",
 			retryParticipantsCount,
 			len(groupMembers),
@@ -172,8 +172,8 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	} else {
 		remainingTries -= uint(tries)
 		return nil, fmt.Errorf(
-			"the retry count [%d] was too large to handle! "+
-				"Tried every single, pair, and triplet, but still needed [%d] more.",
+			"the retry count [%d] was too large to handle; "+
+				"tried every single, pair, and triplet, but still needed [%d] more.",
 			retryCount,
 			remainingTries,
 		)

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -119,10 +119,9 @@ func EvaluateRetryParticipantsForKeyGeneration(
 		)
 	}
 	operatorToSeatCount := calculateSeatCount(groupMembers)
-	source := rand.NewSource(seed)
 	// #nosec G404 (insecure random number source (rand))
 	// Shuffling operators for retries does not require secure randomness.
-	rng := rand.New(source)
+	rng := rand.New(rand.NewSource(seed))
 
 	operators := make([]chain.Address, 0, len(operatorToSeatCount))
 	for operator := range operatorToSeatCount {

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -83,3 +83,137 @@ func EvaluateRetryParticipantsForSigning(
 	}
 	return seats, nil
 }
+
+// EvaluateRetryParticipantsForKeyGeneration takes in a slice of `groupMembers`
+// and returns a subslice of those same members of length >=
+// `retryParticipantsCount` randomly according to the provided `seed` and
+// `retryCount`.
+//
+// This function is intended to be called during key generation after a failure
+// *not* due to inactivity. Assuming that some of the `groupMembers` are
+// sending corrupted information, either on purpose or accidentally, we keep
+// trying to find a subset of `groupMembers` that is as large as possible by
+// first excluding single operators, then pairs of operators, then triplets of
+// operators.
+//
+// The `seed` param needs to vary on a per-message basis but must be the same
+// seed between all operators for each invocation. This can be the hash of the
+// message since cryptographically secure randomness isn't important.
+//
+// The `retryCount` denotes the number of the given retry, so that should be
+// incremented after each attempt while the `seed` stays consistent on a
+// per-message basis.
+func EvaluateRetryParticipantsForKeyGeneration(
+	groupMembers []chain.Address,
+	seed int64,
+	retryCount uint,
+	retryParticipantsCount uint,
+) ([]chain.Address, error) {
+	originalRetryCount := retryCount
+	if int(retryParticipantsCount) > len(groupMembers) {
+		return nil, fmt.Errorf(
+			"asked for too many seats. [%d] seats were requested, "+
+				"but there are only [%d] available.",
+			retryParticipantsCount,
+			len(groupMembers),
+		)
+	}
+	operatorToSeatCount := calculateSeatCount(groupMembers)
+	rand.Seed(seed)
+
+	operators := make([]chain.Address, 0, len(operatorToSeatCount))
+	for operator := range operatorToSeatCount {
+		if len(groupMembers)-int(operatorToSeatCount[operator]) >= int(retryParticipantsCount) {
+			operators = append(operators, operator)
+		}
+	}
+	sort.Sort(byAddress(operators))
+	rand.Shuffle(len(operators), func(i, j int) {
+		operators[i], operators[j] = operators[j], operators[i]
+	})
+
+	if int(retryCount) < len(operators) {
+		removedOperator := operators[retryCount]
+		usedOperators := make([]chain.Address, 0, len(groupMembers))
+		for _, operator := range groupMembers {
+			if operator != removedOperator {
+				usedOperators = append(usedOperators, operator)
+			}
+		}
+		return usedOperators, nil
+	} else {
+		retryCount -= uint(len(operators))
+		pairIndexes := make([][2]int, 0, len(operators)*len(operators))
+		for i := 0; i < len(operators)-1; i++ {
+			for j := i + 1; j < len(operators); j++ {
+				leftOperator := operators[i]
+				rightOperator := operators[j]
+				count := len(groupMembers) -
+					int(operatorToSeatCount[leftOperator]) -
+					int(operatorToSeatCount[rightOperator])
+
+				if count >= int(retryParticipantsCount) {
+					pairIndexes = append(pairIndexes, [2]int{i, j})
+				}
+			}
+		}
+		if retryCount < uint(len(pairIndexes)) {
+			rand.Shuffle(len(pairIndexes), func(i, j int) {
+				pairIndexes[i], pairIndexes[j] = pairIndexes[j], pairIndexes[i]
+			})
+			pair := pairIndexes[retryCount]
+			leftOperator := operators[pair[0]]
+			rightOperator := operators[pair[1]]
+			usedOperators := make([]chain.Address, 0, len(groupMembers))
+			for _, operator := range groupMembers {
+				if operator != leftOperator && operator != rightOperator {
+					usedOperators = append(usedOperators, operator)
+				}
+			}
+			return usedOperators, nil
+		} else {
+			retryCount -= uint(len(pairIndexes))
+			tripletIndexes := make([][3]int, 0, len(operators)*len(operators)*len(operators))
+			for i := 0; i < len(operators)-2; i++ {
+				for j := i + 1; i < len(operators)-1; j++ {
+					for k := j + 1; j < len(operators); k++ {
+						leftOperator := operators[i]
+						middleOperator := operators[j]
+						rightOperator := operators[j]
+						count := len(groupMembers) -
+							int(operatorToSeatCount[leftOperator]) -
+							int(operatorToSeatCount[middleOperator]) -
+							int(operatorToSeatCount[rightOperator])
+
+						if count >= int(retryParticipantsCount) {
+							tripletIndexes = append(tripletIndexes, [3]int{i, j, k})
+						}
+					}
+				}
+			}
+			if retryCount < uint(len(tripletIndexes)) {
+				rand.Shuffle(len(tripletIndexes), func(i, j int) {
+					tripletIndexes[i], tripletIndexes[j] = tripletIndexes[j], tripletIndexes[i]
+				})
+				triplet := tripletIndexes[retryCount]
+				leftOperator := operators[triplet[0]]
+				middleOperator := operators[triplet[1]]
+				rightOperator := operators[triplet[2]]
+				usedOperators := make([]chain.Address, 0, len(groupMembers))
+				for _, operator := range groupMembers {
+					if operator != leftOperator && operator != middleOperator && operator != rightOperator {
+						usedOperators = append(usedOperators, operator)
+					}
+				}
+				return usedOperators, nil
+			} else {
+				return nil, fmt.Errorf(
+					"the retry count [%d] was too large to handle! "+
+						"Tried every single, pair, and triplet, but still needed [%d] more.",
+					originalRetryCount,
+					retryCount,
+				)
+			}
+		}
+	}
+}

--- a/pkg/ecdsa/retry/retry.go
+++ b/pkg/ecdsa/retry/retry.go
@@ -48,7 +48,7 @@ func EvaluateRetryParticipantsForSigning(
 ) ([]chain.Address, error) {
 	if int(retryParticipantsCount) > len(groupMembers) {
 		return nil, fmt.Errorf(
-			"asked for too many seats; [%d] seats were requested, but there are only [%d] available.",
+			"asked for too many seats; [%d] seats were requested, but there are only [%d] available",
 			retryParticipantsCount,
 			len(groupMembers),
 		)
@@ -113,7 +113,7 @@ func EvaluateRetryParticipantsForKeyGeneration(
 	if int(retryParticipantsCount) > len(groupMembers) {
 		return nil, fmt.Errorf(
 			"asked for too many seats; [%d] seats were requested, "+
-				"but there are only [%d] available.",
+				"but there are only [%d] available",
 			retryParticipantsCount,
 			len(groupMembers),
 		)
@@ -172,7 +172,7 @@ func EvaluateRetryParticipantsForKeyGeneration(
 		remainingTries -= uint(tries)
 		return nil, fmt.Errorf(
 			"the retry count [%d] was too large to handle; "+
-				"tried every single, pair, and triplet, but still needed [%d] more.",
+				"tried every single, pair, and triplet, but still needed [%d] more retries",
 			retryCount,
 			remainingTries,
 		)

--- a/pkg/ecdsa/retry/retry_test.go
+++ b/pkg/ecdsa/retry/retry_test.go
@@ -68,7 +68,7 @@ func TestEvaluateRetryParticipantsForKeyGeneration_FewOperators(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		groupMembers[i] = chain.Address(fmt.Sprintf("Operator-%d", i%20))
 	}
-	assertInvariants(t, EvaluateRetryParticipantsForKeyGeneration, groupMembers, int64(456), 0, 90)
+	assertInvariants(t, EvaluateRetryParticipantsForKeyGeneration, groupMembers, int64(456), 800, 80)
 }
 
 func TestEvaluateRetryParticipantsForKeyGeneration_NotEnoughOperators(t *testing.T) {

--- a/pkg/ecdsa/retry/retry_test.go
+++ b/pkg/ecdsa/retry/retry_test.go
@@ -85,7 +85,7 @@ func TestEvaluateRetryParticipantsForKeyGeneration_FewOperators(t *testing.T) {
 
 	// Too many!
 	_, err := EvaluateRetryParticipantsForKeyGeneration(groupMembers, int64(456), 1350, 80)
-	expectation := "the retry count [1350] was too large to handle! Tried every single, pair, and triplet, but still needed [0] more."
+	expectation := "the retry count [1350] was too large to handle; tried every single, pair, and triplet, but still needed [0] more."
 	if err.Error() != expectation {
 		t.Errorf(
 			"unexpected error\nexpected: [%s]\nactual:   [%s]",

--- a/pkg/ecdsa/retry/retry_test.go
+++ b/pkg/ecdsa/retry/retry_test.go
@@ -55,6 +55,45 @@ func TestEvaluateRetryParticipantsForSigning_NotEnoughOperators(t *testing.T) {
 	}
 }
 
+func TestEvaluateRetryParticipantsForKeyGeneration_100DifferentOperators(t *testing.T) {
+	groupMembers := make([]chain.Address, 100)
+	for i := 0; i < 100; i++ {
+		groupMembers[i] = chain.Address(fmt.Sprintf("Operator-%d", i))
+	}
+	assertInvariants(t, EvaluateRetryParticipantsForKeyGeneration, groupMembers, int64(123), 0, 90)
+}
+
+func TestEvaluateRetryParticipantsForKeyGeneration_FewOperators(t *testing.T) {
+	groupMembers := make([]chain.Address, 100)
+	for i := 0; i < 100; i++ {
+		groupMembers[i] = chain.Address(fmt.Sprintf("Operator-%d", i%20))
+	}
+	assertInvariants(t, EvaluateRetryParticipantsForKeyGeneration, groupMembers, int64(456), 0, 90)
+}
+
+func TestEvaluateRetryParticipantsForKeyGeneration_NotEnoughOperators(t *testing.T) {
+	groupMembers := make([]chain.Address, 50)
+	for i := 0; i < 50; i++ {
+		groupMembers[i] = chain.Address(fmt.Sprintf("Operator-%d", i))
+	}
+	_, err := EvaluateRetryParticipantsForKeyGeneration(groupMembers, int64(123), 0, 90)
+	expectation := "asked for too many seats"
+	if err == nil {
+		t.Fatalf(
+			"unexpected error\nexpected: [%s]\nactual:   [%v]",
+			fmt.Sprintf("%s...", expectation),
+			nil,
+		)
+	}
+	if !strings.HasPrefix(err.Error(), expectation) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%s]\nactual:   [%s]",
+			fmt.Sprintf("%s...", expectation),
+			err.Error(),
+		)
+	}
+}
+
 func isSubset(
 	t *testing.T,
 	groupMemberRandomizer groupMemberRandomizer,

--- a/pkg/ecdsa/retry/retry_test.go
+++ b/pkg/ecdsa/retry/retry_test.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -67,22 +68,10 @@ func isSubset(t *testing.T, groupMembers []chain.Address, subset []chain.Address
 	}
 }
 
-func testEq(a, b []chain.Address) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 func isStable(t *testing.T, groupMembers []chain.Address, subset []chain.Address, quantity uint) {
 	for i := 0; i < 30; i++ {
 		newSubset, _ := EvaluateRetryParticipantsForSigning(groupMembers, int64(123), 0, quantity)
-		if ok := testEq(subset, newSubset); !ok {
+		if ok := reflect.DeepEqual(subset, newSubset); !ok {
 			t.Errorf(
 				"The subsets changed\nexpected: [%v]\nactual:   [%v]",
 				subset,
@@ -107,7 +96,7 @@ func affectedBySeed(t *testing.T, groupMembers []chain.Address, subset []chain.A
 	allTheSame := true
 	for seed := int64(0); seed < 30 && allTheSame; seed++ {
 		newSubset, _ := EvaluateRetryParticipantsForSigning(groupMembers, seed, 0, quantity)
-		allTheSame = allTheSame && testEq(subset, newSubset)
+		allTheSame = allTheSame && reflect.DeepEqual(subset, newSubset)
 	}
 	if allTheSame {
 		t.Error("The seed did not affect the subset generation. All subsets were the same.")
@@ -120,7 +109,7 @@ func affectedByRetryCount(t *testing.T, groupMembers []chain.Address, quantity u
 	subset, _ := EvaluateRetryParticipantsForSigning(groupMembers, int64(72312), uint(0), quantity)
 	for retryCount := uint(1); retryCount < 30 && allTheSame; retryCount++ {
 		newSubset, _ := EvaluateRetryParticipantsForSigning(groupMembers, int64(72312), retryCount, quantity)
-		allTheSame = allTheSame && testEq(subset, newSubset)
+		allTheSame = allTheSame && reflect.DeepEqual(subset, newSubset)
 	}
 	if allTheSame {
 		t.Error("The seed did not affect the subset generation. All subsets were the same.")

--- a/pkg/ecdsa/retry/retry_test.go
+++ b/pkg/ecdsa/retry/retry_test.go
@@ -85,7 +85,7 @@ func TestEvaluateRetryParticipantsForKeyGeneration_FewOperators(t *testing.T) {
 
 	// Too many!
 	_, err := EvaluateRetryParticipantsForKeyGeneration(groupMembers, int64(456), 1350, 80)
-	expectation := "the retry count [1350] was too large to handle; tried every single, pair, and triplet, but still needed [0] more."
+	expectation := "the retry count [1350] was too large to handle; tried every single, pair, and triplet, but still needed [0] more retries"
 	if err.Error() != expectation {
 		t.Errorf(
 			"unexpected error\nexpected: [%s]\nactual:   [%s]",


### PR DESCRIPTION
This PR adds a `EvaluateRetryParticipantsForKeyGeneration` function in the new `pkg/ecdsa` package which takes in a list of chain addresses, and returns a subset of those chain addresses subject to a random seed and retry count number. 

We plan on using such a function each time key generation fails *but not due to inactivity* in order to randomly select as many operators as possible to create a signing group, hoping to avoid *just* the misbehaving operators.

We do this by first shuffling the operator set, and one-at-a-time, trying to exclude those operators. If that doesn't work, we shuffle the list of operator pairs, and one-at-a-time exclude those pairs. If that doesn't work, we try again with triplets. If that doesn't work, we're probably out of time.

tagging @lukasz-zimnoch for review