### PR TITLE
Include contracts addresses in the node header

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
+	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 )
 
-func nodeHeader(addrStrings []string, port int) {
+func nodeHeader(addrStrings []string, port int, ethereumConfig commonEthereum.Config) {
 	header := ` 
 
 ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
@@ -45,6 +48,7 @@ Trust math, not hardware.
 		buildLine(maxLineLength, prefix, suffix, fmt.Sprintf("Port: %d", port)),
 		buildMultiLine(maxLineLength, prefix, suffix, "IPs : ", addrStrings),
 		buildLine(maxLineLength, prefix, suffix, ""),
+		buildContractAddresses(maxLineLength, prefix, suffix, ethereumConfig),
 		dashes,
 		"\n",
 	)
@@ -72,4 +76,24 @@ func buildMultiLine(lineLength int, prefix, suffix, startPrefix string, lines []
 	}
 
 	return combinedLines
+}
+
+func buildContractAddresses(lineLength int, prefix, suffix string, ethereumConfig commonEthereum.Config) string {
+	firstLine := buildLine(lineLength, prefix, suffix, "Contracts: ")
+
+	contractNames := []string{
+		chainEthereum.RandomBeaconContractName,
+		chainEthereum.WalletRegistryContractName,
+		chainEthereum.TokenStakingContractName,
+	}
+
+	entries := []string{}
+	for _, contractName := range contractNames {
+		contractAddress, err := ethereumConfig.ContractAddress(contractName)
+		if err != nil {
+			logger.Fatal(err)
+		}
+		entries = append(entries, fmt.Sprintf("%-15s: %s", contractName, contractAddress))
+	}
+	return firstLine + buildMultiLine(lineLength, prefix, suffix, "", entries)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -35,17 +35,18 @@ Trust math, not hardware.
 	}
 
 	maxLineLength += len(prefix) + len(suffix) + 6
-	dashes := strings.Repeat("-", maxLineLength)
+	dashes := strings.Repeat("-", maxLineLength) + "\n"
 
-	fmt.Printf(
-		"%s%s\n%s\n%s\n%s\n%s%s\n\n",
+	fmt.Print(
 		header,
 		dashes,
-		buildLine(maxLineLength, prefix, suffix, "Keep Random Beacon Node"),
+		buildLine(maxLineLength, prefix, suffix, "Keep Client Node"),
 		buildLine(maxLineLength, prefix, suffix, ""),
 		buildLine(maxLineLength, prefix, suffix, fmt.Sprintf("Port: %d", port)),
 		buildMultiLine(maxLineLength, prefix, suffix, "IPs : ", addrStrings),
+		buildLine(maxLineLength, prefix, suffix, ""),
 		dashes,
+		"\n",
 	)
 }
 
@@ -53,21 +54,21 @@ func buildLine(lineLength int, prefix, suffix string, internalContent string) st
 	contentLength := len(prefix) + len(suffix) + len(internalContent)
 	padding := lineLength - contentLength
 
-	return fmt.Sprintf(
-		"%s%s%s%s",
+	return fmt.Sprint(
 		prefix,
 		internalContent,
 		strings.Repeat(" ", padding),
 		suffix,
+		"\n",
 	)
 }
 
 func buildMultiLine(lineLength int, prefix, suffix, startPrefix string, lines []string) string {
-	combinedLines := buildLine(lineLength, prefix+startPrefix, suffix, lines[0]) + "\n"
+	combinedLines := buildLine(lineLength, prefix+startPrefix, suffix, lines[0])
 
 	startPadding := strings.Repeat(" ", len(startPrefix))
 	for _, line := range lines[1:] {
-		combinedLines += buildLine(lineLength, prefix+startPadding, suffix, line) + "\n"
+		combinedLines += buildLine(lineLength, prefix+startPadding, suffix, line)
 	}
 
 	return combinedLines

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -88,7 +88,11 @@ func start(cmd *cobra.Command) error {
 		return fmt.Errorf("failed while creating the network provider: [%v]", err)
 	}
 
-	nodeHeader(netProvider.ConnectionManager().AddrStrings(), clientConfig.LibP2P.Port)
+	nodeHeader(
+		netProvider.ConnectionManager().AddrStrings(),
+		clientConfig.LibP2P.Port,
+		clientConfig.Ethereum,
+	)
 
 	beaconPersistence, err := initializePersistence(clientConfig, "beacon")
 	if err != nil {


### PR DESCRIPTION
We output in the node header contract addresses to which the client is connected. This change improves debugging of clients as it reduces ambiguity.

Sample:
```
 

▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
  ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
  ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
  ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓▌        ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
  ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
  ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓

Trust math, not hardware.

-----------------------------------------------------------------------------------------------
| Keep Client Node                                                                            |
|                                                                                             |
| Port: 3919                                                                                  |
| IPs : /ip4/192.168.0.34/tcp/3919/ipfs/16Uiu2HAmVNfJs6t7bB3hYPTxtuKXdTdqxKYn9wKKfUiGwpCDjySM |
|       /ip4/10.2.0.2/tcp/3919/ipfs/16Uiu2HAmVNfJs6t7bB3hYPTxtuKXdTdqxKYn9wKKfUiGwpCDjySM     |
|       /ip4/10.240.0.10/tcp/3919/ipfs/16Uiu2HAmVNfJs6t7bB3hYPTxtuKXdTdqxKYn9wKKfUiGwpCDjySM  |
|       /ip4/127.0.0.1/tcp/3919/ipfs/16Uiu2HAmVNfJs6t7bB3hYPTxtuKXdTdqxKYn9wKKfUiGwpCDjySM    |
|       /ip6/::1/tcp/3919/ipfs/16Uiu2HAmVNfJs6t7bB3hYPTxtuKXdTdqxKYn9wKKfUiGwpCDjySM          |
|                                                                                             |
| Contracts:                                                                                  |
| RandomBeacon   : 0xf1D14B19419be55013571B3953dE24A503A06f2d                                 |
| WalletRegistry : 0xa646E73FC2F9533afd88391318BdDAD18EA35282                                 |
| TokenStaking   : 0x0754935436b7DC24b62Bc8a01054A108A784d0f8                                 |
-----------------------------------------------------------------------------------------------

```