### PR TITLE
Add Boar Network bootstrap node to Goerli peers

### DIFF
--- a/config/_peers/goerli
+++ b/config/_peers/goerli
@@ -1,2 +1,3 @@
 /dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
 /dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
+/dns4/bst-a01.test.keep.boar.network/tcp/4001/ipfs/16Uiu2HAmMosdpAuRSw1ahNhqFq8e3Y4d4c5WZkjW1FGQi5WJwWZ7

--- a/config/peers_test.go
+++ b/config/peers_test.go
@@ -20,6 +20,7 @@ func TestResolvePeers(t *testing.T) {
 			expectedPeers: []string{
 				"/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH",
 				"/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY",
+				"/dns4/bst-a01.test.keep.boar.network/tcp/4001/ipfs/16Uiu2HAmMosdpAuRSw1ahNhqFq8e3Y4d4c5WZkjW1FGQi5WJwWZ7",
 			},
 		},
 		"developer network": {


### PR DESCRIPTION
We add a bootstrap node run by the Boar Network to the list of Goerli
peers.

To test it run `keep-client start` command with `--goerli` flag and verify if the client connects to the three bootstrap nodes.