### PR TITLE
Add comment to PR-s modifying docs that links to the published preview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,5 +72,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Preview uploaded to https://docs.keep.network/${{ github.head_ref }}/index.html.'
+              body: 'Documentation preview uploaded to https://docs.keep.network/${{ github.head_ref }}/index.html.'
             })

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,3 +62,15 @@ jobs:
           bucket-name: docs.keep.network
           bucket-path: ./${{ github.head_ref }}
           build-folder: ${{ steps.html.outputs.asciidoctor-artifacts }}/docs
+
+      - name: Post preview URL to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Preview uploaded to https://docs.keep.network/${{ github.head_ref }}/index.html.'
+            })


### PR DESCRIPTION
We're adding a step to the `docs.yml` workflow that publishes the comment under
the PR modifying the documents, after preview of the dosc gets published to the
GCP bucket. The comment contains a link to the `index.html` page containing the
table of contents.
Note: we need to have `./docs/index.adoc` file with right config inside to have
it working in the way I described it.

Ref: https://github.com/keep-network/keep-core/pull/3211