### PR TITLE
Pass `amount` to `send-eth` task

### DIFF
--- a/solidity/random-beacon/tasks/ensure-eth-balance.ts
+++ b/solidity/random-beacon/tasks/ensure-eth-balance.ts
@@ -53,7 +53,7 @@ task(
 
         await hre.run(TASK_SEND_ETH, {
           from: args.from,
-          value: topUpAmount.toString(),
+          amount: topUpAmount.toString(),
           to: address,
         })
       }


### PR DESCRIPTION
In the commit 939c42e6a5b8a6671ea74c0e72d7885386f0ca46 we renamed `value` argument to `amount` but missed updating the `ensure-eth-balance` task to use the new argument name.