### PR TITLE
Added a delay between pre-parameters generation

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -229,6 +229,13 @@ func initTbtcFlags(cmd *cobra.Command, cfg *config.Config) {
 		"tECDSA pre-parameters generation timeout.",
 	)
 
+	cmd.Flags().DurationVar(
+		&cfg.Tbtc.PreParamsGenerationDelay,
+		"tbtc.preParamsGenerationDelay",
+		tbtc.DefaultPreParamsGenerationDelay,
+		"tECDSA pre-parameters generation delay.",
+	)
+
 	cmd.Flags().IntVar(
 		&cfg.Tbtc.PreParamsGenerationConcurrency,
 		"tbtc.preParamsGenerationConcurrency",

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -155,6 +155,13 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: 150 * time.Second,
 		defaultValue:          120 * time.Second,
 	},
+	"tbtc.preParamsGenerationDelay": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsGenerationDelay },
+		flagName:              "--tbtc.preParamsGenerationDelay",
+		flagValue:             "1m",
+		expectedValueFromFlag: 60 * time.Second,
+		defaultValue:          10 * time.Second,
+	},
 	"tbtc.preParamsGenerationConcurrency": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsGenerationConcurrency },
 		flagName:              "--tbtc.preParamsGenerationConcurrency",

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -92,6 +92,7 @@ Port = 8081
 # [tbtc]
 # PreParamsPoolSize = 50
 # PreParamsGenerationTimeout = "2m"
+# PreParamsGenerationDelay = "10s"
 # PreParamsGenerationConcurrency = 1
 
 # Developer options to work with locally deployed contracts

--- a/docs/development/cmd-help
+++ b/docs/development/cmd-help
@@ -24,6 +24,7 @@ Flags:
       --diagnostics.port int                       Diagnostics HTTP server listening port. (default 8081)
       --tbtc.preParamsPoolSize int                 tECDSA pre-parameters pool size. (default 50)
       --tbtc.preParamsGenerationTimeout duration   tECDSA pre-parameters generation timeout. (default 2m0s)
+      --tbtc.preParamsGenerationDelay duration     tECDSA pre-parameters generation delay. (default 10s)
       --tbtc.preParamsGenerationConcurrency int    tECDSA pre-parameters generation concurrency. (default 1)
       --developer.randomBeaconAddress string       Address of the RandomBeacon smart contract
       --developer.tokenStakingAddress string       Address of the TokenStaking smart contract

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -33,6 +33,7 @@ func newNode(
 		logger,
 		config.PreParamsPoolSize,
 		config.PreParamsGenerationTimeout,
+		config.PreParamsGenerationDelay,
 		config.PreParamsGenerationConcurrency,
 	)
 

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -21,6 +21,7 @@ const ProtocolName = "tbtc"
 const (
 	DefaultPreParamsPoolSize              = 50
 	DefaultPreParamsGenerationTimeout     = 2 * time.Minute
+	DefaultPreParamsGenerationDelay       = 10 * time.Second
 	DefaultPreParamsGenerationConcurrency = 1
 )
 
@@ -30,6 +31,8 @@ type Config struct {
 	PreParamsPoolSize int
 	// Timeout for pre-parameters generation for tECDSA.
 	PreParamsGenerationTimeout time.Duration
+	// The delay between generating new pre-params for tECDSA.
+	PreParamsGenerationDelay time.Duration
 	// Concurrency level for pre-parameters generation for tECDSA.
 	PreParamsGenerationConcurrency int
 }

--- a/pkg/tecdsa/dkg/dkg.go
+++ b/pkg/tecdsa/dkg/dkg.go
@@ -24,6 +24,7 @@ func NewExecutor(
 	logger log.StandardLogger,
 	preParamsPoolSize int,
 	preParamsGenerationTimeout time.Duration,
+	preParamsGenerationDelay time.Duration,
 	preParamsGenerationConcurrency int,
 ) *Executor {
 	return &Executor{
@@ -32,6 +33,7 @@ func NewExecutor(
 			logger,
 			preParamsPoolSize,
 			preParamsGenerationTimeout,
+			preParamsGenerationDelay,
 			preParamsGenerationConcurrency,
 		),
 	}

--- a/pkg/tecdsa/dkg/params_pool_test.go
+++ b/pkg/tecdsa/dkg/params_pool_test.go
@@ -1,10 +1,11 @@
 package dkg
 
 import (
-	"github.com/keep-network/keep-core/pkg/internal/testutils"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
 
 	"github.com/binance-chain/tss-lib/ecdsa/keygen"
 )
@@ -18,7 +19,7 @@ func TestTSSPreParamsPool(t *testing.T) {
 	testutils.AssertIntsEqual(t, "init length", 0, len(tssPool.pool))
 
 	// Initial pool pump.
-	go tssPool.pumpPool()
+	go tssPool.pumpPool(0)
 	time.Sleep(100 * time.Millisecond)
 
 	testutils.AssertIntsEqual(t, "start length", poolSize, len(tssPool.pool))
@@ -55,7 +56,7 @@ func TestTSSPreParamsPoolEmpty(t *testing.T) {
 		// for an entry.
 		time.Sleep(100 * time.Millisecond)
 
-		tssPool.pumpPool()
+		tssPool.pumpPool(0)
 	}()
 
 	// Get entry from pool.
@@ -96,7 +97,7 @@ func TestTSSPreParamsPoolConcurrent(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	go tssPool.pumpPool()
+	go tssPool.pumpPool(0)
 
 	waitGroup.Wait()
 


### PR DESCRIPTION
Refs #3161 

There is a configurable delay between the generation of pre-parameters.
By default, the delay is 10 seconds. If pre-parameters generation takes a long
time and new parameters are generated one after another, all other client
processes are starved, without access to CPU. Adding a delay should help with
releasing some computing power for a moment.

Still testing it, so PR is in a draft. The code is ready for a review though.