### PR TITLE
Update keep-common dependency to the latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-ipfs-config v0.16.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/jbenet/goprocess v0.1.4
-	github.com/keep-network/keep-common v1.7.1-0.20220801100557-fa6fbdfeb792
+	github.com/keep-network/keep-common v1.7.1-0.20220809113029-7f46d29d4eaa
 	github.com/libp2p/go-addr-util v0.2.0
 	github.com/libp2p/go-libp2p v0.20.1
 	github.com/libp2p/go-libp2p-core v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSik8=
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
-github.com/keep-network/keep-common v1.7.1-0.20220801100557-fa6fbdfeb792 h1:qQ03dpgc4g9lcBKUvos8LcrR3+0H3VD47RVnTQlr9zU=
-github.com/keep-network/keep-common v1.7.1-0.20220801100557-fa6fbdfeb792/go.mod h1:HVmdk7byp310LLNRbL/I5uZT6pj/JwJoYXIrt2K6d+c=
+github.com/keep-network/keep-common v1.7.1-0.20220809113029-7f46d29d4eaa h1:6H3eq9GyGe92WxlfdMkI9PhblFCO5cLvEbEtwimj+7A=
+github.com/keep-network/keep-common v1.7.1-0.20220809113029-7f46d29d4eaa/go.mod h1:HVmdk7byp310LLNRbL/I5uZT6pj/JwJoYXIrt2K6d+c=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
The letest version contains fix for addresses resolvement and defaulting
them to the ones embeded on build.

Refs https://github.com/keep-network/keep-common/pull/97