### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ _local/
 # Executables
 debug
 debug.test
-keep-core
+keep-client
 main
 main.test
 


### PR DESCRIPTION
The `.gitignore` file was updated so that it ignores `keep-client` instead
of `keep-core`.