### PR TITLE
Adding diagnostics scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ yarn-error.log
 
 # Temporary directory
 tmp/
+diagnostics/

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -eou pipefail
+
+LOG_START='\n\e[1;36m'  # new line + bold + color
+LOG_END='\n\e[0m'       # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
+
+IP_ADDRESS_DEFAULT="127.0.0.1" # bootstrap node
+PORT_DEFAULT="9701"            # bootstrap port
+PEER_PORTS_DEFAULT=("9701")    # a range of ports can be provided
+ENDPOINT="diagnostics"         # diagnostics api endpoint
+DIAGNOSTICS_DIR="diagnostics"  # dir for saving peers info
+# At least one of the ports in the range of PEER_PORT_START_DEFAULT..PEER_PORT_END_DEFAULT
+# should be opened for diagnostics.
+PEER_PORT_START_DEFAULT=9701 # peer port start lookup
+PEER_PORT_END_DEFAULT=9701   # peer port end lookup
+
+help() {
+  echo -e "\nUsage: $0" \
+    "--address <bootstrap address>" \
+    "--port <bootstrap port>" \
+    "--peer-port-start <beginning-ports-lookup>" \
+    "--peer-port-end <end-ports-lookup>"
+  echo -e "\n\nOptional command line arguments:\n"
+  echo -e "\t--address: Address of the bootstrap node"
+  echo -e "\t--port: Port of the bootstrap node"
+  echo -e "\t--peer-ports-start: Beginning of the ports lookup"
+  echo -e "\t--end-ports-start: End of the ports lookup\n"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+  "--address") set -- "$@" "-a" ;;
+  "--port") set -- "$@" "-p" ;;
+  "--peer-port-start") set -- "$@" "-s" ;;
+  "--peer-port-end") set -- "$@" "-e" ;;
+  "--help") set -- "$@" "-h" ;;
+  *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "a:p:s:e:h" opt; do
+  case "$opt" in
+  a) address="$OPTARG" ;;
+  p) port="$OPTARG" ;;
+  s) peer_port_start="$OPTARG" ;;
+  e) peer_port_end="$OPTARG" ;;
+  h) help ;;
+  ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+# Overwrite default properties
+ADDRESS=${address:-$IP_ADDRESS_DEFAULT}
+PORT=${port:-$PORT_DEFAULT}
+PEER_PORTS=${peer_ports:-$PEER_PORTS_DEFAULT}
+PEER_PORT_START=${peer_port_start:-$PEER_PORT_START_DEFAULT}
+PEER_PORT_END=${peer_port_end:-$PEER_PORT_END_DEFAULT}
+
+# Run script
+printf "${LOG_START}Starting bootstrap diagnostics...${LOG_END}"
+
+# Clean up for fresh data
+rm -rf ${DIAGNOSTICS_DIR}
+mkdir ${DIAGNOSTICS_DIR}
+
+peerAddresses=$(curl ${ADDRESS}:${PORT}/${ENDPOINT} | jq -r '.connected_peers[].address')
+
+peers=()
+# Iterate over the connected peers using their IP/dns addresses
+for peerAddress in ${peerAddresses[@]}; do
+  # Iterate over the eligible peer ports. First port that returns no error breaks
+  # the loop and assign data to peers[] array.
+  for port in $(seq $PEER_PORT_START $PEER_PORT_END); do
+    if peer=$(curl ${peerAddress}:${port}/${ENDPOINT}); then
+      peerExtractedData=$(jq -r '{chain_address: .client_info.chain_address, version: .client_info.version, preParamPoolSize: .tbtc.preParamsPoolSize}' <<<"${peer}")
+      peers+=(${peerExtractedData})
+      break
+    else
+      echo "${peerAddress}:${port}/${ENDPOINT} is not a valid endpoint"
+    fi
+  done
+done
+
+peersJsonArray=$(jq -s <<<"${peers[@]}")
+peersJson=$(jq --null-input -r --argjson peersJsonArray "${peersJsonArray}" '{peers: $peersJsonArray}')
+
+timestamp=$(date +%s) # unix timestamp, seconds since Jan 01 1970
+printf "${LOG_START}Saving diagnostics to a file ${DIAGNOSTICS_DIR}/peers_$timestamp.json ..${LOG_END}"
+echo $peersJson >"${DIAGNOSTICS_DIR}/peers_$timestamp.json"
+
+printf "${DONE_START}Bootstrap diagnostics completed!${DONE_END}"

--- a/scripts/upload_peers.sh
+++ b/scripts/upload_peers.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eou pipefail
+
+# This script should be run after scripts/diagnostics.sh which creates a single
+# file with peers data.
+
+LOG_START='\n\e[1;36m'           # new line + bold + color
+LOG_END='\n\e[0m'                # new line + reset color
+DONE_START='\n\e[1;32m'          # new line + bold + green
+DONE_END='\n\n\e[0m'             # new line + reset
+LOG_WARNING_START='\n\e\033[33m' # new line + bold + warning color
+LOG_WARNING_END='\n\e\033[0m'    # new line + reset
+
+BUCKET_NAME_DEFAULT="diagnostics_test"
+PEERS_DIR_PATH="diagnostics"
+
+help() {
+  echo -e "\nUsage: $0" \
+    "--oauth2-token-path <GCP-oauth2-token-path>" \
+    "--bucket-name <GCP-bucket-name>"
+  echo -e "\nCommand line arguments:\n"
+  echo -e "\t--oauth2-token: GCP oauth2 token path"
+  echo -e "\t--bucket-name: GCP destination bucket name\n"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+  "--oauth2-token") set -- "$@" "-k" ;;
+  "--bucket-name") set -- "$@" "-b" ;;
+  "--help") set -- "$@" "-h" ;;
+  *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "k:b:h" opt; do
+  case "$opt" in
+  k) oauth2_token_path="$OPTARG" ;;
+  b) bucket_name="$OPTARG" ;;
+  h) help ;;
+  ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+OAUTH2_TOKEN_PATH=${oauth2_token_path:-""}
+BUCKET_NAME=${bucket_name:-${BUCKET_NAME_DEFAULT}}
+
+if [ "$OAUTH2_TOKEN_PATH" == "" ]; then
+  printf "${LOG_WARNING_START}OAuth2 token must be provided.${LOG_WARNING_END}"
+  exit 1
+fi
+
+# Read the file name to be uploaded to GCP bucket
+file_name=`find ${PEERS_DIR_PATH} -type f -exec basename {} \;`
+
+curl -X POST --data-binary @${PEERS_DIR_PATH}"/"${file_name} \
+     -H "Authorization: Bearer `cat ${OAUTH2_TOKEN_PATH}`" \
+     -H "Content-Type: application/json" \
+    "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET_NAME}/o?name=${file_name}"
+
+printf "${DONE_START}Upload completed!${DONE_END}"


### PR DESCRIPTION
> The script should query the bootstrap node for the list of connected peers and for each peer, extract information about the client version and the number of pre-parameters in the pool. Aggregate the result and publish it to a bucket on GCP

This PR handles the bash scripts part. It aggregates the results and publishes them to a GCP bucket.

Depends on https://github.com/keep-network/keep-core/pull/3255

There are two scripts that need to be run to publish peer data to the GCP bucket.
- `scripts/diagnostics.sh` - collects and aggregates the peers data and saves it locally under `diagnostics/peers_<timestamp>.json` file
- `scripts/upload_peers.sh --oauth2-token <path-to-oauth2-token> - uploads the `diagnostics/peers_<timestamp>.json` to the GCP bucket. The oauth2-token must be obtained from GCP and stored locally.

---
## Creation of GCP Bucket and a service account

### Bucket creation
Cloud Storage -> Buckets -> Create. Follow the steps to create a bucket.

### Create a service account
- IAM & Admin -> Service Accounts -> Create Service Account -> follow the steps

### Making a bucket public
Go to the buckets list -> select a bucket -> edit access
![Screenshot 2022-09-16 at 13 42 33](https://user-images.githubusercontent.com/3156420/190631958-253c14c1-9622-49ec-b15f-4cacbd2b17d6.png)

### Add a service account to a bucket
- Cloud Storage -> Buckets -> select a bucket -> Permissions tab -> Add a service account with "Storage Object Creator" role.

### List GCP accounts and set a service account
- `gcloud auth list`
- `gcloud config set account <SERVICE_ACCOUNT>`

### Get oauth2 token
- `gcloud auth print-access-token`
- or https://developers.google.com/oauthplayground/ 