### PR TITLE
Stop setting network peers for keep-test nodes

### DIFF
--- a/infrastructure/kube/keep-test/keep-client/gen/data.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/data.yaml
@@ -5,25 +5,16 @@ clients:
     publicAnnouncedAddress: "bootstrap-0.test.keep.network"
     staticIP: "104.154.61.116"
   - id: 1
-    networkPeers: /dns4/keep-client-0.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
     publicAnnouncedAddress: "bootstrap-1.test.keep.network"
     staticIP: "35.223.100.87"
   - id: 2
-    networkPeers: /dns4/keep-client-1.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
   - id: 3
-    networkPeers: /dns4/keep-client-2.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmNNuCp45z5bgB8KiTHv1vHTNAVbBgxxtTFGAndageo9Dp
   - id: 4
-    networkPeers: /dns4/keep-client-3.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf
   - id: 5
-    networkPeers: /dns4/keep-client-4.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAkxRTeySEWZfW9C83GPFpQUXvrygmZryCN6DL4piZrbAv4
   - id: 6
-    networkPeers: /dns4/keep-client-5.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm7Vq3Xf8xnSQDyj2j3AAEDjJk9Hp1RemTXNKmQwHm8cFt
   - id: 7
-    networkPeers: /dns4/keep-client-6.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmNT1E8Hepthx6sgoHXb7WDpCk9ecPTN7J1FvaD76SvvPG
   - id: 8
-    networkPeers: /dns4/keep-client-7.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmNnbEQy4wi9KNoyoGh3nZy5urkbf5oUKrw69XmVrKeowd
   - id: 9
-    networkPeers: /dns4/keep-client-8.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmCJ9iupUiWed9NmpsPG7W2EiccEceuDrKZuQe7mkyAQxv
 initContainers:
   - name: initcontainer-beacon
     image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest

--- a/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
@@ -296,8 +296,6 @@ spec:
         - "3919"
         - --network.announcedAddresses
         - /dns4/bootstrap-1.test.keep.network/tcp/3919
-        - --network.peers
-        - /dns4/keep-client-0.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -502,8 +500,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-1.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -708,8 +704,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-2.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmNNuCp45z5bgB8KiTHv1vHTNAVbBgxxtTFGAndageo9Dp
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -914,8 +908,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-3.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -1120,8 +1112,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-4.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAkxRTeySEWZfW9C83GPFpQUXvrygmZryCN6DL4piZrbAv4
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -1326,8 +1316,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-5.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAm7Vq3Xf8xnSQDyj2j3AAEDjJk9Hp1RemTXNKmQwHm8cFt
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -1532,8 +1520,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-6.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmNT1E8Hepthx6sgoHXb7WDpCk9ecPTN7J1FvaD76SvvPG
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -1738,8 +1724,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-7.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmNnbEQy4wi9KNoyoGh3nZy5urkbf5oUKrw69XmVrKeowd
         - --metrics.port
         - "9601"
         - --diagnostics.port
@@ -1944,8 +1928,6 @@ spec:
         - /mnt/keep-client/data
         - --network.port
         - "3919"
-        - --network.peers
-        - /dns4/keep-client-8.default.svc.cluster.local/tcp/3919/ipfs/16Uiu2HAmCJ9iupUiWed9NmpsPG7W2EiccEceuDrKZuQe7mkyAQxv
         - --metrics.port
         - "9601"
         - --diagnostics.port


### PR DESCRIPTION
The bootstrap nodes list is hardcoded into the client. There is no need to set them explicitly.