### PR TITLE
Remove `checkout` from `docker-build-push` custom action

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -21,8 +21,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
We will be using the action in the jobs that already do a `checkout` and
they modify the files pulled from the Git repository. If we do another
`checkout` in the composite action, all the changes to the filles will
be overwritten, which is not a wanted behavior.