### PR TITLE
Bootstrap node: skip initializing Beacon and Tbtc

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -33,7 +33,6 @@ func Initialize(
 	netProvider net.Provider,
 	persistence persistence.ProtectedHandle,
 	scheduler *generator.Scheduler,
-	monitorPool bool,
 ) error {
 	groupRegistry := registry.NewGroupRegistry(logger, beaconChain, persistence)
 	groupRegistry.LoadExistingGroups()
@@ -45,20 +44,18 @@ func Initialize(
 		scheduler,
 	)
 
-	if monitorPool {
-		err := sortition.MonitorPool(
-			ctx,
-			logger,
-			beaconChain,
-			sortition.DefaultStatusCheckTick,
-			sortition.NewBetaOperatorPolicy(beaconChain, logger),
+	err := sortition.MonitorPool(
+		ctx,
+		logger,
+		beaconChain,
+		sortition.DefaultStatusCheckTick,
+		sortition.NewBetaOperatorPolicy(beaconChain, logger),
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"could not set up sortition pool monitoring: [%v]",
+			err,
 		)
-		if err != nil {
-			return fmt.Errorf(
-				"could not set up sortition pool monitoring: [%v]",
-				err,
-			)
-		}
 	}
 
 	eventDeduplicator := event.NewDeduplicator(beaconChain)

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -57,7 +57,6 @@ func Initialize(
 	scheduler *generator.Scheduler,
 	config Config,
 	clientInfo *clientinfo.Registry,
-	monitorPool bool,
 ) error {
 	node := newNode(chain, netProvider, keyStorePersistence, workPersistence, scheduler, config)
 	deduplicator := newDeduplicator()
@@ -74,26 +73,24 @@ func Initialize(
 		)
 	}
 
-	if monitorPool {
-		err := sortition.MonitorPool(
-			ctx,
-			logger,
-			chain,
-			sortition.DefaultStatusCheckTick,
-			sortition.NewConjunctionPolicy(
-				sortition.NewBetaOperatorPolicy(chain, logger),
-				&enoughPreParamsInPoolPolicy{
-					node:   node,
-					config: config,
-				},
-			),
+	err := sortition.MonitorPool(
+		ctx,
+		logger,
+		chain,
+		sortition.DefaultStatusCheckTick,
+		sortition.NewConjunctionPolicy(
+			sortition.NewBetaOperatorPolicy(chain, logger),
+			&enoughPreParamsInPoolPolicy{
+				node:   node,
+				config: config,
+			},
+		),
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"could not set up sortition pool monitoring: [%v]",
+			err,
 		)
-		if err != nil {
-			return fmt.Errorf(
-				"could not set up sortition pool monitoring: [%v]",
-				err,
-			)
-		}
 	}
 
 	_ = chain.OnDKGStarted(func(event *DKGStartedEvent) {


### PR DESCRIPTION
This PR adds modifications to the start of keep client: initializing Beacon and Tbtc is skipped for bootstrap nodes.
Bootstrap nodes are only used for network discovery and therefore do not participate in DKG.
Note that bootstrap nodes still validate connection with other peers.

The PR was tested manually.