### PR TITLE
Allow force-updating the sortition pool on testnet

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 
 	"github.com/spf13/cobra"
 
@@ -152,12 +153,18 @@ func start(cmd *cobra.Command) error {
 
 		scheduler := generator.StartScheduler()
 
+		sortitionPoolForceUpdate := clientConfig.Ethereum.Network !=
+			commonEthereum.Mainnet
+
 		err = beacon.Initialize(
 			ctx,
 			beaconChain,
 			netProvider,
 			beaconKeyStorePersistence,
 			scheduler,
+			beacon.Config{
+				SortitionPoolForceUpdate: sortitionPoolForceUpdate,
+			},
 		)
 		if err != nil {
 			return fmt.Errorf("error initializing beacon: [%v]", err)
@@ -170,7 +177,14 @@ func start(cmd *cobra.Command) error {
 			tbtcKeyStorePersistence,
 			tbtcDataPersistence,
 			scheduler,
-			clientConfig.Tbtc,
+			tbtc.Config{
+				PreParamsPoolSize:              clientConfig.Tbtc.PreParamsPoolSize,
+				PreParamsGenerationTimeout:     clientConfig.Tbtc.PreParamsGenerationTimeout,
+				PreParamsGenerationDelay:       clientConfig.Tbtc.PreParamsGenerationDelay,
+				PreParamsGenerationConcurrency: clientConfig.Tbtc.PreParamsGenerationConcurrency,
+				KeyGenerationConcurrency:       clientConfig.Tbtc.KeyGenerationConcurrency,
+				SortitionPoolForceUpdate:       sortitionPoolForceUpdate,
+			},
 			clientInfoRegistry,
 		)
 		if err != nil {

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -23,6 +23,13 @@ var logger = log.Logger("keep-beacon")
 // ProtocolName denotes the name of the protocol defined by this package.
 const ProtocolName = "beacon"
 
+// Config carries the config for beacon protocol.
+type Config struct {
+	// Flag indicating that the sortition pool update should be attempted
+	// regardless of the sortition pool state.
+	SortitionPoolForceUpdate bool
+}
+
 // Initialize kicks off the random beacon by initializing internal state,
 // ensuring preconditions like staking are met, and then kicking off the
 // internal random beacon implementation. Returns an error if this failed,
@@ -33,6 +40,7 @@ func Initialize(
 	netProvider net.Provider,
 	persistence persistence.ProtectedHandle,
 	scheduler *generator.Scheduler,
+	config Config,
 ) error {
 	groupRegistry := registry.NewGroupRegistry(logger, beaconChain, persistence)
 	groupRegistry.LoadExistingGroups()
@@ -50,6 +58,7 @@ func Initialize(
 		beaconChain,
 		sortition.DefaultStatusCheckTick,
 		sortition.NewBetaOperatorPolicy(beaconChain, logger),
+		config.SortitionPoolForceUpdate,
 	)
 	if err != nil {
 		return fmt.Errorf(

--- a/pkg/sortition/sortition.go
+++ b/pkg/sortition/sortition.go
@@ -25,6 +25,7 @@ func MonitorPool(
 	chain Chain,
 	tick time.Duration,
 	policy JoinPolicy,
+	forceUpdate bool,
 ) error {
 	_, isRegistered, err := chain.OperatorToStakingProvider()
 	if err != nil {
@@ -35,7 +36,7 @@ func MonitorPool(
 		return errOperatorUnknown
 	}
 
-	err = checkOperatorStatus(logger, chain, policy)
+	err = checkOperatorStatus(logger, chain, policy, forceUpdate)
 	if err != nil {
 		logger.Errorf("could not check operator sortition pool status: [%v]", err)
 	}
@@ -49,7 +50,7 @@ func MonitorPool(
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				err = checkOperatorStatus(logger, chain, policy)
+				err = checkOperatorStatus(logger, chain, policy, forceUpdate)
 				if err != nil {
 					logger.Errorf("could not check operator sortition pool status: [%v]", err)
 					continue
@@ -65,6 +66,7 @@ func checkOperatorStatus(
 	logger log.StandardLogger,
 	chain Chain,
 	policy JoinPolicy,
+	forceUpdate bool,
 ) error {
 	logger.Info("checking sortition pool operator status")
 
@@ -104,7 +106,7 @@ func checkOperatorStatus(
 		return err
 	}
 
-	if isLocked {
+	if isLocked && !forceUpdate {
 		logger.Info("sortition pool state is locked, waiting with the update")
 		return nil
 	}

--- a/pkg/sortition/sortition_test.go
+++ b/pkg/sortition/sortition_test.go
@@ -46,6 +46,7 @@ func TestMonitorPool_NotRegisteredOperator(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	testutils.AssertErrorsSame(t, errOperatorUnknown, err)
 }
@@ -63,6 +64,7 @@ func TestMonitorPool_NoStake(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -92,6 +94,7 @@ func TestMonitor_JoinPool(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -121,6 +124,7 @@ func TestMonitor_JoinPool_PolicyNotSatisfied(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		&neverJoinPolicy{},
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -153,6 +157,7 @@ func TestMonitor_UpdatePool(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -180,6 +185,7 @@ func TestMonitor_JoinPool_WithDelay(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -222,6 +228,7 @@ func TestMonitor_UpdatePool_WithDelay(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -268,6 +275,7 @@ func TestMonitor_CannotRestoreRewardsEligibility_TimeNotPassed(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -297,7 +305,13 @@ func TestMonitor_CanRestoreRewardsEligibility(t *testing.T) {
 	localChain.SetCurrentTimestamp(big.NewInt(2))
 
 	err := MonitorPool(
-		ctx, &testutils.MockLogger{}, localChain, statusCheckTick, UnconditionalJoinPolicy)
+		ctx,
+		&testutils.MockLogger{},
+		localChain,
+		statusCheckTick,
+		UnconditionalJoinPolicy,
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,6 +345,7 @@ func TestMonitor_CanRestoreRewardsEligibility_WithDelay(t *testing.T) {
 		localChain,
 		statusCheckTick,
 		UnconditionalJoinPolicy,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -43,6 +43,9 @@ type Config struct {
 	PreParamsGenerationConcurrency int
 	// Concurrency level for key-generation for tECDSA.
 	KeyGenerationConcurrency int
+	// Flag indicating that the sortition pool update should be attempted
+	// regardless of the sortition pool state.
+	SortitionPoolForceUpdate bool
 }
 
 // Initialize kicks off the TBTC by initializing internal state, ensuring
@@ -85,6 +88,7 @@ func Initialize(
 				config: config,
 			},
 		),
+		config.SortitionPoolForceUpdate,
 	)
 	if err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
Some implementations of the testnet sortition pools can allow for operator updates and insertions even though being locked. Here we reflect that by adding a bypass of the pool state check for non-mainnet networks.