### PR TITLE
Logging fixes

### DIFF
--- a/pkg/beacon/dkg/result/signing.go
+++ b/pkg/beacon/dkg/result/signing.go
@@ -128,7 +128,7 @@ func (sm *SigningMember) VerifyDKGResultSignatures(
 		// Check if sender sent multiple messages.
 		if duplicatedMessagesFromSender(message.senderIndex) {
 			sm.logger.Infof(
-				"[member: %v] received multiple messages from sender: [%d]",
+				"[member:%v] received multiple messages from sender: [%d]",
 				sm.index,
 				message.senderIndex,
 			)
@@ -139,7 +139,7 @@ func (sm *SigningMember) VerifyDKGResultSignatures(
 		// preferred DKG result hash.
 		if message.resultHash != sm.preferredDKGResultHash {
 			sm.logger.Infof(
-				"[member: %v] signature from sender [%d] supports result different than preferred",
+				"[member:%v] signature from sender [%d] supports result different than preferred",
 				sm.index,
 				message.senderIndex,
 			)
@@ -154,7 +154,7 @@ func (sm *SigningMember) VerifyDKGResultSignatures(
 		)
 		if err != nil {
 			sm.logger.Infof(
-				"[member: %v] verification of signature from sender [%d] failed: [%v]",
+				"[member:%v] verification of signature from sender [%d] failed: [%v]",
 				sm.index,
 				message.senderIndex,
 				err,
@@ -163,7 +163,7 @@ func (sm *SigningMember) VerifyDKGResultSignatures(
 		}
 		if !ok {
 			sm.logger.Infof(
-				"[member: %v] sender [%d] provided invalid signature",
+				"[member:%v] sender [%d] provided invalid signature",
 				sm.index,
 				message.senderIndex,
 			)

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -127,9 +127,9 @@ func Initialize(
 			// There is no need to deduplicate. Test loop events are unique.
 
 			logger.Infof(
-				"signature of message [%v] requested from "+
+				"signature of message [0x%x] requested from "+
 					"wallet [0x%x] at block [%v]",
-				event.Message.Text(16),
+				event.Message,
 				event.WalletPublicKey,
 				event.BlockNumber,
 			)

--- a/pkg/tecdsa/dkg/protocol.go
+++ b/pkg/tecdsa/dkg/protocol.go
@@ -421,7 +421,7 @@ func (sm *signingMember) verifyDKGResultSignatures(
 		// preferred DKG result hash.
 		if message.resultHash != sm.preferredDKGResultHash {
 			sm.logger.Infof(
-				"[member: %v] signature from sender [%d] supports "+
+				"[member:%v] signature from sender [%d] supports "+
 					"result different than preferred",
 				sm.memberIndex,
 				message.senderID,
@@ -439,7 +439,7 @@ func (sm *signingMember) verifyDKGResultSignatures(
 		)
 		if err != nil {
 			sm.logger.Infof(
-				"[member: %v] verification of signature "+
+				"[member:%v] verification of signature "+
 					"from sender [%d] failed: [%v]",
 				sm.memberIndex,
 				message.senderID,
@@ -449,7 +449,7 @@ func (sm *signingMember) verifyDKGResultSignatures(
 		}
 		if !isValid {
 			sm.logger.Infof(
-				"[member: %v] sender [%d] provided invalid signature",
+				"[member:%v] sender [%d] provided invalid signature",
 				sm.memberIndex,
 				message.senderID,
 			)


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/3355

This PR fixes some minor logging issues:
- removes unnecessary space from logs
- makes a hex-string be prepended with `0x`   


Tested the hex-string printing locally:
```
2022-10-11T19:41:35.207+0200    INFOkeep-tbtc       tbtc/tbtc.go:129   signature of message [0xd12ef03bf4a6f3d6dcc5fa8dc2d98d71b3f318d7fd5eed8deae4efaa539cab4a] requested from wallet [0x04e14cbd9eb98da739351c087c78dbbb8f6e42e670e1cd4904e41dbac6e06f41e6348b5ef743feb5f5ad91549942075449d6fbadec2691e8f24d20763580210a9c] at block [1600]
```

 The `signature of message` part contains a hex-string prepended with `0x`.