### PR TITLE
Hardhat task for requesting new ECDSA wallets

### DIFF
--- a/solidity/ecdsa/tasks/index.ts
+++ b/solidity/ecdsa/tasks/index.ts
@@ -1,3 +1,4 @@
 import "./initialize-wallet-owner"
 import "./initialize"
 import "@keep-network/random-beacon/export/tasks/unlock-eth-accounts"
+import "./request-new-wallet"

--- a/solidity/ecdsa/tasks/request-new-wallet.ts
+++ b/solidity/ecdsa/tasks/request-new-wallet.ts
@@ -1,0 +1,31 @@
+import { task } from "hardhat/config"
+
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+task("request-new-wallet", "Requests for a new ECDSA wallet")
+  .addParam("walletOwnerAddress", "The Wallet Owner's address")
+  .setAction(async (args, hre) => {
+    const { walletOwnerAddress } = args
+
+    await requestNewWallet(hre, walletOwnerAddress)
+  })
+
+async function requestNewWallet(
+  hre: HardhatRuntimeEnvironment,
+  walletOwnerAddress: string
+) {
+  const { ethers, helpers } = hre
+
+  if (!ethers.utils.isAddress(walletOwnerAddress)) {
+    throw Error(`invalid address: ${walletOwnerAddress}`)
+  }
+
+  const walletOwner = await ethers.getSigner(walletOwnerAddress)
+
+  const walletRegistry = await helpers.contracts.getContract("WalletRegistry")
+
+  const tx = await walletRegistry.connect(walletOwner).requestNewWallet()
+  await tx.wait()
+
+  console.log("New ECDSA wallet was requested successfully")
+}


### PR DESCRIPTION
Refs: #3041 

Here we introduce a Hardhat task that allows requesting a new ECDSA wallet. This task should facilitate testing on local Ethereum networks. In order to run it, move to the `solidity/ecdsa` directory and do:
```
npx hardhat request-new-wallet --wallet-owner-address <owner> --network <network-name>
```
where `owner` is the wallet owner's address that can be set using the `initialize-wallet-owner` Hardhat task.