### PR TITLE
Fix command for upgrade of forked @keep-network-sortition-pools

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -226,7 +226,7 @@ jobs:
       # test environment it should be used temporarily only.
       - name: Use Sortition Pool forked contracts
         run: |
-          yarn upgrade github:keep-network/sortition-pools#test-fork
+          yarn upgrade @keep-network/sortition-pools@github:keep-network/sortition-pools#test-fork
 
       - name: Configure tenderly
         env:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -222,7 +222,7 @@ jobs:
       # test environment it should be used temporarily only.
       - name: Use Sortition Pool forked contracts
         run: |
-          yarn upgrade github:keep-network/sortition-pools#test-fork
+          yarn upgrade @keep-network/sortition-pools@github:keep-network/sortition-pools#test-fork
 
       - name: Configure tenderly
         env:


### PR DESCRIPTION
In the `Use Sortition Pool forked contracts` step we wanted to upgrade the sortition-pool contracts to verioned stored on `test-fork` branch. Previously used command did not work correctly. Now it should do what we want.

Refs:
https://github.com/keep-network/keep-core/pull/3190
https://github.com/keep-network/sortition-pools/pull/186/files