### PR TITLE
Tweak testnet clients Kubernetes manifests

### DIFF
--- a/infrastructure/kube/keep-test/keep-client/gen/template.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/template.yaml
@@ -54,6 +54,10 @@ spec:
         - name: keep-client
           image: "gcr.io/keep-test-f3e0/keep-client:latest"
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 1500m
+              memory: 512M
           ports:
             - name: network
               containerPort: 3919
@@ -100,6 +104,8 @@ spec:
             #@ end
             - "--clientInfo.port"
             - "9601"
+            - "--tbtc.keyGenerationConcurrency"
+            - "2"
       initContainers:
         #@ for/end initcontainer in data.values.initContainers:
         - name: #@ initcontainer.name

--- a/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
@@ -49,6 +49,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -90,6 +94,8 @@ spec:
         - /dns4/bootstrap-0.test.keep.network/tcp/3919
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -248,6 +254,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -289,6 +299,8 @@ spec:
         - /dns4/bootstrap-1.test.keep.network/tcp/3919
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -447,6 +459,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -486,6 +502,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -644,6 +662,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -683,6 +705,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -841,6 +865,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -880,6 +908,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -1038,6 +1068,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -1077,6 +1111,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -1235,6 +1271,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -1274,6 +1314,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -1432,6 +1474,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -1471,6 +1517,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -1629,6 +1677,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -1668,6 +1720,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest
@@ -1826,6 +1880,10 @@ spec:
       - name: keep-client
         image: gcr.io/keep-test-f3e0/keep-client:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 512M
         ports:
         - name: network
           containerPort: 3919
@@ -1865,6 +1923,8 @@ spec:
         - "3919"
         - --clientInfo.port
         - "9601"
+        - --tbtc.keyGenerationConcurrency
+        - "2"
       initContainers:
       - name: initcontainer-beacon
         image: gcr.io/keep-test-f3e0/keep-random-beacon-hardhat:latest


### PR DESCRIPTION
Here we tweak the k8s manifests of the private testnet clients. Basically, this change is about:
- Setting `tbtc.keyGenerationConcurrency` to `2` in order to limit CPU competition between clients running on the same VM which often results in other processes starvation.
- Setting resource requests that reflect the actual resource consumption. Worth noting that the ultimate value of `resources.request.cpu` should be `2000m` but given the current cluster specification we can set `1500m` at most. Otherwise, we'll end up with unschedulable pods.