### PR TITLE
Use forked sorition pools in testnet deployment

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -204,11 +204,19 @@ jobs:
             @keep-network/random-beacon@${{ steps.upstream-builds-query.outputs.random-beacon-version }} \
             @keep-network/sortition-pools
 
+      # TODO: Remove this step. We replace sortition pools for deployment on testnet
+      # with forked contracts that were tweaked to make operators joining the pool
+      # easier. This should never be used outside of the test environment. On
+      # test environment it should be used temporarily only.
+      - name: Use Sortition Pool forked contracts
+        run: |
+          yarn upgrade github:keep-network/sortition-pools#test-fork
+
       - name: Configure tenderly
         env:
           TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
         run: ./config_tenderly.sh
-      
+
       - name: Deploy contracts
         env:
           CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -200,11 +200,19 @@ jobs:
             @threshold-network/solidity-contracts@${{ steps.upstream-builds-query.outputs.threshold-contracts-version }} \
             @keep-network/sortition-pools
 
+      # TODO: Remove this step. We replace sortition pools for deployment on testnet
+      # with forked contracts that were tweaked to make operators joining the pool
+      # easier. This should never be used outside of the test environment. On
+      # test environment it should be used temporarily only.
+      - name: Use Sortition Pool forked contracts
+        run: |
+          yarn upgrade github:keep-network/sortition-pools#test-fork
+
       - name: Configure tenderly
         env:
           TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
         run: ./config_tenderly.sh
-      
+
       - name: Deploy contracts
         env:
           CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}


### PR DESCRIPTION
We want to modify sortition pools used in the test environment to make joining applications easier for operators. With the changes from the forked sortition pools we will not require the sortition pool to be unlocked when an operator wants to join. Even in case, the DKG process is in progress we will let operators join.

This is just a temporary change that should be reverted in the near future.

Refs: https://github.com/keep-network/sortition-pools/pull/186