### PR TITLE
Deployments scripts for mainnet

### DIFF
--- a/solidity/ecdsa/.gitignore
+++ b/solidity/ecdsa/.gitignore
@@ -8,7 +8,7 @@ export.json
 
 # Contract artifacts
 artifacts/
-deployments/
+deployments/*
 !deployments/mainnet
 
 # OpenZeppelin

--- a/solidity/ecdsa/.prettierignore
+++ b/solidity/ecdsa/.prettierignore
@@ -3,7 +3,7 @@ build/
 cache/
 deployments/
 export/
-external/npm
+external/
 hardhat-dependency-compiler/
 typechain/
 export.json

--- a/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
+++ b/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
@@ -7,7 +7,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { execute } = deployments
   const { to1e18 } = helpers.number
 
-  const POOL_WEIGHT_DIVISOR = to1e18(1) // TODO: Update value
+  const POOL_WEIGHT_DIVISOR = to1e18(1)
 
   const T = await deployments.get("T")
 

--- a/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
+++ b/solidity/ecdsa/deploy/01_deploy_ecdsa_sortition_pool.ts
@@ -21,7 +21,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   await execute(
     "EcdsaSortitionPool",
-    { from: deployer },
+    { from: deployer, log: true, waitConfirmations: 1 },
     "transferChaosnetOwnerRole",
     chaosnetOwner
   )

--- a/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/03_deploy_wallet_registry.ts
@@ -4,6 +4,11 @@ import type { DeployFunction } from "hardhat-deploy/types"
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, ethers, helpers } = hre
   const { deployer } = await getNamedAccounts()
+  const { to1e18 } = helpers.number
+
+  const minimumAuthorization = to1e18(40_000) // 40k T
+  const authorizationDecreaseDelay = 1_209_600 // 1 209 600 seconds = 14 days
+  const authorizationDecreaseChangePeriod = 1_209_600 // 1 209 600 seconds = 14 days
 
   const EcdsaSortitionPool = await deployments.get("EcdsaSortitionPool")
   const TokenStaking = await deployments.get("TokenStaking")
@@ -41,6 +46,15 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
         kind: "transparent",
       },
     }
+  )
+
+  await deployments.execute(
+    "WalletRegistry",
+    { from: deployer, log: true, waitConfirmations: 1 },
+    "updateAuthorizationParameters",
+    minimumAuthorization,
+    authorizationDecreaseDelay,
+    authorizationDecreaseChangePeriod
   )
 
   await helpers.ownable.transferOwnership(

--- a/solidity/ecdsa/deploy/04_approve_wallet_registry.ts
+++ b/solidity/ecdsa/deploy/04_approve_wallet_registry.ts
@@ -20,3 +20,7 @@ export default func
 
 func.tags = ["WalletRegistryApprove"]
 func.dependencies = ["TokenStaking", "WalletRegistry"]
+
+// Skip for mainnet.
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> =>
+  hre.network.name === "mainnet"

--- a/solidity/ecdsa/deploy/10_authorize_in_random_beacon.ts
+++ b/solidity/ecdsa/deploy/10_authorize_in_random_beacon.ts
@@ -3,14 +3,20 @@ import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments } = hre
-  const { governance } = await getNamedAccounts()
+  const { deployer, governance } = await getNamedAccounts()
   const { execute } = deployments
 
   const WalletRegistry = await deployments.get("WalletRegistry")
 
+  // For mainnet we expect the scripts to be executed one by one. It's assumed that
+  // the transfer of RandomBeaconGovernance ownership to governance will happen
+  // after ecdsa contracts migration is done, so the `deployer` is still the
+  // owner of `RandomBeaconGovernance`.
+  const from = hre.network.name === "mainnet" ? deployer : governance
+
   await execute(
     "RandomBeaconGovernance",
-    { from: governance, log: true, waitConfirmations: 1 },
+    { from, log: true, waitConfirmations: 1 },
     "setRequesterAuthorization",
     WalletRegistry.address,
     true

--- a/solidity/ecdsa/deploy/11_transfer_reimbursement_pool_ownerhsip.ts
+++ b/solidity/ecdsa/deploy/11_transfer_reimbursement_pool_ownerhsip.ts
@@ -1,0 +1,18 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { getNamedAccounts, helpers } = hre
+  const { deployer, governance } = await getNamedAccounts()
+
+  await helpers.ownable.transferOwnership(
+    "ReimbursementPool",
+    governance,
+    deployer
+  )
+}
+
+export default func
+
+func.tags = ["ReimbursementPoolTransferGovernance"]
+func.dependencies = ["ReimbursementPool"]

--- a/solidity/ecdsa/external/mainnet/T.json
+++ b/solidity/ecdsa/external/mainnet/T.json
@@ -1,0 +1,1134 @@
+{
+  "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+  "abi": [
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "delegator",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromDelegate",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toDelegate",
+          "type": "address"
+        }
+      ],
+      "name": "DelegateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "delegate",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "previousBalance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newBalance",
+          "type": "uint256"
+        }
+      ],
+      "name": "DelegateVotesChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DELEGATION_TYPEHASH",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PERMIT_TYPEHASH",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "approveAndCall",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burn",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burnFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cachedChainId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cachedDomainSeparator",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint32",
+          "name": "pos",
+          "type": "uint32"
+        }
+      ],
+      "name": "checkpoints",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "fromBlock",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint96",
+              "name": "votes",
+              "type": "uint96"
+            }
+          ],
+          "internalType": "struct Checkpoints.Checkpoint",
+          "name": "checkpoint",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "delegatee",
+          "type": "address"
+        }
+      ],
+      "name": "delegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signatory",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "delegatee",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "delegateBySig",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "delegates",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPastTotalSupply",
+      "outputs": [
+        {
+          "internalType": "uint96",
+          "name": "",
+          "type": "uint96"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPastVotes",
+      "outputs": [
+        {
+          "internalType": "uint96",
+          "name": "",
+          "type": "uint96"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "getVotes",
+      "outputs": [
+        {
+          "internalType": "uint96",
+          "name": "",
+          "type": "uint96"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "nonce",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "numCheckpoints",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "recoverERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC721",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "recoverERC721",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xdfc479f92a88c0a7a2148227c0d4c07db077df75ced4b0409465459a6b1a2454",
+  "receipt": {
+    "to": null,
+    "from": "0x123694886DBf5Ac94DDA07135349534536D14cAf",
+    "contractAddress": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+    "transactionIndex": 34,
+    "gasUsed": "2244990",
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000800000000000000000000800000000000000000000000000000000000000000000000000000400000000000000000000000000000000000001000000000000000000000000000000000000020000000000010000000800000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0xbfc68de83f2c428cd0d55861fd2d63b16e3ac3226814788d2782fc52621be0c9",
+    "transactionHash": "0xdfc479f92a88c0a7a2148227c0d4c07db077df75ced4b0409465459a6b1a2454",
+    "logs": [
+      {
+        "transactionIndex": 34,
+        "blockNumber": 13912436,
+        "transactionHash": "0xdfc479f92a88c0a7a2148227c0d4c07db077df75ced4b0409465459a6b1a2454",
+        "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x000000000000000000000000123694886dbf5ac94dda07135349534536d14caf"
+        ],
+        "data": "0x",
+        "logIndex": 21,
+        "blockHash": "0xbfc68de83f2c428cd0d55861fd2d63b16e3ac3226814788d2782fc52621be0c9"
+      }
+    ],
+    "blockNumber": 13912436,
+    "cumulativeGasUsed": "3554050",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [],
+  "solcInputHash": "43eb8b17fe7c2ce0e21167459a2d9d30",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.9+commit.e5eed63a\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromDelegate\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toDelegate\",\"type\":\"address\"}],\"name\":\"DelegateChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"previousBalance\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newBalance\",\"type\":\"uint256\"}],\"name\":\"DelegateVotesChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DELEGATION_TYPEHASH\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PERMIT_TYPEHASH\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"name\":\"approveAndCall\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"burn\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"burnFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"cachedChainId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"cachedDomainSeparator\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"pos\",\"type\":\"uint32\"}],\"name\":\"checkpoints\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"fromBlock\",\"type\":\"uint32\"},{\"internalType\":\"uint96\",\"name\":\"votes\",\"type\":\"uint96\"}],\"internalType\":\"struct Checkpoints.Checkpoint\",\"name\":\"checkpoint\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatee\",\"type\":\"address\"}],\"name\":\"delegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signatory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"delegatee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"delegateBySig\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"delegates\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getPastTotalSupply\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getPastVotes\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"getVotes\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"mint\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"nonce\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"numCheckpoints\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contract IERC20\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"recoverERC20\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contract IERC721\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"recoverERC721\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"By default, token balance does not account for voting power.      This makes transfers cheaper. The downside is that it requires users      to delegate to themselves to activate checkpoints and have their      voting power tracked.\",\"kind\":\"dev\",\"methods\":{\"approve(address,uint256)\":{\"details\":\"If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.      Beware that changing an allowance with this method brings the risk      that someone may use both the old and the new allowance by      unfortunate transaction ordering. One possible solution to mitigate      this race condition is to first reduce the spender's allowance to 0      and set the desired value afterwards:      https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\",\"returns\":{\"_0\":\"True if the operation succeeded.\"}},\"approveAndCall(address,uint256,bytes)\":{\"details\":\"If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.\",\"returns\":{\"_0\":\"True if both approval and `receiveApproval` calls succeeded.\"}},\"burn(uint256)\":{\"details\":\"Requirements:       - the caller must have a balance of at least `amount`.\"},\"burnFrom(address,uint256)\":{\"details\":\"Requirements:      - `account` must have a balance of at least `amount`,      - the caller must have allowance for `account`'s tokens of at least        `amount`.\"},\"delegate(address)\":{\"params\":{\"delegatee\":\"The address to delegate votes to\"}},\"delegateBySig(address,address,uint256,uint8,bytes32,bytes32)\":{\"params\":{\"deadline\":\"The time at which to expire the signature\",\"delegatee\":\"The address to delegate votes to\",\"r\":\"Half of the ECDSA signature pair\",\"s\":\"Half of the ECDSA signature pair\",\"v\":\"The recovery byte of the signature\"}},\"getPastTotalSupply(uint256)\":{\"details\":\"`blockNumber` must have been already mined\",\"params\":{\"blockNumber\":\"The block number to get the total supply at\"}},\"getPastVotes(address,uint256)\":{\"details\":\"Block number must be a finalized block or else this function will      revert to prevent misinformation.\",\"params\":{\"account\":\"The address of the account to check\",\"blockNumber\":\"The block number to get the vote balance at\"},\"returns\":{\"_0\":\"The number of votes the account had as of the given block\"}},\"getVotes(address)\":{\"params\":{\"account\":\"The address to get votes balance\"},\"returns\":{\"_0\":\"The number of current votes for `account`\"}},\"mint(address,uint256)\":{\"details\":\"Requirements:      - `recipient` cannot be the zero address.\"},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"The deadline argument can be set to `type(uint256).max to create         permits that effectively never expire.  If the `amount` is set         to `type(uint256).max` then `transferFrom` and `burnFrom` will         not reduce an allowance.\"},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.\"},\"transfer(address,uint256)\":{\"details\":\"Requirements:       - `recipient` cannot be the zero address,       - the caller must have a balance of at least `amount`.\",\"returns\":{\"_0\":\"True if the operation succeeded, reverts otherwise.\"}},\"transferFrom(address,address,uint256)\":{\"details\":\"Requirements:      - `spender` and `recipient` cannot be the zero address,      - `spender` must have a balance of at least `amount`,      - the caller must have allowance for `spender`'s tokens of at least        `amount`.\",\"returns\":{\"_0\":\"True if the operation succeeded, reverts otherwise.\"}},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"title\":\"T token\",\"version\":1},\"userdoc\":{\"events\":{\"DelegateChanged(address,address,address)\":{\"notice\":\"Emitted when an account changes their delegate.\"},\"DelegateVotesChanged(address,uint256,uint256)\":{\"notice\":\"Emitted when a balance or delegate change results in changes         to an account's voting power.\"}},\"kind\":\"user\",\"methods\":{\"DELEGATION_TYPEHASH()\":{\"notice\":\"The EIP-712 typehash for the delegation struct used by         `delegateBySig`.\"},\"DOMAIN_SEPARATOR()\":{\"notice\":\"Returns hash of EIP712 Domain struct with the token name as         a signing domain and token contract as a verifying contract.         Used to construct EIP2612 signature provided to `permit`         function.\"},\"PERMIT_TYPEHASH()\":{\"notice\":\"Returns EIP2612 Permit message hash. Used to construct EIP2612         signature provided to `permit` function.\"},\"allowance(address,address)\":{\"notice\":\"The remaining number of tokens that spender will be         allowed to spend on behalf of owner through `transferFrom` and         `burnFrom`. This is zero by default.\"},\"approve(address,uint256)\":{\"notice\":\"Sets `amount` as the allowance of `spender` over the caller's         tokens.\"},\"approveAndCall(address,uint256,bytes)\":{\"notice\":\"Calls `receiveApproval` function on spender previously approving         the spender to withdraw from the caller multiple times, up to         the `amount` amount. If this function is called again, it         overwrites the current allowance with `amount`. Reverts if the         approval reverted or if `receiveApproval` call on the spender         reverted.\"},\"balanceOf(address)\":{\"notice\":\"The amount of tokens owned by the given account.\"},\"burn(uint256)\":{\"notice\":\"Destroys `amount` tokens from the caller.\"},\"burnFrom(address,uint256)\":{\"notice\":\"Destroys `amount` of tokens from `account` using the allowance         mechanism. `amount` is then deducted from the caller's allowance         unless the allowance was made for `type(uint256).max`.\"},\"decimals()\":{\"notice\":\"The decimals places of the token.\"},\"delegate(address)\":{\"notice\":\"Delegate votes from `msg.sender` to `delegatee`.\"},\"delegateBySig(address,address,uint256,uint8,bytes32,bytes32)\":{\"notice\":\"Delegates votes from signatory to `delegatee`\"},\"delegates(address)\":{\"notice\":\"Get the address `account` is currently delegating to.\"},\"getPastTotalSupply(uint256)\":{\"notice\":\"Retrieve the `totalSupply` at the end of `blockNumber`.         Note, this value is the sum of all balances, but it is NOT the         sum of all the delegated votes!\"},\"getPastVotes(address,uint256)\":{\"notice\":\"Determine the prior number of votes for an account as of         a block number.\"},\"getVotes(address)\":{\"notice\":\"Gets the current votes balance for `account`.\"},\"mint(address,uint256)\":{\"notice\":\"Creates `amount` tokens and assigns them to `account`,         increasing the total supply.\"},\"name()\":{\"notice\":\"The name of the token.\"},\"nonce(address)\":{\"notice\":\"Returns the current nonce for EIP2612 permission for the         provided token owner for a replay protection. Used to construct         EIP2612 signature provided to `permit` function.\"},\"numCheckpoints(address)\":{\"notice\":\"Get number of checkpoints for `account`.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"notice\":\"EIP2612 approval made with secp256k1 signature.         Users can authorize a transfer of their tokens with a signature         conforming EIP712 standard, rather than an on-chain transaction         from their address. Anyone can submit this signature on the         user's behalf by calling the permit function, paying gas fees,         and possibly performing other actions in the same transaction.\"},\"symbol()\":{\"notice\":\"The symbol of the token.\"},\"totalSupply()\":{\"notice\":\"The amount of tokens in existence.\"},\"transfer(address,uint256)\":{\"notice\":\"Moves `amount` tokens from the caller's account to `recipient`.\"},\"transferFrom(address,address,uint256)\":{\"notice\":\"Moves `amount` tokens from `spender` to `recipient` using the         allowance mechanism. `amount` is then deducted from the caller's         allowance unless the allowance was made for `type(uint256).max`.\"}},\"notice\":\"Threshold Network T token\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/token/T.sol\":\"T\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":100},\"remappings\":[]},\"sources\":{\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (access/Ownable.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * By default, the owner account will be the one that deploys the contract. This\\n * can later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the deployer as the initial owner.\\n     */\\n    constructor() {\\n        _transferOwnership(_msgSender());\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        require(owner() == _msgSender(), \\\"Ownable: caller is not the owner\\\");\\n        _;\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions anymore. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby removing any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        require(newOwner != address(0), \\\"Ownable: new owner is the zero address\\\");\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xa1b27b3f44ff825974e5268e8f63ad3b03add5b464880d860fbb8cae043e17f7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Interface of the ERC20 standard as defined in the EIP.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Returns the amount of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the amount of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves `amount` tokens from the caller's account to `recipient`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address recipient, uint256 amount) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 amount) external returns (bool);\\n\\n    /**\\n     * @dev Moves `amount` tokens from `sender` to `recipient` using the\\n     * allowance mechanism. `amount` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(\\n        address sender,\\n        address recipient,\\n        uint256 amount\\n    ) external returns (bool);\\n\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n}\\n\",\"keccak256\":\"0xc1452b054778f1926419196ef12ae200758a4ee728df69ae1cd13e5c16ca7df7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC20 standard.\\n *\\n * _Available since v4.1._\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x842c66d5965ed0bf77f274732c2a93a7e2223d53171ec9cccc473bde75104ead\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../IERC20.sol\\\";\\nimport \\\"../../../utils/Address.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    using Address for address;\\n\\n    function safeTransfer(\\n        IERC20 token,\\n        address to,\\n        uint256 value\\n    ) internal {\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));\\n    }\\n\\n    function safeTransferFrom(\\n        IERC20 token,\\n        address from,\\n        address to,\\n        uint256 value\\n    ) internal {\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));\\n    }\\n\\n    /**\\n     * @dev Deprecated. This function has issues similar to the ones found in\\n     * {IERC20-approve}, and its usage is discouraged.\\n     *\\n     * Whenever possible, use {safeIncreaseAllowance} and\\n     * {safeDecreaseAllowance} instead.\\n     */\\n    function safeApprove(\\n        IERC20 token,\\n        address spender,\\n        uint256 value\\n    ) internal {\\n        // safeApprove should only be called when setting an initial allowance,\\n        // or when resetting it to zero. To increase and decrease it, use\\n        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'\\n        require(\\n            (value == 0) || (token.allowance(address(this), spender) == 0),\\n            \\\"SafeERC20: approve from non-zero to non-zero allowance\\\"\\n        );\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));\\n    }\\n\\n    function safeIncreaseAllowance(\\n        IERC20 token,\\n        address spender,\\n        uint256 value\\n    ) internal {\\n        uint256 newAllowance = token.allowance(address(this), spender) + value;\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));\\n    }\\n\\n    function safeDecreaseAllowance(\\n        IERC20 token,\\n        address spender,\\n        uint256 value\\n    ) internal {\\n        unchecked {\\n            uint256 oldAllowance = token.allowance(address(this), spender);\\n            require(oldAllowance >= value, \\\"SafeERC20: decreased allowance below zero\\\");\\n            uint256 newAllowance = oldAllowance - value;\\n            _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since\\n        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that\\n        // the target address contains contract code and also asserts for success in the low-level call.\\n\\n        bytes memory returndata = address(token).functionCall(data, \\\"SafeERC20: low-level call failed\\\");\\n        if (returndata.length > 0) {\\n            // Return data is optional\\n            require(abi.decode(returndata, (bool)), \\\"SafeERC20: ERC20 operation did not succeed\\\");\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x671741933530f343f023a40e58e61bc09d62494b96c6f3e39e647f315facd519\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC721/IERC721.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC721/IERC721.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../../utils/introspection/IERC165.sol\\\";\\n\\n/**\\n * @dev Required interface of an ERC721 compliant contract.\\n */\\ninterface IERC721 is IERC165 {\\n    /**\\n     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);\\n\\n    /**\\n     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.\\n     */\\n    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);\\n\\n    /**\\n     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.\\n     */\\n    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);\\n\\n    /**\\n     * @dev Returns the number of tokens in ``owner``'s account.\\n     */\\n    function balanceOf(address owner) external view returns (uint256 balance);\\n\\n    /**\\n     * @dev Returns the owner of the `tokenId` token.\\n     *\\n     * Requirements:\\n     *\\n     * - `tokenId` must exist.\\n     */\\n    function ownerOf(uint256 tokenId) external view returns (address owner);\\n\\n    /**\\n     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients\\n     * are aware of the ERC721 protocol to prevent tokens from being forever locked.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` cannot be the zero address.\\n     * - `to` cannot be the zero address.\\n     * - `tokenId` token must exist and be owned by `from`.\\n     * - If the caller is not `from`, it must be have been allowed to move this token by either {approve} or {setApprovalForAll}.\\n     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function safeTransferFrom(\\n        address from,\\n        address to,\\n        uint256 tokenId\\n    ) external;\\n\\n    /**\\n     * @dev Transfers `tokenId` token from `from` to `to`.\\n     *\\n     * WARNING: Usage of this method is discouraged, use {safeTransferFrom} whenever possible.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` cannot be the zero address.\\n     * - `to` cannot be the zero address.\\n     * - `tokenId` token must be owned by `from`.\\n     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(\\n        address from,\\n        address to,\\n        uint256 tokenId\\n    ) external;\\n\\n    /**\\n     * @dev Gives permission to `to` to transfer `tokenId` token to another account.\\n     * The approval is cleared when the token is transferred.\\n     *\\n     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.\\n     *\\n     * Requirements:\\n     *\\n     * - The caller must own the token or be an approved operator.\\n     * - `tokenId` must exist.\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address to, uint256 tokenId) external;\\n\\n    /**\\n     * @dev Returns the account approved for `tokenId` token.\\n     *\\n     * Requirements:\\n     *\\n     * - `tokenId` must exist.\\n     */\\n    function getApproved(uint256 tokenId) external view returns (address operator);\\n\\n    /**\\n     * @dev Approve or remove `operator` as an operator for the caller.\\n     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.\\n     *\\n     * Requirements:\\n     *\\n     * - The `operator` cannot be the caller.\\n     *\\n     * Emits an {ApprovalForAll} event.\\n     */\\n    function setApprovalForAll(address operator, bool _approved) external;\\n\\n    /**\\n     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.\\n     *\\n     * See {setApprovalForAll}\\n     */\\n    function isApprovedForAll(address owner, address operator) external view returns (bool);\\n\\n    /**\\n     * @dev Safely transfers `tokenId` token from `from` to `to`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` cannot be the zero address.\\n     * - `to` cannot be the zero address.\\n     * - `tokenId` token must exist and be owned by `from`.\\n     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.\\n     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function safeTransferFrom(\\n        address from,\\n        address to,\\n        uint256 tokenId,\\n        bytes calldata data\\n    ) external;\\n}\\n\",\"keccak256\":\"0x872ba21af7c1f0ae04a715beca31e8fcac764d6c8762940b0fe1bfb6ed8e86f4\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Address.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/Address.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Collection of functions related to the address type\\n */\\nlibrary Address {\\n    /**\\n     * @dev Returns true if `account` is a contract.\\n     *\\n     * [IMPORTANT]\\n     * ====\\n     * It is unsafe to assume that an address for which this function returns\\n     * false is an externally-owned account (EOA) and not a contract.\\n     *\\n     * Among others, `isContract` will return false for the following\\n     * types of addresses:\\n     *\\n     *  - an externally-owned account\\n     *  - a contract in construction\\n     *  - an address where a contract will be created\\n     *  - an address where a contract lived, but was destroyed\\n     * ====\\n     */\\n    function isContract(address account) internal view returns (bool) {\\n        // This method relies on extcodesize, which returns 0 for contracts in\\n        // construction, since the code is only stored at the end of the\\n        // constructor execution.\\n\\n        uint256 size;\\n        assembly {\\n            size := extcodesize(account)\\n        }\\n        return size > 0;\\n    }\\n\\n    /**\\n     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to\\n     * `recipient`, forwarding all available gas and reverting on errors.\\n     *\\n     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost\\n     * of certain opcodes, possibly making contracts go over the 2300 gas limit\\n     * imposed by `transfer`, making them unable to receive funds via\\n     * `transfer`. {sendValue} removes this limitation.\\n     *\\n     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].\\n     *\\n     * IMPORTANT: because control is transferred to `recipient`, care must be\\n     * taken to not create reentrancy vulnerabilities. Consider using\\n     * {ReentrancyGuard} or the\\n     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].\\n     */\\n    function sendValue(address payable recipient, uint256 amount) internal {\\n        require(address(this).balance >= amount, \\\"Address: insufficient balance\\\");\\n\\n        (bool success, ) = recipient.call{value: amount}(\\\"\\\");\\n        require(success, \\\"Address: unable to send value, recipient may have reverted\\\");\\n    }\\n\\n    /**\\n     * @dev Performs a Solidity function call using a low level `call`. A\\n     * plain `call` is an unsafe replacement for a function call: use this\\n     * function instead.\\n     *\\n     * If `target` reverts with a revert reason, it is bubbled up by this\\n     * function (like regular Solidity function calls).\\n     *\\n     * Returns the raw returned data. To convert to the expected return value,\\n     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].\\n     *\\n     * Requirements:\\n     *\\n     * - `target` must be a contract.\\n     * - calling `target` with `data` must not revert.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCall(address target, bytes memory data) internal returns (bytes memory) {\\n        return functionCall(target, data, \\\"Address: low-level call failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with\\n     * `errorMessage` as a fallback revert reason when `target` reverts.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCall(\\n        address target,\\n        bytes memory data,\\n        string memory errorMessage\\n    ) internal returns (bytes memory) {\\n        return functionCallWithValue(target, data, 0, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],\\n     * but also transferring `value` wei to `target`.\\n     *\\n     * Requirements:\\n     *\\n     * - the calling contract must have an ETH balance of at least `value`.\\n     * - the called Solidity function must be `payable`.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCallWithValue(\\n        address target,\\n        bytes memory data,\\n        uint256 value\\n    ) internal returns (bytes memory) {\\n        return functionCallWithValue(target, data, value, \\\"Address: low-level call with value failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but\\n     * with `errorMessage` as a fallback revert reason when `target` reverts.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCallWithValue(\\n        address target,\\n        bytes memory data,\\n        uint256 value,\\n        string memory errorMessage\\n    ) internal returns (bytes memory) {\\n        require(address(this).balance >= value, \\\"Address: insufficient balance for call\\\");\\n        require(isContract(target), \\\"Address: call to non-contract\\\");\\n\\n        (bool success, bytes memory returndata) = target.call{value: value}(data);\\n        return verifyCallResult(success, returndata, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],\\n     * but performing a static call.\\n     *\\n     * _Available since v3.3._\\n     */\\n    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {\\n        return functionStaticCall(target, data, \\\"Address: low-level static call failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],\\n     * but performing a static call.\\n     *\\n     * _Available since v3.3._\\n     */\\n    function functionStaticCall(\\n        address target,\\n        bytes memory data,\\n        string memory errorMessage\\n    ) internal view returns (bytes memory) {\\n        require(isContract(target), \\\"Address: static call to non-contract\\\");\\n\\n        (bool success, bytes memory returndata) = target.staticcall(data);\\n        return verifyCallResult(success, returndata, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],\\n     * but performing a delegate call.\\n     *\\n     * _Available since v3.4._\\n     */\\n    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {\\n        return functionDelegateCall(target, data, \\\"Address: low-level delegate call failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],\\n     * but performing a delegate call.\\n     *\\n     * _Available since v3.4._\\n     */\\n    function functionDelegateCall(\\n        address target,\\n        bytes memory data,\\n        string memory errorMessage\\n    ) internal returns (bytes memory) {\\n        require(isContract(target), \\\"Address: delegate call to non-contract\\\");\\n\\n        (bool success, bytes memory returndata) = target.delegatecall(data);\\n        return verifyCallResult(success, returndata, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the\\n     * revert reason using the provided one.\\n     *\\n     * _Available since v4.3._\\n     */\\n    function verifyCallResult(\\n        bool success,\\n        bytes memory returndata,\\n        string memory errorMessage\\n    ) internal pure returns (bytes memory) {\\n        if (success) {\\n            return returndata;\\n        } else {\\n            // Look for revert reason and bubble it up if present\\n            if (returndata.length > 0) {\\n                // The easiest way to bubble the revert reason is using memory via assembly\\n\\n                assembly {\\n                    let returndata_size := mload(returndata)\\n                    revert(add(32, returndata), returndata_size)\\n                }\\n            } else {\\n                revert(errorMessage);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x9944d1038f27dcebff810d7ba16b3b8058b967173d76874fb72dd7cd84129656\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/Context.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n}\\n\",\"keccak256\":\"0x7736c187e6f1358c1ea9350a2a21aa8528dec1c2f43b374a9067465a3a51f5d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/Strings.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    bytes16 private constant _HEX_SYMBOLS = \\\"0123456789abcdef\\\";\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        // Inspired by OraclizeAPI's implementation - MIT licence\\n        // https://github.com/oraclize/ethereum-api/blob/b42146b063c7d6ee1358846c198246239e9360e8/oraclizeAPI_0.4.25.sol\\n\\n        if (value == 0) {\\n            return \\\"0\\\";\\n        }\\n        uint256 temp = value;\\n        uint256 digits;\\n        while (temp != 0) {\\n            digits++;\\n            temp /= 10;\\n        }\\n        bytes memory buffer = new bytes(digits);\\n        while (value != 0) {\\n            digits -= 1;\\n            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));\\n            value /= 10;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        if (value == 0) {\\n            return \\\"0x00\\\";\\n        }\\n        uint256 temp = value;\\n        uint256 length = 0;\\n        while (temp != 0) {\\n            length++;\\n            temp >>= 8;\\n        }\\n        return toHexString(value, length);\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = _HEX_SYMBOLS[value & 0xf];\\n            value >>= 4;\\n        }\\n        require(value == 0, \\\"Strings: hex length insufficient\\\");\\n        return string(buffer);\\n    }\\n}\\n\",\"keccak256\":\"0x5fa25f305839292fab713256214f2868e0257d29826b14282bbd7f1e34f5af38\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS,\\n        InvalidSignatureV\\n    }\\n\\n    function _throwError(RecoverError error) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert(\\\"ECDSA: invalid signature\\\");\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert(\\\"ECDSA: invalid signature length\\\");\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert(\\\"ECDSA: invalid signature 's' value\\\");\\n        } else if (error == RecoverError.InvalidSignatureV) {\\n            revert(\\\"ECDSA: invalid signature 'v' value\\\");\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature` or error string. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     *\\n     * _Available since v4.3._\\n     */\\n    function tryRecover(bytes32 hash, bytes memory signature) internal pure returns (address, RecoverError) {\\n        // Check the signature length\\n        // - case 65: r,s,v signature (standard)\\n        // - case 64: r,vs signature (cf https://eips.ethereum.org/EIPS/eip-2098) _Available since v4.1._\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else if (signature.length == 64) {\\n            bytes32 r;\\n            bytes32 vs;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly {\\n                r := mload(add(signature, 0x20))\\n                vs := mload(add(signature, 0x40))\\n            }\\n            return tryRecover(hash, r, vs);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error) = tryRecover(hash, signature);\\n        _throwError(error);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[EIP-2098 short signatures]\\n     *\\n     * _Available since v4.3._\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address, RecoverError) {\\n        bytes32 s;\\n        uint8 v;\\n        assembly {\\n            s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)\\n            v := add(shr(255, vs), 27)\\n        }\\n        return tryRecover(hash, v, r, s);\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     *\\n     * _Available since v4.2._\\n     */\\n    function recover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address) {\\n        (address recovered, RecoverError error) = tryRecover(hash, r, vs);\\n        _throwError(error);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     *\\n     * _Available since v4.3._\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address, RecoverError) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS);\\n        }\\n        if (v != 27 && v != 28) {\\n            return (address(0), RecoverError.InvalidSignatureV);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature);\\n        }\\n\\n        return (signer, RecoverError.NoError);\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address) {\\n        (address recovered, RecoverError error) = tryRecover(hash, v, r, s);\\n        _throwError(error);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Returns an Ethereum Signed Message, created from a `hash`. This\\n     * produces hash corresponding to the one signed with the\\n     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]\\n     * JSON-RPC method as part of EIP-191.\\n     *\\n     * See {recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {\\n        // 32 is the length in bytes of hash,\\n        // enforced by the type signature above\\n        return keccak256(abi.encodePacked(\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\", hash));\\n    }\\n\\n    /**\\n     * @dev Returns an Ethereum Signed Message, created from `s`. This\\n     * produces hash corresponding to the one signed with the\\n     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]\\n     * JSON-RPC method as part of EIP-191.\\n     *\\n     * See {recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory s) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", Strings.toString(s.length), s));\\n    }\\n\\n    /**\\n     * @dev Returns an Ethereum Signed Typed Data, created from a\\n     * `domainSeparator` and a `structHash`. This produces hash corresponding\\n     * to the one signed with the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`]\\n     * JSON-RPC method as part of EIP-712.\\n     *\\n     * See {recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(\\\"\\\\x19\\\\x01\\\", domainSeparator, structHash));\\n    }\\n}\\n\",\"keccak256\":\"0x594efd2fa154f4fbe0fa92c2356cb2a9531ef3902e35784c2bc69764d0d8886a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Interface of the ERC165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[EIP].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x6aa521718bf139b44ce56f194f6aea1d590cacef995b5a84703fb1579fa49be9\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/math/Math.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a >= b ? a : b;\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a < b ? a : b;\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds up instead\\n     * of rounding down.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b - 1) / b can overflow on addition, so we distribute.\\n        return a / b + (a % b == 0 ? 0 : 1);\\n    }\\n}\\n\",\"keccak256\":\"0xe936fc79332de2ca7b1c06a70f81345aa2466958aab00f463e312ca0585e85cf\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/math/SafeCast.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n *\\n * Can be combined with {SafeMath} and {SignedSafeMath} to extend it to smaller types, by performing\\n * all math on `uint256` and `int256` and then downcasting.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        require(value <= type(uint224).max, \\\"SafeCast: value doesn't fit in 224 bits\\\");\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        require(value <= type(uint128).max, \\\"SafeCast: value doesn't fit in 128 bits\\\");\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        require(value <= type(uint96).max, \\\"SafeCast: value doesn't fit in 96 bits\\\");\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        require(value <= type(uint64).max, \\\"SafeCast: value doesn't fit in 64 bits\\\");\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        require(value <= type(uint32).max, \\\"SafeCast: value doesn't fit in 32 bits\\\");\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        require(value <= type(uint16).max, \\\"SafeCast: value doesn't fit in 16 bits\\\");\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits.\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        require(value <= type(uint8).max, \\\"SafeCast: value doesn't fit in 8 bits\\\");\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        require(value >= 0, \\\"SafeCast: value must be positive\\\");\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt128(int256 value) internal pure returns (int128) {\\n        require(value >= type(int128).min && value <= type(int128).max, \\\"SafeCast: value doesn't fit in 128 bits\\\");\\n        return int128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt64(int256 value) internal pure returns (int64) {\\n        require(value >= type(int64).min && value <= type(int64).max, \\\"SafeCast: value doesn't fit in 64 bits\\\");\\n        return int64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt32(int256 value) internal pure returns (int32) {\\n        require(value >= type(int32).min && value <= type(int32).max, \\\"SafeCast: value doesn't fit in 32 bits\\\");\\n        return int32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt16(int256 value) internal pure returns (int16) {\\n        require(value >= type(int16).min && value <= type(int16).max, \\\"SafeCast: value doesn't fit in 16 bits\\\");\\n        return int16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt8(int256 value) internal pure returns (int8) {\\n        require(value >= type(int8).min && value <= type(int8).max, \\\"SafeCast: value doesn't fit in 8 bits\\\");\\n        return int8(value);\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        require(value <= uint256(type(int256).max), \\\"SafeCast: value doesn't fit in an int256\\\");\\n        return int256(value);\\n    }\\n}\\n\",\"keccak256\":\"0x47c0131bd8a972c31596958aa86752ea18d60e33f1cd94d412b9e29fd6ab25a6\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\nimport \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\n\\nimport \\\"./IERC20WithPermit.sol\\\";\\nimport \\\"./IReceiveApproval.sol\\\";\\n\\n/// @title  ERC20WithPermit\\n/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can\\n///         authorize a transfer of their token with a signature conforming\\n///         EIP712 standard instead of an on-chain transaction from their\\n///         address. Anyone can submit this signature on the user's behalf by\\n///         calling the permit function, as specified in EIP2612 standard,\\n///         paying gas fees, and possibly performing other actions in the same\\n///         transaction.\\ncontract ERC20WithPermit is IERC20WithPermit, Ownable {\\n    /// @notice The amount of tokens owned by the given account.\\n    mapping(address => uint256) public override balanceOf;\\n\\n    /// @notice The remaining number of tokens that spender will be\\n    ///         allowed to spend on behalf of owner through `transferFrom` and\\n    ///         `burnFrom`. This is zero by default.\\n    mapping(address => mapping(address => uint256)) public override allowance;\\n\\n    /// @notice Returns the current nonce for EIP2612 permission for the\\n    ///         provided token owner for a replay protection. Used to construct\\n    ///         EIP2612 signature provided to `permit` function.\\n    mapping(address => uint256) public override nonce;\\n\\n    uint256 public immutable cachedChainId;\\n    bytes32 public immutable cachedDomainSeparator;\\n\\n    /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612\\n    ///         signature provided to `permit` function.\\n    bytes32 public constant override PERMIT_TYPEHASH =\\n        keccak256(\\n            \\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\"\\n        );\\n\\n    /// @notice The amount of tokens in existence.\\n    uint256 public override totalSupply;\\n\\n    /// @notice The name of the token.\\n    string public override name;\\n\\n    /// @notice The symbol of the token.\\n    string public override symbol;\\n\\n    /// @notice The decimals places of the token.\\n    uint8 public constant override decimals = 18;\\n\\n    constructor(string memory _name, string memory _symbol) {\\n        name = _name;\\n        symbol = _symbol;\\n\\n        cachedChainId = block.chainid;\\n        cachedDomainSeparator = buildDomainSeparator();\\n    }\\n\\n    /// @notice Moves `amount` tokens from the caller's account to `recipient`.\\n    /// @return True if the operation succeeded, reverts otherwise.\\n    /// @dev Requirements:\\n    ///       - `recipient` cannot be the zero address,\\n    ///       - the caller must have a balance of at least `amount`.\\n    function transfer(address recipient, uint256 amount)\\n        external\\n        override\\n        returns (bool)\\n    {\\n        _transfer(msg.sender, recipient, amount);\\n        return true;\\n    }\\n\\n    /// @notice Moves `amount` tokens from `spender` to `recipient` using the\\n    ///         allowance mechanism. `amount` is then deducted from the caller's\\n    ///         allowance unless the allowance was made for `type(uint256).max`.\\n    /// @return True if the operation succeeded, reverts otherwise.\\n    /// @dev Requirements:\\n    ///      - `spender` and `recipient` cannot be the zero address,\\n    ///      - `spender` must have a balance of at least `amount`,\\n    ///      - the caller must have allowance for `spender`'s tokens of at least\\n    ///        `amount`.\\n    function transferFrom(\\n        address spender,\\n        address recipient,\\n        uint256 amount\\n    ) external override returns (bool) {\\n        uint256 currentAllowance = allowance[spender][msg.sender];\\n        if (currentAllowance != type(uint256).max) {\\n            require(\\n                currentAllowance >= amount,\\n                \\\"Transfer amount exceeds allowance\\\"\\n            );\\n            _approve(spender, msg.sender, currentAllowance - amount);\\n        }\\n        _transfer(spender, recipient, amount);\\n        return true;\\n    }\\n\\n    /// @notice EIP2612 approval made with secp256k1 signature.\\n    ///         Users can authorize a transfer of their tokens with a signature\\n    ///         conforming EIP712 standard, rather than an on-chain transaction\\n    ///         from their address. Anyone can submit this signature on the\\n    ///         user's behalf by calling the permit function, paying gas fees,\\n    ///         and possibly performing other actions in the same transaction.\\n    /// @dev    The deadline argument can be set to `type(uint256).max to create\\n    ///         permits that effectively never expire.  If the `amount` is set\\n    ///         to `type(uint256).max` then `transferFrom` and `burnFrom` will\\n    ///         not reduce an allowance.\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 amount,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external override {\\n        /* solhint-disable-next-line not-rely-on-time */\\n        require(deadline >= block.timestamp, \\\"Permission expired\\\");\\n\\n        // Validate `s` and `v` values for a malleability concern described in EIP2.\\n        // Only signatures with `s` value in the lower half of the secp256k1\\n        // curve's order and `v` value of 27 or 28 are considered valid.\\n        require(\\n            uint256(s) <=\\n                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,\\n            \\\"Invalid signature 's' value\\\"\\n        );\\n        require(v == 27 || v == 28, \\\"Invalid signature 'v' value\\\");\\n\\n        bytes32 digest = keccak256(\\n            abi.encodePacked(\\n                \\\"\\\\x19\\\\x01\\\",\\n                DOMAIN_SEPARATOR(),\\n                keccak256(\\n                    abi.encode(\\n                        PERMIT_TYPEHASH,\\n                        owner,\\n                        spender,\\n                        amount,\\n                        nonce[owner]++,\\n                        deadline\\n                    )\\n                )\\n            )\\n        );\\n        address recoveredAddress = ecrecover(digest, v, r, s);\\n        require(\\n            recoveredAddress != address(0) && recoveredAddress == owner,\\n            \\\"Invalid signature\\\"\\n        );\\n        _approve(owner, spender, amount);\\n    }\\n\\n    /// @notice Creates `amount` tokens and assigns them to `account`,\\n    ///         increasing the total supply.\\n    /// @dev Requirements:\\n    ///      - `recipient` cannot be the zero address.\\n    function mint(address recipient, uint256 amount) external onlyOwner {\\n        require(recipient != address(0), \\\"Mint to the zero address\\\");\\n\\n        beforeTokenTransfer(address(0), recipient, amount);\\n\\n        totalSupply += amount;\\n        balanceOf[recipient] += amount;\\n        emit Transfer(address(0), recipient, amount);\\n    }\\n\\n    /// @notice Destroys `amount` tokens from the caller.\\n    /// @dev Requirements:\\n    ///       - the caller must have a balance of at least `amount`.\\n    function burn(uint256 amount) external override {\\n        _burn(msg.sender, amount);\\n    }\\n\\n    /// @notice Destroys `amount` of tokens from `account` using the allowance\\n    ///         mechanism. `amount` is then deducted from the caller's allowance\\n    ///         unless the allowance was made for `type(uint256).max`.\\n    /// @dev Requirements:\\n    ///      - `account` must have a balance of at least `amount`,\\n    ///      - the caller must have allowance for `account`'s tokens of at least\\n    ///        `amount`.\\n    function burnFrom(address account, uint256 amount) external override {\\n        uint256 currentAllowance = allowance[account][msg.sender];\\n        if (currentAllowance != type(uint256).max) {\\n            require(\\n                currentAllowance >= amount,\\n                \\\"Burn amount exceeds allowance\\\"\\n            );\\n            _approve(account, msg.sender, currentAllowance - amount);\\n        }\\n        _burn(account, amount);\\n    }\\n\\n    /// @notice Calls `receiveApproval` function on spender previously approving\\n    ///         the spender to withdraw from the caller multiple times, up to\\n    ///         the `amount` amount. If this function is called again, it\\n    ///         overwrites the current allowance with `amount`. Reverts if the\\n    ///         approval reverted or if `receiveApproval` call on the spender\\n    ///         reverted.\\n    /// @return True if both approval and `receiveApproval` calls succeeded.\\n    /// @dev If the `amount` is set to `type(uint256).max` then\\n    ///      `transferFrom` and `burnFrom` will not reduce an allowance.\\n    function approveAndCall(\\n        address spender,\\n        uint256 amount,\\n        bytes memory extraData\\n    ) external override returns (bool) {\\n        if (approve(spender, amount)) {\\n            IReceiveApproval(spender).receiveApproval(\\n                msg.sender,\\n                amount,\\n                address(this),\\n                extraData\\n            );\\n            return true;\\n        }\\n        return false;\\n    }\\n\\n    /// @notice Sets `amount` as the allowance of `spender` over the caller's\\n    ///         tokens.\\n    /// @return True if the operation succeeded.\\n    /// @dev If the `amount` is set to `type(uint256).max` then\\n    ///      `transferFrom` and `burnFrom` will not reduce an allowance.\\n    ///      Beware that changing an allowance with this method brings the risk\\n    ///      that someone may use both the old and the new allowance by\\n    ///      unfortunate transaction ordering. One possible solution to mitigate\\n    ///      this race condition is to first reduce the spender's allowance to 0\\n    ///      and set the desired value afterwards:\\n    ///      https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n    function approve(address spender, uint256 amount)\\n        public\\n        override\\n        returns (bool)\\n    {\\n        _approve(msg.sender, spender, amount);\\n        return true;\\n    }\\n\\n    /// @notice Returns hash of EIP712 Domain struct with the token name as\\n    ///         a signing domain and token contract as a verifying contract.\\n    ///         Used to construct EIP2612 signature provided to `permit`\\n    ///         function.\\n    /* solhint-disable-next-line func-name-mixedcase */\\n    function DOMAIN_SEPARATOR() public view override returns (bytes32) {\\n        // As explained in EIP-2612, if the DOMAIN_SEPARATOR contains the\\n        // chainId and is defined at contract deployment instead of\\n        // reconstructed for every signature, there is a risk of possible replay\\n        // attacks between chains in the event of a future chain split.\\n        // To address this issue, we check the cached chain ID against the\\n        // current one and in case they are different, we build domain separator\\n        // from scratch.\\n        if (block.chainid == cachedChainId) {\\n            return cachedDomainSeparator;\\n        } else {\\n            return buildDomainSeparator();\\n        }\\n    }\\n\\n    /// @dev Hook that is called before any transfer of tokens. This includes\\n    ///      minting and burning.\\n    ///\\n    /// Calling conditions:\\n    /// - when `from` and `to` are both non-zero, `amount` of `from`'s tokens\\n    ///   will be to transferred to `to`.\\n    /// - when `from` is zero, `amount` tokens will be minted for `to`.\\n    /// - when `to` is zero, `amount` of ``from``'s tokens will be burned.\\n    /// - `from` and `to` are never both zero.\\n    // slither-disable-next-line dead-code\\n    function beforeTokenTransfer(\\n        address from,\\n        address to,\\n        uint256 amount\\n    ) internal virtual {}\\n\\n    function _burn(address account, uint256 amount) internal {\\n        uint256 currentBalance = balanceOf[account];\\n        require(currentBalance >= amount, \\\"Burn amount exceeds balance\\\");\\n\\n        beforeTokenTransfer(account, address(0), amount);\\n\\n        balanceOf[account] = currentBalance - amount;\\n        totalSupply -= amount;\\n        emit Transfer(account, address(0), amount);\\n    }\\n\\n    function _transfer(\\n        address spender,\\n        address recipient,\\n        uint256 amount\\n    ) private {\\n        require(spender != address(0), \\\"Transfer from the zero address\\\");\\n        require(recipient != address(0), \\\"Transfer to the zero address\\\");\\n        require(recipient != address(this), \\\"Transfer to the token address\\\");\\n\\n        beforeTokenTransfer(spender, recipient, amount);\\n\\n        uint256 spenderBalance = balanceOf[spender];\\n        require(spenderBalance >= amount, \\\"Transfer amount exceeds balance\\\");\\n        balanceOf[spender] = spenderBalance - amount;\\n        balanceOf[recipient] += amount;\\n        emit Transfer(spender, recipient, amount);\\n    }\\n\\n    function _approve(\\n        address owner,\\n        address spender,\\n        uint256 amount\\n    ) private {\\n        require(owner != address(0), \\\"Approve from the zero address\\\");\\n        require(spender != address(0), \\\"Approve to the zero address\\\");\\n        allowance[owner][spender] = amount;\\n        emit Approval(owner, spender, amount);\\n    }\\n\\n    function buildDomainSeparator() private view returns (bytes32) {\\n        return\\n            keccak256(\\n                abi.encode(\\n                    keccak256(\\n                        \\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\"\\n                    ),\\n                    keccak256(bytes(name)),\\n                    keccak256(bytes(\\\"1\\\")),\\n                    block.chainid,\\n                    address(this)\\n                )\\n            );\\n    }\\n}\\n\",\"keccak256\":\"0x1e1bf4ec5c9d6fe70f6f834316482aeff3f122ff4ffaa7178099e7ae71a0b16d\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/IApproveAndCall.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\n/// @notice An interface that should be implemented by tokens supporting\\n///         `approveAndCall`/`receiveApproval` pattern.\\ninterface IApproveAndCall {\\n    /// @notice Executes `receiveApproval` function on spender as specified in\\n    ///         `IReceiveApproval` interface. Approves spender to withdraw from\\n    ///         the caller multiple times, up to the `amount`. If this\\n    ///         function is called again, it overwrites the current allowance\\n    ///         with `amount`. Reverts if the approval reverted or if\\n    ///         `receiveApproval` call on the spender reverted.\\n    function approveAndCall(\\n        address spender,\\n        uint256 amount,\\n        bytes memory extraData\\n    ) external returns (bool);\\n}\\n\",\"keccak256\":\"0x393d18ef81a57dcc96fff4c340cc2945deaebb37b9796c322cf2bc96872c3df8\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/IERC20WithPermit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\nimport \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\\\";\\n\\nimport \\\"./IApproveAndCall.sol\\\";\\n\\n/// @title  IERC20WithPermit\\n/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can\\n///         authorize a transfer of their token with a signature conforming\\n///         EIP712 standard instead of an on-chain transaction from their\\n///         address. Anyone can submit this signature on the user's behalf by\\n///         calling the permit function, as specified in EIP2612 standard,\\n///         paying gas fees, and possibly performing other actions in the same\\n///         transaction.\\ninterface IERC20WithPermit is IERC20, IERC20Metadata, IApproveAndCall {\\n    /// @notice EIP2612 approval made with secp256k1 signature.\\n    ///         Users can authorize a transfer of their tokens with a signature\\n    ///         conforming EIP712 standard, rather than an on-chain transaction\\n    ///         from their address. Anyone can submit this signature on the\\n    ///         user's behalf by calling the permit function, paying gas fees,\\n    ///         and possibly performing other actions in the same transaction.\\n    /// @dev    The deadline argument can be set to `type(uint256).max to create\\n    ///         permits that effectively never expire.\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 amount,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /// @notice Destroys `amount` tokens from the caller.\\n    function burn(uint256 amount) external;\\n\\n    /// @notice Destroys `amount` of tokens from `account`, deducting the amount\\n    ///         from caller's allowance.\\n    function burnFrom(address account, uint256 amount) external;\\n\\n    /// @notice Returns hash of EIP712 Domain struct with the token name as\\n    ///         a signing domain and token contract as a verifying contract.\\n    ///         Used to construct EIP2612 signature provided to `permit`\\n    ///         function.\\n    /* solhint-disable-next-line func-name-mixedcase */\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n\\n    /// @notice Returns the current nonce for EIP2612 permission for the\\n    ///         provided token owner for a replay protection. Used to construct\\n    ///         EIP2612 signature provided to `permit` function.\\n    function nonce(address owner) external view returns (uint256);\\n\\n    /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612\\n    ///         signature provided to `permit` function.\\n    /* solhint-disable-next-line func-name-mixedcase */\\n    function PERMIT_TYPEHASH() external pure returns (bytes32);\\n}\\n\",\"keccak256\":\"0xdac9a5086c19a7128b505a7be1ab0ac1aa314f6989cb88d2417e9d7383f89fa9\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/IReceiveApproval.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\n/// @notice An interface that should be implemented by contracts supporting\\n///         `approveAndCall`/`receiveApproval` pattern.\\ninterface IReceiveApproval {\\n    /// @notice Receives approval to spend tokens. Called as a result of\\n    ///         `approveAndCall` call on the token.\\n    function receiveApproval(\\n        address from,\\n        uint256 amount,\\n        address token,\\n        bytes calldata extraData\\n    ) external;\\n}\\n\",\"keccak256\":\"0x6a30d83ad230548b1e7839737affc8489a035314209de14b89dbef7fb0f66395\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/MisfundRecovery.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\nimport \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC721/IERC721.sol\\\";\\n\\n/// @title  MisfundRecovery\\n/// @notice Allows the owner of the token contract extending MisfundRecovery\\n///         to recover any ERC20 and ERC721 sent mistakenly to the token\\n///         contract address.\\ncontract MisfundRecovery is Ownable {\\n    using SafeERC20 for IERC20;\\n\\n    function recoverERC20(\\n        IERC20 token,\\n        address recipient,\\n        uint256 amount\\n    ) external onlyOwner {\\n        token.safeTransfer(recipient, amount);\\n    }\\n\\n    function recoverERC721(\\n        IERC721 token,\\n        address recipient,\\n        uint256 tokenId,\\n        bytes calldata data\\n    ) external onlyOwner {\\n        token.safeTransferFrom(address(this), recipient, tokenId, data);\\n    }\\n}\\n\",\"keccak256\":\"0xbbfea02bf20e2a6df5a497bbc05c7540a3b7c7dfb8b1feeaffef7f6b8ba65d65\",\"license\":\"MIT\"},\"contracts/governance/Checkpoints.sol\":{\"content\":\"// SPDX-License-Identifier: GPL-3.0-or-later\\n\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n\\npragma solidity 0.8.9;\\n\\nimport \\\"./IVotesHistory.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/math/Math.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/math/SafeCast.sol\\\";\\n\\n/// @title Checkpoints\\n/// @dev Abstract contract to support checkpoints for Compound-like voting and\\n///      delegation. This implementation supports token supply up to 2^96 - 1.\\n///      This contract keeps a history (checkpoints) of each account's vote\\n///      power. Vote power can be delegated either by calling the {delegate}\\n///      function directly, or by providing a signature to be used with\\n///      {delegateBySig}. Voting power can be publicly queried through\\n///      {getVotes} and {getPastVotes}.\\n///      NOTE: Extracted from OpenZeppelin ERCVotes.sol.\\nabstract contract Checkpoints is IVotesHistory {\\n    struct Checkpoint {\\n        uint32 fromBlock;\\n        uint96 votes;\\n    }\\n\\n    // slither-disable-next-line uninitialized-state\\n    mapping(address => address) internal _delegates;\\n    mapping(address => uint128[]) internal _checkpoints;\\n    uint128[] internal _totalSupplyCheckpoints;\\n\\n    /// @notice Emitted when an account changes their delegate.\\n    event DelegateChanged(\\n        address indexed delegator,\\n        address indexed fromDelegate,\\n        address indexed toDelegate\\n    );\\n\\n    /// @notice Emitted when a balance or delegate change results in changes\\n    ///         to an account's voting power.\\n    event DelegateVotesChanged(\\n        address indexed delegate,\\n        uint256 previousBalance,\\n        uint256 newBalance\\n    );\\n\\n    function checkpoints(address account, uint32 pos)\\n        public\\n        view\\n        virtual\\n        returns (Checkpoint memory checkpoint)\\n    {\\n        (uint32 fromBlock, uint96 votes) = decodeCheckpoint(\\n            _checkpoints[account][pos]\\n        );\\n        checkpoint = Checkpoint(fromBlock, votes);\\n    }\\n\\n    /// @notice Get number of checkpoints for `account`.\\n    function numCheckpoints(address account)\\n        public\\n        view\\n        virtual\\n        returns (uint32)\\n    {\\n        return SafeCast.toUint32(_checkpoints[account].length);\\n    }\\n\\n    /// @notice Get the address `account` is currently delegating to.\\n    function delegates(address account) public view virtual returns (address) {\\n        return _delegates[account];\\n    }\\n\\n    /// @notice Gets the current votes balance for `account`.\\n    /// @param account The address to get votes balance\\n    /// @return The number of current votes for `account`\\n    function getVotes(address account) public view returns (uint96) {\\n        uint256 pos = _checkpoints[account].length;\\n        return pos == 0 ? 0 : decodeValue(_checkpoints[account][pos - 1]);\\n    }\\n\\n    /// @notice Determine the prior number of votes for an account as of\\n    ///         a block number.\\n    /// @dev Block number must be a finalized block or else this function will\\n    ///      revert to prevent misinformation.\\n    /// @param account The address of the account to check\\n    /// @param blockNumber The block number to get the vote balance at\\n    /// @return The number of votes the account had as of the given block\\n    function getPastVotes(address account, uint256 blockNumber)\\n        public\\n        view\\n        returns (uint96)\\n    {\\n        return lookupCheckpoint(_checkpoints[account], blockNumber);\\n    }\\n\\n    /// @notice Retrieve the `totalSupply` at the end of `blockNumber`.\\n    ///         Note, this value is the sum of all balances, but it is NOT the\\n    ///         sum of all the delegated votes!\\n    /// @param blockNumber The block number to get the total supply at\\n    /// @dev `blockNumber` must have been already mined\\n    function getPastTotalSupply(uint256 blockNumber)\\n        public\\n        view\\n        returns (uint96)\\n    {\\n        return lookupCheckpoint(_totalSupplyCheckpoints, blockNumber);\\n    }\\n\\n    /// @notice Change delegation for `delegator` to `delegatee`.\\n    // slither-disable-next-line dead-code\\n    function delegate(address delegator, address delegatee) internal virtual;\\n\\n    /// @notice Moves voting power from one delegate to another\\n    /// @param src Address of old delegate\\n    /// @param dst Address of new delegate\\n    /// @param amount Voting power amount to transfer between delegates\\n    function moveVotingPower(\\n        address src,\\n        address dst,\\n        uint256 amount\\n    ) internal {\\n        if (src != dst && amount > 0) {\\n            if (src != address(0)) {\\n                // https://github.com/crytic/slither/issues/960\\n                // slither-disable-next-line variable-scope\\n                (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(\\n                    _checkpoints[src],\\n                    subtract,\\n                    amount\\n                );\\n                emit DelegateVotesChanged(src, oldWeight, newWeight);\\n            }\\n\\n            if (dst != address(0)) {\\n                // https://github.com/crytic/slither/issues/959\\n                // slither-disable-next-line uninitialized-local\\n                (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(\\n                    _checkpoints[dst],\\n                    add,\\n                    amount\\n                );\\n                emit DelegateVotesChanged(dst, oldWeight, newWeight);\\n            }\\n        }\\n    }\\n\\n    /// @notice Writes a new checkpoint based on operating last stored value\\n    ///         with a `delta`. Usually, said operation is the `add` or\\n    ///         `subtract` functions from this contract, but more complex\\n    ///         functions can be passed as parameters.\\n    /// @param ckpts The checkpoints array to use\\n    /// @param op The function to apply over the last value and the `delta`\\n    /// @param delta Variation with respect to last stored value to be used\\n    ///              for new checkpoint\\n    function writeCheckpoint(\\n        uint128[] storage ckpts,\\n        function(uint256, uint256) view returns (uint256) op,\\n        uint256 delta\\n    ) internal returns (uint256 oldWeight, uint256 newWeight) {\\n        uint256 pos = ckpts.length;\\n        oldWeight = pos == 0 ? 0 : decodeValue(ckpts[pos - 1]);\\n        newWeight = op(oldWeight, delta);\\n\\n        if (pos > 0) {\\n            uint32 fromBlock = decodeBlockNumber(ckpts[pos - 1]);\\n            // slither-disable-next-line incorrect-equality\\n            if (fromBlock == block.number) {\\n                ckpts[pos - 1] = encodeCheckpoint(\\n                    fromBlock,\\n                    SafeCast.toUint96(newWeight)\\n                );\\n                return (oldWeight, newWeight);\\n            }\\n        }\\n\\n        ckpts.push(\\n            encodeCheckpoint(\\n                SafeCast.toUint32(block.number),\\n                SafeCast.toUint96(newWeight)\\n            )\\n        );\\n    }\\n\\n    /// @notice Lookup a value in a list of (sorted) checkpoints.\\n    /// @param ckpts The checkpoints array to use\\n    /// @param blockNumber Block number when we want to get the checkpoint at\\n    function lookupCheckpoint(uint128[] storage ckpts, uint256 blockNumber)\\n        internal\\n        view\\n        returns (uint96)\\n    {\\n        // We run a binary search to look for the earliest checkpoint taken\\n        // after `blockNumber`. During the loop, the index of the wanted\\n        // checkpoint remains in the range [low-1, high). With each iteration,\\n        // either `low` or `high` is moved towards the middle of the range to\\n        // maintain the invariant.\\n        // - If the middle checkpoint is after `blockNumber`,\\n        //   we look in [low, mid)\\n        // - If the middle checkpoint is before or equal to `blockNumber`,\\n        //   we look in [mid+1, high)\\n        // Once we reach a single value (when low == high), we've found the\\n        // right checkpoint at the index high-1, if not out of bounds (in that\\n        // case we're looking too far in the past and the result is 0).\\n        // Note that if the latest checkpoint available is exactly for\\n        // `blockNumber`, we end up with an index that is past the end of the\\n        // array, so we technically don't find a checkpoint after\\n        // `blockNumber`, but it works out the same.\\n        require(blockNumber < block.number, \\\"Block not yet determined\\\");\\n\\n        uint256 high = ckpts.length;\\n        uint256 low = 0;\\n        while (low < high) {\\n            uint256 mid = Math.average(low, high);\\n            uint32 midBlock = decodeBlockNumber(ckpts[mid]);\\n            if (midBlock > blockNumber) {\\n                high = mid;\\n            } else {\\n                low = mid + 1;\\n            }\\n        }\\n\\n        return high == 0 ? 0 : decodeValue(ckpts[high - 1]);\\n    }\\n\\n    /// @notice Maximum token supply. Defaults to `type(uint96).max` (2^96 - 1)\\n    // slither-disable-next-line dead-code\\n    function maxSupply() internal view virtual returns (uint96) {\\n        return type(uint96).max;\\n    }\\n\\n    /// @notice Encodes a `blockNumber` and `value` into a single `uint128`\\n    ///         checkpoint.\\n    /// @dev `blockNumber` is stored in the first 32 bits, while `value` in the\\n    ///      remaining 96 bits.\\n    function encodeCheckpoint(uint32 blockNumber, uint96 value)\\n        internal\\n        pure\\n        returns (uint128)\\n    {\\n        return (uint128(blockNumber) << 96) | uint128(value);\\n    }\\n\\n    /// @notice Decodes a block number from a `uint128` `checkpoint`.\\n    function decodeBlockNumber(uint128 checkpoint)\\n        internal\\n        pure\\n        returns (uint32)\\n    {\\n        return uint32(bytes4(bytes16(checkpoint)));\\n    }\\n\\n    /// @notice Decodes a voting value from a `uint128` `checkpoint`.\\n    function decodeValue(uint128 checkpoint) internal pure returns (uint96) {\\n        return uint96(checkpoint);\\n    }\\n\\n    /// @notice Decodes a block number and voting value from a `uint128`\\n    ///         `checkpoint`.\\n    function decodeCheckpoint(uint128 checkpoint)\\n        internal\\n        pure\\n        returns (uint32 blockNumber, uint96 value)\\n    {\\n        blockNumber = decodeBlockNumber(checkpoint);\\n        value = decodeValue(checkpoint);\\n    }\\n\\n    // slither-disable-next-line dead-code\\n    function add(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a + b;\\n    }\\n\\n    // slither-disable-next-line dead-code\\n    function subtract(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a - b;\\n    }\\n}\\n\",\"keccak256\":\"0x25f420d34548648aa59703bccdad450815da5c9e18adf575845a659f0945d131\",\"license\":\"GPL-3.0-or-later\"},\"contracts/governance/IVotesHistory.sol\":{\"content\":\"// SPDX-License-Identifier: GPL-3.0-or-later\\n\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n\\npragma solidity 0.8.9;\\n\\ninterface IVotesHistory {\\n    function getPastVotes(address account, uint256 blockNumber)\\n        external\\n        view\\n        returns (uint96);\\n\\n    function getPastTotalSupply(uint256 blockNumber)\\n        external\\n        view\\n        returns (uint96);\\n}\\n\",\"keccak256\":\"0x535e87cf4c2e9a9439d99cf0918f013965fa6c4ddfbab07ff6ca4b195c8edc9f\",\"license\":\"GPL-3.0-or-later\"},\"contracts/token/T.sol\":{\"content\":\"// SPDX-License-Identifier: GPL-3.0-or-later\\n\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n\\npragma solidity 0.8.9;\\n\\nimport \\\"../governance/Checkpoints.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/math/SafeCast.sol\\\";\\nimport \\\"@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol\\\";\\nimport \\\"@thesis/solidity-contracts/contracts/token/MisfundRecovery.sol\\\";\\n\\n/// @title T token\\n/// @notice Threshold Network T token\\n/// @dev By default, token balance does not account for voting power.\\n///      This makes transfers cheaper. The downside is that it requires users\\n///      to delegate to themselves to activate checkpoints and have their\\n///      voting power tracked.\\ncontract T is ERC20WithPermit, MisfundRecovery, Checkpoints {\\n    /// @notice The EIP-712 typehash for the delegation struct used by\\n    ///         `delegateBySig`.\\n    bytes32 public constant DELEGATION_TYPEHASH =\\n        keccak256(\\n            \\\"Delegation(address delegatee,uint256 nonce,uint256 deadline)\\\"\\n        );\\n\\n    constructor() ERC20WithPermit(\\\"Threshold Network Token\\\", \\\"T\\\") {}\\n\\n    /// @notice Delegates votes from signatory to `delegatee`\\n    /// @param delegatee The address to delegate votes to\\n    /// @param deadline The time at which to expire the signature\\n    /// @param v The recovery byte of the signature\\n    /// @param r Half of the ECDSA signature pair\\n    /// @param s Half of the ECDSA signature pair\\n    function delegateBySig(\\n        address signatory,\\n        address delegatee,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external {\\n        /* solhint-disable-next-line not-rely-on-time */\\n        require(deadline >= block.timestamp, \\\"Delegation expired\\\");\\n\\n        // Validate `s` and `v` values for a malleability concern described in EIP2.\\n        // Only signatures with `s` value in the lower half of the secp256k1\\n        // curve's order and `v` value of 27 or 28 are considered valid.\\n        require(\\n            uint256(s) <=\\n                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,\\n            \\\"Invalid signature 's' value\\\"\\n        );\\n        require(v == 27 || v == 28, \\\"Invalid signature 'v' value\\\");\\n\\n        bytes32 digest = keccak256(\\n            abi.encodePacked(\\n                \\\"\\\\x19\\\\x01\\\",\\n                DOMAIN_SEPARATOR(),\\n                keccak256(\\n                    abi.encode(\\n                        DELEGATION_TYPEHASH,\\n                        delegatee,\\n                        nonce[signatory]++,\\n                        deadline\\n                    )\\n                )\\n            )\\n        );\\n\\n        address recoveredAddress = ecrecover(digest, v, r, s);\\n        require(\\n            recoveredAddress != address(0) && recoveredAddress == signatory,\\n            \\\"Invalid signature\\\"\\n        );\\n\\n        return delegate(signatory, delegatee);\\n    }\\n\\n    /// @notice Delegate votes from `msg.sender` to `delegatee`.\\n    /// @param delegatee The address to delegate votes to\\n    function delegate(address delegatee) public virtual {\\n        return delegate(msg.sender, delegatee);\\n    }\\n\\n    // slither-disable-next-line dead-code\\n    function beforeTokenTransfer(\\n        address from,\\n        address to,\\n        uint256 amount\\n    ) internal override {\\n        uint96 safeAmount = SafeCast.toUint96(amount);\\n\\n        // When minting:\\n        if (from == address(0)) {\\n            // Does not allow to mint more than uint96 can fit. Otherwise, the\\n            // Checkpoint might not fit the balance.\\n            require(\\n                totalSupply + amount <= maxSupply(),\\n                \\\"Maximum total supply exceeded\\\"\\n            );\\n            writeCheckpoint(_totalSupplyCheckpoints, add, safeAmount);\\n        }\\n\\n        // When burning:\\n        if (to == address(0)) {\\n            writeCheckpoint(_totalSupplyCheckpoints, subtract, safeAmount);\\n        }\\n\\n        moveVotingPower(delegates(from), delegates(to), safeAmount);\\n    }\\n\\n    function delegate(address delegator, address delegatee)\\n        internal\\n        virtual\\n        override\\n    {\\n        address currentDelegate = delegates(delegator);\\n        uint96 delegatorBalance = SafeCast.toUint96(balanceOf[delegator]);\\n        _delegates[delegator] = delegatee;\\n\\n        emit DelegateChanged(delegator, currentDelegate, delegatee);\\n\\n        moveVotingPower(currentDelegate, delegatee, delegatorBalance);\\n    }\\n}\\n\",\"keccak256\":\"0x6265416225fd15b1108fce13d570b53a862a5d256ba2e6329bccf658eccac430\",\"license\":\"GPL-3.0-or-later\"}},\"version\":1}",
+  "bytecode": "0x60c06040523480156200001157600080fd5b506040518060400160405280601781526020017f5468726573686f6c64204e6574776f726b20546f6b656e000000000000000000815250604051806040016040528060018152602001601560fa1b8152506200007c62000076620000c260201b60201c565b620000c6565b815162000091906005906020850190620001c7565b508051620000a7906006906020840190620001c7565b5046608052620000b662000116565b60a052506200034e9050565b3390565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b60007f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60056040516200014a9190620002aa565b60408051918290038220828201825260018352603160f81b6020938401528151928301939093528101919091527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc660608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b828054620001d5906200026d565b90600052602060002090601f016020900481019282620001f9576000855562000244565b82601f106200021457805160ff191683800117855562000244565b8280016001018555821562000244579182015b828111156200024457825182559160200191906001019062000227565b506200025292915062000256565b5090565b5b8082111562000252576000815560010162000257565b600181811c908216806200028257607f821691505b60208210811415620002a457634e487b7160e01b600052602260045260246000fd5b50919050565b600080835481600182811c915080831680620002c757607f831692505b6020808410821415620002e857634e487b7160e01b86526022600452602486fd5b818015620002ff5760018114620003115762000340565b60ff1986168952848901965062000340565b60008a81526020902060005b86811015620003385781548b8201529085019083016200031d565b505084890196505b509498975050505050505050565b60805160a05161262d620003826000396000818161042301526106f501526000818161038d01526106cc015261262d6000f3fe608060405234801561001057600080fd5b50600436106101bb5760003560e01c8063715018a6116100fa578063b20d7fa91161009d578063b20d7fa91461040b578063b4f94b2e1461041e578063cae9ca5114610445578063d505accf14610458578063dd62ed3e1461046b578063e7a324dc14610496578063f1127ed8146104bd578063f2fde38b146104fa578063fc4e51f61461050d57600080fd5b8063715018a614610380578063771da5c51461038857806379cc6790146103af5780638da5cb5b146103c25780638e539e8c146103ca57806395d89b41146103dd5780639ab24eb0146103e5578063a9059cbb146103f857600080fd5b80633a46b1a8116101625780633a46b1a81461028957806340c10f19146102b457806342966c68146102c7578063587cde1e146102da5780635c19a95c146103055780636fcfff451461031857806370a082311461034057806370ae92d21461036057600080fd5b806306fdde03146101c0578063095ea7b3146101de5780631171bda91461020157806318160ddd1461021657806323b872dd1461022d57806330adf81f14610240578063313ce567146102675780633644e51514610281575b600080fd5b6101c8610520565b6040516101d59190611f0c565b60405180910390f35b6101f16101ec366004611f34565b6105ae565b60405190151581526020016101d5565b61021461020f366004611f60565b6105c4565b005b61021f60045481565b6040519081526020016101d5565b6101f161023b366004611f60565b610615565b61021f7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b61026f601281565b60405160ff90911681526020016101d5565b61021f6106c8565b61029c610297366004611f34565b610724565b6040516001600160601b0390911681526020016101d5565b6102146102c2366004611f34565b610746565b6102146102d5366004611fa1565b610849565b6102ed6102e8366004611fba565b610856565b6040516001600160a01b0390911681526020016101d5565b610214610313366004611fba565b610874565b61032b610326366004611fba565b61087e565b60405163ffffffff90911681526020016101d5565b61021f61034e366004611fba565b60016020526000908152604090205481565b61021f61036e366004611fba565b60036020526000908152604090205481565b6102146108a6565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6102146103bd366004611f34565b6108e1565b6102ed610977565b61029c6103d8366004611fa1565b610986565b6101c8610993565b61029c6103f3366004611fba565b6109a0565b6101f1610406366004611f34565b610a30565b610214610419366004611fed565b610a3d565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6101f1610453366004612066565b610c6a565b610214610466366004612133565b610cf2565b61021f6104793660046121a1565b600260209081526000928352604080842090915290825290205481565b61021f7f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e281565b6104d06104cb3660046121da565b610f2c565b60408051825163ffffffff1681526020928301516001600160601b031692810192909252016101d5565b610214610508366004611fba565b610fd8565b61021461051b366004612211565b611075565b6005805461052d906122b0565b80601f0160208091040260200160405190810160405280929190818152602001828054610559906122b0565b80156105a65780601f1061057b576101008083540402835291602001916105a6565b820191906000526020600020905b81548152906001019060200180831161058957829003601f168201915b505050505081565b60006105bb338484611106565b50600192915050565b336105cd610977565b6001600160a01b0316146105fc5760405162461bcd60e51b81526004016105f3906122eb565b60405180910390fd5b6106106001600160a01b0384168383611214565b505050565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001981146106b0578281101561069c5760405162461bcd60e51b815260206004820152602160248201527f5472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636044820152606560f81b60648201526084016105f3565b6106b085336106ab8685612336565b611106565b6106bb858585611266565b60019150505b9392505050565b60007f000000000000000000000000000000000000000000000000000000000000000046141561071757507f000000000000000000000000000000000000000000000000000000000000000090565b61071f611467565b905090565b6001600160a01b03821660009081526008602052604081206106c19083611516565b3361074f610977565b6001600160a01b0316146107755760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b0382166107c65760405162461bcd60e51b81526020600482015260186024820152774d696e7420746f20746865207a65726f206164647265737360401b60448201526064016105f3565b6107d260008383611611565b80600460008282546107e4919061234d565b90915550506001600160a01b0382166000908152600160205260408120805483929061081190849061234d565b90915550506040518181526001600160a01b038316906000906000805160206125d88339815191529060200160405180910390a35050565b61085333826116fd565b50565b6001600160a01b039081166000908152600760205260409020541690565b61085333826117db565b6001600160a01b0381166000908152600860205260408120546108a09061187d565b92915050565b336108af610977565b6001600160a01b0316146108d55760405162461bcd60e51b81526004016105f3906122eb565b6108df60006118e6565b565b6001600160a01b0382166000908152600260209081526040808320338452909152902054600019811461096d578181101561095e5760405162461bcd60e51b815260206004820152601d60248201527f4275726e20616d6f756e74206578636565647320616c6c6f77616e636500000060448201526064016105f3565b61096d83336106ab8585612336565b61061083836116fd565b6000546001600160a01b031690565b60006108a0600983611516565b6006805461052d906122b0565b6001600160a01b0381166000908152600860205260408120548015610a27576001600160a01b0383166000908152600860205260409020610a22906109e6600184612336565b815481106109f6576109f6612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031690565b6106c1565b60009392505050565b60006105bb338484611266565b42841015610a825760405162461bcd60e51b815260206004820152601260248201527111195b1959d85d1a5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610ab85760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610acd57508260ff16601c145b610ae95760405162461bcd60e51b81526004016105f3906123b2565b6000610af36106c8565b6001600160a01b038816600090815260036020526040812080547f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e2928a9290610b3b836123e9565b9190505588604051602001610b7294939291909384526001600160a01b039290921660208401526040830152606082015260800190565b60405160208183030381529060405280519060200120604051602001610b99929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610c04573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610c3a5750876001600160a01b0316816001600160a01b0316145b610c565760405162461bcd60e51b81526004016105f39061241f565b610c6088886117db565b5050505050505050565b6000610c7684846105ae565b15610ce857604051638f4ffcb160e01b81526001600160a01b03851690638f4ffcb190610cad90339087903090889060040161244a565b600060405180830381600087803b158015610cc757600080fd5b505af1158015610cdb573d6000803e3d6000fd5b50505050600190506106c1565b5060009392505050565b42841015610d375760405162461bcd60e51b815260206004820152601260248201527114195c9b5a5cdcda5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610d6d5760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610d8257508260ff16601c145b610d9e5760405162461bcd60e51b81526004016105f3906123b2565b6000610da86106c8565b6001600160a01b038916600090815260036020526040812080547f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9928c928c928c92909190610df6836123e9565b909155506040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810187905260e00160405160208183030381529060405280519060200120604051602001610e59929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610ec4573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610efa5750886001600160a01b0316816001600160a01b0316145b610f165760405162461bcd60e51b81526004016105f39061241f565b610f21898989611106565b505050505050505050565b60408051808201909152600080825260208201526001600160a01b038316600090815260086020526040812080548291610fad9163ffffffff8716908110610f7657610f76612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031663ffffffff606082901c1691565b6040805180820190915263ffffffff90921682526001600160601b0316602082015295945050505050565b33610fe1610977565b6001600160a01b0316146110075760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b03811661106c5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016105f3565b610853816118e6565b3361107e610977565b6001600160a01b0316146110a45760405162461bcd60e51b81526004016105f3906122eb565b604051635c46a7ef60e11b81526001600160a01b0386169063b88d4fde906110d89030908890889088908890600401612487565b600060405180830381600087803b1580156110f257600080fd5b505af1158015610f21573d6000803e3d6000fd5b6001600160a01b03831661115c5760405162461bcd60e51b815260206004820152601d60248201527f417070726f76652066726f6d20746865207a65726f206164647265737300000060448201526064016105f3565b6001600160a01b0382166111b25760405162461bcd60e51b815260206004820152601b60248201527f417070726f766520746f20746865207a65726f2061646472657373000000000060448201526064016105f3565b6001600160a01b0383811660008181526002602090815260408083209487168084529482529182902085905590518481527f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92591015b60405180910390a3505050565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663a9059cbb60e01b179052610610908490611936565b6001600160a01b0383166112bc5760405162461bcd60e51b815260206004820152601e60248201527f5472616e736665722066726f6d20746865207a65726f2061646472657373000060448201526064016105f3565b6001600160a01b0382166113125760405162461bcd60e51b815260206004820152601c60248201527f5472616e7366657220746f20746865207a65726f20616464726573730000000060448201526064016105f3565b6001600160a01b03821630141561136b5760405162461bcd60e51b815260206004820152601d60248201527f5472616e7366657220746f2074686520746f6b656e206164647265737300000060448201526064016105f3565b611376838383611611565b6001600160a01b038316600090815260016020526040902054818110156113df5760405162461bcd60e51b815260206004820152601f60248201527f5472616e7366657220616d6f756e7420657863656564732062616c616e63650060448201526064016105f3565b6113e98282612336565b6001600160a01b03808616600090815260016020526040808220939093559085168152908120805484929061141f90849061234d565b92505081905550826001600160a01b0316846001600160a01b03166000805160206125d88339815191528460405161145991815260200190565b60405180910390a350505050565b60007f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f600560405161149991906124db565b60408051918290038220828201825260018352603160f81b6020938401528151928301939093528101919091527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc660608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b60004382106115625760405162461bcd60e51b8152602060048201526018602482015277109b1bd8dac81b9bdd081e595d0819195d195c9b5a5b995960421b60448201526064016105f3565b825460005b818110156115eb57600061157b8284611a08565b905060006115be87838154811061159457611594612365565b6000918252602090912060028204015463ffffffff60019092166010026101000a900460601c1690565b9050858163ffffffff1611156115d6578193506115e4565b6115e182600161234d565b92505b5050611567565b811561160557611600856109e6600185612336565b611608565b60005b95945050505050565b600061161c82611a23565b90506001600160a01b0384166116ab576004546001600160601b039061164390849061234d565b11156116915760405162461bcd60e51b815260206004820152601d60248201527f4d6178696d756d20746f74616c20737570706c7920657863656564656400000060448201526064016105f3565b6116a86009611a8b836001600160601b0316611a97565b50505b6001600160a01b0383166116d3576116d06009611bf3836001600160601b0316611a97565b50505b6116f76116df85610856565b6116e885610856565b836001600160601b0316611bff565b50505050565b6001600160a01b038216600090815260016020526040902054818110156117665760405162461bcd60e51b815260206004820152601b60248201527f4275726e20616d6f756e7420657863656564732062616c616e6365000000000060448201526064016105f3565b61177283600084611611565b61177c8282612336565b6001600160a01b038416600090815260016020526040812091909155600480548492906117aa908490612336565b90915550506040518281526000906001600160a01b038516906000805160206125d883398151915290602001611207565b60006117e683610856565b6001600160a01b0384166000908152600160205260408120549192509061180c90611a23565b6001600160a01b0385811660008181526007602052604080822080546001600160a01b031916898616908117909155905194955093928616927f3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f9190a46116f78284836001600160601b0316611bff565b600063ffffffff8211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203360448201526532206269747360d01b60648201526084016105f3565b5090565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600061198b826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316611d3c9092919063ffffffff16565b80519091501561061057808060200190518101906119a99190612577565b6106105760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b60648201526084016105f3565b6000611a176002848418612599565b6106c19084841661234d565b60006001600160601b038211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203960448201526536206269747360d01b60648201526084016105f3565b60006106c1828461234d565b825460009081908015611ab857611ab3866109e6600184612336565b611abb565b60005b6001600160601b03169250611ad483858763ffffffff16565b91508015611b94576000611afd87611aed600185612336565b8154811061159457611594612365565b9050438163ffffffff161415611b9257611b3681611b1a85611a23565b6001600160601b031660609190911b63ffffffff60601b161790565b87611b42600185612336565b81548110611b5257611b52612365565b90600052602060002090600291828204019190066010026101000a8154816001600160801b0302191690836001600160801b031602179055505050611beb565b505b85611baa611ba14361187d565b611b1a85611a23565b81546001818101845560009384526020909320600282040180546001600160801b03938416601093909516929092026101000a938402929093021916179055505b935093915050565b60006106c18284612336565b816001600160a01b0316836001600160a01b031614158015611c215750600081115b15610610576001600160a01b03831615611caf576001600160a01b03831660009081526008602052604081208190611c5c90611bf385611a97565b91509150846001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611ca4929190918252602082015260400190565b60405180910390a250505b6001600160a01b03821615610610576001600160a01b03821660009081526008602052604081208190611ce590611a8b85611a97565b91509150836001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611d2d929190918252602082015260400190565b60405180910390a25050505050565b6060611d4b8484600085611d53565b949350505050565b606082471015611db45760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b60648201526084016105f3565b843b611e025760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e747261637400000060448201526064016105f3565b600080866001600160a01b03168587604051611e1e91906125bb565b60006040518083038185875af1925050503d8060008114611e5b576040519150601f19603f3d011682016040523d82523d6000602084013e611e60565b606091505b5091509150611e70828286611e7b565b979650505050505050565b60608315611e8a5750816106c1565b825115611e9a5782518084602001fd5b8160405162461bcd60e51b81526004016105f39190611f0c565b60005b83811015611ecf578181015183820152602001611eb7565b838111156116f75750506000910152565b60008151808452611ef8816020860160208601611eb4565b601f01601f19169290920160200192915050565b6020815260006106c16020830184611ee0565b6001600160a01b038116811461085357600080fd5b60008060408385031215611f4757600080fd5b8235611f5281611f1f565b946020939093013593505050565b600080600060608486031215611f7557600080fd5b8335611f8081611f1f565b92506020840135611f9081611f1f565b929592945050506040919091013590565b600060208284031215611fb357600080fd5b5035919050565b600060208284031215611fcc57600080fd5b81356106c181611f1f565b803560ff81168114611fe857600080fd5b919050565b60008060008060008060c0878903121561200657600080fd5b863561201181611f1f565b9550602087013561202181611f1f565b94506040870135935061203660608801611fd7565b92506080870135915060a087013590509295509295509295565b634e487b7160e01b600052604160045260246000fd5b60008060006060848603121561207b57600080fd5b833561208681611f1f565b925060208401359150604084013567ffffffffffffffff808211156120aa57600080fd5b818601915086601f8301126120be57600080fd5b8135818111156120d0576120d0612050565b604051601f8201601f19908116603f011681019083821181831017156120f8576120f8612050565b8160405282815289602084870101111561211157600080fd5b8260208601602083013760006020848301015280955050505050509250925092565b600080600080600080600060e0888a03121561214e57600080fd5b873561215981611f1f565b9650602088013561216981611f1f565b9550604088013594506060880135935061218560808901611fd7565b925060a0880135915060c0880135905092959891949750929550565b600080604083850312156121b457600080fd5b82356121bf81611f1f565b915060208301356121cf81611f1f565b809150509250929050565b600080604083850312156121ed57600080fd5b82356121f881611f1f565b9150602083013563ffffffff811681146121cf57600080fd5b60008060008060006080868803121561222957600080fd5b853561223481611f1f565b9450602086013561224481611f1f565b935060408601359250606086013567ffffffffffffffff8082111561226857600080fd5b818801915088601f83011261227c57600080fd5b81358181111561228b57600080fd5b89602082850101111561229d57600080fd5b9699959850939650602001949392505050565b600181811c908216806122c457607f821691505b602082108114156122e557634e487b7160e01b600052602260045260246000fd5b50919050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052601160045260246000fd5b60008282101561234857612348612320565b500390565b6000821982111561236057612360612320565b500190565b634e487b7160e01b600052603260045260246000fd5b6020808252601b908201527f496e76616c6964207369676e6174757265202773272076616c75650000000000604082015260600190565b6020808252601b908201527f496e76616c6964207369676e6174757265202776272076616c75650000000000604082015260600190565b60006000198214156123fd576123fd612320565b5060010190565b61190160f01b81526002810192909252602282015260420190565b602080825260119082015270496e76616c6964207369676e617475726560781b604082015260600190565b6001600160a01b038581168252602082018590528316604082015260806060820181905260009061247d90830184611ee0565b9695505050505050565b6001600160a01b038681168252851660208201526040810184905260806060820181905281018290526000828460a0840137600060a0848401015260a0601f19601f85011683010190509695505050505050565b600080835481600182811c9150808316806124f757607f831692505b602080841082141561251757634e487b7160e01b86526022600452602486fd5b81801561252b576001811461253c57612569565b60ff19861689528489019650612569565b60008a81526020902060005b868110156125615781548b820152908501908301612548565b505084890196505b509498975050505050505050565b60006020828403121561258957600080fd5b815180151581146106c157600080fd5b6000826125b657634e487b7160e01b600052601260045260246000fd5b500490565b600082516125cd818460208701611eb4565b919091019291505056feddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3efa26469706673582212207eecbfb333a500c574d750bd13d9d3944c632e0e6cfefb9d5262bd9cbb14fb8364736f6c63430008090033",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106101bb5760003560e01c8063715018a6116100fa578063b20d7fa91161009d578063b20d7fa91461040b578063b4f94b2e1461041e578063cae9ca5114610445578063d505accf14610458578063dd62ed3e1461046b578063e7a324dc14610496578063f1127ed8146104bd578063f2fde38b146104fa578063fc4e51f61461050d57600080fd5b8063715018a614610380578063771da5c51461038857806379cc6790146103af5780638da5cb5b146103c25780638e539e8c146103ca57806395d89b41146103dd5780639ab24eb0146103e5578063a9059cbb146103f857600080fd5b80633a46b1a8116101625780633a46b1a81461028957806340c10f19146102b457806342966c68146102c7578063587cde1e146102da5780635c19a95c146103055780636fcfff451461031857806370a082311461034057806370ae92d21461036057600080fd5b806306fdde03146101c0578063095ea7b3146101de5780631171bda91461020157806318160ddd1461021657806323b872dd1461022d57806330adf81f14610240578063313ce567146102675780633644e51514610281575b600080fd5b6101c8610520565b6040516101d59190611f0c565b60405180910390f35b6101f16101ec366004611f34565b6105ae565b60405190151581526020016101d5565b61021461020f366004611f60565b6105c4565b005b61021f60045481565b6040519081526020016101d5565b6101f161023b366004611f60565b610615565b61021f7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b61026f601281565b60405160ff90911681526020016101d5565b61021f6106c8565b61029c610297366004611f34565b610724565b6040516001600160601b0390911681526020016101d5565b6102146102c2366004611f34565b610746565b6102146102d5366004611fa1565b610849565b6102ed6102e8366004611fba565b610856565b6040516001600160a01b0390911681526020016101d5565b610214610313366004611fba565b610874565b61032b610326366004611fba565b61087e565b60405163ffffffff90911681526020016101d5565b61021f61034e366004611fba565b60016020526000908152604090205481565b61021f61036e366004611fba565b60036020526000908152604090205481565b6102146108a6565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6102146103bd366004611f34565b6108e1565b6102ed610977565b61029c6103d8366004611fa1565b610986565b6101c8610993565b61029c6103f3366004611fba565b6109a0565b6101f1610406366004611f34565b610a30565b610214610419366004611fed565b610a3d565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6101f1610453366004612066565b610c6a565b610214610466366004612133565b610cf2565b61021f6104793660046121a1565b600260209081526000928352604080842090915290825290205481565b61021f7f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e281565b6104d06104cb3660046121da565b610f2c565b60408051825163ffffffff1681526020928301516001600160601b031692810192909252016101d5565b610214610508366004611fba565b610fd8565b61021461051b366004612211565b611075565b6005805461052d906122b0565b80601f0160208091040260200160405190810160405280929190818152602001828054610559906122b0565b80156105a65780601f1061057b576101008083540402835291602001916105a6565b820191906000526020600020905b81548152906001019060200180831161058957829003601f168201915b505050505081565b60006105bb338484611106565b50600192915050565b336105cd610977565b6001600160a01b0316146105fc5760405162461bcd60e51b81526004016105f3906122eb565b60405180910390fd5b6106106001600160a01b0384168383611214565b505050565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001981146106b0578281101561069c5760405162461bcd60e51b815260206004820152602160248201527f5472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636044820152606560f81b60648201526084016105f3565b6106b085336106ab8685612336565b611106565b6106bb858585611266565b60019150505b9392505050565b60007f000000000000000000000000000000000000000000000000000000000000000046141561071757507f000000000000000000000000000000000000000000000000000000000000000090565b61071f611467565b905090565b6001600160a01b03821660009081526008602052604081206106c19083611516565b3361074f610977565b6001600160a01b0316146107755760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b0382166107c65760405162461bcd60e51b81526020600482015260186024820152774d696e7420746f20746865207a65726f206164647265737360401b60448201526064016105f3565b6107d260008383611611565b80600460008282546107e4919061234d565b90915550506001600160a01b0382166000908152600160205260408120805483929061081190849061234d565b90915550506040518181526001600160a01b038316906000906000805160206125d88339815191529060200160405180910390a35050565b61085333826116fd565b50565b6001600160a01b039081166000908152600760205260409020541690565b61085333826117db565b6001600160a01b0381166000908152600860205260408120546108a09061187d565b92915050565b336108af610977565b6001600160a01b0316146108d55760405162461bcd60e51b81526004016105f3906122eb565b6108df60006118e6565b565b6001600160a01b0382166000908152600260209081526040808320338452909152902054600019811461096d578181101561095e5760405162461bcd60e51b815260206004820152601d60248201527f4275726e20616d6f756e74206578636565647320616c6c6f77616e636500000060448201526064016105f3565b61096d83336106ab8585612336565b61061083836116fd565b6000546001600160a01b031690565b60006108a0600983611516565b6006805461052d906122b0565b6001600160a01b0381166000908152600860205260408120548015610a27576001600160a01b0383166000908152600860205260409020610a22906109e6600184612336565b815481106109f6576109f6612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031690565b6106c1565b60009392505050565b60006105bb338484611266565b42841015610a825760405162461bcd60e51b815260206004820152601260248201527111195b1959d85d1a5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610ab85760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610acd57508260ff16601c145b610ae95760405162461bcd60e51b81526004016105f3906123b2565b6000610af36106c8565b6001600160a01b038816600090815260036020526040812080547f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e2928a9290610b3b836123e9565b9190505588604051602001610b7294939291909384526001600160a01b039290921660208401526040830152606082015260800190565b60405160208183030381529060405280519060200120604051602001610b99929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610c04573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610c3a5750876001600160a01b0316816001600160a01b0316145b610c565760405162461bcd60e51b81526004016105f39061241f565b610c6088886117db565b5050505050505050565b6000610c7684846105ae565b15610ce857604051638f4ffcb160e01b81526001600160a01b03851690638f4ffcb190610cad90339087903090889060040161244a565b600060405180830381600087803b158015610cc757600080fd5b505af1158015610cdb573d6000803e3d6000fd5b50505050600190506106c1565b5060009392505050565b42841015610d375760405162461bcd60e51b815260206004820152601260248201527114195c9b5a5cdcda5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610d6d5760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610d8257508260ff16601c145b610d9e5760405162461bcd60e51b81526004016105f3906123b2565b6000610da86106c8565b6001600160a01b038916600090815260036020526040812080547f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9928c928c928c92909190610df6836123e9565b909155506040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810187905260e00160405160208183030381529060405280519060200120604051602001610e59929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610ec4573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610efa5750886001600160a01b0316816001600160a01b0316145b610f165760405162461bcd60e51b81526004016105f39061241f565b610f21898989611106565b505050505050505050565b60408051808201909152600080825260208201526001600160a01b038316600090815260086020526040812080548291610fad9163ffffffff8716908110610f7657610f76612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031663ffffffff606082901c1691565b6040805180820190915263ffffffff90921682526001600160601b0316602082015295945050505050565b33610fe1610977565b6001600160a01b0316146110075760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b03811661106c5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016105f3565b610853816118e6565b3361107e610977565b6001600160a01b0316146110a45760405162461bcd60e51b81526004016105f3906122eb565b604051635c46a7ef60e11b81526001600160a01b0386169063b88d4fde906110d89030908890889088908890600401612487565b600060405180830381600087803b1580156110f257600080fd5b505af1158015610f21573d6000803e3d6000fd5b6001600160a01b03831661115c5760405162461bcd60e51b815260206004820152601d60248201527f417070726f76652066726f6d20746865207a65726f206164647265737300000060448201526064016105f3565b6001600160a01b0382166111b25760405162461bcd60e51b815260206004820152601b60248201527f417070726f766520746f20746865207a65726f2061646472657373000000000060448201526064016105f3565b6001600160a01b0383811660008181526002602090815260408083209487168084529482529182902085905590518481527f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92591015b60405180910390a3505050565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663a9059cbb60e01b179052610610908490611936565b6001600160a01b0383166112bc5760405162461bcd60e51b815260206004820152601e60248201527f5472616e736665722066726f6d20746865207a65726f2061646472657373000060448201526064016105f3565b6001600160a01b0382166113125760405162461bcd60e51b815260206004820152601c60248201527f5472616e7366657220746f20746865207a65726f20616464726573730000000060448201526064016105f3565b6001600160a01b03821630141561136b5760405162461bcd60e51b815260206004820152601d60248201527f5472616e7366657220746f2074686520746f6b656e206164647265737300000060448201526064016105f3565b611376838383611611565b6001600160a01b038316600090815260016020526040902054818110156113df5760405162461bcd60e51b815260206004820152601f60248201527f5472616e7366657220616d6f756e7420657863656564732062616c616e63650060448201526064016105f3565b6113e98282612336565b6001600160a01b03808616600090815260016020526040808220939093559085168152908120805484929061141f90849061234d565b92505081905550826001600160a01b0316846001600160a01b03166000805160206125d88339815191528460405161145991815260200190565b60405180910390a350505050565b60007f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f600560405161149991906124db565b60408051918290038220828201825260018352603160f81b6020938401528151928301939093528101919091527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc660608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b60004382106115625760405162461bcd60e51b8152602060048201526018602482015277109b1bd8dac81b9bdd081e595d0819195d195c9b5a5b995960421b60448201526064016105f3565b825460005b818110156115eb57600061157b8284611a08565b905060006115be87838154811061159457611594612365565b6000918252602090912060028204015463ffffffff60019092166010026101000a900460601c1690565b9050858163ffffffff1611156115d6578193506115e4565b6115e182600161234d565b92505b5050611567565b811561160557611600856109e6600185612336565b611608565b60005b95945050505050565b600061161c82611a23565b90506001600160a01b0384166116ab576004546001600160601b039061164390849061234d565b11156116915760405162461bcd60e51b815260206004820152601d60248201527f4d6178696d756d20746f74616c20737570706c7920657863656564656400000060448201526064016105f3565b6116a86009611a8b836001600160601b0316611a97565b50505b6001600160a01b0383166116d3576116d06009611bf3836001600160601b0316611a97565b50505b6116f76116df85610856565b6116e885610856565b836001600160601b0316611bff565b50505050565b6001600160a01b038216600090815260016020526040902054818110156117665760405162461bcd60e51b815260206004820152601b60248201527f4275726e20616d6f756e7420657863656564732062616c616e6365000000000060448201526064016105f3565b61177283600084611611565b61177c8282612336565b6001600160a01b038416600090815260016020526040812091909155600480548492906117aa908490612336565b90915550506040518281526000906001600160a01b038516906000805160206125d883398151915290602001611207565b60006117e683610856565b6001600160a01b0384166000908152600160205260408120549192509061180c90611a23565b6001600160a01b0385811660008181526007602052604080822080546001600160a01b031916898616908117909155905194955093928616927f3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f9190a46116f78284836001600160601b0316611bff565b600063ffffffff8211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203360448201526532206269747360d01b60648201526084016105f3565b5090565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600061198b826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316611d3c9092919063ffffffff16565b80519091501561061057808060200190518101906119a99190612577565b6106105760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b60648201526084016105f3565b6000611a176002848418612599565b6106c19084841661234d565b60006001600160601b038211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203960448201526536206269747360d01b60648201526084016105f3565b60006106c1828461234d565b825460009081908015611ab857611ab3866109e6600184612336565b611abb565b60005b6001600160601b03169250611ad483858763ffffffff16565b91508015611b94576000611afd87611aed600185612336565b8154811061159457611594612365565b9050438163ffffffff161415611b9257611b3681611b1a85611a23565b6001600160601b031660609190911b63ffffffff60601b161790565b87611b42600185612336565b81548110611b5257611b52612365565b90600052602060002090600291828204019190066010026101000a8154816001600160801b0302191690836001600160801b031602179055505050611beb565b505b85611baa611ba14361187d565b611b1a85611a23565b81546001818101845560009384526020909320600282040180546001600160801b03938416601093909516929092026101000a938402929093021916179055505b935093915050565b60006106c18284612336565b816001600160a01b0316836001600160a01b031614158015611c215750600081115b15610610576001600160a01b03831615611caf576001600160a01b03831660009081526008602052604081208190611c5c90611bf385611a97565b91509150846001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611ca4929190918252602082015260400190565b60405180910390a250505b6001600160a01b03821615610610576001600160a01b03821660009081526008602052604081208190611ce590611a8b85611a97565b91509150836001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611d2d929190918252602082015260400190565b60405180910390a25050505050565b6060611d4b8484600085611d53565b949350505050565b606082471015611db45760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b60648201526084016105f3565b843b611e025760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e747261637400000060448201526064016105f3565b600080866001600160a01b03168587604051611e1e91906125bb565b60006040518083038185875af1925050503d8060008114611e5b576040519150601f19603f3d011682016040523d82523d6000602084013e611e60565b606091505b5091509150611e70828286611e7b565b979650505050505050565b60608315611e8a5750816106c1565b825115611e9a5782518084602001fd5b8160405162461bcd60e51b81526004016105f39190611f0c565b60005b83811015611ecf578181015183820152602001611eb7565b838111156116f75750506000910152565b60008151808452611ef8816020860160208601611eb4565b601f01601f19169290920160200192915050565b6020815260006106c16020830184611ee0565b6001600160a01b038116811461085357600080fd5b60008060408385031215611f4757600080fd5b8235611f5281611f1f565b946020939093013593505050565b600080600060608486031215611f7557600080fd5b8335611f8081611f1f565b92506020840135611f9081611f1f565b929592945050506040919091013590565b600060208284031215611fb357600080fd5b5035919050565b600060208284031215611fcc57600080fd5b81356106c181611f1f565b803560ff81168114611fe857600080fd5b919050565b60008060008060008060c0878903121561200657600080fd5b863561201181611f1f565b9550602087013561202181611f1f565b94506040870135935061203660608801611fd7565b92506080870135915060a087013590509295509295509295565b634e487b7160e01b600052604160045260246000fd5b60008060006060848603121561207b57600080fd5b833561208681611f1f565b925060208401359150604084013567ffffffffffffffff808211156120aa57600080fd5b818601915086601f8301126120be57600080fd5b8135818111156120d0576120d0612050565b604051601f8201601f19908116603f011681019083821181831017156120f8576120f8612050565b8160405282815289602084870101111561211157600080fd5b8260208601602083013760006020848301015280955050505050509250925092565b600080600080600080600060e0888a03121561214e57600080fd5b873561215981611f1f565b9650602088013561216981611f1f565b9550604088013594506060880135935061218560808901611fd7565b925060a0880135915060c0880135905092959891949750929550565b600080604083850312156121b457600080fd5b82356121bf81611f1f565b915060208301356121cf81611f1f565b809150509250929050565b600080604083850312156121ed57600080fd5b82356121f881611f1f565b9150602083013563ffffffff811681146121cf57600080fd5b60008060008060006080868803121561222957600080fd5b853561223481611f1f565b9450602086013561224481611f1f565b935060408601359250606086013567ffffffffffffffff8082111561226857600080fd5b818801915088601f83011261227c57600080fd5b81358181111561228b57600080fd5b89602082850101111561229d57600080fd5b9699959850939650602001949392505050565b600181811c908216806122c457607f821691505b602082108114156122e557634e487b7160e01b600052602260045260246000fd5b50919050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052601160045260246000fd5b60008282101561234857612348612320565b500390565b6000821982111561236057612360612320565b500190565b634e487b7160e01b600052603260045260246000fd5b6020808252601b908201527f496e76616c6964207369676e6174757265202773272076616c75650000000000604082015260600190565b6020808252601b908201527f496e76616c6964207369676e6174757265202776272076616c75650000000000604082015260600190565b60006000198214156123fd576123fd612320565b5060010190565b61190160f01b81526002810192909252602282015260420190565b602080825260119082015270496e76616c6964207369676e617475726560781b604082015260600190565b6001600160a01b038581168252602082018590528316604082015260806060820181905260009061247d90830184611ee0565b9695505050505050565b6001600160a01b038681168252851660208201526040810184905260806060820181905281018290526000828460a0840137600060a0848401015260a0601f19601f85011683010190509695505050505050565b600080835481600182811c9150808316806124f757607f831692505b602080841082141561251757634e487b7160e01b86526022600452602486fd5b81801561252b576001811461253c57612569565b60ff19861689528489019650612569565b60008a81526020902060005b868110156125615781548b820152908501908301612548565b505084890196505b509498975050505050505050565b60006020828403121561258957600080fd5b815180151581146106c157600080fd5b6000826125b657634e487b7160e01b600052601260045260246000fd5b500490565b600082516125cd818460208701611eb4565b919091019291505056feddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3efa26469706673582212207eecbfb333a500c574d750bd13d9d3944c632e0e6cfefb9d5262bd9cbb14fb8364736f6c63430008090033",
+  "devdoc": {
+    "details": "By default, token balance does not account for voting power.      This makes transfers cheaper. The downside is that it requires users      to delegate to themselves to activate checkpoints and have their      voting power tracked.",
+    "kind": "dev",
+    "methods": {
+      "approve(address,uint256)": {
+        "details": "If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.      Beware that changing an allowance with this method brings the risk      that someone may use both the old and the new allowance by      unfortunate transaction ordering. One possible solution to mitigate      this race condition is to first reduce the spender's allowance to 0      and set the desired value afterwards:      https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729",
+        "returns": {
+          "_0": "True if the operation succeeded."
+        }
+      },
+      "approveAndCall(address,uint256,bytes)": {
+        "details": "If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.",
+        "returns": {
+          "_0": "True if both approval and `receiveApproval` calls succeeded."
+        }
+      },
+      "burn(uint256)": {
+        "details": "Requirements:       - the caller must have a balance of at least `amount`."
+      },
+      "burnFrom(address,uint256)": {
+        "details": "Requirements:      - `account` must have a balance of at least `amount`,      - the caller must have allowance for `account`'s tokens of at least        `amount`."
+      },
+      "delegate(address)": {
+        "params": {
+          "delegatee": "The address to delegate votes to"
+        }
+      },
+      "delegateBySig(address,address,uint256,uint8,bytes32,bytes32)": {
+        "params": {
+          "deadline": "The time at which to expire the signature",
+          "delegatee": "The address to delegate votes to",
+          "r": "Half of the ECDSA signature pair",
+          "s": "Half of the ECDSA signature pair",
+          "v": "The recovery byte of the signature"
+        }
+      },
+      "getPastTotalSupply(uint256)": {
+        "details": "`blockNumber` must have been already mined",
+        "params": {
+          "blockNumber": "The block number to get the total supply at"
+        }
+      },
+      "getPastVotes(address,uint256)": {
+        "details": "Block number must be a finalized block or else this function will      revert to prevent misinformation.",
+        "params": {
+          "account": "The address of the account to check",
+          "blockNumber": "The block number to get the vote balance at"
+        },
+        "returns": {
+          "_0": "The number of votes the account had as of the given block"
+        }
+      },
+      "getVotes(address)": {
+        "params": {
+          "account": "The address to get votes balance"
+        },
+        "returns": {
+          "_0": "The number of current votes for `account`"
+        }
+      },
+      "mint(address,uint256)": {
+        "details": "Requirements:      - `recipient` cannot be the zero address."
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "The deadline argument can be set to `type(uint256).max to create         permits that effectively never expire.  If the `amount` is set         to `type(uint256).max` then `transferFrom` and `burnFrom` will         not reduce an allowance."
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner."
+      },
+      "transfer(address,uint256)": {
+        "details": "Requirements:       - `recipient` cannot be the zero address,       - the caller must have a balance of at least `amount`.",
+        "returns": {
+          "_0": "True if the operation succeeded, reverts otherwise."
+        }
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "Requirements:      - `spender` and `recipient` cannot be the zero address,      - `spender` must have a balance of at least `amount`,      - the caller must have allowance for `spender`'s tokens of at least        `amount`.",
+        "returns": {
+          "_0": "True if the operation succeeded, reverts otherwise."
+        }
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "title": "T token",
+    "version": 1
+  },
+  "userdoc": {
+    "events": {
+      "DelegateChanged(address,address,address)": {
+        "notice": "Emitted when an account changes their delegate."
+      },
+      "DelegateVotesChanged(address,uint256,uint256)": {
+        "notice": "Emitted when a balance or delegate change results in changes         to an account's voting power."
+      }
+    },
+    "kind": "user",
+    "methods": {
+      "DELEGATION_TYPEHASH()": {
+        "notice": "The EIP-712 typehash for the delegation struct used by         `delegateBySig`."
+      },
+      "DOMAIN_SEPARATOR()": {
+        "notice": "Returns hash of EIP712 Domain struct with the token name as         a signing domain and token contract as a verifying contract.         Used to construct EIP2612 signature provided to `permit`         function."
+      },
+      "PERMIT_TYPEHASH()": {
+        "notice": "Returns EIP2612 Permit message hash. Used to construct EIP2612         signature provided to `permit` function."
+      },
+      "allowance(address,address)": {
+        "notice": "The remaining number of tokens that spender will be         allowed to spend on behalf of owner through `transferFrom` and         `burnFrom`. This is zero by default."
+      },
+      "approve(address,uint256)": {
+        "notice": "Sets `amount` as the allowance of `spender` over the caller's         tokens."
+      },
+      "approveAndCall(address,uint256,bytes)": {
+        "notice": "Calls `receiveApproval` function on spender previously approving         the spender to withdraw from the caller multiple times, up to         the `amount` amount. If this function is called again, it         overwrites the current allowance with `amount`. Reverts if the         approval reverted or if `receiveApproval` call on the spender         reverted."
+      },
+      "balanceOf(address)": {
+        "notice": "The amount of tokens owned by the given account."
+      },
+      "burn(uint256)": {
+        "notice": "Destroys `amount` tokens from the caller."
+      },
+      "burnFrom(address,uint256)": {
+        "notice": "Destroys `amount` of tokens from `account` using the allowance         mechanism. `amount` is then deducted from the caller's allowance         unless the allowance was made for `type(uint256).max`."
+      },
+      "decimals()": {
+        "notice": "The decimals places of the token."
+      },
+      "delegate(address)": {
+        "notice": "Delegate votes from `msg.sender` to `delegatee`."
+      },
+      "delegateBySig(address,address,uint256,uint8,bytes32,bytes32)": {
+        "notice": "Delegates votes from signatory to `delegatee`"
+      },
+      "delegates(address)": {
+        "notice": "Get the address `account` is currently delegating to."
+      },
+      "getPastTotalSupply(uint256)": {
+        "notice": "Retrieve the `totalSupply` at the end of `blockNumber`.         Note, this value is the sum of all balances, but it is NOT the         sum of all the delegated votes!"
+      },
+      "getPastVotes(address,uint256)": {
+        "notice": "Determine the prior number of votes for an account as of         a block number."
+      },
+      "getVotes(address)": {
+        "notice": "Gets the current votes balance for `account`."
+      },
+      "mint(address,uint256)": {
+        "notice": "Creates `amount` tokens and assigns them to `account`,         increasing the total supply."
+      },
+      "name()": {
+        "notice": "The name of the token."
+      },
+      "nonce(address)": {
+        "notice": "Returns the current nonce for EIP2612 permission for the         provided token owner for a replay protection. Used to construct         EIP2612 signature provided to `permit` function."
+      },
+      "numCheckpoints(address)": {
+        "notice": "Get number of checkpoints for `account`."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "notice": "EIP2612 approval made with secp256k1 signature.         Users can authorize a transfer of their tokens with a signature         conforming EIP712 standard, rather than an on-chain transaction         from their address. Anyone can submit this signature on the         user's behalf by calling the permit function, paying gas fees,         and possibly performing other actions in the same transaction."
+      },
+      "symbol()": {
+        "notice": "The symbol of the token."
+      },
+      "totalSupply()": {
+        "notice": "The amount of tokens in existence."
+      },
+      "transfer(address,uint256)": {
+        "notice": "Moves `amount` tokens from the caller's account to `recipient`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "notice": "Moves `amount` tokens from `spender` to `recipient` using the         allowance mechanism. `amount` is then deducted from the caller's         allowance unless the allowance was made for `type(uint256).max`."
+      }
+    },
+    "notice": "Threshold Network T token",
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 389,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 6729,
+        "contract": "contracts/token/T.sol:T",
+        "label": "balanceOf",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 6737,
+        "contract": "contracts/token/T.sol:T",
+        "label": "allowance",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 6743,
+        "contract": "contracts/token/T.sol:T",
+        "label": "nonce",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 6758,
+        "contract": "contracts/token/T.sol:T",
+        "label": "totalSupply",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 6762,
+        "contract": "contracts/token/T.sol:T",
+        "label": "name",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 6766,
+        "contract": "contracts/token/T.sol:T",
+        "label": "symbol",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7563,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_delegates",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_mapping(t_address,t_address)"
+      },
+      {
+        "astId": 7568,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_checkpoints",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)"
+      },
+      {
+        "astId": 7571,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_totalSupplyCheckpoints",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_array(t_uint128)dyn_storage"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_array(t_uint128)dyn_storage": {
+        "base": "t_uint128",
+        "encoding": "dynamic_array",
+        "label": "uint128[]",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_address)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => address)",
+        "numberOfBytes": "32",
+        "value": "t_address"
+      },
+      "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint128[])",
+        "numberOfBytes": "32",
+        "value": "t_array(t_uint128)dyn_storage"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint128": {
+        "encoding": "inplace",
+        "label": "uint128",
+        "numberOfBytes": "16"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      }
+    }
+  }
+}

--- a/solidity/ecdsa/external/mainnet/TokenStaking.json
+++ b/solidity/ecdsa/external/mainnet/TokenStaking.json
@@ -1,0 +1,1484 @@
+{
+  "address": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+  "abi": [
+    {
+      "type": "constructor",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "_token"
+        },
+        {
+          "type": "address",
+          "name": "_keepStakingContract"
+        },
+        {
+          "type": "address",
+          "name": "_nucypherStakingContract"
+        },
+        {
+          "type": "address",
+          "name": "_keepVendingMachine"
+        },
+        {
+          "type": "address",
+          "name": "_nucypherVendingMachine"
+        },
+        {
+          "type": "address",
+          "name": "_keepStake"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "ApplicationStatusChanged",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint8",
+          "name": "newStatus",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationCeilingSet",
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "ceiling",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationDecreaseApproved",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationDecreaseRequested",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationIncreased",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationInvoluntaryDecreased",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        },
+        {
+          "type": "bool",
+          "name": "successfulCall",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "DelegateChanged",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "delegator",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "fromDelegate",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "toDelegate",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "DelegateVotesChanged",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "delegate",
+          "indexed": true
+        },
+        {
+          "type": "uint256",
+          "name": "previousBalance",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "newBalance",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "GovernanceTransferred",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "oldGovernance",
+          "indexed": false
+        },
+        {
+          "type": "address",
+          "name": "newGovernance",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "MinimumStakeAmountSet",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotificationRewardPushed",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotificationRewardSet",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotificationRewardWithdrawn",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "recipient",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotifierRewarded",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "notifier",
+          "indexed": true
+        },
+        {
+          "type": "uint256",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "OwnerRefreshed",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "oldOwner",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "newOwner",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "PanicButtonSet",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "panicButton",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "SlashingProcessed",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "caller",
+          "indexed": true
+        },
+        {
+          "type": "uint256",
+          "name": "count",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "tAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "StakeDiscrepancyPenaltySet",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "penalty",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "rewardMultiplier",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "Staked",
+      "inputs": [
+        {
+          "type": "uint8",
+          "name": "stakeType",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "owner",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "beneficiary",
+          "indexed": false
+        },
+        {
+          "type": "address",
+          "name": "authorizer",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "TokensSeized",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        },
+        {
+          "type": "bool",
+          "name": "discrepancy",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "ToppedUp",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "Unstaked",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "applicationInfo",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint8",
+          "name": "status"
+        },
+        {
+          "type": "address",
+          "name": "panicButton"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "applications",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "approveApplication",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "approveAuthorizationDecrease",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "authorizationCeiling",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "authorizedStake",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "checkpoints",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        },
+        {
+          "type": "uint32",
+          "name": "pos"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "tuple",
+          "name": "checkpoint",
+          "components": [
+            {
+              "type": "uint32",
+              "name": "fromBlock"
+            },
+            {
+              "type": "uint96",
+              "name": "votes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "delegateVoting",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "delegatee"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "delegates",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "disableApplication",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "forceDecreaseAuthorization",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "getApplicationsLength",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getAvailableToAuthorize",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96",
+          "name": "availableTValue"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getMinStaked",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint8",
+          "name": "stakeTypes"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getPastTotalSupply",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "blockNumber"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getPastVotes",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        },
+        {
+          "type": "uint256",
+          "name": "blockNumber"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getSlashingQueueLength",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getStartStakingTimestamp",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getVotes",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "governance",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "increaseAuthorization",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "constant": false,
+      "payable": false,
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "minTStakeAmount",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "notificationReward",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "notifiersTreasury",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "notifyKeepStakeDiscrepancy",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "notifyNuStakeDiscrepancy",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "numCheckpoints",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint32"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "pauseApplication",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "processSlashing",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "count"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "pushNotificationReward",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "refreshKeepStakeOwner",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "requestAuthorizationDecrease",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "requestAuthorizationDecrease",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "rolesOf",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address",
+          "name": "owner"
+        },
+        {
+          "type": "address",
+          "name": "beneficiary"
+        },
+        {
+          "type": "address",
+          "name": "authorizer"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "seize",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount"
+        },
+        {
+          "type": "uint256",
+          "name": "rewardMultiplier"
+        },
+        {
+          "type": "address",
+          "name": "notifier"
+        },
+        {
+          "type": "address[]",
+          "name": "_stakingProviders"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setAuthorizationCeiling",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "ceiling"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setMinimumStakeAmount",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setNotificationReward",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setPanicButton",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        },
+        {
+          "type": "address",
+          "name": "panicButton"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setStakeDiscrepancyPenalty",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "penalty"
+        },
+        {
+          "type": "uint256",
+          "name": "rewardMultiplier"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "slash",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount"
+        },
+        {
+          "type": "address[]",
+          "name": "_stakingProviders"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "slashingQueue",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "slashingQueueIndex",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stake",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "beneficiary"
+        },
+        {
+          "type": "address",
+          "name": "authorizer"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "stakeDiscrepancyPenalty",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stakeDiscrepancyRewardMultiplier",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stakeKeep",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "stakeNu",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "beneficiary"
+        },
+        {
+          "type": "address",
+          "name": "authorizer"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "stakedNu",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint256",
+          "name": "nuAmount"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stakes",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96",
+          "name": "tStake"
+        },
+        {
+          "type": "uint96",
+          "name": "keepInTStake"
+        },
+        {
+          "type": "uint96",
+          "name": "nuInTStake"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "topUp",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "topUpKeep",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "topUpNu",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "transferGovernance",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "newGuvnor"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeAll",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeKeep",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeNu",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeT",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "withdrawNotificationReward",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "recipient"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    }
+  ]
+}

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -111,6 +111,14 @@ const config: HardhatUserConfig = {
         : undefined,
       tags: ["etherscan", "tenderly"],
     },
+    mainnet: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 1,
+      accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
+        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+        : undefined,
+      tags: ["etherscan", "tenderly"],
+    },
   },
   // // Define local networks configuration file path to load networks from the file.
   // localNetworksConfig: "./.hardhat/networks.ts",
@@ -125,22 +133,23 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 1, // take the second account
       goerli: 0,
-      // mainnet: ""
+      mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
+      // TODO: Rename to thresholdCouncil
       default: 2,
       goerli: 0,
-      // mainnet: ""
+      mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
       goerli: 0,
-      // mainnet: ""
+      mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     esdm: {
       default: 4,
       goerli: 0,
-      // mainnet: ""
+      mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
   },
   external: {
@@ -174,7 +183,7 @@ const config: HardhatUserConfig = {
         "node_modules/@threshold-network/solidity-contracts/artifacts",
         "node_modules/@keep-network/random-beacon/artifacts",
       ],
-      // mainnet: ["./external/mainnet"],
+      mainnet: ["./external/mainnet"],
     },
   },
   dependencyCompiler:

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -136,7 +136,6 @@ const config: HardhatUserConfig = {
       mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
-      // TODO: Rename to thresholdCouncil
       default: 2,
       goerli: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council

--- a/solidity/random-beacon/.gitignore
+++ b/solidity/random-beacon/.gitignore
@@ -7,5 +7,8 @@ export.json
 
 # Contract artifacts
 artifacts/
-deployments/
+deployments/*
 !deployments/mainnet
+
+# OpenZeppelin
+.openzeppelin/unknown-*.json

--- a/solidity/random-beacon/.prettierignore
+++ b/solidity/random-beacon/.prettierignore
@@ -2,6 +2,7 @@ artifacts/
 build/
 cache/
 deployments/
+external/
 hardhat-dependency-compiler/
 typechain/
 export.json

--- a/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
+++ b/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
@@ -7,7 +7,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { execute } = deployments
   const { to1e18 } = helpers.number
 
-  const POOL_WEIGHT_DIVISOR = to1e18(1) // TODO: Update value
+  const POOL_WEIGHT_DIVISOR = to1e18(1)
 
   const T = await deployments.get("T")
 

--- a/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
+++ b/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
@@ -21,7 +21,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   await execute(
     "BeaconSortitionPool",
-    { from: deployer },
+    { from: deployer, log: true, waitConfirmations: 1 },
     "transferChaosnetOwnerRole",
     chaosnetOwner
   )

--- a/solidity/random-beacon/deploy/04_deploy_random_beacon.ts
+++ b/solidity/random-beacon/deploy/04_deploy_random_beacon.ts
@@ -4,6 +4,11 @@ import type { DeployFunction, DeployOptions } from "hardhat-deploy/types"
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
+  const { to1e18 } = helpers.number
+
+  const minimumAuthorization = to1e18(40_000) // 40k T
+  const authorizationDecreaseDelay = 1_209_600 // 1 209 600 seconds = 14 days
+  const authorizationDecreaseChangePeriod = 1_209_600 // 1 209 600 seconds = 14 days
 
   const T = await deployments.get("T")
   const TokenStaking = await deployments.get("TokenStaking")
@@ -51,6 +56,15 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     },
     ...deployOptions,
   })
+
+  await deployments.execute(
+    "RandomBeacon",
+    { from: deployer, log: true, waitConfirmations: 1 },
+    "updateAuthorizationParameters",
+    minimumAuthorization,
+    authorizationDecreaseDelay,
+    authorizationDecreaseChangePeriod
+  )
 
   await helpers.ownable.transferOwnership(
     "BeaconSortitionPool",

--- a/solidity/random-beacon/deploy/05_approve_random_beacon_in_token_staking.ts
+++ b/solidity/random-beacon/deploy/05_approve_random_beacon_in_token_staking.ts
@@ -8,11 +8,9 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const RandomBeacon = await deployments.get("RandomBeacon")
 
-  deployments.log("approving the RandomBeacon in the TokenStaking")
-
   await execute(
     "TokenStaking",
-    { from: deployer },
+    { from: deployer, log: true, waitConfirmations: 1 },
     "approveApplication",
     RandomBeacon.address
   )

--- a/solidity/random-beacon/deploy/05_approve_random_beacon_in_token_staking.ts
+++ b/solidity/random-beacon/deploy/05_approve_random_beacon_in_token_staking.ts
@@ -22,3 +22,7 @@ export default func
 
 func.tags = ["RandomBeaconApprove"]
 func.dependencies = ["TokenStaking", "RandomBeacon"]
+
+// Skip for mainnet.
+func.skip = async (hre: HardhatRuntimeEnvironment): Promise<boolean> =>
+  hre.network.name === "mainnet"

--- a/solidity/random-beacon/deploy/06_authorize_random_beacon_in_reimbursement_pool.ts
+++ b/solidity/random-beacon/deploy/06_authorize_random_beacon_in_reimbursement_pool.ts
@@ -8,8 +8,6 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const RandomBeacon = await deployments.get("RandomBeacon")
 
-  deployments.log("authorizing the RandomBeacon in the ReimbursementPool")
-
   await execute(
     "ReimbursementPool",
     { from: deployer, log: true, waitConfirmations: 1 },

--- a/solidity/random-beacon/external/mainnet/T.json
+++ b/solidity/random-beacon/external/mainnet/T.json
@@ -1,0 +1,1134 @@
+{
+  "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+  "abi": [
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "delegator",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromDelegate",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toDelegate",
+          "type": "address"
+        }
+      ],
+      "name": "DelegateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "delegate",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "previousBalance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newBalance",
+          "type": "uint256"
+        }
+      ],
+      "name": "DelegateVotesChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DELEGATION_TYPEHASH",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PERMIT_TYPEHASH",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "approveAndCall",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burn",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burnFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cachedChainId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cachedDomainSeparator",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint32",
+          "name": "pos",
+          "type": "uint32"
+        }
+      ],
+      "name": "checkpoints",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "fromBlock",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint96",
+              "name": "votes",
+              "type": "uint96"
+            }
+          ],
+          "internalType": "struct Checkpoints.Checkpoint",
+          "name": "checkpoint",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "delegatee",
+          "type": "address"
+        }
+      ],
+      "name": "delegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signatory",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "delegatee",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "delegateBySig",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "delegates",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPastTotalSupply",
+      "outputs": [
+        {
+          "internalType": "uint96",
+          "name": "",
+          "type": "uint96"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPastVotes",
+      "outputs": [
+        {
+          "internalType": "uint96",
+          "name": "",
+          "type": "uint96"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "getVotes",
+      "outputs": [
+        {
+          "internalType": "uint96",
+          "name": "",
+          "type": "uint96"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "nonce",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "numCheckpoints",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "recoverERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC721",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "recoverERC721",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xdfc479f92a88c0a7a2148227c0d4c07db077df75ced4b0409465459a6b1a2454",
+  "receipt": {
+    "to": null,
+    "from": "0x123694886DBf5Ac94DDA07135349534536D14cAf",
+    "contractAddress": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+    "transactionIndex": 34,
+    "gasUsed": "2244990",
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000800000000000000000000800000000000000000000000000000000000000000000000000000400000000000000000000000000000000000001000000000000000000000000000000000000020000000000010000000800000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0xbfc68de83f2c428cd0d55861fd2d63b16e3ac3226814788d2782fc52621be0c9",
+    "transactionHash": "0xdfc479f92a88c0a7a2148227c0d4c07db077df75ced4b0409465459a6b1a2454",
+    "logs": [
+      {
+        "transactionIndex": 34,
+        "blockNumber": 13912436,
+        "transactionHash": "0xdfc479f92a88c0a7a2148227c0d4c07db077df75ced4b0409465459a6b1a2454",
+        "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x000000000000000000000000123694886dbf5ac94dda07135349534536d14caf"
+        ],
+        "data": "0x",
+        "logIndex": 21,
+        "blockHash": "0xbfc68de83f2c428cd0d55861fd2d63b16e3ac3226814788d2782fc52621be0c9"
+      }
+    ],
+    "blockNumber": 13912436,
+    "cumulativeGasUsed": "3554050",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [],
+  "solcInputHash": "43eb8b17fe7c2ce0e21167459a2d9d30",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.9+commit.e5eed63a\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromDelegate\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toDelegate\",\"type\":\"address\"}],\"name\":\"DelegateChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"previousBalance\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newBalance\",\"type\":\"uint256\"}],\"name\":\"DelegateVotesChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DELEGATION_TYPEHASH\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PERMIT_TYPEHASH\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"name\":\"approveAndCall\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"burn\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"burnFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"cachedChainId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"cachedDomainSeparator\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"pos\",\"type\":\"uint32\"}],\"name\":\"checkpoints\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"fromBlock\",\"type\":\"uint32\"},{\"internalType\":\"uint96\",\"name\":\"votes\",\"type\":\"uint96\"}],\"internalType\":\"struct Checkpoints.Checkpoint\",\"name\":\"checkpoint\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatee\",\"type\":\"address\"}],\"name\":\"delegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signatory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"delegatee\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"delegateBySig\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"delegates\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getPastTotalSupply\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getPastVotes\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"getVotes\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"mint\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"nonce\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"numCheckpoints\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contract IERC20\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"recoverERC20\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contract IERC721\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"recoverERC721\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"By default, token balance does not account for voting power.      This makes transfers cheaper. The downside is that it requires users      to delegate to themselves to activate checkpoints and have their      voting power tracked.\",\"kind\":\"dev\",\"methods\":{\"approve(address,uint256)\":{\"details\":\"If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.      Beware that changing an allowance with this method brings the risk      that someone may use both the old and the new allowance by      unfortunate transaction ordering. One possible solution to mitigate      this race condition is to first reduce the spender's allowance to 0      and set the desired value afterwards:      https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\",\"returns\":{\"_0\":\"True if the operation succeeded.\"}},\"approveAndCall(address,uint256,bytes)\":{\"details\":\"If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.\",\"returns\":{\"_0\":\"True if both approval and `receiveApproval` calls succeeded.\"}},\"burn(uint256)\":{\"details\":\"Requirements:       - the caller must have a balance of at least `amount`.\"},\"burnFrom(address,uint256)\":{\"details\":\"Requirements:      - `account` must have a balance of at least `amount`,      - the caller must have allowance for `account`'s tokens of at least        `amount`.\"},\"delegate(address)\":{\"params\":{\"delegatee\":\"The address to delegate votes to\"}},\"delegateBySig(address,address,uint256,uint8,bytes32,bytes32)\":{\"params\":{\"deadline\":\"The time at which to expire the signature\",\"delegatee\":\"The address to delegate votes to\",\"r\":\"Half of the ECDSA signature pair\",\"s\":\"Half of the ECDSA signature pair\",\"v\":\"The recovery byte of the signature\"}},\"getPastTotalSupply(uint256)\":{\"details\":\"`blockNumber` must have been already mined\",\"params\":{\"blockNumber\":\"The block number to get the total supply at\"}},\"getPastVotes(address,uint256)\":{\"details\":\"Block number must be a finalized block or else this function will      revert to prevent misinformation.\",\"params\":{\"account\":\"The address of the account to check\",\"blockNumber\":\"The block number to get the vote balance at\"},\"returns\":{\"_0\":\"The number of votes the account had as of the given block\"}},\"getVotes(address)\":{\"params\":{\"account\":\"The address to get votes balance\"},\"returns\":{\"_0\":\"The number of current votes for `account`\"}},\"mint(address,uint256)\":{\"details\":\"Requirements:      - `recipient` cannot be the zero address.\"},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"The deadline argument can be set to `type(uint256).max to create         permits that effectively never expire.  If the `amount` is set         to `type(uint256).max` then `transferFrom` and `burnFrom` will         not reduce an allowance.\"},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.\"},\"transfer(address,uint256)\":{\"details\":\"Requirements:       - `recipient` cannot be the zero address,       - the caller must have a balance of at least `amount`.\",\"returns\":{\"_0\":\"True if the operation succeeded, reverts otherwise.\"}},\"transferFrom(address,address,uint256)\":{\"details\":\"Requirements:      - `spender` and `recipient` cannot be the zero address,      - `spender` must have a balance of at least `amount`,      - the caller must have allowance for `spender`'s tokens of at least        `amount`.\",\"returns\":{\"_0\":\"True if the operation succeeded, reverts otherwise.\"}},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"title\":\"T token\",\"version\":1},\"userdoc\":{\"events\":{\"DelegateChanged(address,address,address)\":{\"notice\":\"Emitted when an account changes their delegate.\"},\"DelegateVotesChanged(address,uint256,uint256)\":{\"notice\":\"Emitted when a balance or delegate change results in changes         to an account's voting power.\"}},\"kind\":\"user\",\"methods\":{\"DELEGATION_TYPEHASH()\":{\"notice\":\"The EIP-712 typehash for the delegation struct used by         `delegateBySig`.\"},\"DOMAIN_SEPARATOR()\":{\"notice\":\"Returns hash of EIP712 Domain struct with the token name as         a signing domain and token contract as a verifying contract.         Used to construct EIP2612 signature provided to `permit`         function.\"},\"PERMIT_TYPEHASH()\":{\"notice\":\"Returns EIP2612 Permit message hash. Used to construct EIP2612         signature provided to `permit` function.\"},\"allowance(address,address)\":{\"notice\":\"The remaining number of tokens that spender will be         allowed to spend on behalf of owner through `transferFrom` and         `burnFrom`. This is zero by default.\"},\"approve(address,uint256)\":{\"notice\":\"Sets `amount` as the allowance of `spender` over the caller's         tokens.\"},\"approveAndCall(address,uint256,bytes)\":{\"notice\":\"Calls `receiveApproval` function on spender previously approving         the spender to withdraw from the caller multiple times, up to         the `amount` amount. If this function is called again, it         overwrites the current allowance with `amount`. Reverts if the         approval reverted or if `receiveApproval` call on the spender         reverted.\"},\"balanceOf(address)\":{\"notice\":\"The amount of tokens owned by the given account.\"},\"burn(uint256)\":{\"notice\":\"Destroys `amount` tokens from the caller.\"},\"burnFrom(address,uint256)\":{\"notice\":\"Destroys `amount` of tokens from `account` using the allowance         mechanism. `amount` is then deducted from the caller's allowance         unless the allowance was made for `type(uint256).max`.\"},\"decimals()\":{\"notice\":\"The decimals places of the token.\"},\"delegate(address)\":{\"notice\":\"Delegate votes from `msg.sender` to `delegatee`.\"},\"delegateBySig(address,address,uint256,uint8,bytes32,bytes32)\":{\"notice\":\"Delegates votes from signatory to `delegatee`\"},\"delegates(address)\":{\"notice\":\"Get the address `account` is currently delegating to.\"},\"getPastTotalSupply(uint256)\":{\"notice\":\"Retrieve the `totalSupply` at the end of `blockNumber`.         Note, this value is the sum of all balances, but it is NOT the         sum of all the delegated votes!\"},\"getPastVotes(address,uint256)\":{\"notice\":\"Determine the prior number of votes for an account as of         a block number.\"},\"getVotes(address)\":{\"notice\":\"Gets the current votes balance for `account`.\"},\"mint(address,uint256)\":{\"notice\":\"Creates `amount` tokens and assigns them to `account`,         increasing the total supply.\"},\"name()\":{\"notice\":\"The name of the token.\"},\"nonce(address)\":{\"notice\":\"Returns the current nonce for EIP2612 permission for the         provided token owner for a replay protection. Used to construct         EIP2612 signature provided to `permit` function.\"},\"numCheckpoints(address)\":{\"notice\":\"Get number of checkpoints for `account`.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"notice\":\"EIP2612 approval made with secp256k1 signature.         Users can authorize a transfer of their tokens with a signature         conforming EIP712 standard, rather than an on-chain transaction         from their address. Anyone can submit this signature on the         user's behalf by calling the permit function, paying gas fees,         and possibly performing other actions in the same transaction.\"},\"symbol()\":{\"notice\":\"The symbol of the token.\"},\"totalSupply()\":{\"notice\":\"The amount of tokens in existence.\"},\"transfer(address,uint256)\":{\"notice\":\"Moves `amount` tokens from the caller's account to `recipient`.\"},\"transferFrom(address,address,uint256)\":{\"notice\":\"Moves `amount` tokens from `spender` to `recipient` using the         allowance mechanism. `amount` is then deducted from the caller's         allowance unless the allowance was made for `type(uint256).max`.\"}},\"notice\":\"Threshold Network T token\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/token/T.sol\":\"T\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":100},\"remappings\":[]},\"sources\":{\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (access/Ownable.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * By default, the owner account will be the one that deploys the contract. This\\n * can later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the deployer as the initial owner.\\n     */\\n    constructor() {\\n        _transferOwnership(_msgSender());\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        require(owner() == _msgSender(), \\\"Ownable: caller is not the owner\\\");\\n        _;\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions anymore. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby removing any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        require(newOwner != address(0), \\\"Ownable: new owner is the zero address\\\");\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xa1b27b3f44ff825974e5268e8f63ad3b03add5b464880d860fbb8cae043e17f7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Interface of the ERC20 standard as defined in the EIP.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Returns the amount of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the amount of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves `amount` tokens from the caller's account to `recipient`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address recipient, uint256 amount) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 amount) external returns (bool);\\n\\n    /**\\n     * @dev Moves `amount` tokens from `sender` to `recipient` using the\\n     * allowance mechanism. `amount` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(\\n        address sender,\\n        address recipient,\\n        uint256 amount\\n    ) external returns (bool);\\n\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n}\\n\",\"keccak256\":\"0xc1452b054778f1926419196ef12ae200758a4ee728df69ae1cd13e5c16ca7df7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC20 standard.\\n *\\n * _Available since v4.1._\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x842c66d5965ed0bf77f274732c2a93a7e2223d53171ec9cccc473bde75104ead\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../IERC20.sol\\\";\\nimport \\\"../../../utils/Address.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    using Address for address;\\n\\n    function safeTransfer(\\n        IERC20 token,\\n        address to,\\n        uint256 value\\n    ) internal {\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));\\n    }\\n\\n    function safeTransferFrom(\\n        IERC20 token,\\n        address from,\\n        address to,\\n        uint256 value\\n    ) internal {\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));\\n    }\\n\\n    /**\\n     * @dev Deprecated. This function has issues similar to the ones found in\\n     * {IERC20-approve}, and its usage is discouraged.\\n     *\\n     * Whenever possible, use {safeIncreaseAllowance} and\\n     * {safeDecreaseAllowance} instead.\\n     */\\n    function safeApprove(\\n        IERC20 token,\\n        address spender,\\n        uint256 value\\n    ) internal {\\n        // safeApprove should only be called when setting an initial allowance,\\n        // or when resetting it to zero. To increase and decrease it, use\\n        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'\\n        require(\\n            (value == 0) || (token.allowance(address(this), spender) == 0),\\n            \\\"SafeERC20: approve from non-zero to non-zero allowance\\\"\\n        );\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));\\n    }\\n\\n    function safeIncreaseAllowance(\\n        IERC20 token,\\n        address spender,\\n        uint256 value\\n    ) internal {\\n        uint256 newAllowance = token.allowance(address(this), spender) + value;\\n        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));\\n    }\\n\\n    function safeDecreaseAllowance(\\n        IERC20 token,\\n        address spender,\\n        uint256 value\\n    ) internal {\\n        unchecked {\\n            uint256 oldAllowance = token.allowance(address(this), spender);\\n            require(oldAllowance >= value, \\\"SafeERC20: decreased allowance below zero\\\");\\n            uint256 newAllowance = oldAllowance - value;\\n            _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since\\n        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that\\n        // the target address contains contract code and also asserts for success in the low-level call.\\n\\n        bytes memory returndata = address(token).functionCall(data, \\\"SafeERC20: low-level call failed\\\");\\n        if (returndata.length > 0) {\\n            // Return data is optional\\n            require(abi.decode(returndata, (bool)), \\\"SafeERC20: ERC20 operation did not succeed\\\");\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x671741933530f343f023a40e58e61bc09d62494b96c6f3e39e647f315facd519\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC721/IERC721.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (token/ERC721/IERC721.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../../utils/introspection/IERC165.sol\\\";\\n\\n/**\\n * @dev Required interface of an ERC721 compliant contract.\\n */\\ninterface IERC721 is IERC165 {\\n    /**\\n     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);\\n\\n    /**\\n     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.\\n     */\\n    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);\\n\\n    /**\\n     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.\\n     */\\n    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);\\n\\n    /**\\n     * @dev Returns the number of tokens in ``owner``'s account.\\n     */\\n    function balanceOf(address owner) external view returns (uint256 balance);\\n\\n    /**\\n     * @dev Returns the owner of the `tokenId` token.\\n     *\\n     * Requirements:\\n     *\\n     * - `tokenId` must exist.\\n     */\\n    function ownerOf(uint256 tokenId) external view returns (address owner);\\n\\n    /**\\n     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients\\n     * are aware of the ERC721 protocol to prevent tokens from being forever locked.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` cannot be the zero address.\\n     * - `to` cannot be the zero address.\\n     * - `tokenId` token must exist and be owned by `from`.\\n     * - If the caller is not `from`, it must be have been allowed to move this token by either {approve} or {setApprovalForAll}.\\n     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function safeTransferFrom(\\n        address from,\\n        address to,\\n        uint256 tokenId\\n    ) external;\\n\\n    /**\\n     * @dev Transfers `tokenId` token from `from` to `to`.\\n     *\\n     * WARNING: Usage of this method is discouraged, use {safeTransferFrom} whenever possible.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` cannot be the zero address.\\n     * - `to` cannot be the zero address.\\n     * - `tokenId` token must be owned by `from`.\\n     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(\\n        address from,\\n        address to,\\n        uint256 tokenId\\n    ) external;\\n\\n    /**\\n     * @dev Gives permission to `to` to transfer `tokenId` token to another account.\\n     * The approval is cleared when the token is transferred.\\n     *\\n     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.\\n     *\\n     * Requirements:\\n     *\\n     * - The caller must own the token or be an approved operator.\\n     * - `tokenId` must exist.\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address to, uint256 tokenId) external;\\n\\n    /**\\n     * @dev Returns the account approved for `tokenId` token.\\n     *\\n     * Requirements:\\n     *\\n     * - `tokenId` must exist.\\n     */\\n    function getApproved(uint256 tokenId) external view returns (address operator);\\n\\n    /**\\n     * @dev Approve or remove `operator` as an operator for the caller.\\n     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.\\n     *\\n     * Requirements:\\n     *\\n     * - The `operator` cannot be the caller.\\n     *\\n     * Emits an {ApprovalForAll} event.\\n     */\\n    function setApprovalForAll(address operator, bool _approved) external;\\n\\n    /**\\n     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.\\n     *\\n     * See {setApprovalForAll}\\n     */\\n    function isApprovedForAll(address owner, address operator) external view returns (bool);\\n\\n    /**\\n     * @dev Safely transfers `tokenId` token from `from` to `to`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` cannot be the zero address.\\n     * - `to` cannot be the zero address.\\n     * - `tokenId` token must exist and be owned by `from`.\\n     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.\\n     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function safeTransferFrom(\\n        address from,\\n        address to,\\n        uint256 tokenId,\\n        bytes calldata data\\n    ) external;\\n}\\n\",\"keccak256\":\"0x872ba21af7c1f0ae04a715beca31e8fcac764d6c8762940b0fe1bfb6ed8e86f4\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Address.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/Address.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Collection of functions related to the address type\\n */\\nlibrary Address {\\n    /**\\n     * @dev Returns true if `account` is a contract.\\n     *\\n     * [IMPORTANT]\\n     * ====\\n     * It is unsafe to assume that an address for which this function returns\\n     * false is an externally-owned account (EOA) and not a contract.\\n     *\\n     * Among others, `isContract` will return false for the following\\n     * types of addresses:\\n     *\\n     *  - an externally-owned account\\n     *  - a contract in construction\\n     *  - an address where a contract will be created\\n     *  - an address where a contract lived, but was destroyed\\n     * ====\\n     */\\n    function isContract(address account) internal view returns (bool) {\\n        // This method relies on extcodesize, which returns 0 for contracts in\\n        // construction, since the code is only stored at the end of the\\n        // constructor execution.\\n\\n        uint256 size;\\n        assembly {\\n            size := extcodesize(account)\\n        }\\n        return size > 0;\\n    }\\n\\n    /**\\n     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to\\n     * `recipient`, forwarding all available gas and reverting on errors.\\n     *\\n     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost\\n     * of certain opcodes, possibly making contracts go over the 2300 gas limit\\n     * imposed by `transfer`, making them unable to receive funds via\\n     * `transfer`. {sendValue} removes this limitation.\\n     *\\n     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].\\n     *\\n     * IMPORTANT: because control is transferred to `recipient`, care must be\\n     * taken to not create reentrancy vulnerabilities. Consider using\\n     * {ReentrancyGuard} or the\\n     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].\\n     */\\n    function sendValue(address payable recipient, uint256 amount) internal {\\n        require(address(this).balance >= amount, \\\"Address: insufficient balance\\\");\\n\\n        (bool success, ) = recipient.call{value: amount}(\\\"\\\");\\n        require(success, \\\"Address: unable to send value, recipient may have reverted\\\");\\n    }\\n\\n    /**\\n     * @dev Performs a Solidity function call using a low level `call`. A\\n     * plain `call` is an unsafe replacement for a function call: use this\\n     * function instead.\\n     *\\n     * If `target` reverts with a revert reason, it is bubbled up by this\\n     * function (like regular Solidity function calls).\\n     *\\n     * Returns the raw returned data. To convert to the expected return value,\\n     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].\\n     *\\n     * Requirements:\\n     *\\n     * - `target` must be a contract.\\n     * - calling `target` with `data` must not revert.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCall(address target, bytes memory data) internal returns (bytes memory) {\\n        return functionCall(target, data, \\\"Address: low-level call failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with\\n     * `errorMessage` as a fallback revert reason when `target` reverts.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCall(\\n        address target,\\n        bytes memory data,\\n        string memory errorMessage\\n    ) internal returns (bytes memory) {\\n        return functionCallWithValue(target, data, 0, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],\\n     * but also transferring `value` wei to `target`.\\n     *\\n     * Requirements:\\n     *\\n     * - the calling contract must have an ETH balance of at least `value`.\\n     * - the called Solidity function must be `payable`.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCallWithValue(\\n        address target,\\n        bytes memory data,\\n        uint256 value\\n    ) internal returns (bytes memory) {\\n        return functionCallWithValue(target, data, value, \\\"Address: low-level call with value failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but\\n     * with `errorMessage` as a fallback revert reason when `target` reverts.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function functionCallWithValue(\\n        address target,\\n        bytes memory data,\\n        uint256 value,\\n        string memory errorMessage\\n    ) internal returns (bytes memory) {\\n        require(address(this).balance >= value, \\\"Address: insufficient balance for call\\\");\\n        require(isContract(target), \\\"Address: call to non-contract\\\");\\n\\n        (bool success, bytes memory returndata) = target.call{value: value}(data);\\n        return verifyCallResult(success, returndata, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],\\n     * but performing a static call.\\n     *\\n     * _Available since v3.3._\\n     */\\n    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {\\n        return functionStaticCall(target, data, \\\"Address: low-level static call failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],\\n     * but performing a static call.\\n     *\\n     * _Available since v3.3._\\n     */\\n    function functionStaticCall(\\n        address target,\\n        bytes memory data,\\n        string memory errorMessage\\n    ) internal view returns (bytes memory) {\\n        require(isContract(target), \\\"Address: static call to non-contract\\\");\\n\\n        (bool success, bytes memory returndata) = target.staticcall(data);\\n        return verifyCallResult(success, returndata, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],\\n     * but performing a delegate call.\\n     *\\n     * _Available since v3.4._\\n     */\\n    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {\\n        return functionDelegateCall(target, data, \\\"Address: low-level delegate call failed\\\");\\n    }\\n\\n    /**\\n     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],\\n     * but performing a delegate call.\\n     *\\n     * _Available since v3.4._\\n     */\\n    function functionDelegateCall(\\n        address target,\\n        bytes memory data,\\n        string memory errorMessage\\n    ) internal returns (bytes memory) {\\n        require(isContract(target), \\\"Address: delegate call to non-contract\\\");\\n\\n        (bool success, bytes memory returndata) = target.delegatecall(data);\\n        return verifyCallResult(success, returndata, errorMessage);\\n    }\\n\\n    /**\\n     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the\\n     * revert reason using the provided one.\\n     *\\n     * _Available since v4.3._\\n     */\\n    function verifyCallResult(\\n        bool success,\\n        bytes memory returndata,\\n        string memory errorMessage\\n    ) internal pure returns (bytes memory) {\\n        if (success) {\\n            return returndata;\\n        } else {\\n            // Look for revert reason and bubble it up if present\\n            if (returndata.length > 0) {\\n                // The easiest way to bubble the revert reason is using memory via assembly\\n\\n                assembly {\\n                    let returndata_size := mload(returndata)\\n                    revert(add(32, returndata), returndata_size)\\n                }\\n            } else {\\n                revert(errorMessage);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x9944d1038f27dcebff810d7ba16b3b8058b967173d76874fb72dd7cd84129656\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/Context.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n}\\n\",\"keccak256\":\"0x7736c187e6f1358c1ea9350a2a21aa8528dec1c2f43b374a9067465a3a51f5d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/Strings.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    bytes16 private constant _HEX_SYMBOLS = \\\"0123456789abcdef\\\";\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        // Inspired by OraclizeAPI's implementation - MIT licence\\n        // https://github.com/oraclize/ethereum-api/blob/b42146b063c7d6ee1358846c198246239e9360e8/oraclizeAPI_0.4.25.sol\\n\\n        if (value == 0) {\\n            return \\\"0\\\";\\n        }\\n        uint256 temp = value;\\n        uint256 digits;\\n        while (temp != 0) {\\n            digits++;\\n            temp /= 10;\\n        }\\n        bytes memory buffer = new bytes(digits);\\n        while (value != 0) {\\n            digits -= 1;\\n            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));\\n            value /= 10;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        if (value == 0) {\\n            return \\\"0x00\\\";\\n        }\\n        uint256 temp = value;\\n        uint256 length = 0;\\n        while (temp != 0) {\\n            length++;\\n            temp >>= 8;\\n        }\\n        return toHexString(value, length);\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = _HEX_SYMBOLS[value & 0xf];\\n            value >>= 4;\\n        }\\n        require(value == 0, \\\"Strings: hex length insufficient\\\");\\n        return string(buffer);\\n    }\\n}\\n\",\"keccak256\":\"0x5fa25f305839292fab713256214f2868e0257d29826b14282bbd7f1e34f5af38\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.0;\\n\\nimport \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS,\\n        InvalidSignatureV\\n    }\\n\\n    function _throwError(RecoverError error) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert(\\\"ECDSA: invalid signature\\\");\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert(\\\"ECDSA: invalid signature length\\\");\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert(\\\"ECDSA: invalid signature 's' value\\\");\\n        } else if (error == RecoverError.InvalidSignatureV) {\\n            revert(\\\"ECDSA: invalid signature 'v' value\\\");\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature` or error string. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     *\\n     * _Available since v4.3._\\n     */\\n    function tryRecover(bytes32 hash, bytes memory signature) internal pure returns (address, RecoverError) {\\n        // Check the signature length\\n        // - case 65: r,s,v signature (standard)\\n        // - case 64: r,vs signature (cf https://eips.ethereum.org/EIPS/eip-2098) _Available since v4.1._\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else if (signature.length == 64) {\\n            bytes32 r;\\n            bytes32 vs;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly {\\n                r := mload(add(signature, 0x20))\\n                vs := mload(add(signature, 0x40))\\n            }\\n            return tryRecover(hash, r, vs);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error) = tryRecover(hash, signature);\\n        _throwError(error);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[EIP-2098 short signatures]\\n     *\\n     * _Available since v4.3._\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address, RecoverError) {\\n        bytes32 s;\\n        uint8 v;\\n        assembly {\\n            s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)\\n            v := add(shr(255, vs), 27)\\n        }\\n        return tryRecover(hash, v, r, s);\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     *\\n     * _Available since v4.2._\\n     */\\n    function recover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address) {\\n        (address recovered, RecoverError error) = tryRecover(hash, r, vs);\\n        _throwError(error);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     *\\n     * _Available since v4.3._\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address, RecoverError) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS);\\n        }\\n        if (v != 27 && v != 28) {\\n            return (address(0), RecoverError.InvalidSignatureV);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature);\\n        }\\n\\n        return (signer, RecoverError.NoError);\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address) {\\n        (address recovered, RecoverError error) = tryRecover(hash, v, r, s);\\n        _throwError(error);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Returns an Ethereum Signed Message, created from a `hash`. This\\n     * produces hash corresponding to the one signed with the\\n     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]\\n     * JSON-RPC method as part of EIP-191.\\n     *\\n     * See {recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {\\n        // 32 is the length in bytes of hash,\\n        // enforced by the type signature above\\n        return keccak256(abi.encodePacked(\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\", hash));\\n    }\\n\\n    /**\\n     * @dev Returns an Ethereum Signed Message, created from `s`. This\\n     * produces hash corresponding to the one signed with the\\n     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]\\n     * JSON-RPC method as part of EIP-191.\\n     *\\n     * See {recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory s) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", Strings.toString(s.length), s));\\n    }\\n\\n    /**\\n     * @dev Returns an Ethereum Signed Typed Data, created from a\\n     * `domainSeparator` and a `structHash`. This produces hash corresponding\\n     * to the one signed with the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`]\\n     * JSON-RPC method as part of EIP-712.\\n     *\\n     * See {recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(\\\"\\\\x19\\\\x01\\\", domainSeparator, structHash));\\n    }\\n}\\n\",\"keccak256\":\"0x594efd2fa154f4fbe0fa92c2356cb2a9531ef3902e35784c2bc69764d0d8886a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Interface of the ERC165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[EIP].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x6aa521718bf139b44ce56f194f6aea1d590cacef995b5a84703fb1579fa49be9\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/math/Math.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a >= b ? a : b;\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a < b ? a : b;\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds up instead\\n     * of rounding down.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b - 1) / b can overflow on addition, so we distribute.\\n        return a / b + (a % b == 0 ? 0 : 1);\\n    }\\n}\\n\",\"keccak256\":\"0xe936fc79332de2ca7b1c06a70f81345aa2466958aab00f463e312ca0585e85cf\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts v4.4.0 (utils/math/SafeCast.sol)\\n\\npragma solidity ^0.8.0;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n *\\n * Can be combined with {SafeMath} and {SignedSafeMath} to extend it to smaller types, by performing\\n * all math on `uint256` and `int256` and then downcasting.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        require(value <= type(uint224).max, \\\"SafeCast: value doesn't fit in 224 bits\\\");\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        require(value <= type(uint128).max, \\\"SafeCast: value doesn't fit in 128 bits\\\");\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        require(value <= type(uint96).max, \\\"SafeCast: value doesn't fit in 96 bits\\\");\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        require(value <= type(uint64).max, \\\"SafeCast: value doesn't fit in 64 bits\\\");\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        require(value <= type(uint32).max, \\\"SafeCast: value doesn't fit in 32 bits\\\");\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        require(value <= type(uint16).max, \\\"SafeCast: value doesn't fit in 16 bits\\\");\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits.\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        require(value <= type(uint8).max, \\\"SafeCast: value doesn't fit in 8 bits\\\");\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        require(value >= 0, \\\"SafeCast: value must be positive\\\");\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt128(int256 value) internal pure returns (int128) {\\n        require(value >= type(int128).min && value <= type(int128).max, \\\"SafeCast: value doesn't fit in 128 bits\\\");\\n        return int128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt64(int256 value) internal pure returns (int64) {\\n        require(value >= type(int64).min && value <= type(int64).max, \\\"SafeCast: value doesn't fit in 64 bits\\\");\\n        return int64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt32(int256 value) internal pure returns (int32) {\\n        require(value >= type(int32).min && value <= type(int32).max, \\\"SafeCast: value doesn't fit in 32 bits\\\");\\n        return int32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt16(int256 value) internal pure returns (int16) {\\n        require(value >= type(int16).min && value <= type(int16).max, \\\"SafeCast: value doesn't fit in 16 bits\\\");\\n        return int16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits.\\n     *\\n     * _Available since v3.1._\\n     */\\n    function toInt8(int256 value) internal pure returns (int8) {\\n        require(value >= type(int8).min && value <= type(int8).max, \\\"SafeCast: value doesn't fit in 8 bits\\\");\\n        return int8(value);\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        require(value <= uint256(type(int256).max), \\\"SafeCast: value doesn't fit in an int256\\\");\\n        return int256(value);\\n    }\\n}\\n\",\"keccak256\":\"0x47c0131bd8a972c31596958aa86752ea18d60e33f1cd94d412b9e29fd6ab25a6\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\nimport \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\n\\nimport \\\"./IERC20WithPermit.sol\\\";\\nimport \\\"./IReceiveApproval.sol\\\";\\n\\n/// @title  ERC20WithPermit\\n/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can\\n///         authorize a transfer of their token with a signature conforming\\n///         EIP712 standard instead of an on-chain transaction from their\\n///         address. Anyone can submit this signature on the user's behalf by\\n///         calling the permit function, as specified in EIP2612 standard,\\n///         paying gas fees, and possibly performing other actions in the same\\n///         transaction.\\ncontract ERC20WithPermit is IERC20WithPermit, Ownable {\\n    /// @notice The amount of tokens owned by the given account.\\n    mapping(address => uint256) public override balanceOf;\\n\\n    /// @notice The remaining number of tokens that spender will be\\n    ///         allowed to spend on behalf of owner through `transferFrom` and\\n    ///         `burnFrom`. This is zero by default.\\n    mapping(address => mapping(address => uint256)) public override allowance;\\n\\n    /// @notice Returns the current nonce for EIP2612 permission for the\\n    ///         provided token owner for a replay protection. Used to construct\\n    ///         EIP2612 signature provided to `permit` function.\\n    mapping(address => uint256) public override nonce;\\n\\n    uint256 public immutable cachedChainId;\\n    bytes32 public immutable cachedDomainSeparator;\\n\\n    /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612\\n    ///         signature provided to `permit` function.\\n    bytes32 public constant override PERMIT_TYPEHASH =\\n        keccak256(\\n            \\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\"\\n        );\\n\\n    /// @notice The amount of tokens in existence.\\n    uint256 public override totalSupply;\\n\\n    /// @notice The name of the token.\\n    string public override name;\\n\\n    /// @notice The symbol of the token.\\n    string public override symbol;\\n\\n    /// @notice The decimals places of the token.\\n    uint8 public constant override decimals = 18;\\n\\n    constructor(string memory _name, string memory _symbol) {\\n        name = _name;\\n        symbol = _symbol;\\n\\n        cachedChainId = block.chainid;\\n        cachedDomainSeparator = buildDomainSeparator();\\n    }\\n\\n    /// @notice Moves `amount` tokens from the caller's account to `recipient`.\\n    /// @return True if the operation succeeded, reverts otherwise.\\n    /// @dev Requirements:\\n    ///       - `recipient` cannot be the zero address,\\n    ///       - the caller must have a balance of at least `amount`.\\n    function transfer(address recipient, uint256 amount)\\n        external\\n        override\\n        returns (bool)\\n    {\\n        _transfer(msg.sender, recipient, amount);\\n        return true;\\n    }\\n\\n    /// @notice Moves `amount` tokens from `spender` to `recipient` using the\\n    ///         allowance mechanism. `amount` is then deducted from the caller's\\n    ///         allowance unless the allowance was made for `type(uint256).max`.\\n    /// @return True if the operation succeeded, reverts otherwise.\\n    /// @dev Requirements:\\n    ///      - `spender` and `recipient` cannot be the zero address,\\n    ///      - `spender` must have a balance of at least `amount`,\\n    ///      - the caller must have allowance for `spender`'s tokens of at least\\n    ///        `amount`.\\n    function transferFrom(\\n        address spender,\\n        address recipient,\\n        uint256 amount\\n    ) external override returns (bool) {\\n        uint256 currentAllowance = allowance[spender][msg.sender];\\n        if (currentAllowance != type(uint256).max) {\\n            require(\\n                currentAllowance >= amount,\\n                \\\"Transfer amount exceeds allowance\\\"\\n            );\\n            _approve(spender, msg.sender, currentAllowance - amount);\\n        }\\n        _transfer(spender, recipient, amount);\\n        return true;\\n    }\\n\\n    /// @notice EIP2612 approval made with secp256k1 signature.\\n    ///         Users can authorize a transfer of their tokens with a signature\\n    ///         conforming EIP712 standard, rather than an on-chain transaction\\n    ///         from their address. Anyone can submit this signature on the\\n    ///         user's behalf by calling the permit function, paying gas fees,\\n    ///         and possibly performing other actions in the same transaction.\\n    /// @dev    The deadline argument can be set to `type(uint256).max to create\\n    ///         permits that effectively never expire.  If the `amount` is set\\n    ///         to `type(uint256).max` then `transferFrom` and `burnFrom` will\\n    ///         not reduce an allowance.\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 amount,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external override {\\n        /* solhint-disable-next-line not-rely-on-time */\\n        require(deadline >= block.timestamp, \\\"Permission expired\\\");\\n\\n        // Validate `s` and `v` values for a malleability concern described in EIP2.\\n        // Only signatures with `s` value in the lower half of the secp256k1\\n        // curve's order and `v` value of 27 or 28 are considered valid.\\n        require(\\n            uint256(s) <=\\n                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,\\n            \\\"Invalid signature 's' value\\\"\\n        );\\n        require(v == 27 || v == 28, \\\"Invalid signature 'v' value\\\");\\n\\n        bytes32 digest = keccak256(\\n            abi.encodePacked(\\n                \\\"\\\\x19\\\\x01\\\",\\n                DOMAIN_SEPARATOR(),\\n                keccak256(\\n                    abi.encode(\\n                        PERMIT_TYPEHASH,\\n                        owner,\\n                        spender,\\n                        amount,\\n                        nonce[owner]++,\\n                        deadline\\n                    )\\n                )\\n            )\\n        );\\n        address recoveredAddress = ecrecover(digest, v, r, s);\\n        require(\\n            recoveredAddress != address(0) && recoveredAddress == owner,\\n            \\\"Invalid signature\\\"\\n        );\\n        _approve(owner, spender, amount);\\n    }\\n\\n    /// @notice Creates `amount` tokens and assigns them to `account`,\\n    ///         increasing the total supply.\\n    /// @dev Requirements:\\n    ///      - `recipient` cannot be the zero address.\\n    function mint(address recipient, uint256 amount) external onlyOwner {\\n        require(recipient != address(0), \\\"Mint to the zero address\\\");\\n\\n        beforeTokenTransfer(address(0), recipient, amount);\\n\\n        totalSupply += amount;\\n        balanceOf[recipient] += amount;\\n        emit Transfer(address(0), recipient, amount);\\n    }\\n\\n    /// @notice Destroys `amount` tokens from the caller.\\n    /// @dev Requirements:\\n    ///       - the caller must have a balance of at least `amount`.\\n    function burn(uint256 amount) external override {\\n        _burn(msg.sender, amount);\\n    }\\n\\n    /// @notice Destroys `amount` of tokens from `account` using the allowance\\n    ///         mechanism. `amount` is then deducted from the caller's allowance\\n    ///         unless the allowance was made for `type(uint256).max`.\\n    /// @dev Requirements:\\n    ///      - `account` must have a balance of at least `amount`,\\n    ///      - the caller must have allowance for `account`'s tokens of at least\\n    ///        `amount`.\\n    function burnFrom(address account, uint256 amount) external override {\\n        uint256 currentAllowance = allowance[account][msg.sender];\\n        if (currentAllowance != type(uint256).max) {\\n            require(\\n                currentAllowance >= amount,\\n                \\\"Burn amount exceeds allowance\\\"\\n            );\\n            _approve(account, msg.sender, currentAllowance - amount);\\n        }\\n        _burn(account, amount);\\n    }\\n\\n    /// @notice Calls `receiveApproval` function on spender previously approving\\n    ///         the spender to withdraw from the caller multiple times, up to\\n    ///         the `amount` amount. If this function is called again, it\\n    ///         overwrites the current allowance with `amount`. Reverts if the\\n    ///         approval reverted or if `receiveApproval` call on the spender\\n    ///         reverted.\\n    /// @return True if both approval and `receiveApproval` calls succeeded.\\n    /// @dev If the `amount` is set to `type(uint256).max` then\\n    ///      `transferFrom` and `burnFrom` will not reduce an allowance.\\n    function approveAndCall(\\n        address spender,\\n        uint256 amount,\\n        bytes memory extraData\\n    ) external override returns (bool) {\\n        if (approve(spender, amount)) {\\n            IReceiveApproval(spender).receiveApproval(\\n                msg.sender,\\n                amount,\\n                address(this),\\n                extraData\\n            );\\n            return true;\\n        }\\n        return false;\\n    }\\n\\n    /// @notice Sets `amount` as the allowance of `spender` over the caller's\\n    ///         tokens.\\n    /// @return True if the operation succeeded.\\n    /// @dev If the `amount` is set to `type(uint256).max` then\\n    ///      `transferFrom` and `burnFrom` will not reduce an allowance.\\n    ///      Beware that changing an allowance with this method brings the risk\\n    ///      that someone may use both the old and the new allowance by\\n    ///      unfortunate transaction ordering. One possible solution to mitigate\\n    ///      this race condition is to first reduce the spender's allowance to 0\\n    ///      and set the desired value afterwards:\\n    ///      https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n    function approve(address spender, uint256 amount)\\n        public\\n        override\\n        returns (bool)\\n    {\\n        _approve(msg.sender, spender, amount);\\n        return true;\\n    }\\n\\n    /// @notice Returns hash of EIP712 Domain struct with the token name as\\n    ///         a signing domain and token contract as a verifying contract.\\n    ///         Used to construct EIP2612 signature provided to `permit`\\n    ///         function.\\n    /* solhint-disable-next-line func-name-mixedcase */\\n    function DOMAIN_SEPARATOR() public view override returns (bytes32) {\\n        // As explained in EIP-2612, if the DOMAIN_SEPARATOR contains the\\n        // chainId and is defined at contract deployment instead of\\n        // reconstructed for every signature, there is a risk of possible replay\\n        // attacks between chains in the event of a future chain split.\\n        // To address this issue, we check the cached chain ID against the\\n        // current one and in case they are different, we build domain separator\\n        // from scratch.\\n        if (block.chainid == cachedChainId) {\\n            return cachedDomainSeparator;\\n        } else {\\n            return buildDomainSeparator();\\n        }\\n    }\\n\\n    /// @dev Hook that is called before any transfer of tokens. This includes\\n    ///      minting and burning.\\n    ///\\n    /// Calling conditions:\\n    /// - when `from` and `to` are both non-zero, `amount` of `from`'s tokens\\n    ///   will be to transferred to `to`.\\n    /// - when `from` is zero, `amount` tokens will be minted for `to`.\\n    /// - when `to` is zero, `amount` of ``from``'s tokens will be burned.\\n    /// - `from` and `to` are never both zero.\\n    // slither-disable-next-line dead-code\\n    function beforeTokenTransfer(\\n        address from,\\n        address to,\\n        uint256 amount\\n    ) internal virtual {}\\n\\n    function _burn(address account, uint256 amount) internal {\\n        uint256 currentBalance = balanceOf[account];\\n        require(currentBalance >= amount, \\\"Burn amount exceeds balance\\\");\\n\\n        beforeTokenTransfer(account, address(0), amount);\\n\\n        balanceOf[account] = currentBalance - amount;\\n        totalSupply -= amount;\\n        emit Transfer(account, address(0), amount);\\n    }\\n\\n    function _transfer(\\n        address spender,\\n        address recipient,\\n        uint256 amount\\n    ) private {\\n        require(spender != address(0), \\\"Transfer from the zero address\\\");\\n        require(recipient != address(0), \\\"Transfer to the zero address\\\");\\n        require(recipient != address(this), \\\"Transfer to the token address\\\");\\n\\n        beforeTokenTransfer(spender, recipient, amount);\\n\\n        uint256 spenderBalance = balanceOf[spender];\\n        require(spenderBalance >= amount, \\\"Transfer amount exceeds balance\\\");\\n        balanceOf[spender] = spenderBalance - amount;\\n        balanceOf[recipient] += amount;\\n        emit Transfer(spender, recipient, amount);\\n    }\\n\\n    function _approve(\\n        address owner,\\n        address spender,\\n        uint256 amount\\n    ) private {\\n        require(owner != address(0), \\\"Approve from the zero address\\\");\\n        require(spender != address(0), \\\"Approve to the zero address\\\");\\n        allowance[owner][spender] = amount;\\n        emit Approval(owner, spender, amount);\\n    }\\n\\n    function buildDomainSeparator() private view returns (bytes32) {\\n        return\\n            keccak256(\\n                abi.encode(\\n                    keccak256(\\n                        \\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\"\\n                    ),\\n                    keccak256(bytes(name)),\\n                    keccak256(bytes(\\\"1\\\")),\\n                    block.chainid,\\n                    address(this)\\n                )\\n            );\\n    }\\n}\\n\",\"keccak256\":\"0x1e1bf4ec5c9d6fe70f6f834316482aeff3f122ff4ffaa7178099e7ae71a0b16d\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/IApproveAndCall.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\n/// @notice An interface that should be implemented by tokens supporting\\n///         `approveAndCall`/`receiveApproval` pattern.\\ninterface IApproveAndCall {\\n    /// @notice Executes `receiveApproval` function on spender as specified in\\n    ///         `IReceiveApproval` interface. Approves spender to withdraw from\\n    ///         the caller multiple times, up to the `amount`. If this\\n    ///         function is called again, it overwrites the current allowance\\n    ///         with `amount`. Reverts if the approval reverted or if\\n    ///         `receiveApproval` call on the spender reverted.\\n    function approveAndCall(\\n        address spender,\\n        uint256 amount,\\n        bytes memory extraData\\n    ) external returns (bool);\\n}\\n\",\"keccak256\":\"0x393d18ef81a57dcc96fff4c340cc2945deaebb37b9796c322cf2bc96872c3df8\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/IERC20WithPermit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\nimport \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\\\";\\n\\nimport \\\"./IApproveAndCall.sol\\\";\\n\\n/// @title  IERC20WithPermit\\n/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can\\n///         authorize a transfer of their token with a signature conforming\\n///         EIP712 standard instead of an on-chain transaction from their\\n///         address. Anyone can submit this signature on the user's behalf by\\n///         calling the permit function, as specified in EIP2612 standard,\\n///         paying gas fees, and possibly performing other actions in the same\\n///         transaction.\\ninterface IERC20WithPermit is IERC20, IERC20Metadata, IApproveAndCall {\\n    /// @notice EIP2612 approval made with secp256k1 signature.\\n    ///         Users can authorize a transfer of their tokens with a signature\\n    ///         conforming EIP712 standard, rather than an on-chain transaction\\n    ///         from their address. Anyone can submit this signature on the\\n    ///         user's behalf by calling the permit function, paying gas fees,\\n    ///         and possibly performing other actions in the same transaction.\\n    /// @dev    The deadline argument can be set to `type(uint256).max to create\\n    ///         permits that effectively never expire.\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 amount,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /// @notice Destroys `amount` tokens from the caller.\\n    function burn(uint256 amount) external;\\n\\n    /// @notice Destroys `amount` of tokens from `account`, deducting the amount\\n    ///         from caller's allowance.\\n    function burnFrom(address account, uint256 amount) external;\\n\\n    /// @notice Returns hash of EIP712 Domain struct with the token name as\\n    ///         a signing domain and token contract as a verifying contract.\\n    ///         Used to construct EIP2612 signature provided to `permit`\\n    ///         function.\\n    /* solhint-disable-next-line func-name-mixedcase */\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n\\n    /// @notice Returns the current nonce for EIP2612 permission for the\\n    ///         provided token owner for a replay protection. Used to construct\\n    ///         EIP2612 signature provided to `permit` function.\\n    function nonce(address owner) external view returns (uint256);\\n\\n    /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612\\n    ///         signature provided to `permit` function.\\n    /* solhint-disable-next-line func-name-mixedcase */\\n    function PERMIT_TYPEHASH() external pure returns (bytes32);\\n}\\n\",\"keccak256\":\"0xdac9a5086c19a7128b505a7be1ab0ac1aa314f6989cb88d2417e9d7383f89fa9\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/IReceiveApproval.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\n/// @notice An interface that should be implemented by contracts supporting\\n///         `approveAndCall`/`receiveApproval` pattern.\\ninterface IReceiveApproval {\\n    /// @notice Receives approval to spend tokens. Called as a result of\\n    ///         `approveAndCall` call on the token.\\n    function receiveApproval(\\n        address from,\\n        uint256 amount,\\n        address token,\\n        bytes calldata extraData\\n    ) external;\\n}\\n\",\"keccak256\":\"0x6a30d83ad230548b1e7839737affc8489a035314209de14b89dbef7fb0f66395\",\"license\":\"MIT\"},\"@thesis/solidity-contracts/contracts/token/MisfundRecovery.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.4;\\n\\nimport \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport \\\"@openzeppelin/contracts/token/ERC721/IERC721.sol\\\";\\n\\n/// @title  MisfundRecovery\\n/// @notice Allows the owner of the token contract extending MisfundRecovery\\n///         to recover any ERC20 and ERC721 sent mistakenly to the token\\n///         contract address.\\ncontract MisfundRecovery is Ownable {\\n    using SafeERC20 for IERC20;\\n\\n    function recoverERC20(\\n        IERC20 token,\\n        address recipient,\\n        uint256 amount\\n    ) external onlyOwner {\\n        token.safeTransfer(recipient, amount);\\n    }\\n\\n    function recoverERC721(\\n        IERC721 token,\\n        address recipient,\\n        uint256 tokenId,\\n        bytes calldata data\\n    ) external onlyOwner {\\n        token.safeTransferFrom(address(this), recipient, tokenId, data);\\n    }\\n}\\n\",\"keccak256\":\"0xbbfea02bf20e2a6df5a497bbc05c7540a3b7c7dfb8b1feeaffef7f6b8ba65d65\",\"license\":\"MIT\"},\"contracts/governance/Checkpoints.sol\":{\"content\":\"// SPDX-License-Identifier: GPL-3.0-or-later\\n\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n\\npragma solidity 0.8.9;\\n\\nimport \\\"./IVotesHistory.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/math/Math.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/math/SafeCast.sol\\\";\\n\\n/// @title Checkpoints\\n/// @dev Abstract contract to support checkpoints for Compound-like voting and\\n///      delegation. This implementation supports token supply up to 2^96 - 1.\\n///      This contract keeps a history (checkpoints) of each account's vote\\n///      power. Vote power can be delegated either by calling the {delegate}\\n///      function directly, or by providing a signature to be used with\\n///      {delegateBySig}. Voting power can be publicly queried through\\n///      {getVotes} and {getPastVotes}.\\n///      NOTE: Extracted from OpenZeppelin ERCVotes.sol.\\nabstract contract Checkpoints is IVotesHistory {\\n    struct Checkpoint {\\n        uint32 fromBlock;\\n        uint96 votes;\\n    }\\n\\n    // slither-disable-next-line uninitialized-state\\n    mapping(address => address) internal _delegates;\\n    mapping(address => uint128[]) internal _checkpoints;\\n    uint128[] internal _totalSupplyCheckpoints;\\n\\n    /// @notice Emitted when an account changes their delegate.\\n    event DelegateChanged(\\n        address indexed delegator,\\n        address indexed fromDelegate,\\n        address indexed toDelegate\\n    );\\n\\n    /// @notice Emitted when a balance or delegate change results in changes\\n    ///         to an account's voting power.\\n    event DelegateVotesChanged(\\n        address indexed delegate,\\n        uint256 previousBalance,\\n        uint256 newBalance\\n    );\\n\\n    function checkpoints(address account, uint32 pos)\\n        public\\n        view\\n        virtual\\n        returns (Checkpoint memory checkpoint)\\n    {\\n        (uint32 fromBlock, uint96 votes) = decodeCheckpoint(\\n            _checkpoints[account][pos]\\n        );\\n        checkpoint = Checkpoint(fromBlock, votes);\\n    }\\n\\n    /// @notice Get number of checkpoints for `account`.\\n    function numCheckpoints(address account)\\n        public\\n        view\\n        virtual\\n        returns (uint32)\\n    {\\n        return SafeCast.toUint32(_checkpoints[account].length);\\n    }\\n\\n    /// @notice Get the address `account` is currently delegating to.\\n    function delegates(address account) public view virtual returns (address) {\\n        return _delegates[account];\\n    }\\n\\n    /// @notice Gets the current votes balance for `account`.\\n    /// @param account The address to get votes balance\\n    /// @return The number of current votes for `account`\\n    function getVotes(address account) public view returns (uint96) {\\n        uint256 pos = _checkpoints[account].length;\\n        return pos == 0 ? 0 : decodeValue(_checkpoints[account][pos - 1]);\\n    }\\n\\n    /// @notice Determine the prior number of votes for an account as of\\n    ///         a block number.\\n    /// @dev Block number must be a finalized block or else this function will\\n    ///      revert to prevent misinformation.\\n    /// @param account The address of the account to check\\n    /// @param blockNumber The block number to get the vote balance at\\n    /// @return The number of votes the account had as of the given block\\n    function getPastVotes(address account, uint256 blockNumber)\\n        public\\n        view\\n        returns (uint96)\\n    {\\n        return lookupCheckpoint(_checkpoints[account], blockNumber);\\n    }\\n\\n    /// @notice Retrieve the `totalSupply` at the end of `blockNumber`.\\n    ///         Note, this value is the sum of all balances, but it is NOT the\\n    ///         sum of all the delegated votes!\\n    /// @param blockNumber The block number to get the total supply at\\n    /// @dev `blockNumber` must have been already mined\\n    function getPastTotalSupply(uint256 blockNumber)\\n        public\\n        view\\n        returns (uint96)\\n    {\\n        return lookupCheckpoint(_totalSupplyCheckpoints, blockNumber);\\n    }\\n\\n    /// @notice Change delegation for `delegator` to `delegatee`.\\n    // slither-disable-next-line dead-code\\n    function delegate(address delegator, address delegatee) internal virtual;\\n\\n    /// @notice Moves voting power from one delegate to another\\n    /// @param src Address of old delegate\\n    /// @param dst Address of new delegate\\n    /// @param amount Voting power amount to transfer between delegates\\n    function moveVotingPower(\\n        address src,\\n        address dst,\\n        uint256 amount\\n    ) internal {\\n        if (src != dst && amount > 0) {\\n            if (src != address(0)) {\\n                // https://github.com/crytic/slither/issues/960\\n                // slither-disable-next-line variable-scope\\n                (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(\\n                    _checkpoints[src],\\n                    subtract,\\n                    amount\\n                );\\n                emit DelegateVotesChanged(src, oldWeight, newWeight);\\n            }\\n\\n            if (dst != address(0)) {\\n                // https://github.com/crytic/slither/issues/959\\n                // slither-disable-next-line uninitialized-local\\n                (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(\\n                    _checkpoints[dst],\\n                    add,\\n                    amount\\n                );\\n                emit DelegateVotesChanged(dst, oldWeight, newWeight);\\n            }\\n        }\\n    }\\n\\n    /// @notice Writes a new checkpoint based on operating last stored value\\n    ///         with a `delta`. Usually, said operation is the `add` or\\n    ///         `subtract` functions from this contract, but more complex\\n    ///         functions can be passed as parameters.\\n    /// @param ckpts The checkpoints array to use\\n    /// @param op The function to apply over the last value and the `delta`\\n    /// @param delta Variation with respect to last stored value to be used\\n    ///              for new checkpoint\\n    function writeCheckpoint(\\n        uint128[] storage ckpts,\\n        function(uint256, uint256) view returns (uint256) op,\\n        uint256 delta\\n    ) internal returns (uint256 oldWeight, uint256 newWeight) {\\n        uint256 pos = ckpts.length;\\n        oldWeight = pos == 0 ? 0 : decodeValue(ckpts[pos - 1]);\\n        newWeight = op(oldWeight, delta);\\n\\n        if (pos > 0) {\\n            uint32 fromBlock = decodeBlockNumber(ckpts[pos - 1]);\\n            // slither-disable-next-line incorrect-equality\\n            if (fromBlock == block.number) {\\n                ckpts[pos - 1] = encodeCheckpoint(\\n                    fromBlock,\\n                    SafeCast.toUint96(newWeight)\\n                );\\n                return (oldWeight, newWeight);\\n            }\\n        }\\n\\n        ckpts.push(\\n            encodeCheckpoint(\\n                SafeCast.toUint32(block.number),\\n                SafeCast.toUint96(newWeight)\\n            )\\n        );\\n    }\\n\\n    /// @notice Lookup a value in a list of (sorted) checkpoints.\\n    /// @param ckpts The checkpoints array to use\\n    /// @param blockNumber Block number when we want to get the checkpoint at\\n    function lookupCheckpoint(uint128[] storage ckpts, uint256 blockNumber)\\n        internal\\n        view\\n        returns (uint96)\\n    {\\n        // We run a binary search to look for the earliest checkpoint taken\\n        // after `blockNumber`. During the loop, the index of the wanted\\n        // checkpoint remains in the range [low-1, high). With each iteration,\\n        // either `low` or `high` is moved towards the middle of the range to\\n        // maintain the invariant.\\n        // - If the middle checkpoint is after `blockNumber`,\\n        //   we look in [low, mid)\\n        // - If the middle checkpoint is before or equal to `blockNumber`,\\n        //   we look in [mid+1, high)\\n        // Once we reach a single value (when low == high), we've found the\\n        // right checkpoint at the index high-1, if not out of bounds (in that\\n        // case we're looking too far in the past and the result is 0).\\n        // Note that if the latest checkpoint available is exactly for\\n        // `blockNumber`, we end up with an index that is past the end of the\\n        // array, so we technically don't find a checkpoint after\\n        // `blockNumber`, but it works out the same.\\n        require(blockNumber < block.number, \\\"Block not yet determined\\\");\\n\\n        uint256 high = ckpts.length;\\n        uint256 low = 0;\\n        while (low < high) {\\n            uint256 mid = Math.average(low, high);\\n            uint32 midBlock = decodeBlockNumber(ckpts[mid]);\\n            if (midBlock > blockNumber) {\\n                high = mid;\\n            } else {\\n                low = mid + 1;\\n            }\\n        }\\n\\n        return high == 0 ? 0 : decodeValue(ckpts[high - 1]);\\n    }\\n\\n    /// @notice Maximum token supply. Defaults to `type(uint96).max` (2^96 - 1)\\n    // slither-disable-next-line dead-code\\n    function maxSupply() internal view virtual returns (uint96) {\\n        return type(uint96).max;\\n    }\\n\\n    /// @notice Encodes a `blockNumber` and `value` into a single `uint128`\\n    ///         checkpoint.\\n    /// @dev `blockNumber` is stored in the first 32 bits, while `value` in the\\n    ///      remaining 96 bits.\\n    function encodeCheckpoint(uint32 blockNumber, uint96 value)\\n        internal\\n        pure\\n        returns (uint128)\\n    {\\n        return (uint128(blockNumber) << 96) | uint128(value);\\n    }\\n\\n    /// @notice Decodes a block number from a `uint128` `checkpoint`.\\n    function decodeBlockNumber(uint128 checkpoint)\\n        internal\\n        pure\\n        returns (uint32)\\n    {\\n        return uint32(bytes4(bytes16(checkpoint)));\\n    }\\n\\n    /// @notice Decodes a voting value from a `uint128` `checkpoint`.\\n    function decodeValue(uint128 checkpoint) internal pure returns (uint96) {\\n        return uint96(checkpoint);\\n    }\\n\\n    /// @notice Decodes a block number and voting value from a `uint128`\\n    ///         `checkpoint`.\\n    function decodeCheckpoint(uint128 checkpoint)\\n        internal\\n        pure\\n        returns (uint32 blockNumber, uint96 value)\\n    {\\n        blockNumber = decodeBlockNumber(checkpoint);\\n        value = decodeValue(checkpoint);\\n    }\\n\\n    // slither-disable-next-line dead-code\\n    function add(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a + b;\\n    }\\n\\n    // slither-disable-next-line dead-code\\n    function subtract(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return a - b;\\n    }\\n}\\n\",\"keccak256\":\"0x25f420d34548648aa59703bccdad450815da5c9e18adf575845a659f0945d131\",\"license\":\"GPL-3.0-or-later\"},\"contracts/governance/IVotesHistory.sol\":{\"content\":\"// SPDX-License-Identifier: GPL-3.0-or-later\\n\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n\\npragma solidity 0.8.9;\\n\\ninterface IVotesHistory {\\n    function getPastVotes(address account, uint256 blockNumber)\\n        external\\n        view\\n        returns (uint96);\\n\\n    function getPastTotalSupply(uint256 blockNumber)\\n        external\\n        view\\n        returns (uint96);\\n}\\n\",\"keccak256\":\"0x535e87cf4c2e9a9439d99cf0918f013965fa6c4ddfbab07ff6ca4b195c8edc9f\",\"license\":\"GPL-3.0-or-later\"},\"contracts/token/T.sol\":{\"content\":\"// SPDX-License-Identifier: GPL-3.0-or-later\\n\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n// \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588     \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c     \\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n//               \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c    \\u2590\\u2588\\u2588\\u2588\\u2588\\u258c\\n\\npragma solidity 0.8.9;\\n\\nimport \\\"../governance/Checkpoints.sol\\\";\\nimport \\\"@openzeppelin/contracts/utils/math/SafeCast.sol\\\";\\nimport \\\"@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol\\\";\\nimport \\\"@thesis/solidity-contracts/contracts/token/MisfundRecovery.sol\\\";\\n\\n/// @title T token\\n/// @notice Threshold Network T token\\n/// @dev By default, token balance does not account for voting power.\\n///      This makes transfers cheaper. The downside is that it requires users\\n///      to delegate to themselves to activate checkpoints and have their\\n///      voting power tracked.\\ncontract T is ERC20WithPermit, MisfundRecovery, Checkpoints {\\n    /// @notice The EIP-712 typehash for the delegation struct used by\\n    ///         `delegateBySig`.\\n    bytes32 public constant DELEGATION_TYPEHASH =\\n        keccak256(\\n            \\\"Delegation(address delegatee,uint256 nonce,uint256 deadline)\\\"\\n        );\\n\\n    constructor() ERC20WithPermit(\\\"Threshold Network Token\\\", \\\"T\\\") {}\\n\\n    /// @notice Delegates votes from signatory to `delegatee`\\n    /// @param delegatee The address to delegate votes to\\n    /// @param deadline The time at which to expire the signature\\n    /// @param v The recovery byte of the signature\\n    /// @param r Half of the ECDSA signature pair\\n    /// @param s Half of the ECDSA signature pair\\n    function delegateBySig(\\n        address signatory,\\n        address delegatee,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external {\\n        /* solhint-disable-next-line not-rely-on-time */\\n        require(deadline >= block.timestamp, \\\"Delegation expired\\\");\\n\\n        // Validate `s` and `v` values for a malleability concern described in EIP2.\\n        // Only signatures with `s` value in the lower half of the secp256k1\\n        // curve's order and `v` value of 27 or 28 are considered valid.\\n        require(\\n            uint256(s) <=\\n                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,\\n            \\\"Invalid signature 's' value\\\"\\n        );\\n        require(v == 27 || v == 28, \\\"Invalid signature 'v' value\\\");\\n\\n        bytes32 digest = keccak256(\\n            abi.encodePacked(\\n                \\\"\\\\x19\\\\x01\\\",\\n                DOMAIN_SEPARATOR(),\\n                keccak256(\\n                    abi.encode(\\n                        DELEGATION_TYPEHASH,\\n                        delegatee,\\n                        nonce[signatory]++,\\n                        deadline\\n                    )\\n                )\\n            )\\n        );\\n\\n        address recoveredAddress = ecrecover(digest, v, r, s);\\n        require(\\n            recoveredAddress != address(0) && recoveredAddress == signatory,\\n            \\\"Invalid signature\\\"\\n        );\\n\\n        return delegate(signatory, delegatee);\\n    }\\n\\n    /// @notice Delegate votes from `msg.sender` to `delegatee`.\\n    /// @param delegatee The address to delegate votes to\\n    function delegate(address delegatee) public virtual {\\n        return delegate(msg.sender, delegatee);\\n    }\\n\\n    // slither-disable-next-line dead-code\\n    function beforeTokenTransfer(\\n        address from,\\n        address to,\\n        uint256 amount\\n    ) internal override {\\n        uint96 safeAmount = SafeCast.toUint96(amount);\\n\\n        // When minting:\\n        if (from == address(0)) {\\n            // Does not allow to mint more than uint96 can fit. Otherwise, the\\n            // Checkpoint might not fit the balance.\\n            require(\\n                totalSupply + amount <= maxSupply(),\\n                \\\"Maximum total supply exceeded\\\"\\n            );\\n            writeCheckpoint(_totalSupplyCheckpoints, add, safeAmount);\\n        }\\n\\n        // When burning:\\n        if (to == address(0)) {\\n            writeCheckpoint(_totalSupplyCheckpoints, subtract, safeAmount);\\n        }\\n\\n        moveVotingPower(delegates(from), delegates(to), safeAmount);\\n    }\\n\\n    function delegate(address delegator, address delegatee)\\n        internal\\n        virtual\\n        override\\n    {\\n        address currentDelegate = delegates(delegator);\\n        uint96 delegatorBalance = SafeCast.toUint96(balanceOf[delegator]);\\n        _delegates[delegator] = delegatee;\\n\\n        emit DelegateChanged(delegator, currentDelegate, delegatee);\\n\\n        moveVotingPower(currentDelegate, delegatee, delegatorBalance);\\n    }\\n}\\n\",\"keccak256\":\"0x6265416225fd15b1108fce13d570b53a862a5d256ba2e6329bccf658eccac430\",\"license\":\"GPL-3.0-or-later\"}},\"version\":1}",
+  "bytecode": "0x60c06040523480156200001157600080fd5b506040518060400160405280601781526020017f5468726573686f6c64204e6574776f726b20546f6b656e000000000000000000815250604051806040016040528060018152602001601560fa1b8152506200007c62000076620000c260201b60201c565b620000c6565b815162000091906005906020850190620001c7565b508051620000a7906006906020840190620001c7565b5046608052620000b662000116565b60a052506200034e9050565b3390565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b60007f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60056040516200014a9190620002aa565b60408051918290038220828201825260018352603160f81b6020938401528151928301939093528101919091527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc660608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b828054620001d5906200026d565b90600052602060002090601f016020900481019282620001f9576000855562000244565b82601f106200021457805160ff191683800117855562000244565b8280016001018555821562000244579182015b828111156200024457825182559160200191906001019062000227565b506200025292915062000256565b5090565b5b8082111562000252576000815560010162000257565b600181811c908216806200028257607f821691505b60208210811415620002a457634e487b7160e01b600052602260045260246000fd5b50919050565b600080835481600182811c915080831680620002c757607f831692505b6020808410821415620002e857634e487b7160e01b86526022600452602486fd5b818015620002ff5760018114620003115762000340565b60ff1986168952848901965062000340565b60008a81526020902060005b86811015620003385781548b8201529085019083016200031d565b505084890196505b509498975050505050505050565b60805160a05161262d620003826000396000818161042301526106f501526000818161038d01526106cc015261262d6000f3fe608060405234801561001057600080fd5b50600436106101bb5760003560e01c8063715018a6116100fa578063b20d7fa91161009d578063b20d7fa91461040b578063b4f94b2e1461041e578063cae9ca5114610445578063d505accf14610458578063dd62ed3e1461046b578063e7a324dc14610496578063f1127ed8146104bd578063f2fde38b146104fa578063fc4e51f61461050d57600080fd5b8063715018a614610380578063771da5c51461038857806379cc6790146103af5780638da5cb5b146103c25780638e539e8c146103ca57806395d89b41146103dd5780639ab24eb0146103e5578063a9059cbb146103f857600080fd5b80633a46b1a8116101625780633a46b1a81461028957806340c10f19146102b457806342966c68146102c7578063587cde1e146102da5780635c19a95c146103055780636fcfff451461031857806370a082311461034057806370ae92d21461036057600080fd5b806306fdde03146101c0578063095ea7b3146101de5780631171bda91461020157806318160ddd1461021657806323b872dd1461022d57806330adf81f14610240578063313ce567146102675780633644e51514610281575b600080fd5b6101c8610520565b6040516101d59190611f0c565b60405180910390f35b6101f16101ec366004611f34565b6105ae565b60405190151581526020016101d5565b61021461020f366004611f60565b6105c4565b005b61021f60045481565b6040519081526020016101d5565b6101f161023b366004611f60565b610615565b61021f7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b61026f601281565b60405160ff90911681526020016101d5565b61021f6106c8565b61029c610297366004611f34565b610724565b6040516001600160601b0390911681526020016101d5565b6102146102c2366004611f34565b610746565b6102146102d5366004611fa1565b610849565b6102ed6102e8366004611fba565b610856565b6040516001600160a01b0390911681526020016101d5565b610214610313366004611fba565b610874565b61032b610326366004611fba565b61087e565b60405163ffffffff90911681526020016101d5565b61021f61034e366004611fba565b60016020526000908152604090205481565b61021f61036e366004611fba565b60036020526000908152604090205481565b6102146108a6565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6102146103bd366004611f34565b6108e1565b6102ed610977565b61029c6103d8366004611fa1565b610986565b6101c8610993565b61029c6103f3366004611fba565b6109a0565b6101f1610406366004611f34565b610a30565b610214610419366004611fed565b610a3d565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6101f1610453366004612066565b610c6a565b610214610466366004612133565b610cf2565b61021f6104793660046121a1565b600260209081526000928352604080842090915290825290205481565b61021f7f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e281565b6104d06104cb3660046121da565b610f2c565b60408051825163ffffffff1681526020928301516001600160601b031692810192909252016101d5565b610214610508366004611fba565b610fd8565b61021461051b366004612211565b611075565b6005805461052d906122b0565b80601f0160208091040260200160405190810160405280929190818152602001828054610559906122b0565b80156105a65780601f1061057b576101008083540402835291602001916105a6565b820191906000526020600020905b81548152906001019060200180831161058957829003601f168201915b505050505081565b60006105bb338484611106565b50600192915050565b336105cd610977565b6001600160a01b0316146105fc5760405162461bcd60e51b81526004016105f3906122eb565b60405180910390fd5b6106106001600160a01b0384168383611214565b505050565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001981146106b0578281101561069c5760405162461bcd60e51b815260206004820152602160248201527f5472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636044820152606560f81b60648201526084016105f3565b6106b085336106ab8685612336565b611106565b6106bb858585611266565b60019150505b9392505050565b60007f000000000000000000000000000000000000000000000000000000000000000046141561071757507f000000000000000000000000000000000000000000000000000000000000000090565b61071f611467565b905090565b6001600160a01b03821660009081526008602052604081206106c19083611516565b3361074f610977565b6001600160a01b0316146107755760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b0382166107c65760405162461bcd60e51b81526020600482015260186024820152774d696e7420746f20746865207a65726f206164647265737360401b60448201526064016105f3565b6107d260008383611611565b80600460008282546107e4919061234d565b90915550506001600160a01b0382166000908152600160205260408120805483929061081190849061234d565b90915550506040518181526001600160a01b038316906000906000805160206125d88339815191529060200160405180910390a35050565b61085333826116fd565b50565b6001600160a01b039081166000908152600760205260409020541690565b61085333826117db565b6001600160a01b0381166000908152600860205260408120546108a09061187d565b92915050565b336108af610977565b6001600160a01b0316146108d55760405162461bcd60e51b81526004016105f3906122eb565b6108df60006118e6565b565b6001600160a01b0382166000908152600260209081526040808320338452909152902054600019811461096d578181101561095e5760405162461bcd60e51b815260206004820152601d60248201527f4275726e20616d6f756e74206578636565647320616c6c6f77616e636500000060448201526064016105f3565b61096d83336106ab8585612336565b61061083836116fd565b6000546001600160a01b031690565b60006108a0600983611516565b6006805461052d906122b0565b6001600160a01b0381166000908152600860205260408120548015610a27576001600160a01b0383166000908152600860205260409020610a22906109e6600184612336565b815481106109f6576109f6612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031690565b6106c1565b60009392505050565b60006105bb338484611266565b42841015610a825760405162461bcd60e51b815260206004820152601260248201527111195b1959d85d1a5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610ab85760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610acd57508260ff16601c145b610ae95760405162461bcd60e51b81526004016105f3906123b2565b6000610af36106c8565b6001600160a01b038816600090815260036020526040812080547f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e2928a9290610b3b836123e9565b9190505588604051602001610b7294939291909384526001600160a01b039290921660208401526040830152606082015260800190565b60405160208183030381529060405280519060200120604051602001610b99929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610c04573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610c3a5750876001600160a01b0316816001600160a01b0316145b610c565760405162461bcd60e51b81526004016105f39061241f565b610c6088886117db565b5050505050505050565b6000610c7684846105ae565b15610ce857604051638f4ffcb160e01b81526001600160a01b03851690638f4ffcb190610cad90339087903090889060040161244a565b600060405180830381600087803b158015610cc757600080fd5b505af1158015610cdb573d6000803e3d6000fd5b50505050600190506106c1565b5060009392505050565b42841015610d375760405162461bcd60e51b815260206004820152601260248201527114195c9b5a5cdcda5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610d6d5760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610d8257508260ff16601c145b610d9e5760405162461bcd60e51b81526004016105f3906123b2565b6000610da86106c8565b6001600160a01b038916600090815260036020526040812080547f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9928c928c928c92909190610df6836123e9565b909155506040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810187905260e00160405160208183030381529060405280519060200120604051602001610e59929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610ec4573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610efa5750886001600160a01b0316816001600160a01b0316145b610f165760405162461bcd60e51b81526004016105f39061241f565b610f21898989611106565b505050505050505050565b60408051808201909152600080825260208201526001600160a01b038316600090815260086020526040812080548291610fad9163ffffffff8716908110610f7657610f76612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031663ffffffff606082901c1691565b6040805180820190915263ffffffff90921682526001600160601b0316602082015295945050505050565b33610fe1610977565b6001600160a01b0316146110075760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b03811661106c5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016105f3565b610853816118e6565b3361107e610977565b6001600160a01b0316146110a45760405162461bcd60e51b81526004016105f3906122eb565b604051635c46a7ef60e11b81526001600160a01b0386169063b88d4fde906110d89030908890889088908890600401612487565b600060405180830381600087803b1580156110f257600080fd5b505af1158015610f21573d6000803e3d6000fd5b6001600160a01b03831661115c5760405162461bcd60e51b815260206004820152601d60248201527f417070726f76652066726f6d20746865207a65726f206164647265737300000060448201526064016105f3565b6001600160a01b0382166111b25760405162461bcd60e51b815260206004820152601b60248201527f417070726f766520746f20746865207a65726f2061646472657373000000000060448201526064016105f3565b6001600160a01b0383811660008181526002602090815260408083209487168084529482529182902085905590518481527f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92591015b60405180910390a3505050565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663a9059cbb60e01b179052610610908490611936565b6001600160a01b0383166112bc5760405162461bcd60e51b815260206004820152601e60248201527f5472616e736665722066726f6d20746865207a65726f2061646472657373000060448201526064016105f3565b6001600160a01b0382166113125760405162461bcd60e51b815260206004820152601c60248201527f5472616e7366657220746f20746865207a65726f20616464726573730000000060448201526064016105f3565b6001600160a01b03821630141561136b5760405162461bcd60e51b815260206004820152601d60248201527f5472616e7366657220746f2074686520746f6b656e206164647265737300000060448201526064016105f3565b611376838383611611565b6001600160a01b038316600090815260016020526040902054818110156113df5760405162461bcd60e51b815260206004820152601f60248201527f5472616e7366657220616d6f756e7420657863656564732062616c616e63650060448201526064016105f3565b6113e98282612336565b6001600160a01b03808616600090815260016020526040808220939093559085168152908120805484929061141f90849061234d565b92505081905550826001600160a01b0316846001600160a01b03166000805160206125d88339815191528460405161145991815260200190565b60405180910390a350505050565b60007f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f600560405161149991906124db565b60408051918290038220828201825260018352603160f81b6020938401528151928301939093528101919091527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc660608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b60004382106115625760405162461bcd60e51b8152602060048201526018602482015277109b1bd8dac81b9bdd081e595d0819195d195c9b5a5b995960421b60448201526064016105f3565b825460005b818110156115eb57600061157b8284611a08565b905060006115be87838154811061159457611594612365565b6000918252602090912060028204015463ffffffff60019092166010026101000a900460601c1690565b9050858163ffffffff1611156115d6578193506115e4565b6115e182600161234d565b92505b5050611567565b811561160557611600856109e6600185612336565b611608565b60005b95945050505050565b600061161c82611a23565b90506001600160a01b0384166116ab576004546001600160601b039061164390849061234d565b11156116915760405162461bcd60e51b815260206004820152601d60248201527f4d6178696d756d20746f74616c20737570706c7920657863656564656400000060448201526064016105f3565b6116a86009611a8b836001600160601b0316611a97565b50505b6001600160a01b0383166116d3576116d06009611bf3836001600160601b0316611a97565b50505b6116f76116df85610856565b6116e885610856565b836001600160601b0316611bff565b50505050565b6001600160a01b038216600090815260016020526040902054818110156117665760405162461bcd60e51b815260206004820152601b60248201527f4275726e20616d6f756e7420657863656564732062616c616e6365000000000060448201526064016105f3565b61177283600084611611565b61177c8282612336565b6001600160a01b038416600090815260016020526040812091909155600480548492906117aa908490612336565b90915550506040518281526000906001600160a01b038516906000805160206125d883398151915290602001611207565b60006117e683610856565b6001600160a01b0384166000908152600160205260408120549192509061180c90611a23565b6001600160a01b0385811660008181526007602052604080822080546001600160a01b031916898616908117909155905194955093928616927f3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f9190a46116f78284836001600160601b0316611bff565b600063ffffffff8211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203360448201526532206269747360d01b60648201526084016105f3565b5090565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600061198b826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316611d3c9092919063ffffffff16565b80519091501561061057808060200190518101906119a99190612577565b6106105760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b60648201526084016105f3565b6000611a176002848418612599565b6106c19084841661234d565b60006001600160601b038211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203960448201526536206269747360d01b60648201526084016105f3565b60006106c1828461234d565b825460009081908015611ab857611ab3866109e6600184612336565b611abb565b60005b6001600160601b03169250611ad483858763ffffffff16565b91508015611b94576000611afd87611aed600185612336565b8154811061159457611594612365565b9050438163ffffffff161415611b9257611b3681611b1a85611a23565b6001600160601b031660609190911b63ffffffff60601b161790565b87611b42600185612336565b81548110611b5257611b52612365565b90600052602060002090600291828204019190066010026101000a8154816001600160801b0302191690836001600160801b031602179055505050611beb565b505b85611baa611ba14361187d565b611b1a85611a23565b81546001818101845560009384526020909320600282040180546001600160801b03938416601093909516929092026101000a938402929093021916179055505b935093915050565b60006106c18284612336565b816001600160a01b0316836001600160a01b031614158015611c215750600081115b15610610576001600160a01b03831615611caf576001600160a01b03831660009081526008602052604081208190611c5c90611bf385611a97565b91509150846001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611ca4929190918252602082015260400190565b60405180910390a250505b6001600160a01b03821615610610576001600160a01b03821660009081526008602052604081208190611ce590611a8b85611a97565b91509150836001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611d2d929190918252602082015260400190565b60405180910390a25050505050565b6060611d4b8484600085611d53565b949350505050565b606082471015611db45760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b60648201526084016105f3565b843b611e025760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e747261637400000060448201526064016105f3565b600080866001600160a01b03168587604051611e1e91906125bb565b60006040518083038185875af1925050503d8060008114611e5b576040519150601f19603f3d011682016040523d82523d6000602084013e611e60565b606091505b5091509150611e70828286611e7b565b979650505050505050565b60608315611e8a5750816106c1565b825115611e9a5782518084602001fd5b8160405162461bcd60e51b81526004016105f39190611f0c565b60005b83811015611ecf578181015183820152602001611eb7565b838111156116f75750506000910152565b60008151808452611ef8816020860160208601611eb4565b601f01601f19169290920160200192915050565b6020815260006106c16020830184611ee0565b6001600160a01b038116811461085357600080fd5b60008060408385031215611f4757600080fd5b8235611f5281611f1f565b946020939093013593505050565b600080600060608486031215611f7557600080fd5b8335611f8081611f1f565b92506020840135611f9081611f1f565b929592945050506040919091013590565b600060208284031215611fb357600080fd5b5035919050565b600060208284031215611fcc57600080fd5b81356106c181611f1f565b803560ff81168114611fe857600080fd5b919050565b60008060008060008060c0878903121561200657600080fd5b863561201181611f1f565b9550602087013561202181611f1f565b94506040870135935061203660608801611fd7565b92506080870135915060a087013590509295509295509295565b634e487b7160e01b600052604160045260246000fd5b60008060006060848603121561207b57600080fd5b833561208681611f1f565b925060208401359150604084013567ffffffffffffffff808211156120aa57600080fd5b818601915086601f8301126120be57600080fd5b8135818111156120d0576120d0612050565b604051601f8201601f19908116603f011681019083821181831017156120f8576120f8612050565b8160405282815289602084870101111561211157600080fd5b8260208601602083013760006020848301015280955050505050509250925092565b600080600080600080600060e0888a03121561214e57600080fd5b873561215981611f1f565b9650602088013561216981611f1f565b9550604088013594506060880135935061218560808901611fd7565b925060a0880135915060c0880135905092959891949750929550565b600080604083850312156121b457600080fd5b82356121bf81611f1f565b915060208301356121cf81611f1f565b809150509250929050565b600080604083850312156121ed57600080fd5b82356121f881611f1f565b9150602083013563ffffffff811681146121cf57600080fd5b60008060008060006080868803121561222957600080fd5b853561223481611f1f565b9450602086013561224481611f1f565b935060408601359250606086013567ffffffffffffffff8082111561226857600080fd5b818801915088601f83011261227c57600080fd5b81358181111561228b57600080fd5b89602082850101111561229d57600080fd5b9699959850939650602001949392505050565b600181811c908216806122c457607f821691505b602082108114156122e557634e487b7160e01b600052602260045260246000fd5b50919050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052601160045260246000fd5b60008282101561234857612348612320565b500390565b6000821982111561236057612360612320565b500190565b634e487b7160e01b600052603260045260246000fd5b6020808252601b908201527f496e76616c6964207369676e6174757265202773272076616c75650000000000604082015260600190565b6020808252601b908201527f496e76616c6964207369676e6174757265202776272076616c75650000000000604082015260600190565b60006000198214156123fd576123fd612320565b5060010190565b61190160f01b81526002810192909252602282015260420190565b602080825260119082015270496e76616c6964207369676e617475726560781b604082015260600190565b6001600160a01b038581168252602082018590528316604082015260806060820181905260009061247d90830184611ee0565b9695505050505050565b6001600160a01b038681168252851660208201526040810184905260806060820181905281018290526000828460a0840137600060a0848401015260a0601f19601f85011683010190509695505050505050565b600080835481600182811c9150808316806124f757607f831692505b602080841082141561251757634e487b7160e01b86526022600452602486fd5b81801561252b576001811461253c57612569565b60ff19861689528489019650612569565b60008a81526020902060005b868110156125615781548b820152908501908301612548565b505084890196505b509498975050505050505050565b60006020828403121561258957600080fd5b815180151581146106c157600080fd5b6000826125b657634e487b7160e01b600052601260045260246000fd5b500490565b600082516125cd818460208701611eb4565b919091019291505056feddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3efa26469706673582212207eecbfb333a500c574d750bd13d9d3944c632e0e6cfefb9d5262bd9cbb14fb8364736f6c63430008090033",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106101bb5760003560e01c8063715018a6116100fa578063b20d7fa91161009d578063b20d7fa91461040b578063b4f94b2e1461041e578063cae9ca5114610445578063d505accf14610458578063dd62ed3e1461046b578063e7a324dc14610496578063f1127ed8146104bd578063f2fde38b146104fa578063fc4e51f61461050d57600080fd5b8063715018a614610380578063771da5c51461038857806379cc6790146103af5780638da5cb5b146103c25780638e539e8c146103ca57806395d89b41146103dd5780639ab24eb0146103e5578063a9059cbb146103f857600080fd5b80633a46b1a8116101625780633a46b1a81461028957806340c10f19146102b457806342966c68146102c7578063587cde1e146102da5780635c19a95c146103055780636fcfff451461031857806370a082311461034057806370ae92d21461036057600080fd5b806306fdde03146101c0578063095ea7b3146101de5780631171bda91461020157806318160ddd1461021657806323b872dd1461022d57806330adf81f14610240578063313ce567146102675780633644e51514610281575b600080fd5b6101c8610520565b6040516101d59190611f0c565b60405180910390f35b6101f16101ec366004611f34565b6105ae565b60405190151581526020016101d5565b61021461020f366004611f60565b6105c4565b005b61021f60045481565b6040519081526020016101d5565b6101f161023b366004611f60565b610615565b61021f7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b61026f601281565b60405160ff90911681526020016101d5565b61021f6106c8565b61029c610297366004611f34565b610724565b6040516001600160601b0390911681526020016101d5565b6102146102c2366004611f34565b610746565b6102146102d5366004611fa1565b610849565b6102ed6102e8366004611fba565b610856565b6040516001600160a01b0390911681526020016101d5565b610214610313366004611fba565b610874565b61032b610326366004611fba565b61087e565b60405163ffffffff90911681526020016101d5565b61021f61034e366004611fba565b60016020526000908152604090205481565b61021f61036e366004611fba565b60036020526000908152604090205481565b6102146108a6565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6102146103bd366004611f34565b6108e1565b6102ed610977565b61029c6103d8366004611fa1565b610986565b6101c8610993565b61029c6103f3366004611fba565b6109a0565b6101f1610406366004611f34565b610a30565b610214610419366004611fed565b610a3d565b61021f7f000000000000000000000000000000000000000000000000000000000000000081565b6101f1610453366004612066565b610c6a565b610214610466366004612133565b610cf2565b61021f6104793660046121a1565b600260209081526000928352604080842090915290825290205481565b61021f7f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e281565b6104d06104cb3660046121da565b610f2c565b60408051825163ffffffff1681526020928301516001600160601b031692810192909252016101d5565b610214610508366004611fba565b610fd8565b61021461051b366004612211565b611075565b6005805461052d906122b0565b80601f0160208091040260200160405190810160405280929190818152602001828054610559906122b0565b80156105a65780601f1061057b576101008083540402835291602001916105a6565b820191906000526020600020905b81548152906001019060200180831161058957829003601f168201915b505050505081565b60006105bb338484611106565b50600192915050565b336105cd610977565b6001600160a01b0316146105fc5760405162461bcd60e51b81526004016105f3906122eb565b60405180910390fd5b6106106001600160a01b0384168383611214565b505050565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001981146106b0578281101561069c5760405162461bcd60e51b815260206004820152602160248201527f5472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636044820152606560f81b60648201526084016105f3565b6106b085336106ab8685612336565b611106565b6106bb858585611266565b60019150505b9392505050565b60007f000000000000000000000000000000000000000000000000000000000000000046141561071757507f000000000000000000000000000000000000000000000000000000000000000090565b61071f611467565b905090565b6001600160a01b03821660009081526008602052604081206106c19083611516565b3361074f610977565b6001600160a01b0316146107755760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b0382166107c65760405162461bcd60e51b81526020600482015260186024820152774d696e7420746f20746865207a65726f206164647265737360401b60448201526064016105f3565b6107d260008383611611565b80600460008282546107e4919061234d565b90915550506001600160a01b0382166000908152600160205260408120805483929061081190849061234d565b90915550506040518181526001600160a01b038316906000906000805160206125d88339815191529060200160405180910390a35050565b61085333826116fd565b50565b6001600160a01b039081166000908152600760205260409020541690565b61085333826117db565b6001600160a01b0381166000908152600860205260408120546108a09061187d565b92915050565b336108af610977565b6001600160a01b0316146108d55760405162461bcd60e51b81526004016105f3906122eb565b6108df60006118e6565b565b6001600160a01b0382166000908152600260209081526040808320338452909152902054600019811461096d578181101561095e5760405162461bcd60e51b815260206004820152601d60248201527f4275726e20616d6f756e74206578636565647320616c6c6f77616e636500000060448201526064016105f3565b61096d83336106ab8585612336565b61061083836116fd565b6000546001600160a01b031690565b60006108a0600983611516565b6006805461052d906122b0565b6001600160a01b0381166000908152600860205260408120548015610a27576001600160a01b0383166000908152600860205260409020610a22906109e6600184612336565b815481106109f6576109f6612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031690565b6106c1565b60009392505050565b60006105bb338484611266565b42841015610a825760405162461bcd60e51b815260206004820152601260248201527111195b1959d85d1a5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610ab85760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610acd57508260ff16601c145b610ae95760405162461bcd60e51b81526004016105f3906123b2565b6000610af36106c8565b6001600160a01b038816600090815260036020526040812080547f76995fe87be88484696cfd6792aeb71e0b61f81dfa3b641e5adffa38a0d3b8e2928a9290610b3b836123e9565b9190505588604051602001610b7294939291909384526001600160a01b039290921660208401526040830152606082015260800190565b60405160208183030381529060405280519060200120604051602001610b99929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610c04573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610c3a5750876001600160a01b0316816001600160a01b0316145b610c565760405162461bcd60e51b81526004016105f39061241f565b610c6088886117db565b5050505050505050565b6000610c7684846105ae565b15610ce857604051638f4ffcb160e01b81526001600160a01b03851690638f4ffcb190610cad90339087903090889060040161244a565b600060405180830381600087803b158015610cc757600080fd5b505af1158015610cdb573d6000803e3d6000fd5b50505050600190506106c1565b5060009392505050565b42841015610d375760405162461bcd60e51b815260206004820152601260248201527114195c9b5a5cdcda5bdb88195e1c1a5c995960721b60448201526064016105f3565b6fa2a8918ca85bafe22016d0b997e4df60600160ff1b03811115610d6d5760405162461bcd60e51b81526004016105f39061237b565b8260ff16601b1480610d8257508260ff16601c145b610d9e5760405162461bcd60e51b81526004016105f3906123b2565b6000610da86106c8565b6001600160a01b038916600090815260036020526040812080547f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9928c928c928c92909190610df6836123e9565b909155506040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810187905260e00160405160208183030381529060405280519060200120604051602001610e59929190612404565b60408051601f198184030181528282528051602091820120600080855291840180845281905260ff88169284019290925260608301869052608083018590529092509060019060a0016020604051602081039080840390855afa158015610ec4573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811615801590610efa5750886001600160a01b0316816001600160a01b0316145b610f165760405162461bcd60e51b81526004016105f39061241f565b610f21898989611106565b505050505050505050565b60408051808201909152600080825260208201526001600160a01b038316600090815260086020526040812080548291610fad9163ffffffff8716908110610f7657610f76612365565b90600052602060002090600291828204019190066010029054906101000a90046001600160801b031663ffffffff606082901c1691565b6040805180820190915263ffffffff90921682526001600160601b0316602082015295945050505050565b33610fe1610977565b6001600160a01b0316146110075760405162461bcd60e51b81526004016105f3906122eb565b6001600160a01b03811661106c5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016105f3565b610853816118e6565b3361107e610977565b6001600160a01b0316146110a45760405162461bcd60e51b81526004016105f3906122eb565b604051635c46a7ef60e11b81526001600160a01b0386169063b88d4fde906110d89030908890889088908890600401612487565b600060405180830381600087803b1580156110f257600080fd5b505af1158015610f21573d6000803e3d6000fd5b6001600160a01b03831661115c5760405162461bcd60e51b815260206004820152601d60248201527f417070726f76652066726f6d20746865207a65726f206164647265737300000060448201526064016105f3565b6001600160a01b0382166111b25760405162461bcd60e51b815260206004820152601b60248201527f417070726f766520746f20746865207a65726f2061646472657373000000000060448201526064016105f3565b6001600160a01b0383811660008181526002602090815260408083209487168084529482529182902085905590518481527f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92591015b60405180910390a3505050565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663a9059cbb60e01b179052610610908490611936565b6001600160a01b0383166112bc5760405162461bcd60e51b815260206004820152601e60248201527f5472616e736665722066726f6d20746865207a65726f2061646472657373000060448201526064016105f3565b6001600160a01b0382166113125760405162461bcd60e51b815260206004820152601c60248201527f5472616e7366657220746f20746865207a65726f20616464726573730000000060448201526064016105f3565b6001600160a01b03821630141561136b5760405162461bcd60e51b815260206004820152601d60248201527f5472616e7366657220746f2074686520746f6b656e206164647265737300000060448201526064016105f3565b611376838383611611565b6001600160a01b038316600090815260016020526040902054818110156113df5760405162461bcd60e51b815260206004820152601f60248201527f5472616e7366657220616d6f756e7420657863656564732062616c616e63650060448201526064016105f3565b6113e98282612336565b6001600160a01b03808616600090815260016020526040808220939093559085168152908120805484929061141f90849061234d565b92505081905550826001600160a01b0316846001600160a01b03166000805160206125d88339815191528460405161145991815260200190565b60405180910390a350505050565b60007f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f600560405161149991906124db565b60408051918290038220828201825260018352603160f81b6020938401528151928301939093528101919091527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc660608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b60004382106115625760405162461bcd60e51b8152602060048201526018602482015277109b1bd8dac81b9bdd081e595d0819195d195c9b5a5b995960421b60448201526064016105f3565b825460005b818110156115eb57600061157b8284611a08565b905060006115be87838154811061159457611594612365565b6000918252602090912060028204015463ffffffff60019092166010026101000a900460601c1690565b9050858163ffffffff1611156115d6578193506115e4565b6115e182600161234d565b92505b5050611567565b811561160557611600856109e6600185612336565b611608565b60005b95945050505050565b600061161c82611a23565b90506001600160a01b0384166116ab576004546001600160601b039061164390849061234d565b11156116915760405162461bcd60e51b815260206004820152601d60248201527f4d6178696d756d20746f74616c20737570706c7920657863656564656400000060448201526064016105f3565b6116a86009611a8b836001600160601b0316611a97565b50505b6001600160a01b0383166116d3576116d06009611bf3836001600160601b0316611a97565b50505b6116f76116df85610856565b6116e885610856565b836001600160601b0316611bff565b50505050565b6001600160a01b038216600090815260016020526040902054818110156117665760405162461bcd60e51b815260206004820152601b60248201527f4275726e20616d6f756e7420657863656564732062616c616e6365000000000060448201526064016105f3565b61177283600084611611565b61177c8282612336565b6001600160a01b038416600090815260016020526040812091909155600480548492906117aa908490612336565b90915550506040518281526000906001600160a01b038516906000805160206125d883398151915290602001611207565b60006117e683610856565b6001600160a01b0384166000908152600160205260408120549192509061180c90611a23565b6001600160a01b0385811660008181526007602052604080822080546001600160a01b031916898616908117909155905194955093928616927f3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f9190a46116f78284836001600160601b0316611bff565b600063ffffffff8211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203360448201526532206269747360d01b60648201526084016105f3565b5090565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600061198b826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316611d3c9092919063ffffffff16565b80519091501561061057808060200190518101906119a99190612577565b6106105760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b60648201526084016105f3565b6000611a176002848418612599565b6106c19084841661234d565b60006001600160601b038211156118e25760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203960448201526536206269747360d01b60648201526084016105f3565b60006106c1828461234d565b825460009081908015611ab857611ab3866109e6600184612336565b611abb565b60005b6001600160601b03169250611ad483858763ffffffff16565b91508015611b94576000611afd87611aed600185612336565b8154811061159457611594612365565b9050438163ffffffff161415611b9257611b3681611b1a85611a23565b6001600160601b031660609190911b63ffffffff60601b161790565b87611b42600185612336565b81548110611b5257611b52612365565b90600052602060002090600291828204019190066010026101000a8154816001600160801b0302191690836001600160801b031602179055505050611beb565b505b85611baa611ba14361187d565b611b1a85611a23565b81546001818101845560009384526020909320600282040180546001600160801b03938416601093909516929092026101000a938402929093021916179055505b935093915050565b60006106c18284612336565b816001600160a01b0316836001600160a01b031614158015611c215750600081115b15610610576001600160a01b03831615611caf576001600160a01b03831660009081526008602052604081208190611c5c90611bf385611a97565b91509150846001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611ca4929190918252602082015260400190565b60405180910390a250505b6001600160a01b03821615610610576001600160a01b03821660009081526008602052604081208190611ce590611a8b85611a97565b91509150836001600160a01b03167fdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a7248383604051611d2d929190918252602082015260400190565b60405180910390a25050505050565b6060611d4b8484600085611d53565b949350505050565b606082471015611db45760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b60648201526084016105f3565b843b611e025760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e747261637400000060448201526064016105f3565b600080866001600160a01b03168587604051611e1e91906125bb565b60006040518083038185875af1925050503d8060008114611e5b576040519150601f19603f3d011682016040523d82523d6000602084013e611e60565b606091505b5091509150611e70828286611e7b565b979650505050505050565b60608315611e8a5750816106c1565b825115611e9a5782518084602001fd5b8160405162461bcd60e51b81526004016105f39190611f0c565b60005b83811015611ecf578181015183820152602001611eb7565b838111156116f75750506000910152565b60008151808452611ef8816020860160208601611eb4565b601f01601f19169290920160200192915050565b6020815260006106c16020830184611ee0565b6001600160a01b038116811461085357600080fd5b60008060408385031215611f4757600080fd5b8235611f5281611f1f565b946020939093013593505050565b600080600060608486031215611f7557600080fd5b8335611f8081611f1f565b92506020840135611f9081611f1f565b929592945050506040919091013590565b600060208284031215611fb357600080fd5b5035919050565b600060208284031215611fcc57600080fd5b81356106c181611f1f565b803560ff81168114611fe857600080fd5b919050565b60008060008060008060c0878903121561200657600080fd5b863561201181611f1f565b9550602087013561202181611f1f565b94506040870135935061203660608801611fd7565b92506080870135915060a087013590509295509295509295565b634e487b7160e01b600052604160045260246000fd5b60008060006060848603121561207b57600080fd5b833561208681611f1f565b925060208401359150604084013567ffffffffffffffff808211156120aa57600080fd5b818601915086601f8301126120be57600080fd5b8135818111156120d0576120d0612050565b604051601f8201601f19908116603f011681019083821181831017156120f8576120f8612050565b8160405282815289602084870101111561211157600080fd5b8260208601602083013760006020848301015280955050505050509250925092565b600080600080600080600060e0888a03121561214e57600080fd5b873561215981611f1f565b9650602088013561216981611f1f565b9550604088013594506060880135935061218560808901611fd7565b925060a0880135915060c0880135905092959891949750929550565b600080604083850312156121b457600080fd5b82356121bf81611f1f565b915060208301356121cf81611f1f565b809150509250929050565b600080604083850312156121ed57600080fd5b82356121f881611f1f565b9150602083013563ffffffff811681146121cf57600080fd5b60008060008060006080868803121561222957600080fd5b853561223481611f1f565b9450602086013561224481611f1f565b935060408601359250606086013567ffffffffffffffff8082111561226857600080fd5b818801915088601f83011261227c57600080fd5b81358181111561228b57600080fd5b89602082850101111561229d57600080fd5b9699959850939650602001949392505050565b600181811c908216806122c457607f821691505b602082108114156122e557634e487b7160e01b600052602260045260246000fd5b50919050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052601160045260246000fd5b60008282101561234857612348612320565b500390565b6000821982111561236057612360612320565b500190565b634e487b7160e01b600052603260045260246000fd5b6020808252601b908201527f496e76616c6964207369676e6174757265202773272076616c75650000000000604082015260600190565b6020808252601b908201527f496e76616c6964207369676e6174757265202776272076616c75650000000000604082015260600190565b60006000198214156123fd576123fd612320565b5060010190565b61190160f01b81526002810192909252602282015260420190565b602080825260119082015270496e76616c6964207369676e617475726560781b604082015260600190565b6001600160a01b038581168252602082018590528316604082015260806060820181905260009061247d90830184611ee0565b9695505050505050565b6001600160a01b038681168252851660208201526040810184905260806060820181905281018290526000828460a0840137600060a0848401015260a0601f19601f85011683010190509695505050505050565b600080835481600182811c9150808316806124f757607f831692505b602080841082141561251757634e487b7160e01b86526022600452602486fd5b81801561252b576001811461253c57612569565b60ff19861689528489019650612569565b60008a81526020902060005b868110156125615781548b820152908501908301612548565b505084890196505b509498975050505050505050565b60006020828403121561258957600080fd5b815180151581146106c157600080fd5b6000826125b657634e487b7160e01b600052601260045260246000fd5b500490565b600082516125cd818460208701611eb4565b919091019291505056feddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3efa26469706673582212207eecbfb333a500c574d750bd13d9d3944c632e0e6cfefb9d5262bd9cbb14fb8364736f6c63430008090033",
+  "devdoc": {
+    "details": "By default, token balance does not account for voting power.      This makes transfers cheaper. The downside is that it requires users      to delegate to themselves to activate checkpoints and have their      voting power tracked.",
+    "kind": "dev",
+    "methods": {
+      "approve(address,uint256)": {
+        "details": "If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.      Beware that changing an allowance with this method brings the risk      that someone may use both the old and the new allowance by      unfortunate transaction ordering. One possible solution to mitigate      this race condition is to first reduce the spender's allowance to 0      and set the desired value afterwards:      https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729",
+        "returns": {
+          "_0": "True if the operation succeeded."
+        }
+      },
+      "approveAndCall(address,uint256,bytes)": {
+        "details": "If the `amount` is set to `type(uint256).max` then      `transferFrom` and `burnFrom` will not reduce an allowance.",
+        "returns": {
+          "_0": "True if both approval and `receiveApproval` calls succeeded."
+        }
+      },
+      "burn(uint256)": {
+        "details": "Requirements:       - the caller must have a balance of at least `amount`."
+      },
+      "burnFrom(address,uint256)": {
+        "details": "Requirements:      - `account` must have a balance of at least `amount`,      - the caller must have allowance for `account`'s tokens of at least        `amount`."
+      },
+      "delegate(address)": {
+        "params": {
+          "delegatee": "The address to delegate votes to"
+        }
+      },
+      "delegateBySig(address,address,uint256,uint8,bytes32,bytes32)": {
+        "params": {
+          "deadline": "The time at which to expire the signature",
+          "delegatee": "The address to delegate votes to",
+          "r": "Half of the ECDSA signature pair",
+          "s": "Half of the ECDSA signature pair",
+          "v": "The recovery byte of the signature"
+        }
+      },
+      "getPastTotalSupply(uint256)": {
+        "details": "`blockNumber` must have been already mined",
+        "params": {
+          "blockNumber": "The block number to get the total supply at"
+        }
+      },
+      "getPastVotes(address,uint256)": {
+        "details": "Block number must be a finalized block or else this function will      revert to prevent misinformation.",
+        "params": {
+          "account": "The address of the account to check",
+          "blockNumber": "The block number to get the vote balance at"
+        },
+        "returns": {
+          "_0": "The number of votes the account had as of the given block"
+        }
+      },
+      "getVotes(address)": {
+        "params": {
+          "account": "The address to get votes balance"
+        },
+        "returns": {
+          "_0": "The number of current votes for `account`"
+        }
+      },
+      "mint(address,uint256)": {
+        "details": "Requirements:      - `recipient` cannot be the zero address."
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "The deadline argument can be set to `type(uint256).max to create         permits that effectively never expire.  If the `amount` is set         to `type(uint256).max` then `transferFrom` and `burnFrom` will         not reduce an allowance."
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner."
+      },
+      "transfer(address,uint256)": {
+        "details": "Requirements:       - `recipient` cannot be the zero address,       - the caller must have a balance of at least `amount`.",
+        "returns": {
+          "_0": "True if the operation succeeded, reverts otherwise."
+        }
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "Requirements:      - `spender` and `recipient` cannot be the zero address,      - `spender` must have a balance of at least `amount`,      - the caller must have allowance for `spender`'s tokens of at least        `amount`.",
+        "returns": {
+          "_0": "True if the operation succeeded, reverts otherwise."
+        }
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "title": "T token",
+    "version": 1
+  },
+  "userdoc": {
+    "events": {
+      "DelegateChanged(address,address,address)": {
+        "notice": "Emitted when an account changes their delegate."
+      },
+      "DelegateVotesChanged(address,uint256,uint256)": {
+        "notice": "Emitted when a balance or delegate change results in changes         to an account's voting power."
+      }
+    },
+    "kind": "user",
+    "methods": {
+      "DELEGATION_TYPEHASH()": {
+        "notice": "The EIP-712 typehash for the delegation struct used by         `delegateBySig`."
+      },
+      "DOMAIN_SEPARATOR()": {
+        "notice": "Returns hash of EIP712 Domain struct with the token name as         a signing domain and token contract as a verifying contract.         Used to construct EIP2612 signature provided to `permit`         function."
+      },
+      "PERMIT_TYPEHASH()": {
+        "notice": "Returns EIP2612 Permit message hash. Used to construct EIP2612         signature provided to `permit` function."
+      },
+      "allowance(address,address)": {
+        "notice": "The remaining number of tokens that spender will be         allowed to spend on behalf of owner through `transferFrom` and         `burnFrom`. This is zero by default."
+      },
+      "approve(address,uint256)": {
+        "notice": "Sets `amount` as the allowance of `spender` over the caller's         tokens."
+      },
+      "approveAndCall(address,uint256,bytes)": {
+        "notice": "Calls `receiveApproval` function on spender previously approving         the spender to withdraw from the caller multiple times, up to         the `amount` amount. If this function is called again, it         overwrites the current allowance with `amount`. Reverts if the         approval reverted or if `receiveApproval` call on the spender         reverted."
+      },
+      "balanceOf(address)": {
+        "notice": "The amount of tokens owned by the given account."
+      },
+      "burn(uint256)": {
+        "notice": "Destroys `amount` tokens from the caller."
+      },
+      "burnFrom(address,uint256)": {
+        "notice": "Destroys `amount` of tokens from `account` using the allowance         mechanism. `amount` is then deducted from the caller's allowance         unless the allowance was made for `type(uint256).max`."
+      },
+      "decimals()": {
+        "notice": "The decimals places of the token."
+      },
+      "delegate(address)": {
+        "notice": "Delegate votes from `msg.sender` to `delegatee`."
+      },
+      "delegateBySig(address,address,uint256,uint8,bytes32,bytes32)": {
+        "notice": "Delegates votes from signatory to `delegatee`"
+      },
+      "delegates(address)": {
+        "notice": "Get the address `account` is currently delegating to."
+      },
+      "getPastTotalSupply(uint256)": {
+        "notice": "Retrieve the `totalSupply` at the end of `blockNumber`.         Note, this value is the sum of all balances, but it is NOT the         sum of all the delegated votes!"
+      },
+      "getPastVotes(address,uint256)": {
+        "notice": "Determine the prior number of votes for an account as of         a block number."
+      },
+      "getVotes(address)": {
+        "notice": "Gets the current votes balance for `account`."
+      },
+      "mint(address,uint256)": {
+        "notice": "Creates `amount` tokens and assigns them to `account`,         increasing the total supply."
+      },
+      "name()": {
+        "notice": "The name of the token."
+      },
+      "nonce(address)": {
+        "notice": "Returns the current nonce for EIP2612 permission for the         provided token owner for a replay protection. Used to construct         EIP2612 signature provided to `permit` function."
+      },
+      "numCheckpoints(address)": {
+        "notice": "Get number of checkpoints for `account`."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "notice": "EIP2612 approval made with secp256k1 signature.         Users can authorize a transfer of their tokens with a signature         conforming EIP712 standard, rather than an on-chain transaction         from their address. Anyone can submit this signature on the         user's behalf by calling the permit function, paying gas fees,         and possibly performing other actions in the same transaction."
+      },
+      "symbol()": {
+        "notice": "The symbol of the token."
+      },
+      "totalSupply()": {
+        "notice": "The amount of tokens in existence."
+      },
+      "transfer(address,uint256)": {
+        "notice": "Moves `amount` tokens from the caller's account to `recipient`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "notice": "Moves `amount` tokens from `spender` to `recipient` using the         allowance mechanism. `amount` is then deducted from the caller's         allowance unless the allowance was made for `type(uint256).max`."
+      }
+    },
+    "notice": "Threshold Network T token",
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 389,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 6729,
+        "contract": "contracts/token/T.sol:T",
+        "label": "balanceOf",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 6737,
+        "contract": "contracts/token/T.sol:T",
+        "label": "allowance",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 6743,
+        "contract": "contracts/token/T.sol:T",
+        "label": "nonce",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 6758,
+        "contract": "contracts/token/T.sol:T",
+        "label": "totalSupply",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 6762,
+        "contract": "contracts/token/T.sol:T",
+        "label": "name",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 6766,
+        "contract": "contracts/token/T.sol:T",
+        "label": "symbol",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7563,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_delegates",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_mapping(t_address,t_address)"
+      },
+      {
+        "astId": 7568,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_checkpoints",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)"
+      },
+      {
+        "astId": 7571,
+        "contract": "contracts/token/T.sol:T",
+        "label": "_totalSupplyCheckpoints",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_array(t_uint128)dyn_storage"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_array(t_uint128)dyn_storage": {
+        "base": "t_uint128",
+        "encoding": "dynamic_array",
+        "label": "uint128[]",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_address)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => address)",
+        "numberOfBytes": "32",
+        "value": "t_address"
+      },
+      "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint128[])",
+        "numberOfBytes": "32",
+        "value": "t_array(t_uint128)dyn_storage"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint128": {
+        "encoding": "inplace",
+        "label": "uint128",
+        "numberOfBytes": "16"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      }
+    }
+  }
+}

--- a/solidity/random-beacon/external/mainnet/TokenStaking.json
+++ b/solidity/random-beacon/external/mainnet/TokenStaking.json
@@ -1,0 +1,1484 @@
+{
+  "address": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+  "abi": [
+    {
+      "type": "constructor",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "_token"
+        },
+        {
+          "type": "address",
+          "name": "_keepStakingContract"
+        },
+        {
+          "type": "address",
+          "name": "_nucypherStakingContract"
+        },
+        {
+          "type": "address",
+          "name": "_keepVendingMachine"
+        },
+        {
+          "type": "address",
+          "name": "_nucypherVendingMachine"
+        },
+        {
+          "type": "address",
+          "name": "_keepStake"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "ApplicationStatusChanged",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint8",
+          "name": "newStatus",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationCeilingSet",
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "ceiling",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationDecreaseApproved",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationDecreaseRequested",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationIncreased",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "AuthorizationInvoluntaryDecreased",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "fromAmount",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "toAmount",
+          "indexed": false
+        },
+        {
+          "type": "bool",
+          "name": "successfulCall",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "DelegateChanged",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "delegator",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "fromDelegate",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "toDelegate",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "DelegateVotesChanged",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "delegate",
+          "indexed": true
+        },
+        {
+          "type": "uint256",
+          "name": "previousBalance",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "newBalance",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "GovernanceTransferred",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "oldGovernance",
+          "indexed": false
+        },
+        {
+          "type": "address",
+          "name": "newGovernance",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "MinimumStakeAmountSet",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotificationRewardPushed",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotificationRewardSet",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotificationRewardWithdrawn",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "recipient",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "NotifierRewarded",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "notifier",
+          "indexed": true
+        },
+        {
+          "type": "uint256",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "OwnerRefreshed",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "oldOwner",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "newOwner",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "PanicButtonSet",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "panicButton",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "SlashingProcessed",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "caller",
+          "indexed": true
+        },
+        {
+          "type": "uint256",
+          "name": "count",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "tAmount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "StakeDiscrepancyPenaltySet",
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "penalty",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "rewardMultiplier",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "Staked",
+      "inputs": [
+        {
+          "type": "uint8",
+          "name": "stakeType",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "owner",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "beneficiary",
+          "indexed": false
+        },
+        {
+          "type": "address",
+          "name": "authorizer",
+          "indexed": false
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "TokensSeized",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        },
+        {
+          "type": "bool",
+          "name": "discrepancy",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "ToppedUp",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "Unstaked",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider",
+          "indexed": true
+        },
+        {
+          "type": "uint96",
+          "name": "amount",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "applicationInfo",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint8",
+          "name": "status"
+        },
+        {
+          "type": "address",
+          "name": "panicButton"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "applications",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "approveApplication",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "approveAuthorizationDecrease",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "authorizationCeiling",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "authorizedStake",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "checkpoints",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        },
+        {
+          "type": "uint32",
+          "name": "pos"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "tuple",
+          "name": "checkpoint",
+          "components": [
+            {
+              "type": "uint32",
+              "name": "fromBlock"
+            },
+            {
+              "type": "uint96",
+              "name": "votes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "delegateVoting",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "delegatee"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "delegates",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "disableApplication",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "forceDecreaseAuthorization",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "getApplicationsLength",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getAvailableToAuthorize",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96",
+          "name": "availableTValue"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getMinStaked",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint8",
+          "name": "stakeTypes"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getPastTotalSupply",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "blockNumber"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getPastVotes",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        },
+        {
+          "type": "uint256",
+          "name": "blockNumber"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getSlashingQueueLength",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getStartStakingTimestamp",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "getVotes",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "governance",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "increaseAuthorization",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "constant": false,
+      "payable": false,
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "minTStakeAmount",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "notificationReward",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "notifiersTreasury",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "notifyKeepStakeDiscrepancy",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "notifyNuStakeDiscrepancy",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "numCheckpoints",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "account"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint32"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "pauseApplication",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "processSlashing",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "count"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "pushNotificationReward",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "refreshKeepStakeOwner",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "requestAuthorizationDecrease",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "requestAuthorizationDecrease",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "rolesOf",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address",
+          "name": "owner"
+        },
+        {
+          "type": "address",
+          "name": "beneficiary"
+        },
+        {
+          "type": "address",
+          "name": "authorizer"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "seize",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount"
+        },
+        {
+          "type": "uint256",
+          "name": "rewardMultiplier"
+        },
+        {
+          "type": "address",
+          "name": "notifier"
+        },
+        {
+          "type": "address[]",
+          "name": "_stakingProviders"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setAuthorizationCeiling",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "ceiling"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setMinimumStakeAmount",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setNotificationReward",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "reward"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setPanicButton",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "application"
+        },
+        {
+          "type": "address",
+          "name": "panicButton"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "setStakeDiscrepancyPenalty",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "penalty"
+        },
+        {
+          "type": "uint256",
+          "name": "rewardMultiplier"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "slash",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint96",
+          "name": "amount"
+        },
+        {
+          "type": "address[]",
+          "name": "_stakingProviders"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "slashingQueue",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        },
+        {
+          "type": "address",
+          "name": "application"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "slashingQueueIndex",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stake",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "beneficiary"
+        },
+        {
+          "type": "address",
+          "name": "authorizer"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "stakeDiscrepancyPenalty",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint96"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stakeDiscrepancyRewardMultiplier",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stakeKeep",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "stakeNu",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "address",
+          "name": "beneficiary"
+        },
+        {
+          "type": "address",
+          "name": "authorizer"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "stakedNu",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint256",
+          "name": "nuAmount"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "stakes",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "uint96",
+          "name": "tStake"
+        },
+        {
+          "type": "uint96",
+          "name": "keepInTStake"
+        },
+        {
+          "type": "uint96",
+          "name": "nuInTStake"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "topUp",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "topUpKeep",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "topUpNu",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "transferGovernance",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "newGuvnor"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeAll",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeKeep",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeNu",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "unstakeT",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "stakingProvider"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "withdrawNotificationReward",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "recipient"
+        },
+        {
+          "type": "uint96",
+          "name": "amount"
+        }
+      ],
+      "outputs": []
+    }
+  ]
+}

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -125,7 +125,6 @@ const config: HardhatUserConfig = {
       mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
-      // TODO: Rename to thresholdCouncil
       default: 2,
       goerli: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -100,6 +100,14 @@ const config: HardhatUserConfig = {
         : undefined,
       tags: ["etherscan", "tenderly"],
     },
+    mainnet: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 1,
+      accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
+        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+        : undefined,
+      tags: ["etherscan", "tenderly"],
+    },
   },
   // // Define local networks configuration file path to load networks from the file.
   // localNetworksConfig: "./.hardhat/networks.ts",
@@ -114,16 +122,18 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 1,
       goerli: 0,
+      mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
+      // TODO: Rename to thresholdCouncil
       default: 2,
       goerli: 0,
-      // mainnet: ""
+      mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
       goerli: 0,
-      // mainnet: ""
+      mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
   },
   external: {
@@ -148,7 +158,7 @@ const config: HardhatUserConfig = {
         "node_modules/@threshold-network/solidity-contracts/deployments/development",
       ],
       goerli: ["node_modules/@threshold-network/solidity-contracts/artifacts"],
-      // mainnet: ["./external/mainnet"],
+      mainnet: ["./external/mainnet"],
     },
   },
   dependencyCompiler: {


### PR DESCRIPTION
This PR updates the script to handle mainnet contracts deployment as described in https://github.com/keep-network/keep-core/issues/3315.

### Mainnet Deployment Scripts Execution Scenario

#### Configure environment variables:

```sh
export CHAIN_API_URL = <HTTP ENDPOINT URL>
export CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY = <DEPLOYER PRIVATE KEY>
```

#### In `solidity/ecdsa/random-beacon` execute:

```sh
yarn deploy --network mainnet --tags ReimbursementPool
yarn deploy --network mainnet --tags BeaconSortitionPool
yarn deploy --network mainnet --tags BeaconDkgValidator
yarn deploy --network mainnet --tags RandomBeacon
yarn deploy --network mainnet --tags RandomBeaconAuthorize
yarn deploy --network mainnet --tags RandomBeaconGovernance
```

#### In `solidity/ecdsa/ecdsa` execute:
```sh
yarn deploy --network mainnet --tags EcdsaSortitionPool
yarn deploy --network mainnet --tags EcdsaDkgValidator
yarn deploy --network mainnet --tags WalletRegistry
yarn deploy --network mainnet --tags WalletRegistryAuthorize
yarn deploy --network mainnet --tags WalletRegistryGovernance
yarn deploy --network mainnet --tags WalletRegistryTransferGovernance
yarn deploy --network mainnet --tags TransferProxyAdminOwnership
yarn deploy --network mainnet --tags WalletRegistryAuthorizeInBeacon
yarn deploy --network mainnet --tags ReimbursementPoolTransferGovernance

```

#### In `solidity/ecdsa/random-beacon` execute:
```sh
yarn deploy --network mainnet --tags RandomBeaconTransferGovernance
```