### PR TITLE
Updated TSS lib dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/urfave/cli => github.com/keep-network/cli v1.20.0
 
 require (
-	github.com/binance-chain/tss-lib v1.3.3
+	github.com/bnb-chain/tss-lib v1.3.4-0.20220817120442-2f5f2e4fb79e
 	github.com/btcsuite/btcd v0.22.1
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/ethereum/go-ethereum v1.10.19

--- a/go.sum
+++ b/go.sum
@@ -112,9 +112,9 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/binance-chain/tss-lib v1.3.3 h1:fW9O2ynr4j4apsx/2J39kv/xw/ia23mwmZI4gnmo48c=
-github.com/binance-chain/tss-lib v1.3.3/go.mod h1:xfM6gCPA61WIV5q5tK9Acdv46n1QJLhXnZ4eD17hJpI=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/bnb-chain/tss-lib v1.3.4-0.20220817120442-2f5f2e4fb79e h1:w27rLS8zzSFjz3rw1n5QCH0ROEd7MtO1z9Jzq0U/oxM=
+github.com/bnb-chain/tss-lib v1.3.4-0.20220817120442-2f5f2e4fb79e/go.mod h1:avz+lZjqmDB/5aleGe1JBxYKY6BzMmFlhZ0VmuifpsU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=

--- a/pkg/internal/tecdsatest/tecdsatest.go
+++ b/pkg/internal/tecdsatest/tecdsatest.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
 )
 
 const (
@@ -17,9 +17,12 @@ const (
 
 // LoadPrivateKeyShareTestFixtures loads tECDSA private key share test data.
 // Code copied from:
-//   https://github.com/bnb-chain/tss-lib/blob/v1.3.3/ecdsa/keygen/test_utils.go#L36
+//
+//	https://github.com/bnb-chain/tss-lib/blob/v1.3.3/ecdsa/keygen/test_utils.go#L36
+//
 // Test data JSON files copied from:
-//   https://github.com/bnb-chain/tss-lib/tree/v1.3.3/test/_ecdsa_fixtures
+//
+//	https://github.com/bnb-chain/tss-lib/tree/v1.3.3/test/_ecdsa_fixtures
 func LoadPrivateKeyShareTestFixtures(count int) (
 	[]keygen.LocalPartySaveData,
 	error,

--- a/pkg/tecdsa/dkg/marshaling.go
+++ b/pkg/tecdsa/dkg/marshaling.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa/dkg/gen/pb"

--- a/pkg/tecdsa/dkg/member.go
+++ b/pkg/tecdsa/dkg/member.go
@@ -2,12 +2,13 @@ package dkg
 
 import (
 	"fmt"
-	"github.com/keep-network/keep-core/pkg/tecdsa"
 	"math/big"
 	"strconv"
 
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
-	"github.com/binance-chain/tss-lib/tss"
+	"github.com/keep-network/keep-core/pkg/tecdsa"
+
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/tss"
 	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"

--- a/pkg/tecdsa/dkg/member_test.go
+++ b/pkg/tecdsa/dkg/member_test.go
@@ -2,16 +2,17 @@ package dkg
 
 import (
 	"fmt"
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
-	"github.com/binance-chain/tss-lib/tss"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/tss"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
 	"github.com/keep-network/keep-core/pkg/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
-	"math/big"
-	"strconv"
-	"testing"
 )
 
 func TestShouldAcceptMessage(t *testing.T) {

--- a/pkg/tecdsa/dkg/preparams.go
+++ b/pkg/tecdsa/dkg/preparams.go
@@ -3,7 +3,7 @@ package dkg
 import (
 	"time"
 
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
 	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-core/pkg/miner"
 )

--- a/pkg/tecdsa/dkg/protocol.go
+++ b/pkg/tecdsa/dkg/protocol.go
@@ -3,7 +3,8 @@ package dkg
 import (
 	"context"
 	"fmt"
-	"github.com/binance-chain/tss-lib/tss"
+
+	"github.com/bnb-chain/tss-lib/tss"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )

--- a/pkg/tecdsa/dkg/protocol_test.go
+++ b/pkg/tecdsa/dkg/protocol_test.go
@@ -5,17 +5,18 @@ import (
 	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
-	"github.com/binance-chain/tss-lib/crypto/paillier"
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
-	"github.com/binance-chain/tss-lib/tss"
-	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
-	"github.com/keep-network/keep-core/pkg/internal/testutils"
-	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"math/big"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/bnb-chain/tss-lib/crypto/paillier"
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/tss"
+	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // TODO: This file contains unit tests that stress each protocol phase

--- a/pkg/tecdsa/key.go
+++ b/pkg/tecdsa/key.go
@@ -2,8 +2,9 @@ package tecdsa
 
 import (
 	"crypto/ecdsa"
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
-	"github.com/binance-chain/tss-lib/tss"
+
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/tss"
 )
 
 // Curve is the curve implementation used across the tecdsa package.

--- a/pkg/tecdsa/marshaling.go
+++ b/pkg/tecdsa/marshaling.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/binance-chain/tss-lib/crypto"
-	"github.com/binance-chain/tss-lib/crypto/paillier"
-	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/crypto"
+	"github.com/bnb-chain/tss-lib/crypto/paillier"
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
 	"github.com/keep-network/keep-core/pkg/tecdsa/gen/pb"
 )
 

--- a/pkg/tecdsa/marshaling_test.go
+++ b/pkg/tecdsa/marshaling_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/bnb-chain/tss-lib/crypto"
 	"github.com/keep-network/keep-core/pkg/internal/pbutils"
 	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
 	"github.com/keep-network/keep-core/pkg/internal/testutils"


### PR DESCRIPTION
Refs #3161
Depends on #3174 

The new version includes changes to the pre-parameters generator allowing to stop the generator immediately: 
https://github.com/bnb-chain/tss-lib/pull/191

The new version includes the rebranding from `binance-chain` to `bnb-chain` so I had to cover it here as well.