### PR TITLE
Pre-param metrics

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -177,7 +177,7 @@ func initializeMetrics(
 	blockCounter chain.BlockCounter,
 ) (*metrics.Registry, bool) {
 	registry, isConfigured := metrics.Initialize(
-		config.Metrics.Port,
+		ctx, config.Metrics.Port,
 	)
 	if !isConfigured {
 		logger.Infof("metrics are not configured")
@@ -190,20 +190,17 @@ func initializeMetrics(
 	)
 
 	registry.ObserveConnectedPeersCount(
-		ctx,
 		netProvider,
 		config.Metrics.NetworkMetricsTick,
 	)
 
 	registry.ObserveConnectedBootstrapCount(
-		ctx,
 		netProvider,
 		config.LibP2P.Peers,
 		config.Metrics.NetworkMetricsTick,
 	)
 
 	registry.ObserveEthConnectivity(
-		ctx,
 		blockCounter,
 		config.Metrics.EthereumMetricsTick,
 	)

--- a/docs/resources/client-start-help
+++ b/docs/resources/client-start-help
@@ -25,7 +25,7 @@ Flags:
       --tbtc.preParamsGenerationTimeout duration   tECDSA pre-parameters generation timeout. (default 2m0s)
       --tbtc.preParamsGenerationDelay duration     tECDSA pre-parameters generation delay. (default 10s)
       --tbtc.preParamsGenerationConcurrency int    tECDSA pre-parameters generation concurrency. (default 1)
-      --tbtc.keyGenerationConcurrency int          tECDSA key generation concurrency. (default 10)
+      --tbtc.keyGenerationConcurrency int          tECDSA key generation concurrency. (default number of cores)
       --developer.bridgeAddress string             Address of the Bridge smart contract
       --developer.randomBeaconAddress string       Address of the RandomBeacon smart contract
       --developer.tokenStakingAddress string       Address of the TokenStaking smart contract

--- a/docs/resources/client-start-help
+++ b/docs/resources/client-start-help
@@ -25,7 +25,8 @@ Flags:
       --tbtc.preParamsGenerationTimeout duration   tECDSA pre-parameters generation timeout. (default 2m0s)
       --tbtc.preParamsGenerationDelay duration     tECDSA pre-parameters generation delay. (default 10s)
       --tbtc.preParamsGenerationConcurrency int    tECDSA pre-parameters generation concurrency. (default 1)
-      --tbtc.keyGenerationConcurrency int          tECDSA key generation concurrency. (default number of cores)
+      --tbtc.keyGenerationConcurrency int          tECDSA key generation concurrency. (default 10)
+      --developer.bridgeAddress string             Address of the Bridge smart contract
       --developer.randomBeaconAddress string       Address of the RandomBeacon smart contract
       --developer.tokenStakingAddress string       Address of the TokenStaking smart contract
       --developer.walletRegistryAddress string     Address of the WalletRegistry smart contract

--- a/pkg/generator/pool.go
+++ b/pkg/generator/pool.go
@@ -47,11 +47,11 @@ func NewParameterPool[T any](
 	logger log.StandardLogger,
 	scheduler *Scheduler,
 	persistence Persistence[T],
-	targetSize int,
+	poolSize int,
 	generateFn func(context.Context) *T,
 	generateDelay time.Duration,
 ) *ParameterPool[T] {
-	pool := make(chan *Persisted[T], targetSize)
+	pool := make(chan *Persisted[T], poolSize)
 
 	all, err := persistence.ReadAll()
 	if err != nil {
@@ -62,9 +62,9 @@ func NewParameterPool[T any](
 
 	for i, parameter := range all {
 		// Load to the pool only the number of the parameters read from the persistence
-		// that can fit within the pool's target size, to avoid locking on writing to the
+		// that can fit within the pool's size, to avoid locking on writing to the
 		// channel.
-		if i >= targetSize {
+		if i >= poolSize {
 			break
 		}
 
@@ -130,8 +130,7 @@ func (pp *ParameterPool[T]) GetNow() (*T, error) {
 	}
 }
 
-// CurrentSize returns the current size of the pool - the number of available
-// parameters.
-func (pp *ParameterPool[T]) CurrentSize() int {
+// ParametersCount returns the number of parameters in the pool.
+func (pp *ParameterPool[T]) ParametersCount() int {
 	return len(pp.pool)
 }

--- a/pkg/generator/pool_test.go
+++ b/pkg/generator/pool_test.go
@@ -21,7 +21,7 @@ func TestGetNow(t *testing.T) {
 	defer scheduler.stop()
 
 	for {
-		if pool.CurrentSize() == 5 {
+		if pool.ParametersCount() == 5 {
 			break
 		}
 		// Yield the processor so that the generation goroutines could do their
@@ -70,11 +70,11 @@ func TestStop(t *testing.T) {
 	// give some time for the generation process to stop and capture the number
 	// of parameters generated
 	time.Sleep(10 * time.Millisecond)
-	size := pool.CurrentSize()
+	size := pool.ParametersCount()
 
 	// wait some time and make sure no new parameters are generated
 	time.Sleep(20 * time.Millisecond)
-	if size != pool.CurrentSize() {
+	if size != pool.ParametersCount() {
 		t.Errorf("expected no new parameters to be generated")
 	}
 }
@@ -95,7 +95,7 @@ func TestStopNoNils(t *testing.T) {
 	// give some time for the generation process to stop
 	time.Sleep(10 * time.Millisecond)
 
-	if pool.CurrentSize() != 0 {
+	if pool.ParametersCount() != 0 {
 		t.Errorf("expected no parameters to be generated")
 	}
 }
@@ -111,7 +111,7 @@ func TestPersist(t *testing.T) {
 	// give some time for the generation process to stop
 	time.Sleep(10 * time.Millisecond)
 
-	if pool.CurrentSize() != persistence.parameterCount() {
+	if pool.ParametersCount() != persistence.parameterCount() {
 		t.Errorf("not all parameters have been persisted")
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -125,8 +125,8 @@ func (r *Registry) ObserveEthConnectivity(
 	)
 }
 
-// ObserveEthConnectivity triggers an observation process of application-specific
-// metrics.
+// ObserveApplicationSource triggers an observation process of
+// application-specific metrics.
 func (r *Registry) ObserveApplicationSource(
 	application string,
 	inputs map[string]Source,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,17 +32,20 @@ type Config struct {
 // for registering client-custom metrics.
 type Registry struct {
 	*metrics.Registry
+
+	ctx context.Context
 }
 
 // Initialize set up the metrics registry and enables metrics server.
 func Initialize(
+	ctx context.Context,
 	port int,
 ) (*Registry, bool) {
 	if port == 0 {
 		return nil, false
 	}
 
-	registry := &Registry{metrics.NewRegistry()}
+	registry := &Registry{metrics.NewRegistry(), ctx}
 
 	registry.EnableServer(port)
 
@@ -52,7 +55,6 @@ func Initialize(
 // ObserveConnectedPeersCount triggers an observation process of the
 // connected_peers_count metric.
 func (r *Registry) ObserveConnectedPeersCount(
-	ctx context.Context,
 	netProvider net.Provider,
 	tick time.Duration,
 ) {
@@ -62,7 +64,6 @@ func (r *Registry) ObserveConnectedPeersCount(
 	}
 
 	r.observe(
-		ctx,
 		"connected_peers_count",
 		input,
 		validateTick(tick, DefaultNetworkMetricsTick),
@@ -72,7 +73,6 @@ func (r *Registry) ObserveConnectedPeersCount(
 // ObserveConnectedBootstrapCount triggers an observation process of the
 // connected_bootstrap_count metric.
 func (r *Registry) ObserveConnectedBootstrapCount(
-	ctx context.Context,
 	netProvider net.Provider,
 	bootstraps []string,
 	tick time.Duration,
@@ -90,7 +90,6 @@ func (r *Registry) ObserveConnectedBootstrapCount(
 	}
 
 	r.observe(
-		ctx,
 		"connected_bootstrap_count",
 		input,
 		validateTick(tick, DefaultNetworkMetricsTick),
@@ -100,7 +99,6 @@ func (r *Registry) ObserveConnectedBootstrapCount(
 // ObserveEthConnectivity triggers an observation process of the
 // eth_connectivity metric.
 func (r *Registry) ObserveEthConnectivity(
-	ctx context.Context,
 	blockCounter chain.BlockCounter,
 	tick time.Duration,
 ) {
@@ -115,7 +113,6 @@ func (r *Registry) ObserveEthConnectivity(
 	}
 
 	r.observe(
-		ctx,
 		"eth_connectivity",
 		input,
 		validateTick(tick, DefaultEthereumMetricsTick),
@@ -123,7 +120,6 @@ func (r *Registry) ObserveEthConnectivity(
 }
 
 func (r *Registry) observe(
-	ctx context.Context,
 	name string,
 	input metrics.ObserverInput,
 	tick time.Duration,
@@ -134,7 +130,7 @@ func (r *Registry) observe(
 		return
 	}
 
-	observer.Observe(ctx, tick)
+	observer.Observe(r.ctx, tick)
 
 	logger.Infof("observing %s with [%s] tick", name, tick)
 }

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -66,7 +66,7 @@ func Initialize(
 		metricsRegistry.ObserveApplicationSource(
 			"tbtc",
 			map[string]metrics.Source{
-				"pre_params_in_pool": func() float64 {
+				"pre_params_count": func() float64 {
 					return float64(node.dkgExecutor.PreParamsCount())
 				},
 			},

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -66,7 +66,7 @@ func Initialize(
 		metricsRegistry.ObserveApplicationSource(
 			"tbtc",
 			map[string]metrics.Source{
-				"pre_params_pool_size": func() float64 {
+				"pre_params_in_pool": func() float64 {
 					return float64(node.dkgExecutor.PreParamsCount())
 				},
 			},
@@ -78,7 +78,7 @@ func Initialize(
 		logger,
 		chain,
 		sortition.DefaultStatusCheckTick,
-		&enoughPreParamsPoolSizePolicy{
+		&enoughPreParamsInPoolPolicy{
 			node:   node,
 			config: config,
 		},
@@ -142,15 +142,15 @@ func Initialize(
 	return nil
 }
 
-// enoughPreParamsPoolSizePolicy is a policy that enforces the sufficient size
+// enoughPreParamsInPoolPolicy is a policy that enforces the sufficient size
 // of the DKG pre-parameters pool before joining the sortition pool.
-type enoughPreParamsPoolSizePolicy struct {
+type enoughPreParamsInPoolPolicy struct {
 	node   *node
 	config Config
 }
 
-func (epppsp *enoughPreParamsPoolSizePolicy) ShouldJoin() bool {
-	actualPoolSize := epppsp.node.dkgExecutor.PreParamsCount()
-	targetPoolSize := epppsp.config.PreParamsPoolSize
-	return actualPoolSize >= targetPoolSize
+func (eppip *enoughPreParamsInPoolPolicy) ShouldJoin() bool {
+	paramsInPool := eppip.node.dkgExecutor.PreParamsCount()
+	poolSize := eppip.config.PreParamsPoolSize
+	return paramsInPool >= poolSize
 }

--- a/pkg/tecdsa/dkg/dkg.go
+++ b/pkg/tecdsa/dkg/dkg.go
@@ -115,7 +115,7 @@ func (e *Executor) Execute(
 
 // PreParamsCount returns the current count of the DKG pre-parameters.
 func (e *Executor) PreParamsCount() int {
-	return e.tssPreParamsPool.CurrentSize()
+	return e.tssPreParamsPool.ParametersCount()
 }
 
 // SignedResult represents information pertaining to the process of signing


### PR DESCRIPTION
We now expose `tbtc_pre_params_pool_size` in metrics instead of exposing pre-params pool size in diagnostics. This value fits the time series definition expected by Prometheus: streams of timestamped values belonging to the same metric and the same set of labeled dimensions. This will allow to aggregate and present this value easily in monitoring tools.

Before:
```
❯ curl localhost:9004/diagnostics
{
  "client_info": {
    "chain_address":"0x3365D0Ed0e526D3B1d8b417fc0fdE5b1cEF2f416",
    "network_id":"16Uiu2HAm2TUrDJbpAyuVwhNRmdju6QyQG1Q4661CvCKNgtN9Z6NQ",
    "revision":"c32b8b5f1",
    "version":"v1.3.1-6245-gc32b8b5f1"
  },
  "connected_peers":[],
  "tbtc":{
    "preParamsPoolSize":509
    }
  }                                                                                                                                      

❯ curl localhost:8084/metrics
# TYPE connected_peers_count gauge
connected_peers_count 0 1663838285304

# TYPE connected_bootstrap_count gauge
connected_bootstrap_count 0 1663838285304

# TYPE eth_connectivity gauge
eth_connectivity 1 1663838285304% 
```

After:
```
❯ curl localhost:9004/diagnostics
{
  "client_info":{
      "chain_address":"0x3365D0Ed0e526D3B1d8b417fc0fdE5b1cEF2f416",
      "network_id":"16Uiu2HAm2TUrDJbpAyuVwhNRmdju6QyQG1Q4661CvCKNgtN9Z6NQ",
      "revision":"8f4b89fcd",
      "version":"v1.3.1-6298-g8f4b89fcd"
    },
    "connected_peers":[]
} 

❯ curl localhost:8084/metrics
# TYPE connected_peers_count gauge
connected_peers_count 0 1663839503142

# TYPE connected_bootstrap_count gauge
connected_bootstrap_count 0 1663839503142

# TYPE eth_connectivity gauge
eth_connectivity 1 1663839203172

# TYPE tbtc_pre_params_pool_size gauge
tbtc_pre_params_count 516 1663839203525%  
```