### PR TITLE
[Backport] Fix blocked undelegate button when unstaking all tokens from t dahboard

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,6 +12,7 @@ ca823db2fc25dcf318df84d2b3efc74347aeb552
 e884d097787c1fd3f541088717c946f53503ea79
 e0880e124c2dcefa6a6fbb4e16ef4b8fe2ab861a
 bf037460a86573b61f62f9acec46f1688d44d409
+a2ec8c4724756d4422df491a978b9ea4e5bf7b99
 
 # Linting and formatting code for solidity/random-beacon.
 # Most of the changes were done by `yarn format:fix` to auto-fix the issues.

--- a/solidity-v1/dashboard/src/lib/keep/keep-to-t-staking/index.js
+++ b/solidity-v1/dashboard/src/lib/keep/keep-to-t-staking/index.js
@@ -59,7 +59,7 @@ class KeepToTStaking {
 
     const amountOfKeepTokensStakedInBN = new BigNumber(keepInTStake)
 
-    return !amountOfKeepTokensStakedInBN.eq("0")
+    return amountOfKeepTokensStakedInBN.gt("0")
   }
 
   getOperatorConfirmedEvents = async (operatorAddresses) => {

--- a/solidity-v1/dashboard/src/lib/keep/keep-to-t-staking/index.js
+++ b/solidity-v1/dashboard/src/lib/keep/keep-to-t-staking/index.js
@@ -33,7 +33,7 @@ class KeepToTStaking {
    * Returns all tokens staked by the operator in T Network
    *
    * @param {string} operatorAddress
-   * @returns {Promise} Tokens staked in T Network as object:
+   * @return {Promise} Tokens staked in T Network as object:
    * {
    *    tStake: string,
    *    keepInTStake: string,
@@ -51,7 +51,7 @@ class KeepToTStaking {
    * Checks if the operator has Keep tokens staked in T Network
    *
    * @param {string} operatorAddress
-   * @returns {Promise<boolean>} true if the operator has Keep tokens staked in
+   * @return {Promise<boolean>} true if the operator has Keep tokens staked in
    * T Network and false otherwise
    */
   hasKeepTokensStakedInTNetwork = async (operatorAddress) => {

--- a/solidity-v1/dashboard/src/lib/keep/keep-to-t-staking/index.js
+++ b/solidity-v1/dashboard/src/lib/keep/keep-to-t-staking/index.js
@@ -29,6 +29,39 @@ class KeepToTStaking {
     })
   }
 
+  /**
+   * Returns all tokens staked by the operator in T Network
+   *
+   * @param {string} operatorAddress
+   * @returns {Promise} Tokens staked in T Network as object:
+   * {
+   *    tStake: string,
+   *    keepInTStake: string,
+   *    nuInTStake: string,
+   * }
+   */
+  tokensStakedInTNetwork = async (operatorAddress) => {
+    return await this.thresholdStakingContract.makeCall(
+      "stakes",
+      operatorAddress
+    )
+  }
+
+  /**
+   * Checks if the operator has Keep tokens staked in T Network
+   *
+   * @param {string} operatorAddress
+   * @returns {Promise<boolean>} true if the operator has Keep tokens staked in
+   * T Network and false otherwise
+   */
+  hasKeepTokensStakedInTNetwork = async (operatorAddress) => {
+    const { keepInTStake } = await this.tokensStakedInTNetwork(operatorAddress)
+
+    const amountOfKeepTokensStakedInBN = new BigNumber(keepInTStake)
+
+    return !amountOfKeepTokensStakedInBN.eq("0")
+  }
+
   getOperatorConfirmedEvents = async (operatorAddresses) => {
     return await this.simplePREApplicationContract.getPastEvents(
       "OperatorConfirmed",

--- a/solidity-v1/dashboard/src/services/tokens-page.service.js
+++ b/solidity-v1/dashboard/src/services/tokens-page.service.js
@@ -152,13 +152,8 @@ const getDelegations = async (
       )
       .call()
 
-    const keepToTStakedEvents =
-      await Keep.keepToTStaking.getStakedEventsByOperator(operatorAddress)
-
-    const operatorsStakedToT = keepToTStakedEvents.reduce((map, _) => {
-      map[_.returnValues.stakingProvider] = { ..._.returnValues }
-      return map
-    }, {})
+    const hasKeepTokensStakedInTNetwork =
+      await Keep.keepToTStaking.hasKeepTokensStakedInTNetwork(operatorAddress)
 
     const operatorData = {
       undelegatedAt,
@@ -173,7 +168,7 @@ const getDelegations = async (
       managedGrantContractInstance,
       isCopiedStake,
       isTStakingContractAuthorized,
-      isStakedToT: operatorsStakedToT.hasOwnProperty(operatorAddress),
+      isStakedToT: hasKeepTokensStakedInTNetwork,
     }
     const balance = web3Utils.toBN(amount)
 


### PR DESCRIPTION
Backport of: [#3191 ](https://github.com/keep-network/keep-core/pull/3191)

There is a bug in Keep dashboard which blocked the user to unstake the
delegation from Keep if he unstaked all the tokens from T dashboard.

It was happening because normally user should not be allowed to unstake
when the stake is moved to T, but we were checking if it was moved there
wrongly. Previosly we examined the "Staked" events in T contract, and
if there were any we assumed that the staked is moved. However, there
can be a situation when the operator stake the keep tokens, and then
unstake them all and we didn't check any "Unstaked" events at all.

To fix this, instead of checking all the events, we will be calling
"stakes" method from TokenStaking contract, which will return all the
tokens staked in T Network (keep, nu and T). Then we will check if keep
tokens are equal to 0 - if it's true, then the T stake is not there
anymore and user can safely unstake his Keeps from Keep dahsboard.

We don't have to check if other tokens are equal to 0, because they have
nothing to do with the stked Keep tokens.