### PR TITLE
Ensure existence of application storage directory

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -142,6 +142,19 @@ func initializePersistence(clientConfig *config.Config, application string) (
 	persistence.Handle,
 	error,
 ) {
+	err := persistence.EnsureDirectoryExists(
+		clientConfig.Storage.DataDir,
+		application,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot create storage directory for "+
+				"application [%v]: [%w]",
+			application,
+			err,
+		)
+	}
+
 	path := fmt.Sprintf("%s/%s", clientConfig.Storage.DataDir, application)
 
 	diskHandle, err := persistence.NewDiskHandle(path)


### PR DESCRIPTION
The changes from this PR were originally introduced in https://github.com/keep-network/keep-core/pull/3179 but disappeared from the main branch. We add it back again.

So far, the client exited with an error in case
the appropriate storage directory for the beacon
or tbtc application was missing. Here we check
whether the storage directory exists, and we
create a fresh one in case it is missing.