### PR TITLE
tECDSA signing: TSS finalization

### DIFF
--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -489,7 +489,7 @@ func (n *node) joinSigningIfEligible(
 					"[member:%v] generated signature [%v] "+
 						"for message [%v]",
 					signer.signingGroupMemberIndex,
-					result,
+					result.Signature,
 					message,
 				)
 			}(currentSigner)

--- a/pkg/tecdsa/signature.go
+++ b/pkg/tecdsa/signature.go
@@ -1,0 +1,46 @@
+package tecdsa
+
+import (
+	"fmt"
+	"github.com/bnb-chain/tss-lib/common"
+	"math/big"
+)
+
+// Signature holds a signature in a form of two big.Int `r` and `s` values and
+// a recovery ID value in {0, 1, 2, 3}.
+//
+// The signature is chain-agnostic. Some chains (e.g. Ethereum and BTC)
+// requires `v` to start from 27. Please consult the documentation about
+// what the particular chain expects.
+type Signature struct {
+	R          *big.Int
+	S          *big.Int
+	RecoveryID int
+}
+
+// NewSignature constructs a new instance of the tECDSA signature based on
+// the signing result.
+func NewSignature(data *common.SignatureData) *Signature {
+	// `SignatureData` contains recovery ID as a byte slice. Only the first
+	// byte is relevant and is converted to `int`.
+	recoveryBytes := data.GetSignatureRecovery()
+	recoveryInt := 0
+	recoveryInt = (recoveryInt << 8) | int(recoveryBytes[0])
+
+	return &Signature{
+		R:          new(big.Int).SetBytes(data.GetR()),
+		S:          new(big.Int).SetBytes(data.GetS()),
+		RecoveryID: recoveryInt,
+	}
+}
+
+// String formats Signature to a string that contains R and S values
+// as hexadecimals.
+func (s *Signature) String() string {
+	return fmt.Sprintf(
+		"R: %#x, S: %#x, RecoveryID: %d",
+		s.R,
+		s.S,
+		s.RecoveryID,
+	)
+}

--- a/pkg/tecdsa/signing/result.go
+++ b/pkg/tecdsa/signing/result.go
@@ -1,22 +1,12 @@
 package signing
 
 import (
-	"fmt"
-	"math/big"
+	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
 
 // Result of the tECDSA signing protocol.
 type Result struct {
-	R          *big.Int
-	S          *big.Int
-	RecoveryID int
-}
-
-func (r *Result) String() string {
-	return fmt.Sprintf(
-		"R: %#x, S: %#x, RecoveryID: %d",
-		r.R,
-		r.S,
-		r.RecoveryID,
-	)
+	// Signature is the tECDSA signature produced as result of the tECDSA
+	// signing process.
+	Signature *tecdsa.Signature
 }

--- a/pkg/tecdsa/signing/signing.go
+++ b/pkg/tecdsa/signing/signing.go
@@ -68,18 +68,12 @@ func Execute(
 		return nil, err
 	}
 
-	_, ok := lastState.(*tssRoundNineState)
+	finalizationState, ok := lastState.(*finalizationState)
 	if !ok {
 		return nil, fmt.Errorf("execution ended on state: %T", lastState)
 	}
 
-	// TODO: Temporary result. Eventually, take the result from the
-	//       finalization state.
-	return &Result{
-		R:          new(big.Int).Add(message, big.NewInt(1)),
-		S:          new(big.Int).Add(message, big.NewInt(2)),
-		RecoveryID: 1,
-	}, nil
+	return finalizationState.result(), nil
 }
 
 // registerUnmarshallers initializes the given broadcast channel to be able to


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3042
Depends on: https://github.com/keep-network/keep-core/pull/3250

Here we implement the TSS finalization for the tECDSA signing protocol. This round expects simple broadcast messages produced in round nine as input and produces a TSS result representing the signature.

### Next steps

This PR is just a part of the entire work regarding the tECDSA signing test loop. Please refer to the description of https://github.com/keep-network/keep-core/issues/3042 for the full roadmap and the current status of the work. At this point, the next step will be introducing the retry algorithm.