### PR TITLE
Bump `@keep-network/hardhat-helpers` to `0.6.0-pre.15`

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.14",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
@@ -68,6 +67,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.15",
     "@keep-network/random-beacon": "development",
     "@keep-network/sortition-pools": "^2.0.0-pre.13",
     "@openzeppelin/contracts": "^4.6.0",

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -665,10 +665,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.14":
-  version "0.6.0-pre.14"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.14.tgz#4e1fae3611c1cdd8417df90cc52cd3d16227bbd6"
-  integrity sha512-Eumc3TDJUO5So9G7/LY6adywY9zGYX+orkPc99ydlDn2AukhTnK9wi2wu+vooVOncKlK+Q6VZQctPms/rqnvBQ==
+"@keep-network/hardhat-helpers@^0.6.0-pre.15":
+  version "0.6.0-pre.15"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.15.tgz#7f01949a2e059c0d27fd144b834200a24e5f1cf9"
+  integrity sha512-yPjpUy4vjXzj6/t6DNtXZ2V/ZYLZReUXPvND2L70wqlWXc9d9tUVaTjdl/r9J9iSFJprAv74rAADeKqRPXmGFg==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -33,6 +33,7 @@
     "prepublishOnly": "hardhat prepare-artifacts --network $npm_config_network"
   },
   "dependencies": {
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.15",
     "@keep-network/sortition-pools": "^2.0.0-pre.13",
     "@openzeppelin/contracts": "^4.6.0",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
@@ -40,7 +41,6 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.14",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.0",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -957,10 +957,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.14":
-  version "0.6.0-pre.14"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.14.tgz#4e1fae3611c1cdd8417df90cc52cd3d16227bbd6"
-  integrity sha512-Eumc3TDJUO5So9G7/LY6adywY9zGYX+orkPc99ydlDn2AukhTnK9wi2wu+vooVOncKlK+Q6VZQctPms/rqnvBQ==
+"@keep-network/hardhat-helpers@^0.6.0-pre.15":
+  version "0.6.0-pre.15"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.15.tgz#7f01949a2e059c0d27fd144b834200a24e5f1cf9"
+  integrity sha512-yPjpUy4vjXzj6/t6DNtXZ2V/ZYLZReUXPvND2L70wqlWXc9d9tUVaTjdl/r9J9iSFJprAv74rAADeKqRPXmGFg==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.0":
   version "0.1.0-pre.0"


### PR DESCRIPTION
New package of hardhat-helpers got published. It contains a change to the way how etherscan validation failures are being logged (the error gets printed, but process is not killed).