### PR TITLE
Update default ports for Metrics and Diagnostics

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -199,7 +199,7 @@ func initMetricsFlags(cmd *cobra.Command, cfg *config.Config) {
 	cmd.Flags().IntVar(
 		&cfg.Metrics.Port,
 		"metrics.port",
-		8080,
+		9601,
 		"Metrics HTTP server listening port.",
 	)
 
@@ -223,7 +223,7 @@ func initDiagnosticsFlags(cmd *cobra.Command, cfg *config.Config) {
 	cmd.Flags().IntVar(
 		&cfg.Diagnostics.Port,
 		"diagnostics.port",
-		8081,
+		9701,
 		"Diagnostics HTTP server listening port.",
 	)
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -122,7 +122,7 @@ var cmdFlagsTests = map[string]struct {
 		flagName:              "--metrics.port",
 		flagValue:             "9870",
 		expectedValueFromFlag: 9870,
-		defaultValue:          8080,
+		defaultValue:          9601,
 	},
 	"metrics.networkMetricsTick": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Metrics.NetworkMetricsTick },
@@ -143,7 +143,7 @@ var cmdFlagsTests = map[string]struct {
 		flagName:              "--diagnostics.port",
 		flagValue:             "6089",
 		expectedValueFromFlag: 6089,
-		defaultValue:          8081,
+		defaultValue:          9701,
 	},
 	"tbtc.preParamsPoolSize": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsPoolSize },

--- a/docs/resources/docker-start-mainnet-sample
+++ b/docs/resources/docker-start-mainnet-sample
@@ -14,8 +14,8 @@ docker run \
     --log-opt max-size=100m \
     --log-opt max-file=3 \
     -p 3919:3919 \
-    -p 8080:8080 \
-    -p 8081:8081 \
+    -p 9601:9601 \
+    -p 9701:9701 \
     keepnetwork/keep-client:latest \
     start \
     --ethereum.url $ETHEREUM_WS_URL \

--- a/docs/resources/docker-start-testnet-sample
+++ b/docs/resources/docker-start-testnet-sample
@@ -14,8 +14,8 @@ docker run \
     --log-opt max-size=100m \
     --log-opt max-file=3 \
     -p 3919:3919 \
-    -p 8080:8080 \
-    -p 8081:8081 \
+    -p 9601:9601 \
+    -p 9701:9701 \
     us-docker.pkg.dev/keep-test-f3e0/public/keep-client:latest \
     start \
     --goerli \

--- a/docs/run-keep-node.adoc
+++ b/docs/run-keep-node.adoc
@@ -268,7 +268,7 @@ Exposed metrics contain the value and timestamp at which they were collected.
 
 Example metrics endpoint call result:
 ```
-$ curl localhost:8080/metrics
+$ curl localhost:9601/metrics
 # TYPE connected_peers_count gauge
 connected_peers_count 108 1623235129569
 
@@ -291,7 +291,7 @@ the port at which diagnostics endpoint is exposed.
 
 Example diagnostics endpoint call result:
 ```
-$ curl localhost:8081/diagnostics
+$ curl localhost:9701/diagnostics
 {
   "client_info" { 
    "ethereum_address":"0xDcd4199e22d09248cA2583cBDD2759b2acD22381",


### PR DESCRIPTION
Updated the default ports to:
Metrics: `9601`
Diagnostics: `9701`

These ports were used in the V1. Also the ones we have currently (`8080`
and `8081`) are not the best ones and may be confusing and clashing with
HTTP services.