### PR TITLE
Provide a cancel signal for the parameter pool getter

### DIFF
--- a/pkg/generator/pool.go
+++ b/pkg/generator/pool.go
@@ -88,9 +88,9 @@ func NewParameterPool[T any](
 	}
 }
 
-// Get returns a new parameter. It is fetched from the pool or generated if the
-// pool is empty.
-func (pp *ParameterPool[T]) Get(ctx context.Context) (*T, error) {
+// GetNow returns a new parameter. It is fetched from the pool or an error is
+// returned when the pool is empty.
+func (pp *ParameterPool[T]) GetNow() (*T, error) {
 	select {
 	case generated := <-pp.pool:
 		err := pp.persistence.Delete(generated)
@@ -102,8 +102,8 @@ func (pp *ParameterPool[T]) Get(ctx context.Context) (*T, error) {
 		}
 
 		return generated, nil
-	case <-ctx.Done():
-		return nil, fmt.Errorf("context is done")
+	default:
+		return nil, fmt.Errorf("pool is empty")
 	}
 }
 

--- a/pkg/tecdsa/dkg/dkg.go
+++ b/pkg/tecdsa/dkg/dkg.go
@@ -1,7 +1,6 @@
 package dkg
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -13,12 +12,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/protocol/state"
 )
-
-// preParamsGetTimeout determines how long a specific DKG member will wait
-// for a TSS pre-parameters set in case the pool is empty. If the member
-// does not receive a pre-parameters set within that time, it exits with
-// an error.
-const preParamsGetTimeout = 1 * time.Minute
 
 // Executor represents an ECDSA distributed key generation process executor.
 type Executor struct {
@@ -71,13 +64,7 @@ func (e *Executor) Execute(
 
 	registerUnmarshallers(channel)
 
-	preParamsCtx, cancelPreParamsCtx := context.WithTimeout(
-		context.Background(),
-		preParamsGetTimeout,
-	)
-	defer cancelPreParamsCtx()
-
-	preParams, err := e.tssPreParamsPool.Get(preParamsCtx)
+	preParams, err := e.tssPreParamsPool.GetNow()
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed fetching pre-params: [%v]", err)
 	}


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3161

The `Get` function exposed by the `generator.ParameterPool` type can hang on the `<-pp.pool` instruction in case the parameter pool is empty. Although this behavior is proper if the pool is working, it may cause deadlocks if the pool is stopped by the scheduler who is waiting for resume signals from clients which are in turn waiting for parameters that are supposed to be provided by the empty pool. Such a scenario occurred for tECDSA DKG. Here we aim to fix it by renaming `Get` to `GetNow` function which now uses a "get or fail" logic that provides an immediate result of a `GetNow` call without blocking.