### PR TITLE
tECDSA signing: TSS round 7

### DIFF
--- a/pkg/tecdsa/signing/gen/pb/message.pb.go
+++ b/pkg/tecdsa/signing/gen/pb/message.pb.go
@@ -447,6 +447,65 @@ func (m *TSSRoundSixMessage) GetSessionID() string {
 	return ""
 }
 
+type TSSRoundSevenMessage struct {
+	SenderID  uint32 `protobuf:"varint,1,opt,name=senderID,proto3" json:"senderID,omitempty"`
+	Payload   []byte `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
+	SessionID string `protobuf:"bytes,3,opt,name=sessionID,proto3" json:"sessionID,omitempty"`
+}
+
+func (m *TSSRoundSevenMessage) Reset()      { *m = TSSRoundSevenMessage{} }
+func (*TSSRoundSevenMessage) ProtoMessage() {}
+func (*TSSRoundSevenMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8447775385e7eb85, []int{7}
+}
+func (m *TSSRoundSevenMessage) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TSSRoundSevenMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TSSRoundSevenMessage.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TSSRoundSevenMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TSSRoundSevenMessage.Merge(m, src)
+}
+func (m *TSSRoundSevenMessage) XXX_Size() int {
+	return m.Size()
+}
+func (m *TSSRoundSevenMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_TSSRoundSevenMessage.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TSSRoundSevenMessage proto.InternalMessageInfo
+
+func (m *TSSRoundSevenMessage) GetSenderID() uint32 {
+	if m != nil {
+		return m.SenderID
+	}
+	return 0
+}
+
+func (m *TSSRoundSevenMessage) GetPayload() []byte {
+	if m != nil {
+		return m.Payload
+	}
+	return nil
+}
+
+func (m *TSSRoundSevenMessage) GetSessionID() string {
+	if m != nil {
+		return m.SessionID
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*EphemeralPublicKeyMessage)(nil), "signing.EphemeralPublicKeyMessage")
 	proto.RegisterMapType((map[uint32][]byte)(nil), "signing.EphemeralPublicKeyMessage.EphemeralPublicKeysEntry")
@@ -458,12 +517,13 @@ func init() {
 	proto.RegisterType((*TSSRoundFourMessage)(nil), "signing.TSSRoundFourMessage")
 	proto.RegisterType((*TSSRoundFiveMessage)(nil), "signing.TSSRoundFiveMessage")
 	proto.RegisterType((*TSSRoundSixMessage)(nil), "signing.TSSRoundSixMessage")
+	proto.RegisterType((*TSSRoundSevenMessage)(nil), "signing.TSSRoundSevenMessage")
 }
 
 func init() { proto.RegisterFile("pb/message.proto", fileDescriptor_8447775385e7eb85) }
 
 var fileDescriptor_8447775385e7eb85 = []byte{
-	// 417 bytes of a gzipped FileDescriptorProto
+	// 427 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x28, 0x48, 0xd2, 0xcf,
 	0x4d, 0x2d, 0x2e, 0x4e, 0x4c, 0x4f, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x2f, 0xce,
 	0x4c, 0xcf, 0xcb, 0xcc, 0x4b, 0x57, 0xea, 0x61, 0xe2, 0x92, 0x74, 0x2d, 0xc8, 0x48, 0xcd, 0x4d,
@@ -484,13 +544,13 @@ var fileDescriptor_8447775385e7eb85 = []byte{
 	0x26, 0x40, 0xd0, 0x3d, 0xc9, 0x84, 0xc3, 0x93, 0x08, 0xe3, 0x48, 0xf3, 0x24, 0x33, 0xd5, 0x3d,
 	0x99, 0xc5, 0x25, 0x02, 0x77, 0x54, 0x46, 0x51, 0x2a, 0x51, 0xd1, 0x2e, 0xc1, 0xc5, 0x5e, 0x80,
 	0x12, 0xdb, 0x30, 0x2e, 0x7e, 0xc7, 0x2a, 0x65, 0x72, 0x09, 0xc3, 0xec, 0x72, 0xcb, 0x2f, 0x2d,
-	0xa2, 0x97, 0x55, 0x99, 0x65, 0x34, 0xf5, 0x55, 0x06, 0x22, 0x95, 0x04, 0x67, 0x56, 0xd0, 0xd0,
-	0x26, 0x27, 0x8b, 0x0b, 0x0f, 0xe5, 0x18, 0x6e, 0x3c, 0x94, 0x63, 0xf8, 0xf0, 0x50, 0x8e, 0xb1,
-	0xe1, 0x91, 0x1c, 0xe3, 0x8a, 0x47, 0x72, 0x8c, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7,
-	0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x8b, 0x47, 0x72, 0x0c, 0x1f, 0x1e, 0xc9, 0x31, 0x4e, 0x78, 0x2c,
-	0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x51, 0x4c, 0x05, 0x49, 0x49, 0x6c,
-	0xe0, 0xa2, 0xcf, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0x37, 0xf0, 0xf3, 0x49, 0x0e, 0x05, 0x00,
-	0x00,
+	0xa2, 0x97, 0x55, 0x99, 0x65, 0x34, 0xf5, 0x55, 0x06, 0x22, 0x95, 0x04, 0x67, 0x56, 0xd0, 0xd2,
+	0x26, 0xa4, 0xb8, 0x0a, 0x4e, 0x2d, 0x4b, 0xcd, 0xa3, 0xa1, 0x5d, 0x4e, 0x16, 0x17, 0x1e, 0xca,
+	0x31, 0xdc, 0x78, 0x28, 0xc7, 0xf0, 0xe1, 0xa1, 0x1c, 0x63, 0xc3, 0x23, 0x39, 0xc6, 0x15, 0x8f,
+	0xe4, 0x18, 0x4f, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x17,
+	0x8f, 0xe4, 0x18, 0x3e, 0x3c, 0x92, 0x63, 0x9c, 0xf0, 0x58, 0x8e, 0xe1, 0xc2, 0x63, 0x39, 0x86,
+	0x1b, 0x8f, 0xe5, 0x18, 0xa2, 0x98, 0x0a, 0x92, 0x92, 0xd8, 0xc0, 0xc5, 0xac, 0x31, 0x20, 0x00,
+	0x00, 0xff, 0xff, 0xff, 0xd4, 0x27, 0x0d, 0x7a, 0x05, 0x00, 0x00,
 }
 
 func (this *EphemeralPublicKeyMessage) Equal(that interface{}) bool {
@@ -721,6 +781,36 @@ func (this *TSSRoundSixMessage) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *TSSRoundSevenMessage) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*TSSRoundSevenMessage)
+	if !ok {
+		that2, ok := that.(TSSRoundSevenMessage)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.SenderID != that1.SenderID {
+		return false
+	}
+	if !bytes.Equal(this.Payload, that1.Payload) {
+		return false
+	}
+	if this.SessionID != that1.SessionID {
+		return false
+	}
+	return true
+}
 func (this *EphemeralPublicKeyMessage) GoString() string {
 	if this == nil {
 		return "nil"
@@ -836,6 +926,18 @@ func (this *TSSRoundSixMessage) GoString() string {
 	}
 	s := make([]string, 0, 7)
 	s = append(s, "&pb.TSSRoundSixMessage{")
+	s = append(s, "SenderID: "+fmt.Sprintf("%#v", this.SenderID)+",\n")
+	s = append(s, "Payload: "+fmt.Sprintf("%#v", this.Payload)+",\n")
+	s = append(s, "SessionID: "+fmt.Sprintf("%#v", this.SessionID)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *TSSRoundSevenMessage) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&pb.TSSRoundSevenMessage{")
 	s = append(s, "SenderID: "+fmt.Sprintf("%#v", this.SenderID)+",\n")
 	s = append(s, "Payload: "+fmt.Sprintf("%#v", this.Payload)+",\n")
 	s = append(s, "SessionID: "+fmt.Sprintf("%#v", this.SessionID)+",\n")
@@ -1187,6 +1289,48 @@ func (m *TSSRoundSixMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TSSRoundSevenMessage) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TSSRoundSevenMessage) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TSSRoundSevenMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.SessionID) > 0 {
+		i -= len(m.SessionID)
+		copy(dAtA[i:], m.SessionID)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.SessionID)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Payload) > 0 {
+		i -= len(m.Payload)
+		copy(dAtA[i:], m.Payload)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.Payload)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.SenderID != 0 {
+		i = encodeVarintMessage(dAtA, i, uint64(m.SenderID))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintMessage(dAtA []byte, offset int, v uint64) int {
 	offset -= sovMessage(v)
 	base := offset
@@ -1366,6 +1510,26 @@ func (m *TSSRoundSixMessage) Size() (n int) {
 	return n
 }
 
+func (m *TSSRoundSevenMessage) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SenderID != 0 {
+		n += 1 + sovMessage(uint64(m.SenderID))
+	}
+	l = len(m.Payload)
+	if l > 0 {
+		n += 1 + l + sovMessage(uint64(l))
+	}
+	l = len(m.SessionID)
+	if l > 0 {
+		n += 1 + l + sovMessage(uint64(l))
+	}
+	return n
+}
+
 func sovMessage(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -1480,6 +1644,18 @@ func (this *TSSRoundSixMessage) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&TSSRoundSixMessage{`,
+		`SenderID:` + fmt.Sprintf("%v", this.SenderID) + `,`,
+		`Payload:` + fmt.Sprintf("%v", this.Payload) + `,`,
+		`SessionID:` + fmt.Sprintf("%v", this.SessionID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *TSSRoundSevenMessage) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&TSSRoundSevenMessage{`,
 		`SenderID:` + fmt.Sprintf("%v", this.SenderID) + `,`,
 		`Payload:` + fmt.Sprintf("%v", this.Payload) + `,`,
 		`SessionID:` + fmt.Sprintf("%v", this.SessionID) + `,`,
@@ -2606,6 +2782,141 @@ func (m *TSSRoundSixMessage) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: TSSRoundSixMessage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SenderID", wireType)
+			}
+			m.SenderID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SenderID |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Payload", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Payload = append(m.Payload[:0], dAtA[iNdEx:postIndex]...)
+			if m.Payload == nil {
+				m.Payload = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SessionID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SessionID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMessage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TSSRoundSevenMessage) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMessage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TSSRoundSevenMessage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TSSRoundSevenMessage: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/pkg/tecdsa/signing/gen/pb/message.proto
+++ b/pkg/tecdsa/signing/gen/pb/message.proto
@@ -45,3 +45,9 @@ message TSSRoundSixMessage {
     bytes payload = 2;
     string sessionID = 3;
 }
+
+message TSSRoundSevenMessage {
+    uint32 senderID = 1;
+    bytes payload = 2;
+    string sessionID = 3;
+}

--- a/pkg/tecdsa/signing/marshaling.go
+++ b/pkg/tecdsa/signing/marshaling.go
@@ -244,6 +244,34 @@ func (trsm *tssRoundSixMessage) Unmarshal(bytes []byte) error {
 	return nil
 }
 
+// Marshal converts this tssRoundSevenMessage to a byte array suitable for
+// network communication.
+func (trsm *tssRoundSevenMessage) Marshal() ([]byte, error) {
+	return (&pb.TSSRoundSevenMessage{
+		SenderID:  uint32(trsm.senderID),
+		Payload:   trsm.payload,
+		SessionID: trsm.sessionID,
+	}).Marshal()
+}
+
+// Unmarshal converts a byte array produced by Marshal to an tssRoundSevenMessage.
+func (trsm *tssRoundSevenMessage) Unmarshal(bytes []byte) error {
+	pbMsg := pb.TSSRoundSevenMessage{}
+	if err := pbMsg.Unmarshal(bytes); err != nil {
+		return err
+	}
+
+	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+		return err
+	}
+
+	trsm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trsm.payload = pbMsg.Payload
+	trsm.sessionID = pbMsg.SessionID
+
+	return nil
+}
+
 func validateMemberIndex(protoIndex uint32) error {
 	// Protobuf does not have uint8 type, so we are using uint32. When
 	// unmarshalling message, we need to make sure we do not overflow.

--- a/pkg/tecdsa/signing/marshaling_test.go
+++ b/pkg/tecdsa/signing/marshaling_test.go
@@ -368,3 +368,51 @@ func TestFuzzTssRoundSixMessage_MarshalingRoundtrip(t *testing.T) {
 func TestFuzzTssRoundSixMessage_Unmarshaler(t *testing.T) {
 	pbutils.FuzzUnmarshaler(&tssRoundSixMessage{})
 }
+
+func TestTssRoundSevenMessage_MarshalingRoundtrip(t *testing.T) {
+	msg := &tssRoundSevenMessage{
+		senderID:  group.MemberIndex(50),
+		payload:   []byte{1, 2, 3, 4, 5},
+		sessionID: "session-1",
+	}
+	unmarshaled := &tssRoundSevenMessage{}
+
+	err := pbutils.RoundTrip(msg, unmarshaled)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(msg, unmarshaled) {
+		t.Fatalf("unexpected content of unmarshaled message")
+	}
+}
+
+func TestFuzzTssRoundSevenMessage_MarshalingRoundtrip(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		var (
+			senderID  group.MemberIndex
+			payload   []byte
+			sessionID string
+		)
+
+		f := fuzz.New().NilChance(0.1).
+			NumElements(0, 512).
+			Funcs(pbutils.FuzzFuncs()...)
+
+		f.Fuzz(&senderID)
+		f.Fuzz(&payload)
+		f.Fuzz(&sessionID)
+
+		message := &tssRoundSevenMessage{
+			senderID:  senderID,
+			payload:   payload,
+			sessionID: sessionID,
+		}
+
+		_ = pbutils.RoundTrip(message, &tssRoundSevenMessage{})
+	}
+}
+
+func TestFuzzTssRoundSevenMessage_Unmarshaler(t *testing.T) {
+	pbutils.FuzzUnmarshaler(&tssRoundSevenMessage{})
+}

--- a/pkg/tecdsa/signing/member.go
+++ b/pkg/tecdsa/signing/member.go
@@ -307,3 +307,29 @@ func (trsm *tssRoundSixMember) markInactiveMembers(
 
 	filter.FlushInactiveMembers()
 }
+
+// initializeTssRoundSeven returns a member to perform next protocol operations.
+func (trsm *tssRoundSixMember) initializeTssRoundSeven() *tssRoundSevenMember {
+	return &tssRoundSevenMember{
+		tssRoundSixMember: trsm,
+	}
+}
+
+// tssRoundSevenMember represents one member in a signing group performing the
+// seventh round of the TSS keygen.
+type tssRoundSevenMember struct {
+	*tssRoundSixMember
+}
+
+// markInactiveMembers takes all messages from the previous signing protocol
+// execution phase and marks all member who did not send a message as inactive.
+func (trsm *tssRoundSevenMember) markInactiveMembers(
+	tssRoundSixMessages []*tssRoundSixMessage,
+) {
+	filter := trsm.inactiveMemberFilter()
+	for _, message := range tssRoundSixMessages {
+		filter.MarkMemberAsActive(message.senderID)
+	}
+
+	filter.FlushInactiveMembers()
+}

--- a/pkg/tecdsa/signing/message.go
+++ b/pkg/tecdsa/signing/message.go
@@ -151,3 +151,23 @@ func (trsm *tssRoundSixMessage) SenderID() group.MemberIndex {
 func (trfm *tssRoundSixMessage) Type() string {
 	return messageTypePrefix + "tss_round_six_message"
 }
+
+// tssRoundSevenMessage is a message payload that carries the sender's
+// TSS round seven components.
+type tssRoundSevenMessage struct {
+	senderID group.MemberIndex
+
+	payload   []byte
+	sessionID string
+}
+
+// SenderID returns protocol-level identifier of the message sender.
+func (trsm *tssRoundSevenMessage) SenderID() group.MemberIndex {
+	return trsm.senderID
+}
+
+// Type returns a string describing an tssRoundSevenMessage type for
+// marshaling purposes.
+func (trfm *tssRoundSevenMessage) Type() string {
+	return messageTypePrefix + "tss_round_seven_message"
+}

--- a/pkg/tecdsa/signing/signing.go
+++ b/pkg/tecdsa/signing/signing.go
@@ -68,7 +68,7 @@ func Execute(
 		return nil, err
 	}
 
-	_, ok := lastState.(*tssRoundSixState)
+	_, ok := lastState.(*tssRoundSevenState)
 	if !ok {
 		return nil, fmt.Errorf("execution ended on state: %T", lastState)
 	}
@@ -106,5 +106,8 @@ func registerUnmarshallers(channel net.BroadcastChannel) {
 	})
 	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
 		return &tssRoundSixMessage{}
+	})
+	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &tssRoundSevenMessage{}
 	})
 }


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3042
Depends on: https://github.com/keep-network/keep-core/pull/3246

Here we implement the TSS round seven for the tECDSA signing protocol. This round expects simple broadcast messages produced in round six as input and produces a simple broadcast message as output.

### Next steps

This PR is just a part of the entire work regarding the tECDSA signing test loop. Please refer to the description of https://github.com/keep-network/keep-core/issues/3042 for the full roadmap and the current status of the work. At this point, the next step will be introducing the eighth round of TSS signing.