### PR TITLE
Prevent pre-params generation during DKG

### DIFF
--- a/pkg/generator/pool.go
+++ b/pkg/generator/pool.go
@@ -74,8 +74,8 @@ func NewParameterPool[T any](
 	logger.Infof("loaded [%d] parameters from persistence", len(pool))
 
 	scheduler.compute(func(ctx context.Context) {
-		// Only generate new parameters if the pool is not full. Otherwise
-		// go to sleep.
+		// Only generate a new parameter if the target number of parameters has
+		// not been reached yet. Otherwise do nothing.
 		if len(pool) < poolSize {
 			start := time.Now()
 
@@ -107,7 +107,8 @@ func NewParameterPool[T any](
 		// took some time or not. We want to ensure all other processes of the
 		// client receive access to CPU.
 		// Additionally, make sure the generation delay is at least 1 second,
-		// so that this function is not executed too often.
+		// so that this function is not executed too often when the parameter
+		// target has been reached.
 		if generateDelay < 1*time.Second {
 			generateDelay = 1 * time.Second
 		}

--- a/pkg/generator/pool.go
+++ b/pkg/generator/pool.go
@@ -74,6 +74,8 @@ func NewParameterPool[T any](
 	logger.Infof("loaded [%d] parameters from persistence", len(pool))
 
 	scheduler.compute(func(ctx context.Context) {
+		// Only generate new parameters if the pool is not full. Otherwise
+		// go to sleep.
 		if len(pool) < poolSize {
 			start := time.Now()
 
@@ -104,6 +106,11 @@ func NewParameterPool[T any](
 		// Wait some time after delivering the result regardless if the delivery
 		// took some time or not. We want to ensure all other processes of the
 		// client receive access to CPU.
+		// Additionally, make sure the generation delay is at least 1 second,
+		// so that this function is not executed too often.
+		if generateDelay < 1*time.Second {
+			generateDelay = 1 * time.Second
+		}
 		time.Sleep(generateDelay)
 	})
 


### PR DESCRIPTION
This PR adds a fix for the problem of parameter generating goroutines not being stopped on procedure start.
The problem occurs when the parameter pool is full - the parameter generation goroutine generates one more parameter and it hangs on writing it to the pool. Stopping parameter generation does not stop the goroutine  since it hangs, leaving a memory leak.
Each round of parameter generation (resumption <=> stopping) generate such a hanging goroutine, and they are only stopped by TBTC DKG removing some parameters from the pool.

The simplest solution was to check if the pool is full and if it is so sleep instead of parameter generation.

The solution was tested locally.