### PR TITLE
Updates to the CLI commands and flags

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"path"
+
 	"github.com/ipfs/go-log"
+	"github.com/spf13/cobra"
+
 	"github.com/keep-network/keep-core/config"
 )
 
@@ -13,3 +19,28 @@ var configFilePath string
 var clientConfig = &config.Config{}
 
 var logger = log.Logger("keep-cmd")
+
+// RootCmd contains the definition of the root command-line command.
+var RootCmd = &cobra.Command{
+	Use:              path.Base(os.Args[0]),
+	Short:            "CLI for The Keep Network",
+	Long:             "Command line interface (CLI) for running a Keep provider",
+	TraverseChildren: true,
+}
+
+func init() {
+	initGlobalFlags(RootCmd, &configFilePath)
+
+	RootCmd.AddCommand(
+		StartCommand,
+		PingCommand,
+		EthereumCommand,
+	)
+}
+
+// Initialize initializes the root command and returns it.
+func Initialize(version, revision string) *cobra.Command {
+	RootCmd.Version = fmt.Sprintf("%s (revision %s)", version, revision)
+
+	return RootCmd
+}

--- a/cmd/ethereum.go
+++ b/cmd/ethereum.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/keep-network/keep-core/config"
+
 	beaconcmd "github.com/keep-network/keep-core/pkg/chain/ethereum/beacon/gen/cmd"
 	ecdsacmd "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen/cmd"
 	tbtccmd "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen/cmd"
 	thresholdcmd "github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen/cmd"
-	"github.com/spf13/cobra"
 )
 
 // EthereumCommand contains the definition of the ethereum command-line
@@ -25,12 +27,22 @@ func init() {
 		Use:   "ethereum",
 		Short: `Provides access to Keep network Ethereum contracts.`,
 		Long:  ethereumDescription,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if err := clientConfig.ReadConfig(configFilePath, cmd.Flags(), config.General, config.Ethereum); err != nil {
+				logger.Fatalf("error reading config: %v", err)
+			}
+
+			beaconcmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+			ecdsacmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+			tbtccmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+			thresholdcmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+		},
 	}
 
 	initFlags(EthereumCommand, &configFilePath, clientConfig, config.General, config.Ethereum)
 
-	EthereumCommand.AddCommand(beaconcmd.Command)
-	EthereumCommand.AddCommand(ecdsacmd.Command)
-	EthereumCommand.AddCommand(tbtccmd.Command)
-	EthereumCommand.AddCommand(thresholdcmd.Command)
+	EthereumCommand.AddCommand(&beaconcmd.ModuleCommand.Command)
+	EthereumCommand.AddCommand(&ecdsacmd.ModuleCommand.Command)
+	EthereumCommand.AddCommand(&tbtccmd.ModuleCommand.Command)
+	EthereumCommand.AddCommand(&thresholdcmd.ModuleCommand.Command)
 }

--- a/cmd/ethereum.go
+++ b/cmd/ethereum.go
@@ -13,7 +13,21 @@ import (
 
 // EthereumCommand contains the definition of the ethereum command-line
 // subcommand and its own subcommands.
-var EthereumCommand *cobra.Command
+var EthereumCommand = &cobra.Command{
+	Use:   "ethereum",
+	Short: `Provides access to Keep network Ethereum contracts.`,
+	Long:  ethereumDescription,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if err := clientConfig.ReadConfig(configFilePath, cmd.Flags(), config.General, config.Ethereum); err != nil {
+			logger.Fatalf("error reading config: %v", err)
+		}
+
+		beaconcmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+		ecdsacmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+		tbtccmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+		thresholdcmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
+	},
+}
 
 const ethereumDescription = `The ethereum command allows interacting with Keep's Ethereum
 contracts directly. Each subcommand corresponds to one contract, and has subcommands 
@@ -23,22 +37,6 @@ based on the contract method's parameters.
 See the subcommand help for additional details.`
 
 func init() {
-	EthereumCommand = &cobra.Command{
-		Use:   "ethereum",
-		Short: `Provides access to Keep network Ethereum contracts.`,
-		Long:  ethereumDescription,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if err := clientConfig.ReadConfig(configFilePath, cmd.Flags(), config.General, config.Ethereum); err != nil {
-				logger.Fatalf("error reading config: %v", err)
-			}
-
-			beaconcmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
-			ecdsacmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
-			tbtccmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
-			thresholdcmd.ModuleCommand.SetConfig(&clientConfig.Ethereum)
-		},
-	}
-
 	initFlags(EthereumCommand, &configFilePath, clientConfig, config.General, config.Ethereum)
 
 	EthereumCommand.AddCommand(&beaconcmd.ModuleCommand.Command)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -29,8 +29,7 @@ func initFlags(
 			initConfigFlags(cmd, configFilePath)
 		case config.Ethereum:
 			initEthereumNetworkFlags(cmd)
-			initEthereumGlobalFlags(cmd, cfg)
-			initEthereumLocalFlags(cmd, cfg)
+			initEthereumFlags(cmd, cfg)
 		case config.Network:
 			initNetworkFlags(cmd, cfg)
 		case config.Storage:
@@ -94,9 +93,8 @@ func initEthereumNetworkFlags(cmd *cobra.Command) {
 	)
 }
 
-// Initialize flags for global Ethereum configuration. The flags are defined for the
-// scope of the current command and all its children.
-func initEthereumGlobalFlags(cmd *cobra.Command, cfg *config.Config) {
+// Initialize flags for Ethereum configuration.
+func initEthereumFlags(cmd *cobra.Command, cfg *config.Config) {
 	cmd.PersistentFlags().StringVar(
 		&cfg.Ethereum.URL,
 		"ethereum.url",
@@ -110,11 +108,7 @@ func initEthereumGlobalFlags(cmd *cobra.Command, cfg *config.Config) {
 		"",
 		"The local filesystem path to Keep operator account keyfile.",
 	)
-}
 
-// Initialize flags for local Ethereum configuration. The flags are defined for the
-// scope of the current command only.
-func initEthereumLocalFlags(cmd *cobra.Command, cfg *config.Config) {
 	cmd.Flags().DurationVar(
 		&cfg.Ethereum.MiningCheckInterval,
 		"ethereum.miningCheckInterval",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -68,19 +68,19 @@ func initConfigFlags(cmd *cobra.Command, configFilePath *string) {
 func initEthereumNetworkFlags(cmd *cobra.Command) {
 	// TODO: Consider removing `--mainnet` flag. For now it's here to reduce a confusion
 	// when developing and testing the client.
-	cmd.Flags().Bool(
+	cmd.PersistentFlags().Bool(
 		commonEthereum.Mainnet.String(),
 		false,
 		"Mainnet network",
 	)
 
-	cmd.Flags().Bool(
+	cmd.PersistentFlags().Bool(
 		commonEthereum.Goerli.String(),
 		false,
 		"Görli network",
 	)
 
-	cmd.Flags().Bool(
+	cmd.PersistentFlags().Bool(
 		commonEthereum.Developer.String(),
 		false,
 		"Developer network",
@@ -95,14 +95,14 @@ func initEthereumNetworkFlags(cmd *cobra.Command) {
 
 // Initialize flags for Ethereum configuration.
 func initEthereumFlags(cmd *cobra.Command, cfg *config.Config) {
-	cmd.Flags().StringVar(
+	cmd.PersistentFlags().StringVar(
 		&cfg.Ethereum.URL,
 		"ethereum.url",
 		"",
 		"WS connection URL for Ethereum client.",
 	)
 
-	cmd.Flags().StringVar(
+	cmd.PersistentFlags().StringVar(
 		&cfg.Ethereum.Account.KeyFile,
 		"ethereum.keyFile",
 		"",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -68,19 +68,19 @@ func initConfigFlags(cmd *cobra.Command, configFilePath *string) {
 func initEthereumNetworkFlags(cmd *cobra.Command) {
 	// TODO: Consider removing `--mainnet` flag. For now it's here to reduce a confusion
 	// when developing and testing the client.
-	cmd.Flags().Bool(
+	cmd.PersistentFlags().Bool(
 		commonEthereum.Mainnet.String(),
 		false,
 		"Mainnet network",
 	)
 
-	cmd.Flags().Bool(
+	cmd.PersistentFlags().Bool(
 		commonEthereum.Goerli.String(),
 		false,
 		"Görli network",
 	)
 
-	cmd.Flags().Bool(
+	cmd.PersistentFlags().Bool(
 		commonEthereum.Developer.String(),
 		false,
 		"Developer network",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -29,7 +29,8 @@ func initFlags(
 			initConfigFlags(cmd, configFilePath)
 		case config.Ethereum:
 			initEthereumNetworkFlags(cmd)
-			initEthereumFlags(cmd, cfg)
+			initEthereumGlobalFlags(cmd, cfg)
+			initEthereumLocalFlags(cmd, cfg)
 		case config.Network:
 			initNetworkFlags(cmd, cfg)
 		case config.Storage:
@@ -93,8 +94,9 @@ func initEthereumNetworkFlags(cmd *cobra.Command) {
 	)
 }
 
-// Initialize flags for Ethereum configuration.
-func initEthereumFlags(cmd *cobra.Command, cfg *config.Config) {
+// Initialize flags for global Ethereum configuration. The flags are defined for the
+// scope of the current command and all its children.
+func initEthereumGlobalFlags(cmd *cobra.Command, cfg *config.Config) {
 	cmd.PersistentFlags().StringVar(
 		&cfg.Ethereum.URL,
 		"ethereum.url",
@@ -108,7 +110,11 @@ func initEthereumFlags(cmd *cobra.Command, cfg *config.Config) {
 		"",
 		"The local filesystem path to Keep operator account keyfile.",
 	)
+}
 
+// Initialize flags for local Ethereum configuration. The flags are defined for the
+// scope of the current command only.
+func initEthereumLocalFlags(cmd *cobra.Command, cfg *config.Config) {
 	cmd.Flags().DurationVar(
 		&cfg.Ethereum.MiningCheckInterval,
 		"ethereum.miningCheckInterval",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -68,19 +68,19 @@ func initConfigFlags(cmd *cobra.Command, configFilePath *string) {
 func initEthereumNetworkFlags(cmd *cobra.Command) {
 	// TODO: Consider removing `--mainnet` flag. For now it's here to reduce a confusion
 	// when developing and testing the client.
-	cmd.PersistentFlags().Bool(
+	cmd.Flags().Bool(
 		commonEthereum.Mainnet.String(),
 		false,
 		"Mainnet network",
 	)
 
-	cmd.PersistentFlags().Bool(
+	cmd.Flags().Bool(
 		commonEthereum.Goerli.String(),
 		false,
 		"Görli network",
 	)
 
-	cmd.PersistentFlags().Bool(
+	cmd.Flags().Bool(
 		commonEthereum.Developer.String(),
 		false,
 		"Developer network",
@@ -95,14 +95,14 @@ func initEthereumNetworkFlags(cmd *cobra.Command) {
 
 // Initialize flags for Ethereum configuration.
 func initEthereumFlags(cmd *cobra.Command, cfg *config.Config) {
-	cmd.PersistentFlags().StringVar(
+	cmd.Flags().StringVar(
 		&cfg.Ethereum.URL,
 		"ethereum.url",
 		"",
 		"WS connection URL for Ethereum client.",
 	)
 
-	cmd.PersistentFlags().StringVar(
+	cmd.Flags().StringVar(
 		&cfg.Ethereum.Account.KeyFile,
 		"ethereum.keyFile",
 		"",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -17,6 +17,14 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
+func initGlobalFlags(
+	cmd *cobra.Command,
+	configFilePath *string,
+) {
+	initGlobalConfigFlags(cmd, configFilePath)
+	initGlobalEthereumFlags(cmd)
+}
+
 func initFlags(
 	cmd *cobra.Command,
 	configFilePath *string,
@@ -25,10 +33,7 @@ func initFlags(
 ) {
 	for _, category := range categories {
 		switch category {
-		case config.General:
-			initConfigFlags(cmd, configFilePath)
 		case config.Ethereum:
-			initEthereumNetworkFlags(cmd)
 			initEthereumFlags(cmd, cfg)
 		case config.Network:
 			initNetworkFlags(cmd, cfg)
@@ -51,7 +56,7 @@ func initFlags(
 }
 
 // Initialize flag for configuration file path.
-func initConfigFlags(cmd *cobra.Command, configFilePath *string) {
+func initGlobalConfigFlags(cmd *cobra.Command, configFilePath *string) {
 	cmd.PersistentFlags().StringVarP(
 		configFilePath,
 		"config",
@@ -65,7 +70,7 @@ func initConfigFlags(cmd *cobra.Command, configFilePath *string) {
 // to run a client for a specific Ethereum network, e.g. add `--goerli` to the client
 // start command to run the client against Görli Ethereum network. Only one flag
 // from this set is allowed.
-func initEthereumNetworkFlags(cmd *cobra.Command) {
+func initGlobalEthereumFlags(cmd *cobra.Command) {
 	// TODO: Consider removing `--mainnet` flag. For now it's here to reduce a confusion
 	// when developing and testing the client.
 	cmd.PersistentFlags().Bool(

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -337,6 +337,7 @@ func initTestCommand() (*cobra.Command, *config.Config, *string) {
 		Run: func(cmd *cobra.Command, args []string) {},
 	}
 
+	initGlobalFlags(testCommand, &testConfigFilePath)
 	initFlags(testCommand, &testConfigFilePath, testConfig, config.AllCategories...)
 
 	return testCommand, testConfig, &testConfigFilePath

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -11,16 +11,23 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	"github.com/spf13/cobra"
+
 	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
 	"github.com/keep-network/keep-core/pkg/operator"
-	"github.com/spf13/cobra"
 )
 
 // PingCommand contains the definition of the ping command-line subcommand.
-var PingCommand *cobra.Command
+var PingCommand = &cobra.Command{
+	Use:                   "ping [multiaddr]...",
+	Short:                 `bidirectional send between two peers to test the network`,
+	Long:                  pingDescription,
+	DisableFlagsInUseLine: true,
+	RunE:                  pingRequest,
+}
 
 const (
 	ping         = "PING"
@@ -32,16 +39,6 @@ const pingDescription = `The ping command conducts a simple peer-to-peer test
    between a bootstrap node and another peer: can known peers communicate over
    a peer-to-peer network. Both peers send a "PING" and expect to receive a
    corresponding "PONG". Notably, this does not exercise peer discovery.`
-
-func init() {
-	PingCommand = &cobra.Command{
-		Use:                   "ping [multiaddr]...",
-		Short:                 `bidirectional send between two peers to test the network`,
-		Long:                  pingDescription,
-		DisableFlagsInUseLine: true,
-		RunE:                  pingRequest,
-	}
-}
 
 func isBootstrapNode(args []string) (bool, []string) {
 	var bootstrapPeers []string

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -22,25 +22,23 @@ import (
 )
 
 // StartCommand contains the definition of the start command-line subcommand.
-var StartCommand *cobra.Command
+var StartCommand = &cobra.Command{
+	Use:   "start",
+	Short: "Starts the Keep Client",
+	Long:  "Starts the Keep Client in the foreground",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := clientConfig.ReadConfig(configFilePath, cmd.Flags(), config.AllCategories...); err != nil {
+			logger.Fatalf("error reading config: %v", err)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := start(cmd); err != nil {
+			logger.Fatal(err)
+		}
+	},
+}
 
 func init() {
-	StartCommand = &cobra.Command{
-		Use:   "start",
-		Short: "Starts the Keep Client",
-		Long:  "Starts the Keep Client in the foreground",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			if err := clientConfig.ReadConfig(configFilePath, cmd.Flags(), config.AllCategories...); err != nil {
-				logger.Fatalf("error reading config: %v", err)
-			}
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := start(cmd); err != nil {
-				logger.Fatal(err)
-			}
-		},
-	}
-
 	initFlags(StartCommand, &configFilePath, clientConfig, config.AllCategories...)
 
 	StartCommand.SetUsageTemplate(

--- a/config/config.go
+++ b/config/config.go
@@ -188,33 +188,6 @@ func validateConfig(config *Config, categories ...Category) error {
 	return result.ErrorOrNil()
 }
 
-// ReadEthereumConfig reads in the configuration from a file specified by `--config`
-// flag and other flags provided in the `flagSet` and returns its contained Ethereum
-// config, or an error if something fails.
-//
-// This is the same as invoking ReadConfig and reading the Ethereum property
-// from the returned config, but is available for external functions that expect
-// to interact solely with Ethereum and are therefore independent of the rest of
-// the config structure.
-func ReadEthereumConfig(flagSet *pflag.FlagSet) (commonEthereum.Config, error) {
-	config := Config{}
-
-	configPath, err := flagSet.GetString("config")
-	if err != nil {
-		return commonEthereum.Config{},
-			fmt.Errorf(
-				"failed to read config file path from command flag: %w",
-				err,
-			)
-	}
-
-	if err := config.ReadConfig(configPath, flagSet, Ethereum); err != nil {
-		return commonEthereum.Config{}, err
-	}
-
-	return config.Ethereum, nil
-}
-
 // readConfigFile uses viper to read configuration from a config file. The config file
 // is not mandatory, if the path is
 func readConfigFile(configFilePath string) error {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-ipfs-config v0.16.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/jbenet/goprocess v0.1.4
-	github.com/keep-network/keep-common v1.7.1-0.20220825152535-a0fc42b51b4f
+	github.com/keep-network/keep-common v1.7.1-0.20220829235520-8deccfef39d6
 	github.com/libp2p/go-addr-util v0.2.0
 	github.com/libp2p/go-libp2p v0.20.1
 	github.com/libp2p/go-libp2p-core v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSik8=
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
-github.com/keep-network/keep-common v1.7.1-0.20220825152535-a0fc42b51b4f h1:Qi4xDezT9ObpKTDWTzRPTEr4E/yBZOrw9VZOhlkSkT0=
-github.com/keep-network/keep-common v1.7.1-0.20220825152535-a0fc42b51b4f/go.mod h1:ofYXkwO8qSTgdih1LKe2DqGUicz45SKqMocLcEr8llI=
+github.com/keep-network/keep-common v1.7.1-0.20220829235520-8deccfef39d6 h1:+RoA3Nh0D7R+liyqprxF00torLKqwTdRyG21+fzycNY=
+github.com/keep-network/keep-common v1.7.1-0.20220829235520-8deccfef39d6/go.mod h1:ofYXkwO8qSTgdih1LKe2DqGUicz45SKqMocLcEr8llI=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 	rootCmd.Short = "CLI for The Keep Network"
 	rootCmd.Long = "Command line interface (CLI) for running a Keep provider"
 	rootCmd.Version = fmt.Sprintf("%s (revision %s)", version, revision)
+	rootCmd.TraverseChildren = true
 
 	rootCmd.AddCommand(
 		cmd.StartCommand,

--- a/main.go
+++ b/main.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"os"
-	"path"
 
 	"fmt"
 
 	"github.com/ipfs/go-log"
+
 	"github.com/keep-network/keep-common/pkg/logging"
 	"github.com/keep-network/keep-core/cmd"
 	"github.com/keep-network/keep-core/config"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -33,19 +32,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to configure logging: [%v]\n", err)
 	}
 
-	var rootCmd = &cobra.Command{}
-
-	rootCmd.Use = path.Base(os.Args[0])
-	rootCmd.Short = "CLI for The Keep Network"
-	rootCmd.Long = "Command line interface (CLI) for running a Keep provider"
-	rootCmd.Version = fmt.Sprintf("%s (revision %s)", version, revision)
-	rootCmd.TraverseChildren = true
-
-	rootCmd.AddCommand(
-		cmd.StartCommand,
-		cmd.PingCommand,
-		cmd.EthereumCommand,
-	)
+	rootCmd := cmd.Initialize(version, revision)
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.Fatal(err)

--- a/pkg/chain/ethereum/beacon/gen/cmd/BeaconSortitionPool.go
+++ b/pkg/chain/ethereum/beacon/gen/cmd/BeaconSortitionPool.go
@@ -15,7 +15,6 @@ import (
 
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd"
-	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/beacon/gen/contract"
 
 	"github.com/spf13/cobra"
@@ -78,7 +77,7 @@ func init() {
 		bspWithdrawRewardsCommand(),
 	)
 
-	Command.AddCommand(BeaconSortitionPoolCommand)
+	ModuleCommand.AddCommand(BeaconSortitionPoolCommand)
 }
 
 /// ------------------- Const methods -------------------
@@ -1341,10 +1340,7 @@ func bspWithdrawRewards(c *cobra.Command, args []string) error {
 /// ------------------- Initialization -------------------
 
 func initializeBeaconSortitionPool(c *cobra.Command) (*contract.BeaconSortitionPool, error) {
-	cfg, err := config.ReadEthereumConfig(c.Flags())
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from file: [%v]", err)
-	}
+	cfg := *ModuleCommand.GetConfig()
 
 	client, err := ethclient.Dial(cfg.URL)
 	if err != nil {

--- a/pkg/chain/ethereum/beacon/gen/cmd/RandomBeacon.go
+++ b/pkg/chain/ethereum/beacon/gen/cmd/RandomBeacon.go
@@ -14,7 +14,6 @@ import (
 
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd"
-	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/beacon/gen/contract"
 
 	"github.com/spf13/cobra"
@@ -94,7 +93,7 @@ func init() {
 		rbWithdrawRewardsCommand(),
 	)
 
-	Command.AddCommand(RandomBeaconCommand)
+	ModuleCommand.AddCommand(RandomBeaconCommand)
 }
 
 /// ------------------- Const methods -------------------
@@ -2159,10 +2158,7 @@ func rbWithdrawRewards(c *cobra.Command, args []string) error {
 /// ------------------- Initialization -------------------
 
 func initializeRandomBeacon(c *cobra.Command) (*contract.RandomBeacon, error) {
-	cfg, err := config.ReadEthereumConfig(c.Flags())
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from file: [%v]", err)
-	}
+	cfg := *ModuleCommand.GetConfig()
 
 	client, err := ethclient.Dial(cfg.URL)
 	if err != nil {

--- a/pkg/chain/ethereum/beacon/gen/cmd/cmd.go
+++ b/pkg/chain/ethereum/beacon/gen/cmd/cmd.go
@@ -2,15 +2,19 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/keep-network/keep-core/pkg/chain/ethereum"
 )
 
-// Command is the exported list of generated commands that can be
+// ModuleCommand is the exported list of generated commands that can be
 // installed on a CLI app. Generated contract command files set up init
 // functions that add the contract's command and subcommands to this global
 // variable, and any top-level command that wishes to include these commands can
 // reference this variable and expect it to contain all generated contract
 // commands.
-var Command = &cobra.Command{
-	Use:   "beacon",
-	Short: `Provides access to Keep Random Beacon contracts.`,
+var ModuleCommand = ethereum.Command{
+	Command: cobra.Command{
+		Use:   "beacon",
+		Short: `Provides access to Keep Random Beacon contracts.`,
+	},
 }

--- a/pkg/chain/ethereum/cmd.go
+++ b/pkg/chain/ethereum/cmd.go
@@ -1,0 +1,25 @@
+package ethereum
+
+import (
+	"github.com/spf13/cobra"
+
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
+)
+
+// Command if a wrapper for cobra.Command that holds Ethereum config used by the
+// generated sub-commands to initialize the Ethereum chain connection.
+type Command struct {
+	cobra.Command
+	config *commonEthereum.Config
+}
+
+// SetConfig is used to set the ethereum configuration that is used by the
+// generated sub-commands to initialize the Ethereum chain connection.
+func (c *Command) SetConfig(config *commonEthereum.Config) {
+	c.config = config
+}
+
+// GetConfig returns the Ethereum config.
+func (c *Command) GetConfig() *commonEthereum.Config {
+	return c.config
+}

--- a/pkg/chain/ethereum/ecdsa/gen/cmd/EcdsaSortitionPool.go
+++ b/pkg/chain/ethereum/ecdsa/gen/cmd/EcdsaSortitionPool.go
@@ -15,7 +15,6 @@ import (
 
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd"
-	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen/contract"
 
 	"github.com/spf13/cobra"
@@ -78,7 +77,7 @@ func init() {
 		espWithdrawRewardsCommand(),
 	)
 
-	Command.AddCommand(EcdsaSortitionPoolCommand)
+	ModuleCommand.AddCommand(EcdsaSortitionPoolCommand)
 }
 
 /// ------------------- Const methods -------------------
@@ -1341,10 +1340,7 @@ func espWithdrawRewards(c *cobra.Command, args []string) error {
 /// ------------------- Initialization -------------------
 
 func initializeEcdsaSortitionPool(c *cobra.Command) (*contract.EcdsaSortitionPool, error) {
-	cfg, err := config.ReadEthereumConfig(c.Flags())
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from file: [%v]", err)
-	}
+	cfg := *ModuleCommand.GetConfig()
 
 	client, err := ethclient.Dial(cfg.URL)
 	if err != nil {

--- a/pkg/chain/ethereum/ecdsa/gen/cmd/WalletRegistry.go
+++ b/pkg/chain/ethereum/ecdsa/gen/cmd/WalletRegistry.go
@@ -14,7 +14,6 @@ import (
 
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd"
-	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen/contract"
 
 	"github.com/spf13/cobra"
@@ -94,7 +93,7 @@ func init() {
 		wrWithdrawRewardsCommand(),
 	)
 
-	Command.AddCommand(WalletRegistryCommand)
+	ModuleCommand.AddCommand(WalletRegistryCommand)
 }
 
 /// ------------------- Const methods -------------------
@@ -2174,10 +2173,7 @@ func wrWithdrawRewards(c *cobra.Command, args []string) error {
 /// ------------------- Initialization -------------------
 
 func initializeWalletRegistry(c *cobra.Command) (*contract.WalletRegistry, error) {
-	cfg, err := config.ReadEthereumConfig(c.Flags())
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from file: [%v]", err)
-	}
+	cfg := *ModuleCommand.GetConfig()
 
 	client, err := ethclient.Dial(cfg.URL)
 	if err != nil {

--- a/pkg/chain/ethereum/ecdsa/gen/cmd/cmd.go
+++ b/pkg/chain/ethereum/ecdsa/gen/cmd/cmd.go
@@ -2,15 +2,19 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/keep-network/keep-core/pkg/chain/ethereum"
 )
 
-// Command is the exported list of generated commands that can be
+// ModuleCommand is the exported list of generated commands that can be
 // installed on a CLI app. Generated contract command files set up init
 // functions that add the contract's command and subcommands to this global
 // variable, and any top-level command that wishes to include these commands can
 // reference this variable and expect it to contain all generated contract
 // commands.
-var Command = &cobra.Command{
-	Use:   "ecdsa",
-	Short: `Provides access to Keep ECDSA contracts.`,
+var ModuleCommand = ethereum.Command{
+	Command: cobra.Command{
+		Use:   "ecdsa",
+		Short: `Provides access to Keep ECDSA contracts.`,
+	},
 }

--- a/pkg/chain/ethereum/tbtc/gen/cmd/Bridge.go
+++ b/pkg/chain/ethereum/tbtc/gen/cmd/Bridge.go
@@ -14,7 +14,6 @@ import (
 
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd"
-	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen/contract"
 
 	"github.com/spf13/cobra"
@@ -72,7 +71,7 @@ func init() {
 		bTransferGovernanceCommand(),
 	)
 
-	Command.AddCommand(BridgeCommand)
+	ModuleCommand.AddCommand(BridgeCommand)
 }
 
 /// ------------------- Const methods -------------------
@@ -960,10 +959,7 @@ func bTransferGovernance(c *cobra.Command, args []string) error {
 /// ------------------- Initialization -------------------
 
 func initializeBridge(c *cobra.Command) (*contract.Bridge, error) {
-	cfg, err := config.ReadEthereumConfig(c.Flags())
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from file: [%v]", err)
-	}
+	cfg := *ModuleCommand.GetConfig()
 
 	client, err := ethclient.Dial(cfg.URL)
 	if err != nil {

--- a/pkg/chain/ethereum/tbtc/gen/cmd/cmd.go
+++ b/pkg/chain/ethereum/tbtc/gen/cmd/cmd.go
@@ -2,15 +2,19 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/keep-network/keep-core/pkg/chain/ethereum"
 )
 
-// Command is the exported list of generated commands that can be
+// ModuleCommand is the exported list of generated commands that can be
 // installed on a CLI app. Generated contract command files set up init
 // functions that add the contract's command and subcommands to this global
 // variable, and any top-level command that wishes to include these commands can
 // reference this variable and expect it to contain all generated contract
 // commands.
-var Command = &cobra.Command{
-	Use:   "tbtc",
-	Short: `Provides access to Keep TBTCv2 contracts.`,
+var ModuleCommand = ethereum.Command{
+	Command: cobra.Command{
+		Use:   "tbtc",
+		Short: `Provides access to Keep TBTCv2 contracts.`,
+	},
 }

--- a/pkg/chain/ethereum/threshold/gen/cmd/TokenStaking.go
+++ b/pkg/chain/ethereum/threshold/gen/cmd/TokenStaking.go
@@ -15,7 +15,6 @@ import (
 
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/cmd"
-	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen/contract"
 
 	"github.com/spf13/cobra"
@@ -97,7 +96,7 @@ func init() {
 		tsUnstakeKeepCommand(),
 	)
 
-	Command.AddCommand(TokenStakingCommand)
+	ModuleCommand.AddCommand(TokenStakingCommand)
 }
 
 /// ------------------- Const methods -------------------
@@ -2362,10 +2361,7 @@ func tsUnstakeKeep(c *cobra.Command, args []string) error {
 /// ------------------- Initialization -------------------
 
 func initializeTokenStaking(c *cobra.Command) (*contract.TokenStaking, error) {
-	cfg, err := config.ReadEthereumConfig(c.Flags())
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from file: [%v]", err)
-	}
+	cfg := *ModuleCommand.GetConfig()
 
 	client, err := ethclient.Dial(cfg.URL)
 	if err != nil {

--- a/pkg/chain/ethereum/threshold/gen/cmd/cmd.go
+++ b/pkg/chain/ethereum/threshold/gen/cmd/cmd.go
@@ -2,15 +2,19 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/keep-network/keep-core/pkg/chain/ethereum"
 )
 
-// Command is the exported list of generated commands that can be
+// ModuleCommand is the exported list of generated commands that can be
 // installed on a CLI app. Generated contract command files set up init
 // functions that add the contract's command and subcommands to this global
 // variable, and any top-level command that wishes to include these commands can
 // reference this variable and expect it to contain all generated contract
 // commands.
-var Command = &cobra.Command{
-	Use:   "threshold",
-	Short: `Provides access to Threshold Network contracts.`,
+var ModuleCommand = ethereum.Command{
+	Command: cobra.Command{
+		Use:   "threshold",
+		Short: `Provides access to Threshold Network contracts.`,
+	},
 }


### PR DESCRIPTION
With the current implementation, the `ethereum` commands fails with: `Error: unknown flag: --ethereum.url`.

We add `TraverseChildren` flag to the main command to let each of the subcommands define their flags.

The change mentioned above was not enough to make it work as the way we were reading the config with `config.ReadEthereumConfig` required flags to be provided, but the flags were defined on the parent `ethereum` command, which wasn't accessible in the context of the contract functions commands.

In https://github.com/keep-network/keep-common/pull/101 we modify the way we chain handle is initialized in the generated ethereum commands, and in this PR we align with that.

We defined a wrapper for the `cobra.Command` that also holds the Ethereum config that is used by the generated commands bindings.

Depends on https://github.com/keep-network/keep-common/pull/101

We also took a chance to modify how we initialize the `RootCmd` and move all command-related stuff to the `cmd` package.

The `RootCommand` is initialized with the persistent (global) flags that can be configured on any command in the command chain, so each of the examples will work:
```
keep-core --config configs/config.1.toml --developer start
keep-core start --config configs/config.1.toml --developer
keep-core --config configs/config.1.toml start --developer
```