### PR TITLE
Validate submitted DKG result

### DIFF
--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -270,7 +270,6 @@ func (lc *localChain) SubmitDKGResult(
 
 	lc.dkgState = Challenge
 	lc.dkgResult = dkgResult
-	lc.dkgResultValid = true
 
 	return nil
 }
@@ -304,30 +303,16 @@ func (lc *localChain) IsDKGResultValid(dkgResult *DKGChainResult) (bool, error) 
 	lc.dkgMutex.Lock()
 	defer lc.dkgMutex.Unlock()
 
-	if lc.dkgState != Challenge {
-		return false, fmt.Errorf("not in DKG result challenge period")
-	}
-
-	if !reflect.DeepEqual(dkgResult, lc.dkgResult) {
-		return false, fmt.Errorf("result does not match the submitted one")
-	}
-
 	return lc.dkgResultValid, nil
 }
 
-func (lc *localChain) invalidateDKGResult(dkgResult *DKGChainResult) error {
+func (lc *localChain) setDKGResultValidity(
+	isValid bool,
+) error {
 	lc.dkgMutex.Lock()
 	defer lc.dkgMutex.Unlock()
 
-	if lc.dkgState != Challenge {
-		return fmt.Errorf("not in DKG result challenge period")
-	}
-
-	if !reflect.DeepEqual(dkgResult, lc.dkgResult) {
-		return fmt.Errorf("result does not match the submitted one")
-	}
-
-	lc.dkgResultValid = false
+	lc.dkgResultValid = isValid
 
 	return nil
 }
@@ -367,7 +352,6 @@ func (lc *localChain) ChallengeDKGResult(dkgResult *DKGChainResult) error {
 
 	lc.dkgState = AwaitingResult
 	lc.dkgResult = nil
-	lc.dkgResultValid = false
 
 	return nil
 }
@@ -410,7 +394,6 @@ func (lc *localChain) ApproveDKGResult(dkgResult *DKGChainResult) error {
 
 	lc.dkgState = Idle
 	lc.dkgResult = nil
-	lc.dkgResultValid = false
 
 	return nil
 }

--- a/pkg/tbtc/dkg_submit_test.go
+++ b/pkg/tbtc/dkg_submit_test.go
@@ -294,6 +294,10 @@ func TestSubmitResult_MemberSubmitsResult(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 
+	if err = localChain.setDKGResultValidity(true); err != nil {
+		t.Fatal(err)
+	}
+
 	err = dkgResultSubmitter.SubmitResult(
 		ctx,
 		memberIndex,
@@ -388,6 +392,10 @@ func TestSubmitResult_AnotherMemberSubmitsResult(t *testing.T) {
 			cancelCtx()
 		})
 
+	if err = localChain.setDKGResultValidity(true); err != nil {
+		t.Fatal(err)
+	}
+
 	secondMemberSubmissionChannel := make(chan error)
 
 	// Attempt to submit result for the second member on a separate goroutine.
@@ -444,6 +452,92 @@ func TestSubmitResult_AnotherMemberSubmitsResult(t *testing.T) {
 			"unexpected group public key \nexpected: [0x%x]\nactual:   [0x%x]\n",
 			expectedGroupPublicKey,
 			localChain.dkgResult.GroupPublicKey,
+		)
+	}
+}
+
+func TestSubmitResult_InvalidResult(t *testing.T) {
+	groupParameters := &GroupParameters{
+		GroupSize:       5,
+		GroupQuorum:     4,
+		HonestThreshold: 3,
+	}
+
+	localChain := Connect()
+
+	err := localChain.startDKG()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	operatorAddress, err := localChain.operatorAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	operatorID, err := localChain.GetOperatorID(operatorAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var operatorsIDs chain.OperatorIDs
+	var operatorsAddresses chain.Addresses
+
+	for memberIndex := uint8(1); int(memberIndex) <= groupParameters.GroupSize; memberIndex++ {
+		operatorsIDs = append(operatorsIDs, operatorID)
+		operatorsAddresses = append(operatorsAddresses, operatorAddress)
+	}
+
+	groupSelectionResult := &GroupSelectionResult{
+		OperatorsIDs:       operatorsIDs,
+		OperatorsAddresses: operatorsAddresses,
+	}
+
+	dkgResultSubmitter := newDkgResultSubmitter(
+		&testutils.MockLogger{},
+		localChain,
+		groupParameters,
+		groupSelectionResult,
+		testWaitForBlockFn(localChain),
+	)
+
+	testData, err := tecdsatest.LoadPrivateKeyShareTestFixtures(1)
+	if err != nil {
+		t.Fatalf("failed to load test data: [%v]", err)
+	}
+	result := &dkg.Result{
+		Group:           group.NewGroup(groupParameters.DishonestThreshold(), groupParameters.GroupSize),
+		PrivateKeyShare: tecdsa.NewPrivateKeyShare(testData[0]),
+	}
+
+	memberIndex := group.MemberIndex(1)
+	signatures := map[group.MemberIndex][]byte{
+		1: []byte("signature 1"),
+		2: []byte("signature 2"),
+		3: []byte("signature 3"),
+		4: []byte("signature 4"),
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	if err = localChain.setDKGResultValidity(false); err != nil {
+		t.Fatal(err)
+	}
+
+	err = dkgResultSubmitter.SubmitResult(
+		ctx,
+		memberIndex,
+		result,
+		signatures,
+	)
+
+	expectedErr := fmt.Errorf("invalid DKG result")
+	if !reflect.DeepEqual(expectedErr, err) {
+		t.Errorf(
+			"unexpected error \nexpected: [%v]\nactual:   [%v]\n",
+			expectedErr,
+			err,
 		)
 	}
 }
@@ -514,6 +608,10 @@ func TestSubmitResult_ContextCancelled(t *testing.T) {
 
 	// Simulate the case when timeout occurs and the context gets cancelled.
 	cancelCtx()
+
+	if err = localChain.setDKGResultValidity(true); err != nil {
+		t.Fatal(err)
+	}
 
 	err = dkgResultSubmitter.SubmitResult(
 		ctx,

--- a/pkg/tbtc/dkg_test.go
+++ b/pkg/tbtc/dkg_test.go
@@ -310,11 +310,9 @@ func TestDkgExecutor_ExecuteDkgValidation(t *testing.T) {
 
 			dkgResultSubmittedEvent := <-dkgResultSubmittedEventChan
 
-			if !test.resultValid {
-				err = localChain.invalidateDKGResult(dkgResultSubmittedEvent.Result)
-				if err != nil {
-					t.Fatal(err)
-				}
+			err = localChain.setDKGResultValidity(test.resultValid)
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			// Setting only the fields really needed for this test.


### PR DESCRIPTION
Closes: #3461

Here we add an on-chain validation of the submitted DKG result. This way, honest clients may abort the submission of an invalid result and avoid slashing.