### PR TITLE
Fixing client docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,7 @@ token-tracker/
 # Legacy V1 contracts bindings.
 # We won't generate new bindings in the docker build process, but use the existing ones.
 !pkg/chain/gen
+
+pkg/chain/ethereum/threshold/gen/_address/TokenStaking
+pkg/chain/ethereum/beacon/gen/_address/RandomBeacon
+pkg/chain/ethereum/ecdsa/gen/_address/WalletRegistry

--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,7 @@ token-tracker/
 # We won't generate new bindings in the docker build process, but use the existing ones.
 !pkg/chain/gen
 
-pkg/chain/ethereum/threshold/gen/_address/TokenStaking
-pkg/chain/ethereum/beacon/gen/_address/RandomBeacon
-pkg/chain/ethereum/ecdsa/gen/_address/WalletRegistry
+# Contract addresses.
+# We do not want to overwrite extracted contract addresses with empty content while
+# coping local root directory to docker image context.
+**/gen/_address/*

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build Docker Build Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           target: build-docker
           tags: go-build-env
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build Docker Runtime Image
         if: github.event_name != 'workflow_dispatch'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           target: runtime-docker
           labels: |
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build and publish Docker Runtime Image
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         env:
           IMAGE_NAME: "keep-client"
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -92,6 +92,7 @@ jobs:
           load: true # load image to local registry to use it in next steps
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+          context: .
 
       - name: Run Go tests
         run: |
@@ -109,6 +110,7 @@ jobs:
             version=${{ env.version }}
             revision=${{ env.revision }}
           push: false
+          context: .
 
       - name: Login to Google Container Registry
         if: github.event_name == 'workflow_dispatch'
@@ -138,6 +140,7 @@ jobs:
             VERSION=${{ env.version }}
             REVISION=${{ env.revision }}
           push: true
+          context: .
 
       - name: Build Client Binaries
         uses: docker/build-push-action@v3
@@ -149,6 +152,7 @@ jobs:
             VERSION=${{ env.version }}
             REVISION=${{ env.revision }}
           push: false
+          context: .
 
       - name: Archive Client Binaries
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY ./pkg/tbtc/gen $APP_DIR/pkg/tbtc/gen
 COPY ./pkg/tecdsa/dkg/gen $APP_DIR/pkg/tecdsa/dkg/gen
 COPY ./pkg/tecdsa/signing/gen $APP_DIR/pkg/tecdsa/signing/gen
 COPY ./pkg/tecdsa/gen $APP_DIR/pkg/tecdsa/gen
+COPY ./pkg/protocol/announcer/gen $APP_DIR/pkg/protocol/announcer/gen
 
 # Environment is to download published and tagged NPM packages versions.
 ARG ENVIRONMENT


### PR DESCRIPTION
The current version of Dockerfile is split into a couple of layers. The
top layers are responsible for Go code generators. However, part of this
generation includes the extraction of addresses from three contracts:
TokenStaking, RandomBeacon, and WalletRegistry. Addresses are written in
the files that the client will later use during the startup.
But the following `COPY` command that copies the root dir to a Docker working dir
overwrites these 3 files with empty content. To mitigate the issue, we
can exclude these 3 files from the Docker context and they won't
overwrite addresses as part of `COPY ./ $APP_DIR/` command.