### PR TITLE
Generate bindings for TBTC contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,10 @@ local:
 
 all: get_artifacts generate build release cmd-help
 
-# FIXME: tbtc module was removed as it's not used in the client. Add it back
-# while implementing tbtc integration.
 modules := beacon \
 	ecdsa \
-	threshold
+	threshold \
+	tbtc
 
 # Required by get_npm_package function.
 npm_beacon_package := @keep-network/random-beacon

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -20,6 +20,7 @@ import (
 	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 	ethereumBeacon "github.com/keep-network/keep-core/pkg/chain/ethereum/beacon/gen"
 	ethereumEcdsa "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen"
+	ethereumTbtc "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen"
 	ethereumThreshold "github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen"
 )
 
@@ -224,9 +225,7 @@ var cmdFlagsTests = map[string]struct {
 		flagName:              "--developer.bridgeAddress",
 		flagValue:             "0xd21DE06574811450E722a33D8093558E8c04eacc",
 		expectedValueFromFlag: common.HexToAddress("0xd21DE06574811450E722a33D8093558E8c04eacc"),
-		// FIXME: Commented out temporarily for mainnet build.
-		// defaultValue: common.HexToAddress(ethereumTbtc.BridgeAddress),
-		defaultValue: common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		defaultValue:          common.HexToAddress(ethereumTbtc.BridgeAddress),
 	},
 	"developer.tokenStakingAddress": {
 		readValueFunc: func(c *config.Config) interface{} {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jbenet/goprocess v0.1.4
-	github.com/keep-network/keep-common v1.7.1-0.20220927141039-5689702dc79f
+	github.com/keep-network/keep-common v1.7.1-0.20221208135356-df8061aa9b36
 	github.com/libp2p/go-addr-util v0.2.0
 	github.com/libp2p/go-libp2p v0.20.1
 	github.com/libp2p/go-libp2p-core v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/keep-common v1.7.1-0.20220927141039-5689702dc79f h1:FuxmLSMdqovZ8kpTT+0XbYgbAkm6n67kI2fy4U77IvE=
-github.com/keep-network/keep-common v1.7.1-0.20220927141039-5689702dc79f/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
+github.com/keep-network/keep-common v1.7.1-0.20221208135356-df8061aa9b36 h1:lZXOfj3yRSGETQVbWGlCx/3RzKIueRucTQixMAb2hxk=
+github.com/keep-network/keep-common v1.7.1-0.20221208135356-df8061aa9b36/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/keep-network/tss-lib v1.3.3-0.20220826121242-73ee9558285f h1:8tCqIjMDoexUwaKFCcNH8moYUkl0LINeCLXnfag57No=
 github.com/keep-network/tss-lib v1.3.3-0.20220826121242-73ee9558285f/go.mod h1:avz+lZjqmDB/5aleGe1JBxYKY6BzMmFlhZ0VmuifpsU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/chain/ethereum/tbtc/gen/gen.go
+++ b/pkg/chain/ethereum/tbtc/gen/gen.go
@@ -5,12 +5,10 @@ import (
 	"strings"
 )
 
-// FIXME: Commented out temporarily for mainnet build.
-//// go:generate make
+//go:generate make
 
 var (
-	// FIXME: Commented out temporarily for mainnet build.
-	////go:embed _address/Bridge
+	//go:embed _address/Bridge
 	bridgeAddressFileContent string
 
 	// BridgeAddress is a Bridge contract's address read from the NPM package.


### PR DESCRIPTION
This PR reverts commit d03a33a630026dde1d7d7c822f725f7716aa9f8a.

We are getting ready to deploy and publish TBTCv2 contracts (Bridge) and the client requires them to generate bindings.

We bump up version of keep-common dependency to fix bindings generation for the Bridge contract.

Depends on https://github.com/keep-network/keep-common/pull/110