### PR TITLE
Remove openzeppelin manifest for fresh installation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ KEEP_CORE_PATH=$PWD
 KEEP_BEACON_SOL_PATH="$KEEP_CORE_PATH/solidity/random-beacon"
 KEEP_ECDSA_SOL_PATH="$KEEP_CORE_PATH/solidity/ecdsa"
 TMP="$KEEP_CORE_PATH/tmp"
-OPENZEPPELIN_MANIFEST=".openzeppelin/*-1101.json"
+OPENZEPPELIN_MANIFEST=".openzeppelin/unknown-*.json"
 
 # Defaults, can be overwritten by env variables/input parameters
 NETWORK_DEFAULT="development"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ KEEP_CORE_PATH=$PWD
 KEEP_BEACON_SOL_PATH="$KEEP_CORE_PATH/solidity/random-beacon"
 KEEP_ECDSA_SOL_PATH="$KEEP_CORE_PATH/solidity/ecdsa"
 TMP="$KEEP_CORE_PATH/tmp"
-OPENZEPPELIN_MANIFEST=".openzeppelin"
+OPENZEPPELIN_MANIFEST=".openzeppelin/*-1101.json"
 
 # Defaults, can be overwritten by env variables/input parameters
 NETWORK_DEFAULT="development"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@ KEEP_CORE_PATH=$PWD
 KEEP_BEACON_SOL_PATH="$KEEP_CORE_PATH/solidity/random-beacon"
 KEEP_ECDSA_SOL_PATH="$KEEP_CORE_PATH/solidity/ecdsa"
 TMP="$KEEP_CORE_PATH/tmp"
+OPENZEPPELIN_MANIFEST=".openzeppelin"
 
 # Defaults, can be overwritten by env variables/input parameters
 NETWORK_DEFAULT="development"
@@ -139,6 +140,8 @@ if [ "$SKIP_DEPLOYMENT" != true ]; then
   yarn prepack
 
   cd $KEEP_ECDSA_SOL_PATH
+  # remove openzeppelin manifest for fresh installation
+  rm -rf $OPENZEPPELIN_MANIFEST
 
   printf "${LOG_START}Linking solidity-contracts...${LOG_END}"
   yarn link @threshold-network/solidity-contracts


### PR DESCRIPTION
It happens that open zeppelin's manifest in ecdsa (.openzeppelin) is not updated properly and the error is thrown during deployment of the `WalletRegistry` as transparent proxy. Removing this folder forces a fresh installation.