### PR TITLE
Do not copy the lock value in broadcast channel

### DIFF
--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -252,12 +252,12 @@ func (c *channel) processPubsubMessage(pubsubMessage *pubsub.Message) error {
 		return err
 	}
 
-	return c.processContainerMessage(pubsubMessage.GetFrom(), messageProto)
+	return c.processContainerMessage(pubsubMessage.GetFrom(), &messageProto)
 }
 
 func (c *channel) processContainerMessage(
 	proposedSender peer.ID,
-	message pb.BroadcastNetworkMessage,
+	message *pb.BroadcastNetworkMessage,
 ) error {
 	// The protocol type is on the envelope; let's pull that type
 	// from our map of unmarshallers.


### PR DESCRIPTION
Addressed the following go vet warning:


pkg/net/libp2p/channel.go:255:60: call of c.processContainerMessage copies lock value: github.com/keep-network/keep-core/pkg/net/gen/pb.BroadcastNetworkMessage contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex

pkg/net/libp2p/channel.go:260:10: processContainerMessage passes lock by value: github.com/keep-network/keep-core/pkg/net/gen/pb.BroadcastNetworkMessage contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
