### PR TITLE
Fix getting upstream version of `random-beacon` package

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -357,7 +357,7 @@ jobs:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
             threshold-contracts-version = github.com/threshold-network/solidity-contracts#version
-            random-beacon-version = github.com/keep-network/keep-core/solidity/random-beacon#version
+            random-beacon-version = github.com/keep-network/keep-core/random-beacon#version
 
       - name: Resolve latest contracts
         run: |


### PR DESCRIPTION
We no longer use `/solidity` in the name of the `keep-core` CI modules. We
already replaced the old name with the new one, but we missed one place where
the old name was still being used. This PR fixes that.