### PR TITLE
Trigger publish of a new package on changes to `tasks` folder

### DIFF
--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "solidity/random-beacon/contracts/**"
       - "solidity/random-beacon/deploy/**"
+      - "solidity/random-beacon/tasks/**"
       - "solidity/random-beacon/hardhat.config.ts"
       - "solidity/random-beacon/package.json"
       - "solidity/random-beacon/yarn.lock"


### PR DESCRIPTION
As the tasks stored in `solidity/random-beacon/tasks` get published in the NPM packages, we should trigger publishing of a new package when there are changes to the files in that directory (on merge to `main`).

Refs:
https://github.com/keep-network/keep-core/pull/3307
https://github.com/keep-network/tbtc-v2/pull/411