### PR TITLE
Build linux binaries on debian based Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,9 +96,13 @@ CMD []
 #
 # Build Binaries
 #
-FROM build-sources AS build-bins
+FROM golang:1.18.3-bullseye AS build-bins
+
+ENV APP_DIR=/go/src/github.com/keep-network/keep-core
 
 WORKDIR $APP_DIR
+
+COPY --from=build-sources $APP_DIR $APP_DIR
 
 ARG ENVIRONMENT
 


### PR DESCRIPTION
We were using alpine as a base for the binaries building which was causing some inconveniences when running the binary on ubuntu as it required `musl` library installation.
Alpine is using `musl` instead of `glibc`, so the binary build on alpine won't work right away on ubuntu.
In this PR we use a debian-based (bullseye) golang docker image to build the binaries.