### PR TITLE
DKG saga, part 3: Adjusted the memberID / memberIndex nomenclature

### DIFF
--- a/pkg/beacon/dkg/dkg.go
+++ b/pkg/beacon/dkg/dkg.go
@@ -62,7 +62,7 @@ func ExecuteDKG(
 
 	startPublicationBlockHeight := gjkrEndBlockHeight
 
-	operatingMemberIDs := gjkrResult.Group.OperatingMemberIDs()
+	operatingMemberIndexes := gjkrResult.Group.OperatingMemberIndexes()
 
 	dkgResultChannel := make(chan *event.DKGResultSubmission)
 	dkgResultSubscription := beaconChain.OnDKGResultSubmitted(
@@ -97,7 +97,7 @@ func ExecuteDKG(
 			err,
 		)
 
-		if operatingMemberIDs, err = decideMemberFate(
+		if operatingMemberIndexes, err = decideMemberFate(
 			memberIndex,
 			gjkrResult,
 			dkgResultChannel,
@@ -111,7 +111,7 @@ func ExecuteDKG(
 
 	groupOperators, err := resolveGroupOperators(
 		selectedOperators,
-		operatingMemberIDs,
+		operatingMemberIndexes,
 		beaconConfig,
 	)
 	if err != nil {
@@ -180,14 +180,14 @@ func decideMemberFate(
 
 	// Construct a new view of the operating members according to the accepted
 	// DKG result.
-	operatingMemberIDs := make([]group.MemberIndex, 0)
-	for _, memberID := range gjkrResult.Group.MemberIDs() {
+	operatingMemberIndexes := make([]group.MemberIndex, 0)
+	for _, memberID := range gjkrResult.Group.MemberIndexes() {
 		if _, isMisbehaved := misbehavedSet[memberID]; !isMisbehaved {
-			operatingMemberIDs = append(operatingMemberIDs, memberID)
+			operatingMemberIndexes = append(operatingMemberIndexes, memberID)
 		}
 	}
 
-	return operatingMemberIDs, nil
+	return operatingMemberIndexes, nil
 }
 
 func waitForDkgResultEvent(

--- a/pkg/beacon/dkg/dkg_test.go
+++ b/pkg/beacon/dkg/dkg_test.go
@@ -49,7 +49,7 @@ func TestDecideMemberFate_HappyPath(t *testing.T) {
 		Misbehaved:     []byte{7, 10},
 	}
 
-	operatingMemberIDs, err := decideMemberFate(
+	operatingMemberIndexes, err := decideMemberFate(
 		playerIndex,
 		gjkrResult,
 		dkgResultChannel,
@@ -65,12 +65,12 @@ func TestDecideMemberFate_HappyPath(t *testing.T) {
 		)
 	}
 
-	expectedOperatingMemberIDs := []group.MemberIndex{1, 2, 3, 4, 5, 6, 8, 9}
-	if !reflect.DeepEqual(expectedOperatingMemberIDs, operatingMemberIDs) {
+	expectedOperatingMemberIndexes := []group.MemberIndex{1, 2, 3, 4, 5, 6, 8, 9}
+	if !reflect.DeepEqual(expectedOperatingMemberIndexes, operatingMemberIndexes) {
 		t.Errorf(
 			"unexpected operating members\nexpected: %v\nactual:   %v\n",
-			expectedOperatingMemberIDs,
-			operatingMemberIDs,
+			expectedOperatingMemberIndexes,
+			operatingMemberIndexes,
 		)
 	}
 }

--- a/pkg/beacon/dkg/result/conversion.go
+++ b/pkg/beacon/dkg/result/conversion.go
@@ -1,8 +1,9 @@
 package result
 
 import (
-	beaconchain "github.com/keep-network/keep-core/pkg/beacon/chain"
 	"sort"
+
+	beaconchain "github.com/keep-network/keep-core/pkg/beacon/chain"
 
 	"github.com/keep-network/keep-core/pkg/beacon/gjkr"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -55,8 +56,8 @@ func convertGjkrResult(gjkrResult *gjkr.Result) *beaconchain.DKGResult {
 	return &beaconchain.DKGResult{
 		GroupPublicKey: groupPublicKey,
 		Misbehaved: convertToMisbehaved(
-			gjkrResult.Group.InactiveMemberIDs(),
-			gjkrResult.Group.DisqualifiedMemberIDs(),
+			gjkrResult.Group.InactiveMemberIndexes(),
+			gjkrResult.Group.DisqualifiedMemberIndexes(),
 		),
 	}
 }

--- a/pkg/beacon/dkg/result/conversion_test.go
+++ b/pkg/beacon/dkg/result/conversion_test.go
@@ -1,9 +1,10 @@
 package result
 
 import (
-	beaconchain "github.com/keep-network/keep-core/pkg/beacon/chain"
 	"math/big"
 	"testing"
+
+	beaconchain "github.com/keep-network/keep-core/pkg/beacon/chain"
 
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 	"github.com/keep-network/keep-core/pkg/beacon/gjkr"
@@ -15,14 +16,14 @@ func TestConvertResult(t *testing.T) {
 	marshalledPublicKey := publicKey.Marshal()
 
 	var tests = map[string]struct {
-		disqualifiedMemberIDs []group.MemberIndex
-		inactiveMemberIDs     []group.MemberIndex
-		gjkrResult            *gjkr.Result
-		expectedResult        *beaconchain.DKGResult
+		disqualifiedMemberIndexes []group.MemberIndex
+		inactiveMemberIndexes     []group.MemberIndex
+		gjkrResult                *gjkr.Result
+		expectedResult            *beaconchain.DKGResult
 	}{
 		"group public key not provided, DQ and IA empty": {
-			disqualifiedMemberIDs: []group.MemberIndex{},
-			inactiveMemberIDs:     []group.MemberIndex{},
+			disqualifiedMemberIndexes: []group.MemberIndex{},
+			inactiveMemberIndexes:     []group.MemberIndex{},
 			gjkrResult: &gjkr.Result{
 				GroupPublicKey: nil,
 				Group:          group.NewGroup(32, 64),
@@ -33,8 +34,8 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		"group public key provided, DQ and IA empty": {
-			disqualifiedMemberIDs: []group.MemberIndex{},
-			inactiveMemberIDs:     []group.MemberIndex{},
+			disqualifiedMemberIndexes: []group.MemberIndex{},
+			inactiveMemberIndexes:     []group.MemberIndex{},
 			gjkrResult: &gjkr.Result{
 				GroupPublicKey: publicKey,
 				Group:          group.NewGroup(32, 64),
@@ -45,8 +46,8 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		"group public key provided, both DQ and IA non-empty": {
-			disqualifiedMemberIDs: []group.MemberIndex{1, 4, 3, 50},
-			inactiveMemberIDs:     []group.MemberIndex{5, 3, 50},
+			disqualifiedMemberIndexes: []group.MemberIndex{1, 4, 3, 50},
+			inactiveMemberIndexes:     []group.MemberIndex{5, 3, 50},
 			gjkrResult: &gjkr.Result{
 				GroupPublicKey: publicKey,
 				Group:          group.NewGroup(32, 64),
@@ -57,8 +58,8 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		"group public key provided, DQ empty, IA non-empty": {
-			disqualifiedMemberIDs: []group.MemberIndex{},
-			inactiveMemberIDs:     []group.MemberIndex{5},
+			disqualifiedMemberIndexes: []group.MemberIndex{},
+			inactiveMemberIndexes:     []group.MemberIndex{5},
 			gjkrResult: &gjkr.Result{
 				GroupPublicKey: publicKey,
 				Group:          group.NewGroup(32, 64),
@@ -69,8 +70,8 @@ func TestConvertResult(t *testing.T) {
 			},
 		},
 		"group public key provided, DQ non-empty, IA empty": {
-			disqualifiedMemberIDs: []group.MemberIndex{60, 1, 5},
-			inactiveMemberIDs:     []group.MemberIndex{},
+			disqualifiedMemberIndexes: []group.MemberIndex{60, 1, 5},
+			inactiveMemberIndexes:     []group.MemberIndex{},
 			gjkrResult: &gjkr.Result{
 				GroupPublicKey: publicKey,
 				Group:          group.NewGroup(32, 64),
@@ -82,11 +83,11 @@ func TestConvertResult(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		for _, disqualifiedMember := range test.disqualifiedMemberIDs {
+		for _, disqualifiedMember := range test.disqualifiedMemberIndexes {
 			test.gjkrResult.Group.MarkMemberAsDisqualified(disqualifiedMember)
 		}
 
-		for _, inactiveMember := range test.inactiveMemberIDs {
+		for _, inactiveMember := range test.inactiveMemberIndexes {
 			test.gjkrResult.Group.MarkMemberAsInactive(inactiveMember)
 		}
 

--- a/pkg/beacon/gjkr/member.go
+++ b/pkg/beacon/gjkr/member.go
@@ -1,8 +1,9 @@
 package gjkr
 
 import (
-	"github.com/ipfs/go-log/v2"
 	"math/big"
+
+	"github.com/ipfs/go-log/v2"
 
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
@@ -42,7 +43,7 @@ type LocalMember struct {
 
 // EphemeralKeyPairGeneratingMember represents one member in a distributed key
 // generating group performing ephemeral key pair generation. It has a full list
-// of `memberIDs` that belong to its threshold group.
+// of `memberIndexes` that belong to its threshold group.
 //
 // Executes Phase 1 of the protocol.
 type EphemeralKeyPairGeneratingMember struct {

--- a/pkg/beacon/gjkr/protocol.go
+++ b/pkg/beacon/gjkr/protocol.go
@@ -34,7 +34,7 @@ func (em *EphemeralKeyPairGeneratingMember) GenerateEphemeralKeyPair() (
 	ephemeralKeys := make(map[group.MemberIndex]*ephemeral.PublicKey)
 
 	// Calculate ephemeral key pair for every other group member
-	for _, member := range em.group.MemberIDs() {
+	for _, member := range em.group.MemberIndexes() {
 		if member == em.ID {
 			// don’t actually generate a key with ourselves
 			continue
@@ -131,7 +131,7 @@ func (sm *SymmetricKeyGeneratingMember) GenerateSymmetricKeys(
 func (sm *SymmetricKeyGeneratingMember) isValidEphemeralPublicKeyMessage(
 	message *EphemeralPublicKeyMessage,
 ) bool {
-	for _, memberID := range sm.group.MemberIDs() {
+	for _, memberID := range sm.group.MemberIndexes() {
 		if memberID == message.senderID {
 			// Message contains ephemeral public keys only for other group members
 			continue
@@ -189,7 +189,7 @@ func (cm *CommittingMember) CalculateMembersSharesAndCommitments() (
 	// Calculate shares for other group members by evaluating polynomials
 	// defined by coefficients `a_i` and `b_i`
 	var sharesMessage = newPeerSharesMessage(cm.ID, cm.sessionID)
-	for _, receiverID := range cm.group.MemberIDs() {
+	for _, receiverID := range cm.group.MemberIndexes() {
 		// s_j = f_(j) mod q
 		memberShareS := cm.evaluateMemberShare(receiverID, coefficientsA)
 		// t_j = g_(j) mod q
@@ -483,7 +483,7 @@ func (cvm *CommitmentsVerifyingMember) isValidMemberCommitmentsMessage(
 func (cvm *CommitmentsVerifyingMember) isValidPeerSharesMessage(
 	message *PeerSharesMessage,
 ) bool {
-	for _, memberID := range cvm.group.OperatingMemberIDs() {
+	for _, memberID := range cvm.group.OperatingMemberIndexes() {
 		if memberID == message.senderID {
 			// Message contains shares only for other group members.
 			continue
@@ -1241,7 +1241,7 @@ func (rm *RevealingMember) membersForReconstruction() []group.MemberIndex {
 
 	// From disqualified members list filter those
 	// whose shares need to be reconstructed.
-	for _, disqualifiedMemberID := range rm.group.DisqualifiedMemberIDs() {
+	for _, disqualifiedMemberID := range rm.group.DisqualifiedMemberIndexes() {
 		if needsReconstruction(disqualifiedMemberID) {
 			members = append(members, disqualifiedMemberID)
 		}
@@ -1249,7 +1249,7 @@ func (rm *RevealingMember) membersForReconstruction() []group.MemberIndex {
 
 	// From inactive members list filter those
 	// whose shares need to be reconstructed.
-	for _, inactiveMemberID := range rm.group.InactiveMemberIDs() {
+	for _, inactiveMemberID := range rm.group.InactiveMemberIndexes() {
 		if needsReconstruction(inactiveMemberID) {
 			members = append(members, inactiveMemberID)
 		}
@@ -1747,7 +1747,7 @@ func (cm *CombiningMember) ComputeGroupPublicKeyShares() {
 		groupPublicKeyShares := make(map[group.MemberIndex]*bn256.G2)
 
 		// Calculate group public key shares for all other operating members.
-		for _, operatingMemberID := range cm.group.OperatingMemberIDs() {
+		for _, operatingMemberID := range cm.group.OperatingMemberIndexes() {
 			if operatingMemberID == cm.ID {
 				continue
 			}

--- a/pkg/beacon/gjkr/protocol_accusations_test.go
+++ b/pkg/beacon/gjkr/protocol_accusations_test.go
@@ -206,7 +206,7 @@ func TestResolveSecretSharesAccusations(t *testing.T) {
 				t.Fatalf("\nexpected: %s\nactual:   %s\n", test.expectedError, err)
 			}
 
-			result := justifyingMember.group.DisqualifiedMemberIDs()
+			result := justifyingMember.group.DisqualifiedMemberIndexes()
 			if !reflect.DeepEqual(result, test.expectedResult) {
 				t.Fatalf("\nexpected: %d\nactual:   %d\n", test.expectedResult, result)
 			}
@@ -389,7 +389,7 @@ func TestResolvePublicKeySharePointsAccusationsMessages(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := justifyingMember.group.DisqualifiedMemberIDs()
+			result := justifyingMember.group.DisqualifiedMemberIndexes()
 			if !reflect.DeepEqual(result, test.expectedResult) {
 				t.Fatalf("\nexpected: %d\nactual:   %d\n", test.expectedResult, result)
 			}
@@ -445,7 +445,7 @@ func TestResolveSecretSharesAccusationsIncorrectAccussedMemberId(t *testing.T) {
 				t.Fatalf("resolving of secret shares accusation messages failed [%s]", err)
 			}
 
-			actualDisqualified := justifyingMember.group.DisqualifiedMemberIDs()
+			actualDisqualified := justifyingMember.group.DisqualifiedMemberIndexes()
 			if !reflect.DeepEqual(actualDisqualified, test.expectedDisqualified) {
 				t.Fatalf(
 					"unexpected members disqualified\nexpected: %d\nactual:   %d\n",
@@ -505,7 +505,7 @@ func TestResolvePublicKeySharePointsAccusationsIncorrectAccusedMemberId(t *testi
 				t.Fatalf("resolving of public key share points accusation messages failed [%s]", err)
 			}
 
-			actualDisqualified := justifyingMember.group.DisqualifiedMemberIDs()
+			actualDisqualified := justifyingMember.group.DisqualifiedMemberIndexes()
 			if !reflect.DeepEqual(actualDisqualified, test.expectedDisqualified) {
 				t.Fatalf(
 					"unexpected members disqualified\nexpected: %d\nactual:   %d\n",

--- a/pkg/beacon/gjkr/protocol_reconstructions_test.go
+++ b/pkg/beacon/gjkr/protocol_reconstructions_test.go
@@ -116,15 +116,15 @@ func TestRevealMisbehavedMembersShares(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedDisqualifiedMemberIDs := make([]group.MemberIndex, 0)
+	expectedDisqualifiedMemberIndexes := make([]group.MemberIndex, 0)
 	for _, disqualifiedMember := range disqualifiedMembers {
-		expectedDisqualifiedMemberIDs = append(expectedDisqualifiedMemberIDs, disqualifiedMember.ID)
+		expectedDisqualifiedMemberIndexes = append(expectedDisqualifiedMemberIndexes, disqualifiedMember.ID)
 	}
-	expectedDisqualifiedMemberIDs = append(expectedDisqualifiedMemberIDs, invalidRevealingMember.ID)
-	if !reflect.DeepEqual(expectedDisqualifiedMemberIDs, member1.group.DisqualifiedMemberIDs()) {
+	expectedDisqualifiedMemberIndexes = append(expectedDisqualifiedMemberIndexes, invalidRevealingMember.ID)
+	if !reflect.DeepEqual(expectedDisqualifiedMemberIndexes, member1.group.DisqualifiedMemberIndexes()) {
 		t.Fatalf("\nexpected: %v\nactual:   %v\n",
-			expectedDisqualifiedMemberIDs,
-			member1.group.DisqualifiedMemberIDs(),
+			expectedDisqualifiedMemberIndexes,
+			member1.group.DisqualifiedMemberIndexes(),
 		)
 	}
 

--- a/pkg/protocol/group/group.go
+++ b/pkg/protocol/group/group.go
@@ -2,10 +2,6 @@
 // and auxiliary tools that help during group-related operations.
 package group
 
-// TODO: Adjust the nomenclature to be about `memberIndex` not `memberID`.
-//       Rename all public functions as well. See:
-//       https://github.com/keep-network/keep-core/pull/3112#discussion_r933165274
-
 // MemberIndex is an index of a member in a group. The maximum member index
 // value is 255.
 type MemberIndex = uint8
@@ -19,40 +15,40 @@ type Group struct {
 	// The maximum number of misbehaving participants for which it is still
 	// possible to generate a signature.
 	dishonestThreshold int
-	// IDs of all disqualified members of the group.
-	disqualifiedMemberIDs []MemberIndex
-	// IDs of all inactive members of the group.
-	inactiveMemberIDs []MemberIndex
-	// All member IDs in this group.
-	memberIDs []MemberIndex
+	// Indexes of all disqualified members of the group.
+	disqualifiedMemberIndexes []MemberIndex
+	// Indexes of all inactive members of the group.
+	inactiveMemberIndexes []MemberIndex
+	// All member indexes in this group.
+	memberIndexes []MemberIndex
 }
 
-// NewGroup creates a new Group with the provided dishonest threshold, member
-// identifiers, and empty IA and DQ members list.
+// NewGroup creates a new Group with the provided dishonest threshold and empty
+// IA and DQ members list.
 func NewGroup(dishonestThreshold int, size int) *Group {
-	memberIDs := make([]MemberIndex, size)
+	memberIndexes := make([]MemberIndex, size)
 	for i := 0; i < size; i++ {
-		memberIDs[i] = MemberIndex(i + 1)
+		memberIndexes[i] = MemberIndex(i + 1)
 	}
 
 	return &Group{
-		dishonestThreshold:    dishonestThreshold,
-		disqualifiedMemberIDs: []MemberIndex{},
-		inactiveMemberIDs:     []MemberIndex{},
-		memberIDs:             memberIDs,
+		dishonestThreshold:        dishonestThreshold,
+		disqualifiedMemberIndexes: []MemberIndex{},
+		inactiveMemberIndexes:     []MemberIndex{},
+		memberIndexes:             memberIndexes,
 	}
 }
 
-// MemberIDs returns IDs of all group members, as initially selected to the
-// group. Returned list contains IDs of all members, including those marked as
-// inactive or disqualified.
-func (g *Group) MemberIDs() []MemberIndex {
-	return g.memberIDs
+// MemberIndexes returns indexes of all group members, as initially selected to
+// the group. Returned list contains indexes of all members, including those
+// marked as inactive or disqualified.
+func (g *Group) MemberIndexes() []MemberIndex {
+	return g.memberIndexes
 }
 
 // GroupSize returns the full size of the group, including IA and DQ members.
 func (g *Group) GroupSize() int {
-	return len(g.memberIDs)
+	return len(g.memberIndexes)
 }
 
 // DishonestThreshold returns value of the dishonest members threshold as set
@@ -67,24 +63,24 @@ func (g *Group) HonestThreshold() int {
 	return g.GroupSize() - g.DishonestThreshold()
 }
 
-// DisqualifiedMemberIDs returns indexes of all group members that have been
+// DisqualifiedMemberIndexes returns indexes of all group members that have been
 // disqualified during the protocol execution.
-func (g *Group) DisqualifiedMemberIDs() []MemberIndex {
-	return g.disqualifiedMemberIDs
+func (g *Group) DisqualifiedMemberIndexes() []MemberIndex {
+	return g.disqualifiedMemberIndexes
 }
 
-// InactiveMemberIDs returns indexes of all group members that have been marked
-// as inactive during the protocol execution.
-func (g *Group) InactiveMemberIDs() []MemberIndex {
-	return g.inactiveMemberIDs
+// InactiveMemberIndexes returns indexes of all group members that have been
+// marked as inactive during the protocol execution.
+func (g *Group) InactiveMemberIndexes() []MemberIndex {
+	return g.inactiveMemberIndexes
 }
 
-// OperatingMemberIDs returns IDs of all group members that are active and have
-// not been disqualified. All those members are properly operating in the group
-// at the moment of calling this method.
-func (g *Group) OperatingMemberIDs() []MemberIndex {
+// OperatingMemberIndexes returns indexes of all group members that are active
+// and have not been disqualified. All those members are properly operating in
+// the group at the moment of calling this method.
+func (g *Group) OperatingMemberIndexes() []MemberIndex {
 	operatingMembers := make([]MemberIndex, 0)
-	for _, member := range g.MemberIDs() {
+	for _, member := range g.MemberIndexes() {
 		if g.IsOperating(member) {
 			operatingMembers = append(operatingMembers, member)
 		}
@@ -93,35 +89,35 @@ func (g *Group) OperatingMemberIDs() []MemberIndex {
 	return operatingMembers
 }
 
-// MarkMemberAsDisqualified adds the member with the given ID to the list of
+// MarkMemberAsDisqualified adds the member with the given index to the list of
 // disqualified members. If the member is not a part of the group, is already
 // disqualified or marked as inactive, method does nothing.
-func (g *Group) MarkMemberAsDisqualified(memberID MemberIndex) {
-	if g.IsOperating(memberID) {
-		g.disqualifiedMemberIDs = append(g.disqualifiedMemberIDs, memberID)
+func (g *Group) MarkMemberAsDisqualified(memberIndex MemberIndex) {
+	if g.IsOperating(memberIndex) {
+		g.disqualifiedMemberIndexes = append(g.disqualifiedMemberIndexes, memberIndex)
 	}
 }
 
-// MarkMemberAsInactive adds the member with the given ID to the list of
+// MarkMemberAsInactive adds the member with the given index to the list of
 // inactive members. If the member is not a part of the group, is already
 // disqualified or marked as inactive, method does nothing.
-func (g *Group) MarkMemberAsInactive(memberID MemberIndex) {
-	if g.IsOperating(memberID) {
-		g.inactiveMemberIDs = append(g.inactiveMemberIDs, memberID)
+func (g *Group) MarkMemberAsInactive(memberIndex MemberIndex) {
+	if g.IsOperating(memberIndex) {
+		g.inactiveMemberIndexes = append(g.inactiveMemberIndexes, memberIndex)
 	}
 }
 
 // IsOperating returns true if member with the given index has not been marked
 // as IA or DQ in the group.
-func (g *Group) IsOperating(memberID MemberIndex) bool {
-	return g.isInGroup(memberID) &&
-		!g.isInactive(memberID) &&
-		!g.isDisqualified(memberID)
+func (g *Group) IsOperating(memberIndex MemberIndex) bool {
+	return g.isInGroup(memberIndex) &&
+		!g.isInactive(memberIndex) &&
+		!g.isDisqualified(memberIndex)
 }
 
-func (g *Group) isInGroup(memberID MemberIndex) bool {
-	for _, groupMember := range g.MemberIDs() {
-		if groupMember == memberID {
+func (g *Group) isInGroup(memberIndex MemberIndex) bool {
+	for _, groupMember := range g.MemberIndexes() {
+		if groupMember == memberIndex {
 			return true
 		}
 	}
@@ -129,9 +125,9 @@ func (g *Group) isInGroup(memberID MemberIndex) bool {
 	return false
 }
 
-func (g *Group) isInactive(memberID MemberIndex) bool {
-	for _, inactiveMemberID := range g.inactiveMemberIDs {
-		if memberID == inactiveMemberID {
+func (g *Group) isInactive(memberIndex MemberIndex) bool {
+	for _, inactiveMemberIndex := range g.inactiveMemberIndexes {
+		if memberIndex == inactiveMemberIndex {
 			return true
 		}
 	}
@@ -139,9 +135,9 @@ func (g *Group) isInactive(memberID MemberIndex) bool {
 	return false
 }
 
-func (g *Group) isDisqualified(memberID MemberIndex) bool {
-	for _, disqualifiedMemberID := range g.disqualifiedMemberIDs {
-		if memberID == disqualifiedMemberID {
+func (g *Group) isDisqualified(memberIndex MemberIndex) bool {
+	for _, disqualifiedMemberIndex := range g.disqualifiedMemberIndexes {
+		if memberIndex == disqualifiedMemberIndex {
 			return true
 		}
 	}

--- a/pkg/protocol/group/group_test.go
+++ b/pkg/protocol/group/group_test.go
@@ -88,9 +88,9 @@ func TestMarkMemberAsDisqualified(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			group := &Group{
-				memberIDs:             test.initialMembers,
-				disqualifiedMemberIDs: []MemberIndex{},
-				inactiveMemberIDs:     []MemberIndex{},
+				memberIndexes:             test.initialMembers,
+				disqualifiedMemberIndexes: []MemberIndex{},
+				inactiveMemberIndexes:     []MemberIndex{},
 			}
 
 			if test.updateFunc != nil {
@@ -99,23 +99,23 @@ func TestMarkMemberAsDisqualified(t *testing.T) {
 
 			if !reflect.DeepEqual(
 				test.expectedDisqualifiedMembers,
-				group.disqualifiedMemberIDs,
+				group.disqualifiedMemberIndexes,
 			) {
 				t.Fatalf(
 					"unexpected list of disqualified members\nexpected: %v\nactual:   %v\n",
 					test.expectedDisqualifiedMembers,
-					group.disqualifiedMemberIDs,
+					group.disqualifiedMemberIndexes,
 				)
 			}
 
 			if !reflect.DeepEqual(
 				test.expectedInactiveMembers,
-				group.inactiveMemberIDs,
+				group.inactiveMemberIndexes,
 			) {
 				t.Fatalf(
 					"unexpected list of inactive members\nexpected: %v\nactual:   %v\n",
 					test.expectedInactiveMembers,
-					group.inactiveMemberIDs,
+					group.inactiveMemberIndexes,
 				)
 			}
 		})
@@ -124,7 +124,7 @@ func TestMarkMemberAsDisqualified(t *testing.T) {
 
 func TestIsDisqualified(t *testing.T) {
 	group := &Group{
-		memberIDs: []MemberIndex{19, 11, 31, 33},
+		memberIndexes: []MemberIndex{19, 11, 31, 33},
 	}
 
 	if group.isDisqualified(19) {
@@ -140,7 +140,7 @@ func TestIsDisqualified(t *testing.T) {
 
 func TestIsInactive(t *testing.T) {
 	group := &Group{
-		memberIDs: []MemberIndex{19, 11, 31, 33},
+		memberIndexes: []MemberIndex{19, 11, 31, 33},
 	}
 
 	if group.isInactive(31) {
@@ -207,13 +207,13 @@ func TestOperatingMembers(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			group := &Group{}
-			group.memberIDs = test.initialMembers
+			group.memberIndexes = test.initialMembers
 
 			if test.updateFunc != nil {
 				test.updateFunc(group)
 			}
 
-			operatingMembers := group.OperatingMemberIDs()
+			operatingMembers := group.OperatingMemberIndexes()
 			if !reflect.DeepEqual(
 				test.expectedOperatingMembers,
 				operatingMembers,

--- a/pkg/protocol/group/message_filter.go
+++ b/pkg/protocol/group/message_filter.go
@@ -53,7 +53,7 @@ func (mf *InactiveMemberFilter) FlushInactiveMembers() {
 		return false
 	}
 
-	for _, operatingMemberID := range mf.group.OperatingMemberIDs() {
+	for _, operatingMemberID := range mf.group.OperatingMemberIndexes() {
 		if !isActive(operatingMemberID) {
 			mf.logger.Warnf(
 				"[member:%v] marking member [%v] as inactive",

--- a/pkg/protocol/group/message_filter_test.go
+++ b/pkg/protocol/group/message_filter_test.go
@@ -9,27 +9,27 @@ import (
 
 func TestFilterInactiveMembers(t *testing.T) {
 	var tests = map[string]struct {
-		selfMemberID             MemberIndex
+		selfMemberIndex          MemberIndex
 		groupMembers             []MemberIndex
-		messageSenderIDs         []MemberIndex
+		messageSenderIndexes     []MemberIndex
 		expectedOperatingMembers []MemberIndex
 	}{
 		"all other members active": {
-			selfMemberID:             4,
+			selfMemberIndex:          4,
 			groupMembers:             []MemberIndex{3, 2, 4, 5, 1, 9},
-			messageSenderIDs:         []MemberIndex{3, 2, 5, 9, 1},
+			messageSenderIndexes:     []MemberIndex{3, 2, 5, 9, 1},
 			expectedOperatingMembers: []MemberIndex{3, 2, 4, 5, 1, 9},
 		},
 		"all other members inactive": {
-			selfMemberID:             9,
+			selfMemberIndex:          9,
 			groupMembers:             []MemberIndex{9, 1, 2, 3},
-			messageSenderIDs:         []MemberIndex{},
+			messageSenderIndexes:     []MemberIndex{},
 			expectedOperatingMembers: []MemberIndex{9},
 		},
 		"some members inactive": {
-			selfMemberID:             3,
+			selfMemberIndex:          3,
 			groupMembers:             []MemberIndex{3, 4, 5, 1, 2, 8},
-			messageSenderIDs:         []MemberIndex{1, 4, 2},
+			messageSenderIndexes:     []MemberIndex{1, 4, 2},
 			expectedOperatingMembers: []MemberIndex{3, 4, 1, 2},
 		},
 	}
@@ -37,23 +37,23 @@ func TestFilterInactiveMembers(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			group := &Group{
-				memberIDs: test.groupMembers,
+				memberIndexes: test.groupMembers,
 			}
 
 			filter := &InactiveMemberFilter{
 				logger:             &testutils.MockLogger{},
-				selfMemberID:       test.selfMemberID,
+				selfMemberID:       test.selfMemberIndex,
 				group:              group,
 				phaseActiveMembers: make([]MemberIndex, 0),
 			}
 
-			for _, member := range test.messageSenderIDs {
+			for _, member := range test.messageSenderIndexes {
 				filter.MarkMemberAsActive(member)
 			}
 
 			filter.FlushInactiveMembers()
 
-			actual := filter.group.OperatingMemberIDs()
+			actual := filter.group.OperatingMemberIndexes()
 			expected := test.expectedOperatingMembers
 
 			if !reflect.DeepEqual(actual, expected) {

--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -438,7 +438,7 @@ func (de *dkgExecutor) registerSigner(
 	// group outputted by the sortition protocol. One need to
 	// determine the final signing group based on the selected
 	// group members who behaved correctly during DKG protocol.
-	operatingMemberIndexes := result.Group.OperatingMemberIDs()
+	operatingMemberIndexes := result.Group.OperatingMemberIndexes()
 	finalSigningGroupOperators, finalSigningGroupMembersIndexes, err :=
 		finalSigningGroup(
 			selectedSigningGroupOperators,

--- a/pkg/tbtc/dkg_test.go
+++ b/pkg/tbtc/dkg_test.go
@@ -37,9 +37,9 @@ func TestRegisterSigner(t *testing.T) {
 	}
 
 	var tests = map[string]struct {
-		memberIndex           group.MemberIndex
-		disqualifiedMemberIDs []group.MemberIndex
-		inactiveMemberIDs     []group.MemberIndex
+		memberIndex               group.MemberIndex
+		disqualifiedMemberIndexes []group.MemberIndex
+		inactiveMemberIndexes     []group.MemberIndex
 
 		expectedError                      error
 		expectedFinalSigningGroupIndex     group.MemberIndex
@@ -47,37 +47,37 @@ func TestRegisterSigner(t *testing.T) {
 	}{
 		"all members participating": {
 			memberIndex:                        1,
-			disqualifiedMemberIDs:              nil,
-			inactiveMemberIDs:                  nil,
+			disqualifiedMemberIndexes:          nil,
+			inactiveMemberIndexes:              nil,
 			expectedFinalSigningGroupIndex:     1,
 			expectedFinalSigningGroupOperators: selectedOperators,
 		},
 		"some member inactive": {
 			memberIndex:                        3,
-			disqualifiedMemberIDs:              nil,
-			inactiveMemberIDs:                  []group.MemberIndex{2, 5},
+			disqualifiedMemberIndexes:          nil,
+			inactiveMemberIndexes:              []group.MemberIndex{2, 5},
 			expectedFinalSigningGroupIndex:     2,
 			expectedFinalSigningGroupOperators: []chain.Address{"0xAA", "0xCC", "0xDD"},
 		},
 		"some members disqualified": {
 			memberIndex:                        1,
-			disqualifiedMemberIDs:              []group.MemberIndex{2, 5},
-			inactiveMemberIDs:                  nil,
+			disqualifiedMemberIndexes:          []group.MemberIndex{2, 5},
+			inactiveMemberIndexes:              nil,
 			expectedError:                      nil,
 			expectedFinalSigningGroupIndex:     1,
 			expectedFinalSigningGroupOperators: []chain.Address{"0xAA", "0xCC", "0xDD"},
 		},
 		"the current member inactive": {
-			memberIndex:           2,
-			disqualifiedMemberIDs: nil,
-			inactiveMemberIDs:     []group.MemberIndex{2, 5},
-			expectedError:         fmt.Errorf("failed to resolve final signing group member index"),
+			memberIndex:               2,
+			disqualifiedMemberIndexes: nil,
+			inactiveMemberIndexes:     []group.MemberIndex{2, 5},
+			expectedError:             fmt.Errorf("failed to resolve final signing group member index"),
 		},
 		"the current member disqualified": {
-			memberIndex:           5,
-			disqualifiedMemberIDs: []group.MemberIndex{2, 5},
-			inactiveMemberIDs:     nil,
-			expectedError:         fmt.Errorf("failed to resolve final signing group member index"),
+			memberIndex:               5,
+			disqualifiedMemberIndexes: []group.MemberIndex{2, 5},
+			inactiveMemberIndexes:     nil,
+			expectedError:             fmt.Errorf("failed to resolve final signing group member index"),
 		},
 	}
 
@@ -93,10 +93,10 @@ func TestRegisterSigner(t *testing.T) {
 			}
 
 			group := group.NewGroup(dishonestThreshold, groupSize)
-			for _, disqualifiedMember := range test.disqualifiedMemberIDs {
+			for _, disqualifiedMember := range test.disqualifiedMemberIndexes {
 				group.MarkMemberAsDisqualified(disqualifiedMember)
 			}
-			for _, inactiveMember := range test.inactiveMemberIDs {
+			for _, inactiveMember := range test.inactiveMemberIndexes {
 				group.MarkMemberAsInactive(inactiveMember)
 			}
 

--- a/pkg/tecdsa/dkg/member.go
+++ b/pkg/tecdsa/dkg/member.go
@@ -90,7 +90,7 @@ func (m *member) initializeEphemeralKeysGeneration() *ephemeralKeyPairGenerating
 
 // ephemeralKeyPairGeneratingMember represents one member in a distributed key
 // generating group performing ephemeral key pair generation. It has a full list
-// of `memberIDs` that belong to its threshold group.
+// of `memberIndexes` that belong to its threshold group.
 type ephemeralKeyPairGeneratingMember struct {
 	*member
 
@@ -131,7 +131,7 @@ func (skgm *symmetricKeyGeneratingMember) initializeTssRoundOne() (
 	// beginning of the protocol.
 	tssPartyID, groupTssPartiesIDs := common.GenerateTssPartiesIDs(
 		skgm.id,
-		skgm.group.OperatingMemberIDs(),
+		skgm.group.OperatingMemberIndexes(),
 		skgm.identityConverter,
 	)
 

--- a/pkg/tecdsa/dkg/protocol.go
+++ b/pkg/tecdsa/dkg/protocol.go
@@ -3,6 +3,7 @@ package dkg
 import (
 	"context"
 	"fmt"
+
 	"github.com/bnb-chain/tss-lib/tss"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -19,7 +20,7 @@ func (ekpgm *ephemeralKeyPairGeneratingMember) generateEphemeralKeyPair() (
 	ephemeralKeys := make(map[group.MemberIndex]*ephemeral.PublicKey)
 
 	// Calculate ephemeral key pair for every other group member
-	for _, member := range ekpgm.group.MemberIDs() {
+	for _, member := range ekpgm.group.MemberIndexes() {
 		if member == ekpgm.id {
 			// don’t actually generate a key with ourselves
 			continue
@@ -98,7 +99,7 @@ func (skgm *symmetricKeyGeneratingMember) generateSymmetricKeys(
 func (skgm *symmetricKeyGeneratingMember) isValidEphemeralPublicKeyMessage(
 	message *ephemeralPublicKeyMessage,
 ) bool {
-	for _, memberID := range skgm.group.MemberIDs() {
+	for _, memberID := range skgm.group.MemberIndexes() {
 		if memberID == message.senderID {
 			// Message contains ephemeral public keys only for other group members
 			continue
@@ -196,7 +197,7 @@ outgoingMessagesLoop:
 		case tssMessage := <-trtm.tssOutgoingMessagesChan:
 			tssMessages = append(tssMessages, tssMessage)
 
-			if len(tssMessages) == len(trtm.group.OperatingMemberIDs()) {
+			if len(tssMessages) == len(trtm.group.OperatingMemberIndexes()) {
 				break outgoingMessagesLoop
 			}
 		case <-ctx.Done():
@@ -220,7 +221,7 @@ outgoingMessagesLoop:
 	}
 
 	ok := len(broadcastPayload) > 0 &&
-		len(peersPayload) == len(trtm.group.OperatingMemberIDs())-1
+		len(peersPayload) == len(trtm.group.OperatingMemberIndexes())-1
 	if !ok {
 		return nil, fmt.Errorf("cannot produce a proper TSS round two message")
 	}

--- a/pkg/tecdsa/dkg/result.go
+++ b/pkg/tecdsa/dkg/result.go
@@ -42,10 +42,10 @@ func (r *Result) GroupPublicKeyBytes() ([]byte, error) {
 func (r *Result) MisbehavedMembersIndexes() []group.MemberIndex {
 	// Merge inactive and disqualified member indexes into 'misbehaved' set.
 	misbehaving := make(map[group.MemberIndex]bool)
-	for _, inactiveMemberIndex := range r.Group.InactiveMemberIDs() {
+	for _, inactiveMemberIndex := range r.Group.InactiveMemberIndexes() {
 		misbehaving[inactiveMemberIndex] = true
 	}
-	for _, disqualifiedMemberIndex := range r.Group.DisqualifiedMemberIDs() {
+	for _, disqualifiedMemberIndex := range r.Group.DisqualifiedMemberIndexes() {
 		misbehaving[disqualifiedMemberIndex] = true
 	}
 

--- a/pkg/tecdsa/dkg/states.go
+++ b/pkg/tecdsa/dkg/states.go
@@ -53,7 +53,7 @@ func (ekpgs *ephemeralKeyPairGenerationState) Receive(netMessage net.Message) er
 
 func (ekpgs *ephemeralKeyPairGenerationState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*ephemeralPublicKeyMessage](ekpgs.BaseAsyncState)) ==
-		len(ekpgs.member.group.OperatingMemberIDs())-1
+		len(ekpgs.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -165,7 +165,7 @@ func (tros *tssRoundOneState) Receive(netMessage net.Message) error {
 
 func (tros *tssRoundOneState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundOneMessage](tros.BaseAsyncState)) ==
-		len(tros.member.group.OperatingMemberIDs())-1
+		len(tros.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -227,7 +227,7 @@ func (trts *tssRoundTwoState) Receive(netMessage net.Message) error {
 
 func (trts *tssRoundTwoState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundTwoMessage](trts.BaseAsyncState)) ==
-		len(trts.member.group.OperatingMemberIDs())-1
+		len(trts.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -289,7 +289,7 @@ func (trts *tssRoundThreeState) Receive(netMessage net.Message) error {
 
 func (trts *tssRoundThreeState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundThreeMessage](trts.BaseAsyncState)) ==
-		len(trts.member.group.OperatingMemberIDs())-1
+		len(trts.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -351,7 +351,7 @@ func (fs *finalizationState) Receive(netMessage net.Message) error {
 
 func (fs *finalizationState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssFinalizationMessage](fs.BaseAsyncState)) ==
-		len(fs.member.group.OperatingMemberIDs())-1
+		len(fs.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -441,7 +441,7 @@ func (rss *resultSigningState) CanTransition() bool {
 	// bound the signing state to a fixed duration and one can move to the
 	// next state as soon as possible.
 	messagingDone := len(receivedMessages[*resultSignatureMessage](rss.BaseAsyncState)) ==
-		len(rss.member.group.OperatingMemberIDs())-1
+		len(rss.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }

--- a/pkg/tecdsa/signing/member.go
+++ b/pkg/tecdsa/signing/member.go
@@ -90,7 +90,7 @@ func (m *member) initializeEphemeralKeysGeneration() *ephemeralKeyPairGenerating
 }
 
 // ephemeralKeyPairGeneratingMember represents one member in a signing group
-// performing ephemeral key pair generation. It has a full list of `memberIDs`
+// performing ephemeral key pair generation. It has a full list of `memberIndexes`
 // that belong to its threshold group.
 type ephemeralKeyPairGeneratingMember struct {
 	*member
@@ -129,7 +129,7 @@ func (skgm *symmetricKeyGeneratingMember) initializeTssRoundOne() *tssRoundOneMe
 	// beginning of the protocol.
 	tssPartyID, groupTssPartiesIDs := common.GenerateTssPartiesIDs(
 		skgm.id,
-		skgm.group.OperatingMemberIDs(),
+		skgm.group.OperatingMemberIndexes(),
 		skgm.identityConverter,
 	)
 

--- a/pkg/tecdsa/signing/protocol.go
+++ b/pkg/tecdsa/signing/protocol.go
@@ -3,6 +3,7 @@ package signing
 import (
 	"context"
 	"fmt"
+
 	"github.com/bnb-chain/tss-lib/tss"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -19,7 +20,7 @@ func (ekpgm *ephemeralKeyPairGeneratingMember) generateEphemeralKeyPair() (
 	ephemeralKeys := make(map[group.MemberIndex]*ephemeral.PublicKey)
 
 	// Calculate ephemeral key pair for every other group member
-	for _, member := range ekpgm.group.MemberIDs() {
+	for _, member := range ekpgm.group.MemberIndexes() {
 		if member == ekpgm.id {
 			// don’t actually generate a key with ourselves
 			continue
@@ -98,7 +99,7 @@ func (skgm *symmetricKeyGeneratingMember) generateSymmetricKeys(
 func (skgm *symmetricKeyGeneratingMember) isValidEphemeralPublicKeyMessage(
 	message *ephemeralPublicKeyMessage,
 ) bool {
-	for _, memberID := range skgm.group.MemberIDs() {
+	for _, memberID := range skgm.group.MemberIndexes() {
 		if memberID == message.senderID {
 			// Message contains ephemeral public keys only for other group members
 			continue
@@ -140,7 +141,7 @@ outgoingMessagesLoop:
 		case tssMessage := <-trom.tssOutgoingMessagesChan:
 			tssMessages = append(tssMessages, tssMessage)
 
-			if len(tssMessages) == len(trom.group.OperatingMemberIDs()) {
+			if len(tssMessages) == len(trom.group.OperatingMemberIndexes()) {
 				break outgoingMessagesLoop
 			}
 		case <-ctx.Done():
@@ -164,7 +165,7 @@ outgoingMessagesLoop:
 	}
 
 	ok := len(broadcastPayload) > 0 &&
-		len(peersPayload) == len(trom.group.OperatingMemberIDs())-1
+		len(peersPayload) == len(trom.group.OperatingMemberIndexes())-1
 	if !ok {
 		return nil, fmt.Errorf("cannot produce a proper TSS round one message")
 	}
@@ -263,7 +264,7 @@ outgoingMessagesLoop:
 		case tssMessage := <-trtm.tssOutgoingMessagesChan:
 			tssMessages = append(tssMessages, tssMessage)
 
-			if len(tssMessages) == len(trtm.group.OperatingMemberIDs())-1 {
+			if len(tssMessages) == len(trtm.group.OperatingMemberIndexes())-1 {
 				break outgoingMessagesLoop
 			}
 		case <-ctx.Done():
@@ -289,7 +290,7 @@ outgoingMessagesLoop:
 	// Unlike the previous phase (TSS round 1), we don't expect a broadcast
 	// payload here.
 	ok := len(broadcastPayload) == 0 &&
-		len(peersPayload) == len(trtm.group.OperatingMemberIDs())-1
+		len(peersPayload) == len(trtm.group.OperatingMemberIndexes())-1
 	if !ok {
 		return nil, fmt.Errorf("cannot produce a proper TSS round two message")
 	}

--- a/pkg/tecdsa/signing/states.go
+++ b/pkg/tecdsa/signing/states.go
@@ -2,10 +2,11 @@ package signing
 
 import (
 	"context"
+	"strconv"
+
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/protocol/state"
-	"strconv"
 )
 
 // ephemeralKeyPairGenerationState is the state during which members broadcast
@@ -47,7 +48,7 @@ func (ekpgs *ephemeralKeyPairGenerationState) Receive(netMessage net.Message) er
 
 func (ekpgs *ephemeralKeyPairGenerationState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*ephemeralPublicKeyMessage](ekpgs.BaseAsyncState)) ==
-		len(ekpgs.member.group.OperatingMemberIDs())-1
+		len(ekpgs.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -147,7 +148,7 @@ func (tros *tssRoundOneState) Receive(netMessage net.Message) error {
 
 func (tros *tssRoundOneState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundOneMessage](tros.BaseAsyncState)) ==
-		len(tros.member.group.OperatingMemberIDs())-1
+		len(tros.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -205,7 +206,7 @@ func (trts *tssRoundTwoState) Receive(netMessage net.Message) error {
 
 func (trts *tssRoundTwoState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundTwoMessage](trts.BaseAsyncState)) ==
-		len(trts.member.group.OperatingMemberIDs())-1
+		len(trts.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -263,7 +264,7 @@ func (trts *tssRoundThreeState) Receive(netMessage net.Message) error {
 
 func (trts *tssRoundThreeState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundThreeMessage](trts.BaseAsyncState)) ==
-		len(trts.member.group.OperatingMemberIDs())-1
+		len(trts.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -321,7 +322,7 @@ func (trfs *tssRoundFourState) Receive(netMessage net.Message) error {
 
 func (trfs *tssRoundFourState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundFourMessage](trfs.BaseAsyncState)) ==
-		len(trfs.member.group.OperatingMemberIDs())-1
+		len(trfs.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -379,7 +380,7 @@ func (trfs *tssRoundFiveState) Receive(netMessage net.Message) error {
 
 func (trfs *tssRoundFiveState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundFiveMessage](trfs.BaseAsyncState)) ==
-		len(trfs.member.group.OperatingMemberIDs())-1
+		len(trfs.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -437,7 +438,7 @@ func (trss *tssRoundSixState) Receive(netMessage net.Message) error {
 
 func (trss *tssRoundSixState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundSixMessage](trss.BaseAsyncState)) ==
-		len(trss.member.group.OperatingMemberIDs())-1
+		len(trss.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -495,7 +496,7 @@ func (trss *tssRoundSevenState) Receive(netMessage net.Message) error {
 
 func (trss *tssRoundSevenState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundSevenMessage](trss.BaseAsyncState)) ==
-		len(trss.member.group.OperatingMemberIDs())-1
+		len(trss.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -553,7 +554,7 @@ func (tres *tssRoundEightState) Receive(netMessage net.Message) error {
 
 func (tres *tssRoundEightState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundEightMessage](tres.BaseAsyncState)) ==
-		len(tres.member.group.OperatingMemberIDs())-1
+		len(tres.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }
@@ -611,7 +612,7 @@ func (trns *tssRoundNineState) Receive(netMessage net.Message) error {
 
 func (trns *tssRoundNineState) CanTransition() bool {
 	messagingDone := len(receivedMessages[*tssRoundNineMessage](trns.BaseAsyncState)) ==
-		len(trns.member.group.OperatingMemberIDs())-1
+		len(trns.member.group.OperatingMemberIndexes())-1
 
 	return messagingDone
 }


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3368
Depends on https://github.com/keep-network/keep-core/pull/3426

Adjusted the nomenclature to be about `memberIndex` not `memberID`. See: https://github.com/keep-network/keep-core/pull/3112#discussion_r933165274

We could live with this inconsistency but we start integrating with ECDSA smart contracts and the member ID means something different on-chain. In the contract, member ID is the operator ID assigned by the sortition pool.

This had to be cleaned up in the client before the integration happens.