### PR TITLE
Support local artifacts in the Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY ./pkg/beacon/registry/gen $APP_DIR/pkg/beacon/registry/gen
 ARG ENVIRONMENT=development
 
 COPY ./Makefile $APP_DIR/Makefile
-RUN make download_artifacts environment=$ENVIRONMENT
+RUN make get_artifacts environment=$ENVIRONMENT
 
 # Need this to resolve imports in generated Ethereum commands.
 COPY ./config $APP_DIR/config

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,20 @@
 # not overwritten it defaults to `development`.
 environment = development
 
+# Build with contract packages published to the NPM registry and tagged `development`.
 development:
 	make all environment=development
 
+# Build with contract packages published to the NPM registry and tagged `goerli`.
 goerli:
 	make all environment=goerli
 
 # TODO: Mainnet packages have not been published yet.
+# Build with contract packages published to the NPM registry and tagged `mainnet`.
 # mainnet:
 # 	make all environment=mainnet
 
+# Build with contract packages deployed locally.
 local:
 	make all environment=local
 

--- a/Makefile
+++ b/Makefile
@@ -12,22 +12,37 @@ goerli:
 # mainnet:
 # 	make all environment=mainnet
 
-all: download_artifacts generate build cmd-help
+local:
+	make all environment=local
 
-# List of NPM packages containing contracts needed by the client contracts bindings
-# generation.
-npm_packages := @keep-network/random-beacon \
-	@keep-network/ecdsa \
-	@threshold-network/solidity-contracts \
-	@keep-network/tbtc-v2
+all: get_artifacts generate build cmd-help
+
+modules := beacon \
+	ecdsa \
+	threshold \
+	tbtc
+
+# Required by get_npm_package function.
+npm_beacon_package := @keep-network/random-beacon
+npm_ecdsa_package := @keep-network/ecdsa
+npm_threshold_package := @threshold-network/solidity-contracts
+npm_tbtc_package := @keep-network/tbtc-v2
+
+# Required by get_local_package function. The paths can be overwritten when calling
+# the make command, e.g.:
+#   make local local_threshold_path=/other/path/threshold
+local_beacon_path := ./solidity/random-beacon
+local_ecdsa_path := ./solidity/ecdsa
+local_threshold_path := ../../threshold-network/solidity-contracts
+local_tbtc_path := ../tbtc-v2/solidity
 
 # Working directory where contracts artifacts should be fetched to.
 contracts_dir := tmp/contracts
 
 # It requires npm of at least 7.x version to support `pack-destination` flag.
 define get_npm_package
-$(eval npm_package_tag := $(1))
-$(eval npm_package_name := $(2))
+$(eval npm_package_name := $(npm_$(1)_package))
+$(eval npm_package_tag := $(2))
 $(eval destination_dir := ${contracts_dir}/${npm_package_tag}/${npm_package_name})
 @rm -rf ${destination_dir}
 @mkdir -p ${destination_dir}
@@ -38,8 +53,24 @@ $(eval destination_dir := ${contracts_dir}/${npm_package_tag}/${npm_package_name
 $(info Downloaded NPM package ${npm_package_name}@${npm_package_tag} to ${contracts_dir})
 endef
 
-download_artifacts:
-	$(foreach package,$(npm_packages),$(call get_npm_package,$(environment),$(package)))
+define get_local_package
+$(eval module := $(1))
+$(eval local_solidity_path := $(local_$(module)_path))
+$(eval npm_package_name := $(npm_$(module)_package))
+$(eval destination_dir := ${contracts_dir}/local/${npm_package_name})
+@[ -d "$(local_solidity_path)" ] || { echo "$(module) path [$(local_solidity_path)] does not exist!"; exit 1; }
+@rm -rf ${destination_dir}
+@mkdir -p ${destination_dir}
+$(info Fetching local package ${module} from path ${local_solidity_path})
+rsync -a $(local_solidity_path)/deployments/development/ ${destination_dir}/artifacts
+endef
+
+get_artifacts:
+ifeq ($(environment), local)
+	$(foreach module,$(modules),$(call get_local_package,$(module)))
+else
+	$(foreach module,$(modules),$(call get_npm_package,$(module),$(environment)))
+endif
 
 generate:
 	$(info Running Go code generator)


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-core/pull/3126

On developer machine contracts are deployed to local geth instance. We need to use them in the client, instead of downloading a package from NPM registry.

Here we add support for local artifacts. The make command will fetch the artifacts from local directories and use them for client build.

This is useful if a developer wants to generate bindings for locally deployed contracts.

What is more, the client will embed the addresses of locally deployer contracts, so running the client locally won't require setting the addresses in the configuration file or `--developer` flags.

The directories can be provided by the caller, e.g.:
make local local_threshold_path=/other/path/threshold

If the directories are not provided default paths are assumed:
```
local_beacon_path := ./solidity/random-beacon
local_ecdsa_path := ./solidity/ecdsa
local_threshold_path := ../../threshold-network/solidity-contracts
local_tbtc_path := ../tbtc-v2/solidity
```