### PR TITLE
Increase scan timeout to 3 seconds

### DIFF
--- a/infrastructure/kube/keep-prd/monitoring/prometheus/prometheus-deployment.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/prometheus/prometheus-deployment.yaml
@@ -66,6 +66,7 @@ spec:
             - --source.address=bst-a01.tbtc.boar.network:9601
             - --source.address=bst-b01.tbtc.boar.network:9601
             - --refresh.interval=5m
+            - --scan.timeout=3s
             - --log.json
           resources:
             limits:

--- a/infrastructure/kube/keep-test/monitoring/prometheus/prometheus-deployment.yaml
+++ b/infrastructure/kube/keep-test/monitoring/prometheus/prometheus-deployment.yaml
@@ -66,6 +66,7 @@ spec:
             - --source.address=bootstrap-0.test.keep.network:9601
             - --source.address=bootstrap-1.test.keep.network:9601
             - --refresh.interval=5m
+            - --scan.timeout=3s
             - --log.json
             - --scan.allowPrivateAddresses
           resources:


### PR DESCRIPTION
1 second was too agressive, as some nodes were failing scanning due to
  long response time.