### PR TITLE
Added extra gas requirement for Beacon DKG result challenge

### DIFF
--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -790,6 +790,12 @@ contract WalletRegistry is
     ///         invalid it reverts the DKG back to the result submission phase.
     /// @param dkgResult Result to challenge. Must match the submitted result
     ///        stored during `submitDkgResult`.
+    /// @dev Due to EIP-150 1/64 of the gas is not forwarded to the call, and
+    ///      will be kept to execute the remaining operations in the function
+    ///      after the call inside the try-catch. To eliminate a class of
+    ///      attacks related to the gas limit manipulation, this function
+    ///      requires an extra amount of gas to be left at the end of the
+    ///      execution.
     function challengeDkgResult(DKG.Result calldata dkgResult) external {
         (
             bytes32 maliciousDkgResultHash,
@@ -829,7 +835,7 @@ contract WalletRegistry is
             );
         }
 
-        // Due to EIP150, 1/64 of the gas is not forwarded to the call, and
+        // Due to EIP-150, 1/64 of the gas is not forwarded to the call, and
         // will be kept to execute the remaining operations in the function
         // after the call inside the try-catch.
         //

--- a/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaDkg.sol
@@ -456,8 +456,8 @@ library EcdsaDkg {
     ///         and the rest of the function is executed with the remaining
     ///         1/64 of gas, we require an extra gas amount to be left at the
     ///         end of the call to the function challenging DKG result and
-    ///         wrapping the call to EcdsaDkgValidator in TokenStaking contract
-    ///         inside a try-catch.
+    ///         wrapping the call to EcdsaDkgValidator and TokenStaking
+    ///         contracts inside a try-catch.
     function requireChallengeExtraGas(Data storage self) internal view {
         require(
             gasleft() >= self.parameters.resultChallengeExtraGas,

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -46,6 +46,9 @@ contract RandomBeaconGovernance is Ownable {
     uint256 public newDkgResultChallengePeriodLength;
     uint256 public dkgResultChallengePeriodLengthChangeInitiated;
 
+    uint256 public newDkgResultChallengeExtraGas;
+    uint256 public dkgResultChallengeExtraGasChangeInitiated;
+
     uint256 public newDkgResultSubmissionTimeout;
     uint256 public dkgResultSubmissionTimeoutChangeInitiated;
 
@@ -146,6 +149,12 @@ contract RandomBeaconGovernance is Ownable {
     event DkgResultChallengePeriodLengthUpdated(
         uint256 dkgResultChallengePeriodLength
     );
+
+    event DkgResultChallengeExtraGasUpdateStarted(
+        uint256 dkgResultChallengeExtraGas,
+        uint256 timestamp
+    );
+    event DkgResultChallengeExtraGasUpdated(uint256 dkgResultChallengeExtraGas);
 
     event DkgResultSubmissionTimeoutUpdateStarted(
         uint256 dkgResultSubmissionTimeout,
@@ -515,6 +524,7 @@ contract RandomBeaconGovernance is Ownable {
             ,
             uint256 groupLifetime,
             uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultChallengeExtraGas,
             uint256 dkgResultSubmissionTimeout,
             uint256 dkgSubmitterPrecedencePeriodLength
         ) = randomBeacon.groupCreationParameters();
@@ -523,6 +533,7 @@ contract RandomBeaconGovernance is Ownable {
             newGroupCreationFrequency,
             groupLifetime,
             dkgResultChallengePeriodLength,
+            dkgResultChallengeExtraGas,
             dkgResultSubmissionTimeout,
             dkgSubmitterPrecedencePeriodLength
         );
@@ -562,6 +573,7 @@ contract RandomBeaconGovernance is Ownable {
             uint256 groupCreationFrequency,
             ,
             uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultChallengeExtraGas,
             uint256 dkgResultSubmissionTimeout,
             uint256 dkgSubmitterPrecedencePeriodLength
         ) = randomBeacon.groupCreationParameters();
@@ -570,6 +582,7 @@ contract RandomBeaconGovernance is Ownable {
             groupCreationFrequency,
             newGroupLifetime,
             dkgResultChallengePeriodLength,
+            dkgResultChallengeExtraGas,
             dkgResultSubmissionTimeout,
             dkgSubmitterPrecedencePeriodLength
         );
@@ -613,6 +626,7 @@ contract RandomBeaconGovernance is Ownable {
             uint256 groupCreationFrequency,
             uint256 groupLifetime,
             ,
+            uint256 dkgResultChallengeExtraGas,
             uint256 dkgResultSubmissionTimeout,
             uint256 dkgSubmitterPrecedencePeriodLength
         ) = randomBeacon.groupCreationParameters();
@@ -621,11 +635,58 @@ contract RandomBeaconGovernance is Ownable {
             groupCreationFrequency,
             groupLifetime,
             newDkgResultChallengePeriodLength,
+            dkgResultChallengeExtraGas,
             dkgResultSubmissionTimeout,
             dkgSubmitterPrecedencePeriodLength
         );
         dkgResultChallengePeriodLengthChangeInitiated = 0;
         newDkgResultChallengePeriodLength = 0;
+    }
+
+    /// @notice Begins the DKG result challenge extra gas update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newDkgResultChallengeExtraGas New DKG result challenge extra gas
+    function beginDkgResultChallengeExtraGasUpdate(
+        uint256 _newDkgResultChallengeExtraGas
+    ) external onlyOwner {
+        /* solhint-disable not-rely-on-time */
+        newDkgResultChallengeExtraGas = _newDkgResultChallengeExtraGas;
+        dkgResultChallengeExtraGasChangeInitiated = block.timestamp;
+        emit DkgResultChallengeExtraGasUpdateStarted(
+            _newDkgResultChallengeExtraGas,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the DKG result challenge extra gas update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeDkgResultChallengeExtraGasUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(dkgResultChallengeExtraGasChangeInitiated)
+    {
+        emit DkgResultChallengeExtraGasUpdated(newDkgResultChallengeExtraGas);
+        (
+            uint256 groupCreationFrequency,
+            uint256 groupLifetime,
+            uint256 dkgResultChallengePeriodLength,
+            ,
+            uint256 dkgResultSubmissionTimeout,
+            uint256 dkgSubmitterPrecedencePeriodLength
+        ) = randomBeacon.groupCreationParameters();
+        // slither-disable-next-line reentrancy-no-eth
+        randomBeacon.updateGroupCreationParameters(
+            groupCreationFrequency,
+            groupLifetime,
+            dkgResultChallengePeriodLength,
+            newDkgResultChallengeExtraGas,
+            dkgResultSubmissionTimeout,
+            dkgSubmitterPrecedencePeriodLength
+        );
+        dkgResultChallengeExtraGasChangeInitiated = 0;
+        newDkgResultChallengeExtraGas = 0;
     }
 
     /// @notice Begins the DKG result submission timeout update
@@ -664,6 +725,7 @@ contract RandomBeaconGovernance is Ownable {
             uint256 groupCreationFrequency,
             uint256 groupLifetime,
             uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultChallengeExtraGas,
             ,
             uint256 dkgSubmitterPrecedencePeriodLength
         ) = randomBeacon.groupCreationParameters();
@@ -672,6 +734,7 @@ contract RandomBeaconGovernance is Ownable {
             groupCreationFrequency,
             groupLifetime,
             dkgResultChallengePeriodLength,
+            dkgResultChallengeExtraGas,
             newDkgResultSubmissionTimeout,
             dkgSubmitterPrecedencePeriodLength
         );
@@ -717,6 +780,7 @@ contract RandomBeaconGovernance is Ownable {
             uint256 groupCreationFrequency,
             uint256 groupLifetime,
             uint256 dkgResultChallengePeriodLength,
+            uint256 dkgResultChallengeExtraGas,
             uint256 dkgResultSubmissionTimeout,
 
         ) = randomBeacon.groupCreationParameters();
@@ -725,6 +789,7 @@ contract RandomBeaconGovernance is Ownable {
             groupCreationFrequency,
             groupLifetime,
             dkgResultChallengePeriodLength,
+            dkgResultChallengeExtraGas,
             dkgResultSubmissionTimeout,
             newDkgSubmitterPrecedencePeriodLength
         );
@@ -1488,6 +1553,18 @@ contract RandomBeaconGovernance is Ownable {
             getRemainingChangeTime(
                 dkgResultChallengePeriodLengthChangeInitiated
             );
+    }
+
+    /// @notice Get the time remaining until the DKG result challenge extra
+    ///         gas can be updated.
+    /// @return Remaining time in seconds.
+    function getRemainingDkgResultChallengeExtraGasUpdateTime()
+        external
+        view
+        returns (uint256)
+    {
+        return
+            getRemainingChangeTime(dkgResultChallengeExtraGasChangeInitiated);
     }
 
     /// @notice Get the time remaining until the DKG result submission timeout

--- a/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconDkg.sol
@@ -26,6 +26,9 @@ library BeaconDkg {
     struct Parameters {
         // Time in blocks during which a submitted result can be challenged.
         uint256 resultChallengePeriodLength;
+        // Extra gas required to be left at the end of the challenge DKG result
+        // transaction.
+        uint256 resultChallengeExtraGas;
         // Time in blocks during which a result is expected to be submitted.
         uint256 resultSubmissionTimeout;
         // Time in blocks during which only the result submitter is allowed to
@@ -425,10 +428,31 @@ library BeaconDkg {
         return (maliciousResultHash, maliciousSubmitter);
     }
 
+    /// @notice Due to EIP150, 1/64 of the gas is not forwarded to the call, and
+    ///         will be kept to execute the remaining operations in the function
+    ///         after the call inside the try-catch.
+    ///
+    ///         To ensure there is no way for the caller to manipulate gas limit
+    ///         in such a way that the call inside try-catch fails with out-of-gas
+    ///         and the rest of the function is executed with the remaining
+    ///         1/64 of gas, we require an extra gas amount to be left at the
+    ///         end of the call to the function challenging DKG result and
+    ///         wrapping the call to BeaconDkgValidator and TokenStaking
+    ///         contracts inside a try-catch.
+    function requireChallengeExtraGas(Data storage self) internal view {
+        require(
+            gasleft() >= self.parameters.resultChallengeExtraGas,
+            "Not enough extra gas left"
+        );
+    }
+
     /// @notice Updates DKG-related parmaeters
     /// @param _resultChallengePeriodLength New value of the result challenge
     ///        period length. It is the number of blocks for which a DKG result
     ///        can be challenged.
+    /// @param _resultChallengeExtraGas New value of the result challenge extra
+    ///        gas. It is the extra gas required to be left at the end of the
+    ///        challenge DKG result transaction.
     /// @param _resultSubmissionTimeout New value of the result submission
     ///        timeout in seconds. It is a timeout for a group to provide a DKG
     ///        result.
@@ -438,6 +462,7 @@ library BeaconDkg {
     function setParameters(
         Data storage self,
         uint256 _resultChallengePeriodLength,
+        uint256 _resultChallengeExtraGas,
         uint256 _resultSubmissionTimeout,
         uint256 _submitterPrecedencePeriodLength
     ) internal {
@@ -459,6 +484,7 @@ library BeaconDkg {
         self
             .parameters
             .resultChallengePeriodLength = _resultChallengePeriodLength;
+        self.parameters.resultChallengeExtraGas = _resultChallengeExtraGas;
         self.parameters.resultSubmissionTimeout = _resultSubmissionTimeout;
         self
             .parameters

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -185,7 +185,8 @@ describe("RandomBeacon - Parameters", () => {
     const newGroupCreationFrequency = 100
     const newGroupLifetime = 200
     const newDkgResultChallengePeriodLength = 300
-    const newDkgResultSubmissionTimeout = 400
+    const newDkgResultChallengeExtraGas = 400
+    const newDkgResultSubmissionTimeout = 500
     const newDkgSubmitterPrecedencePeriodLength = 200
 
     context("when the caller is not the governance", () => {
@@ -197,6 +198,7 @@ describe("RandomBeacon - Parameters", () => {
               newGroupCreationFrequency,
               newGroupLifetime,
               newDkgResultChallengePeriodLength,
+              newDkgResultChallengeExtraGas,
               newDkgResultSubmissionTimeout,
               newDkgSubmitterPrecedencePeriodLength
             )
@@ -216,6 +218,7 @@ describe("RandomBeacon - Parameters", () => {
             newGroupCreationFrequency,
             newGroupLifetime,
             newDkgResultChallengePeriodLength,
+            newDkgResultChallengeExtraGas,
             newDkgResultSubmissionTimeout,
             newDkgSubmitterPrecedencePeriodLength
           )
@@ -267,6 +270,7 @@ describe("RandomBeacon - Parameters", () => {
             newGroupCreationFrequency,
             newGroupLifetime,
             newDkgResultChallengePeriodLength,
+            newDkgResultChallengeExtraGas,
             newDkgResultSubmissionTimeout,
             newDkgSubmitterPrecedencePeriodLength
           )
@@ -287,6 +291,7 @@ describe("RandomBeacon - Parameters", () => {
                     newGroupCreationFrequency,
                     newGroupLifetime,
                     newDkgResultChallengePeriodLength,
+                    newDkgResultChallengeExtraGas,
                     newDkgResultSubmissionTimeout,
                     invalidDkgSubmitterPrecedencePeriodLength
                   )
@@ -311,6 +316,7 @@ describe("RandomBeacon - Parameters", () => {
                     newGroupCreationFrequency,
                     newGroupLifetime,
                     newDkgResultChallengePeriodLength,
+                    newDkgResultChallengeExtraGas,
                     newDkgResultSubmissionTimeout,
                     invalidDkgSubmitterPrecedencePeriodLength
                   )

--- a/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Parameters.test.ts
@@ -247,6 +247,14 @@ describe("RandomBeacon - Parameters", () => {
         )
       })
 
+      it("should update the DKG result challenge extra gas", async () => {
+        const { dkgResultChallengeExtraGas } =
+          await randomBeacon.groupCreationParameters()
+        expect(dkgResultChallengeExtraGas).to.be.equal(
+          newDkgResultChallengeExtraGas
+        )
+      })
+
       it("should update the DKG result submission timeout", async () => {
         const { dkgResultSubmissionTimeout } =
           await randomBeacon.groupCreationParameters()

--- a/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
+++ b/solidity/random-beacon/test/RandomBeacon.Relay.test.ts
@@ -1924,7 +1924,7 @@ describe("RandomBeacon - Relay", () => {
         })
       })
 
-      context("when group is active but terminated", () => {
+      context("when group was active but got terminated", () => {
         before(async () => {
           await createSnapshot()
 
@@ -1950,7 +1950,7 @@ describe("RandomBeacon - Relay", () => {
               0,
               membersIDs
             )
-          ).to.be.revertedWith("Group must be active and non-terminated")
+          ).to.be.revertedWith("Group is not active")
         })
       })
 
@@ -1989,7 +1989,7 @@ describe("RandomBeacon - Relay", () => {
               0,
               membersIDs
             )
-          ).to.be.revertedWith("Group must be active and non-terminated")
+          ).to.be.revertedWith("Group is not active")
         })
       })
     })

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -31,31 +31,32 @@ export const dkgState = {
 }
 
 export const params = {
-  governanceDelay: 604800, // 1 week
+  governanceDelay: 604_800, // 1 week
   relayEntrySoftTimeout: 35,
   relayEntryHardTimeout: 100,
-  callbackGasLimit: 200000,
+  callbackGasLimit: 200_000,
   groupCreationFrequency: 10,
   groupLifetime: 5761, // 1 day in blocks assuming 15s block time
   dkgResultChallengePeriodLength: 100,
+  dkgResultChallengeExtraGas: 50_000,
   dkgResultSubmissionTimeout: 30,
   dkgSubmitterPrecedencePeriodLength: 5,
-  sortitionPoolRewardsBanDuration: 1209600, // 2 weeks
+  sortitionPoolRewardsBanDuration: 1_209_600, // 2 weeks
   relayEntrySubmissionFailureSlashingAmount: to1e18(1000),
-  maliciousDkgResultSlashingAmount: to1e18(50000),
+  maliciousDkgResultSlashingAmount: to1e18(50_000),
   relayEntryTimeoutNotificationRewardMultiplier: 40,
   unauthorizedSigningNotificationRewardMultiplier: 50,
   dkgMaliciousResultNotificationRewardMultiplier: 100,
-  unauthorizedSigningSlashingAmount: to1e18(100000),
-  minimumAuthorization: to1e18(200000),
-  authorizationDecreaseDelay: 403200,
-  authorizationDecreaseChangePeriod: 403200,
-  reimbursementPoolStaticGas: 40800,
+  unauthorizedSigningSlashingAmount: to1e18(100_000),
+  minimumAuthorization: to1e18(200_000),
+  authorizationDecreaseDelay: 403_200,
+  authorizationDecreaseChangePeriod: 403_200,
+  reimbursementPoolStaticGas: 40_800,
   reimbursementPoolMaxGasPrice: ethers.utils.parseUnits("500", "gwei"),
-  dkgResultSubmissionGas: 237650,
-  dkgResultApprovalGasOffset: 41500,
-  notifyOperatorInactivityGasOffset: 54500,
-  relayEntrySubmissionGasOffset: 11250,
+  dkgResultSubmissionGas: 237_650,
+  dkgResultApprovalGasOffset: 41_500,
+  notifyOperatorInactivityGasOffset: 54_500,
+  relayEntrySubmissionGasOffset: 11_250,
 }
 
 export interface DeployedContracts {

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -29,7 +29,10 @@ export async function genesis(
     ethers.utils.keccak256(
       ethers.utils.solidityPack(
         ["uint256", "uint256"],
-        [await randomBeacon.genesisSeed(), tx.blockNumber]
+        [
+          "31415926535897932384626433832795028841971693993751058209749445923078164062862",
+          tx.blockNumber,
+        ]
       )
     )
   )


### PR DESCRIPTION
See #3133 for ECDSA part.

Due to EIP150, 1/64 of the gas is not forwarded to the call, and will be kept to execute the remaining operations in the function after the call inside the try-catch.

To ensure there is no way for the caller to manipulate the gas limit in such a way that the call inside try-catch fails with out-of-gas and the rest of the function is executed with the remaining 1/64 of gas, we require an extra gas amount to be left at the end of the call to `RandomBeacon.challengeDkgResult`.

In practice, with the current version of the code, such a scenario should not be possible anyway but the extra gas requirement provides an extra layer of protection in case of any code changes. In the current version of the code, the cost of `dkg.challegeResult(dkgResult)` is about 1M gas units and the cost of everything that happens later is around 118k gas units. It means that the cost of the rest of the logic is about 10% of the cost of the entire function which is more than 1/64.

Another option for solving this problem was trying to eliminate try-catch altogether. This option would be more error-prone for future changes in the code though. We would need to check all functions on the execution stack of the DKG result challenge and ensure they can not revert or if they revert, they revert with a specific error. Any future change to the code would require inspecting the possible cases of reverts again. That's why a general try-catch with an extra gas requirement at the end feels safer long-term.

Note that the functions on the execution stack of the DKG result challenge may revert. One example is the corrupted signature verification covered by `with dkg result submitted with unrecoverable signatures` unit tests. That's why some try catch is necessary, even if not on the highest level, then more try-catches on the lower levels of the execution stack.

An unpleasant surprise when working on this PR was the `RandomBeacon` contract size. After adding the extra gas logic, the maximum contract size got exceeded and I had to do two sacrifices to take it back under the limit. The first change is making `genesisSeed` internal and the second one is shortening the revert message in `notifyOperatorInactivity`. With these two changes, the contract size is at 24.576, so exactly at the limit.