### PR TITLE
Improvements for the beacon DKG result submitter

### DIFF
--- a/pkg/beacon/dkg/result/submission.go
+++ b/pkg/beacon/dkg/result/submission.go
@@ -84,7 +84,7 @@ func (sm *SubmittingMember) SubmitDKGResult(
 	alreadySubmitted, err := chainRelay.IsGroupRegistered(result.GroupPublicKey)
 	if err != nil {
 		return fmt.Errorf(
-			"could not check if the result is already submitted: [%v]",
+			"could not check if the result is already submitted: [%w]",
 			err,
 		)
 	}
@@ -101,7 +101,7 @@ func (sm *SubmittingMember) SubmitDKGResult(
 		config.ResultPublicationBlockStep,
 	)
 	if err != nil {
-		return fmt.Errorf("wait for eligibility failure: [%v]", err)
+		return fmt.Errorf("wait for eligibility failure: [%w]", err)
 	}
 
 	for {
@@ -164,7 +164,7 @@ func (sm *SubmittingMember) waitForSubmissionEligibility(
 
 	waiter, err := blockCounter.BlockHeightWaiter(eligibleBlockHeight)
 	if err != nil {
-		return nil, fmt.Errorf("block height waiter failure [%v]", err)
+		return nil, fmt.Errorf("block height waiter failure [%w]", err)
 	}
 
 	return waiter, err

--- a/pkg/beacon/dkg/result/submission.go
+++ b/pkg/beacon/dkg/result/submission.go
@@ -79,26 +79,19 @@ func (sm *SubmittingMember) SubmitDKGResult(
 			onSubmittedResultChan <- event.BlockNumber
 		},
 	)
-
-	returnWithError := func(err error) error {
-		subscription.Unsubscribe()
-		close(onSubmittedResultChan)
-		return err
-	}
+	defer subscription.Unsubscribe()
 
 	alreadySubmitted, err := chainRelay.IsGroupRegistered(result.GroupPublicKey)
 	if err != nil {
-		return returnWithError(
-			fmt.Errorf(
-				"could not check if the result is already submitted: [%v]",
-				err,
-			),
+		return fmt.Errorf(
+			"could not check if the result is already submitted: [%v]",
+			err,
 		)
 	}
 
 	// Someone who was ahead of us in the queue submitted the result. Giving up.
 	if alreadySubmitted {
-		return returnWithError(nil)
+		return nil
 	}
 
 	// Wait until the current member is eligible to submit the result.
@@ -108,17 +101,21 @@ func (sm *SubmittingMember) SubmitDKGResult(
 		config.ResultPublicationBlockStep,
 	)
 	if err != nil {
-		return returnWithError(
-			fmt.Errorf("wait for eligibility failure: [%v]", err),
-		)
+		return fmt.Errorf("wait for eligibility failure: [%v]", err)
 	}
 
 	for {
 		select {
 		case blockNumber := <-eligibleToSubmitWaiter:
-			// Member becomes eligible to submit the result.
+			// Member becomes eligible to submit the result. Result submission
+			// would trigger the sender side of the result submission event
+			// listener but also cause the receiver side (this select)
+			// termination that will result with a dangling goroutine blocked
+			// forever on the `onSubmittedResultChan` channel. This would
+			// cause a resource leak. In order to avoid that, we should
+			// unsubscribe from the result submission event listener before
+			// submitting the result.
 			subscription.Unsubscribe()
-			close(onSubmittedResultChan)
 
 			sm.logger.Infof(
 				"[member:%v] submitting DKG result with public key [0x%x] and "+
@@ -142,7 +139,7 @@ func (sm *SubmittingMember) SubmitDKGResult(
 			)
 			// A result has been submitted by other member. Leave without
 			// publishing the result.
-			return returnWithError(nil)
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
Closing the `onSubmittedResultChan` channel is not needed in that case and is the source of the frequently observed test failure:
```
panic: send on closed channel

goroutine 49841 [running]:
github.com/keep-network/keep-core/pkg/beacon/dkg/result.(*SubmittingMember).SubmitDKGResult.func1(0xa27720?)
	/go/src/github.com/keep-network/keep-core/pkg/beacon/dkg/result/submission.go:79 +0x26
github.com/keep-network/keep-core/pkg/chain/local_v1.(*localChain).SubmitDKGResult.func1(0xc00000e300?, 0x0?)
	/go/src/github.com/keep-network/keep-core/pkg/chain/local_v1/local.go:290 +0x23
created by github.com/keep-network/keep-core/pkg/chain/local_v1.(*localChain).SubmitDKGResult
	/go/src/github.com/keep-network/keep-core/pkg/chain/local_v1/local.go:289 +0x41e
```
It is ok to leave Go channels open as they will be garbage collected as soon as they become unreachable.

Regarding the result submission event subscription, it is enough to defer its unsubscription and do it manually only when the given member is about to submit the result by itself. The latter must be done in order to avoid a resource leak that is explained by the comment placed in the code.