### PR TITLE
Remove jobs veryfying contracts on Etherscan

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -274,55 +274,6 @@ jobs:
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: |
-            ./solidity/ecdsa/deployments
-            ./solidity/ecdsa/package.json
-            ./solidity/ecdsa/yarn.lock
-
-  contracts-etherscan-verification:
-    needs: [contracts-deployment-testnet]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity/ecdsa
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: ./solidity/ecdsa
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "14.x"
-          cache: "yarn"
-          cache-dependency-path: solidity/ecdsa/yarn.lock
-
-      - name: Install needed dependencies
-        run: yarn install --frozen-lockfile
-
-      # If we don't remove the artifacts from `node-modules`, the
-      # `etherscan-verify` plugins tries to verify them, which is not desired.
-      - name: Prepare for verification on Etherscan
-        run: |
-          rm -rf ./node_modules/@keep-network/random-beacon/artifacts
-          rm -rf ./node_modules/@threshold-network/solidity-contracts/artifacts
-          rm -rf ./external/npm
-
-      - name: Verify contracts on Etherscan
-        env:
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-        run: |
-          yarn run hardhat --network ${{ github.event.inputs.environment }} \
-            etherscan-verify
-
   # This job is responsible for publishing packackes with slightly modified
   # contracts. The modifications are there to help with the process of testing
   # some features on the T Token Dashboard. The job starts only if workflow

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -270,54 +270,6 @@ jobs:
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: |
-            ./solidity/random-beacon/deployments
-            ./solidity/random-beacon/package.json
-            ./solidity/random-beacon/yarn.lock
-
-  contracts-etherscan-verification:
-    needs: [contracts-deployment-testnet]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity/random-beacon
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
-        with:
-          name: Artifacts for etherscan verifcation
-          path: ./solidity/random-beacon
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "14.x"
-          cache: "yarn"
-          cache-dependency-path: solidity/random-beacon/yarn.lock
-
-      - name: Install needed dependencies
-        run: yarn install --frozen-lockfile
-
-      # If we don't remove the artifacts from `node-modules`, the
-      # `etherscan-verify` plugins tries to verify them, which is not desired.
-      - name: Prepare for verification on Etherscan
-        run: |
-          rm -rf ./node_modules/@threshold-network/solidity-contracts/artifacts
-          rm -rf ./external/npm
-
-      - name: Verify contracts on Etherscan
-        env:
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-        run: |
-          yarn run hardhat --network ${{ github.event.inputs.environment }} \
-            etherscan-verify
-
   # This job is responsible for publishing packackes with slightly modified
   # contracts. The modifications are there to help with the process of testing
   # some features on the T Token Dashboard. The job starts only if workflow


### PR DESCRIPTION
We're switching to a different method of contracts verification on Etherscan.
Instad of veryfying contracts using `hardhat-deploy` plugin (which had problems
with verifying some contracts), we're doing that using
`@nomiclabs/hardhat-ethers` plugin. The use of new plugin was already added in a
different PR/commits. With that new plugin the contracts get verified during the
deployment step, this means that we don't need the
`contracts-etherscan-verification` job anymore in the CI workflows.
We're not removing the `hardhat-deploy` plugin, because it is still used for
contracts deployment.

Ref:
https://github.com/keep-network/keep-core/pull/3235