### PR TITLE
Use @nomiclabs/hardhat-etherscan for contract verification

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -274,55 +274,6 @@ jobs:
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: |
-            ./solidity/ecdsa/deployments
-            ./solidity/ecdsa/package.json
-            ./solidity/ecdsa/yarn.lock
-
-  contracts-etherscan-verification:
-    needs: [contracts-deployment-testnet]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity/ecdsa
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: ./solidity/ecdsa
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "14.x"
-          cache: "yarn"
-          cache-dependency-path: solidity/ecdsa/yarn.lock
-
-      - name: Install needed dependencies
-        run: yarn install --frozen-lockfile
-
-      # If we don't remove the artifacts from `node-modules`, the
-      # `etherscan-verify` plugins tries to verify them, which is not desired.
-      - name: Prepare for verification on Etherscan
-        run: |
-          rm -rf ./node_modules/@keep-network/random-beacon/artifacts
-          rm -rf ./node_modules/@threshold-network/solidity-contracts/artifacts
-          rm -rf ./external/npm
-
-      - name: Verify contracts on Etherscan
-        env:
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-        run: |
-          yarn run hardhat --network ${{ github.event.inputs.environment }} \
-            etherscan-verify
-
   # This job is responsible for publishing packackes with slightly modified
   # contracts. The modifications are there to help with the process of testing
   # some features on the T Token Dashboard. The job starts only if workflow

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -270,54 +270,6 @@ jobs:
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: |
-            ./solidity/random-beacon/deployments
-            ./solidity/random-beacon/package.json
-            ./solidity/random-beacon/yarn.lock
-
-  contracts-etherscan-verification:
-    needs: [contracts-deployment-testnet]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity/random-beacon
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: ./solidity/random-beacon
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "14.x"
-          cache: "yarn"
-          cache-dependency-path: solidity/random-beacon/yarn.lock
-
-      - name: Install needed dependencies
-        run: yarn install --frozen-lockfile
-
-      # If we don't remove the artifacts from `node-modules`, the
-      # `etherscan-verify` plugins tries to verify them, which is not desired.
-      - name: Prepare for verification on Etherscan
-        run: |
-          rm -rf ./node_modules/@threshold-network/solidity-contracts/artifacts
-          rm -rf ./external/npm
-
-      - name: Verify contracts on Etherscan
-        env:
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-        run: |
-          yarn run hardhat --network ${{ github.event.inputs.environment }} \
-            etherscan-verify
-
   # This job is responsible for publishing packackes with slightly modified
   # contracts. The modifications are there to help with the process of testing
   # some features on the T Token Dashboard. The job starts only if workflow

--- a/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
+++ b/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
@@ -18,6 +18,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     waitConfirmations: 1,
   })
 
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(SortitionPool)
+  }
+
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "EcdsaSortitionPool",

--- a/solidity/ecdsa/deploy/02_deploy_dkg_validator.ts
+++ b/solidity/ecdsa/deploy/02_deploy_dkg_validator.ts
@@ -2,7 +2,7 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  const { getNamedAccounts, deployments } = hre
+  const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
   const SortitionPool = await deployments.get("EcdsaSortitionPool")
@@ -13,6 +13,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
     waitConfirmations: 1,
   })
+
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(EcdsaDkgValidator)
+  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({

--- a/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
@@ -50,9 +50,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   )
 
   if (hre.network.tags.etherscan) {
-    if (hre.network.tags.etherscan) {
-      await helpers.etherscan.verify(EcdsaInactivity)
-    }
+    await helpers.etherscan.verify(EcdsaInactivity)
 
     // We use `verify` instead of `verify:verify` as the `verify` task is defined
     // in "@openzeppelin/hardhat-upgrades" to perform Etherscan verification

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -1,9 +1,10 @@
+import "@nomiclabs/hardhat-etherscan"
 import "@keep-network/hardhat-helpers"
 import "@keep-network/hardhat-local-networks-config"
 import "@nomiclabs/hardhat-waffle"
+import "@openzeppelin/hardhat-upgrades"
 import "@typechain/hardhat"
 import "hardhat-deploy"
-import "@nomiclabs/hardhat-etherscan"
 import "@tenderly/hardhat-tenderly"
 import "hardhat-contract-sizer"
 import "hardhat-dependency-compiler"
@@ -108,7 +109,7 @@ const config: HardhatUserConfig = {
       accounts: process.env.ACCOUNTS_PRIVATE_KEYS
         ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
         : undefined,
-      tags: ["tenderly"],
+      tags: ["etherscan", "tenderly"],
     },
   },
   // // Define local networks configuration file path to load networks from the file.

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.11",
+    "@keep-network/hardhat-helpers": "^0.6.0-dev.4",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-dev.4",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.14",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -24,7 +24,7 @@
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix && prettier --write '**/*.sol'",
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
-    "clean": "hardhat clean && rm -rf cache/ export/ external/npm export.json",
+    "clean": "hardhat clean && rm -rf cache/ export/ external/npm typechain/ export.json",
     "build": "hardhat compile",
     "test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_ECDSA=true hardhat test",
     "deploy": "hardhat deploy --export export.json",

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -665,10 +665,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@^0.6.0-dev.4":
-  version "0.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-dev.4.tgz#6a0536d4b0715e059283db078f5cdf6385ed0370"
-  integrity sha512-RVIeDnQ3UqCSsDkm4y8krU24a49vwYe0b87JIkvsCq8wGe6Mo5CqNYqGgAD02RKLd/dI6dii+qJ7cqAHDdIQGw==
+"@keep-network/hardhat-helpers@^0.6.0-pre.14":
+  version "0.6.0-pre.14"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.14.tgz#4e1fae3611c1cdd8417df90cc52cd3d16227bbd6"
+  integrity sha512-Eumc3TDJUO5So9G7/LY6adywY9zGYX+orkPc99ydlDn2AukhTnK9wi2wu+vooVOncKlK+Q6VZQctPms/rqnvBQ==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -665,10 +665,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.11":
-  version "0.6.0-pre.11"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.11.tgz#5f7221f3e479b368be1f191c867fe0c62438c2c1"
-  integrity sha512-Ru+mf6tXDz8awhoJdOP4reED7/HYc0Bwq2Y7YPvOiLxclOt5zzNHNGRUbMLX1B4krufgKiNeL/nxu9eTQGMJKA==
+"@keep-network/hardhat-helpers@^0.6.0-dev.4":
+  version "0.6.0-dev.4"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-dev.4.tgz#6a0536d4b0715e059283db078f5cdf6385ed0370"
+  integrity sha512-RVIeDnQ3UqCSsDkm4y8krU24a49vwYe0b87JIkvsCq8wGe6Mo5CqNYqGgAD02RKLd/dI6dii+qJ7cqAHDdIQGw==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"

--- a/solidity/random-beacon/deploy/01_deploy_reimbursement_pool.ts
+++ b/solidity/random-beacon/deploy/01_deploy_reimbursement_pool.ts
@@ -2,7 +2,7 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  const { getNamedAccounts, deployments } = hre
+  const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
   const staticGas = 40_800 // gas amount consumed by the refund() + tx cost
@@ -14,6 +14,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
     waitConfirmations: 1,
   })
+
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(ReimbursementPool, "ReimbursementPool")
+  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({

--- a/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
+++ b/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
@@ -18,6 +18,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     waitConfirmations: 1,
   })
 
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(BeaconSortitionPool)
+  }
+
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "BeaconSortitionPool",

--- a/solidity/random-beacon/deploy/03_deploy_beacon_dkg_validator.ts
+++ b/solidity/random-beacon/deploy/03_deploy_beacon_dkg_validator.ts
@@ -2,7 +2,7 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  const { getNamedAccounts, deployments } = hre
+  const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
   const BeaconSortitionPool = await deployments.get("BeaconSortitionPool")
@@ -13,6 +13,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
     waitConfirmations: 1,
   })
+
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(BeaconDkgValidator)
+  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({

--- a/solidity/random-beacon/deploy/04_deploy_random_beacon.ts
+++ b/solidity/random-beacon/deploy/04_deploy_random_beacon.ts
@@ -58,6 +58,14 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     deployer
   )
 
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(BLS)
+    await helpers.etherscan.verify(BeaconAuthorization)
+    await helpers.etherscan.verify(BeaconDkg)
+    await helpers.etherscan.verify(BeaconInactivity)
+    await helpers.etherscan.verify(RandomBeacon)
+  }
+
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "RandomBeacon",

--- a/solidity/random-beacon/deploy/07_deploy_random_beacon_governance.ts
+++ b/solidity/random-beacon/deploy/07_deploy_random_beacon_governance.ts
@@ -2,7 +2,7 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  const { getNamedAccounts, deployments } = hre
+  const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
   const RandomBeacon = await deployments.get("RandomBeacon")
@@ -18,6 +18,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
       waitConfirmations: 1,
     }
   )
+
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(RandomBeaconGovernance)
+  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -1,8 +1,8 @@
+import "@nomiclabs/hardhat-etherscan"
 import "@keep-network/hardhat-local-networks-config"
 import "@keep-network/hardhat-helpers"
 import "@nomiclabs/hardhat-ethers"
 import "hardhat-deploy"
-import "@nomiclabs/hardhat-etherscan"
 import "@tenderly/hardhat-tenderly"
 import "@nomiclabs/hardhat-waffle"
 import "hardhat-gas-reporter"
@@ -98,7 +98,7 @@ const config: HardhatUserConfig = {
       accounts: process.env.ACCOUNTS_PRIVATE_KEYS
         ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
         : undefined,
-      tags: ["tenderly"],
+      tags: ["etherscan", "tenderly"],
     },
   },
   // // Define local networks configuration file path to load networks from the file.

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -14,7 +14,7 @@
     "export.json"
   ],
   "scripts": {
-    "clean": "hardhat clean && rm -rf cache/ export/ external/npm export.json",
+    "clean": "hardhat clean && rm -rf cache/ export/ external/npm typechain/ export.json",
     "build": "hardhat compile",
     "test": "hardhat check-accounts-count && USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_BEACON=true hardhat test",
     "deploy": "hardhat deploy --export export.json",

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-dev.4",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.14",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.0",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.10",
+    "@keep-network/hardhat-helpers": "^0.6.0-dev.4",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.0",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",

--- a/solidity/random-beacon/tasks/send-eth.ts
+++ b/solidity/random-beacon/tasks/send-eth.ts
@@ -1,8 +1,10 @@
 import { task, types } from "hardhat/config"
 
-import type { BigNumber, Signer } from "ethers"
-import type { TransactionResponse } from "@ethersproject/abstract-provider"
 import { parseValue } from "./utils"
+
+import type { BigNumber } from "ethers"
+import type { TransactionResponse } from "@ethersproject/abstract-provider"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 // eslint-disable-next-line import/prefer-default-export
 export const TASK_SEND_ETH = "send-eth"
@@ -22,7 +24,7 @@ task(TASK_SEND_ETH, "Send ether to an address")
   )
   .addParam("to", "Transfer receiver address", undefined, types.string)
   .setAction(async (args, hre) => {
-    const from: Signer = args.from
+    const from: SignerWithAddress = args.from
       ? await hre.ethers.getSigner(args.from)
       : (await hre.ethers.getSigners())[0]
 

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -957,10 +957,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.10":
-  version "0.6.0-pre.10"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.10.tgz#e202e79bed99b6cbcd6e8ec13944d4bcdefbc443"
-  integrity sha512-qvSixo9bjG4vSMJjwn60DkhSpLqYI+zVf77wuEo62nXcw9nb87kcTp4VKvQhwDwCLJZCEZiDUEf8fkNeDswR7g==
+"@keep-network/hardhat-helpers@^0.6.0-dev.4":
+  version "0.6.0-dev.4"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-dev.4.tgz#6a0536d4b0715e059283db078f5cdf6385ed0370"
+  integrity sha512-RVIeDnQ3UqCSsDkm4y8krU24a49vwYe0b87JIkvsCq8wGe6Mo5CqNYqGgAD02RKLd/dI6dii+qJ7cqAHDdIQGw==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.0":
   version "0.1.0-pre.0"

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -957,10 +957,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@keep-network/hardhat-helpers@^0.6.0-dev.4":
-  version "0.6.0-dev.4"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-dev.4.tgz#6a0536d4b0715e059283db078f5cdf6385ed0370"
-  integrity sha512-RVIeDnQ3UqCSsDkm4y8krU24a49vwYe0b87JIkvsCq8wGe6Mo5CqNYqGgAD02RKLd/dI6dii+qJ7cqAHDdIQGw==
+"@keep-network/hardhat-helpers@^0.6.0-pre.14":
+  version "0.6.0-pre.14"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.14.tgz#4e1fae3611c1cdd8417df90cc52cd3d16227bbd6"
+  integrity sha512-Eumc3TDJUO5So9G7/LY6adywY9zGYX+orkPc99ydlDn2AukhTnK9wi2wu+vooVOncKlK+Q6VZQctPms/rqnvBQ==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.0":
   version "0.1.0-pre.0"


### PR DESCRIPTION
@nomiclabs/hardhat-etherscan exposes verification functions for
Etherscan that are recommended by the hardhat team.

See https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan

Previously we were using `etherscan-verify` from `hardhat-deploy`
plugin, which had some problems with verification of e.g. `RandomBeacon`
and `WalletRegistry`.

TODO:
- [x] Update CI workflows

Depends on https://github.com/keep-network/hardhat-helpers/pull/31
Depends on https://github.com/keep-network/hardhat-helpers/pull/32