### PR TITLE
Introduce broadcast channel retransmission strategies

### DIFF
--- a/pkg/internal/interception/interception.go
+++ b/pkg/internal/interception/interception.go
@@ -56,7 +56,11 @@ func (c *channel) Name() string {
 	return c.delegate.Name()
 }
 
-func (c *channel) Send(ctx context.Context, m net.TaggedMarshaler) error {
+func (c *channel) Send(
+	ctx context.Context,
+	m net.TaggedMarshaler,
+	strategy ...net.RetransmissionStrategy,
+) error {
 	altered := c.rules(m)
 	if altered == nil {
 		// drop the message

--- a/pkg/net/retransmission/retransmission_test.go
+++ b/pkg/net/retransmission/retransmission_test.go
@@ -23,6 +23,7 @@ func TestRetransmitExpectedNumberOfTimes(t *testing.T) {
 			atomic.AddUint64(&retransmissionsCount, 1)
 			return nil
 		},
+		WithStandardStrategy(),
 	)
 
 	<-ctx.Done()

--- a/pkg/net/retransmission/strategy.go
+++ b/pkg/net/retransmission/strategy.go
@@ -1,0 +1,74 @@
+package retransmission
+
+import "github.com/keep-network/keep-core/pkg/net"
+
+// Strategy represents a specific retransmission strategy.
+type Strategy interface {
+	// Tick asks the strategy to run the provided retransmission routine.
+	// The strategy uses their internal state and logic to decide whether to
+	// call the retransmission function or not.
+	Tick(retransmitFn RetransmitFn) error
+}
+
+// WithStrategy is a strategy factory function that returns the requested
+// strategy instance.
+func WithStrategy(strategy net.RetransmissionStrategy) Strategy {
+	switch strategy {
+	case net.StandardRetransmissionStrategy:
+		return WithStandardStrategy()
+	case net.BackoffRetransmissionStrategy:
+		return WithBackoffStrategy()
+	default:
+		panic("retransmission strategy not implemented")
+	}
+}
+
+// StandardStrategy is the basic retransmission strategy that triggers the
+// retransmission routine on every tick.
+type StandardStrategy struct{}
+
+// WithStandardStrategy uses the StandardStrategy as the retransmission
+// strategy.
+func WithStandardStrategy() *StandardStrategy {
+	return &StandardStrategy{}
+}
+
+// Tick implements the Strategy.Tick function.
+func (ss *StandardStrategy) Tick(retransmitFn RetransmitFn) error {
+	return retransmitFn()
+}
+
+// BackoffStrategy is a retransmission strategy that triggers the retransmission
+// routine with an exponentially increasing delay. That is, the delay between
+// first and second retransmission is 1 tick, between second and third is 2
+// ticks, between third and fourth is 4 ticks and so on. Graphically, the
+// schedule looks as follows: R _ R _ _ R _ _ _ _  R _ _ _ _ _ _ _ _ R
+type BackoffStrategy struct {
+	tickCounter    uint64
+	delay          uint64
+	retransmitTick uint64
+}
+
+// WithBackoffStrategy uses the BackoffStrategy as the retransmission
+// strategy.
+func WithBackoffStrategy() *BackoffStrategy {
+	return &BackoffStrategy{
+		tickCounter:    0,
+		delay:          1,
+		retransmitTick: 1,
+	}
+}
+
+// Tick implements the Strategy.Tick function.
+func (bos *BackoffStrategy) Tick(retransmitFn RetransmitFn) error {
+	bos.tickCounter++
+
+	if bos.tickCounter == bos.retransmitTick {
+		bos.retransmitTick += bos.delay + 1
+		bos.delay *= 2
+
+		return retransmitFn()
+	}
+
+	return nil
+}

--- a/pkg/net/retransmission/strategy_test.go
+++ b/pkg/net/retransmission/strategy_test.go
@@ -1,0 +1,79 @@
+package retransmission
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStandardStrategy(t *testing.T) {
+	strategy := WithStandardStrategy()
+
+	retransmitInvocations := make(map[int]bool)
+
+	for i := 1; i <= 10; i++ {
+		err := strategy.Tick(func() error {
+			retransmitInvocations[i] = true
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	expectedRetransmitInvocations := map[int]bool{
+		1:  true,
+		2:  true,
+		3:  true,
+		4:  true,
+		5:  true,
+		6:  true,
+		7:  true,
+		8:  true,
+		9:  true,
+		10: true,
+	}
+	if !reflect.DeepEqual(expectedRetransmitInvocations, retransmitInvocations) {
+		t.Errorf(
+			"unexpected invocations\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedRetransmitInvocations,
+			retransmitInvocations,
+		)
+	}
+}
+
+func TestBackoffStrategy(t *testing.T) {
+	strategy := WithBackoffStrategy()
+
+	retransmitInvocations := make(map[int]bool)
+
+	for i := 1; i <= 100; i++ {
+		err := strategy.Tick(func() error {
+			retransmitInvocations[i] = true
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	expectedRetransmitInvocations := map[int]bool{
+		1:  true,
+		3:  true,
+		6:  true,
+		11: true,
+		20: true,
+		37: true,
+		70: true,
+	}
+	if !reflect.DeepEqual(expectedRetransmitInvocations, retransmitInvocations) {
+		t.Errorf(
+			"unexpected invocations\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedRetransmitInvocations,
+			retransmitInvocations,
+		)
+	}
+}


### PR DESCRIPTION
Refs: #3366

So far, the broadcast channel used a simple retransmission strategy that triggered a new retransmission on every new tick. Such an aggressive approach turned out to be not suitable for all use cases. Specifically, this approach tends to cause network congestion if a large amount of messages is retransmitted for a long time. To make the retransmission mechanism more flexible, here we introduce the way to customize it through strategies. We are also adding an implementation of a backoff strategy that decreases its retransmission frequency over time in an exponential way.