### PR TITLE
Made keep-client exclude own address from bootstrap peer list

### DIFF
--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -479,8 +479,8 @@ func (p *provider) bootstrap(
 	ownID := p.identity.id
 	filteredPeerInfos := make([]peer.AddrInfo, 0)
 
-	// If the client's own address is mistakenly added to the list of bootstrap
-	// peers, filter it out. This will prevent self-dialing.
+	// If the client's own address is on the list of bootstrap peers, filter it
+	// out to prevent self-dialing.
 	for _, peerInfo := range peerInfos {
 		if peerInfo.ID != ownID {
 			filteredPeerInfos = append(filteredPeerInfos, peerInfo)

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -476,7 +476,21 @@ func (p *provider) bootstrap(
 		return err
 	}
 
-	bootstrapConfig := bootstrapConfigWithPeers(peerInfos)
+	ownID := p.identity.id
+	filteredPeerInfos := make([]peer.AddrInfo, 0)
+
+	for _, peerInfo := range peerInfos {
+		if peerInfo.ID == ownID {
+			logger.Infof(
+				"Found own address [%v] on bootstrap peer list. Ignoring it.",
+				peerInfo.ID,
+			)
+		} else {
+			filteredPeerInfos = append(filteredPeerInfos, peerInfo)
+		}
+	}
+
+	bootstrapConfig := bootstrapConfigWithPeers(filteredPeerInfos)
 
 	// TODO: use the io.Closer to shutdown the bootstrapper when we build out
 	// a shutdown process.

--- a/pkg/net/libp2p/libp2p.go
+++ b/pkg/net/libp2p/libp2p.go
@@ -479,13 +479,10 @@ func (p *provider) bootstrap(
 	ownID := p.identity.id
 	filteredPeerInfos := make([]peer.AddrInfo, 0)
 
+	// If the client's own address is mistakenly added to the list of bootstrap
+	// peers, filter it out. This will prevent self-dialing.
 	for _, peerInfo := range peerInfos {
-		if peerInfo.ID == ownID {
-			logger.Infof(
-				"Found own address [%v] on bootstrap peer list. Ignoring it.",
-				peerInfo.ID,
-			)
-		} else {
+		if peerInfo.ID != ownID {
 			filteredPeerInfos = append(filteredPeerInfos, peerInfo)
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/3218.

This PR adds a check for the keep-client's own address on the bootstrap peer list.
If own address is found, it is ignored and the bootstrapping continues.
This change prevents a constantly appearing warning in keep-client's logs. 
