### PR TITLE
Improvements to signature scheme

### DIFF
--- a/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
+++ b/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
@@ -220,6 +220,7 @@ contract EcdsaDkgValidator {
     ) public view returns (bool) {
         bytes32 hash = keccak256(
             abi.encode(
+                block.chainid,
                 result.groupPubKey,
                 result.misbehavedMembersIndices,
                 startBlock

--- a/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
+++ b/solidity/ecdsa/contracts/EcdsaDkgValidator.sol
@@ -219,7 +219,7 @@ contract EcdsaDkgValidator {
         uint256 startBlock
     ) public view returns (bool) {
         bytes32 hash = keccak256(
-            abi.encodePacked(
+            abi.encode(
                 result.groupPubKey,
                 result.misbehavedMembersIndices,
                 startBlock

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -702,11 +702,11 @@ contract WalletRegistry is
     ///         list corresponds to the expected set of members determined
     ///         by the sortition pool.
     /// @dev The message to be signed by each member is keccak256 hash of the
-    ///      calculated group public key, misbehaved members indices and DKG
-    ///      start block. The calculated hash should be prefixed with prefixed with
+    ///      chain ID, calculated group public key, misbehaved members indices
+    ///      and DKG start block. The calculated hash should be prefixed with
     ///      `\x19Ethereum signed message:\n` before signing, so the message to
     ///      sign is:
-    ///      `\x19Ethereum signed message:\n${keccak256(groupPubKey,misbehavedIndices,startBlock)}`
+    ///      `\x19Ethereum signed message:\n${keccak256(chainID,groupPubKey,misbehavedIndices,startBlock)}`
     /// @param dkgResult DKG result.
     function submitDkgResult(DKG.Result calldata dkgResult) external {
         wallets.validatePublicKey(dkgResult.groupPubKey);

--- a/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
@@ -39,13 +39,13 @@ library EcdsaInactivity {
         bool heartbeatFailed;
         // Concatenation of signatures from members supporting the claim.
         // The message to be signed by each member is keccak256 hash of the
-        // concatenation of inactivity claim nonce for the given wallet, wallet
-        // public key, inactive members indices, and boolean flag indicating
-        // if this is a wallet-wide heartbeat failure. The calculated hash should
-        // be prefixed with `\x19Ethereum signed message:\n` before signing, so
-        // the message to sign is:
+        // concatenation of the chain ID, inactivity claim nonce for the given
+        // wallet, wallet public key, inactive members indices, and boolean flag
+        // indicating if this is a wallet-wide heartbeat failure. The calculated
+        // hash should be prefixed with `\x19Ethereum signed message:\n` before
+        // signing, so the message to sign is:
         // `\x19Ethereum signed message:\n${keccak256(
-        //    nonce | walletPubKey | inactiveMembersIndices | heartbeatFailed
+        //    chainID | nonce | walletPubKey | inactiveMembersIndices | heartbeatFailed
         // )}`
         bytes signatures;
         // Indices of members corresponding to each signature. Indices must be
@@ -112,9 +112,10 @@ library EcdsaInactivity {
             claim.signingMembersIndices,
             groupMembers.length
         );
-       
+
         bytes32 signedMessageHash = keccak256(
             abi.encode(
+                block.chainid,
                 nonce,
                 walletPubKey,
                 claim.inactiveMembersIndices,

--- a/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
+++ b/solidity/ecdsa/contracts/libraries/EcdsaInactivity.sol
@@ -112,9 +112,9 @@ library EcdsaInactivity {
             claim.signingMembersIndices,
             groupMembers.length
         );
-
+       
         bytes32 signedMessageHash = keccak256(
-            abi.encodePacked(
+            abi.encode(
                 nonce,
                 walletPubKey,
                 claim.inactiveMembersIndices,

--- a/solidity/ecdsa/test/DKGValidator.test.ts
+++ b/solidity/ecdsa/test/DKGValidator.test.ts
@@ -5,7 +5,12 @@ import { expect } from "chai"
 
 import { constants, walletRegistryFixture } from "./fixtures"
 import { selectGroup, hashUint32Array } from "./utils/groups"
-import { signDkgResult, noMisbehaved, hashDKGMembers } from "./utils/dkg"
+import {
+  signDkgResult,
+  noMisbehaved,
+  hashDKGMembers,
+  hardhatNetworkId,
+} from "./utils/dkg"
 import ecdsaData from "./data/ecdsa"
 
 import type { IWalletOwner } from "../typechain/IWalletOwner"
@@ -695,10 +700,17 @@ describe("EcdsaDkgValidator", () => {
 
     context("when signatures contain wrong result hash", () => {
       const signWithWrongResultHash = async (signingOperators: Operator[]) => {
-        const wrongResultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-          ["bytes", "uint8[]", "uint256"],
-          [groupPublicKey, noMisbehaved, dkgStartBlock + 12345]
-        ))
+        const wrongResultHash = ethers.utils.keccak256(
+          ethers.utils.defaultAbiCoder.encode(
+            ["uint256", "bytes", "uint8[]", "uint256"],
+            [
+              hardhatNetworkId,
+              groupPublicKey,
+              noMisbehaved,
+              dkgStartBlock + 12345,
+            ]
+          )
+        )
         const signatures = []
         for (let i = 0; i < signingOperators.length; i++) {
           const { signer: ethersSigner } = signingOperators[i]

--- a/solidity/ecdsa/test/DKGValidator.test.ts
+++ b/solidity/ecdsa/test/DKGValidator.test.ts
@@ -695,10 +695,10 @@ describe("EcdsaDkgValidator", () => {
 
     context("when signatures contain wrong result hash", () => {
       const signWithWrongResultHash = async (signingOperators: Operator[]) => {
-        const wrongResultHash = ethers.utils.solidityKeccak256(
+        const wrongResultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
           ["bytes", "uint8[]", "uint256"],
           [groupPublicKey, noMisbehaved, dkgStartBlock + 12345]
-        )
+        ))
         const signatures = []
         for (let i = 0; i < signingOperators.length; i++) {
           const { signer: ethersSigner } = signingOperators[i]

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -17,6 +17,9 @@ import type {
 
 const { provider } = waffle
 
+// default Hardhat's networks blockchain, see https://hardhat.org/config/
+export const hardhatNetworkId = 31337
+
 export interface DkgResult {
   submitterMemberIndex: number
   groupPubKey: BytesLike
@@ -196,10 +199,12 @@ export async function signDkgResult(
   signingMembersIndices: number[]
   signaturesBytes: string
 }> {
-  const resultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-    ["bytes", "uint8[]", "uint256"],
-    [groupPublicKey, misbehavedMembersIndices, startBlock]
-  ))
+  const resultHash = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ["uint256", "bytes", "uint8[]", "uint256"],
+      [hardhatNetworkId, groupPublicKey, misbehavedMembersIndices, startBlock]
+    )
+  )
 
   const members: number[] = []
   const signingMembersIndices: number[] = []

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -196,10 +196,10 @@ export async function signDkgResult(
   signingMembersIndices: number[]
   signaturesBytes: string
 }> {
-  const resultHash = ethers.utils.solidityKeccak256(
+  const resultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
     ["bytes", "uint8[]", "uint256"],
     [groupPublicKey, misbehavedMembersIndices, startBlock]
-  )
+  ))
 
   const members: number[] = []
   const signingMembersIndices: number[] = []

--- a/solidity/ecdsa/test/utils/inactivity.ts
+++ b/solidity/ecdsa/test/utils/inactivity.ts
@@ -14,10 +14,10 @@ export async function signOperatorInactivityClaim(
   signatures: string
   signingMembersIndices: number[]
 }> {
-  const messageHash = ethers.utils.solidityKeccak256(
+  const messageHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
     ["uint256", "bytes", "uint8[]", "bool"],
     [nonce, groupPubKey, inactiveMembersIndices, failedHeartbeat]
-  )
+  ))
 
   const signingMembersIndices: number[] = []
   const signatures: string[] = []

--- a/solidity/ecdsa/test/utils/inactivity.ts
+++ b/solidity/ecdsa/test/utils/inactivity.ts
@@ -2,6 +2,9 @@ import { ethers } from "hardhat"
 
 import type { Operator } from "./operators"
 
+// default Hardhat's networks blockchain, see https://hardhat.org/config/
+const hardhatNetworkId = 31337
+
 // eslint-disable-next-line import/prefer-default-export
 export async function signOperatorInactivityClaim(
   signers: Operator[],
@@ -14,10 +17,18 @@ export async function signOperatorInactivityClaim(
   signatures: string
   signingMembersIndices: number[]
 }> {
-  const messageHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-    ["uint256", "bytes", "uint8[]", "bool"],
-    [nonce, groupPubKey, inactiveMembersIndices, failedHeartbeat]
-  ))
+  const messageHash = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ["uint256", "uint256", "bytes", "uint8[]", "bool"],
+      [
+        hardhatNetworkId,
+        nonce,
+        groupPubKey,
+        inactiveMembersIndices,
+        failedHeartbeat,
+      ]
+    )
+  )
 
   const signingMembersIndices: number[] = []
   const signatures: string[] = []

--- a/solidity/random-beacon/contracts/BeaconDkgValidator.sol
+++ b/solidity/random-beacon/contracts/BeaconDkgValidator.sol
@@ -216,6 +216,7 @@ contract BeaconDkgValidator {
     {
         bytes32 hash = keccak256(
             abi.encode(
+                block.chainid,
                 result.groupPubKey,
                 result.misbehavedMembersIndices,
                 startBlock

--- a/solidity/random-beacon/contracts/BeaconDkgValidator.sol
+++ b/solidity/random-beacon/contracts/BeaconDkgValidator.sol
@@ -215,7 +215,7 @@ contract BeaconDkgValidator {
         returns (bool)
     {
         bytes32 hash = keccak256(
-            abi.encodePacked(
+            abi.encode(
                 result.groupPubKey,
                 result.misbehavedMembersIndices,
                 startBlock

--- a/solidity/random-beacon/contracts/RandomBeacon.sol
+++ b/solidity/random-beacon/contracts/RandomBeacon.sol
@@ -854,11 +854,12 @@ contract RandomBeacon is IRandomBeacon, IApplication, Governable, Reimbursable {
     ///         A candidate group is registered based on the submitted DKG result
     ///         details.
     /// @dev The message to be signed by each member is keccak256 hash of the
-    ///      calculated group public key, misbehaved members as bytes and DKG
-    ///      start block. The calculated hash should be prefixed with prefixed with
+    ///      chain ID, calculated group public key, misbehaved members as bytes
+    ///      and DKG start block. The calculated hash should be prefixed with
+    //       prefixed with
     ///      `\x19Ethereum signed message:\n` before signing, so the message to
     ///      sign is:
-    ///      `\x19Ethereum signed message:\n${keccak256(groupPubKey,misbehaved,startBlock)}`
+    ///      `\x19Ethereum signed message:\n${keccak256(chainID,groupPubKey,misbehaved,startBlock)}`
     /// @param dkgResult DKG result.
     function submitDkgResult(DKG.Result calldata dkgResult) external {
         groups.validatePublicKey(dkgResult.groupPubKey);

--- a/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
@@ -106,7 +106,7 @@ library BeaconInactivity {
         // them in future in case some other application has a group with the
         // same ID and subset of members.
         bytes32 signedMessageHash = keccak256(
-            abi.encodePacked(nonce, groupPubKey, claim.inactiveMembersIndices)
+            abi.encode(nonce, groupPubKey, claim.inactiveMembersIndices)
         ).toEthSignedMessageHash();
 
         address[] memory groupMembersAddresses = sortitionPool.getIDOperators(

--- a/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
+++ b/solidity/random-beacon/contracts/libraries/BeaconInactivity.sol
@@ -31,12 +31,12 @@ library BeaconInactivity {
         uint256[] inactiveMembersIndices;
         // Concatenation of signatures from members supporting the claim.
         // The message to be signed by each member is keccak256 hash of the
-        // concatenation of inactivity claim nonce for the given group, group
-        // public key, and inactive members indices. The calculated hash should
-        // be prefixed with `\x19Ethereum signed message:\n` before signing, so
-        // the message to sign is:
+        // concatenation of the chain ID, inactivity claim nonce for the given
+        // group, group public key, and inactive members indices. The calculated
+        // hash should be prefixed with `\x19Ethereum signed message:\n` before
+        // signing, so the message to sign is:
         // `\x19Ethereum signed message:\n${keccak256(
-        //    nonce | groupPubKey | inactiveMembersIndices
+        //    chainID | nonce | groupPubKey | inactiveMembersIndices
         // )}`
         bytes signatures;
         // Indices of members corresponding to each signature. Indices must be
@@ -106,7 +106,12 @@ library BeaconInactivity {
         // them in future in case some other application has a group with the
         // same ID and subset of members.
         bytes32 signedMessageHash = keccak256(
-            abi.encode(nonce, groupPubKey, claim.inactiveMembersIndices)
+            abi.encode(
+                block.chainid,
+                nonce,
+                groupPubKey,
+                claim.inactiveMembersIndices
+            )
         ).toEthSignedMessageHash();
 
         address[] memory groupMembersAddresses = sortitionPool.getIDOperators(

--- a/solidity/random-beacon/test/BeaconDkgValidator.test.ts
+++ b/solidity/random-beacon/test/BeaconDkgValidator.test.ts
@@ -691,10 +691,10 @@ describe("BeaconDkgValidator", () => {
 
     context("when signatures contain wrong result hash", () => {
       const signWithWrongResultHash = async (signingOperators: Operator[]) => {
-        const wrongResultHash = ethers.utils.solidityKeccak256(
+        const wrongResultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
           ["bytes", "uint8[]", "uint256"],
           [groupPublicKey, noMisbehaved, dkgStartBlock + 12345]
-        )
+        ))
         const signatures = []
         for (let i = 0; i < signingOperators.length; i++) {
           const { signer: ethersSigner } = signingOperators[i]

--- a/solidity/random-beacon/test/BeaconDkgValidator.test.ts
+++ b/solidity/random-beacon/test/BeaconDkgValidator.test.ts
@@ -13,7 +13,12 @@ import { expect } from "chai"
 import blsData from "./data/bls"
 import { constants } from "./fixtures"
 import { selectGroup, hashUint32Array } from "./utils/groups"
-import { signDkgResult, noMisbehaved, hashDKGMembers } from "./utils/dkg"
+import {
+  signDkgResult,
+  noMisbehaved,
+  hashDKGMembers,
+  hardhatNetworkId,
+} from "./utils/dkg"
 
 import type { BigNumberish } from "ethers"
 import type { Operator } from "./utils/operators"
@@ -691,10 +696,17 @@ describe("BeaconDkgValidator", () => {
 
     context("when signatures contain wrong result hash", () => {
       const signWithWrongResultHash = async (signingOperators: Operator[]) => {
-        const wrongResultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-          ["bytes", "uint8[]", "uint256"],
-          [groupPublicKey, noMisbehaved, dkgStartBlock + 12345]
-        ))
+        const wrongResultHash = ethers.utils.keccak256(
+          ethers.utils.defaultAbiCoder.encode(
+            ["uint256", "bytes", "uint8[]", "uint256"],
+            [
+              hardhatNetworkId,
+              groupPublicKey,
+              noMisbehaved,
+              dkgStartBlock + 12345,
+            ]
+          )
+        )
         const signatures = []
         for (let i = 0; i < signingOperators.length; i++) {
           const { signer: ethersSigner } = signingOperators[i]

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -16,6 +16,9 @@ import type {
 
 const { provider } = waffle
 
+// default Hardhat's networks blockchain, see https://hardhat.org/config/
+export const hardhatNetworkId = 31337
+
 export const noMisbehaved: number[] = []
 
 export async function genesis(
@@ -219,10 +222,12 @@ export async function signDkgResult(
   signingMembersIndices: number[]
   signaturesBytes: string
 }> {
-  const resultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-    ["bytes", "uint8[]", "uint256"],
-    [groupPublicKey, misbehavedMembersIndices, startBlock]
-  ))
+  const resultHash = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ["uint256", "bytes", "uint8[]", "uint256"],
+      [hardhatNetworkId, groupPublicKey, misbehavedMembersIndices, startBlock]
+    )
+  )
 
   const members: number[] = []
   const signingMembersIndices: number[] = []

--- a/solidity/random-beacon/test/utils/dkg.ts
+++ b/solidity/random-beacon/test/utils/dkg.ts
@@ -219,10 +219,10 @@ export async function signDkgResult(
   signingMembersIndices: number[]
   signaturesBytes: string
 }> {
-  const resultHash = ethers.utils.solidityKeccak256(
+  const resultHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
     ["bytes", "uint8[]", "uint256"],
     [groupPublicKey, misbehavedMembersIndices, startBlock]
-  )
+  ))
 
   const members: number[] = []
   const signingMembersIndices: number[] = []

--- a/solidity/random-beacon/test/utils/inactivity.ts
+++ b/solidity/random-beacon/test/utils/inactivity.ts
@@ -2,6 +2,9 @@ import { ethers } from "hardhat"
 
 import type { Operator } from "./operators"
 
+// default Hardhat's networks blockchain, see https://hardhat.org/config/
+const hardhatNetworkId = 31337
+
 // eslint-disable-next-line import/prefer-default-export
 export async function signOperatorInactivityClaim(
   signers: Operator[],
@@ -13,10 +16,12 @@ export async function signOperatorInactivityClaim(
   signatures: string
   signingMembersIndices: number[]
 }> {
-  const messageHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-    ["uint256", "bytes", "uint8[]"],
-    [nonce, groupPubKey, inactiveMembersIndices]
-  ))
+  const messageHash = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ["uint256", "uint256", "bytes", "uint8[]"],
+      [hardhatNetworkId, nonce, groupPubKey, inactiveMembersIndices]
+    )
+  )
 
   const signingMembersIndices: number[] = []
   const signatures: string[] = []

--- a/solidity/random-beacon/test/utils/inactivity.ts
+++ b/solidity/random-beacon/test/utils/inactivity.ts
@@ -13,10 +13,10 @@ export async function signOperatorInactivityClaim(
   signatures: string
   signingMembersIndices: number[]
 }> {
-  const messageHash = ethers.utils.solidityKeccak256(
+  const messageHash = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
     ["uint256", "bytes", "uint8[]"],
     [nonce, groupPubKey, inactiveMembersIndices]
-  )
+  ))
 
   const signingMembersIndices: number[] = []
   const signatures: string[] = []


### PR DESCRIPTION
# Use `abi.encode` instead of `abi.encodePacked`

Solidity documentation says:

> If you use `keccak256(abi.encodePacked(a, b))` and both `a` and `b` are dynamic types, it is easy to craft collisions in the hash value by moving parts of `a` into `b` and vice-versa. More specifically, `abi.encodePacked("a", "bc") == abi.encodePacked("ab", "c")`. If you use `abi.encodePacked` for signatures, authentication or data integrity, make sure to always use the same types and check that at most one of them is dynamic. Unless there is a compelling reason, `abi.encode` should be preferred.

During the course of the security review, for `EcdsaDkgValidator`, we stated that:

> Solidity does not provide `bytes64` type so the group public key is passed as `bytes` with the length enforced to `64` by the validation code. This way, both `result.groupPublicKey` and `startBlock` have a fixed length and only `result.misbehavedMembersIndices` is of variable-length. Thus, there is no risk of collision by using dynamic types.
> 
> For `EcdsaInactivity` this is not a problem because every inactivity claim has a unique nonce.

Auditors stated that the length-checks are not enforced in `validateSignatures` (which is a public function), and thereby the issue depends on the implementation of contracts interacting with `EcdsaDkgValidator`.

The current implementation of `WalletRegistry` does not use `validateSignatures` directly but we can replace `abi.encodePacked` with `abi.encode` for potentially safer code long-term given the gas difference is small, about 6k of gas units increase for `notifyOperatorInactivity` and 2k of gas units decrease for `challengeDkgResult`.

The same change has been applied to the random beacon.

# Append `block.chainid` to signature schemes

During the course of the security review, auditors noticed that we do not append chain ID to the signature hash, and as a result, if there is a fork of Ethereum’s mainnet after the EcdsaInactivity contract’s creation, or if we upgrade the
 contract to a new version, the DKG signatures will be valid on both forks.

This is partially true because the same wallet must not be reused between independent state forks because doing so would allow attackers to try to replay wallet Bitcoin signatures. The same Bitcoin can not be spent on two state forks so we always require Bridge and WalletRegistry contracts on any other chain to be different.

Even if a state fork occurred, the value of the token on the state fork would require the network and DAO recognizing it as a valid state fork. If the network generates a valid accusation against state fork A, it is only valid against contracts in fork B if those contracts are considered canonical. However, we require that contracts on any other chains be different, and the network will not recognize the same contracts on other chains.

`walletPubKey` which is a part of the input used to generate the hash for signing is generated using a threshold ECDSA off-chain protocol and the probability of generating two threshold ECDSA wallets with the same public key is negligible.

To address the problem of temporary soft-forks of Ethereum mainnet, the off-chain client needs to wait for enough confirmations before executing any action based on the Ethereum state update received.

The rule of not reusing the wallet between state forks must not be violated. If this rule is not violated, the signatures may not be replayed between forks. If this rule is violated, worse things can happen than replying inactivity claim signature.

However, given that adding the chain ID to the signature hash is pretty much transparent in gas, we added it.

The same change has been applied to the random beacon.

I have also considered adjusting the signature scheme to follow EIP-712.

From EIP-712:

> The domain separator prevents collision of otherwise identical structures. It is possible that two DApps come up with an identical structure like `Transfer(address from,address to,uint256 amount)` that should not be compatible. By introducing a domain separator the DApp developers are guaranteed that there can be no signature collision.

In our case, the wallet must not sign anything else than Bitcoin transactions or inactivity claims. Otherwise, the wallet may be accused of fraud. Hence, participation of the wallet in dApps is not possible and the domain separator is not needed.

Gas comparison results are [here](https://docs.google.com/spreadsheets/d/1IQD_NHZlQKMJLJTukO3KfL3xfjledlPs4lis1x4lAZw/edit?usp=sharing)