### PR TITLE
Set network properties for bootstrap nodes

### DIFF
--- a/infrastructure/kube/keep-test/keep-client/gen/data.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/data.yaml
@@ -2,8 +2,12 @@
 ---
 clients:
   - id: 0
+    publicAnnouncedAddress: "bootstrap-0.test.keep.network"
+    staticIP: "104.154.61.116"
   - id: 1
     networkPeers: /dns4/keep-client-0.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
+    publicAnnouncedAddress: "bootstrap-1.test.keep.network"
+    staticIP: "35.223.100.87"
   - id: 2
     networkPeers: /dns4/keep-client-1.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
   - id: 3

--- a/infrastructure/kube/keep-test/keep-client/gen/schema.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/schema.yaml
@@ -4,6 +4,10 @@ clients:
   - id: 0
     #@schema/nullable
     networkPeers: ""
+    #@schema/nullable
+    publicAnnouncedAddress: ""
+    #@schema/nullable
+    staticIP: ""
     stakeAmount: 800_000
 initContainers:
   - name: ""

--- a/infrastructure/kube/keep-test/keep-client/gen/template.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/template.yaml
@@ -16,6 +16,14 @@ network: goerli
 #@ def account():
 #@   return "account-" + str(client.id)
 #@ end
+
+#@ def announcedAddresses():
+#@   result = "/dns4/" + name() + ".default.svc.cluster.local/tcp/3919"
+#@   if client.publicAnnouncedAddress:
+#@     result += ",/dns4/" + client.publicAnnouncedAddress + "/tcp/3919"
+#@   end
+#@   return result
+#@ end
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -90,7 +98,7 @@ spec:
             - "--network.port"
             - "3919"
             - "--network.announcedAddresses"
-            -  #@ "/dns4/" + name() + ".default.svc.cluster.local/tcp/3919"
+            -  #@ announcedAddresses()
             #@ if client.networkPeers:
             - "--network.peers"
             -  #@ client.networkPeers
@@ -163,4 +171,5 @@ spec:
       targetPort: 9701
       name: diagnostics
   selector: #@ labels()
+  loadBalancerIP: #@ client.staticIP
 #@ end

--- a/infrastructure/kube/keep-test/keep-client/gen/template.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/template.yaml
@@ -63,9 +63,12 @@ spec:
           image: "gcr.io/keep-test-f3e0/keep-client:latest"
           imagePullPolicy: Always
           ports:
-            - containerPort: 3919
-            - containerPort: 9601
-            - containerPort: 9701
+            - name: network
+              containerPort: 3919
+            - name: metrics
+              containerPort: 9601
+            - name: diagnostics
+              containerPort: 9701
           env:
             - name: KEEP_ETHEREUM_PASSWORD
               valueFrom:
@@ -161,15 +164,15 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 3919
-      targetPort: 3919
-      name: network
-    - port: 9601
-      targetPort: 9601
-      name: metrics
-    - port: 9701
-      targetPort: 9701
-      name: diagnostics
+    - name: network
+      port: 3919
+      targetPort: network
+    - name: metrics
+      port: 9601
+      targetPort: metrics
+    - name: diagnostics
+      port: 9701
+      targetPort: diagnostics
   selector: #@ labels()
   loadBalancerIP: #@ client.staticIP
 #@ end

--- a/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
@@ -86,7 +86,7 @@ spec:
         - --network.port
         - "3919"
         - --network.announcedAddresses
-        - /dns4/keep-client-0.default.svc.cluster.local/tcp/3919
+        - /dns4/keep-client-0.default.svc.cluster.local/tcp/3919,/dns4/bootstrap-0.test.keep.network/tcp/3919
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -200,6 +200,7 @@ spec:
     type: client
     id: "0"
     network: goerli
+  loadBalancerIP: 104.154.61.116
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -288,7 +289,7 @@ spec:
         - --network.port
         - "3919"
         - --network.announcedAddresses
-        - /dns4/keep-client-1.default.svc.cluster.local/tcp/3919
+        - /dns4/keep-client-1.default.svc.cluster.local/tcp/3919,/dns4/bootstrap-1.test.keep.network/tcp/3919
         - --network.peers
         - /dns4/keep-client-0.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
         - --metrics.port
@@ -404,6 +405,7 @@ spec:
     type: client
     id: "1"
     network: goerli
+  loadBalancerIP: 35.223.100.87
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -608,6 +610,7 @@ spec:
     type: client
     id: "2"
     network: goerli
+  loadBalancerIP: null
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -812,6 +815,7 @@ spec:
     type: client
     id: "3"
     network: goerli
+  loadBalancerIP: null
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1016,3 +1020,4 @@ spec:
     type: client
     id: "4"
     network: goerli
+  loadBalancerIP: null

--- a/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
@@ -50,9 +50,12 @@ spec:
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3919
-        - containerPort: 9601
-        - containerPort: 9701
+        - name: network
+          containerPort: 3919
+        - name: metrics
+          containerPort: 9601
+        - name: diagnostics
+          containerPort: 9701
         env:
         - name: KEEP_ETHEREUM_PASSWORD
           valueFrom:
@@ -186,15 +189,15 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 3919
-    targetPort: 3919
-    name: network
-  - port: 9601
-    targetPort: 9601
-    name: metrics
-  - port: 9701
-    targetPort: 9701
-    name: diagnostics
+  - name: network
+    port: 3919
+    targetPort: network
+  - name: metrics
+    port: 9601
+    targetPort: metrics
+  - name: diagnostics
+    port: 9701
+    targetPort: diagnostics
   selector:
     app: keep
     type: client
@@ -253,9 +256,12 @@ spec:
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3919
-        - containerPort: 9601
-        - containerPort: 9701
+        - name: network
+          containerPort: 3919
+        - name: metrics
+          containerPort: 9601
+        - name: diagnostics
+          containerPort: 9701
         env:
         - name: KEEP_ETHEREUM_PASSWORD
           valueFrom:
@@ -391,15 +397,15 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 3919
-    targetPort: 3919
-    name: network
-  - port: 9601
-    targetPort: 9601
-    name: metrics
-  - port: 9701
-    targetPort: 9701
-    name: diagnostics
+  - name: network
+    port: 3919
+    targetPort: network
+  - name: metrics
+    port: 9601
+    targetPort: metrics
+  - name: diagnostics
+    port: 9701
+    targetPort: diagnostics
   selector:
     app: keep
     type: client
@@ -458,9 +464,12 @@ spec:
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3919
-        - containerPort: 9601
-        - containerPort: 9701
+        - name: network
+          containerPort: 3919
+        - name: metrics
+          containerPort: 9601
+        - name: diagnostics
+          containerPort: 9701
         env:
         - name: KEEP_ETHEREUM_PASSWORD
           valueFrom:
@@ -596,15 +605,15 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 3919
-    targetPort: 3919
-    name: network
-  - port: 9601
-    targetPort: 9601
-    name: metrics
-  - port: 9701
-    targetPort: 9701
-    name: diagnostics
+  - name: network
+    port: 3919
+    targetPort: network
+  - name: metrics
+    port: 9601
+    targetPort: metrics
+  - name: diagnostics
+    port: 9701
+    targetPort: diagnostics
   selector:
     app: keep
     type: client
@@ -663,9 +672,12 @@ spec:
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3919
-        - containerPort: 9601
-        - containerPort: 9701
+        - name: network
+          containerPort: 3919
+        - name: metrics
+          containerPort: 9601
+        - name: diagnostics
+          containerPort: 9701
         env:
         - name: KEEP_ETHEREUM_PASSWORD
           valueFrom:
@@ -801,15 +813,15 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 3919
-    targetPort: 3919
-    name: network
-  - port: 9601
-    targetPort: 9601
-    name: metrics
-  - port: 9701
-    targetPort: 9701
-    name: diagnostics
+  - name: network
+    port: 3919
+    targetPort: network
+  - name: metrics
+    port: 9601
+    targetPort: metrics
+  - name: diagnostics
+    port: 9701
+    targetPort: diagnostics
   selector:
     app: keep
     type: client
@@ -868,9 +880,12 @@ spec:
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3919
-        - containerPort: 9601
-        - containerPort: 9701
+        - name: network
+          containerPort: 3919
+        - name: metrics
+          containerPort: 9601
+        - name: diagnostics
+          containerPort: 9701
         env:
         - name: KEEP_ETHEREUM_PASSWORD
           valueFrom:
@@ -1006,15 +1021,15 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 3919
-    targetPort: 3919
-    name: network
-  - port: 9601
-    targetPort: 9601
-    name: metrics
-  - port: 9701
-    targetPort: 9701
-    name: diagnostics
+  - name: network
+    port: 3919
+    targetPort: network
+  - name: metrics
+    port: 9601
+    targetPort: metrics
+  - name: diagnostics
+    port: 9701
+    targetPort: diagnostics
   selector:
     app: keep
     type: client


### PR DESCRIPTION
We need to configure bootstrap nodes with publicly exposed announced addresses and make the service use a static IP predefined in GCP DNS config.