### PR TITLE
Added extra gas requirement for ECDSA DKG result challenge

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -528,11 +528,11 @@ contract WalletRegistry is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _minimumAuthorization New minimum authorization amount
+    /// @param _minimumAuthorization New minimum authorization amount.
     /// @param _authorizationDecreaseDelay New authorization decrease delay in
-    ///        seconds
+    ///        seconds.
     /// @param _authorizationDecreaseChangePeriod New authorization decrease
-    ///        change period in seconds
+    ///        change period in seconds.
     function updateAuthorizationParameters(
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay,
@@ -557,14 +557,14 @@ contract WalletRegistry is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _seedTimeout New seed timeout
+    /// @param _seedTimeout New seed timeout.
     /// @param _resultChallengePeriodLength New DKG result challenge period
-    ///        length
+    ///        length.
     /// @param _resultChallengeExtraGas New extra gas value required to be left
-    ///        at the end of the DKG result challenge transaction
-    /// @param _resultSubmissionTimeout New DKG result submission timeout
+    ///        at the end of the DKG result challenge transaction.
+    /// @param _resultSubmissionTimeout New DKG result submission timeout.
     /// @param _submitterPrecedencePeriodLength New submitter precedence period
-    ///        length
+    ///        length.
     function updateDkgParameters(
         uint256 _seedTimeout,
         uint256 _resultChallengePeriodLength,
@@ -615,7 +615,7 @@ contract WalletRegistry is
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
     /// @param maliciousDkgResultSlashingAmount New malicious DKG result
-    ///        slashing amount
+    ///        slashing amount.
     function updateSlashingParameters(uint96 maliciousDkgResultSlashingAmount)
         external
         onlyGovernance
@@ -628,14 +628,14 @@ contract WalletRegistry is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param dkgResultSubmissionGas New DKG result submission gas
-    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset
+    /// @param dkgResultSubmissionGas New DKG result submission gas.
+    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset.
     /// @param notifyOperatorInactivityGasOffset New operator inactivity
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifySeedTimeoutGasOffset New seed for DKG delivery timeout
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifyDkgTimeoutNegativeGasOffset New DKG timeout notification gas
-    ///        offset
+    ///        offset.
     function updateGasParameters(
         uint256 dkgResultSubmissionGas,
         uint256 dkgResultApprovalGasOffset,
@@ -856,10 +856,10 @@ contract WalletRegistry is
     ///         function and provide new signatures.
     ///         The sender of the claim must be one of the claim signers. This
     ///         function can be called only for registered wallets
-    /// @param claim Operator inactivity claim
+    /// @param claim Operator inactivity claim.
     /// @param nonce Current inactivity claim nonce for the given wallet signing
-    ///              group. Must be the same as the stored one
-    /// @param groupMembers Identifiers of the wallet signing group members
+    ///              group. Must be the same as the stored one.
+    /// @param groupMembers Identifiers of the wallet signing group members.
     function notifyOperatorInactivity(
         Inactivity.Claim calldata claim,
         uint256 nonce,
@@ -917,12 +917,12 @@ contract WalletRegistry is
     ///         contract. The notifier will receive reward per each group member
     ///         from the staking contract notifiers treasury. The reward is
     ///         scaled by the `rewardMultiplier` provided as a parameter.
-    /// @param amount Amount of tokens to seize from each signing group member
+    /// @param amount Amount of tokens to seize from each signing group member.
     /// @param rewardMultiplier Fraction of the staking contract notifiers
-    ///        reward the notifier should receive; should be between [0, 100]
-    /// @param notifier Address of the misbehavior notifier
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    ///        reward the notifier should receive; should be between [0, 100].
+    /// @param notifier Address of the misbehavior notifier.
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
     /// @dev Requirements:
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
@@ -985,11 +985,11 @@ contract WalletRegistry is
 
     /// @notice Checks whether the given operator is a member of the given
     ///         wallet signing group.
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
-    /// @param operator Address of the checked operator
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
+    /// @param operator Address of the checked operator.
     /// @param walletMemberIndex Position of the operator in the wallet signing
-    ///        group members list
+    ///        group members list.
     /// @return True - if the operator is a member of the given wallet signing
     ///         group. False - otherwise.
     /// @dev Requirements:

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -181,9 +181,9 @@ contract WalletRegistry is
     event DkgParametersUpdated(
         uint256 seedTimeout,
         uint256 resultChallengePeriodLength,
+        uint256 resultChallengeExtraGas,
         uint256 resultSubmissionTimeout,
-        uint256 resultSubmitterPrecedencePeriodLength,
-        uint256 resultChallengeExtraGas
+        uint256 resultSubmitterPrecedencePeriodLength
     );
 
     event GasParametersUpdated(
@@ -333,9 +333,9 @@ contract WalletRegistry is
         dkg.init(sortitionPool, _ecdsaDkgValidator);
         dkg.setSeedTimeout(11_520);
         dkg.setResultChallengePeriodLength(11_520);
+        dkg.setResultChallengeExtraGas(50_000);
         dkg.setResultSubmissionTimeout(100 * 20);
         dkg.setSubmitterPrecedencePeriodLength(20);
-        dkg.setResultChallengeExtraGas(50_000);
 
         // Gas parameters were adjusted based on Ethereum state in April 2022.
         // If the cost of EVM opcodes change over time, these parameters will
@@ -557,36 +557,36 @@ contract WalletRegistry is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _seedTimeout New seed timeout.
+    /// @param _seedTimeout New seed timeout
     /// @param _resultChallengePeriodLength New DKG result challenge period
     ///        length
+    /// @param _resultChallengeExtraGas New extra gas value required to be left
+    ///        at the end of the DKG result challenge transaction
     /// @param _resultSubmissionTimeout New DKG result submission timeout
     /// @param _submitterPrecedencePeriodLength New submitter precedence period
     ///        length
-    /// @param _resultChallengeExtraGas New extra gas value required to be left
-    ///        at the end of the DKG result challenge transaction.
     function updateDkgParameters(
         uint256 _seedTimeout,
         uint256 _resultChallengePeriodLength,
+        uint256 _resultChallengeExtraGas,
         uint256 _resultSubmissionTimeout,
-        uint256 _submitterPrecedencePeriodLength,
-        uint256 _resultChallengeExtraGas
+        uint256 _submitterPrecedencePeriodLength
     ) external onlyGovernance {
         dkg.setSeedTimeout(_seedTimeout);
         dkg.setResultChallengePeriodLength(_resultChallengePeriodLength);
+        dkg.setResultChallengeExtraGas(_resultChallengeExtraGas);
         dkg.setResultSubmissionTimeout(_resultSubmissionTimeout);
         dkg.setSubmitterPrecedencePeriodLength(
             _submitterPrecedencePeriodLength
         );
-        dkg.setResultChallengeExtraGas(_resultChallengeExtraGas);
 
         // slither-disable-next-line reentrancy-events
         emit DkgParametersUpdated(
             _seedTimeout,
             _resultChallengePeriodLength,
+            _resultChallengeExtraGas,
             _resultSubmissionTimeout,
-            _submitterPrecedencePeriodLength,
-            _resultChallengeExtraGas
+            _submitterPrecedencePeriodLength
         );
     }
 

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -977,7 +977,7 @@ contract WalletRegistryGovernance is Ownable {
         newDkgResultChallengePeriodLength = 0;
     }
 
-    /// @notice Begins the DKG result challenge extra gas update process.    .
+    /// @notice Begins the DKG result challenge extra gas update process.
     /// @dev Can be called only by the contract owner.
     /// @param _newDkgResultChallengeExtraGas New DKG result challenge extra gas
     function beginDkgResultChallengeExtraGasUpdate(

--- a/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
@@ -40,15 +40,15 @@ library EcdsaDkg {
         uint256 seedTimeout;
         // Time in blocks during which a submitted result can be challenged.
         uint256 resultChallengePeriodLength;
+        // Extra gas required to be left at the end of the challenge DKG result
+        // transaction.
+        uint256 resultChallengeExtraGas;
         // Time in blocks during which a result is expected to be submitted.
         uint256 resultSubmissionTimeout;
         // Time in blocks during which only the result submitter is allowed to
         // approve it. Once this period ends and the submitter have not approved
         // the result, anyone can do it.
         uint256 submitterPrecedencePeriodLength;
-        // Extra gas required to be left at the end of the challenge DKG result
-        // transaction.
-        uint256 resultChallengeExtraGas;
         // This struct doesn't contain `__gap` property as the structure is
         // stored inside `Data` struct, that already have a gap that can be used
         // on upgrade.
@@ -507,6 +507,16 @@ library EcdsaDkg {
             .resultChallengePeriodLength = newResultChallengePeriodLength;
     }
 
+    /// @notice Set resultChallengeExtraGas parameter.
+    function setResultChallengeExtraGas(
+        Data storage self,
+        uint256 newResultChallengeExtraGas
+    ) internal {
+        require(currentState(self) == State.IDLE, "Current state is not IDLE");
+
+        self.parameters.resultChallengeExtraGas = newResultChallengeExtraGas;
+    }
+
     /// @notice Set resultSubmissionTimeout parameter.
     function setResultSubmissionTimeout(
         Data storage self,
@@ -538,16 +548,6 @@ library EcdsaDkg {
         self
             .parameters
             .submitterPrecedencePeriodLength = newSubmitterPrecedencePeriodLength;
-    }
-
-    /// @notice Set resultChallengeExtraGas parameter.
-    function setResultChallengeExtraGas(
-        Data storage self,
-        uint256 newResultChallengeExtraGas
-    ) internal {
-        require(currentState(self) == State.IDLE, "Current state is not IDLE");
-
-        self.parameters.resultChallengeExtraGas = newResultChallengeExtraGas;
     }
 
     /// @notice Completes DKG by cleaning up state.

--- a/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2.sol
+++ b/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2.sol
@@ -190,6 +190,7 @@ contract WalletRegistryV2 is
     event DkgParametersUpdated(
         uint256 seedTimeout,
         uint256 resultChallengePeriodLength,
+        uint256 resultChallengeExtraGas,
         uint256 resultSubmissionTimeout,
         uint256 resultSubmitterPrecedencePeriodLength
     );
@@ -483,11 +484,11 @@ contract WalletRegistryV2 is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _minimumAuthorization New minimum authorization amount
+    /// @param _minimumAuthorization New minimum authorization amount.
     /// @param _authorizationDecreaseDelay New authorization decrease delay in
-    ///        seconds
+    ///        seconds.
     /// @param _authorizationDecreaseChangePeriod New authorization decrease
-    ///        change period in seconds
+    ///        change period in seconds.
     function updateAuthorizationParameters(
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay,
@@ -514,18 +515,22 @@ contract WalletRegistryV2 is
     ///      validating parameters.
     /// @param _seedTimeout New seed timeout.
     /// @param _resultChallengePeriodLength New DKG result challenge period
-    ///        length
-    /// @param _resultSubmissionTimeout New DKG result submission timeout
+    ///        length.
+    /// @param _resultChallengeExtraGas New extra gas value required to be left
+    ///        at the end of the DKG result challenge transaction.
+    /// @param _resultSubmissionTimeout New DKG result submission timeout.
     /// @param _submitterPrecedencePeriodLength New submitter precedence period
-    ///        length
+    ///        length.
     function updateDkgParameters(
         uint256 _seedTimeout,
         uint256 _resultChallengePeriodLength,
+        uint256 _resultChallengeExtraGas,
         uint256 _resultSubmissionTimeout,
         uint256 _submitterPrecedencePeriodLength
     ) external onlyGovernance {
         dkg.setSeedTimeout(_seedTimeout);
         dkg.setResultChallengePeriodLength(_resultChallengePeriodLength);
+        dkg.setResultChallengeExtraGas(_resultChallengeExtraGas);
         dkg.setResultSubmissionTimeout(_resultSubmissionTimeout);
         dkg.setSubmitterPrecedencePeriodLength(
             _submitterPrecedencePeriodLength
@@ -535,6 +540,7 @@ contract WalletRegistryV2 is
         emit DkgParametersUpdated(
             _seedTimeout,
             _resultChallengePeriodLength,
+            _resultChallengeExtraGas,
             _resultSubmissionTimeout,
             _submitterPrecedencePeriodLength
         );
@@ -565,7 +571,7 @@ contract WalletRegistryV2 is
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
     /// @param maliciousDkgResultSlashingAmount New malicious DKG result
-    ///        slashing amount
+    ///        slashing amount.
     function updateSlashingParameters(uint96 maliciousDkgResultSlashingAmount)
         external
         onlyGovernance
@@ -578,14 +584,14 @@ contract WalletRegistryV2 is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param dkgResultSubmissionGas New DKG result submission gas
-    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset
+    /// @param dkgResultSubmissionGas New DKG result submission gas.
+    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset.
     /// @param notifyOperatorInactivityGasOffset New operator inactivity
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifySeedTimeoutGasOffset New seed for DKG delivery timeout
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifyDkgTimeoutNegativeGasOffset New DKG timeout notification gas
-    ///        offset
+    ///        offset.
     function updateGasParameters(
         uint256 dkgResultSubmissionGas,
         uint256 dkgResultApprovalGasOffset,
@@ -763,6 +769,17 @@ contract WalletRegistryV2 is
                 maliciousDkgResultSubmitterAddress
             );
         }
+
+        // Due to EIP150, 1/64 of the gas is not forwarded to the call, and
+        // will be kept to execute the remaining operations in the function
+        // after the call inside the try-catch.
+        //
+        // To ensure there is no way for the caller to manipulate gas limit in
+        // such a way that the call inside try-catch fails with out-of-gas and
+        // the rest of the function is executed with the remaining 1/64 of gas,
+        // we require an extra gas amount to be left at the end of the call to
+        // `challengeDkgResult`.
+        dkg.requireChallengeExtraGas();
     }
 
     /// @notice Notifies about operators who are inactive. Using this function,
@@ -780,10 +797,10 @@ contract WalletRegistryV2 is
     ///         function and provide new signatures.
     ///         The sender of the claim must be one of the claim signers. This
     ///         function can be called only for registered wallets
-    /// @param claim Operator inactivity claim
+    /// @param claim Operator inactivity claim.
     /// @param nonce Current inactivity claim nonce for the given wallet signing
-    ///              group. Must be the same as the stored one
-    /// @param groupMembers Identifiers of the wallet signing group members
+    ///              group. Must be the same as the stored one.
+    /// @param groupMembers Identifiers of the wallet signing group members.
     function notifyOperatorInactivity(
         Inactivity.Claim calldata claim,
         uint256 nonce,
@@ -841,12 +858,12 @@ contract WalletRegistryV2 is
     ///         contract. The notifier will receive reward per each group member
     ///         from the staking contract notifiers treasury. The reward is
     ///         scaled by the `rewardMultiplier` provided as a parameter.
-    /// @param amount Amount of tokens to seize from each signing group member
+    /// @param amount Amount of tokens to seize from each signing group member.
     /// @param rewardMultiplier Fraction of the staking contract notifiers
-    ///        reward the notifier should receive; should be between [0, 100]
-    /// @param notifier Address of the misbehavior notifier
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    ///        reward the notifier should receive; should be between [0, 100].
+    /// @param notifier Address of the misbehavior notifier.
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
     /// @dev Requirements:
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
@@ -909,11 +926,11 @@ contract WalletRegistryV2 is
 
     /// @notice Checks whether the given operator is a member of the given
     ///         wallet signing group.
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
-    /// @param operator Address of the checked operator
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
+    /// @param operator Address of the checked operator.
     /// @param walletMemberIndex Position of the operator in the wallet signing
-    ///        group members list
+    ///        group members list.
     /// @return True - if the operator is a member of the given wallet signing
     ///         group. False - otherwise.
     /// @dev Requirements:

--- a/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2.sol
+++ b/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2.sol
@@ -35,9 +35,6 @@ import "@keep-network/random-beacon/contracts/Governable.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IApplication.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IStaking.sol";
 
-// TODO: We used RC version of @openzeppelin/contracts-upgradeable to use `reinitializer`
-// in upgrades. We should revisit this part before mainnet deployment and use
-// a final release package if it's ready.
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract WalletRegistryV2 is

--- a/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MisplacedNewSlot.sol
+++ b/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MisplacedNewSlot.sol
@@ -190,6 +190,7 @@ contract WalletRegistryV2MisplacedNewSlot is
     event DkgParametersUpdated(
         uint256 seedTimeout,
         uint256 resultChallengePeriodLength,
+        uint256 resultChallengeExtraGas,
         uint256 resultSubmissionTimeout,
         uint256 resultSubmitterPrecedencePeriodLength
     );
@@ -483,11 +484,11 @@ contract WalletRegistryV2MisplacedNewSlot is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _minimumAuthorization New minimum authorization amount
+    /// @param _minimumAuthorization New minimum authorization amount.
     /// @param _authorizationDecreaseDelay New authorization decrease delay in
-    ///        seconds
+    ///        seconds.
     /// @param _authorizationDecreaseChangePeriod New authorization decrease
-    ///        change period in seconds
+    ///        change period in seconds.
     function updateAuthorizationParameters(
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay,
@@ -514,18 +515,22 @@ contract WalletRegistryV2MisplacedNewSlot is
     ///      validating parameters.
     /// @param _seedTimeout New seed timeout.
     /// @param _resultChallengePeriodLength New DKG result challenge period
-    ///        length
-    /// @param _resultSubmissionTimeout New DKG result submission timeout
+    ///        length.
+    /// @param _resultChallengeExtraGas New extra gas value required to be left
+    ///        at the end of the DKG result challenge transaction.
+    /// @param _resultSubmissionTimeout New DKG result submission timeout.
     /// @param _submitterPrecedencePeriodLength New submitter precedence period
-    ///        length
+    ///        length.
     function updateDkgParameters(
         uint256 _seedTimeout,
         uint256 _resultChallengePeriodLength,
+        uint256 _resultChallengeExtraGas,
         uint256 _resultSubmissionTimeout,
         uint256 _submitterPrecedencePeriodLength
     ) external onlyGovernance {
         dkg.setSeedTimeout(_seedTimeout);
         dkg.setResultChallengePeriodLength(_resultChallengePeriodLength);
+        dkg.setResultChallengeExtraGas(_resultChallengeExtraGas);
         dkg.setResultSubmissionTimeout(_resultSubmissionTimeout);
         dkg.setSubmitterPrecedencePeriodLength(
             _submitterPrecedencePeriodLength
@@ -535,6 +540,7 @@ contract WalletRegistryV2MisplacedNewSlot is
         emit DkgParametersUpdated(
             _seedTimeout,
             _resultChallengePeriodLength,
+            _resultChallengeExtraGas,
             _resultSubmissionTimeout,
             _submitterPrecedencePeriodLength
         );
@@ -565,7 +571,7 @@ contract WalletRegistryV2MisplacedNewSlot is
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
     /// @param maliciousDkgResultSlashingAmount New malicious DKG result
-    ///        slashing amount
+    ///        slashing amount.
     function updateSlashingParameters(uint96 maliciousDkgResultSlashingAmount)
         external
         onlyGovernance
@@ -578,14 +584,14 @@ contract WalletRegistryV2MisplacedNewSlot is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param dkgResultSubmissionGas New DKG result submission gas
-    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset
+    /// @param dkgResultSubmissionGas New DKG result submission gas.
+    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset.
     /// @param notifyOperatorInactivityGasOffset New operator inactivity
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifySeedTimeoutGasOffset New seed for DKG delivery timeout
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifyDkgTimeoutNegativeGasOffset New DKG timeout notification gas
-    ///        offset
+    ///        offset.
     function updateGasParameters(
         uint256 dkgResultSubmissionGas,
         uint256 dkgResultApprovalGasOffset,
@@ -778,6 +784,17 @@ contract WalletRegistryV2MisplacedNewSlot is
                 maliciousDkgResultSubmitterAddress
             );
         }
+
+        // Due to EIP150, 1/64 of the gas is not forwarded to the call, and
+        // will be kept to execute the remaining operations in the function
+        // after the call inside the try-catch.
+        //
+        // To ensure there is no way for the caller to manipulate gas limit in
+        // such a way that the call inside try-catch fails with out-of-gas and
+        // the rest of the function is executed with the remaining 1/64 of gas,
+        // we require an extra gas amount to be left at the end of the call to
+        // `challengeDkgResult`.
+        dkg.requireChallengeExtraGas();
     }
 
     /// @notice Notifies about operators who are inactive. Using this function,
@@ -795,10 +812,10 @@ contract WalletRegistryV2MisplacedNewSlot is
     ///         function and provide new signatures.
     ///         The sender of the claim must be one of the claim signers. This
     ///         function can be called only for registered wallets
-    /// @param claim Operator inactivity claim
+    /// @param claim Operator inactivity claim.
     /// @param nonce Current inactivity claim nonce for the given wallet signing
-    ///              group. Must be the same as the stored one
-    /// @param groupMembers Identifiers of the wallet signing group members
+    ///              group. Must be the same as the stored one.
+    /// @param groupMembers Identifiers of the wallet signing group members.
     function notifyOperatorInactivity(
         Inactivity.Claim calldata claim,
         uint256 nonce,
@@ -856,12 +873,12 @@ contract WalletRegistryV2MisplacedNewSlot is
     ///         contract. The notifier will receive reward per each group member
     ///         from the staking contract notifiers treasury. The reward is
     ///         scaled by the `rewardMultiplier` provided as a parameter.
-    /// @param amount Amount of tokens to seize from each signing group member
+    /// @param amount Amount of tokens to seize from each signing group member.
     /// @param rewardMultiplier Fraction of the staking contract notifiers
-    ///        reward the notifier should receive; should be between [0, 100]
-    /// @param notifier Address of the misbehavior notifier
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    ///        reward the notifier should receive; should be between [0, 100].
+    /// @param notifier Address of the misbehavior notifier.
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
     /// @dev Requirements:
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
@@ -924,11 +941,11 @@ contract WalletRegistryV2MisplacedNewSlot is
 
     /// @notice Checks whether the given operator is a member of the given
     ///         wallet signing group.
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
-    /// @param operator Address of the checked operator
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
+    /// @param operator Address of the checked operator.
     /// @param walletMemberIndex Position of the operator in the wallet signing
-    ///        group members list
+    ///        group members list.
     /// @return True - if the operator is a member of the given wallet signing
     ///         group. False - otherwise.
     /// @dev Requirements:

--- a/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MisplacedNewSlot.sol
+++ b/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MisplacedNewSlot.sol
@@ -35,9 +35,6 @@ import "@keep-network/random-beacon/contracts/Governable.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IApplication.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IStaking.sol";
 
-// TODO: We used RC version of @openzeppelin/contracts-upgradeable to use `reinitializer`
-// in upgrades. We should revisit this part before mainnet deployment and use
-// a final release package if it's ready.
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract WalletRegistryV2MisplacedNewSlot is

--- a/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MissingSlot.sol
+++ b/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MissingSlot.sol
@@ -188,6 +188,7 @@ contract WalletRegistryV2MissingSlot is
     event DkgParametersUpdated(
         uint256 seedTimeout,
         uint256 resultChallengePeriodLength,
+        uint256 resultChallengeExtraGas,
         uint256 resultSubmissionTimeout,
         uint256 resultSubmitterPrecedencePeriodLength
     );
@@ -277,6 +278,8 @@ contract WalletRegistryV2MissingSlot is
     constructor(SortitionPool _sortitionPool, IStaking _staking) {
         sortitionPool = _sortitionPool;
         staking = _staking;
+
+        _disableInitializers();
     }
 
     /// @dev Initializes upgradable contract on deployment.
@@ -479,11 +482,11 @@ contract WalletRegistryV2MissingSlot is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param _minimumAuthorization New minimum authorization amount
+    /// @param _minimumAuthorization New minimum authorization amount.
     /// @param _authorizationDecreaseDelay New authorization decrease delay in
-    ///        seconds
+    ///        seconds.
     /// @param _authorizationDecreaseChangePeriod New authorization decrease
-    ///        change period in seconds
+    ///        change period in seconds.
     function updateAuthorizationParameters(
         uint96 _minimumAuthorization,
         uint64 _authorizationDecreaseDelay,
@@ -510,18 +513,22 @@ contract WalletRegistryV2MissingSlot is
     ///      validating parameters.
     /// @param _seedTimeout New seed timeout.
     /// @param _resultChallengePeriodLength New DKG result challenge period
-    ///        length
-    /// @param _resultSubmissionTimeout New DKG result submission timeout
+    ///        length.
+    /// @param _resultChallengeExtraGas New extra gas value required to be left
+    ///        at the end of the DKG result challenge transaction.
+    /// @param _resultSubmissionTimeout New DKG result submission timeout.
     /// @param _submitterPrecedencePeriodLength New submitter precedence period
-    ///        length
+    ///        length.
     function updateDkgParameters(
         uint256 _seedTimeout,
         uint256 _resultChallengePeriodLength,
+        uint256 _resultChallengeExtraGas,
         uint256 _resultSubmissionTimeout,
         uint256 _submitterPrecedencePeriodLength
     ) external onlyGovernance {
         dkg.setSeedTimeout(_seedTimeout);
         dkg.setResultChallengePeriodLength(_resultChallengePeriodLength);
+        dkg.setResultChallengeExtraGas(_resultChallengeExtraGas);
         dkg.setResultSubmissionTimeout(_resultSubmissionTimeout);
         dkg.setSubmitterPrecedencePeriodLength(
             _submitterPrecedencePeriodLength
@@ -531,6 +538,7 @@ contract WalletRegistryV2MissingSlot is
         emit DkgParametersUpdated(
             _seedTimeout,
             _resultChallengePeriodLength,
+            _resultChallengeExtraGas,
             _resultSubmissionTimeout,
             _submitterPrecedencePeriodLength
         );
@@ -562,7 +570,7 @@ contract WalletRegistryV2MissingSlot is
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
     /// @param maliciousDkgResultSlashingAmount New malicious DKG result
-    ///        slashing amount
+    ///        slashing amount.
     function updateSlashingParameters(uint96 maliciousDkgResultSlashingAmount)
         external
         onlyGovernance
@@ -575,14 +583,14 @@ contract WalletRegistryV2MissingSlot is
     /// @dev Can be called only by the contract guvnor, which should be the
     ///      wallet registry governance contract. The caller is responsible for
     ///      validating parameters.
-    /// @param dkgResultSubmissionGas New DKG result submission gas
-    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset
+    /// @param dkgResultSubmissionGas New DKG result submission gas.
+    /// @param dkgResultApprovalGasOffset New DKG result approval gas offset.
     /// @param notifyOperatorInactivityGasOffset New operator inactivity
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifySeedTimeoutGasOffset New seed for DKG delivery timeout
-    ///        notification gas offset
+    ///        notification gas offset.
     /// @param notifyDkgTimeoutNegativeGasOffset New DKG timeout notification gas
-    ///        offset
+    ///        offset.
     function updateGasParameters(
         uint256 dkgResultSubmissionGas,
         uint256 dkgResultApprovalGasOffset,
@@ -775,6 +783,17 @@ contract WalletRegistryV2MissingSlot is
                 maliciousDkgResultSubmitterAddress
             );
         }
+
+        // Due to EIP150, 1/64 of the gas is not forwarded to the call, and
+        // will be kept to execute the remaining operations in the function
+        // after the call inside the try-catch.
+        //
+        // To ensure there is no way for the caller to manipulate gas limit in
+        // such a way that the call inside try-catch fails with out-of-gas and
+        // the rest of the function is executed with the remaining 1/64 of gas,
+        // we require an extra gas amount to be left at the end of the call to
+        // `challengeDkgResult`.
+        dkg.requireChallengeExtraGas();
     }
 
     /// @notice Notifies about operators who are inactive. Using this function,
@@ -792,10 +811,10 @@ contract WalletRegistryV2MissingSlot is
     ///         function and provide new signatures.
     ///         The sender of the claim must be one of the claim signers. This
     ///         function can be called only for registered wallets
-    /// @param claim Operator inactivity claim
+    /// @param claim Operator inactivity claim.
     /// @param nonce Current inactivity claim nonce for the given wallet signing
-    ///              group. Must be the same as the stored one
-    /// @param groupMembers Identifiers of the wallet signing group members
+    ///              group. Must be the same as the stored one.
+    /// @param groupMembers Identifiers of the wallet signing group members.
     function notifyOperatorInactivity(
         Inactivity.Claim calldata claim,
         uint256 nonce,
@@ -853,12 +872,12 @@ contract WalletRegistryV2MissingSlot is
     ///         contract. The notifier will receive reward per each group member
     ///         from the staking contract notifiers treasury. The reward is
     ///         scaled by the `rewardMultiplier` provided as a parameter.
-    /// @param amount Amount of tokens to seize from each signing group member
+    /// @param amount Amount of tokens to seize from each signing group member.
     /// @param rewardMultiplier Fraction of the staking contract notifiers
-    ///        reward the notifier should receive; should be between [0, 100]
-    /// @param notifier Address of the misbehavior notifier
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
+    ///        reward the notifier should receive; should be between [0, 100].
+    /// @param notifier Address of the misbehavior notifier.
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
     /// @dev Requirements:
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
@@ -921,11 +940,11 @@ contract WalletRegistryV2MissingSlot is
 
     /// @notice Checks whether the given operator is a member of the given
     ///         wallet signing group.
-    /// @param walletID ID of the wallet
-    /// @param walletMembersIDs Identifiers of the wallet signing group members
-    /// @param operator Address of the checked operator
+    /// @param walletID ID of the wallet.
+    /// @param walletMembersIDs Identifiers of the wallet signing group members.
+    /// @param operator Address of the checked operator.
     /// @param walletMemberIndex Position of the operator in the wallet signing
-    ///        group members list
+    ///        group members list.
     /// @return True - if the operator is a member of the given wallet signing
     ///         group. False - otherwise.
     /// @dev Requirements:

--- a/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MissingSlot.sol
+++ b/solidity/ecdsa/contracts/test/upgrades/WalletRegistryV2MissingSlot.sol
@@ -35,9 +35,6 @@ import "@keep-network/random-beacon/contracts/Governable.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IApplication.sol";
 import "@threshold-network/solidity-contracts/contracts/staking/IStaking.sol";
 
-// TODO: We used RC version of @openzeppelin/contracts-upgradeable to use `reinitializer`
-// in upgrades. We should revisit this part before mainnet deployment and use
-// a final release package if it's ready.
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract WalletRegistryV2MissingSlot is

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -56,7 +56,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by the deployer", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(deployer).updateDkgParameters(1, 2, 3, 4)
+          walletRegistry.connect(deployer).updateDkgParameters(1, 2, 3, 4, 5)
         ).to.be.revertedWith("Caller is not the governance")
       })
     })
@@ -66,7 +66,7 @@ describe("WalletRegistry - Parameters", async () => {
         await expect(
           walletRegistry
             .connect(walletOwner.wallet)
-            .updateDkgParameters(1, 2, 3, 4)
+            .updateDkgParameters(1, 2, 3, 4, 5)
         ).to.be.revertedWith("Caller is not the governance")
       })
     })
@@ -74,7 +74,7 @@ describe("WalletRegistry - Parameters", async () => {
     context("when called by a third party", async () => {
       it("should revert", async () => {
         await expect(
-          walletRegistry.connect(thirdParty).updateDkgParameters(1, 2, 3, 4)
+          walletRegistry.connect(thirdParty).updateDkgParameters(1, 2, 3, 4, 5)
         ).to.be.revertedWith("Caller is not the governance")
       })
     })

--- a/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
+++ b/solidity/ecdsa/test/WalletRegistryGovernance.test.ts
@@ -632,7 +632,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -715,7 +715,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -766,7 +766,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -849,7 +849,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1044,7 +1044,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1129,7 +1129,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1185,7 +1185,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1269,7 +1269,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1322,7 +1322,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1407,7 +1407,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1473,7 +1473,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner and value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1558,7 +1558,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1794,7 +1794,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner and the value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -1874,7 +1874,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -1957,7 +1957,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner and the value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2040,7 +2040,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2125,7 +2125,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2208,7 +2208,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2295,7 +2295,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner and the value is correct", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2317,7 +2317,7 @@ describe("WalletRegistryGovernance", async () => {
 
       it("should start the governance delay timer", async () => {
         expect(
-          await walletRegistryGovernance.getRemainingSubmitterPrecedencePeriodLengthUpdateTime()
+          await walletRegistryGovernance.getRemainingDkgSubmitterPrecedencePeriodLengthUpdateTime()
         ).to.be.equal(constants.governanceDelay)
       })
 
@@ -2378,7 +2378,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2416,7 +2416,140 @@ describe("WalletRegistryGovernance", async () => {
 
         it("should reset the governance delay timer", async () => {
           await expect(
-            walletRegistryGovernance.getRemainingSubmitterPrecedencePeriodLengthUpdateTime()
+            walletRegistryGovernance.getRemainingDkgSubmitterPrecedencePeriodLengthUpdateTime()
+          ).to.be.revertedWith("Change not initiated")
+        })
+      }
+    )
+  })
+
+  describe("beginDkgResultChallengeExtraGasUpdate", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(thirdParty)
+            .beginDkgResultChallengeExtraGasUpdate(1)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the caller is the owner", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await walletRegistryGovernance
+          .connect(governance)
+          .beginDkgResultChallengeExtraGasUpdate(1337)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should not update the DKG result challenge extra gas", async () => {
+        expect(
+          (await walletRegistry.dkgParameters()).resultChallengeExtraGas
+        ).to.be.equal(params.dkgResultChallengeExtraGas)
+      })
+
+      it("should emit DkgResultChallengeExtraGasUpdateStarted", async () => {
+        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
+          .timestamp
+        await expect(tx)
+          .to.emit(
+            walletRegistryGovernance,
+            "DkgResultChallengeExtraGasUpdateStarted"
+          )
+          .withArgs(1337, blockTimestamp)
+      })
+    })
+  })
+
+  describe("finalizeDkgResultChallengeExtraGasUpdate", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(thirdParty)
+            .finalizeDkgResultChallengeExtraGasUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initialized", () => {
+      it("should revert", async () => {
+        await expect(
+          walletRegistryGovernance
+            .connect(governance)
+            .finalizeDkgResultChallengeExtraGasUpdate()
+        ).to.be.revertedWith("Change not initiated")
+      })
+    })
+
+    context("when the governance delay has not passed", () => {
+      it("should revert", async () => {
+        await createSnapshot()
+
+        await walletRegistryGovernance
+          .connect(governance)
+          .beginDkgResultChallengeExtraGasUpdate(1)
+
+        await helpers.time.increaseTime(constants.governanceDelay - 60) // -1min
+
+        await expect(
+          walletRegistryGovernance
+            .connect(governance)
+            .finalizeDkgResultChallengeExtraGasUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+
+        await restoreSnapshot()
+      })
+    })
+
+    context(
+      "when the update process is initialized and governance delay passed",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await walletRegistryGovernance
+            .connect(governance)
+            .beginDkgResultChallengeExtraGasUpdate(1337)
+
+          await helpers.time.increaseTime(constants.governanceDelay)
+
+          tx = await walletRegistryGovernance
+            .connect(governance)
+            .finalizeDkgResultChallengeExtraGasUpdate()
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the DKG result challenge extra gas", async () => {
+          expect(
+            (await walletRegistry.dkgParameters()).resultChallengeExtraGas
+          ).to.be.equal(1337)
+        })
+
+        it("should emit DkgResultChallengeExtraGasUpdated event", async () => {
+          await expect(tx)
+            .to.emit(
+              walletRegistryGovernance,
+              "DkgResultChallengeExtraGasUpdated"
+            )
+            .withArgs(1337)
+        })
+
+        it("should reset the governance delay timer", async () => {
+          await expect(
+            walletRegistryGovernance.getRemainingDkgResultChallengeExtraGasUpdateTime()
           ).to.be.revertedWith("Change not initiated")
         })
       }
@@ -2581,7 +2714,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2666,7 +2799,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2722,7 +2855,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2807,7 +2940,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
@@ -2863,7 +2996,7 @@ describe("WalletRegistryGovernance", async () => {
     })
 
     context("when the caller is the owner", () => {
-      let tx
+      let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
@@ -2948,7 +3081,7 @@ describe("WalletRegistryGovernance", async () => {
     context(
       "when the update process is initialized and governance delay passed",
       () => {
-        let tx
+        let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -26,8 +26,8 @@ export const constants = {
   groupSize: 100,
   groupThreshold: 51,
   poolWeightDivisor: to1e18(1),
-  tokenStakingNotificationReward: to1e18(10000), // 10k T
-  governanceDelay: 604800, // 1 week
+  tokenStakingNotificationReward: to1e18(10_000), // 10k T
+  governanceDelay: 604_800, // 1 week
 }
 
 export const dkgState = {
@@ -38,14 +38,15 @@ export const dkgState = {
 }
 
 export const params = {
-  minimumAuthorization: to1e18(40000),
-  authorizationDecreaseDelay: 3888000,
-  authorizationDecreaseChangePeriod: 3888000,
+  minimumAuthorization: to1e18(40_000),
+  authorizationDecreaseDelay: 3_888_000,
+  authorizationDecreaseChangePeriod: 3_888_000,
   dkgSeedTimeout: 8,
   dkgResultChallengePeriodLength: 10,
   dkgResultSubmissionTimeout: 30,
   dkgSubmitterPrecedencePeriodLength: 5,
-  sortitionPoolRewardsBanDuration: 1209600, // 14 days
+  dkgResultChallengeExtraGas: 50_000,
+  sortitionPoolRewardsBanDuration: 1_209_600, // 14 days
 }
 
 export const walletRegistryFixture = deployments.createFixture(

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -43,9 +43,9 @@ export const params = {
   authorizationDecreaseChangePeriod: 3_888_000,
   dkgSeedTimeout: 8,
   dkgResultChallengePeriodLength: 10,
+  dkgResultChallengeExtraGas: 50_000,
   dkgResultSubmissionTimeout: 30,
   dkgSubmitterPrecedencePeriodLength: 5,
-  dkgResultChallengeExtraGas: 50_000,
   sortitionPoolRewardsBanDuration: 1_209_600, // 14 days
 }
 


### PR DESCRIPTION
Due to EIP150, 1/64 of the gas is not forwarded to the call, and will be kept to execute the remaining operations in the function after the call inside the try-catch.

To ensure there is no way for the caller to manipulate the gas limit in such a way that the call inside try-catch fails with out-of-gas and the rest of the function is executed with the remaining 1/64 of gas, we require an extra gas amount to be left at the end of the call to `WalletRegistry.challengeDkgResult`.

In practice, with the current version of the code, such a scenario should not be possible anyway but the extra gas requirement provides an extra layer of protection in case of any code changes. In the current version of the code, the cost of `dkg.challegeResult(dkgResult)` is about 1.6M gas units and the cost of everything that happens later is around 144k gas units. It means that the cost of the rest of the logic is about 6% of the cost of the entire function which is more than 1/64.

Another option for solving this problem was trying to eliminate try-catch altogether. This option would be more error-prone for future changes in the code though. We would need to check all functions on the execution stack of the DKG result challenge and ensure they can not revert or if they revert, they revert with a specific error. Any future change to the code would require inspecting the possible cases of reverts again. That's why a general try-catch with an extra gas requirement at the end feels safer long-term.

Note that the functions on the execution stack of the DKG result challenge may revert. One example is the corrupted signature verification covered by `with dkg result submitted with unrecoverable signatures` unit tests. That's why some try-catch is necessary, even if not on the highest level, then more try-catches on the lower levels of the execution stack.