### PR TITLE
Include `tasks` in the `ecdsa` package

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "solidity/ecdsa/contracts/**"
       - "solidity/ecdsa/deploy/**"
+      - "solidity/ecdsa/tasks/**"
       - "solidity/ecdsa/hardhat.config.ts"
       - "solidity/ecdsa/package.json"
       - "solidity/ecdsa/yarn.lock"

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -11,6 +11,7 @@
     "!**/test/",
     "deploy/",
     "export/",
+    "tasks/",
     "export.json"
   ],
   "scripts": {


### PR DESCRIPTION
This commit/PR adds the `tasks` folder to the list of files published in the NPM package, so that the tasks could be used by other projects. Modification of the content of the folder (on merge to `main`) will trigger a job publishing new package.

Refs:
https://github.com/keep-network/tbtc-v2/pull/411
https://github.com/keep-network/keep-core/pull/3306