### PR TITLE
Fast state machine

### DIFF
--- a/pkg/net/local/broadcast_channel.go
+++ b/pkg/net/local/broadcast_channel.go
@@ -3,9 +3,10 @@ package local
 import (
 	"context"
 	"fmt"
-	"github.com/keep-network/keep-core/pkg/operator"
 	"sync"
 	"sync/atomic"
+
+	"github.com/keep-network/keep-core/pkg/operator"
 
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/internal"
@@ -61,7 +62,7 @@ func (lc *localChannel) Send(ctx context.Context, message net.TaggedMarshaler) e
 	netMessage := internal.BasicMessage(
 		lc.identifier,
 		unmarshaled,
-		"local",
+		message.Type(),
 		operatorPublicKeyBytes,
 		lc.nextSeqno(),
 	)

--- a/pkg/net/local/broadcast_channel_test.go
+++ b/pkg/net/local/broadcast_channel_test.go
@@ -2,12 +2,13 @@ package local
 
 import (
 	"context"
-	"github.com/keep-network/keep-core/pkg/operator"
 	"reflect"
 	"sort"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/keep-network/keep-core/pkg/operator"
 
 	"github.com/keep-network/keep-core/pkg/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/net"
@@ -218,7 +219,7 @@ loop:
 				msg.Payload(),
 			)
 		}
-		if "local" != msg.Type() {
+		if mockNetMessageType != msg.Type() {
 			t.Errorf(
 				"invalid type\nexpected: [%+v]\nactual:   [%+v]\n",
 				"local",
@@ -251,10 +252,12 @@ func initTestChannel(channelName string) (*operator.PublicKey, net.BroadcastChan
 	return operatorPublicKey, localChannel, nil
 }
 
+const mockNetMessageType = "mock_message"
+
 type mockNetMessage struct{}
 
 func (mm *mockNetMessage) Type() string {
-	return "mock_message"
+	return mockNetMessageType
 }
 
 func (mm *mockNetMessage) Marshal() ([]byte, error) {

--- a/pkg/protocol/faststate/faststate.go
+++ b/pkg/protocol/faststate/faststate.go
@@ -110,17 +110,12 @@ func (bs *BaseState) receive(msg net.Message) {
 	defer bs.messagesMutex.Unlock()
 
 	messageType := msg.Type()
-	received, ok := bs.messages[messageType]
-
-	if ok {
-		bs.messages[messageType] = append(received, msg)
-	} else {
-		bs.messages[messageType] = []net.Message{msg}
-	}
+	bs.messages[messageType] = append(bs.messages[messageType], msg)
 }
 
 // GetAllReceivedMessages returns all messages of the given Type() received
-// so far.
+// so far. If no messages of the given Type() were received, nil slice is
+// returned.
 func (bs *BaseState) GetAllReceivedMessages(messageType string) []net.Message {
 	bs.messagesMutex.RLock()
 	defer bs.messagesMutex.RUnlock()

--- a/pkg/protocol/faststate/faststate.go
+++ b/pkg/protocol/faststate/faststate.go
@@ -104,8 +104,14 @@ func NewBaseState() *BaseState {
 	}
 }
 
-// receive stores the received message by its Type()
-func (bs *BaseState) receive(msg net.Message) {
+// ReceiveToHistory stores the received message by its Type() in the internal
+// history of received messages.
+//
+// This function is NOT performing any validation of the received net.Message,
+// especially if the public key matches member index or if the given operator is
+// allowed to publish messages in the broadcast channel. This function should
+// be wrapped with a set of validations.
+func (bs *BaseState) ReceiveToHistory(msg net.Message) {
 	bs.messagesMutex.Lock()
 	defer bs.messagesMutex.Unlock()
 

--- a/pkg/protocol/faststate/faststate.go
+++ b/pkg/protocol/faststate/faststate.go
@@ -1,0 +1,129 @@
+// Package faststate contains a generic state machine implementation that is
+// meant to be used with interactive protocols which do not require a strict
+// synchronization mechanism between protocol members. The synchronization is
+// based on an signal from each participant that they are ready to proceed to
+// the next step when, for example, they received all the necessary information
+// from all the other participants.
+//
+// This approach allows for faster execution of protocols but has strict
+// requirements regarding the implementation of states.
+//
+// Requirement 1: Context lifetime and retransmissions
+//
+// The context passed to `faststate.NewMachine` must be active as long as the
+// result is not published to the chain or until a fixed time for the protocol
+// execution has not passed.
+//
+// The context is used for the retransmission of messages and all protocol
+// participants must have a chance to receive messages from other participants.
+//
+// Consider the following example: there are two participants of the protocol:
+// A and B, and they are executing the final state of the protocol. If the
+// context was canceled right after the completion of work by the participant,
+// without a confirmation that the result was published on-chain, we could run
+// into a situation when A received a message from B and exited immediately,
+// without giving B a chance to receive a message:
+//
+// A: |-S------R-|
+// B:        |-S----------(...)
+//
+// |- denotes when the last state starts and -| denotes when it ends. S denotes
+// when the given participant sent its message and R denotes when the given
+// participant received the message from the other. Since B initiated the last
+// state later than A (it could execute some time-consuming computations in the
+// last state), A already sent its message and now B needs to wait for the
+// retransmissions. B sends its message immediately upon the initiation and this
+// message is received by A. Since A exits and cancels the context immediately
+// after receiving a message from B, it is no longer retransmitting its message
+// and B hangs forever.
+//
+// There are two solutions. One is that both A and B observe the chain and they
+// keep the context active until the result is published. Another is that each
+// member waits for some time before completing the protocol and canceling the
+// context for retransmissions or that the entire protocol has a fixed maximum
+// execution time until the timeout.
+//
+// Requirement 2: Store all received messages
+//
+// Since the state machine does not require strict synchronization between
+// participants, it is not guaranteed at which moment of the execution the rest
+// of the group is. If the current member is at the first state of the
+// execution, and all other members advanced to further states, the current
+// member should accept and store messages from further states "for the future"
+// instead of rejecting them. This can be achieved using `faststate.BaseState`
+// structure.
+package faststate
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// State is and interface that should be implemented by protocol states.
+type State interface {
+
+	// CanTransition indicates if the state has all the information needed and
+	// is ready to advance to the next one.
+	CanTransition() bool
+
+	// Initiate performs all the required calculations and sends out all the
+	// messages associated with the current state. The context passed to this
+	// function is scoped to the lifetime of the entire state machine and is
+	// cancelled when te state machine completed. Use this context for message
+	// retransmission to ensure all late protocol participants can catch up.
+	Initiate(ctx context.Context) error
+
+	// Receive is called each time a new message arrived. Receive is expected to
+	// be called for all broadcast channel messages, including the member's own
+	// messages.
+	Receive(msg net.Message) error
+
+	// Next performs a state transition to the next state of the protocol.
+	// If the current state is the last one, nextState returns `nil`.
+	Next() (State, error)
+
+	// MemberIndex returns the index of member associated with the current state.
+	MemberIndex() group.MemberIndex
+}
+
+// BaseState allows to store all received messages even if they are not
+// used for the currently executed state. This is important to allow the state
+// machine to eventually synchronize with other participants if the current
+// state machine is late compared to the rest of the group.
+type BaseState struct {
+	messages      map[string][]net.Message
+	messagesMutex sync.RWMutex
+}
+
+func NewBaseState() *BaseState {
+	return &BaseState{
+		messages: make(map[string][]net.Message),
+	}
+}
+
+// receive stores the received message by its Type()
+func (bs *BaseState) receive(msg net.Message) {
+	bs.messagesMutex.Lock()
+	defer bs.messagesMutex.Unlock()
+
+	messageType := msg.Type()
+	received, ok := bs.messages[messageType]
+
+	if ok {
+		bs.messages[messageType] = append(received, msg)
+	} else {
+		bs.messages[messageType] = []net.Message{msg}
+	}
+}
+
+// GetAllReceivedMessages returns all messages of the given Type() received
+// so far.
+func (bs *BaseState) GetAllReceivedMessages(messageType string) []net.Message {
+	bs.messagesMutex.RLock()
+	defer bs.messagesMutex.RUnlock()
+
+	return bs.messages[messageType]
+}

--- a/pkg/protocol/faststate/faststate_test.go
+++ b/pkg/protocol/faststate/faststate_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/net"
 )
 
-func TestBaseStateReceive(t *testing.T) {
+func TestBaseStateReceiveToHistory(t *testing.T) {
 	const type1 = "faststate/test_type1"
 	const type2 = "faststate/test_type2"
 
@@ -22,10 +22,10 @@ func TestBaseStateReceive(t *testing.T) {
 		t.Fatalf("expected no messages of the second type yet")
 	}
 
-	state.receive(&mockMessage{_type: type1, payload: "a"})
-	state.receive(&mockMessage{_type: type1, payload: "b"})
-	state.receive(&mockMessage{_type: type2, payload: "a"})
-	state.receive(&mockMessage{_type: type1, payload: "c"})
+	state.ReceiveToHistory(&mockMessage{_type: type1, payload: "a"})
+	state.ReceiveToHistory(&mockMessage{_type: type1, payload: "b"})
+	state.ReceiveToHistory(&mockMessage{_type: type2, payload: "a"})
+	state.ReceiveToHistory(&mockMessage{_type: type1, payload: "c"})
 
 	messages = state.GetAllReceivedMessages(type1)
 	testutils.AssertIntsEqual(

--- a/pkg/protocol/faststate/faststate_test.go
+++ b/pkg/protocol/faststate/faststate_test.go
@@ -1,0 +1,65 @@
+package faststate
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/net"
+)
+
+func TestBaseStateReceive(t *testing.T) {
+	const type1 = "faststate/test_type1"
+	const type2 = "faststate/test_type2"
+
+	state := NewBaseState()
+
+	messages := state.GetAllReceivedMessages(type1)
+	if len(messages) != 0 {
+		t.Fatalf("expected no messages of the first type yet")
+	}
+	messages = state.GetAllReceivedMessages(type2)
+	if len(messages) != 0 {
+		t.Fatalf("expected no messages of the second type yet")
+	}
+
+	state.receive(&mockMessage{_type: type1, payload: "a"})
+	state.receive(&mockMessage{_type: type1, payload: "b"})
+	state.receive(&mockMessage{_type: type2, payload: "a"})
+	state.receive(&mockMessage{_type: type1, payload: "c"})
+
+	messages = state.GetAllReceivedMessages(type1)
+	testutils.AssertIntsEqual(
+		t,
+		"number of messages of the first type",
+		3,
+		len(messages),
+	)
+	messages = state.GetAllReceivedMessages(type2)
+	testutils.AssertIntsEqual(
+		t,
+		"number of messages of the second type",
+		1,
+		len(messages),
+	)
+}
+
+type mockMessage struct {
+	payload string
+	_type   string
+}
+
+func (mm *mockMessage) TransportSenderID() net.TransportIdentifier {
+	panic("unsupported in mock")
+}
+func (mm *mockMessage) SenderPublicKey() []byte {
+	panic("unsupported in mock")
+}
+func (mm *mockMessage) Payload() interface{} {
+	return mm.payload
+}
+func (mm *mockMessage) Type() string {
+	return mm._type
+}
+func (mm *mockMessage) Seqno() uint64 {
+	panic("unsupported in mock")
+}

--- a/pkg/protocol/faststate/machine.go
+++ b/pkg/protocol/faststate/machine.go
@@ -117,8 +117,6 @@ func (m *Machine) Execute() (State, error) {
 			if err != nil {
 				return nil, err
 			}
-
-			continue
 		}
 	}
 }

--- a/pkg/protocol/faststate/machine.go
+++ b/pkg/protocol/faststate/machine.go
@@ -1,0 +1,168 @@
+package faststate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/go-log"
+	"github.com/keep-network/keep-core/pkg/net"
+)
+
+// For the entire time of initiating the state transition, messages
+// are not handled. We use a buffer to unblock producers and let
+// them perform optional filtering/validation during that time.
+// The size of that buffer should not be lower than the number of messages
+// which can be delivered by the broadcast channel during the time the state
+// is blocked on initiation.
+// This version of the state machine does not require a strict synchronization
+// between participants, so this number is also the maximum number of messages
+// that could be delivered when the current machine is blocked on initiation
+// and the rest of participants advance with work.
+const receiveBuffer = 512
+
+// The time interval with which the CanTransition of the State condition
+// is checked.
+const transitionCheckInterval = 100 * time.Millisecond
+
+// Machine is a state machine that executes states implementing the State
+// interface.
+type Machine struct {
+	logger       log.StandardLogger
+	ctx          context.Context
+	channel      net.BroadcastChannel
+	initialState State // first state from which execution starts
+}
+
+// NewMachine returns a new protocol state machine.
+// The context passed to `faststate.NewMachine` must be active as long as the
+// result is not published to the chain or until a fixed time for the protocol
+// execution has not passed.
+//
+// The context is used for the retransmission of messages and all protocol
+// participants must have a chance to receive messages from other participants.
+// See `faststate` package documentation for more information.
+func NewMachine(
+	logger log.StandardLogger,
+	ctx context.Context,
+	channel net.BroadcastChannel,
+	initialState State,
+) *Machine {
+	return &Machine{
+		logger:       logger,
+		ctx:          ctx,
+		channel:      channel,
+		initialState: initialState,
+	}
+}
+
+// Execute state machine starting with initial state up to finalization. It
+// requires the broadcast channel to be pre-initialized.
+func (m *Machine) Execute() (State, error) {
+	recvChan := make(chan net.Message, receiveBuffer)
+	handler := func(msg net.Message) {
+		recvChan <- msg
+	}
+	m.channel.Recv(m.ctx, handler)
+
+	currentState := m.initialState
+
+	onStateDone, err := stateTransition(
+		m.ctx,
+		m.logger,
+		currentState,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		select {
+		case msg := <-recvChan:
+			err := currentState.Receive(msg)
+			if err != nil {
+				m.logger.Errorf(
+					"[member:%v,state:%T] failed to receive a message: [%v]",
+					currentState.MemberIndex(),
+					currentState,
+					err,
+				)
+			}
+
+		case <-onStateDone:
+			nextState, err := currentState.Next()
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to complete state [%T]: [%w]",
+					currentState,
+					err,
+				)
+			}
+
+			if nextState == nil {
+				m.logger.Infof(
+					"[member:%v,state:%T] reached final state",
+					currentState.MemberIndex(),
+					currentState,
+				)
+				return currentState, nil
+			}
+
+			currentState = nextState
+			onStateDone, err = stateTransition(
+				m.ctx,
+				m.logger,
+				currentState,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			continue
+		}
+	}
+}
+
+func stateTransition(
+	ctx context.Context,
+	logger log.StandardLogger,
+	currentState State,
+) (<-chan interface{}, error) {
+	logger.Infof(
+		"[member:%v,state:%T] transitioning to a new state",
+		currentState.MemberIndex(),
+		currentState,
+	)
+
+	err := currentState.Initiate(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate new state [%w]", err)
+	}
+
+	onDone := make(chan interface{})
+	ticker := time.NewTicker(transitionCheckInterval)
+
+	go func() {
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if currentState.CanTransition() {
+					close(onDone)
+					return
+				}
+			}
+		}
+	}()
+
+	logger.Infof(
+		"[member:%v,state:%T] transitioned to new state",
+		currentState.MemberIndex(),
+		currentState,
+	)
+
+	return onDone, nil
+}

--- a/pkg/protocol/faststate/machine_test.go
+++ b/pkg/protocol/faststate/machine_test.go
@@ -1,0 +1,232 @@
+package faststate
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/net"
+	netLocal "github.com/keep-network/keep-core/pkg/net/local"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+const (
+	partyCount        = 3
+	round2MessageType = "test/round_2_message"
+	round3MessageType = "test/round_3_message"
+)
+
+func TestExecute(t *testing.T) {
+	provider := netLocal.Connect()
+	channel, err := provider.BroadcastChannelFor("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &round2Message{}
+	})
+	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &round3Message{}
+	})
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	var logger = &testutils.MockLogger{}
+
+	initialState1 := &testState1{
+		BaseState:   NewBaseState(),
+		memberIndex: group.MemberIndex(1),
+		channel:     channel,
+	}
+	initialState2 := &testState1{
+		BaseState:   NewBaseState(),
+		memberIndex: group.MemberIndex(2),
+		channel:     channel,
+	}
+	initialState3 := &testState1{
+		BaseState:   NewBaseState(),
+		memberIndex: group.MemberIndex(3),
+		channel:     channel,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		NewMachine(logger, ctx, channel, initialState1).Execute()
+		wg.Done()
+	}()
+	go func() {
+		NewMachine(logger, ctx, channel, initialState2).Execute()
+		wg.Done()
+	}()
+	go func() {
+		NewMachine(logger, ctx, channel, initialState3).Execute()
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	expectedExecutionLog := "1-initiate 1-done 2-initiate 2-done 3-initiate 3-done"
+	testutils.AssertStringsEqual(
+		t,
+		"member 1 execution log",
+		expectedExecutionLog,
+		strings.Join(initialState1.testLog, " "),
+	)
+	testutils.AssertStringsEqual(
+		t,
+		"member 2 execution log",
+		expectedExecutionLog,
+		strings.Join(initialState2.testLog, " "),
+	)
+	testutils.AssertStringsEqual(
+		t,
+		"member 3 execution log",
+		expectedExecutionLog,
+		strings.Join(initialState3.testLog, " "),
+	)
+}
+
+//
+// testState1 can transition to the next state immediately;
+// it is not receiving or sending any messages.
+//
+type testState1 struct {
+	*BaseState
+
+	memberIndex group.MemberIndex
+	channel     net.BroadcastChannel
+	testLog     []string
+}
+
+func (ts *testState1) addToTestLog(log string) {
+	ts.testLog = append(ts.testLog, log)
+}
+
+func (ts *testState1) CanTransition() bool {
+	return true
+}
+func (ts *testState1) Initiate(ctx context.Context) error {
+	ts.addToTestLog("1-initiate")
+	return nil
+}
+func (ts *testState1) Receive(msg net.Message) error {
+	ts.receive(msg)
+	return nil
+}
+func (ts *testState1) Next() (State, error) {
+	ts.addToTestLog("1-done")
+	return &testState2{testState1: ts}, nil
+}
+func (ts *testState1) MemberIndex() group.MemberIndex { return ts.memberIndex }
+
+//
+// testState2 waits for `partyCount` messages to be received;
+// it is sending one message immediately upon the initiation.
+//
+type testState2 struct {
+	*testState1
+}
+
+func (ts *testState2) CanTransition() bool {
+	return len(ts.GetAllReceivedMessages(round2MessageType)) == partyCount
+}
+func (ts *testState2) Initiate(ctx context.Context) error {
+	ts.addToTestLog("2-initiate")
+	ts.channel.Send(ctx, newRound2Message(strconv.Itoa(int(ts.memberIndex))))
+	return nil
+}
+func (ts *testState2) Receive(msg net.Message) error {
+	ts.receive(msg)
+	return nil
+}
+func (ts *testState2) Next() (State, error) {
+	ts.addToTestLog("2-done")
+	return &testState3{testState2: ts}, nil
+}
+func (ts *testState2) MemberIndex() group.MemberIndex { return ts.memberIndex }
+
+//
+// testState3 waits for `partyCount` messages to be received.
+// It is sending one message after some random delay upon the initiation.
+//
+type testState3 struct {
+	*testState2
+}
+
+func (ts *testState3) CanTransition() bool {
+	return len(ts.GetAllReceivedMessages(round3MessageType)) == partyCount
+}
+func (ts *testState3) Initiate(ctx context.Context) error {
+	ts.addToTestLog("3-initiate")
+	rand.Seed(time.Now().UnixNano())
+	time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+	ts.channel.Send(ctx, newRound3Message(strconv.Itoa(int(ts.memberIndex))))
+	return nil
+}
+func (ts *testState3) Receive(msg net.Message) error {
+	ts.receive(msg)
+	return nil
+}
+func (ts *testState3) Next() (State, error) {
+	ts.addToTestLog("3-done")
+	return nil, nil
+}
+func (ts *testState3) MemberIndex() group.MemberIndex { return ts.memberIndex }
+
+//
+// testState2 message
+//
+type round2Message struct {
+	Type_   string `json:"type"`
+	Payload string `json:"payload"`
+}
+
+func (r2m *round2Message) Type() string {
+	return "test/round_2_message"
+}
+func (r2m *round2Message) Marshal() ([]byte, error) {
+	return json.Marshal(r2m)
+}
+func (r2m *round2Message) Unmarshal(bytes []byte) error {
+	return json.Unmarshal(bytes, r2m)
+}
+func newRound2Message(payload string) *round2Message {
+	return &round2Message{
+		Type_:   round2MessageType,
+		Payload: payload,
+	}
+}
+
+//
+// testState3 message
+//
+type round3Message struct {
+	Type_   string `json:"type"`
+	Payload string `json:"payload"`
+}
+
+func (r3m *round3Message) Type() string {
+	return "test/round_3_message"
+}
+func (r3m *round3Message) Marshal() ([]byte, error) {
+	return json.Marshal(r3m)
+}
+func (r3m *round3Message) Unmarshal(bytes []byte) error {
+	return json.Unmarshal(bytes, r3m)
+}
+func newRound3Message(payload string) *round3Message {
+	return &round3Message{
+		Type_:   round3MessageType,
+		Payload: payload,
+	}
+}

--- a/pkg/protocol/faststate/machine_test.go
+++ b/pkg/protocol/faststate/machine_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/net"
-	netLocal "github.com/keep-network/keep-core/pkg/net/local"
+	netlocal "github.com/keep-network/keep-core/pkg/net/local"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -23,7 +23,7 @@ const (
 )
 
 func TestExecute(t *testing.T) {
-	provider := netLocal.Connect()
+	provider := netlocal.Connect()
 	channel, err := provider.BroadcastChannelFor("test")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/protocol/faststate/machine_test.go
+++ b/pkg/protocol/faststate/machine_test.go
@@ -120,7 +120,7 @@ func (ts *testState1) Initiate(ctx context.Context) error {
 	return nil
 }
 func (ts *testState1) Receive(msg net.Message) error {
-	ts.receive(msg)
+	ts.ReceiveToHistory(msg)
 	return nil
 }
 func (ts *testState1) Next() (State, error) {
@@ -146,7 +146,7 @@ func (ts *testState2) Initiate(ctx context.Context) error {
 	return nil
 }
 func (ts *testState2) Receive(msg net.Message) error {
-	ts.receive(msg)
+	ts.ReceiveToHistory(msg)
 	return nil
 }
 func (ts *testState2) Next() (State, error) {
@@ -174,7 +174,7 @@ func (ts *testState3) Initiate(ctx context.Context) error {
 	return nil
 }
 func (ts *testState3) Receive(msg net.Message) error {
-	ts.receive(msg)
+	ts.ReceiveToHistory(msg)
 	return nil
 }
 func (ts *testState3) Next() (State, error) {

--- a/pkg/protocol/faststate/machine_test.go
+++ b/pkg/protocol/faststate/machine_test.go
@@ -36,8 +36,8 @@ func TestExecute(t *testing.T) {
 		return &round3Message{}
 	})
 
-	ctx, cancelFn := context.WithCancel(context.Background())
-	defer cancelFn()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
 
 	var logger = &testutils.MockLogger{}
 

--- a/pkg/protocol/state/machine.go
+++ b/pkg/protocol/state/machine.go
@@ -26,9 +26,7 @@ type Machine struct {
 	initialState State // first state from which execution starts
 }
 
-// NewMachine returns a new protocol state machine. It requires a broadcast
-// channel and an initialization function for the channel to be able to
-// perform interactions between protocol parties.
+// NewMachine returns a new protocol state machine.
 func NewMachine(
 	logger log.StandardLogger,
 	channel net.BroadcastChannel,
@@ -150,10 +148,11 @@ func stateTransition(
 		lastStateEndBlockHeight,
 	)
 
-	// We delay the initialization of the new state by one block to give all
-	// other coopearating state machines a chance to enter the new state.
-	// This is needed when, for example, during the initialization some
-	// state-specific messages are sent.
+	// We delay the initialization of the new state by `initiateDelay` of blocks
+	// to give all other participants a chance to enter the new state. This is
+	// needed when state accepts only messages specific to that state.
+	// In that case, if the message is sent too early, it is lost given that the
+	// receiveBuffer has the retransmissions filtered out.
 	initiateDelay := lastStateEndBlockHeight + currentState.DelayBlocks()
 	err := blockCounter.WaitForBlockHeight(initiateDelay)
 	if err != nil {

--- a/pkg/protocol/state/machine.go
+++ b/pkg/protocol/state/machine.go
@@ -12,9 +12,12 @@ import (
 // For the entire time of state transition (delay + initiate), messages
 // are not handled. We use a buffer to unblock producers and let
 // them perform optional filtering/validation during that time.
-// The size of that buffer should be equal to the biggest possible
-// message count which can be delivered by the broadcast channel
-// in the same moment.
+// The size of that buffer should not be lower than the number of messages
+// which can be delivered by the broadcast channel during the time the state
+// is blocked on initiation.
+// This version of the state machine requires a strict synchronization between
+// participants, so this number is also the maximum number of messages that
+// could be delivered in a single state.
 const receiveBuffer = 128
 
 // Machine is a state machine that executes states implementing the State

--- a/pkg/protocol/state/machine.go
+++ b/pkg/protocol/state/machine.go
@@ -131,8 +131,6 @@ func (m *Machine) Execute(startBlockHeight uint64) (State, uint64, error) {
 				cancelCtx()
 				return nil, 0, err
 			}
-
-			continue
 		}
 	}
 }

--- a/pkg/protocol/state/state.go
+++ b/pkg/protocol/state/state.go
@@ -1,6 +1,10 @@
 // Package state contains a generic state machine implementation that is
 // meant to be used with interactive protocols which require a synchronization
-// mechanism between protocol members.
+// mechanism between protocol members. The synchronization is based on
+// a fixed number of active and delay blocks. Even if the given participant
+// received all the necessary information to continue the protocol, the state
+// machine waits with proceeding to the next step for the fixed duration of
+// blocks.
 package state
 
 import (


### PR DESCRIPTION
Package `faststate` contains a generic state machine implementation that is meant to be used with interactive protocols which do not require a strict synchronization mechanism between protocol members. The synchronization is based on an signal from each participant that they are ready to proceed to the next step when, for example, they received all the necessary information from all the other participants.

This approach allows for faster execution of protocols but has strict requirements regarding the implementation of states.

# Requirement 1: Context lifetime and retransmissions

The context passed to `faststate.NewMachine` must be active as long as the result is not published to the chain or until a fixed time for the protocol execution has not passed.

The context is used for the retransmission of messages and all protocol participants must have a chance to receive messages from other participants. Consider the following example: there are two participants of the protocol: A and B, and they are executing the final state of the protocol. If the context was canceled right after the completion of work by the participant, without a confirmation that the result was published on-chain, we could run into a situation when A received a message from B and exited immediately, without giving B a chance to receive a message:
```
A: |-S------R-|
B:        |-S----------(...)
```
`|-` denotes when the last state starts and `-|` denotes when it ends. `S` denotes when the given participant sent its message and `R` denotes when the given participant received the message from the other. Since B initiated the last state later than A (it could execute some time-consuming computations in the last state), A already sent its message and now B needs to wait for the retransmissions. B sends its message immediately upon the initiation and this message is received by A. Since A exits and cancels the context immediately after receiving a message from B, it is no longer retransmitting its message and B hangs forever.

There are two solutions. One is that both A and B observe the chain and they keep the context active until the result is published. Another is that each member waits for some time before completing the protocol and canceling the context for retransmissions or that the entire protocol has a fixed maximum execution time until the timeout.

# Requirement 2: Store all received messages

Since the state machine does not require strict synchronization between participants, it is not guaranteed at which moment of the execution the rest of the group is. If the current member is at the first state of the execution, and all other members advanced to further states, the current member should accept and store messages from further states "for the future" instead of rejecting them. This can be achieved using `faststate.BaseState` structure.