### PR TITLE
Add Private Testnet bundles generator

### DIFF
--- a/infrastructure/eth-networks/private-testnet/.gitignore
+++ b/infrastructure/eth-networks/private-testnet/.gitignore
@@ -1,0 +1,13 @@
+# Local NPM Command Installation
+package.json
+package-lock.json
+node_modules/
+
+# Secrets
+bundles/*/secret/
+
+# Generated Documentation
+bundles/*/index.html
+
+# Bundles
+*.tgz

--- a/infrastructure/eth-networks/private-testnet/README.adoc
+++ b/infrastructure/eth-networks/private-testnet/README.adoc
@@ -1,4 +1,4 @@
-# Keep Network Private Testnet
+= Keep Network Private Testnet
 
 We set up a Keep Network Private Testnet that is accessible by the permitted parties.
 Here we hold the code helping us to create a bundles for the parties.
@@ -10,9 +10,9 @@ receives a stake delegation to the `provider` account with authorized `beacon` a
 `tbtc` application. This is a production-like experience for the Staking Providers,
 where they will receive stakes from their customers.
 
-## Scripts
+== Scripts
 
-### Create New Bundle
+=== Create New Bundle
 
 To create a new bundle run:
 
@@ -20,7 +20,7 @@ To create a new bundle run:
 ./scripts/new-bundle.sh
 ```
 
-### Initialize Provider
+=== Initialize Provider
 
 To simulate a Staker delegation to a Provider and authorize the applications run:
 

--- a/infrastructure/eth-networks/private-testnet/README.adoc
+++ b/infrastructure/eth-networks/private-testnet/README.adoc
@@ -1,11 +1,11 @@
 = Keep Network Private Testnet
 
 We set up a Keep Network Private Testnet that is accessible by the permitted parties.
-Here we hold the code helping us to create a bundles for the parties.
+Here we hold the code helping us to create bundles for the parties.
 
 The network runs against the link:https://goerli.net/[Ethereum Görli Testnet].
 
-The generated bundles contains a preinitialized Ethereum Account details. The account
+The generated bundles contain a preinitialized Ethereum Account details. The account
 receives a stake delegation to the Staking Provider Account with authorized `beacon` and
 `tbtc` application. This is a production-like experience for the Staking Providers,
 where they will receive stakes from their customers.

--- a/infrastructure/eth-networks/private-testnet/README.adoc
+++ b/infrastructure/eth-networks/private-testnet/README.adoc
@@ -12,6 +12,15 @@ where they will receive stakes from their customers.
 
 == Scripts
 
+=== Prerequisites
+
+The scripts require the following tools to be installed:
+
+- `npx` - link:https://nodejs.org/en/download/package-manager/#macos[macOS install]
+- `geth` -  link:https://geth.ethereum.org/docs/install-and-build/installing-geth#macos-via-homebrew[macOS install]
+- `asciidoctor` - link:https://asciidoctor.org/docs/install-asciidoctor-macos/#homebrew-procedure[macOS install]
+- `docker` - link:https://docs.docker.com/desktop/install/mac-install/[macOS install]
+
 === Create New Bundle
 
 To create a new bundle run:

--- a/infrastructure/eth-networks/private-testnet/README.adoc
+++ b/infrastructure/eth-networks/private-testnet/README.adoc
@@ -6,7 +6,7 @@ Here we hold the code helping us to create a bundles for the parties.
 The network runs against the link:https://goerli.net/[Ethereum Görli Testnet].
 
 The generated bundles contains a preinitialized Ethereum Account details. The account
-receives a stake delegation to the `provider` account with authorized `beacon` and
+receives a stake delegation to the Staking Provider Account with authorized `beacon` and
 `tbtc` application. This is a production-like experience for the Staking Providers,
 where they will receive stakes from their customers.
 
@@ -20,9 +20,9 @@ To create a new bundle run:
 ./scripts/new-bundle.sh
 ```
 
-=== Initialize Provider
+=== Initialize Staking Provider
 
-To simulate a Staker delegation to a Provider and authorize the applications run:
+To simulate a Staker delegation to a Staking Provider and authorize the applications run:
 
 ```bash
 ./scripts/init-provider.sh

--- a/infrastructure/eth-networks/private-testnet/README.md
+++ b/infrastructure/eth-networks/private-testnet/README.md
@@ -1,0 +1,29 @@
+# Keep Network Private Testnet
+
+We set up a Keep Network Private Testnet that is accessible by the permitted parties.
+Here we hold the code helping us to create a bundles for the parties.
+
+The network runs against the link:https://goerli.net/[Ethereum Görli Testnet].
+
+The generated bundles contains a preinitialized Ethereum Account details. The account
+receives a stake delegation to the `provider` account with authorized `beacon` and
+`tbtc` application. This is a production-like experience for the Staking Providers,
+where they will receive stakes from their customers.
+
+## Scripts
+
+### Create New Bundle
+
+To create a new bundle run:
+
+```bash
+./scripts/new-bundle.sh
+```
+
+### Initialize Provider
+
+To simulate a Staker delegation to a Provider and authorize the applications run:
+
+```bash
+./scripts/init-provider.sh
+```

--- a/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
+++ b/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
@@ -16,34 +16,34 @@ link:https://docs.keep.network/run-keep-node.html[Run Keep Node documentation].
 
 == Stake and Register
 
-This bundle comes with an Provider Ethereum Account that was already staked and
+This bundle comes with an Staking Provider Ethereum Account that was already staked and
 authorized, similar to what a staker would do in the production.
 
-IMPORTANT: Delivering the Provider Account details in the bundle is a simplification
-for this bundle. In the production the Staking Provider will have to provide the
-address for the Staker. See <<#provider-account>> section.
+IMPORTANT: Delivering the Staking Provider Account details in the bundle is a
+simplification for this bundle. In the production the Staking Provider will have
+to provide the address for the Staker. See <<#staking-provider-account>> section.
 
-[#provider-account]
-=== Provider Account
+[#staking-provider-account]
+=== Staking Provider Account
 
-A Staking Provider is responsible for providing a Staker with a Provider Account
-address where the stake should be delegated to.
+A Staking Provider is responsible for providing a Staker with a Staking Provider
+Account address where the stake should be delegated to.
 
-The Provider account is controlled by the Staking Provider.
+The Staking Provider Account is controlled by the Staking Provider.
 
-The Provider account can be an Ethereum account managed by any kind of a wallet,
-that can sign transactions (i.e. it doesn't have to be a Key File). 
+The Staking Provider account can be an Ethereum account managed by any kind of
+a wallet, that can sign transactions (i.e. it doesn't have to be a Key File). 
 
 === Operator Account
 
-The Operator account is an Ethereum account that the Keep Client runs with. The
+The Operator Account is an Ethereum account that the Keep Client runs with. The
 client requires an encrypted Ethereum Key File along with the Password for the
-Operator account to run.
+Operator Account to run.
 
-The Operator account is controlled by the Staking Provider.
+The Operator Account is controlled by the Staking Provider.
 
-The Staking Provider has to register an Operator address for the stake delegation
-received to the Provider account.
+The Staking Provider has to register an Operator Account address for the stake delegation
+received to the Staking Provider Account.
 
 To generate an Ethereum Account Key File you can use `geth account new` command.
 
@@ -55,8 +55,8 @@ geth account new --keystore ./keystore
 Keep the password used for the Key File encryption as it will
 have to be passed to the Keep Client start command.
 
-Once the Operator address is known it should be registered with a transaction
-submitted from the Provider account, please refer to
+Once the Operator Account address is known it should be registered with a transaction
+submitted from the Staking Provider Account, please refer to
 link:https://docs.keep.network/registration.html#register-operator[Register Operator]
 documentation.
 

--- a/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
+++ b/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
@@ -16,8 +16,8 @@ link:https://docs.keep.network/run-keep-node.html[Run Keep Node documentation].
 
 == Stake and Register
 
-This bundle comes with an Staking Provider Ethereum Account that was already staked and
-authorized, similar to what a staker would do in the production.
+This bundle comes with a Staking Provider Ethereum Account that was already staked and
+authorized, similar to what a Staker would do in the production.
 
 IMPORTANT: Delivering the Staking Provider Account details in the bundle is a
 simplification for this bundle. In the production the Staking Provider will have
@@ -31,8 +31,8 @@ Account address where the stake should be delegated to.
 
 The Staking Provider Account is controlled by the Staking Provider.
 
-The Staking Provider account can be an Ethereum account managed by any kind of
-a wallet, that can sign transactions (i.e. it doesn't have to be a Key File). 
+The Staking Provider Account can be an Ethereum account managed by any kind of
+a wallet that can sign transactions (i.e. it doesn't have to be a Key File). 
 
 === Operator Account
 

--- a/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
+++ b/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
@@ -20,7 +20,7 @@ This bundle comes with a Staking Provider Ethereum Account that was already stak
 authorized, similar to what a Staker would do in the production.
 
 IMPORTANT: Delivering the Staking Provider Account details in the bundle is a
-simplification for this bundle. In the production the Staking Provider will have
+simplification for testnet. On mainnet, the Staking Provider will have
 to provide the address for the Staker. See <<#staking-provider-account>> section.
 
 [#staking-provider-account]

--- a/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
+++ b/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
@@ -1,0 +1,81 @@
+:toc: left
+:toclevels: 3
+:sectanchors: true
+:sectids: true
+:source-highlighter: rouge
+:icons: font
+
+= Keep Network Private Testnet Bundle
+
+Use this bundle to setup Keep Network node running on Keep Network Private Testnet.
+The Keep Network Private Testnet is running against the 
+link:https://goerli.net/[Ethereum Görli Testnet].
+
+This is a quickstart guide, for the full documentation please visit
+link:https://docs.keep.network/run-keep-node.html[Run Keep Node documentation].
+
+== Stake and Register
+
+This bundle comes with an Provider Ethereum Account that was already staked and
+authorized, similar to what a staker would do in the production.
+
+IMPORTANT: Delivering the Provider Account details in the bundle is a simplification
+for this bundle. In the production the Staking Provider will have to provide the
+address for the Staker. See <<#provider-account>> section.
+
+[#provider-account]
+=== Provider Account
+
+A Staking Provider is responsible for providing a Staker with a Provider Account
+address where the stake should be delegated to.
+
+The Provider account is controlled by the Staking Provider.
+
+The Provider account can be an Ethereum account managed by any kind of a wallet,
+that can sign transactions (i.e. it doesn't have to be a Key File). 
+
+=== Operator Account
+
+The Operator account is an Ethereum account that the Keep Client runs with. The
+client requires an encrypted Ethereum Key File along with the Password for the
+Operator account to run.
+
+The Operator account is controlled by the Staking Provider.
+
+The Staking Provider has to register an Operator address for the stake delegation
+received to the Provider account.
+
+To generate an Ethereum Account Key File you can use `geth account new` command.
+
+[source,shell]
+----
+geth account new --keystore ./keystore
+----
+
+Keep the password used for the Key File encryption as it will
+have to be passed to the Keep Client start command.
+
+Once the Operator address is known it should be registered with a transaction
+submitted from the Provider account, please refer to
+link:https://docs.keep.network/registration.html#register-operator[Register Operator]
+documentation.
+
+== Configuration
+
+For details on the Keep Client Node configuration visit
+link:https://docs.keep.network/run-keep-node.html#configuration[Configuration documentation].
+
+== Running
+
+For details on running the Keep Client Node on Testnet visit 
+link:https://docs.keep.network/run-keep-node.html#testnet[Testnet documentation].
+
+=== Validate
+
+To validate the running client check the metrics for the number of connected peers.
+The client should connect to the bootstrap nodes (at least 2) and other nodes that
+are working in the network. There should be at least 10 connections.
+
+```
+curl localhost:8081/metrics
+```

--- a/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -eou pipefail
+
+ROOT_DIR="$(realpath "$(dirname $0)/../bundles")"
+
+if [ -z "${CHAIN_API_URL+x}" ]; then
+    read -p "Provide Ethereum API URL: " CHAIN_API_URL
+fi
+
+if [ -z "${PURSE_PRIVATE_KEY+x}" ]; then
+    read -p "Provide ETH Purse Private Key: " PURSE_PRIVATE_KEY
+fi
+
+if [ -z "${GOERLI_DEPLOYER_PRIVATE_KEY+x}" ]; then
+    read -p "Provide GOERLI_DEPLOYER_PRIVATE_KEY: " GOERLI_DEPLOYER_PRIVATE_KEY
+fi
+
+STAKING_PROVIDER=${1-}
+if [ -z "$STAKING_PROVIDER" ]; then
+    read -p "Provide Staking Provider name: " STAKING_PROVIDER
+fi
+
+STAKING_PROVIDER_DIR="$(realpath "$ROOT_DIR/$STAKING_PROVIDER")"
+
+if [ ! -d "$STAKING_PROVIDER_DIR" ]; then
+    echo "Directory for $STAKING_PROVIDER does not exists."
+    exit 1
+fi
+
+CONFIG_DIR="$STAKING_PROVIDER_DIR/config"
+SECRETS_DIR="$STAKING_PROVIDER_DIR/secret"
+
+KEY_FILE_PATH="$CONFIG_DIR/provider-eth-account-key-file.json"
+KEY_FILE_PASSWORD_PATH="$SECRETS_DIR/provider-eth-account-password"
+PRIVATE_KEY_FILE_PATH="$SECRETS_DIR/provider-eth-account-private-key"
+
+ACCOUNT_ADDRESS=$(jq -jr .address $KEY_FILE_PATH)
+ACCOUNT_PRIVATE_KEY=$(cat $PRIVATE_KEY_FILE_PATH)
+
+[[ $ACCOUNT_ADDRESS == 0x* ]] || ACCOUNT_ADDRESS="0x$ACCOUNT_ADDRESS"
+
+printf "Provider Address: $ACCOUNT_ADDRESS\n"
+
+printf "Pull the latest images...\n"
+
+docker pull gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
+docker pull gcr.io/keep-test-f3e0/keep-ecdsa-hardhat:latest
+
+printf "Fund provider address with ether from purse...\n"
+
+docker run \
+    --rm \
+    --env "CHAIN_API_URL=$CHAIN_API_URL" \
+    --env "ACCOUNTS_PRIVATE_KEYS=$PURSE_PRIVATE_KEY" \
+    gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest \
+    ensure-eth-balance \
+    --network goerli \
+    --target-balance "0.1 ether" \
+    $ACCOUNT_ADDRESS
+
+printf "Initialize staking...\n"
+
+docker run \
+    --rm \
+    --env "CHAIN_API_URL=$CHAIN_API_URL" \
+    --env "ACCOUNTS_PRIVATE_KEYS=$GOERLI_DEPLOYER_PRIVATE_KEY,$ACCOUNT_PRIVATE_KEY" \
+    gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest \
+    initialize:staking \
+    --network goerli \
+    --owner $ACCOUNT_ADDRESS \
+    --provider $ACCOUNT_ADDRESS
+
+printf "Authorize the Random Beacon...\n"
+
+docker run \
+    --rm \
+    --env "CHAIN_API_URL=$CHAIN_API_URL" \
+    --env "ACCOUNTS_PRIVATE_KEYS=$GOERLI_DEPLOYER_PRIVATE_KEY,$ACCOUNT_PRIVATE_KEY" \
+    gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest \
+    authorize:beacon \
+    --network goerli \
+    --owner $ACCOUNT_ADDRESS \
+    --provider $ACCOUNT_ADDRESS
+
+printf "Authorize the ECDSA...\n"
+
+docker run \
+    --rm \
+    --env "CHAIN_API_URL=$CHAIN_API_URL" \
+    --env "ACCOUNTS_PRIVATE_KEYS=$GOERLI_DEPLOYER_PRIVATE_KEY,$ACCOUNT_PRIVATE_KEY" \
+    gcr.io/keep-test-f3e0/keep-ecdsa-hardhat:latest \
+    authorize:ecdsa \
+    --network goerli \
+    --owner $ACCOUNT_ADDRESS \
+    --provider $ACCOUNT_ADDRESS
+
+printf "\n\e[1;32mDONE!\n\n\e[0m"

--- a/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
@@ -64,6 +64,7 @@ docker run \
     --rm \
     --env "CHAIN_API_URL=$CHAIN_API_URL" \
     --env "ACCOUNTS_PRIVATE_KEYS=$GOERLI_DEPLOYER_PRIVATE_KEY,$ACCOUNT_PRIVATE_KEY" \
+    --platform linux/amd64 \
     gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest \
     initialize:staking \
     --network goerli \
@@ -76,6 +77,7 @@ docker run \
     --rm \
     --env "CHAIN_API_URL=$CHAIN_API_URL" \
     --env "ACCOUNTS_PRIVATE_KEYS=$GOERLI_DEPLOYER_PRIVATE_KEY,$ACCOUNT_PRIVATE_KEY" \
+    --platform linux/amd64 \
     gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest \
     authorize:beacon \
     --network goerli \
@@ -88,6 +90,7 @@ docker run \
     --rm \
     --env "CHAIN_API_URL=$CHAIN_API_URL" \
     --env "ACCOUNTS_PRIVATE_KEYS=$GOERLI_DEPLOYER_PRIVATE_KEY,$ACCOUNT_PRIVATE_KEY" \
+    --platform linux/amd64 \
     gcr.io/keep-test-f3e0/keep-ecdsa-hardhat:latest \
     authorize:ecdsa \
     --network goerli \

--- a/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
@@ -30,23 +30,23 @@ fi
 CONFIG_DIR="$STAKING_PROVIDER_DIR/config"
 SECRETS_DIR="$STAKING_PROVIDER_DIR/secret"
 
-KEY_FILE_PATH="$CONFIG_DIR/provider-eth-account-key-file.json"
-KEY_FILE_PASSWORD_PATH="$SECRETS_DIR/provider-eth-account-password"
-PRIVATE_KEY_FILE_PATH="$SECRETS_DIR/provider-eth-account-private-key"
+KEY_FILE_PATH="$CONFIG_DIR/staking-provider-eth-account-key-file.json"
+KEY_FILE_PASSWORD_PATH="$SECRETS_DIR/staking-provider-eth-account-password"
+PRIVATE_KEY_FILE_PATH="$SECRETS_DIR/staking-provider-eth-account-private-key"
 
 ACCOUNT_ADDRESS=$(jq -jr .address $KEY_FILE_PATH)
 ACCOUNT_PRIVATE_KEY=$(cat $PRIVATE_KEY_FILE_PATH)
 
 [[ $ACCOUNT_ADDRESS == 0x* ]] || ACCOUNT_ADDRESS="0x$ACCOUNT_ADDRESS"
 
-printf "Provider Address: $ACCOUNT_ADDRESS\n"
+printf "Staking Provider Account Address: $ACCOUNT_ADDRESS\n"
 
 printf "Pull the latest images...\n"
 
 docker pull gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
 docker pull gcr.io/keep-test-f3e0/keep-ecdsa-hardhat:latest
 
-printf "Fund provider address with ether from purse...\n"
+printf "Fund Staking Provider Account Address with ether from purse...\n"
 
 docker run \
     --rm \

--- a/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/init-provider.sh
@@ -52,6 +52,7 @@ docker run \
     --rm \
     --env "CHAIN_API_URL=$CHAIN_API_URL" \
     --env "ACCOUNTS_PRIVATE_KEYS=$PURSE_PRIVATE_KEY" \
+    --platform linux/amd64 \
     gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest \
     ensure-eth-balance \
     --network goerli \

--- a/infrastructure/eth-networks/private-testnet/scripts/new-bundle.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/new-bundle.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -eou pipefail
+
+ROOT_DIR="$(realpath "$(dirname $0)/../bundles")"
+
+if ! npx eth-helper --version &>/dev/null; then
+    printf "eth-helper could not be found; installing... \n"
+    npm install nkuba/eth-helper
+fi
+
+STAKING_PROVIDER=${1-}
+if [ -z "${STAKING_PROVIDER}" ]; then
+    read -p "Provide Staking Provider name: " STAKING_PROVIDER
+fi
+
+STAKING_PROVIDER_DIR="$(realpath "$ROOT_DIR/$STAKING_PROVIDER")"
+
+if [ -d "$STAKING_PROVIDER_DIR" ]; then
+    echo "Directory for $STAKING_PROVIDER already exists."
+    exit 1
+fi
+
+if [ -z "${KEYFILE_PASSWORD+x}" ]; then
+    read -s -r -p "Provide password for key file encryption: " KEYFILE_PASSWORD
+    if [ -z "$KEYFILE_PASSWORD" ]; then
+        printf "KEYFILE_PASSWORD not set\n"
+        exit 1
+    fi
+    printf "\n"
+fi
+
+CONFIG_DIR="$STAKING_PROVIDER_DIR/config"
+SECRETS_DIR="$STAKING_PROVIDER_DIR/secret"
+
+KEY_FILE_PATH="$CONFIG_DIR/provider-eth-account-key-file.json"
+KEY_FILE_PASSWORD_PATH="$SECRETS_DIR/provider-eth-account-password"
+PRIVATE_KEY_FILE_PATH="$SECRETS_DIR/provider-eth-account-private-key"
+
+mkdir $STAKING_PROVIDER_DIR
+mkdir $SECRETS_DIR
+mkdir $CONFIG_DIR
+
+cd $STAKING_PROVIDER_DIR
+
+echo -n "$KEYFILE_PASSWORD" >"$KEY_FILE_PASSWORD_PATH"
+
+geth account new \
+    --keystore ./ \
+    --password "$KEY_FILE_PASSWORD_PATH"
+
+mv UTC-* $KEY_FILE_PATH
+
+npx eth-helper extract-private-key \
+    -k "$KEY_FILE_PATH" \
+    -p "$KEY_FILE_PASSWORD_PATH" \
+    -o "$PRIVATE_KEY_FILE_PATH"
+
+asciidoctor ../bundle-guide.adoc -o index.html --doctype book
+
+tar -zcvf keep-test-bundle-$STAKING_PROVIDER.tgz .
+
+printf "A bundle was saved: keep-test-bundle-$STAKING_PROVIDER.tgz"
+
+printf "\n\e[1;32mDONE!\n\n\e[0m"

--- a/infrastructure/eth-networks/private-testnet/scripts/new-bundle.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/new-bundle.sh
@@ -32,9 +32,9 @@ fi
 CONFIG_DIR="$STAKING_PROVIDER_DIR/config"
 SECRETS_DIR="$STAKING_PROVIDER_DIR/secret"
 
-KEY_FILE_PATH="$CONFIG_DIR/provider-eth-account-key-file.json"
-KEY_FILE_PASSWORD_PATH="$SECRETS_DIR/provider-eth-account-password"
-PRIVATE_KEY_FILE_PATH="$SECRETS_DIR/provider-eth-account-private-key"
+KEY_FILE_PATH="$CONFIG_DIR/staking-provider-eth-account-key-file.json"
+KEY_FILE_PASSWORD_PATH="$SECRETS_DIR/staking-provider-eth-account-password"
+PRIVATE_KEY_FILE_PATH="$SECRETS_DIR/staking-provider-eth-account-private-key"
 
 mkdir $STAKING_PROVIDER_DIR
 mkdir $SECRETS_DIR

--- a/infrastructure/eth-networks/private-testnet/scripts/new-bundle.sh
+++ b/infrastructure/eth-networks/private-testnet/scripts/new-bundle.sh
@@ -57,7 +57,7 @@ npx eth-helper extract-private-key \
 
 asciidoctor ../bundle-guide.adoc -o index.html --doctype book
 
-tar -zcvf keep-test-bundle-$STAKING_PROVIDER.tgz .
+tar -zcvf keep-test-bundle-$STAKING_PROVIDER.tgz --exclude *.tgz .
 
 printf "A bundle was saved: keep-test-bundle-$STAKING_PROVIDER.tgz"
 


### PR DESCRIPTION
We need to generate a bundles for the parties that are joining our
Private Testnet.

The generated bundles contains a preinitialized Ethereum Account details. The account
receives a stake delegation to the `provider` account with authorized `beacon` and
`tbtc` application. This is a production-like experience for the Staking Providers,
where they will receive stakes from their customers.

We have a scripts to create a bundle and initialize the provider
account.

Please see README.md for more details.

Depends on https://github.com/keep-network/keep-core/pull/3211