### PR TITLE
Replace Jerome1337/gofmt-action with gofmt command

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -172,6 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Go format
-        uses: Jerome1337/gofmt-action@v1.0.4
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+      - name: gofmt
+        run: gofmt -d -e .


### PR DESCRIPTION
The Jerome1337/gofmt-action started reporting [false-positive problems](https://github.com/keep-network/keep-core/runs/7878381256?check_suite_focus=true) that is expected to be caused by old version of Go it is running with, as it's based on [cytophia/gofmt image that is 2 years old](https://hub.docker.com/layers/gofmt/cytopia/gofmt/latest/images/sha256-4841f8441239afcb23202626a572b43f24e1420ec9d96901f84f7b81d4e6f5aa?context=explore).

Here we switch to `setup-go` action that will checkout the version of go specified in the `go.mod` file. Then we run `gofmt` command for the installed `go` version.