### PR TITLE
Build client with passing the version and revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,14 @@ generate:
 	$(info Running Go code generator)
 	go generate ./...
 
+version = $(shell git describe --tags --match "v[0-9]*" HEAD)
+revision = $(shell git rev-parse --short HEAD)
+
+go_build_cmd = go build -ldflags "-X main.version=$(version) -X main.revision=$(revision)" -a -o $(1) .
+
 build:
 	$(info Building Go code)
-	go build -o keep-client -a . 
+	$(call go_build_cmd,keep-client)
 
 cmd-help: build
 	@echo '$$ keep-client start --help' > docs/development/cmd-help


### PR DESCRIPTION
The client expects version and revision to be provided on build with
`-ldflags`.

Here we use the git commands to obtain the values.

### `version`
Will be set to the latest tag on the branch, so when we
checked out a tag it will be set to the tag name, e.g. `v1.3.1`.
But if the current HEAD is not a tag it will produce a uniqe value
based on the latest tag, number of commits since the tag, and commit
hash, e.g. `v1.3.1-5816-g8219ddcf9`.

Read more: https://git-scm.com/docs/git-describe

### `revision`
Revision will be set simply to a short version of the HEAD commit hash.
Read more: https://git-scm.com/docs/git-rev-parse

## `make build` command

The `make build` command will default to the `version` and `revision` values described above. However the values can be overwritten when calling the command by simply appending the arguments: `make build version=2.0.0` or `make build version=2.0.0-dev revision=rev-123`.
