### PR TITLE
tECDSA DKG: Do not bump blocks delay every 100 attempts

### DIFF
--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -35,9 +35,7 @@ type dkgRetryLoop struct {
 	randomRetryCounter uint
 	randomRetrySeed    int64
 
-	delayBlocks              uint64
-	delayBlocksBumpFrequency uint
-	delayBlocksBumpFactor    uint64
+	delayBlocks uint64
 }
 
 func newDkgRetryLoop(
@@ -55,17 +53,15 @@ func newDkgRetryLoop(
 	randomRetrySeed := int64(binary.BigEndian.Uint64(seedSha256[:8]))
 
 	return &dkgRetryLoop{
-		memberIndex:              memberIndex,
-		selectedOperators:        selectedOperators,
-		inactiveOperatorsSet:     make(map[chain.Address]bool),
-		chainConfig:              chainConfig,
-		attemptCounter:           0,
-		attemptStartBlock:        initialStartBlock,
-		randomRetryCounter:       0,
-		randomRetrySeed:          randomRetrySeed,
-		delayBlocks:              5,
-		delayBlocksBumpFrequency: 100,
-		delayBlocksBumpFactor:    20,
+		memberIndex:          memberIndex,
+		selectedOperators:    selectedOperators,
+		inactiveOperatorsSet: make(map[chain.Address]bool),
+		chainConfig:          chainConfig,
+		attemptCounter:       0,
+		attemptStartBlock:    initialStartBlock,
+		randomRetryCounter:   0,
+		randomRetrySeed:      randomRetrySeed,
+		delayBlocks:          5,
 	}
 }
 
@@ -115,18 +111,10 @@ func (drl *dkgRetryLoop) start(
 		// For example, the attempt may fail at
 		// the end of the protocol but the error is returned after some time
 		// and more blocks than expected are mined in the meantime.
-		// Additionally, we want to strongly extend the delay period
-		// periodically in order to give some additional time for nodes to
-		// recover and re-fill their internal TSS pre-parameters pools.
 		if drl.attemptCounter > 1 {
-			delayBlocks := drl.delayBlocks
-			if drl.attemptCounter%drl.delayBlocksBumpFrequency == 0 {
-				delayBlocks *= drl.delayBlocksBumpFactor
-			}
-
 			drl.attemptStartBlock = drl.attemptStartBlock +
 				dkg.ProtocolBlocks() +
-				delayBlocks
+				drl.delayBlocks
 		}
 
 		// Exclude all members controlled by the operators that were not

--- a/pkg/tbtc/dkg_test.go
+++ b/pkg/tbtc/dkg_test.go
@@ -260,19 +260,15 @@ func TestDkgRetryLoop(t *testing.T) {
 				return testResult, attempt.startBlock + dkg.ProtocolBlocks(), nil
 			},
 			expectedErr:               nil,
-			expectedExecutionEndBlock: 2370, // 2245 + 125
+			expectedExecutionEndBlock: 2275, // 2150 + 125
 			expectedResult:            testResult,
-			// Random algorithm is used from the very beginning. We also
-			// observe a delay blocks bump on the 10th attempt which is
-			// 100 blocks instead of 5. That said, the start block for the 16th
-			// attempt can be calculated as follows:
-			// 200 + 130 + 130 + 130 + 130 + 130 + 130 + 130 + 130 + 225 + 130 + 130 + 130 + 130 + 130 + 130
-			// where all 130 denotes a duration of a normal attempt (125 blocks
-			// plus 5 delay blocks) and 225 is the duration of the 10th attempt
-			// (125 + 100 bumped delay blocks).
+			// Random algorithm is used from the very beginning. The start block
+			// for the 16th attempt can be calculated as follows: 200 + 15 * 130
+			// where 130 denotes a duration of an attempt (125 blocks plus 5
+			// delay blocks).
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 16,
-				startBlock:             2245,
+				startBlock:             2150,
 				excludedMembersIndexes: []group.MemberIndex{7, 9},
 			},
 		},
@@ -328,11 +324,6 @@ func TestDkgRetryLoop(t *testing.T) {
 				selectedOperators,
 				chainConfig,
 			)
-
-			// Given the small group size, we never reach the original
-			// bump frequency which is 100. Here we make it smaller in order
-			// to test its behavior.
-			retryLoop.delayBlocksBumpFrequency = 10
 
 			ctx, cancelCtx := test.ctxFn()
 			defer cancelCtx()

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -106,7 +106,7 @@ func (srl *signingRetryLoop) start(
 		//
 		// For example, the attempt may fail at the end of the protocol but the
 		// error is returned after some time and more blocks than expected are
-		//mined in the meantime.
+		// mined in the meantime.
 		if srl.attemptCounter > 1 {
 			srl.attemptStartBlock = srl.attemptStartBlock +
 				signing.ProtocolBlocks() +


### PR DESCRIPTION
The bump is useless as we now have a huge TSS pre-parameters pool and the client does not join the sortition pool until the pool is filled. Additionally, we aim for limiting the maximum number of DKG retries to a small number (probably 10) in the near future.