### PR TITLE
Update unit test for peers to check if the list contains entry

### DIFF
--- a/config/peers_test.go
+++ b/config/peers_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 )
 
@@ -45,12 +47,14 @@ func TestResolvePeers(t *testing.T) {
 				)
 			}
 
-			if !reflect.DeepEqual(test.expectedPeers, cfg.LibP2P.Peers) {
-				t.Errorf(
-					"unexpected peers\nexpected: %v\nactual:   %v\n",
-					test.expectedPeers,
-					cfg.LibP2P.Peers,
-				)
+			for _, expectedPeer := range test.expectedPeers {
+				if !slices.Contains(cfg.LibP2P.Peers, expectedPeer) {
+					t.Errorf(
+						"expected peer %v is not included in the resolved peers list: %v",
+						expectedPeer,
+						cfg.LibP2P.Peers,
+					)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
We don't want to execute an exact match validation as it makes adding and removing peers to/from the list hardher. We will just check for the peers that will be included in the list for sure.