### PR TITLE
tECDSA signing: Phase duration tweaks

### DIFF
--- a/pkg/tecdsa/signing/states.go
+++ b/pkg/tecdsa/signing/states.go
@@ -16,10 +16,10 @@ const (
 	ephemeralKeyPairStateActiveBlocks = 5
 
 	tssRoundOneStateDelayBlocks  = 1
-	tssRoundOneStateActiveBlocks = 5
+	tssRoundOneStateActiveBlocks = 11
 
 	tssRoundTwoStateDelayBlocks  = 1
-	tssRoundTwoStateActiveBlocks = 5
+	tssRoundTwoStateActiveBlocks = 6
 
 	tssRoundThreeStateDelayBlocks  = 1
 	tssRoundThreeStateActiveBlocks = 5


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3042
Depends on: https://github.com/keep-network/keep-core/pull/3254

We performed benchmarks for each tECDSA signing phase. The table below shows the results for Apple M1 Max (10 cores):

| **benchmark**          | **single call duration** | **suggested phase blocks**      |
|------------------------|--------------------------|---------------------------------|
| BenchmarkTssRoundOne   |                 2.0800 s | (51 * 2.0800 / 12) * 120% ≈ 11  |
| BenchmarkTssRoundTwo   |                 1.1400 s | (51 * 1.1400 / 12) * 120% ≈ 6   |
| BenchmarkTssRoundThree |                 0.7600 s | (51 * 0.7600 / 12) * 120% ≈ 4   |
| BenchmarkTssRoundFour  |                 0.0002 s | (51 * 0.0002 / 12) * 120% ≈ 1   |
| BenchmarkTssRoundFive  |                 0.0100 s | (51 * 0.0100 / 12) * 120% ≈ 1   |
| BenchmarkTssRoundSix   |                 0.0004 s | (51 * 0.0004 / 12) * 120% ≈ 1   |
| BenchmarkTssRoundSeven |                 0.0200 s | (51 * 0.0200 / 12) * 120% ≈ 1   |
| BenchmarkTssRoundEight |                 0.0001 s | (51 * 0.0001 / 12) * 120% ≈ 1   |
| BenchmarkTssRoundNine  |                 0.0010 s | (51 * 0.0010 / 12) * 120% ≈ 1   |
| BenchmarkTssFinalize   |                 0.0003 s | (51 * 0.0003 / 12) * 120% ≈ 1   |

The _single call duration_ column shows how much time is needed for a single member to execute the given phase. The _suggested phase blocks_ column indicates how many blocks the given phase should last to allow a successful execution for the worst case defined as 51 members doing that phase on a single machine. We assume the average block time is 12 seconds and add a safety margin of 20% to cover unexpected performance drops. According to those results, multiple phases require just 1 active block. However, based on experiences from v1 DKG, we know that 1 active block is often not enough in terms of networking, so we should use a higher count. The usual choice is 5 active blocks as this value gives a good balance between resiliency and execution time. That said, the final number of active blocks for each phase is as follows:

- TSS round 1: 11 blocks
- TSS round 2: 6 blocks
- TSS round 3: 5 blocks
- TSS round 4: 5 blocks
- TSS round 5: 5 blocks
- TSS round 6: 5 blocks
- TSS round 7: 5 blocks
- TSS round 8: 5 blocks
- TSS round 9: 5 blocks
- TSS finalization: 5 blocks

### Next steps

This PR is just a part of the entire work regarding the tECDSA signing test loop. Please refer to the description of https://github.com/keep-network/keep-core/issues/3042 for the full roadmap and the current status of the work. At this point, the next step will be introducing the retry algorithm.