### PR TITLE
tECDSA signing: TSS round 2

### DIFF
--- a/pkg/tecdsa/signing/gen/pb/message.pb.go
+++ b/pkg/tecdsa/signing/gen/pb/message.pb.go
@@ -152,17 +152,78 @@ func (m *TSSRoundOneMessage) GetSessionID() string {
 	return ""
 }
 
+type TSSRoundTwoMessage struct {
+	SenderID     uint32            `protobuf:"varint,1,opt,name=senderID,proto3" json:"senderID,omitempty"`
+	PeersPayload map[uint32][]byte `protobuf:"bytes,2,rep,name=peersPayload,proto3" json:"peersPayload,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	SessionID    string            `protobuf:"bytes,3,opt,name=sessionID,proto3" json:"sessionID,omitempty"`
+}
+
+func (m *TSSRoundTwoMessage) Reset()      { *m = TSSRoundTwoMessage{} }
+func (*TSSRoundTwoMessage) ProtoMessage() {}
+func (*TSSRoundTwoMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8447775385e7eb85, []int{2}
+}
+func (m *TSSRoundTwoMessage) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TSSRoundTwoMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TSSRoundTwoMessage.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TSSRoundTwoMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TSSRoundTwoMessage.Merge(m, src)
+}
+func (m *TSSRoundTwoMessage) XXX_Size() int {
+	return m.Size()
+}
+func (m *TSSRoundTwoMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_TSSRoundTwoMessage.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TSSRoundTwoMessage proto.InternalMessageInfo
+
+func (m *TSSRoundTwoMessage) GetSenderID() uint32 {
+	if m != nil {
+		return m.SenderID
+	}
+	return 0
+}
+
+func (m *TSSRoundTwoMessage) GetPeersPayload() map[uint32][]byte {
+	if m != nil {
+		return m.PeersPayload
+	}
+	return nil
+}
+
+func (m *TSSRoundTwoMessage) GetSessionID() string {
+	if m != nil {
+		return m.SessionID
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*EphemeralPublicKeyMessage)(nil), "signing.EphemeralPublicKeyMessage")
 	proto.RegisterMapType((map[uint32][]byte)(nil), "signing.EphemeralPublicKeyMessage.EphemeralPublicKeysEntry")
 	proto.RegisterType((*TSSRoundOneMessage)(nil), "signing.TSSRoundOneMessage")
 	proto.RegisterMapType((map[uint32][]byte)(nil), "signing.TSSRoundOneMessage.PeersPayloadEntry")
+	proto.RegisterType((*TSSRoundTwoMessage)(nil), "signing.TSSRoundTwoMessage")
+	proto.RegisterMapType((map[uint32][]byte)(nil), "signing.TSSRoundTwoMessage.PeersPayloadEntry")
 }
 
 func init() { proto.RegisterFile("pb/message.proto", fileDescriptor_8447775385e7eb85) }
 
 var fileDescriptor_8447775385e7eb85 = []byte{
-	// 344 bytes of a gzipped FileDescriptorProto
+	// 369 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x28, 0x48, 0xd2, 0xcf,
 	0x4d, 0x2d, 0x2e, 0x4e, 0x4c, 0x4f, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x2f, 0xce,
 	0x4c, 0xcf, 0xcb, 0xcc, 0x4b, 0x57, 0xea, 0x61, 0xe2, 0x92, 0x74, 0x2d, 0xc8, 0x48, 0xcd, 0x4d,
@@ -179,12 +240,14 @@ var fileDescriptor_8447775385e7eb85 = []byte{
 	0xc5, 0x25, 0x01, 0x89, 0x95, 0x39, 0xf9, 0x89, 0x29, 0x50, 0x73, 0x31, 0xc4, 0x85, 0x02, 0xb9,
 	0x78, 0x0a, 0x52, 0x53, 0x8b, 0x8a, 0x61, 0xea, 0x98, 0xc1, 0x81, 0xa5, 0x0b, 0x0f, 0x2c, 0x4c,
 	0xab, 0xf5, 0x02, 0x90, 0xd4, 0x43, 0x82, 0x07, 0xc5, 0x08, 0xd4, 0x70, 0x61, 0x41, 0x0f, 0x17,
-	0x7b, 0x2e, 0x41, 0x0c, 0x03, 0x48, 0x09, 0x10, 0x27, 0x8b, 0x0b, 0x0f, 0xe5, 0x18, 0x6e, 0x3c,
-	0x94, 0x63, 0xf8, 0xf0, 0x50, 0x8e, 0xb1, 0xe1, 0x91, 0x1c, 0xe3, 0x8a, 0x47, 0x72, 0x8c, 0x27,
-	0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x8b, 0x47, 0x72, 0x0c,
-	0x1f, 0x1e, 0xc9, 0x31, 0x4e, 0x78, 0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72,
-	0x0c, 0x51, 0x4c, 0x05, 0x49, 0x49, 0x6c, 0xe0, 0x94, 0x66, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff,
-	0x39, 0x54, 0x7d, 0xbd, 0x7d, 0x02, 0x00, 0x00,
+	0x7b, 0x2e, 0x41, 0x0c, 0x03, 0x48, 0x0a, 0x90, 0x47, 0x8c, 0x88, 0x00, 0x09, 0x29, 0xcf, 0x27,
+	0x26, 0x40, 0xd0, 0x3d, 0xc9, 0x84, 0xc3, 0x93, 0x08, 0xe3, 0x48, 0xf3, 0x24, 0x33, 0xb5, 0x3d,
+	0xe9, 0x64, 0x71, 0xe1, 0xa1, 0x1c, 0xc3, 0x8d, 0x87, 0x72, 0x0c, 0x1f, 0x1e, 0xca, 0x31, 0x36,
+	0x3c, 0x92, 0x63, 0x5c, 0xf1, 0x48, 0x8e, 0xf1, 0xc4, 0x23, 0x39, 0xc6, 0x0b, 0x8f, 0xe4, 0x18,
+	0x1f, 0x3c, 0x92, 0x63, 0x7c, 0xf1, 0x48, 0x8e, 0xe1, 0xc3, 0x23, 0x39, 0xc6, 0x09, 0x8f, 0xe5,
+	0x18, 0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1, 0x58, 0x8e, 0x21, 0x8a, 0xa9, 0x20, 0x29, 0x89, 0x0d,
+	0x9c, 0x9d, 0x8c, 0x01, 0x01, 0x00, 0x00, 0xff, 0xff, 0x53, 0x08, 0x7d, 0x05, 0x62, 0x03, 0x00,
+	0x00,
 }
 
 func (this *EphemeralPublicKeyMessage) Equal(that interface{}) bool {
@@ -260,6 +323,41 @@ func (this *TSSRoundOneMessage) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *TSSRoundTwoMessage) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*TSSRoundTwoMessage)
+	if !ok {
+		that2, ok := that.(TSSRoundTwoMessage)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.SenderID != that1.SenderID {
+		return false
+	}
+	if len(this.PeersPayload) != len(that1.PeersPayload) {
+		return false
+	}
+	for i := range this.PeersPayload {
+		if !bytes.Equal(this.PeersPayload[i], that1.PeersPayload[i]) {
+			return false
+		}
+	}
+	if this.SessionID != that1.SessionID {
+		return false
+	}
+	return true
+}
 func (this *EphemeralPublicKeyMessage) GoString() string {
 	if this == nil {
 		return "nil"
@@ -292,6 +390,30 @@ func (this *TSSRoundOneMessage) GoString() string {
 	s = append(s, "&pb.TSSRoundOneMessage{")
 	s = append(s, "SenderID: "+fmt.Sprintf("%#v", this.SenderID)+",\n")
 	s = append(s, "BroadcastPayload: "+fmt.Sprintf("%#v", this.BroadcastPayload)+",\n")
+	keysForPeersPayload := make([]uint32, 0, len(this.PeersPayload))
+	for k, _ := range this.PeersPayload {
+		keysForPeersPayload = append(keysForPeersPayload, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Uint32s(keysForPeersPayload)
+	mapStringForPeersPayload := "map[uint32][]byte{"
+	for _, k := range keysForPeersPayload {
+		mapStringForPeersPayload += fmt.Sprintf("%#v: %#v,", k, this.PeersPayload[k])
+	}
+	mapStringForPeersPayload += "}"
+	if this.PeersPayload != nil {
+		s = append(s, "PeersPayload: "+mapStringForPeersPayload+",\n")
+	}
+	s = append(s, "SessionID: "+fmt.Sprintf("%#v", this.SessionID)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *TSSRoundTwoMessage) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&pb.TSSRoundTwoMessage{")
+	s = append(s, "SenderID: "+fmt.Sprintf("%#v", this.SenderID)+",\n")
 	keysForPeersPayload := make([]uint32, 0, len(this.PeersPayload))
 	for k, _ := range this.PeersPayload {
 		keysForPeersPayload = append(keysForPeersPayload, k)
@@ -432,6 +554,60 @@ func (m *TSSRoundOneMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TSSRoundTwoMessage) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TSSRoundTwoMessage) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TSSRoundTwoMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.SessionID) > 0 {
+		i -= len(m.SessionID)
+		copy(dAtA[i:], m.SessionID)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.SessionID)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.PeersPayload) > 0 {
+		for k := range m.PeersPayload {
+			v := m.PeersPayload[k]
+			baseI := i
+			if len(v) > 0 {
+				i -= len(v)
+				copy(dAtA[i:], v)
+				i = encodeVarintMessage(dAtA, i, uint64(len(v)))
+				i--
+				dAtA[i] = 0x12
+			}
+			i = encodeVarintMessage(dAtA, i, uint64(k))
+			i--
+			dAtA[i] = 0x8
+			i = encodeVarintMessage(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.SenderID != 0 {
+		i = encodeVarintMessage(dAtA, i, uint64(m.SenderID))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintMessage(dAtA []byte, offset int, v uint64) int {
 	offset -= sovMessage(v)
 	base := offset
@@ -503,6 +679,34 @@ func (m *TSSRoundOneMessage) Size() (n int) {
 	return n
 }
 
+func (m *TSSRoundTwoMessage) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SenderID != 0 {
+		n += 1 + sovMessage(uint64(m.SenderID))
+	}
+	if len(m.PeersPayload) > 0 {
+		for k, v := range m.PeersPayload {
+			_ = k
+			_ = v
+			l = 0
+			if len(v) > 0 {
+				l = 1 + len(v) + sovMessage(uint64(len(v)))
+			}
+			mapEntrySize := 1 + sovMessage(uint64(k)) + l
+			n += mapEntrySize + 1 + sovMessage(uint64(mapEntrySize))
+		}
+	}
+	l = len(m.SessionID)
+	if l > 0 {
+		n += 1 + l + sovMessage(uint64(l))
+	}
+	return n
+}
+
 func sovMessage(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -548,6 +752,28 @@ func (this *TSSRoundOneMessage) String() string {
 	s := strings.Join([]string{`&TSSRoundOneMessage{`,
 		`SenderID:` + fmt.Sprintf("%v", this.SenderID) + `,`,
 		`BroadcastPayload:` + fmt.Sprintf("%v", this.BroadcastPayload) + `,`,
+		`PeersPayload:` + mapStringForPeersPayload + `,`,
+		`SessionID:` + fmt.Sprintf("%v", this.SessionID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *TSSRoundTwoMessage) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForPeersPayload := make([]uint32, 0, len(this.PeersPayload))
+	for k, _ := range this.PeersPayload {
+		keysForPeersPayload = append(keysForPeersPayload, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Uint32s(keysForPeersPayload)
+	mapStringForPeersPayload := "map[uint32][]byte{"
+	for _, k := range keysForPeersPayload {
+		mapStringForPeersPayload += fmt.Sprintf("%v: %v,", k, this.PeersPayload[k])
+	}
+	mapStringForPeersPayload += "}"
+	s := strings.Join([]string{`&TSSRoundTwoMessage{`,
+		`SenderID:` + fmt.Sprintf("%v", this.SenderID) + `,`,
 		`PeersPayload:` + mapStringForPeersPayload + `,`,
 		`SessionID:` + fmt.Sprintf("%v", this.SessionID) + `,`,
 		`}`,
@@ -974,6 +1200,221 @@ func (m *TSSRoundOneMessage) Unmarshal(dAtA []byte) error {
 			m.PeersPayload[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SessionID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SessionID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMessage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TSSRoundTwoMessage) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMessage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TSSRoundTwoMessage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TSSRoundTwoMessage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SenderID", wireType)
+			}
+			m.SenderID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SenderID |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PeersPayload", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.PeersPayload == nil {
+				m.PeersPayload = make(map[uint32][]byte)
+			}
+			var mapkey uint32
+			mapvalue := []byte{}
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowMessage
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowMessage
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapkey |= uint32(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+				} else if fieldNum == 2 {
+					var mapbyteLen uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowMessage
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapbyteLen |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intMapbyteLen := int(mapbyteLen)
+					if intMapbyteLen < 0 {
+						return ErrInvalidLengthMessage
+					}
+					postbytesIndex := iNdEx + intMapbyteLen
+					if postbytesIndex < 0 {
+						return ErrInvalidLengthMessage
+					}
+					if postbytesIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = make([]byte, mapbyteLen)
+					copy(mapvalue, dAtA[iNdEx:postbytesIndex])
+					iNdEx = postbytesIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipMessage(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthMessage
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.PeersPayload[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SessionID", wireType)
 			}

--- a/pkg/tecdsa/signing/gen/pb/message.proto
+++ b/pkg/tecdsa/signing/gen/pb/message.proto
@@ -15,3 +15,9 @@ message TSSRoundOneMessage {
     map<uint32, bytes> peersPayload = 3;
     string sessionID = 4;
 }
+
+message TSSRoundTwoMessage {
+    uint32 senderID = 1;
+    map<uint32, bytes> peersPayload = 2;
+    string sessionID = 3;
+}

--- a/pkg/tecdsa/signing/marshaling.go
+++ b/pkg/tecdsa/signing/marshaling.go
@@ -90,6 +90,48 @@ func (trom *tssRoundOneMessage) Unmarshal(bytes []byte) error {
 	return nil
 }
 
+// Marshal converts this tssRoundTwoMessage to a byte array suitable for
+// network communication.
+func (trtm *tssRoundTwoMessage) Marshal() ([]byte, error) {
+	peersPayload := make(map[uint32][]byte, len(trtm.peersPayload))
+	for receiverID, payload := range trtm.peersPayload {
+		peersPayload[uint32(receiverID)] = payload
+	}
+
+	return (&pb.TSSRoundTwoMessage{
+		SenderID:         uint32(trtm.senderID),
+		PeersPayload:     peersPayload,
+		SessionID:        trtm.sessionID,
+	}).Marshal()
+}
+
+// Unmarshal converts a byte array produced by Marshal to an tssRoundTwoMessage.
+func (trtm *tssRoundTwoMessage) Unmarshal(bytes []byte) error {
+	pbMsg := pb.TSSRoundTwoMessage{}
+	if err := pbMsg.Unmarshal(bytes); err != nil {
+		return err
+	}
+
+	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+		return err
+	}
+
+	peersPayload := make(map[group.MemberIndex][]byte, len(pbMsg.PeersPayload))
+	for receiverID, payload := range pbMsg.PeersPayload {
+		if err := validateMemberIndex(receiverID); err != nil {
+			return err
+		}
+
+		peersPayload[group.MemberIndex(receiverID)] = payload
+	}
+
+	trtm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trtm.peersPayload = peersPayload
+	trtm.sessionID = pbMsg.SessionID
+
+	return nil
+}
+
 func validateMemberIndex(protoIndex uint32) error {
 	// Protobuf does not have uint8 type, so we are using uint32. When
 	// unmarshalling message, we need to make sure we do not overflow.

--- a/pkg/tecdsa/signing/marshaling_test.go
+++ b/pkg/tecdsa/signing/marshaling_test.go
@@ -125,3 +125,54 @@ func TestFuzzTssRoundOneMessage_MarshalingRoundtrip(t *testing.T) {
 func TestFuzzTssRoundOneMessage_Unmarshaler(t *testing.T) {
 	pbutils.FuzzUnmarshaler(&tssRoundOneMessage{})
 }
+
+func TestTssRoundTwoMessage_MarshalingRoundtrip(t *testing.T) {
+	msg := &tssRoundTwoMessage{
+		senderID:     group.MemberIndex(50),
+		peersPayload: map[group.MemberIndex][]byte{
+			1: {6, 7, 8, 9, 10},
+			2: {11, 12, 13, 14, 15},
+		},
+		sessionID:    "session-1",
+	}
+	unmarshaled := &tssRoundTwoMessage{}
+
+	err := pbutils.RoundTrip(msg, unmarshaled)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(msg, unmarshaled) {
+		t.Fatalf("unexpected content of unmarshaled message")
+	}
+}
+
+func TestFuzzTssRoundTwoMessage_MarshalingRoundtrip(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		var (
+			senderID     group.MemberIndex
+			peersPayload map[group.MemberIndex][]byte
+			sessionID    string
+		)
+
+		f := fuzz.New().NilChance(0.1).
+			NumElements(0, 512).
+			Funcs(pbutils.FuzzFuncs()...)
+
+		f.Fuzz(&senderID)
+		f.Fuzz(&peersPayload)
+		f.Fuzz(&sessionID)
+
+		message := &tssRoundTwoMessage{
+			senderID:         senderID,
+			peersPayload:     peersPayload,
+			sessionID:        sessionID,
+		}
+
+		_ = pbutils.RoundTrip(message, &tssRoundTwoMessage{})
+	}
+}
+
+func TestFuzzTssRoundTwoMessage_Unmarshaler(t *testing.T) {
+	pbutils.FuzzUnmarshaler(&tssRoundTwoMessage{})
+}

--- a/pkg/tecdsa/signing/member.go
+++ b/pkg/tecdsa/signing/member.go
@@ -177,3 +177,29 @@ type tssRoundOneMember struct {
 	tssOutgoingMessagesChan <-chan tss.Message
 	tssResultChan           <-chan tsslibcommon.SignatureData
 }
+
+// initializeTssRoundTwo returns a member to perform next protocol operations.
+func (trom *tssRoundOneMember) initializeTssRoundTwo() *tssRoundTwoMember {
+	return &tssRoundTwoMember{
+		tssRoundOneMember: trom,
+	}
+}
+
+// tssRoundTwoMember represents one member in a signing group performing the
+// second round of the TSS keygen.
+type tssRoundTwoMember struct {
+	*tssRoundOneMember
+}
+
+// MarkInactiveMembers takes all messages from the previous signing protocol
+// execution phase and marks all member who did not send a message as inactive.
+func (trtm *tssRoundTwoMember) MarkInactiveMembers(
+	tssRoundOneMessages []*tssRoundOneMessage,
+) {
+	filter := trtm.inactiveMemberFilter()
+	for _, message := range tssRoundOneMessages {
+		filter.MarkMemberAsActive(message.senderID)
+	}
+
+	filter.FlushInactiveMembers()
+}

--- a/pkg/tecdsa/signing/message.go
+++ b/pkg/tecdsa/signing/message.go
@@ -51,3 +51,23 @@ func (trom *tssRoundOneMessage) SenderID() group.MemberIndex {
 func (trom *tssRoundOneMessage) Type() string {
 	return messageTypePrefix + "tss_round_one_message"
 }
+
+// tssRoundTwoMessage is a message payload that carries the sender's
+// TSS round two components.
+type tssRoundTwoMessage struct {
+	senderID group.MemberIndex
+
+	peersPayload     map[group.MemberIndex][]byte
+	sessionID        string
+}
+
+// SenderID returns protocol-level identifier of the message sender.
+func (trtm *tssRoundTwoMessage) SenderID() group.MemberIndex {
+	return trtm.senderID
+}
+
+// Type returns a string describing an tssRoundTwoMessage type for
+// marshaling purposes.
+func (trtm *tssRoundTwoMessage) Type() string {
+	return messageTypePrefix + "tss_round_two_message"
+}

--- a/pkg/tecdsa/signing/signing.go
+++ b/pkg/tecdsa/signing/signing.go
@@ -68,7 +68,7 @@ func Execute(
 		return nil, err
 	}
 
-	_, ok := lastState.(*tssRoundOneState)
+	_, ok := lastState.(*tssRoundTwoState)
 	if !ok {
 		return nil, fmt.Errorf("execution ended on state: %T", lastState)
 	}


### PR DESCRIPTION
Refs: #3042

Here we implement the TSS round two for the tECDSA signing protocol. This round expects aggregate messages produced in TSS round one as input. Each input message consists of a public broadcast part and encrypted parts intended for specific participants. The TSS round two produces an aggregate message as output. The output message has only the encrypted point-to-point parts and, unlike the previous round output, does not contain the public broadcast part.

### Next steps

This PR is just a part of the entire work regarding the tECDSA signing test loop. Please refer to the description of https://github.com/keep-network/keep-core/issues/3042 for the full roadmap and the current status of the work. At this point, the next step will be introducing the third round of TSS signing.