### PR TITLE
Ensure the ECDSA DKG result is signed by the quorum of group members

### DIFF
--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -462,12 +462,11 @@ func (drs *dkgResultSubmitter) SubmitResult(
 ) error {
 	config := drs.chain.GetConfig()
 
-	if len(signatures) < config.HonestThreshold {
+	if len(signatures) < config.GroupQuorum {
 		return fmt.Errorf(
-			"could not submit result with [%v] signatures for signature "+
-				"honest threshold [%v]",
+			"could not submit result with [%v] signatures for group quorum [%v]",
 			len(signatures),
-			config.HonestThreshold,
+			config.GroupQuorum,
 		)
 	}
 

--- a/pkg/tbtc/dkg_test.go
+++ b/pkg/tbtc/dkg_test.go
@@ -835,6 +835,7 @@ func TestSubmitResult_MemberSubmitsResult(t *testing.T) {
 		1: []byte("signature 1"),
 		2: []byte("signature 2"),
 		3: []byte("signature 3"),
+		4: []byte("signature 4"),
 	}
 	startBlock := uint64(3)
 
@@ -878,6 +879,7 @@ func TestSubmitResult_MemberDoesNotSubmitsResult(t *testing.T) {
 		1: []byte("signature 1"),
 		2: []byte("signature 2"),
 		3: []byte("signature 3"),
+		4: []byte("signature 4"),
 	}
 	startBlock := uint64(2)
 
@@ -953,6 +955,7 @@ func TestSubmitResult_TooFewSignatures(t *testing.T) {
 	signatures := map[group.MemberIndex][]byte{
 		1: []byte("signature 1"),
 		2: []byte("signature 2"),
+		3: []byte("signature 3"),
 	}
 	startBlock := uint64(3)
 
@@ -964,8 +967,7 @@ func TestSubmitResult_TooFewSignatures(t *testing.T) {
 	)
 
 	expectedError := fmt.Errorf(
-		"could not submit result with [2] signatures for signature honest " +
-			"threshold [3]",
+		"could not submit result with [3] signatures for group quorum [4]",
 	)
 	if !reflect.DeepEqual(expectedError, err) {
 		t.Errorf(


### PR DESCRIPTION
Even if that requirement is not forced by the on-chain contract, every ECDSA DKG participant must ensure it submits a DKG result that was signed by the quorum of the group. This way we are making sure the protocol was completed by a quorum of members that are ready to handle signature requests.

This change should soften the case when members fail at the last phase of DKG (finalization round) that is not followed by any communication round allowing for detection of such a failures. In that scenario, members who failed the last round do not produce the key material but, in the same time, are not excluded by other participants as misbehaved, so they can be selected for signing normally. As result, signature attempts including those members fail and the wallet needs more attempts in total to exclude those members using the random algorithm and come with a successful signature. However, thanks to this change, we now guarantee that the total number of signing-ready members is at least equal to the `GroupQuorum` which should strongly increase the success chance of particular signing attempts and result with a lower number of total trials (comparing to at least `HonestThreshold` signing-ready members).

Note that the problem may still occur if the number of successful participants is greater than the `GroupQuorum` yet less than the total number of members participating in the last DKG attempt. The ultimate solution should probably involve an additional communication round after the ECDSA DKG finalization round.