### PR TITLE
Fix badges after change in shields.io syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = keep-core
 
-https://github.com/keep-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Solidity%20ECDSA/main?event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
-https://github.com/keep-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Solidity%20Random%20Beacon/main?event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
-https://github.com/keep-network/keep-core/actions/workflows/client.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Client/main?event=push&label=Client build[Go client build status]]
+https://github.com/keep-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-ecdsa.yml?branch=main&event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
+https://github.com/keep-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-random-beacon.yml?branch=main&event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
+https://github.com/keep-network/keep-core/actions/workflows/client.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/client.yml?branch=main&event=push&label=Client build[Go client build status]]
 https://docs.threshold.network[image:https://img.shields.io/badge/docs-website-green.svg[Docs]]
 https://discord.gg/threshold[image:https://img.shields.io/badge/chat-Discord-5865f2.svg[Chat with us on Discord]]
 

--- a/solidity/ecdsa/README.adoc
+++ b/solidity/ecdsa/README.adoc
@@ -3,7 +3,7 @@
 
 = Keep ECDSA v2
 
-https://github.com/keep-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Solidity%20ECDSA/main?event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
+https://github.com/keep-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-ecdsa.yml?branch=main&event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
 
 The Keep Network offers threshold ECDSA protocol to generate ECDSA wallets
 without any single signer having access to the corresponding private key. This

--- a/solidity/random-beacon/README.adoc
+++ b/solidity/random-beacon/README.adoc
@@ -3,7 +3,7 @@
 
 = Keep Random Beacon v2
 
-https://github.com/keep-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/workflow/status/keep-network/keep-core/Solidity%20Random%20Beacon/main?event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
+https://github.com/keep-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-random-beacon.yml?branch=main&event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
 
 The Keep Network requires a trusted source of randomness for the process of
 trustless group selection. While the network requires that randomness to function


### PR DESCRIPTION
The `shields.io` have changed the syntax of the endpoints generating status badges, resulting in showing false failure status when old syntax was used. Updating the READMEs to use the new syntax.
Read more: https://github.com/badges/shields/issues/8671.

Refs:
https://github.com/keep-network/keep-common/pull/112
https://github.com/keep-network/sortition-pools/pull/198
https://github.com/keep-network/tbtc-v2/pull/429
https://github.com/keep-network/coverage-pools/pull/221