### PR TITLE
Fix the publishing of Docker images

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -67,7 +67,7 @@ runs:
         # GCR image should be named according to following convention:
         # HOSTNAME/PROJECT-ID/IMAGE:TAG
         # We don't use TAG yet, will be added at later stages of work on RFC-18.
-        tags: ${{ inputs.imageName }}
+        tags: ${{ env.IMAGE_NAME }}
         labels: |
           revision=${{ github.sha }}
         push: ${{ inputs.push == 'true' }}


### PR DESCRIPTION
We have a GH composite action config that's responsible for building and
publishing Docker images. The publishing wasn't working properly due to
incorrect value passed in the `tags` property. Now we're fixing that.