### PR TITLE
TSS pre-params: Fetch pre-params only after symmetric keys are generated

### DIFF
--- a/pkg/tecdsa/dkg/dkg.go
+++ b/pkg/tecdsa/dkg/dkg.go
@@ -73,11 +73,6 @@ func (e *Executor) Execute(
 
 	registerUnmarshallers(channel)
 
-	preParams, err := e.tssPreParamsPool.GetNow()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed fetching pre-params: [%w]", err)
-	}
-
 	member := newMember(
 		e.logger,
 		seed,
@@ -86,7 +81,7 @@ func (e *Executor) Execute(
 		dishonestThreshold,
 		membershipValidator,
 		sessionID,
-		preParams.data,
+		e.tssPreParamsPool.GetNow,
 		e.keyGenerationConcurrency,
 	)
 

--- a/pkg/tecdsa/dkg/member_test.go
+++ b/pkg/tecdsa/dkg/member_test.go
@@ -90,7 +90,11 @@ func TestShouldAcceptMessage(t *testing.T) {
 				groupSize-honestThreshold,
 				membershipValdator,
 				"1",
-				&keygen.LocalPreParams{},
+				func() (*PreParams, error) {
+					return &PreParams{
+						data: &keygen.LocalPreParams{},
+					}, nil
+				},
 				1,
 			)
 

--- a/pkg/tecdsa/dkg/protocol_test.go
+++ b/pkg/tecdsa/dkg/protocol_test.go
@@ -1814,13 +1814,19 @@ func initializeEphemeralKeyPairGeneratingMembersGroup(
 	for i := 1; i <= groupSize; i++ {
 		id := group.MemberIndex(i)
 
+		preParamsFn := func() (*PreParams, error) {
+			return &PreParams{
+				data: tssPreParams[id],
+			}, nil
+		}
+
 		members = append(members, &ephemeralKeyPairGeneratingMember{
 			member: &member{
 				logger:                   &testutils.MockLogger{},
 				id:                       id,
 				group:                    dkgGroup,
 				sessionID:                sessionID,
-				tssPreParams:             tssPreParams[id],
+				preParamsFn:              preParamsFn,
 				keyGenerationConcurrency: 10,
 				identityConverter:        &identityConverter{seed: big.NewInt(200)},
 			},
@@ -1909,9 +1915,17 @@ func initializeTssRoundOneMembersGroup(
 			)
 		}
 
+		tssRoundOneMember, err := member.initializeTssRoundOne()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"cannot initialize TSS round one member: [%v]",
+				err,
+			)
+		}
+
 		tssRoundOneMembers = append(
 			tssRoundOneMembers,
-			member.initializeTssRoundOne(),
+			tssRoundOneMember,
 		)
 	}
 

--- a/pkg/tecdsa/dkg/states.go
+++ b/pkg/tecdsa/dkg/states.go
@@ -3,6 +3,7 @@ package dkg
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/net"
@@ -145,9 +146,17 @@ func (skgs *symmetricKeyGenerationState) Receive(msg net.Message) error {
 }
 
 func (skgs *symmetricKeyGenerationState) Next() (state.State, error) {
+	member, err := skgs.member.initializeTssRoundOne()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot initialize TSS round one member: [%w]",
+			err,
+		)
+	}
+
 	return &tssRoundOneState{
 		channel:     skgs.channel,
-		member:      skgs.member.initializeTssRoundOne(),
+		member:      member,
 		outcomeChan: make(chan error),
 	}, nil
 }


### PR DESCRIPTION
Here we delay the moment when TSS pre-params are fetched from the pool. So far, we fetched them at the very beginning of tECDSA DKG which could drain the pool too early when, for example, some members are inactive from the start. This change moves the moment when pre-params are fetched to occur just after symmetric keys are generated and actual TSS is about to be started. Such a logic should preserve the pre-params up to the moment when two first phases (ephemeral key exchange and symmetric key generation) are done successfully so the chances that the group is healthy are higher. That should result in wiser pre-params management.