### PR TITLE
Fix the link for Mainnet Contracts Addresses

### DIFF
--- a/docs/registration.adoc
+++ b/docs/registration.adoc
@@ -122,10 +122,8 @@ For each of the `RandomBeacon` and `WalletRegistry` contracts perform the follow
 4. Submit the `registerOperator` function with your Operator address as an argument.
 
 Please see the 
-link:https://docs.threshold.network/extras/contract-addresses#keep-network-contracts[Keep Network Contract Addresses]
+link:https://docs.threshold.network/extras/contract-addresses/ethereum-mainnet[Ethereum Mainnet Contract Addresses]
 page for the recent Mainnet addresses of the contracts.
-// TODO: Add section with the Keep Network contracts addresses to the Threshold Network docs.
-
 
 NOTE: icon:flask[] For addresses of Testnet contracts please visit the
 link:https://docs.threshold.network/extras/contract-addresses/goerli-testnet#tbtc-application-contracts[link].


### PR DESCRIPTION
Instead of linking to the Contracts Addresses main page, we link to the subpage dedicated to Mainnet contracts Addresses. We also remove lo longer valid TODO.