### PR TITLE
[Backport] Remove specific stakes from t auth data

### DIFF
--- a/solidity-v1/dashboard/src/components/threshold/AuthorizeThresholdContracts.jsx
+++ b/solidity-v1/dashboard/src/components/threshold/AuthorizeThresholdContracts.jsx
@@ -94,6 +94,7 @@ const AuthorizeThresholdContracts = ({
             stakeAmount,
             isFromGrant,
             canBeMovedToT,
+            isInInitializationPeriod,
           }) => (
             <AuthorizeActions
               key={contract.contractName}
@@ -108,6 +109,7 @@ const AuthorizeThresholdContracts = ({
               canBeMovedToT={canBeMovedToT}
               onAuthorizeBtn={onAuthorizeBtn}
               onStakeBtn={onStakeBtn}
+              isInInitializationPeriod={isInInitializationPeriod}
             />
           )}
         />
@@ -139,6 +141,7 @@ const AuthorizeActions = ({
   canBeMovedToT,
   onAuthorizeBtn,
   onStakeBtn,
+  isInInitializationPeriod,
 }) => {
   const onAuthorize = useCallback(
     async (awaitingPromise) => {
@@ -227,6 +230,35 @@ const AuthorizeActions = ({
       </ReactTooltip>
       stake
     </Button>
+  ) : isInInitializationPeriod ? (
+    <>
+      <ReactTooltip
+        id={`stake-tooltip-for-operator-${operatorAddress}`}
+        place="top"
+        type="dark"
+        effect={"solid"}
+        className={"react-tooltip-base react-tooltip-base--arrow-right"}
+        offset={{ left: "100%!important" }}
+      >
+        <span>
+          This stake is still in initialization period. You will be able to move
+          the stake to T when the initialization period ends.
+        </span>
+      </ReactTooltip>
+      <Button
+        onClick={onAuthorize}
+        className="btn btn-secondary btn-semi-sm"
+        style={{ marginLeft: "auto" }}
+        disabled={true}
+      >
+        <Icons.QuestionFill
+          data-tip
+          data-for={`stake-tooltip-for-operator-${operatorAddress}`}
+          className={"tooltip--button-corner"}
+        />
+        authorize and stake
+      </Button>
+    </>
   ) : (
     <Button
       onClick={onAuthorize}

--- a/solidity-v1/dashboard/src/reducers/threshold-authorization.js
+++ b/solidity-v1/dashboard/src/reducers/threshold-authorization.js
@@ -140,6 +140,7 @@ const addStakeToAuthData = (
     isStakedToT: false,
     isFromGrant: _isFromGrant,
     canBeMovedToT: !_isFromGrant,
+    isInInitializationPeriod: true,
   }
 
   const updatedAuthData = [...authData, newStake]


### PR DESCRIPTION
Backport of: https://github.com/keep-network/keep-core/pull/3023

Removes stakes that are cancelled (while in initialization period) from
threshold authorization table. Also disable the `Authorize and Stake` button for
the stakes that are in initialization period (and add tooltip informing about
why it is disabled).