### PR TITLE
Fix random beacon registration hardhat task

### DIFF
--- a/solidity/random-beacon/tasks/initialize.ts
+++ b/solidity/random-beacon/tasks/initialize.ts
@@ -126,5 +126,5 @@ task(
   .addParam("provider", "Staking Provider", undefined, types.string)
   .addParam("operator", "Staking Operator", undefined, types.string)
   .setAction(async (args, hre) => {
-    await register(hre, "RandomBeacon", args.provider, args.owner)
+    await register(hre, "RandomBeacon", args.provider, args.operator)
   })


### PR DESCRIPTION
The argument that is expected by the `register` function is an operator
not owner. We fix it.