### PR TITLE
Chaosnet: update ecdsa contracts

### DIFF
--- a/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
+++ b/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
@@ -3,14 +3,15 @@ import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, helpers } = hre
-  const { deployer } = await getNamedAccounts()
+  const { deployer, chaosnetOwner } = await getNamedAccounts()
+  const { execute } = deployments
   const { to1e18 } = helpers.number
 
   const POOL_WEIGHT_DIVISOR = to1e18(1) // TODO: Update value
 
   const T = await deployments.get("T")
 
-  const SortitionPool = await deployments.deploy("EcdsaSortitionPool", {
+  const EcdsaSortitionPool = await deployments.deploy("EcdsaSortitionPool", {
     contract: "SortitionPool",
     from: deployer,
     args: [T.address, POOL_WEIGHT_DIVISOR],
@@ -18,14 +19,21 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     waitConfirmations: 1,
   })
 
+  await execute(
+    "EcdsaSortitionPool",
+    { from: deployer },
+    "transferChaosnetOwnerRole",
+    chaosnetOwner
+  )
+
   if (hre.network.tags.etherscan) {
-    await helpers.etherscan.verify(SortitionPool)
+    await helpers.etherscan.verify(EcdsaSortitionPool)
   }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "EcdsaSortitionPool",
-      address: SortitionPool.address,
+      address: EcdsaSortitionPool.address,
     })
   }
 }

--- a/solidity/ecdsa/deploy/02_deploy_dkg_validator.ts
+++ b/solidity/ecdsa/deploy/02_deploy_dkg_validator.ts
@@ -5,11 +5,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
-  const SortitionPool = await deployments.get("EcdsaSortitionPool")
+  const EcdsaSortitionPool = await deployments.get("EcdsaSortitionPool")
 
   const EcdsaDkgValidator = await deployments.deploy("EcdsaDkgValidator", {
     from: deployer,
-    args: [SortitionPool.address],
+    args: [EcdsaSortitionPool.address],
     log: true,
     waitConfirmations: 1,
   })

--- a/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
@@ -5,7 +5,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, ethers, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
-  const SortitionPool = await deployments.get("EcdsaSortitionPool")
+  const EcdsaSortitionPool = await deployments.get("EcdsaSortitionPool")
   const TokenStaking = await deployments.get("TokenStaking")
   const ReimbursementPool = await deployments.get("ReimbursementPool")
   const RandomBeacon = await deployments.get("RandomBeacon")
@@ -36,7 +36,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
         },
       },
       proxyOpts: {
-        constructorArgs: [SortitionPool.address, TokenStaking.address],
+        constructorArgs: [EcdsaSortitionPool.address, TokenStaking.address],
         unsafeAllow: ["external-library-linking"],
         kind: "transparent",
       },

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -132,8 +132,13 @@ const config: HardhatUserConfig = {
       goerli: 0,
       // mainnet: ""
     },
-    esdm: {
+    chaosnetOwner: {
       default: 3,
+      goerli: 0,
+      // mainnet: ""
+    },
+    esdm: {
+      default: 4,
       goerli: 0,
       // mainnet: ""
     },

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@keep-network/hardhat-helpers": "^0.6.0-pre.15",
     "@keep-network/random-beacon": "development",
-    "@keep-network/sortition-pools": "^2.0.0-pre.13",
+    "@keep-network/sortition-pools": "^2.0.0-pre.15",
     "@openzeppelin/contracts": "^4.6.0",
     "@openzeppelin/contracts-upgradeable": "^4.6.0",
     "@threshold-network/solidity-contracts": "development"

--- a/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
@@ -73,6 +73,9 @@ describe("WalletRegistry - Authorization", () => {
     thirdParty = await ethers.getSigner(accounts[6])
     ;({ deployer, governance } = await helpers.signers.getNamedSigners())
 
+    const { chaosnetOwner } = await helpers.signers.getNamedSigners()
+    await sortitionPool.connect(chaosnetOwner).deactivateChaosnet()
+
     walletOwner = await initializeWalletOwner(
       walletRegistryGovernance,
       governance

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -1674,8 +1674,8 @@ describe("WalletRegistry - Wallet Creation", async () => {
                   )
                 })
 
-                it("should use close to 272 000 gas", async () => {
-                  await assertGasUsed(tx, 272_000)
+                it("should use close to 274 000 gas", async () => {
+                  await assertGasUsed(tx, 274_000)
                 })
               })
 
@@ -3450,8 +3450,8 @@ describe("WalletRegistry - Wallet Creation", async () => {
               )
             })
 
-            it("should use close to 80 000 gas", async () => {
-              await assertGasUsed(tx, 80_000)
+            it("should use close to 82 000 gas", async () => {
+              await assertGasUsed(tx, 82_000)
             })
           })
 
@@ -3605,8 +3605,8 @@ describe("WalletRegistry - Wallet Creation", async () => {
                 )
               })
 
-              it("should use close to 74 000 gas", async () => {
-                await assertGasUsed(tx, 74_000)
+              it("should use close to 76 000 gas", async () => {
+                await assertGasUsed(tx, 76_000)
               })
             })
           })

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -89,7 +89,10 @@ export const walletRegistryFixture = deployments.createFixture(
       walletRegistry
     )
 
-    const { deployer, governance } = await helpers.signers.getNamedSigners()
+    const { deployer, governance, chaosnetOwner } =
+      await helpers.signers.getNamedSigners()
+
+    await sortitionPool.connect(chaosnetOwner).deactivateChaosnet()
 
     const [thirdParty] = await helpers.signers.getUnnamedSigners()
 

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -687,19 +687,20 @@
     openzeppelin-solidity "2.4.0"
 
 "@keep-network/random-beacon@development":
-  version "2.0.0-dev.56"
-  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.56.tgz#70999781d6fa93e67b47e953472fa72f6f312455"
-  integrity sha512-eoqwSFeFIoR2NI0/5TutqRHHom91nJtoCNtdPMGK1eqH+Jo6SAZh9jAbz9KIEoX0bnhOoMQhyJdbdOv3Nr4S7w==
+  version "2.0.0-dev.72"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.72.tgz#0e96714628ac4fb5a3cdf67d5a7f56c6b67b4f50"
+  integrity sha512-mx7lUf9sdtK/9/dYV0TBXPM2zA3xeKqkspII2T9LZ1BxX8IhELvmjrgErzg5Za5IXUDQYFUco4BHU/fpjR+Q+w==
   dependencies:
-    "@keep-network/sortition-pools" "^2.0.0-pre.13"
+    "@keep-network/hardhat-helpers" "^0.6.0-pre.15"
+    "@keep-network/sortition-pools" "^2.0.0-pre.15"
     "@openzeppelin/contracts" "^4.6.0"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts" "1.2.0-dev.18"
+    "@threshold-network/solidity-contracts" "1.2.0-dev.22"
 
-"@keep-network/sortition-pools@^2.0.0-pre.13":
-  version "2.0.0-pre.13"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.13.tgz#80dbe8066ce378ae4242c3aef6864224477a9e41"
-  integrity sha512-+6VXCJyYT3+HApDExeySHjOgezg+umvdpm5lZXIUlhSx7xmbXSK/YwLXkdeWkGyVdyfwRO4ZXo1CbscbC0XGnA==
+"@keep-network/sortition-pools@^2.0.0-pre.15":
+  version "2.0.0-pre.15"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-2.0.0-pre.15.tgz#3a289f7cd502e5d6c629f2fb625d390b77c02950"
+  integrity sha512-FuEk6uvIL5n82LnxyP6piV8Y7eRae3Vp7n1yQcSK2M9+gaZqzT1eaxX6FtZrXMzAOz3M+aQ8X3DVEyTScQOO2Q==
   dependencies:
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
@@ -1109,10 +1110,10 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@1.2.0-dev.18":
-  version "1.2.0-dev.18"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.18.tgz#814721dea03e47c3fe2f21644802e99d49dd9260"
-  integrity sha512-ao6Kngc8Q9rPg42/DlSlsOi2k/GH0DfdAOB4fmzcQSBl4H4D+dP0k0ymqvK6zfeMgxYmjRYP2KI5kDLPpaF2jg==
+"@threshold-network/solidity-contracts@1.2.0-dev.22":
+  version "1.2.0-dev.22"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.22.tgz#c82da61b51d0086fb6fd2d662db74ec278b7ffcf"
+  integrity sha512-QpJXl0ViOMbWeGQ1m02cM//UwedjMKG4Vm9JILyn0VZiFxoMo0Jtcdm0V1+4+j+cAXbGjWFQGKMvSFYh34ONCw==
   dependencies:
     "@keep-network/keep-core" ">1.8.1-dev <1.8.1-goerli"
     "@openzeppelin/contracts" "~4.5.0"


### PR DESCRIPTION
See #3297

Updating `sortition-pools` and `random-beacon` dependencies to the ones with Chaosnet support from https://github.com/keep-network/sortition-pools/pull/188.

Updated deployment scripts for ecdsa contracts to transfer the chaosnet owner to a named account.

Deactivated chaosnet in unit tests to avoid problems with adding operators to the pool