### PR TITLE
Hardhat task to ensure accounts ether balances

### DIFF
--- a/solidity/random-beacon/.eslintrc
+++ b/solidity/random-beacon/.eslintrc
@@ -16,6 +16,7 @@
         "groups": ["builtin", "external", "parent", "sibling", "index", "type"],
         "newlines-between": "always"
       }
-    ]
+    ],
+    "no-await-in-loop": "off"
   }
 }

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -47,7 +47,7 @@
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/hardhat-upgrades": "^1.17.0",
     "@tenderly/hardhat-tenderly": "^1.0.12",
-    "@thesis-co/eslint-config": "github:thesis/eslint-config",
+    "@thesis-co/eslint-config": "github:thesis/eslint-config#v0.2.0",
     "@typechain/ethers-v5": "^9.0.0",
     "@typechain/hardhat": "^4.0.0",
     "@types/chai": "^4.2.22",

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -15,8 +15,8 @@ task(
     types.string
   )
   .addPositionalParam(
-    "balance",
-    'Minimum ether balance the addresses are expected to hold, e.g. "0.5 ether", "100 gwei"',
+    "target-balance",
+    'Expected target balances of the addresses, e.g. "0.5 ether", "100 gwei"',
     undefined,
     types.string
   )
@@ -37,7 +37,7 @@ task(
 
     // eslint-disable-next-line no-restricted-syntax
     for (const address of addresses) {
-      const expectedBalance = parseValue(args.balance, hre)
+      const expectedBalance = parseValue(args.targetBalance, hre)
       const currentBalance = await ethers.provider.getBalance(address)
 
       console.log(

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -16,7 +16,7 @@ task(
     types.string
   )
   .addParam(
-    "target-balance",
+    "targetBalance",
     'Expected target balances of the addresses, e.g. "0.5 ether", "100 gwei"',
     undefined,
     types.string

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -2,7 +2,7 @@ import { task, types } from "hardhat/config"
 
 import { parseValue, TASK_SEND_ETH } from "./send-eth"
 
-export const TASK_ENSURE_ETH_BALANCE = "ensure-eth-balance"
+const TASK_ENSURE_ETH_BALANCE = "ensure-eth-balance"
 
 task(
   TASK_ENSURE_ETH_BALANCE,
@@ -35,7 +35,8 @@ task(
       Array.from(args.addresses).map(hre.helpers.address.validate)
     )
 
-    for (let address of addresses) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const address of addresses) {
       const expectedBalance = parseValue(args.balance, hre)
       const currentBalance = await ethers.provider.getBalance(address)
 

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -11,7 +11,7 @@ task(
 )
   .addOptionalParam(
     "from",
-    "Address to send value from",
+    "Address to send the ether from",
     undefined,
     types.string
   )

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -1,0 +1,58 @@
+import { task, types } from "hardhat/config"
+
+import { parseValue, TASK_SEND_ETH } from "./send-eth"
+
+export const TASK_ENSURE_ETH_BALANCE = "ensure-eth-balance"
+
+task(
+  TASK_ENSURE_ETH_BALANCE,
+  "Ensure addresses hold a minimum ether balance, top-up if needed"
+)
+  .addOptionalParam(
+    "from",
+    "Address to send value from",
+    undefined,
+    types.string
+  )
+  .addPositionalParam(
+    "balance",
+    'Minimum ether balance the addresses are expected to hold, e.g. "0.5 ether", "100 gwei"',
+    undefined,
+    types.string
+  )
+  .addVariadicPositionalParam(
+    "addresses",
+    "Addresses for which balance should be validated",
+    undefined,
+    types.string
+  )
+  .setAction(async (args, hre) => {
+    const { ethers } = hre
+
+    // FIXME: `validate` will fail for badly checksummed addresses
+    // see: https://github.com/ethers-io/ethers.js/discussions/3261
+    const addresses: Set<string> = new Set(
+      Array.from(args.addresses).map(hre.helpers.address.validate)
+    )
+
+    for (let address of addresses) {
+      const expectedBalance = parseValue(args.balance, hre)
+      const currentBalance = await ethers.provider.getBalance(address)
+
+      console.log(
+        `current balance of ${address} is ${ethers.utils.formatEther(
+          currentBalance
+        )} ether`
+      )
+
+      if (currentBalance.lt(expectedBalance)) {
+        const topUpAmount = expectedBalance.sub(currentBalance)
+
+        await hre.run(TASK_SEND_ETH, {
+          from: args.from,
+          value: topUpAmount.toString(),
+          to: address,
+        })
+      }
+    }
+  })

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -35,9 +35,10 @@ task(
       Array.from(args.addresses).map(hre.helpers.address.validate)
     )
 
+    const expectedBalance = parseValue(args.targetBalance, hre)
+
     // eslint-disable-next-line no-restricted-syntax
     for (const address of addresses) {
-      const expectedBalance = parseValue(args.targetBalance, hre)
       const currentBalance = await ethers.provider.getBalance(address)
 
       console.log(

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -15,7 +15,7 @@ task(
     undefined,
     types.string
   )
-  .addPositionalParam(
+  .addParam(
     "target-balance",
     'Expected target balances of the addresses, e.g. "0.5 ether", "100 gwei"',
     undefined,

--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -1,6 +1,7 @@
 import { task, types } from "hardhat/config"
 
-import { parseValue, TASK_SEND_ETH } from "./send-eth"
+import { TASK_SEND_ETH } from "./send-eth"
+import { parseValue } from "./utils"
 
 const TASK_ENSURE_ETH_BALANCE = "ensure-eth-balance"
 

--- a/solidity/random-beacon/tasks/index.ts
+++ b/solidity/random-beacon/tasks/index.ts
@@ -2,3 +2,5 @@
 require("./unlock-eth-accounts")
 require("./initialize")
 require("./genesis")
+require("./send-eth")
+require("./ensure-eth-balance")

--- a/solidity/random-beacon/tasks/send-eth.ts
+++ b/solidity/random-beacon/tasks/send-eth.ts
@@ -1,0 +1,59 @@
+import { BigNumber, Signer } from "ethers"
+import { task, types } from "hardhat/config"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+import type { TransactionResponse } from "@ethersproject/abstract-provider"
+
+export const TASK_SEND_ETH = "send-eth"
+
+task(TASK_SEND_ETH, "Send ether to an address")
+  .addOptionalParam(
+    "from",
+    "Address to send value from",
+    undefined,
+    types.string
+  )
+  .addParam(
+    "value",
+    'Value to transfer with unit, e.g. "0.5 ether", "100 gwei"',
+    undefined,
+    types.string
+  )
+  .addParam("to", "Transfer receiver address", undefined, types.string)
+  .setAction(async (args, hre) => {
+    const from: Signer = args.from
+      ? await hre.ethers.getSigner(args.from)
+      : (await hre.ethers.getSigners())[0]
+
+    const value: BigNumber = parseValue(args.value, hre)
+
+    // FIXME: `validate` will fail for badly checksummed addresses
+    // see: https://github.com/ethers-io/ethers.js/discussions/3261
+    const to = hre.helpers.address.validate(args.to)
+
+    const tx: TransactionResponse = await from.sendTransaction({
+      to: to,
+      value: value,
+    })
+
+    console.log(
+      `sending ${value} wei from ${await from.getAddress()} to ${to} in tx ${
+        tx.hash
+      }...`
+    )
+
+    await tx.wait()
+  })
+
+export function parseValue(
+  value: string,
+  hre: HardhatRuntimeEnvironment
+): BigNumber {
+  const parsed = String(value).trim().split(" ")
+
+  if (parsed.length == 0 || parsed.length > 2) {
+    throw new Error(`invalid value: ${value}`)
+  }
+
+  return hre.ethers.utils.parseUnits(parsed[0], parsed[1] || "wei")
+}

--- a/solidity/random-beacon/tasks/send-eth.ts
+++ b/solidity/random-beacon/tasks/send-eth.ts
@@ -15,8 +15,8 @@ task(TASK_SEND_ETH, "Send ether to an address")
     types.string
   )
   .addParam(
-    "value",
-    'Value to transfer with unit, e.g. "0.5 ether", "100 gwei"',
+    "amount",
+    'Amount to transfer with unit, e.g. "0.5 ether", "100 gwei"',
     undefined,
     types.string
   )
@@ -26,7 +26,7 @@ task(TASK_SEND_ETH, "Send ether to an address")
       ? await hre.ethers.getSigner(args.from)
       : (await hre.ethers.getSigners())[0]
 
-    const value: BigNumber = parseValue(args.value, hre)
+    const amount: BigNumber = parseValue(args.amount, hre)
 
     // FIXME: `validate` will fail for badly checksummed addresses
     // see: https://github.com/ethers-io/ethers.js/discussions/3261
@@ -34,11 +34,11 @@ task(TASK_SEND_ETH, "Send ether to an address")
 
     const tx: TransactionResponse = await from.sendTransaction({
       to,
-      value,
+      value: amount,
     })
 
     console.log(
-      `sending ${value} wei from ${await from.getAddress()} to ${to} in tx ${
+      `sending ${amount} wei from ${await from.getAddress()} to ${to} in tx ${
         tx.hash
       }...`
     )

--- a/solidity/random-beacon/tasks/send-eth.ts
+++ b/solidity/random-beacon/tasks/send-eth.ts
@@ -1,8 +1,8 @@
 import { task, types } from "hardhat/config"
 
 import type { BigNumber, Signer } from "ethers"
-import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { TransactionResponse } from "@ethersproject/abstract-provider"
+import { parseValue } from "./utils"
 
 // eslint-disable-next-line import/prefer-default-export
 export const TASK_SEND_ETH = "send-eth"
@@ -45,16 +45,3 @@ task(TASK_SEND_ETH, "Send ether to an address")
 
     await tx.wait()
   })
-
-export function parseValue(
-  value: string,
-  hre: HardhatRuntimeEnvironment
-): BigNumber {
-  const parsed = String(value).trim().split(" ")
-
-  if (parsed.length === 0 || parsed.length > 2) {
-    throw new Error(`invalid value: ${value}`)
-  }
-
-  return hre.ethers.utils.parseUnits(parsed[0], parsed[1] || "wei")
-}

--- a/solidity/random-beacon/tasks/send-eth.ts
+++ b/solidity/random-beacon/tasks/send-eth.ts
@@ -1,9 +1,10 @@
-import { BigNumber, Signer } from "ethers"
 import { task, types } from "hardhat/config"
-import { HardhatRuntimeEnvironment } from "hardhat/types"
 
+import type { BigNumber, Signer } from "ethers"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { TransactionResponse } from "@ethersproject/abstract-provider"
 
+// eslint-disable-next-line import/prefer-default-export
 export const TASK_SEND_ETH = "send-eth"
 
 task(TASK_SEND_ETH, "Send ether to an address")
@@ -32,8 +33,8 @@ task(TASK_SEND_ETH, "Send ether to an address")
     const to = hre.helpers.address.validate(args.to)
 
     const tx: TransactionResponse = await from.sendTransaction({
-      to: to,
-      value: value,
+      to,
+      value,
     })
 
     console.log(
@@ -51,7 +52,7 @@ export function parseValue(
 ): BigNumber {
   const parsed = String(value).trim().split(" ")
 
-  if (parsed.length == 0 || parsed.length > 2) {
+  if (parsed.length === 0 || parsed.length > 2) {
     throw new Error(`invalid value: ${value}`)
   }
 

--- a/solidity/random-beacon/tasks/unlock-eth-accounts.ts
+++ b/solidity/random-beacon/tasks/unlock-eth-accounts.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { task } from "hardhat/config"
 
 import type { HttpNetworkConfig } from "hardhat/types"

--- a/solidity/random-beacon/tasks/utils/ether.ts
+++ b/solidity/random-beacon/tasks/utils/ether.ts
@@ -1,0 +1,16 @@
+import type { BigNumber } from "ethers"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+// eslint-disable-next-line import/prefer-default-export
+export function parseValue(
+  value: string,
+  hre: HardhatRuntimeEnvironment
+): BigNumber {
+  const parsed = String(value).trim().split(" ")
+
+  if (parsed.length === 0 || parsed.length > 2) {
+    throw new Error(`invalid value: ${value}`)
+  }
+
+  return hre.ethers.utils.parseUnits(parsed[0], parsed[1] || "wei")
+}

--- a/solidity/random-beacon/tasks/utils/index.ts
+++ b/solidity/random-beacon/tasks/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./authorize"
+export * from "./ether"
 export * from "./mint"
 export * from "./register"
 export * from "./stake"

--- a/solidity/random-beacon/test/Groups.Expiration.test.ts
+++ b/solidity/random-beacon/test/Groups.Expiration.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { ethers, waffle, helpers } from "hardhat"
 import { expect } from "chai"
 

--- a/solidity/random-beacon/test/Groups.Termination.test.ts
+++ b/solidity/random-beacon/test/Groups.Termination.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { ethers, waffle, helpers } from "hardhat"
 import { expect } from "chai"
 

--- a/solidity/random-beacon/test/Groups.test.ts
+++ b/solidity/random-beacon/test/Groups.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { ethers, waffle } from "hardhat"
 import { expect } from "chai"
 

--- a/solidity/random-beacon/test/system/e2e.test.ts
+++ b/solidity/random-beacon/test/system/e2e.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { ethers, waffle, helpers } from "hardhat"
 import { expect } from "chai"
 

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { ethers, waffle } from "hardhat"
 import { expect } from "chai"
 import { BigNumber } from "ethers"

--- a/solidity/random-beacon/test/utils/operators.ts
+++ b/solidity/random-beacon/test/utils/operators.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import { ethers, helpers } from "hardhat"
 
 import { params } from "../fixtures"

--- a/solidity/random-beacon/tsconfig.json
+++ b/solidity/random-beacon/tsconfig.json
@@ -10,6 +10,7 @@
   ],
   "compilerOptions": {
     "esModuleInterop": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "downlevelIteration": true
   }
 }

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -1354,9 +1354,9 @@
     fs-extra "^9.0.1"
     js-yaml "^3.14.0"
 
-"@thesis-co/eslint-config@github:thesis/eslint-config":
-  version "0.1.0"
-  resolved "https://codeload.github.com/thesis/eslint-config/tar.gz/778365bbebb6b056bf973d25c57b8b466d21cbcf"
+"@thesis-co/eslint-config@github:thesis/eslint-config#v0.2.0":
+  version "0.2.0"
+  resolved "https://codeload.github.com/thesis/eslint-config/tar.gz/e63608fab2a1ad5c8fe89873bf0d4d4f9ef4a081"
   dependencies:
     "@thesis-co/prettier-config" "github:thesis/prettier-config"
     "@typescript-eslint/eslint-plugin" "^4.32.0"
@@ -1367,6 +1367,7 @@
     eslint-config-prettier "^8.3.0"
     eslint-plugin-import "^2.23.4"
     eslint-plugin-jsx-a11y "^6.4.1"
+    eslint-plugin-no-only-tests "^2.6.0"
     eslint-plugin-prettier "^4.0.0"
     eslint-plugin-react "^7.25.2"
     eslint-plugin-react-hooks "^4.2.0"
@@ -4333,6 +4334,11 @@ eslint-plugin-jsx-a11y@^6.4.1:
     has "^1.0.3"
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
+
+eslint-plugin-no-only-tests@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
+  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
 
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Blocked by https://github.com/thesis/eslint-config/pull/4

We add a hardhat task that can be used to ensure addresses are funded with a minimum value of ether. This will be used in test environments setup to ensure when a client starts the operator has enough funds to run.

Sample command:
```
npx hardhat ensure-eth-balance "0.5 ether" \
  0x6299496199d99941193Fdd2d717ef585F431eA05 \
  0x93df7c54c41A9D7FB17C1E8039d387a2A924708c
```