### PR TITLE
Unit tests for DKG result signatures verification phase

### DIFF
--- a/pkg/tecdsa/dkg/protocol.go
+++ b/pkg/tecdsa/dkg/protocol.go
@@ -439,12 +439,10 @@ func (sm *signingMember) signDKGResult(
 // that the public key presented in each message is the correct one.
 // This key needs to be compared against the one used by network client earlier,
 // before this function is called.
-//
-// TODO: Add unit tests.
 func (sm *signingMember) verifyDKGResultSignatures(
 	messages []*resultSignatureMessage,
 	resultSigner ResultSigner,
-) (map[group.MemberIndex][]byte, error) {
+) map[group.MemberIndex][]byte {
 	receivedValidResultSignatures := make(map[group.MemberIndex][]byte)
 
 	for _, message := range deduplicateBySender(messages) {
@@ -461,7 +459,7 @@ func (sm *signingMember) verifyDKGResultSignatures(
 		}
 
 		// Check if the signature is valid.
-		ok, err := resultSigner.VerifySignature(
+		isValid, err := resultSigner.VerifySignature(
 			&SignedResult{
 				ResultHash: message.resultHash,
 				Signature:  message.signature,
@@ -478,7 +476,7 @@ func (sm *signingMember) verifyDKGResultSignatures(
 			)
 			continue
 		}
-		if !ok {
+		if !isValid {
 			sm.logger.Infof(
 				"[member: %v] sender [%d] provided invalid signature",
 				sm.memberIndex,
@@ -493,7 +491,7 @@ func (sm *signingMember) verifyDKGResultSignatures(
 	// Register member's self signature.
 	receivedValidResultSignatures[sm.memberIndex] = sm.selfDKGResultSignature
 
-	return receivedValidResultSignatures, nil
+	return receivedValidResultSignatures
 }
 
 // submitDKGResult submits the DKG result along with the supporting signatures

--- a/pkg/tecdsa/dkg/protocol_test.go
+++ b/pkg/tecdsa/dkg/protocol_test.go
@@ -1226,6 +1226,450 @@ func TestSignDKGResult_ErrorDuringSigning(t *testing.T) {
 	}
 }
 
+func TestVerifyDKGResultSignatures(t *testing.T) {
+	signingMember := initializeSigningMember()
+	signingMember.preferredDKGResultHash = ResultHash{11: 11}
+	signingMember.selfDKGResultSignature = []byte("sign 1")
+
+	type messageWithOutcome struct {
+		message *resultSignatureMessage
+		outcome *verificationOutcome
+	}
+
+	tests := map[string]struct {
+		messagesWithOutcomes    []messageWithOutcome
+		expectedValidSignatures map[group.MemberIndex][]byte
+	}{
+		"messages from other members with valid signatures for the preferred result": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   3,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 3"),
+						publicKey:  []byte("pubKey 3"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+				2:                         []byte("sign 2"),
+				3:                         []byte("sign 3"),
+			},
+		},
+		"multiple messages from other member with different signatures for " +
+			"the preferred result and the first signature is invalid": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("bad sign"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+			},
+		},
+		"multiple messages from other member with different signatures for " +
+			"the preferred result and the first signature is valid": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("bad sign"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+				2:                         []byte("sign 2"),
+			},
+		},
+		"multiple messages from other member for different results and the " +
+			"result in the first message is different than the preferred one": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{12: 12},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+			},
+		},
+		"multiple messages from other member for different results and the " +
+			"result in the first message is the same as the preferred one": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{12: 12},
+						signature:  []byte("bad sign"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+				2:                         []byte("sign 2"),
+			},
+		},
+		"received a message from other member with signature for result " +
+			"different than preferred": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{12: 12},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+			},
+		},
+		"message from other member that causes an error during signature " +
+			"verification": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     fmt.Errorf("dummy error"),
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+			},
+		},
+		"message from other member with invalid signature": {
+			messagesWithOutcomes: []messageWithOutcome{
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("bad sign"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     nil,
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+			},
+		},
+		"mixed cases with correct and incorrect messages from other members": {
+			messagesWithOutcomes: []messageWithOutcome{
+				// multiple signatures from the same member for the preferred
+				// result - the first one is valid
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 2"),
+						publicKey:  []byte("pubKey 2"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   2,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("bad sign"),
+						publicKey:  []byte("pubKey 3"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     nil,
+					},
+				},
+				// multiple signatures from the same member for the preferred
+				// result - the first one is invalid
+				{
+					&resultSignatureMessage{
+						senderID:   3,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("bad sign"),
+						publicKey:  []byte("pubKey 3"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   3,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 3"),
+						publicKey:  []byte("pubKey 3"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				// valid signature supporting the same result as preferred
+				{
+					&resultSignatureMessage{
+						senderID:   4,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 4"),
+						publicKey:  []byte("pubKey 4"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				// member supporting different result than preferred
+				{
+					&resultSignatureMessage{
+						senderID:   5,
+						resultHash: ResultHash{12: 12},
+						signature:  []byte("sign 5"),
+						publicKey:  []byte("pubKey 5"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				// multiple messages from the same member with different results -
+				// the first one contains preferred result
+				{
+					&resultSignatureMessage{
+						senderID:   6,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 6"),
+						publicKey:  []byte("pubKey 6"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   6,
+						resultHash: ResultHash{12: 12},
+						signature:  []byte("sign 6"),
+						publicKey:  []byte("pubKey 6"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				// multiple messages from the same member with different results -
+				// the first one contains result different than the preferred one
+				{
+					&resultSignatureMessage{
+						senderID:   7,
+						resultHash: ResultHash{12: 12},
+						signature:  []byte("sign 7"),
+						publicKey:  []byte("pubKey 7"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				{
+					&resultSignatureMessage{
+						senderID:   7,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 7"),
+						publicKey:  []byte("pubKey 7"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: true,
+						err:     nil,
+					},
+				},
+				// message from member results in an error during signature
+				// verification
+				{
+					&resultSignatureMessage{
+						senderID:   8,
+						resultHash: ResultHash{11: 11},
+						signature:  []byte("sign 8"),
+						publicKey:  []byte("pubKey 8"),
+						sessionID:  "session-1",
+					},
+					&verificationOutcome{
+						isValid: false,
+						err:     fmt.Errorf("dummy error"),
+					},
+				},
+			},
+			expectedValidSignatures: map[group.MemberIndex][]byte{
+				signingMember.memberIndex: signingMember.selfDKGResultSignature,
+				2:                         []byte("sign 2"),
+				4:                         []byte("sign 4"),
+				6:                         []byte("sign 6"),
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			resultSigner := newMockResultSigner([]byte("publicKey"))
+
+			var messages []*resultSignatureMessage
+			for _, messageWithOutcome := range test.messagesWithOutcomes {
+				messages = append(messages, messageWithOutcome.message)
+				resultSigner.setVerificationOutcome(
+					messageWithOutcome.message,
+					messageWithOutcome.outcome,
+				)
+			}
+
+			validSignatures := signingMember.verifyDKGResultSignatures(
+				messages,
+				resultSigner,
+			)
+			if !reflect.DeepEqual(validSignatures, test.expectedValidSignatures) {
+				t.Errorf(
+					"unexpected valid signatures\nexpected: %v\nactual:   %v\n",
+					test.expectedValidSignatures,
+					validSignatures,
+				)
+			}
+		})
+	}
+}
+
 func TestSubmitDKGResult(t *testing.T) {
 	submittingMember := initializeSubmittingMember()
 
@@ -1643,6 +2087,7 @@ func initializeFinalizingMembersGroup(
 func initializeSigningMember() *signingMember {
 	dkgGroup := group.NewGroup(dishonestThreshold, groupSize)
 	return &signingMember{
+		logger:      &testutils.MockLogger{},
 		memberIndex: 1,
 		group:       dkgGroup,
 		sessionID:   sessionID,
@@ -1764,20 +2209,42 @@ type signingOutcome struct {
 	err        error
 }
 
+type verificationOutcome struct {
+	isValid bool
+	err     error
+}
+
 type mockResultSigner struct {
-	publicKey       []byte
-	signingOutcomes map[*Result]*signingOutcome
+	publicKey            []byte
+	signingOutcomes      map[*Result]*signingOutcome
+	verificationOutcomes map[string]*verificationOutcome
 }
 
 func newMockResultSigner(publicKey []byte) *mockResultSigner {
 	return &mockResultSigner{
-		publicKey:       publicKey,
-		signingOutcomes: make(map[*Result]*signingOutcome),
+		publicKey:            publicKey,
+		signingOutcomes:      make(map[*Result]*signingOutcome),
+		verificationOutcomes: make(map[string]*verificationOutcome),
 	}
 }
 
-func (mrs *mockResultSigner) setSigningOutcome(result *Result, outcome *signingOutcome) {
+func (mrs *mockResultSigner) setSigningOutcome(
+	result *Result,
+	outcome *signingOutcome,
+) {
 	mrs.signingOutcomes[result] = outcome
+}
+
+func (mrs *mockResultSigner) setVerificationOutcome(
+	message *resultSignatureMessage,
+	outcome *verificationOutcome,
+) {
+	key := signatureVerificationKey(
+		message.publicKey,
+		message.signature,
+		message.resultHash,
+	)
+	mrs.verificationOutcomes[key] = outcome
 }
 
 func (mrs *mockResultSigner) SignResult(result *Result) (*SignedResult, error) {
@@ -1795,7 +2262,26 @@ func (mrs *mockResultSigner) SignResult(result *Result) (*SignedResult, error) {
 }
 
 func (mrs *mockResultSigner) VerifySignature(signedResult *SignedResult) (bool, error) {
-	return false, nil
+	key := signatureVerificationKey(
+		signedResult.PublicKey,
+		signedResult.Signature,
+		signedResult.ResultHash,
+	)
+	if outcome, ok := mrs.verificationOutcomes[key]; ok {
+		return outcome.isValid, outcome.err
+	}
+
+	return false, fmt.Errorf(
+		"could not find signature verification outcome for the signed result",
+	)
+}
+
+func signatureVerificationKey(
+	publicKey []byte,
+	signature []byte,
+	resultHash ResultHash,
+) string {
+	return fmt.Sprintf("%s-%s-%s", publicKey, signature, resultHash[:])
 }
 
 type mockResultSubmitter struct {
@@ -1821,7 +2307,6 @@ func (mrs *mockResultSubmitter) SubmitResult(
 	if err, ok := mrs.submittingOutcomes[result]; ok {
 		return err
 	}
-
 	return fmt.Errorf(
 		"could not find submitting outcome for the result",
 	)

--- a/pkg/tecdsa/dkg/states.go
+++ b/pkg/tecdsa/dkg/states.go
@@ -591,15 +591,10 @@ func (svs *signaturesVerificationState) ActiveBlocks() uint64 {
 }
 
 func (svs *signaturesVerificationState) Initiate(ctx context.Context) error {
-	signatures, err := svs.member.verifyDKGResultSignatures(
+	svs.validSignatures = svs.member.verifyDKGResultSignatures(
 		svs.signatureMessages,
 		svs.resultSigner,
 	)
-	if err != nil {
-		return err
-	}
-
-	svs.validSignatures = signatures
 	return nil
 }
 


### PR DESCRIPTION
This PR is the follow-up PR to https://github.com/keep-network/keep-core/pull/3120.
Missing unit tests for `signingMember.verifyDKGResultSignatures` were added.
Additionally, made the function not return an error since it never fails and always returns a list of valid signatures.