### PR TITLE
Extract contracts artifacts downloading to the main Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,7 @@ export.json
 typechain/
 
 # Go bindings generator
-pkg/chain/*/*/gen/_contracts
 pkg/chain/*/*/gen/_address
+
+# Temporary directory
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ COPY ./config $APP_DIR/config
 RUN make generate environment=$ENVIRONMENT
 
 COPY ./ $APP_DIR/
-RUN go generate ./pkg/gen
 
 # Client Versioning.
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --update --no-cache \
 	npm \
 	bash \
 	python3 \
+	tar \
 	jq && \
 	rm -rf /var/cache/apk/ && mkdir /var/cache/apk/ && \
 	rm -rf /usr/share/man
@@ -46,13 +47,16 @@ COPY ./pkg/beacon/gjkr/gen $APP_DIR/pkg/beacon/gjkr/gen
 COPY ./pkg/beacon/dkg/result/gen $APP_DIR/pkg/beacon/dkg/result/gen
 COPY ./pkg/beacon/registry/gen $APP_DIR/pkg/beacon/registry/gen
 
-# If CONTRACTS_NPM_PACKAGE_TAG is not set it will download NPM packages versions
+# If ENVIRONMENT is not set it will download NPM packages versions
 # published and tagged as `development`.
-ARG CONTRACTS_NPM_PACKAGE_TAG
+ARG ENVIRONMENT=development
+
+COPY ./Makefile $APP_DIR/Makefile
+RUN make download_artifacts environment=$ENVIRONMENT
 
 # Need this to resolve imports in generated Ethereum commands.
 COPY ./config $APP_DIR/config
-RUN go generate ./.../gen
+RUN make generate environment=$ENVIRONMENT
 
 COPY ./ $APP_DIR/
 RUN go generate ./pkg/gen

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(eval destination_dir := ${contracts_dir}/${npm_package_tag}/${npm_package_name
 @npm pack --silent \
 	--pack-destination=${destination_dir} \
 	$(shell npm view ${npm_package_name}@${npm_package_tag} _id) \
-	| xargs -I{} tar -zxvf ${destination_dir}/{} -C ${destination_dir} --strip-components 1 package/artifacts
+	| xargs -I{} tar -zxf ${destination_dir}/{} -C ${destination_dir} --strip-components 1 package/artifacts
 $(info Downloaded NPM package ${npm_package_name}@${npm_package_tag} to ${contracts_dir})
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ npm_packages := @keep-network/random-beacon \
 	@threshold-network/solidity-contracts \
 	@keep-network/tbtc-v2
 
-# Working directory where contracts artifacts should be fetched to.
+# Working directory where contracts artifacts should be stored.
 contracts_dir := tmp/contracts
 
 # It requires npm of at least 7.x version to support `pack-destination` flag.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@
 # not overwritten it defaults to `development`.
 environment = development
 
+development:
+	make all environment=development
+
+goerli:
+	make all environment=goerli
+
+# TODO: Mainnet packages have not been published yet.
+# mainnet:
+# 	make all environment=mainnet
+
 all: download_artifacts generate build cmd-help
 
 # List of NPM packages containing contracts needed by the client contracts bindings

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ cmd-help: build
 	@echo '$$ keep-client start --help' > docs/development/cmd-help
 	./keep-client start --help >> docs/development/cmd-help
 
-.PHONY: all
+.PHONY: all development goerli download_artifacts generate build cmd-help

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,11 @@ download_artifacts:
 	$(foreach package,$(npm_packages),$(call get_npm_package,$(environment),$(package)))
 
 generate:
+	$(info Running Go code generator)
 	go generate ./...
 
 build:
+	$(info Building Go code)
 	go build -o keep-client -a . 
 
 cmd-help: build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: all
-
 # environment is used as a tag of the npm packages for contracts artifacts. If
 # not overwritten it defaults to `development`.
 environment = development
@@ -54,3 +52,5 @@ build:
 cmd-help: build
 	@echo '$$ keep-client start --help' > docs/development/cmd-help
 	./keep-client start --help >> docs/development/cmd-help
+
+.PHONY: all

--- a/pkg/chain/ethereum/beacon/gen/gen.go
+++ b/pkg/chain/ethereum/beacon/gen/gen.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-//go:generate make download_artifacts
 //go:generate make
 
 var (

--- a/pkg/chain/ethereum/common/gen/Makefile
+++ b/pkg/chain/ethereum/common/gen/Makefile
@@ -5,6 +5,10 @@ endif
 root_dir := $(realpath ../../../../..)
 artifacts_dir := ${root_dir}/tmp/contracts/${environment}/${npm_package_name}/artifacts
 
+$(info Package              ${npm_package_name})
+$(info Environment          ${environment})
+$(info Artifacts directory  ${artifacts_dir})
+
 # Go bindings generated for the solidity contracts.
 contract_files = $(addprefix contract/,$(addsuffix .go,${required_contracts}))
 
@@ -14,12 +18,13 @@ address_files = $(addprefix _address/,${required_contracts})
 all: clean check_artifacts ${address_files} gen_contract_go
 
 clean:
-	rm -rf _address/*
-	rm -rf abi/*
-	rm -rf contract/*
-	mkdir tmp && mv cmd/cmd*.go tmp
-	rm -rf cmd/*
-	mv tmp/* cmd && rm -rf tmp
+	$(info Cleaning up for ${npm_package_name})
+	@rm -rf _address/*
+	@rm -rf abi/*
+	@rm -rf contract/*
+	@mkdir tmp && mv cmd/cmd*.go tmp
+	@rm -rf cmd/*
+	@mv tmp/* cmd && rm -rf tmp
 
 # Check if artifacts directory exists. If the directory doesn't exists it is
 # likely a problem inside a fetched contracts package.
@@ -29,24 +34,28 @@ check_artifacts:
 gen_contract_go: ${contract_files}
 
 abi/%.abi: ${artifacts_dir}/%.json
-	jq .abi $< > abi/$*.abi
+	$(info $* - generating ABI)
+	@jq .abi $< > abi/$*.abi
 
 abi/%.go: abi/%.abi
-	go run github.com/ethereum/go-ethereum/cmd/abigen --abi $< --pkg abi --type $* --out $@
+	$(info $* - generating Ethereum bindings)
+	@go run github.com/ethereum/go-ethereum/cmd/abigen --abi $< --pkg abi --type $* --out $@
 
 # Extract address of a contract from an artifact. Artfifacts that are published
 # with `development` tag are not accessible on developers' environments, so we
 # replace them with zeros.
 _address/%: ${artifacts_dir}/%.json
 ifeq ($(environment), development)
-	@echo "Skipping address extraction for development package"
+	$(info $* - skipping address extraction for development package)
 	@echo "0x0000000000000000000000000000000000000000" > _address/$*
 else
-	jq -jr .address ${artifacts_dir}/$*.json > _address/$*
+	$(info $* - extracting address)
+	@jq -jr .address ${artifacts_dir}/$*.json > _address/$*
 endif
 
 contract/%.go cmd/%.go: abi/%.abi abi/%.go _address/% ${artifacts_dir}/%.json
-	go run github.com/keep-network/keep-common/tools/generators/ethereum $< contract/$*.go cmd/$*.go
+	$(info $* - generating Keep bindings)
+	@go run github.com/keep-network/keep-common/tools/generators/ethereum $< contract/$*.go cmd/$*.go
 
 # Don't remove intermediate files that got generated.
 .PRECIOUS: abi/%.abi abi/%.go _address/%

--- a/pkg/chain/ethereum/common/gen/Makefile
+++ b/pkg/chain/ethereum/common/gen/Makefile
@@ -11,7 +11,7 @@ contract_files = $(addprefix contract/,$(addsuffix .go,${required_contracts}))
 # Files containing addresses extracted from the artifacts.
 address_files = $(addprefix _address/,${required_contracts})
 
-all: clean ${address_files} gen_contract_go
+all: clean check_artifacts ${address_files} gen_contract_go
 
 clean:
 	rm -rf _address/*
@@ -20,6 +20,11 @@ clean:
 	mkdir tmp && mv cmd/cmd*.go tmp
 	rm -rf cmd/*
 	mv tmp/* cmd && rm -rf tmp
+
+# Check if artifacts directory exists. If the directory doesn't exists it is
+# likely a problem inside a fetched contracts package.
+check_artifacts:
+	@[ -d "$(artifacts_dir)" ] || { echo "$(artifacts_dir) does not exist!"; exit 1; }
 
 gen_contract_go: ${contract_files}
 

--- a/pkg/chain/ethereum/common/gen/Makefile
+++ b/pkg/chain/ethereum/common/gen/Makefile
@@ -1,13 +1,9 @@
-
-# Tag of the npm package version for contracts artifacts. If not set by the 
-# `CONTRACTS_NPM_PACKAGE_TAG` environment variable it defaults to `development`.
-npm_package_tag:=$(CONTRACTS_NPM_PACKAGE_TAG)
-ifndef npm_package_tag
-	npm_package_tag=development
+ifndef environment
+	$(error environment not defined)
 endif
 
-contracts_dir =_contracts
-artifacts_dir = $(realpath ${contracts_dir}/package/artifacts)
+root_dir := $(realpath ../../../../..)
+artifacts_dir := ${root_dir}/tmp/contracts/${environment}/${npm_package_name}/artifacts
 
 # Go bindings generated for the solidity contracts.
 contract_files = $(addprefix contract/,$(addsuffix .go,${required_contracts}))
@@ -25,14 +21,6 @@ clean:
 	rm -rf cmd/*
 	mv tmp/* cmd && rm -rf tmp
 
-# It requires npm of at least 7.x version to support `pack-destination` flag.
-download_artifacts:
-	rm -rf ${contracts_dir} && mkdir ${contracts_dir}
-	npm pack --silent \
-		--pack-destination=${contracts_dir} \
-		$(shell npm view ${npm_package_name}@${npm_package_tag} _id) \
-		| xargs -I{} tar -zxf ${contracts_dir}/{} -C ${contracts_dir}
-
 gen_contract_go: ${contract_files}
 
 abi/%.abi: ${artifacts_dir}/%.json
@@ -45,7 +33,7 @@ abi/%.go: abi/%.abi
 # with `development` tag are not accessible on developers' environments, so we
 # replace them with zeros.
 _address/%: ${artifacts_dir}/%.json
-ifeq ($(npm_package_tag), development)
+ifeq ($(environment), development)
 	@echo "Skipping address extraction for development package"
 	@echo "0x0000000000000000000000000000000000000000" > _address/$*
 else

--- a/pkg/chain/ethereum/ecdsa/gen/gen.go
+++ b/pkg/chain/ethereum/ecdsa/gen/gen.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-//go:generate make download_artifacts
 //go:generate make
 
 var (

--- a/pkg/chain/ethereum/tbtc/gen/gen.go
+++ b/pkg/chain/ethereum/tbtc/gen/gen.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-//go:generate make download_artifacts
 //go:generate make
 
 var (

--- a/pkg/chain/ethereum/threshold/gen/gen.go
+++ b/pkg/chain/ethereum/threshold/gen/gen.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-//go:generate make download_artifacts
 //go:generate make
 
 var (


### PR DESCRIPTION
In this PR we extract artifacts downloading to the main Makefile, instead of doing it in the bindings generation process.

This is preparation for multi-network clients and supporting local developer machine's contracts artifacts.

Also, the execution experience was improved. To run generation and building for goerli environment you have to run `make goerli` instead of `CONTRACTS_NPM_PACKAGE_TAG=local go generate ./...`.