### PR TITLE
Use cobra for ping command

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -16,11 +16,11 @@ import (
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
 	"github.com/keep-network/keep-core/pkg/operator"
-	"github.com/urfave/cli"
+	"github.com/spf13/cobra"
 )
 
 // PingCommand contains the definition of the ping command-line subcommand.
-var PingCommand cli.Command
+var PingCommand *cobra.Command
 
 const (
 	ping         = "PING"
@@ -34,22 +34,21 @@ const pingDescription = `The ping command conducts a simple peer-to-peer test
    corresponding "PONG". Notably, this does not exercise peer discovery.`
 
 func init() {
-	PingCommand =
-		cli.Command{
-			Name:        "ping",
-			Usage:       `bidirectional send between two peers to test the network`,
-			ArgsUsage:   "[multiaddr]",
-			Description: pingDescription,
-			Action:      pingRequest,
-		}
+	PingCommand = &cobra.Command{
+		Use:                   "ping [multiaddr]...",
+		Short:                 `bidirectional send between two peers to test the network`,
+		Long:                  pingDescription,
+		DisableFlagsInUseLine: true,
+		RunE:                  pingRequest,
+	}
 }
 
-func isBootstrapNode(args cli.Args) (bool, []string) {
+func isBootstrapNode(args []string) (bool, []string) {
 	var bootstrapPeers []string
 
 	// Not a bootstrap node
 	if len(args) > 0 {
-		bootstrapPeers = append(bootstrapPeers, args.Get(0))
+		bootstrapPeers = append(bootstrapPeers, args[0])
 	}
 
 	return len(bootstrapPeers) == 0, bootstrapPeers
@@ -57,8 +56,8 @@ func isBootstrapNode(args cli.Args) (bool, []string) {
 
 // pingRequest tests the functionality and availability of Keep's libp2p
 // network layer.
-func pingRequest(c *cli.Context) error {
-	isBootstrapNode, bootstrapPeers := isBootstrapNode(c.Args())
+func pingRequest(cmd *cobra.Command, args []string) error {
+	isBootstrapNode, bootstrapPeers := isBootstrapNode(args)
 	var (
 		libp2pConfig = libp2p.Config{Peers: bootstrapPeers}
 		ctx          = context.Background()
@@ -95,8 +94,8 @@ func pingRequest(c *cli.Context) error {
 		}
 
 		fmt.Printf("You can ping this node using:\n"+
-			"    %s ping %s\n\n",
-			c.App.Name,
+			"    %s %s\n\n",
+			cmd.CommandPath(),
 			bootstrapAddr,
 		)
 	}

--- a/main.go
+++ b/main.go
@@ -42,9 +42,8 @@ func main() {
 
 	rootCmd.AddCommand(
 		cmd.StartCommand,
-		// TODO: Refactor PingCommand and EthereumCommand to register them in the root
-		// command.
-		// cmd.PingCommand,
+		cmd.PingCommand,
+		// TODO: Refactor EthereumCommand to register them in the root command.
 		// cmd.EthereumCommand,
 	)
 


### PR DESCRIPTION
In https://github.com/keep-network/keep-core/pull/3090 we replaced urfave/cli with cobra for `start` command. 
In this PR we refactor `ping` comamnd to use `cobra`.

```
$ ./keep-client ping --help
The ping command conducts a simple peer-to-peer test between a bootstrap node and another peer: 
can known peers communicate over a peer-to-peer network. Both peers send a "PING" and expect to
receive a corresponding "PONG". Notably, this does not exercise peer discovery.

Usage:
  keep-client ping [multiaddr]...

Flags:
  -h, --help   help for ping
```