### PR TITLE
Log tweaks

### DIFF
--- a/pkg/beacon/node.go
+++ b/pkg/beacon/node.go
@@ -69,7 +69,13 @@ func (n *node) JoinDKGIfEligible(
 
 	selectedOperators, err := n.beaconChain.SelectGroup(dkgSeed)
 	if err != nil {
-		dkgLogger.Errorf("failed to select group: [%v]", err)
+		// TODO: We should consider switching this log to Errorf when the
+		// Chaosnet 0 phase is completed and results are submitted to the chain.
+		// To let the operators join the pool, the dev team will keep unlocking
+		// it via DKG timeout from time to time. During the period pool is
+		// unlocked, selecting the group will not work.
+		//dkgLogger.Errorf("failed to select group: [%v]", err)
+		dkgLogger.Warnf("selecting group not possible: [%v]", err)
 		return
 	}
 

--- a/pkg/sortition/sortition.go
+++ b/pkg/sortition/sortition.go
@@ -137,7 +137,11 @@ func checkRewardsEligibility(logger log.StandardLogger, chain Chain) error {
 	}
 
 	if isEligibleForRewards {
-		logger.Info("operator is eligible for rewards")
+		// TODO: Uncomment once the rewards get allocated via the sortition pool.
+		// We do not want to confuse the operators not meeting the requirements
+		// for the interim rewards allocations with false-positive messages
+		// from logs.
+		// logger.Info("operator is eligible for rewards")
 	} else {
 		logger.Info("operator is marked as ineligible for rewards")
 

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -76,7 +76,13 @@ func (n *node) joinDKGIfEligible(seed *big.Int, startBlockNumber uint64) {
 
 	selectedSigningGroupOperators, err := n.chain.SelectGroup(seed)
 	if err != nil {
-		dkgLogger.Errorf("failed to select group: [%v]", err)
+		// TODO: We should consider switching this log to Errorf when the
+		// Chaosnet 0 phase is completed and results are submitted to the chain.
+		// To let the operators join the pool, the dev team will keep unlocking
+		// it via DKG timeout from time to time. During the period pool is
+		// unlocked, selecting the group will not work.
+		//dkgLogger.Errorf("failed to select group: [%v]", err)
+		dkgLogger.Warnf("selecting group not possible: [%v]", err)
 		return
 	}
 


### PR DESCRIPTION
Two small log tweaks for Chaosnet 0

[Log problems with selecting group on warn level](https://github.com/keep-network/keep-core/commit/c75f8879285e8365120aaa747e33fe2061a8a41a)

We should consider switching this log to Errorf when the Chaosnet 0 phase is
completed and results are submitted to the chain. To let the operators join the
pool, the dev team will keep unlocking it via DKG timeout from time to time.
During the period pool is unlocked, selecting the group will not work.

[Do not log the status of sortition pool reward eligibility check](https://github.com/keep-network/keep-core/commit/91cd4075fc78b3324603edff4947c29684fd89f8)

We should uncomment this log once the rewards get allocated via the sortition
pool. We do not want to confuse the operators not meeting the requirements for
the interim rewards allocations with false-positive messages from logs.