### PR TITLE
Add `staticcheck` to Go pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
  - repo: https://github.com/keep-network/pre-commit-golang.git
-   rev: 979f199 # update after merging https://github.com/keep-network/pre-commit-golang/pull/5 
+   rev: 466ade9296d8445d520ec7ab246a30cfa8a07b71
    hooks:
     - id: go-imports
     - id: go-vet

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 repos:
  - repo: https://github.com/keep-network/pre-commit-golang.git
-   rev: 4cc73f21101f9da1208719b02bbbe0a4c491497e
+   rev: 979f199 # update after merging https://github.com/keep-network/pre-commit-golang/pull/5 
    hooks:
     - id: go-imports
     - id: go-vet
     - id: go-fmt
+    - id: staticcheck
  - repo: https://github.com/keep-network/pre-commit-hooks.git
    rev: 63e729f
    hooks:

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -20,7 +20,7 @@ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 echo "Installing precommit requirements..."
 brew list pre-commit &>/dev/null || brew install pre-commit
 go install golang.org/x/tools/cmd/goimports@latest
-go install golang.org/x/lint/golint@latest
+go install honnef.co/go/tools/cmd/staticcheck@latest
 
 echo "Installing jq..."
 brew list jq &>/dev/null || brew install jq


### PR DESCRIPTION
[The Go's `lint` tool got deprecated](https://github.com/golang/lint) some time ago. It can be replaced by the `staticcheck` tool, which offers similar functionalities.

In the `keep-network/keep-core` project we've previously added a GH Action job that runs the `staticcheck` tool as part of the CI. We want now to also add it to the Go pre-commit hooks, so that developers could be informed about the problems in their code before they push it to the remote repository. In a separate PR we've adding a new custom hook to the `keep-network/pre-commit-golang` repository. In this PR we're changing the config to use that new custom hook. We're also removing deprecated `lint` hook from the config.
Apart from modifyng the `.pre-commit-config.yaml` we're also updating the `macos-setup.sh` script - so that it would be in line with the modified config.

To adjust the pre-commit hooks on local machine to the new configuration users should:
1. Install the `staticcheck` tool:
```
go install honnef.co/go/tools/cmd/staticcheck@latest
```
2. Apply the pre-commit hooks config:
```
pre-commit install --install-hooks
```

Ref: https://github.com/keep-network/pre-commit-golang/pull/5

TODO:

- [x] Update the `rev` value after https://github.com/keep-network/pre-commit-golang/pull/5 gets merged
- [x] Set the `client-lint` and `client-vet` as required for PR merge (@nkuba)