### PR TITLE
Prepend hexstrings with 0x

### DIFF
--- a/pkg/beacon/node.go
+++ b/pkg/beacon/node.go
@@ -62,7 +62,7 @@ func (n *node) JoinDKGIfEligible(
 	dkgStartBlockNumber uint64,
 ) {
 	dkgLogger := logger.With(
-		zap.String("seed", dkgSeed.Text(16)),
+		zap.String("seed", fmt.Sprintf("0x%x", dkgSeed)),
 	)
 
 	dkgLogger.Info("checking eligibility for DKG")
@@ -168,7 +168,7 @@ func (n *node) JoinDKGIfEligible(
 				err = n.groupRegistry.RegisterGroup(signer, groupPublicKey)
 				if err != nil {
 					dkgLogger.Errorf(
-						"[member:%v] failed to register a group [%v]: [%v]",
+						"[member:%v] failed to register a group [0x%v]: [%v]",
 						signer.MemberID(),
 						groupPublicKey,
 						err,
@@ -177,7 +177,7 @@ func (n *node) JoinDKGIfEligible(
 				}
 
 				dkgLogger.Infof(
-					"[member:%v] group [%v] registered successfully",
+					"[member:%v] group [0x%v] registered successfully",
 					signer.MemberID(),
 					groupPublicKey,
 				)
@@ -323,8 +323,8 @@ func (n *node) GenerateRelayEntry(
 	startBlockHeight uint64,
 ) {
 	relayLogger := logger.With(
-		zap.String("groupPublicKey", hex.EncodeToString(groupPublicKey)),
-		zap.String("previousEntry", hex.EncodeToString(previousEntry)),
+		zap.String("groupPublicKey", fmt.Sprintf("0x%x", groupPublicKey)),
+		zap.String("previousEntry", fmt.Sprintf("0x%x", previousEntry)),
 	)
 
 	memberships := n.groupRegistry.GetGroup(groupPublicKey)

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -69,7 +69,7 @@ func newNode(
 // completes the on-chain operation.
 func (n *node) joinDKGIfEligible(seed *big.Int, startBlockNumber uint64) {
 	dkgLogger := logger.With(
-		zap.String("seed", seed.Text(16)),
+		zap.String("seed", fmt.Sprintf("0x%x", seed)),
 	)
 
 	dkgLogger.Info("checking eligibility for DKG")
@@ -406,7 +406,7 @@ func (n *node) joinSigningIfEligible(
 	startBlockNumber uint64,
 ) {
 	signingLogger := logger.With(
-		zap.String("message", message.Text(16)),
+		zap.String("message", fmt.Sprintf("0x%x", message)),
 	)
 
 	walletPublicKeyBytes, err := marshalPublicKey(walletPublicKey)
@@ -416,7 +416,7 @@ func (n *node) joinSigningIfEligible(
 	}
 
 	signingLogger = signingLogger.With(
-		zap.String("wallet", hex.EncodeToString(walletPublicKeyBytes)),
+		zap.String("wallet", fmt.Sprintf("0x%x", walletPublicKeyBytes)),
 	)
 
 	signingLogger.Info("checking eligibility for signing")


### PR DESCRIPTION
Hexstrings found in keep-client's logs were prepended with `0x`.