### PR TITLE
Run cmd-help after release when making all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ mainnet:
 local:
 	make all environment=local
 
-all: get_artifacts generate build cmd-help release
+all: get_artifacts generate build release cmd-help
 
 # FIXME: tbtc module was removed as it's not used in the client. Add it back
 # while implementing tbtc integration.


### PR DESCRIPTION
This is a change to Makefile to do not regenerate cmd-help as a part of the release. This is needed because of a problem with default value for key generation concurrency flag. The value depends on the machine on which the file is generated and it should default to the number of cores on the host machine. This is a temporary workaround and once we fix the problem with code generation, we should be able to switch back the order.