### PR TITLE
Set docker entrypoint to keep-client only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ ENV APP_NAME=keep-client \
 COPY --from=gobuild $BIN_PATH/$APP_NAME $BIN_PATH
 
 # ENTRYPOINT cant handle ENV variables.
-ENTRYPOINT ["keep-client", "-config", "/keepclient/config.toml"]
+ENTRYPOINT ["keep-client"]
 
 # docker caches more when using CMD [] resulting in a faster build.
 CMD []


### PR DESCRIPTION
We set the entrypoint to `keep-client` only, so when running the docker
image we specify the remaining commands and arguments like `start
--config config.toml`, etc.

The current entrypoint was problematic as it required `-config /keepclient/config.toml` by default.