### PR TITLE
Adjust `client.yml` for use in v2

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -7,12 +7,12 @@ on:
     branches:
       - main
     paths-ignore:
+      - "docs-v1/**"
       - "docs/**"
       - "infrastructure/**"
       - "scripts/**"
+      - "solidity-v1/**"
       - "token-stakedrop/**"
-      - "solidity-v1/dashboard/**"
-      - "solidity/**"
   pull_request:
   workflow_dispatch:
     inputs:
@@ -43,7 +43,7 @@ jobs:
         with:
           filters: |
             path-filter:
-              - './!((docs|infrastructure|scripts|token-stakedrop|(solidity-v1/dashboard)|solidity)/**)'
+              - './!((docs-v1|docs|infrastructure|scripts|solidity-v1|token-stakedrop)/**)'
 
   client-build-test-publish:
     needs: client-detect-changes
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@v2
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -124,11 +124,11 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/keep-core"
+          module: "github.com/keep-network/keep-core/client"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}


### PR DESCRIPTION
In v2 of the system we modified the structure of the components that we
build to set up the system. There have been changes in the structure of
the `keep-core` repository and the order of the execution of modules in
the CI has changed as well. In this PR/commit we upgrade the custom CI
actions to `v2`, which uses the latest module order. We also adjust
slightly the workflow triggering conditions.

Workflow executed here: https://github.com/keep-network/keep-core/runs/7784716537?check_suite_focus=true (it pushed the image to `gcr.io/keep-test-f3e0/keep-client-wip`)

Note: to make the workflow integrated in the CI flow, we need to adjust the `config.json` in the `ci` repo (https://github.com/keep-network/ci/pull/31).