### PR TITLE
Upgrade grafana to v9.2.5

### DIFF
--- a/infrastructure/kube/keep-prd/monitoring/grafana/grafana-deployment.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/grafana/grafana-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: grafana
-          image: grafana/grafana:9.1.8
+          image: grafana/grafana:9.2.5
           env:
             - name: GF_SERVER_DOMAIN
               value: monitoring.threshold.network

--- a/infrastructure/kube/keep-test/monitoring/grafana/grafana-deployment.yaml
+++ b/infrastructure/kube/keep-test/monitoring/grafana/grafana-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: grafana
-          image: grafana/grafana:9.1.8
+          image: grafana/grafana:9.2.5
           env:
             - name: GF_SERVER_DOMAIN
               value: monitoring.test.keep.network


### PR DESCRIPTION
Grafana had problems with connecting to Prometheus, returning meaningless errors. Upgrading it to the latest version fixed the issue.