### PR TITLE
Chaosnet: update random beacon contracts

### DIFF
--- a/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
+++ b/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
@@ -3,7 +3,8 @@ import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, helpers } = hre
-  const { deployer } = await getNamedAccounts()
+  const { deployer, chaosnetOwner } = await getNamedAccounts()
+  const { execute } = deployments
   const { to1e18 } = helpers.number
 
   const POOL_WEIGHT_DIVISOR = to1e18(1) // TODO: Update value
@@ -17,6 +18,13 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     log: true,
     waitConfirmations: 1,
   })
+
+  await execute(
+    "BeaconSortitionPool",
+    { from: deployer },
+    "transferChaosnetOwnerRole",
+    chaosnetOwner
+  )
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(BeaconSortitionPool)

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -120,6 +120,11 @@ const config: HardhatUserConfig = {
       goerli: 0,
       // mainnet: ""
     },
+    chaosnetOwner: {
+      default: 3,
+      goerli: 0,
+      // mainnet: ""
+    },
   },
   external: {
     contracts:

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@keep-network/hardhat-helpers": "^0.6.0-pre.15",
-    "@keep-network/sortition-pools": "^2.0.0-pre.13",
+    "@keep-network/sortition-pools": "^2.0.0-pre.15",
     "@openzeppelin/contracts": "^4.6.0",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
     "@threshold-network/solidity-contracts": "development"

--- a/solidity/random-beacon/test/BeaconDkgValidator.test.ts
+++ b/solidity/random-beacon/test/BeaconDkgValidator.test.ts
@@ -42,6 +42,8 @@ const fixture = async () => {
     constants.poolWeightDivisor
   )) as SortitionPool
 
+  await sortitionPool.deactivateChaosnet()
+
   const DKGValidator = await ethers.getContractFactory("BeaconDkgValidator")
   const dkgValidator = (await DKGValidator.deploy(
     sortitionPool.address

--- a/solidity/random-beacon/test/fixtures/index.ts
+++ b/solidity/random-beacon/test/fixtures/index.ts
@@ -80,7 +80,7 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
   const staking: TokenStaking =
     await helpers.contracts.getContract<TokenStaking>("TokenStaking")
 
-  const { deployer } = await helpers.signers.getNamedSigners()
+  const { deployer, chaosnetOwner } = await helpers.signers.getNamedSigners()
 
   const sortitionPool: SortitionPool = await helpers.contracts.getContract(
     "BeaconSortitionPool"
@@ -102,6 +102,8 @@ export async function randomBeaconDeployment(): Promise<DeployedContracts> {
 
   await updateTokenStakingParams(t, staking, deployer)
   await setFixtureParameters(randomBeacon)
+
+  await sortitionPool.connect(chaosnetOwner).deactivateChaosnet()
 
   const contracts: DeployedContracts = {
     sortitionPool,

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -978,10 +978,10 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/sortition-pools@^2.0.0-pre.13":
-  version "2.0.0-pre.13"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.13.tgz#80dbe8066ce378ae4242c3aef6864224477a9e41"
-  integrity sha512-+6VXCJyYT3+HApDExeySHjOgezg+umvdpm5lZXIUlhSx7xmbXSK/YwLXkdeWkGyVdyfwRO4ZXo1CbscbC0XGnA==
+"@keep-network/sortition-pools@^2.0.0-pre.15":
+  version "2.0.0-pre.15"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.15.tgz#3a289f7cd502e5d6c629f2fb625d390b77c02950"
+  integrity sha512-FuEk6uvIL5n82LnxyP6piV8Y7eRae3Vp7n1yQcSK2M9+gaZqzT1eaxX6FtZrXMzAOz3M+aQ8X3DVEyTScQOO2Q==
   dependencies:
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"


### PR DESCRIPTION
Updating `sortition-pools` dependency to the one with Chaosnet support from https://github.com/keep-network/sortition-pools/pull/188.

Updated deployment scripts for random beacon to transfer the chaosnet owner to a named account.

Deactivated chaosnet in unit tests to avoid problems with adding operators to the pool