### PR TITLE
Increase announcer's receiver buffer to 512

### DIFF
--- a/pkg/protocol/announcer/announcer.go
+++ b/pkg/protocol/announcer/announcer.go
@@ -67,19 +67,16 @@ func (am *announcementMessage) Type() string {
 // readiness announcement over the provided broadcast channel.
 type Announcer struct {
 	protocolID          string
-	groupSize           int
 	broadcastChannel    net.BroadcastChannel
 	membershipValidator *group.MembershipValidator
 }
 
 // New creates a new instance of the Announcer. It expects a unique protocol
-// identifier, the size of the group performing the protocol, a broadcast
-// channel configured to mediate between group members, and a membership
-// validator configured to validate the group membership of announcements
-// senders.
+// identifier, a broadcast channel configured to mediate between group members,
+// and a membership validator configured to validate the group membership of
+// announcements senders.
 func New(
 	protocolID string,
-	groupSize int,
 	broadcastChannel net.BroadcastChannel,
 	membershipValidator *group.MembershipValidator,
 ) *Announcer {
@@ -89,7 +86,6 @@ func New(
 
 	return &Announcer{
 		protocolID:          protocolID,
-		groupSize:           groupSize,
 		broadcastChannel:    broadcastChannel,
 		membershipValidator: membershipValidator,
 	}

--- a/pkg/protocol/announcer/announcer_test.go
+++ b/pkg/protocol/announcer/announcer_test.go
@@ -2,6 +2,11 @@ package announcer
 
 import (
 	"context"
+	"math/big"
+	"reflect"
+	"sync"
+	"testing"
+
 	fuzz "github.com/google/gofuzz"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
@@ -10,10 +15,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/net/local"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
-	"math/big"
-	"reflect"
-	"sync"
-	"testing"
 )
 
 func TestAnnouncementMessage_MarshalingRoundtrip(t *testing.T) {
@@ -150,7 +151,6 @@ func TestAnnouncer(t *testing.T) {
 
 			announcer := New(
 				protocolID,
-				groupSize,
 				broadcastChannel,
 				membershipValidator,
 			)

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -205,7 +205,6 @@ func (n *node) joinDKGIfEligible(seed *big.Int, startBlockNumber uint64) {
 
 				announcer := announcer.New(
 					fmt.Sprintf("%v-%v", ProtocolName, "dkg"),
-					n.chain.GetConfig().GroupSize,
 					broadcastChannel,
 					membershipValidator,
 				)

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -214,7 +214,6 @@ func (se *signingExecutor) sign(
 
 			announcer := announcer.New(
 				fmt.Sprintf("%v-%v", ProtocolName, "signing"),
-				se.chainConfig.GroupSize,
 				se.broadcastChannel,
 				se.membershipValidator,
 			)


### PR DESCRIPTION
Closes #3419
Depends on #3422

During the tests of the code orchestrating tECDSA signing in, we noticed the announcer's buffer sometimes gets full and the messages are dropped with the famous "message handler is too slow" warning. It turns out that the problem lies in the size of the buffer used by the announcer. Before a message in which the announcer is not interested is dropped, it is buffered in this channel. This also includes retransmissions from the previous signing protocols because the retransmission cache filter is scoped to the given `Recv` handler:
```
func WithRetransmissionSupport(delegate func(m net.Message)) func(m net.Message) {
  mutex := &sync.Mutex{}
  cache := make(map[string]bool)
  // (...)
}
```

The announcer's buffer size has been increased to 512 elements, just like the buffer of the asynchronous state machine, and the problem seems to be gone based on local machine tests.