### PR TITLE
Adjust deployment scripts for testnet

### DIFF
--- a/solidity/ecdsa/deploy/06_deploy_wallet_registry_governance.ts
+++ b/solidity/ecdsa/deploy/06_deploy_wallet_registry_governance.ts
@@ -7,8 +7,8 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const WalletRegistry = await deployments.get("WalletRegistry")
 
-  // 1 week for mainnet, 1 second for other test and dev networks.
-  const GOVERNANCE_DELAY = hre.network.name === "mainnet" ? 604800 : 1
+  // 60 seconds for Goerli. 1 week otherwise.
+  const GOVERNANCE_DELAY = hre.network.name === "goerli" ? 60 : 604800
 
   const WalletRegistryGovernance = await deployments.deploy(
     "WalletRegistryGovernance",

--- a/solidity/ecdsa/deploy/06_deploy_wallet_registry_governance.ts
+++ b/solidity/ecdsa/deploy/06_deploy_wallet_registry_governance.ts
@@ -7,7 +7,8 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const WalletRegistry = await deployments.get("WalletRegistry")
 
-  const GOVERNANCE_DELAY = 604800 // 1 week
+  // 1 week for mainnet, 1 second for other test and dev networks.
+  const GOVERNANCE_DELAY = hre.network.name === "mainnet" ? 604800 : 1
 
   const WalletRegistryGovernance = await deployments.deploy(
     "WalletRegistryGovernance",

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -146,17 +146,17 @@ const config: HardhatUserConfig = {
     },
     governance: {
       default: 2,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     esdm: {
       default: 4,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
   },


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/456

Here we make some adjustments to increase the flexibility of testnet deployments. The main goal is to have a short test feedback cycle that will allow to check multiple scenarios using different combinations of contract's governance parameters. In order to achieve that, we must be able to change governable parameters quickly. This change sets a 60-second governance delay for testnet and passes the governance over testnet contracts to an address controlled by the dev team.