### PR TITLE
Update actions using deprecated commands

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -71,10 +71,10 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -82,7 +82,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build Docker Build Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           target: build-docker
           tags: go-build-env
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build Docker Runtime Image
         if: github.event_name != 'workflow_dispatch'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           target: runtime-docker
           labels: |
@@ -112,7 +112,7 @@ jobs:
 
       - name: Login to Google Container Registry
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.GCR_REGISTRY_URL }}
           username: _json_key
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build and publish Docker Runtime Image
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         env:
           IMAGE_NAME: "keep-client"
         with:


### PR DESCRIPTION
As explained in
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, the `set-output` and `save-state` GH Action commands will become deprecated after 31st May 2023. In our `Client` workflow we use some actions that use those commands in their code. All those actions already published new versions which do not use the problematic code. We're now updating our workflow to use the latest versions of those actions.

Ref:
https://github.com/threshold-network/token-dashboard/pull/312