### PR TITLE
Use newer version (v3) of the `setup-node` action

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v2
@@ -52,7 +52,7 @@ jobs:
         || needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1
@@ -152,7 +152,7 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: securego/gosec@master
         with:
           args: |
@@ -169,7 +169,7 @@ jobs:
         || needs.client-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Go format
         uses: Jerome1337/gofmt-action@v1.0.4

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v2
@@ -50,7 +50,7 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -77,7 +77,7 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -120,7 +120,7 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -147,7 +147,7 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -169,7 +169,7 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -149,7 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v2
@@ -50,7 +50,7 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -77,7 +77,7 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -118,7 +118,7 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -145,7 +145,7 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -167,7 +167,7 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -169,7 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"

--- a/.github/workflows/contracts-v1.yml
+++ b/.github/workflows/contracts-v1.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v2
@@ -51,7 +51,7 @@ jobs:
       run:
         working-directory: ./solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -84,7 +84,7 @@ jobs:
       run:
         working-directory: ./solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -108,7 +108,7 @@ jobs:
     outputs:
       version: ${{ steps.npm-version-bump.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1
@@ -185,7 +185,7 @@ jobs:
     if: needs.contracts-migrate-and-publish.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1
@@ -262,7 +262,7 @@ jobs:
       run:
         working-directory: ./solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download files needed for etherscan verification
         uses: actions/download-artifact@v2

--- a/.github/workflows/contracts-v1.yml
+++ b/.github/workflows/contracts-v1.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "npm"
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "npm"
@@ -115,7 +115,7 @@ jobs:
         with:
           environment: ${{ github.event.inputs.environment }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "npm"
@@ -275,7 +275,7 @@ jobs:
         with:
           environment: ${{ github.event.inputs.environment }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "npm"

--- a/.github/workflows/dashboard-v1-format.yaml
+++ b/.github/workflows/dashboard-v1-format.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: github.event_name == 'pull_request'
 
     - uses: dorny/paths-filter@v2
@@ -37,7 +37,7 @@ jobs:
         || needs.dashboard-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/dashboard-v1-mainnet.yml
+++ b/.github/workflows/dashboard-v1-mainnet.yml
@@ -15,7 +15,7 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -56,7 +56,7 @@ jobs:
       run:
         working-directory: solidity-v1/dashboard
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/dashboard-v1-mainnet.yml
+++ b/.github/workflows/dashboard-v1-mainnet.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       # This step forces Git to download dependencies using `https://` protocol,

--- a/.github/workflows/dashboard-v1-testnet.yml
+++ b/.github/workflows/dashboard-v1-testnet.yml
@@ -60,7 +60,7 @@ jobs:
           # in config files.
           environment: 'ropsten'
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "npm"

--- a/.github/workflows/dashboard-v1-testnet.yml
+++ b/.github/workflows/dashboard-v1-testnet.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v2
@@ -50,7 +50,7 @@ jobs:
       run:
         working-directory: ./solidity-v1/dashboard
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request' 
       - uses: dorny/paths-filter@v2
         if: github.event_name == 'pull_request' 
@@ -40,7 +40,7 @@ jobs:
     env:
       DOCS_DIR: ${{ github.workspace }}/tmp/docs-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Step generates files based on Makefile config. Current config produces
       # a number of .png files, which are then used to generate 
@@ -83,7 +83,7 @@ jobs:
     env:
       SOLIDITY_DOCS_DIR: ${{ github.workspace }}/docs-v1/solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Generate solidity docs
         working-directory: ./solidity-v1
@@ -107,7 +107,7 @@ jobs:
         && (github.event_name != 'pull_request'
         || needs.docs-detect-changes.outputs.path-filter == 'true')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download Solidity Docs Artifact
         uses: actions/download-artifact@v2
@@ -153,7 +153,7 @@ jobs:
         && (github.event_name != 'pull_request'
         || needs.docs-detect-changes.outputs.path-filter == 'true')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download a Build Artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/genesis-testnet.yml
+++ b/.github/workflows/genesis-testnet.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           environment: 'ropsten'
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "npm"

--- a/.github/workflows/genesis-testnet.yml
+++ b/.github/workflows/genesis-testnet.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: ./solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/npm-v1.yml
+++ b/.github/workflows/npm-v1.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "npm"

--- a/.github/workflows/npm-v1.yml
+++ b/.github/workflows/npm-v1.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: ./solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/submitter-testnet.yaml
+++ b/.github/workflows/submitter-testnet.yaml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: ./solidity-v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load environment variables
         uses: keep-network/ci/actions/load-env-variables@v1

--- a/.github/workflows/submitter-testnet.yaml
+++ b/.github/workflows/submitter-testnet.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           environment: 'ropsten'
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "npm"


### PR DESCRIPTION
New version of the action is now available. With `v2` we're sometimes
seeing problems with parallel execution of jobs. We hope that updating
to `v3` will help.