### PR TITLE
Add gas limit margin for approve DKG result calls

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -868,7 +868,7 @@ func (tc *TbtcChain) ApproveDKGResult(dkgResult *tbtc.DKGChainResult) error {
 	}
 
 	// The original estimate for this contract call turned out to be too low.
-	// Here we add a 20% margin to overcome out of gas problems.
+	// Here we add a 20% margin to overcome the gas problems.
 	gasEstimateWithMargin := float64(gasEstimate) * float64(1.2)
 
 	_, err = tc.walletRegistry.ApproveDkgResult(


### PR DESCRIPTION
The original estimate made by the `go-ethereum` library for the `WalletRegistry.approveDkgResult` turned out to be too low. The root cause of the problem is probably related with the reimbursement pool. To overcome that problem, we add a 20% margin to the original gas limit estimate.