### PR TITLE
Tiny tweaks: immutable fields in governance contracts and pure functions

### DIFF
--- a/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
+++ b/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
@@ -109,7 +109,7 @@ contract EcdsaDkgValidator {
     /// @return errorMsg validation error message; empty for a valid result
     function validateFields(EcdsaDkg.Result calldata result)
         public
-        view
+        pure
         returns (bool isValid, string memory errorMsg)
     {
         if (result.groupPubKey.length != publicKeyByteSize) {
@@ -263,7 +263,7 @@ contract EcdsaDkgValidator {
     /// one that is challenged.
     function validateMembersHash(EcdsaDkg.Result calldata result)
         public
-        view
+        pure
         returns (bool)
     {
         if (result.misbehavedMembersIndices.length > 0) {

--- a/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
+++ b/solidity/ecdsa/contracts/WalletRegistryGovernance.sol
@@ -86,7 +86,7 @@ contract WalletRegistryGovernance is Ownable {
     address payable public newReimbursementPool;
     uint256 public reimbursementPoolChangeInitiated;
 
-    WalletRegistry public walletRegistry;
+    WalletRegistry public immutable walletRegistry;
 
     uint256 public governanceDelay;
 

--- a/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
@@ -169,7 +169,7 @@ library EcdsaInactivity {
     function validateMembersIndices(
         uint256[] calldata indices,
         uint256 groupSize
-    ) internal view {
+    ) internal pure {
         require(
             indices.length > 0 && indices.length <= groupSize,
             "Corrupted members indices"

--- a/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
+++ b/solidity/random-beacon/contracts/RandomBeaconGovernance.sol
@@ -99,7 +99,7 @@ contract RandomBeaconGovernance is Ownable {
     uint256 public newRelayEntrySubmissionGasOffset;
     uint256 public relayEntrySubmissionGasOffsetChangeInitiated;
 
-    RandomBeacon public randomBeacon;
+    RandomBeacon public immutable randomBeacon;
 
     uint256 public governanceDelay;
 


### PR DESCRIPTION
Three small tweaks have been done here:
- Made `WalletRegistry` reference immutable in `WalletRegistryGovernance`. `WalletRegistry` address is set in the constructor and never changes.
- Made `RandomBeacon` reference immutable in `RandomBeaconGovernance`. `RandomBeacon` address is set in the constructor and never changes.
- Some functions in `EcdsaDkgValidator` and `EcdsaInactivity` that were marked as `view` can actually be marked as `pure`. Updated the modifier.