### PR TITLE
Update port in the Private Testnet bundle's metrics command

### DIFF
--- a/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
+++ b/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
@@ -5,6 +5,14 @@
 :source-highlighter: rouge
 :icons: font
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 = Keep Network Private Testnet Bundle
 
 Use this bundle to setup Keep Network node running on Keep Network Private Testnet.

--- a/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
+++ b/infrastructure/eth-networks/private-testnet/bundles/bundle-guide.adoc
@@ -79,10 +79,12 @@ link:https://docs.keep.network/run-keep-node.html#testnet[Testnet documentation]
 
 === Validate
 
-To validate the running client check the metrics for the number of connected peers.
+To validate the running client check the metrics for the number of connected peers
+(`connected_peers_count`).
+
 The client should connect to the bootstrap nodes (at least 2) and other nodes that
 are working in the network. There should be at least 10 connections.
 
 ```
-curl localhost:8081/metrics
+curl localhost:9601/metrics
 ```


### PR DESCRIPTION
We updated the default port for metrics to `9601` but missed the bundle
guide to be updated.