### PR TITLE
Vet and lint the Go code in the CI

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -229,3 +229,29 @@ jobs:
             gofmt -d -e .
             exit 1
           fi
+
+  client-vet:
+    needs: client-detect-changes
+    if: |
+      github.event_name == 'push'
+        || needs.client-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+      - run: go vet
+
+  client-lint:
+    needs: client-detect-changes
+    if: |
+      github.event_name == 'push'
+        || needs.client-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Staticcheck
+        uses: dominikh/staticcheck-action@v1.2.0
+
+


### PR DESCRIPTION
We've been already performing some static analysis of the Go code in the CI, by running `gofmt` tool (which checks if the code complies to the formatting standards). But this is not the only tool that can be used to improve the code quality - we can also use `go vet` (which highlights the places in code which may work different than intended) and we can lint code using `Staticcheck` tool (which checks if the code complies to the coding conventions). In this commit we add two jobs to the `client.yml` workflow, which will be used to run those tools. The jobs wil be executed in PRs that may affect the client code and also after those PRs get merged to main.