### PR TITLE
Ensure existence of the application storage directory

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-
 	"github.com/keep-network/keep-core/pkg/tbtc"
 
 	"github.com/keep-network/keep-core/config"
@@ -142,6 +141,19 @@ func initializePersistence(clientConfig *config.Config, application string) (
 	persistence.Handle,
 	error,
 ) {
+	err := persistence.EnsureDirectoryExists(
+		clientConfig.Storage.DataDir,
+		application,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot create storage directory for "+
+				"application [%v]: [%w]",
+			application,
+			err,
+		)
+	}
+
 	path := fmt.Sprintf("%s/%s", clientConfig.Storage.DataDir, application)
 
 	diskHandle, err := persistence.NewDiskHandle(path)


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3014

So far, the client exited with an error in case the appropriate storage directory for the beacon or tbtc application was missing. Here we check whether the storage directory exists, and we create a fresh one in case it is missing.