### PR TITLE
Embed predefined bootstrap peers list into the client

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum"
+	"github.com/spf13/cobra"
+
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd/flag"
 	"github.com/keep-network/keep-common/pkg/rate"
@@ -13,7 +15,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/metrics"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/tbtc"
-	"github.com/spf13/cobra"
 )
 
 func initFlags(
@@ -68,27 +69,27 @@ func initEthereumNetworkFlags(cmd *cobra.Command) {
 	// TODO: Consider removing `--mainnet` flag. For now it's here to reduce a confusion
 	// when developing and testing the client.
 	cmd.Flags().Bool(
-		ethereum.Mainnet.String(),
+		commonEthereum.Mainnet.String(),
 		false,
 		"Mainnet network",
 	)
 
 	cmd.Flags().Bool(
-		ethereum.Goerli.String(),
+		commonEthereum.Goerli.String(),
 		false,
 		"Görli network",
 	)
 
 	cmd.Flags().Bool(
-		ethereum.Developer.String(),
+		commonEthereum.Developer.String(),
 		false,
 		"Developer network",
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(
-		ethereum.Mainnet.String(),
-		ethereum.Goerli.String(),
-		ethereum.Developer.String(),
+		commonEthereum.Mainnet.String(),
+		commonEthereum.Goerli.String(),
+		commonEthereum.Developer.String(),
 	)
 }
 
@@ -141,7 +142,7 @@ func initEthereumFlags(cmd *cobra.Command, cfg *config.Config) {
 		cmd.Flags(),
 		&cfg.Ethereum.BalanceAlertThreshold,
 		"ethereum.balanceAlertThreshold",
-		*ethereum.WrapWei(big.NewInt(500000000000000000)), // 0.5 ether
+		*commonEthereum.WrapWei(big.NewInt(500000000000000000)), // 0.5 ether
 		"The minimum balance of operator account below which client starts reporting errors in logs.",
 	)
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,12 +9,11 @@ import (
 	"github.com/keep-network/keep-common/pkg/cmd/flag"
 	"github.com/keep-network/keep-common/pkg/rate"
 	"github.com/keep-network/keep-core/config"
+	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/metrics"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 	"github.com/spf13/cobra"
-
-	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 )
 
 func initFlags(
@@ -28,6 +27,7 @@ func initFlags(
 		case config.General:
 			initConfigFlags(cmd, configFilePath)
 		case config.Ethereum:
+			initEthereumNetworkFlags(cmd)
 			initEthereumFlags(cmd, cfg)
 		case config.Network:
 			initNetworkFlags(cmd, cfg)
@@ -57,6 +57,38 @@ func initConfigFlags(cmd *cobra.Command, configFilePath *string) {
 		"c",
 		"", // Don't define default value as it would fail configuration reading.
 		"Path to the configuration file. Supported formats: TOML, YAML, JSON.",
+	)
+}
+
+// Initializes boolean flags for Ethereum network configuration. The flags can be used
+// to run a client for a specific Ethereum network, e.g. add `--goerli` to the client
+// start command to run the client against Görli Ethereum network. Only one flag
+// from this set is allowed.
+func initEthereumNetworkFlags(cmd *cobra.Command) {
+	// TODO: Consider removing `--mainnet` flag. For now it's here to reduce a confusion
+	// when developing and testing the client.
+	cmd.Flags().Bool(
+		ethereum.Mainnet.String(),
+		false,
+		"Mainnet network",
+	)
+
+	cmd.Flags().Bool(
+		ethereum.Goerli.String(),
+		false,
+		"Görli network",
+	)
+
+	cmd.Flags().Bool(
+		ethereum.Developer.String(),
+		false,
+		"Developer network",
+	)
+
+	cmd.MarkFlagsMutuallyExclusive(
+		ethereum.Mainnet.String(),
+		ethereum.Goerli.String(),
+		ethereum.Developer.String(),
 	)
 }
 

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -1,17 +1,21 @@
 package cmd
 
 import (
+	"bufio"
+	"fmt"
 	"math/big"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/keep-network/keep-core/config"
-	"github.com/keep-network/keep-core/pkg/chain/ethereum"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
+	"github.com/keep-network/keep-core/config"
+	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 	ethereumBeacon "github.com/keep-network/keep-core/pkg/chain/ethereum/beacon/gen"
 	ethereumEcdsa "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen"
 	ethereumThreshold "github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen"
@@ -88,7 +92,7 @@ var cmdFlagsTests = map[string]struct {
 			"/ip4/127.0.0.1/tcp/5001/ipfs/3w6C4TFVo",
 			"/dns4/domain.local/tcp/3819/ipfs/16xtuKXdTd",
 		},
-		defaultValue: []string{},
+		defaultValue: readPeers(commonEthereum.Mainnet),
 	},
 	"network.announcedAddresses": {
 		readValueFunc: func(c *config.Config) interface{} { return c.LibP2P.AnnouncedAddresses },
@@ -171,7 +175,7 @@ var cmdFlagsTests = map[string]struct {
 	},
 	"developer.randomBeaconAddress": {
 		readValueFunc: func(c *config.Config) interface{} {
-			address, _ := c.Ethereum.ContractAddress(ethereum.RandomBeaconContractName)
+			address, _ := c.Ethereum.ContractAddress(chainEthereum.RandomBeaconContractName)
 			return address.String()
 		},
 		flagName:              "--developer.randomBeaconAddress",
@@ -181,7 +185,7 @@ var cmdFlagsTests = map[string]struct {
 	},
 	"developer.walletRegistryAddress": {
 		readValueFunc: func(c *config.Config) interface{} {
-			address, _ := c.Ethereum.ContractAddress(ethereum.WalletRegistryContractName)
+			address, _ := c.Ethereum.ContractAddress(chainEthereum.WalletRegistryContractName)
 			return address.String()
 		},
 		flagName:              "--developer.walletRegistryAddress",
@@ -191,7 +195,7 @@ var cmdFlagsTests = map[string]struct {
 	},
 	"developer.tokenStakingAddress": {
 		readValueFunc: func(c *config.Config) interface{} {
-			address, _ := c.Ethereum.ContractAddress(ethereum.TokenStakingContractName)
+			address, _ := c.Ethereum.ContractAddress(chainEthereum.TokenStakingContractName)
 			return address.String()
 		},
 		flagName:              "--developer.tokenStakingAddress",
@@ -336,4 +340,28 @@ func initTestCommand() (*cobra.Command, *config.Config, *string) {
 	initFlags(testCommand, &testConfigFilePath, testConfig, config.AllCategories...)
 
 	return testCommand, testConfig, &testConfigFilePath
+}
+
+func readPeers(network commonEthereum.Network) []string {
+	file, err := os.Open(fmt.Sprintf("../config/_peers/%s", network))
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	result := []string{}
+	for scanner.Scan() {
+		str := scanner.Text()
+		if str == "" || strings.HasPrefix(str, "#") {
+			continue
+		}
+		result = append(result, str)
+	}
+
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+
+	return result
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -35,7 +35,6 @@ func init() {
 			if err := clientConfig.ReadConfig(configFilePath, cmd.Flags(), config.AllCategories...); err != nil {
 				logger.Fatalf("error reading config: %v", err)
 			}
-
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := start(cmd); err != nil {
@@ -62,6 +61,11 @@ Environment variables:
 // start starts a node
 func start(cmd *cobra.Command) error {
 	ctx := context.Background()
+
+	logger.Infof(
+		"Starting the client against [%s] ethereum network...",
+		clientConfig.Ethereum.Network,
+	)
 
 	beaconChain, tbtcChain, blockCounter, signing, operatorPrivateKey, err :=
 		ethereum.Connect(ctx, clientConfig.Ethereum)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,23 +4,21 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/keep-network/keep-core/pkg/generator"
-	"github.com/keep-network/keep-core/pkg/tbtc"
-
-	"github.com/keep-network/keep-core/config"
-	"github.com/keep-network/keep-core/pkg/chain/ethereum"
-	"github.com/keep-network/keep-core/pkg/diagnostics"
-	"github.com/keep-network/keep-core/pkg/metrics"
-	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/spf13/cobra"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
+	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/beacon"
 	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/ethereum"
+	"github.com/keep-network/keep-core/pkg/diagnostics"
 	"github.com/keep-network/keep-core/pkg/firewall"
+	"github.com/keep-network/keep-core/pkg/generator"
+	"github.com/keep-network/keep-core/pkg/metrics"
+	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
-
-	"github.com/spf13/cobra"
+	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
 // StartCommand contains the definition of the start command-line subcommand.

--- a/config/_peers/goerli
+++ b/config/_peers/goerli
@@ -1,1 +1,2 @@
-# TODO: Add bootstrap nodes
+/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
+/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY

--- a/config/_peers/goerli
+++ b/config/_peers/goerli
@@ -1,0 +1,1 @@
+# TODO: Add bootstrap nodes

--- a/config/_peers/mainnet
+++ b/config/_peers/mainnet
@@ -1,0 +1,2 @@
+# TODO: Add bootstrap nodes
+MAINNET IS NOT YET SUPPORTED

--- a/config/config.go
+++ b/config/config.go
@@ -8,16 +8,17 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-log"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"golang.org/x/crypto/ssh/terminal"
+
 	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/beacon/registry"
 	"github.com/keep-network/keep-core/pkg/diagnostics"
 	"github.com/keep-network/keep-core/pkg/metrics"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/tbtc"
-	"github.com/mitchellh/mapstructure"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var logger = log.Logger("keep-config")

--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func (c *Config) resolveEthereumNetwork(flagSet *pflag.FlagSet) error {
 			return commonEthereum.Unknown, err
 		}
 		if isGoerli {
-			return commonEthereum.Goerli, err
+			return commonEthereum.Goerli, nil
 		}
 
 		isDeveloper, err := flagSet.GetBool(commonEthereum.Developer.String())
@@ -70,7 +70,7 @@ func (c *Config) resolveEthereumNetwork(flagSet *pflag.FlagSet) error {
 			return commonEthereum.Unknown, err
 		}
 		if isDeveloper {
-			return commonEthereum.Developer, err
+			return commonEthereum.Developer, nil
 		}
 
 		return commonEthereum.Mainnet, nil

--- a/config/config.go
+++ b/config/config.go
@@ -56,10 +56,19 @@ func (c *Config) resolveEthereumNetwork(flagSet *pflag.FlagSet) error {
 	var err error
 
 	c.Ethereum.Network, err = func() (commonEthereum.Network, error) {
-		if ok, err := flagSet.GetBool(commonEthereum.Goerli.String()); ok {
+		isGoerli, err := flagSet.GetBool(commonEthereum.Goerli.String())
+		if err != nil {
+			return commonEthereum.Unknown, err
+		}
+		if isGoerli {
 			return commonEthereum.Goerli, err
 		}
-		if ok, err := flagSet.GetBool(commonEthereum.Developer.String()); ok {
+
+		isDeveloper, err := flagSet.GetBool(commonEthereum.Developer.String())
+		if err != nil {
+			return commonEthereum.Unknown, err
+		}
+		if isDeveloper {
 			return commonEthereum.Developer, err
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-log"
-	"github.com/keep-network/keep-common/pkg/chain/ethereum"
 	ethereumCommon "github.com/keep-network/keep-common/pkg/chain/ethereum"
 
 	"github.com/keep-network/keep-core/pkg/beacon/registry"
@@ -160,12 +159,12 @@ func validateConfig(config *Config, categories ...Category) error {
 // from the returned config, but is available for external functions that expect
 // to interact solely with Ethereum and are therefore independent of the rest of
 // the config structure.
-func ReadEthereumConfig(flagSet *pflag.FlagSet) (ethereum.Config, error) {
+func ReadEthereumConfig(flagSet *pflag.FlagSet) (ethereumCommon.Config, error) {
 	config := Config{}
 
 	configPath, err := flagSet.GetString("config")
 	if err != nil {
-		return ethereum.Config{},
+		return ethereumCommon.Config{},
 			fmt.Errorf(
 				"failed to read config file path from command flag: %w",
 				err,
@@ -173,7 +172,7 @@ func ReadEthereumConfig(flagSet *pflag.FlagSet) (ethereum.Config, error) {
 	}
 
 	if err := config.ReadConfig(configPath, flagSet, Ethereum); err != nil {
-		return ethereum.Config{}, err
+		return ethereumCommon.Config{}, err
 	}
 
 	return config.Ethereum, nil

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,12 @@ func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categ
 	// Resolve contracts addresses.
 	c.resolveContractsAddresses()
 
+	// Resolve network peers.
+	err := c.resolvePeers()
+	if err != nil {
+		return fmt.Errorf("failed to resolve peers: %w", err)
+	}
+
 	// Validate configuration.
 	if err := validateConfig(c, categories...); err != nil {
 		return fmt.Errorf("validation failed: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,24 @@ func bindFlags(flagSet *pflag.FlagSet) error {
 	return nil
 }
 
+// Resolve ethereum network based on the set boolean flags.
+func (c *Config) resolveEthereumNetwork(flagSet *pflag.FlagSet) error {
+	var err error
+
+	c.Ethereum.Network, err = func() (ethereumCommon.Network,error) {
+		if ok, err := flagSet.GetBool(ethereumCommon.Goerli.String()); ok {
+			return ethereumCommon.Goerli, err
+		}
+		if ok, err := flagSet.GetBool(ethereumCommon.Developer.String()); ok {
+			return ethereumCommon.Developer, err
+		}
+
+		return ethereumCommon.Mainnet, nil
+	}()
+
+	return err
+}
+
 // ReadConfig reads in the configuration file at `configFilePath` and flags defined in
 // the `flagSet`.
 func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categories ...Category) error {
@@ -60,6 +78,10 @@ func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categ
 	if flagSet != nil {
 		if err := bindFlags(flagSet); err != nil {
 			return fmt.Errorf("unable to bind the flags: [%w]", err)
+		}
+
+		if  err := c.resolveEthereumNetwork(flagSet); err != nil {
+			return fmt.Errorf("unable to resolve ethereum network: [%w]", err)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-log"
-	ethereumCommon "github.com/keep-network/keep-common/pkg/chain/ethereum"
-
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/beacon/registry"
 	"github.com/keep-network/keep-core/pkg/diagnostics"
 	"github.com/keep-network/keep-core/pkg/metrics"
@@ -35,7 +34,7 @@ const (
 
 // Config is the top level config structure.
 type Config struct {
-	Ethereum    ethereumCommon.Config
+	Ethereum    commonEthereum.Config
 	LibP2P      libp2p.Config `mapstructure:"network"`
 	Storage     registry.Config
 	Metrics     metrics.Config
@@ -56,15 +55,15 @@ func bindFlags(flagSet *pflag.FlagSet) error {
 func (c *Config) resolveEthereumNetwork(flagSet *pflag.FlagSet) error {
 	var err error
 
-	c.Ethereum.Network, err = func() (ethereumCommon.Network,error) {
-		if ok, err := flagSet.GetBool(ethereumCommon.Goerli.String()); ok {
-			return ethereumCommon.Goerli, err
+	c.Ethereum.Network, err = func() (commonEthereum.Network, error) {
+		if ok, err := flagSet.GetBool(commonEthereum.Goerli.String()); ok {
+			return commonEthereum.Goerli, err
 		}
-		if ok, err := flagSet.GetBool(ethereumCommon.Developer.String()); ok {
-			return ethereumCommon.Developer, err
+		if ok, err := flagSet.GetBool(commonEthereum.Developer.String()); ok {
+			return commonEthereum.Developer, err
 		}
 
-		return ethereumCommon.Mainnet, nil
+		return commonEthereum.Mainnet, nil
 	}()
 
 	return err
@@ -80,7 +79,7 @@ func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categ
 			return fmt.Errorf("unable to bind the flags: [%w]", err)
 		}
 
-		if  err := c.resolveEthereumNetwork(flagSet); err != nil {
+		if err := c.resolveEthereumNetwork(flagSet); err != nil {
 			return fmt.Errorf("unable to resolve ethereum network: [%w]", err)
 		}
 	}
@@ -187,12 +186,12 @@ func validateConfig(config *Config, categories ...Category) error {
 // from the returned config, but is available for external functions that expect
 // to interact solely with Ethereum and are therefore independent of the rest of
 // the config structure.
-func ReadEthereumConfig(flagSet *pflag.FlagSet) (ethereumCommon.Config, error) {
+func ReadEthereumConfig(flagSet *pflag.FlagSet) (commonEthereum.Config, error) {
 	config := Config{}
 
 	configPath, err := flagSet.GetString("config")
 	if err != nil {
-		return ethereumCommon.Config{},
+		return commonEthereum.Config{},
 			fmt.Errorf(
 				"failed to read config file path from command flag: %w",
 				err,
@@ -200,7 +199,7 @@ func ReadEthereumConfig(flagSet *pflag.FlagSet) (ethereumCommon.Config, error) {
 	}
 
 	if err := config.ReadConfig(configPath, flagSet, Ethereum); err != nil {
-		return ethereumCommon.Config{}, err
+		return commonEthereum.Config{}, err
 	}
 
 	return config.Ethereum, nil

--- a/config/peers.go
+++ b/config/peers.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/keep-network/keep-common/pkg/chain/ethereum"
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 )
 
 //go:embed _peers/*
 var peersData embed.FS
 
 // readPeers reads peers from an embedded file for the given ethereum `network`.
-func readPeers(network ethereum.Network) ([]string, error) {
+func readPeers(network commonEthereum.Network) ([]string, error) {
 	peers, err := peersData.ReadFile(fmt.Sprintf("_peers/%s", network))
 	if err != nil {
 		return nil, err

--- a/config/peers.go
+++ b/config/peers.go
@@ -46,9 +46,9 @@ func (c *Config) resolvePeers() error {
 		return nil
 	}
 
-	// For developer network we don't expect the default peers to be embedded in
-	// the client. The user should configure them in the config file.
-	if network == ethereum.Developer {
+	// For unknown and developer networks we don't expect the default peers to be
+	// embedded in the client. The user should configure them in the config file.
+	if network == commonEthereum.Developer || network == commonEthereum.Unknown {
 		logger.Warnf(
 			"peers were not configured for [%s] network; "+
 				"see network section in configuration",

--- a/config/peers.go
+++ b/config/peers.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/keep-network/keep-common/pkg/chain/ethereum"
+)
+
+//go:embed _peers/*
+var peersData embed.FS
+
+// readPeers reads peers from an embedded file for the given ethereum `network`.
+func readPeers(network ethereum.Network) ([]string, error) {
+	peers, err := peersData.ReadFile(fmt.Sprintf("_peers/%s", network))
+	if err != nil {
+		return nil, err
+	}
+
+	return cleanStrings(strings.Split(string(peers), "\n")), nil
+}
+
+// cleanStrings iterates over entires in a slice and trims spaces from the beginning
+// and the end of a string. It also removes empty entries or entries commented with `#`.
+func cleanStrings(s []string) []string {
+	var r []string
+	for _, str := range s {
+		str = strings.TrimSpace(str)
+		if str == "" || strings.HasPrefix(str, "#") {
+			continue
+		}
+
+		r = append(r, str)
+	}
+	return r
+}
+
+// resolvePeers checks if peers are already set. If the peers list is empty it
+// reads the peers from the embedded peers list for the given network.
+func (c *Config) resolvePeers() error {
+	network := c.Ethereum.Network
+
+	// Return if peers are already set.
+	if len(c.LibP2P.Peers) > 0 {
+		return nil
+	}
+
+	// For developer network we don't expect the default peers to be embedded in
+	// the client. The user should configure them in the config file.
+	if network == ethereum.Developer {
+		logger.Warnf(
+			"peers were not configured for [%s] network; "+
+				"see network section in configuration",
+			network,
+		)
+		return nil
+	}
+
+	logger.Debugf(
+		"peers were not configured for [%s] ethereum network; reading defaults",
+		network,
+	)
+
+	peers, err := readPeers(network)
+	if err != nil {
+		return fmt.Errorf("failed to read default peers: [%v]", err)
+	}
+
+	c.LibP2P.Peers = peers
+
+	return nil
+}

--- a/config/peers.go
+++ b/config/peers.go
@@ -24,16 +24,16 @@ func readPeers(network commonEthereum.Network) ([]string, error) {
 // cleanStrings iterates over entires in a slice and trims spaces from the beginning
 // and the end of a string. It also removes empty entries or entries commented with `#`.
 func cleanStrings(s []string) []string {
-	var r []string
+	var peers []string
 	for _, str := range s {
 		str = strings.TrimSpace(str)
 		if str == "" || strings.HasPrefix(str, "#") {
 			continue
 		}
 
-		r = append(r, str)
+		peers = append(peers, str)
 	}
-	return r
+	return peers
 }
 
 // resolvePeers checks if peers are already set. If the peers list is empty it

--- a/config/peers_test.go
+++ b/config/peers_test.go
@@ -1,38 +1,32 @@
 package config
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
-	ethereumCommon "github.com/keep-network/keep-common/pkg/chain/ethereum"
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 )
 
 func TestResolvePeers(t *testing.T) {
 	var tests = map[string]struct {
-		network       ethereumCommon.Network
+		network       commonEthereum.Network
 		expectedPeers []string
 		expectedError error
 	}{
 		// TODO: Add mainnet support
 		// "mainnet network": {},
 		"goerli network": {
-			network: ethereumCommon.Goerli,
+			network: commonEthereum.Goerli,
 			expectedPeers: []string{
 				"/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH",
 				"/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY",
 			},
 		},
 		"developer network": {
-			network: ethereumCommon.Developer,
+			network: commonEthereum.Developer,
 		},
 		"unknown network": {
-			network:       ethereumCommon.Unknown,
-			expectedError: fmt.Errorf("failed to read default peers: [open _peers/unknown: file does not exist]"),
-		},
-		"not supported network": {
-			network:       ethereumCommon.Network(999),
-			expectedError: fmt.Errorf("failed to read default peers: [open _peers/unknown: file does not exist]"),
+			network: commonEthereum.Unknown,
 		},
 	}
 

--- a/config/peers_test.go
+++ b/config/peers_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	ethereumCommon "github.com/keep-network/keep-common/pkg/chain/ethereum"
+)
+
+func TestResolvePeers(t *testing.T) {
+	var tests = map[string]struct {
+		network       ethereumCommon.Network
+		expectedPeers []string
+		expectedError error
+	}{
+		// TODO: Add mainnet support
+		// "mainnet network": {},
+		"goerli network": {
+			network: ethereumCommon.Goerli,
+			expectedPeers: []string{
+				"/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH",
+				"/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY",
+			},
+		},
+		"developer network": {
+			network: ethereumCommon.Developer,
+		},
+		"unknown network": {
+			network:       ethereumCommon.Unknown,
+			expectedError: fmt.Errorf("failed to read default peers: [open _peers/unknown: file does not exist]"),
+		},
+		"not supported network": {
+			network:       ethereumCommon.Network(999),
+			expectedError: fmt.Errorf("failed to read default peers: [open _peers/unknown: file does not exist]"),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.Ethereum.Network = test.network
+
+			err := cfg.resolvePeers()
+			if !reflect.DeepEqual(test.expectedError, err) {
+				t.Errorf(
+					"unexpected error\nexpected: %+v\nactual:   %+v\n",
+					test.expectedError,
+					err,
+				)
+			}
+
+			if !reflect.DeepEqual(test.expectedPeers, cfg.LibP2P.Peers) {
+				t.Errorf(
+					"unexpected peers\nexpected: %v\nactual:   %v\n",
+					test.expectedPeers,
+					cfg.LibP2P.Peers,
+				)
+			}
+		})
+	}
+}

--- a/docs/development/cmd-help
+++ b/docs/development/cmd-help
@@ -5,6 +5,9 @@ Usage:
   start [flags]
 
 Flags:
+      --mainnet                                    Mainnet network
+      --goerli                                     Görli network
+      --developer                                  Developer network
   -c, --config string                              Path to the configuration file. Supported formats: TOML, YAML, JSON.
       --ethereum.url string                        WS connection URL for Ethereum client.
       --ethereum.keyFile string                    The local filesystem path to Keep operator account keyfile.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-ipfs-config v0.16.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/jbenet/goprocess v0.1.4
-	github.com/keep-network/keep-common v1.7.1-0.20220819081622-7bd71edfeb30
+	github.com/keep-network/keep-common v1.7.1-0.20220825152535-a0fc42b51b4f
 	github.com/libp2p/go-addr-util v0.2.0
 	github.com/libp2p/go-libp2p v0.20.1
 	github.com/libp2p/go-libp2p-core v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSik8=
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
-github.com/keep-network/keep-common v1.7.1-0.20220819081622-7bd71edfeb30 h1:REpBHKFa7Vno8BIiWhgB2CNAjdNVXrqANYEZqimttZs=
-github.com/keep-network/keep-common v1.7.1-0.20220819081622-7bd71edfeb30/go.mod h1:ofYXkwO8qSTgdih1LKe2DqGUicz45SKqMocLcEr8llI=
+github.com/keep-network/keep-common v1.7.1-0.20220825152535-a0fc42b51b4f h1:Qi4xDezT9ObpKTDWTzRPTEr4E/yBZOrw9VZOhlkSkT0=
+github.com/keep-network/keep-common v1.7.1-0.20220825152535-a0fc42b51b4f/go.mod h1:ofYXkwO8qSTgdih1LKe2DqGUicz45SKqMocLcEr8llI=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -104,4 +104,4 @@ printf "${LOG_START}Starting keep-core client...${LOG_END}"
 cd $KEEP_CORE_PATH
 KEEP_ETHEREUM_PASSWORD=$KEEP_ETHEREUM_PASSWORD \
     LOG_LEVEL=${LOG_LEVEL} \
-    ./keep-client --config $KEEP_CORE_CONFIG_FILE_PATH start
+    ./keep-client --config $KEEP_CORE_CONFIG_FILE_PATH start --developer


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-common/pull/99

The client requires a list of network peers to connect to. The list had to be configured by a user under the `ethereum.network.peers` property. To simplify running the node we will embed into the client the list of bootstrap peers supporting a given Ethereum network. 

When running the client a user can use one of the flags: `--mainnet`, `--goerli` or `--developer` to specify against which Ethereum network the client should be started. If non of the aforementioned flags is set, the client will assume `--mainnet`

If the list of peers in the config file under `ethereum.network.peers` is empty the client will resolve the default peers that were set in the client build.

The bootstrap peers configuration is expected to be provided in the `config/_peers/` directory in a separate file for each network.

If the client is run with `--developer` flag, the peers are expected to be set in the config file, they won't be resolved automagically.

