### PR TITLE
Client build mainnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,11 @@ local:
 
 all: get_artifacts generate build cmd-help release
 
+# FIXME: tbtc module was removed as it's not used in the client. Add it back
+# while implementing tbtc integration.
 modules := beacon \
 	ecdsa \
-	threshold \
-	tbtc
+	threshold
 
 # Required by get_npm_package function.
 npm_beacon_package := @keep-network/random-beacon

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,9 @@ development:
 goerli:
 	make all environment=goerli
 
-# TODO: Mainnet packages have not been published yet.
 # Build with contract packages published to the NPM registry and tagged `mainnet`.
-# mainnet:
-# 	make all environment=mainnet
+mainnet:
+	make all environment=mainnet
 
 # Build with contract packages deployed locally.
 local:

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -19,7 +19,6 @@ import (
 	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 	ethereumBeacon "github.com/keep-network/keep-core/pkg/chain/ethereum/beacon/gen"
 	ethereumEcdsa "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen"
-	ethereumTbtc "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen"
 	ethereumThreshold "github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen"
 )
 
@@ -210,7 +209,9 @@ var cmdFlagsTests = map[string]struct {
 		flagName:              "--developer.bridgeAddress",
 		flagValue:             "0xd21DE06574811450E722a33D8093558E8c04eacc",
 		expectedValueFromFlag: "0xd21DE06574811450E722a33D8093558E8c04eacc",
-		defaultValue:          ethereumTbtc.BridgeAddress,
+		// FIXME: Commented out temporarily for mainnet build.
+		// defaultValue: ethereumTbtc.BridgeAddress,
+		defaultValue: "0x0000000000000000000000000000000000000000",
 	},
 	"developer.tokenStakingAddress": {
 		readValueFunc: func(c *config.Config) interface{} {

--- a/pkg/chain/ethereum/tbtc/gen/gen.go
+++ b/pkg/chain/ethereum/tbtc/gen/gen.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 )
 
-//go:generate make
+// FIXME: Commented out temporarily for mainnet build.
+//// go:generate make
 
 var (
-	//go:embed _address/Bridge
+	// FIXME: Commented out temporarily for mainnet build.
+	////go:embed _address/Bridge
 	bridgeAddressFileContent string
 
 	// BridgeAddress is a Bridge contract's address read from the NPM package.


### PR DESCRIPTION
The target should be used for mainnet client building. To run the build process execute:
```
make mainnet
```

The command will download contracts artifacts, generate the bindings and other go code and build the client.

### tbtc workaround

`tbtc` package is not yet used by the client for the current milestone. For now, contracts from `keep-core` package are enough (key generation, signing). The contracts were not yet migrated on mainnet so the build process for mainnet cannot complete. We remove tbtc NPM package part of the code generator to let the client build for mainnet. The commit d3a67ffce6498ee75085959e87c5ded8a888695c  should be reverted when adding integration with `Bridge` contract.