### PR TITLE
Update signature to string formatting

### DIFF
--- a/pkg/tecdsa/signature.go
+++ b/pkg/tecdsa/signature.go
@@ -1,9 +1,11 @@
 package tecdsa
 
 import (
+	"encoding/hex"
 	"fmt"
-	"github.com/bnb-chain/tss-lib/common"
 	"math/big"
+
+	"github.com/bnb-chain/tss-lib/common"
 )
 
 // Signature holds a signature in a form of two big.Int `r` and `s` values and
@@ -38,9 +40,9 @@ func NewSignature(data *common.SignatureData) *Signature {
 // as hexadecimals.
 func (s *Signature) String() string {
 	return fmt.Sprintf(
-		"R: %#x, S: %#x, RecoveryID: %d",
-		s.R,
-		s.S,
+		"R: 0x%s, S: 0x%s, RecoveryID: %d",
+		hex.EncodeToString(s.R.Bytes()),
+		hex.EncodeToString(s.S.Bytes()),
 		s.RecoveryID,
 	)
 }

--- a/pkg/tecdsa/signature_test.go
+++ b/pkg/tecdsa/signature_test.go
@@ -1,10 +1,56 @@
 package tecdsa
 
 import (
-	"github.com/keep-network/keep-core/pkg/internal/testutils"
 	"math/big"
 	"testing"
+
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
 )
+
+func TestSignatureString(t *testing.T) {
+	var tests = map[string]struct {
+		signature      *Signature
+		expectedResult string
+	}{
+		"R and S values with leading zeros": {
+			signature: &Signature{
+				R:          big.NewInt(495),
+				S:          big.NewInt(253885074),
+				RecoveryID: 2,
+			},
+			expectedResult: "R: 0x01ef, S: 0x0f21fa92, RecoveryID: 2",
+		},
+		"R and S values with trailing zeros": {
+			signature: &Signature{
+				R:          big.NewInt(1308688384),
+				S:          big.NewInt(4096),
+				RecoveryID: 1,
+			},
+			expectedResult: "R: 0x4e010000, S: 0x1000, RecoveryID: 1",
+		},
+		"R and S values with no leading nor trailing zero": {
+			signature: &Signature{
+				R:          big.NewInt(12300),
+				S:          big.NewInt(231),
+				RecoveryID: 0,
+			},
+			expectedResult: "R: 0x300c, S: 0xe7, RecoveryID: 0",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := test.signature.String()
+
+			testutils.AssertStringsEqual(
+				t,
+				"equals result",
+				test.expectedResult,
+				result,
+			)
+		})
+	}
+}
 
 func TestSignatureEquals(t *testing.T) {
 	var tests = map[string]struct {


### PR DESCRIPTION
The previous solution used to convert R and S values to string was outputing inproperly formatted hex value that was not even. With this change we ensure the values are encoded to even hex string prefixed with 0x.

Closes: https://github.com/keep-network/keep-core/issues/3489