### PR TITLE
Add --detach to sample docker run commands

### DIFF
--- a/docs/resources/docker-start-mainnet-sample
+++ b/docs/resources/docker-start-mainnet-sample
@@ -6,7 +6,7 @@ OPERATOR_KEY_FILE_PASSWORD="<Ethereum Key File Password>"
 CONFIG_DIR=$(pwd)/config
 STORAGE_DIR=$(pwd)/storage
 
-docker run \
+docker run --detach \
     --volume $CONFIG_DIR:/mnt/keep/config \
     --volume $STORAGE_DIR:/mnt/keep/storage \
     --env KEEP_ETHEREUM_PASSWORD=$OPERATOR_KEY_FILE_PASSWORD \

--- a/docs/resources/docker-start-testnet-sample
+++ b/docs/resources/docker-start-testnet-sample
@@ -6,7 +6,7 @@ OPERATOR_KEY_FILE_PASSWORD="<Ethereum Key File Password>"
 CONFIG_DIR=$(pwd)/config
 STORAGE_DIR=$(pwd)/storage
 
-docker run \
+docker run --detach \
     --volume $CONFIG_DIR:/mnt/keep/config \
     --volume $STORAGE_DIR:/mnt/keep/storage \
     --env KEEP_ETHEREUM_PASSWORD=$OPERATOR_KEY_FILE_PASSWORD \


### PR DESCRIPTION
The container could be run in a detached mode so it's not quiting when
an user closes the terminal.