### PR TITLE
Do not wrap nil inside PreParams in generateFn

### DIFF
--- a/pkg/tecdsa/dkg/preparams.go
+++ b/pkg/tecdsa/dkg/preparams.go
@@ -67,6 +67,13 @@ func newTssPreParamsPool(
 			logger.Warnf("failed to generate TSS pre-params: [%v]", err)
 		}
 
+		// If the context is done, GeneratePreParamsWithContext that got
+		// interrupted returns nil result. We do not want to wrap nil inside
+		// PreParams structure, so we return nil here.
+		if preParams == nil {
+			return nil
+		}
+
 		return &PreParams{preParams}
 	}
 


### PR DESCRIPTION
If the context passed to tss-lib `GeneratePreParamsWithContext` is done,
the interrupted function returns `nil` result. We do not want to wrap `nil`
inside `PreParams` structure so we should return `nil` early.

See #3197 
Refs #3161