### PR TITLE
Set default TSS pre-params target pool size to 1000

### DIFF
--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -152,7 +152,7 @@ var cmdFlagsTests = map[string]struct {
 		flagName:              "--tbtc.preParamsPoolSize",
 		flagValue:             "75",
 		expectedValueFromFlag: 75,
-		defaultValue:          3000,
+		defaultValue:          1000,
 	},
 	"tbtc.preParamsGenerationTimeout": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsGenerationTimeout },

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -23,7 +23,7 @@ var logger = log.Logger("keep-tbtc")
 const ProtocolName = "tbtc"
 
 const (
-	DefaultPreParamsPoolSize              = 3000
+	DefaultPreParamsPoolSize              = 1000
 	DefaultPreParamsGenerationTimeout     = 2 * time.Minute
 	DefaultPreParamsGenerationDelay       = 10 * time.Second
 	DefaultPreParamsGenerationConcurrency = 1


### PR DESCRIPTION
We now do not take pre-params from the pool until we are sure we really need them. This means the target pool size can be much lower than the original value. This allows clients to register in the sortition pool faster.