### PR TITLE
Abstraction to manage computationally-heavy operation

### DIFF
--- a/pkg/internal/testutils/testutils.go
+++ b/pkg/internal/testutils/testutils.go
@@ -62,8 +62,24 @@ func AssertBigIntsEqual(t *testing.T, description string, expected *big.Int, act
 	}
 }
 
-// AssertBytesEqual takes a testing.T and two byte slices and reports an error
-// if the two bytes are not equal.
+// AssertBigIntNonZero checks if the provided not-nil big integer is non-zero.
+// If the provided big integer is zero, it reports a test failure.
+func AssertBigIntNonZero(t *testing.T, description string, actual *big.Int) {
+	if actual.Cmp(big.NewInt(0)) == 0 {
+		t.Errorf("expected %s to be non-zero", description)
+	}
+}
+
+// AssertBigIntsNotEqual checks if two not-nil big integers are not equal.
+// If they are equal, reports a test failure.
+func AssertBigIntsNotEqual(t *testing.T, description string, a *big.Int, b *big.Int) {
+	if a.Cmp(b) == 0 {
+		t.Errorf("expected %s to not be equal", description)
+	}
+}
+
+// AssertBytesEqual checks if the two bytes array are equal. If not, it reports
+// a test failure.
 func AssertBytesEqual(t *testing.T, expectedBytes []byte, actualBytes []byte) {
 	err := testBytesEqual(expectedBytes, actualBytes)
 

--- a/pkg/miner/miner.go
+++ b/pkg/miner/miner.go
@@ -1,0 +1,93 @@
+package miner
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-log"
+)
+
+var logger = log.Logger("keep-miner")
+
+type state int
+
+const (
+	working state = iota
+	stopped
+)
+
+// Miner allows managing computationally heavy operations: stopping and resuming
+// them. The client needs to generate parameters for cryptographic algorithms
+// and generating these parameters requires a lot of CPU cycles. The generation
+// process may starve other processes in the client when it comes to access to
+// the CPU. The miner allows starting the parameter generation when no other
+// processes such as key generation or signing are executed on the client. This
+// way, the client that would normally be idle, can spend CPU cycles on
+// computationally heavy operations and stop these operations when CPU cycles
+// are needed elsewhere.
+type Miner struct {
+	state   state
+	workers []func()
+	stops   []chan interface{}
+
+	mutex sync.Mutex
+}
+
+// Mine takes the worker function and starts the computations in a separate
+// goroutine if the miner status is "working". Otherwise, when the miner status
+// is "stopped", the worker function is scheduled for execution later.
+func (m *Miner) Mine(miningFn func()) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.workers = append(m.workers, miningFn)
+
+	if m.state == working {
+		m.startWorker(miningFn)
+	}
+}
+
+// Stop asks all worker functions to stop their work. Note that there is no
+// guarantee the worker function will stop immediately but the miner will not
+// call the worker function again until the miner's work is resumed.
+func (m *Miner) Stop() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	logger.Info("stopping computations")
+	m.state = stopped
+
+	for _, stop := range m.stops {
+		stop <- struct{}{}
+	}
+	m.stops = nil
+}
+
+// Resume resumes the work of all worker functions, each in a separate
+// goroutine.
+func (m *Miner) Resume() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	logger.Info("resuming computations")
+	m.state = working
+
+	for _, worker := range m.workers {
+		m.startWorker(worker)
+	}
+}
+
+func (m *Miner) startWorker(miningFn func()) {
+	stopChan := make(chan interface{})
+	m.stops = append(m.stops, stopChan)
+
+	go func() {
+		for {
+			select {
+			case <-stopChan:
+				return
+			default:
+				miningFn()
+			}
+		}
+	}()
+}

--- a/pkg/miner/miner_test.go
+++ b/pkg/miner/miner_test.go
@@ -1,0 +1,181 @@
+package miner
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
+)
+
+var one = big.NewInt(1)
+
+// TestMineStop tests the situation when two new worker functions are added to
+// a miner in a working state. The test ensures the worker functions starts
+// doing their work. Then, the miner is stopped and the test ensures the worker
+// functions are stopped.
+func TestMineStop(t *testing.T) {
+	miner := new(Miner)
+
+	number1 := big.NewInt(0)
+	number2 := big.NewInt(0)
+
+	miner.Mine(func() {
+		number1.Add(number1, one)
+	})
+	miner.Mine(func() {
+		number2.Add(number2, one)
+	})
+
+	// give some time for the miner to perform computations
+	time.Sleep(10 * time.Millisecond)
+
+	// ensure computations started
+	testutils.AssertBigIntNonZero(t, "computation result", number1)
+	testutils.AssertBigIntNonZero(t, "computation result", number2)
+
+	// send the stop signal and give the miner some time to stop computations
+	miner.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	// at this point, all computations should be stopped, capture the current
+	// result
+	result1 := new(big.Int).Set(number1)
+	result2 := new(big.Int).Set(number2)
+
+	// wait some time and ensure computations stopped
+	time.Sleep(20 * time.Millisecond)
+	testutils.AssertBigIntsEqual(
+		t,
+		"computation result after stop signal",
+		result1,
+		number1,
+	)
+	testutils.AssertBigIntsEqual(
+		t,
+		"computation result after stop signal",
+		result2,
+		number2,
+	)
+}
+
+// TestMineStopResume tests the situation when two new worker functions are
+// added to a miner in a working state. Then, the miner is stopped and after
+// some time its work is resumed. The test ensures the worker functions resume
+// their work.
+func TestMineStopResume(t *testing.T) {
+	miner := new(Miner)
+	defer miner.Stop()
+
+	number1 := big.NewInt(0)
+	number2 := big.NewInt(0)
+
+	miner.Mine(func() {
+		number1.Add(number1, one)
+	})
+	miner.Mine(func() {
+		number2.Add(number2, one)
+	})
+
+	// send the stop signal and give the miner some time to stop computations
+	miner.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	// at this point, all computations should be stopped, capture the current
+	// result
+	intermediateResult1 := new(big.Int).Set(number1)
+	intermediateResult2 := new(big.Int).Set(number2)
+
+	// send the resume signal and give the miner some time to resume computations
+	miner.Resume()
+	time.Sleep(100 * time.Millisecond)
+
+	// ensure computations have been resumed
+	testutils.AssertBigIntsNotEqual(
+		t,
+		"computation results after resume signal",
+		intermediateResult1,
+		number1,
+	)
+	testutils.AssertBigIntsNotEqual(
+		t,
+		"computation results after resume signal",
+		intermediateResult2,
+		number2,
+	)
+}
+
+// TestMineStopResumeStop tests the situation when two new worker functions are
+// added to a miner in a working state. Then, the miner is stopped, resumed,
+// and stopped again. The test ensures the worker functions are stopped at the
+// end of the cycle.
+func TestMineStopResumeStop(t *testing.T) {
+	miner := new(Miner)
+
+	number1 := big.NewInt(0)
+	number2 := big.NewInt(0)
+
+	miner.Mine(func() {
+		number1.Add(number1, one)
+	})
+	miner.Mine(func() {
+		number2.Add(number2, one)
+	})
+
+	miner.Stop()
+	miner.Resume()
+	miner.Stop()
+
+	// at this point, all computations should be stopped, capture the current
+	// result
+	result1 := new(big.Int).Set(number1)
+	result2 := new(big.Int).Set(number2)
+
+	// wait some time and ensure computations stopped
+	time.Sleep(20 * time.Millisecond)
+	testutils.AssertBigIntsEqual(
+		t,
+		"computation result after stop signal",
+		result1,
+		number1,
+	)
+	testutils.AssertBigIntsEqual(
+		t,
+		"computation result after stop signal",
+		result2,
+		number2,
+	)
+}
+
+// TestStopMineResume tests the situation when two new worker functions are
+// added to a stopped miner. Then, the miner work is resumed. The test ensures
+// the worker functions are not working before the resume and that they are
+// working after the resume.
+func TestStopMineResume(t *testing.T) {
+	miner := new(Miner)
+	defer miner.Stop()
+
+	miner.Stop()
+
+	number1 := big.NewInt(0)
+	number2 := big.NewInt(0)
+
+	miner.Mine(func() {
+		number1.Add(number1, one)
+	})
+	miner.Mine(func() {
+		number2.Add(number2, one)
+	})
+
+	// assert computations have not started - the miner is stopped
+	testutils.AssertBigIntsEqual(t, "computation result", big.NewInt(0), number1)
+	testutils.AssertBigIntsEqual(t, "computation result", big.NewInt(0), number2)
+
+	miner.Resume()
+	// give some time for the miner to perform computations
+	time.Sleep(10 * time.Millisecond)
+
+	// ensure computations started
+	testutils.AssertBigIntNonZero(t, "computation result", number1)
+	testutils.AssertBigIntNonZero(t, "computation result", number2)
+}


### PR DESCRIPTION
Refs #3161

Miner allows managing computationally heavy operations: stopping and resuming
them. The client needs to generate parameters for cryptographic algorithms
and generating these parameters requires a lot of CPU cycles. The generation
process may starve other processes in the client when it comes to access to
the CPU. The miner allows starting the parameter generation when no other
processes such as key generation or signing are executed on the client. This
way, the client that would normally be idle, can spend CPU cycles on
computationally heavy operations and stop these operations when CPU cycles
are needed elsewhere.