### PR TITLE
Events retry log level Errof->Warnf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jbenet/goprocess v0.1.4
-	github.com/keep-network/keep-common v1.7.1-0.20221209141213-c5370c90bf9f
+	github.com/keep-network/keep-common v1.7.1-0.20230124141416-6f84b758111f
 	github.com/libp2p/go-addr-util v0.2.0
 	github.com/libp2p/go-libp2p v0.20.1
 	github.com/libp2p/go-libp2p-core v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -692,6 +692,8 @@ github.com/keep-network/go-electrum v0.0.0-20220912200153-b862ac442cf9 h1:cx5nKm
 github.com/keep-network/go-electrum v0.0.0-20220912200153-b862ac442cf9/go.mod h1:EjLxYzaf/28gOdSRlifeLfjoOA6aUjtJZhwaZPnjL9c=
 github.com/keep-network/keep-common v1.7.1-0.20221209141213-c5370c90bf9f h1:hSQHUILojmmMsYOkLgGoPbHSWIcgxj11JBjF9tbqvg0=
 github.com/keep-network/keep-common v1.7.1-0.20221209141213-c5370c90bf9f/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
+github.com/keep-network/keep-common v1.7.1-0.20230124141416-6f84b758111f h1:pNg8ZPT+Um8YZn0ebgAyGzifPB8fA6IjXreI++Pq5T0=
+github.com/keep-network/keep-common v1.7.1-0.20230124141416-6f84b758111f/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/keep-network/tss-lib v1.3.3-0.20220826121242-73ee9558285f h1:8tCqIjMDoexUwaKFCcNH8moYUkl0LINeCLXnfag57No=
 github.com/keep-network/tss-lib v1.3.3-0.20220826121242-73ee9558285f/go.mod h1:avz+lZjqmDB/5aleGe1JBxYKY6BzMmFlhZ0VmuifpsU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/chain/ethereum/beacon/gen/contract/BeaconSortitionPool.go
+++ b/pkg/chain/ethereum/beacon/gen/contract/BeaconSortitionPool.go
@@ -3082,7 +3082,7 @@ func (bsp *BeaconSortitionPool) watchBetaOperatorsAdded(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bspLogger.Errorf(
+		bspLogger.Warnf(
 			"subscription to event BetaOperatorsAdded had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3259,7 +3259,7 @@ func (bsp *BeaconSortitionPool) watchChaosnetDeactivated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bspLogger.Errorf(
+		bspLogger.Warnf(
 			"subscription to event ChaosnetDeactivated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3440,7 +3440,7 @@ func (bsp *BeaconSortitionPool) watchChaosnetOwnerRoleTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bspLogger.Errorf(
+		bspLogger.Warnf(
 			"subscription to event ChaosnetOwnerRoleTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3621,7 +3621,7 @@ func (bsp *BeaconSortitionPool) watchIneligibleForRewards(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bspLogger.Errorf(
+		bspLogger.Warnf(
 			"subscription to event IneligibleForRewards had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3816,7 +3816,7 @@ func (bsp *BeaconSortitionPool) watchOwnershipTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bspLogger.Errorf(
+		bspLogger.Warnf(
 			"subscription to event OwnershipTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -4015,7 +4015,7 @@ func (bsp *BeaconSortitionPool) watchRewardEligibilityRestored(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bspLogger.Errorf(
+		bspLogger.Warnf(
 			"subscription to event RewardEligibilityRestored had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/pkg/chain/ethereum/beacon/gen/contract/RandomBeacon.go
+++ b/pkg/chain/ethereum/beacon/gen/contract/RandomBeacon.go
@@ -5677,7 +5677,7 @@ func (rb *RandomBeacon) watchAuthorizationDecreaseApproved(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event AuthorizationDecreaseApproved had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -5880,7 +5880,7 @@ func (rb *RandomBeacon) watchAuthorizationDecreaseRequested(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event AuthorizationDecreaseRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6083,7 +6083,7 @@ func (rb *RandomBeacon) watchAuthorizationIncreased(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event AuthorizationIncreased had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6270,7 +6270,7 @@ func (rb *RandomBeacon) watchAuthorizationParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event AuthorizationParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6451,7 +6451,7 @@ func (rb *RandomBeacon) watchCallbackFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event CallbackFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6641,7 +6641,7 @@ func (rb *RandomBeacon) watchDkgMaliciousResultSlashed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgMaliciousResultSlashed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6833,7 +6833,7 @@ func (rb *RandomBeacon) watchDkgMaliciousResultSlashingFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgMaliciousResultSlashingFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7030,7 +7030,7 @@ func (rb *RandomBeacon) watchDkgResultApproved(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgResultApproved had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7231,7 +7231,7 @@ func (rb *RandomBeacon) watchDkgResultChallenged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgResultChallenged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7432,7 +7432,7 @@ func (rb *RandomBeacon) watchDkgResultSubmitted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgResultSubmitted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7613,7 +7613,7 @@ func (rb *RandomBeacon) watchDkgSeedTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgSeedTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7799,7 +7799,7 @@ func (rb *RandomBeacon) watchDkgStarted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgStarted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7978,7 +7978,7 @@ func (rb *RandomBeacon) watchDkgStateLocked(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgStateLocked had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8155,7 +8155,7 @@ func (rb *RandomBeacon) watchDkgTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event DkgTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8340,7 +8340,7 @@ func (rb *RandomBeacon) watchGasParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event GasParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8521,7 +8521,7 @@ func (rb *RandomBeacon) watchGovernanceTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event GovernanceTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8710,7 +8710,7 @@ func (rb *RandomBeacon) watchGroupCreationParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event GroupCreationParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8905,7 +8905,7 @@ func (rb *RandomBeacon) watchGroupRegistered(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event GroupRegistered had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9099,7 +9099,7 @@ func (rb *RandomBeacon) watchInactivityClaimed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event InactivityClaimed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9300,7 +9300,7 @@ func (rb *RandomBeacon) watchInvoluntaryAuthorizationDecreaseFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event InvoluntaryAuthorizationDecreaseFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9499,7 +9499,7 @@ func (rb *RandomBeacon) watchOperatorJoinedSortitionPool(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event OperatorJoinedSortitionPool had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9698,7 +9698,7 @@ func (rb *RandomBeacon) watchOperatorRegistered(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event OperatorRegistered had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9897,7 +9897,7 @@ func (rb *RandomBeacon) watchOperatorStatusUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event OperatorStatusUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10080,7 +10080,7 @@ func (rb *RandomBeacon) watchReimbursementPoolUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event ReimbursementPoolUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10270,7 +10270,7 @@ func (rb *RandomBeacon) watchRelayEntryDelaySlashed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryDelaySlashed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10462,7 +10462,7 @@ func (rb *RandomBeacon) watchRelayEntryDelaySlashingFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryDelaySlashingFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10647,7 +10647,7 @@ func (rb *RandomBeacon) watchRelayEntryParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10837,7 +10837,7 @@ func (rb *RandomBeacon) watchRelayEntryRequested(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11029,7 +11029,7 @@ func (rb *RandomBeacon) watchRelayEntrySubmitted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntrySubmitted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11219,7 +11219,7 @@ func (rb *RandomBeacon) watchRelayEntryTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11411,7 +11411,7 @@ func (rb *RandomBeacon) watchRelayEntryTimeoutSlashed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryTimeoutSlashed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11603,7 +11603,7 @@ func (rb *RandomBeacon) watchRelayEntryTimeoutSlashingFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RelayEntryTimeoutSlashingFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11793,7 +11793,7 @@ func (rb *RandomBeacon) watchRequesterAuthorizationUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RequesterAuthorizationUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11980,7 +11980,7 @@ func (rb *RandomBeacon) watchRewardParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RewardParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -12168,7 +12168,7 @@ func (rb *RandomBeacon) watchRewardsWithdrawn(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event RewardsWithdrawn had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -12353,7 +12353,7 @@ func (rb *RandomBeacon) watchSlashingParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event SlashingParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -12543,7 +12543,7 @@ func (rb *RandomBeacon) watchUnauthorizedSigningSlashed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event UnauthorizedSigningSlashed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -12735,7 +12735,7 @@ func (rb *RandomBeacon) watchUnauthorizedSigningSlashingFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		rbLogger.Errorf(
+		rbLogger.Warnf(
 			"subscription to event UnauthorizedSigningSlashingFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/pkg/chain/ethereum/ecdsa/gen/contract/EcdsaSortitionPool.go
+++ b/pkg/chain/ethereum/ecdsa/gen/contract/EcdsaSortitionPool.go
@@ -3082,7 +3082,7 @@ func (esp *EcdsaSortitionPool) watchBetaOperatorsAdded(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		espLogger.Errorf(
+		espLogger.Warnf(
 			"subscription to event BetaOperatorsAdded had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3259,7 +3259,7 @@ func (esp *EcdsaSortitionPool) watchChaosnetDeactivated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		espLogger.Errorf(
+		espLogger.Warnf(
 			"subscription to event ChaosnetDeactivated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3440,7 +3440,7 @@ func (esp *EcdsaSortitionPool) watchChaosnetOwnerRoleTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		espLogger.Errorf(
+		espLogger.Warnf(
 			"subscription to event ChaosnetOwnerRoleTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3621,7 +3621,7 @@ func (esp *EcdsaSortitionPool) watchIneligibleForRewards(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		espLogger.Errorf(
+		espLogger.Warnf(
 			"subscription to event IneligibleForRewards had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -3816,7 +3816,7 @@ func (esp *EcdsaSortitionPool) watchOwnershipTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		espLogger.Errorf(
+		espLogger.Warnf(
 			"subscription to event OwnershipTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -4015,7 +4015,7 @@ func (esp *EcdsaSortitionPool) watchRewardEligibilityRestored(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		espLogger.Errorf(
+		espLogger.Warnf(
 			"subscription to event RewardEligibilityRestored had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/pkg/chain/ethereum/ecdsa/gen/contract/WalletRegistry.go
+++ b/pkg/chain/ethereum/ecdsa/gen/contract/WalletRegistry.go
@@ -5682,7 +5682,7 @@ func (wr *WalletRegistry) watchAuthorizationDecreaseApproved(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event AuthorizationDecreaseApproved had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -5885,7 +5885,7 @@ func (wr *WalletRegistry) watchAuthorizationDecreaseRequested(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event AuthorizationDecreaseRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6088,7 +6088,7 @@ func (wr *WalletRegistry) watchAuthorizationIncreased(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event AuthorizationIncreased had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6275,7 +6275,7 @@ func (wr *WalletRegistry) watchAuthorizationParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event AuthorizationParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6465,7 +6465,7 @@ func (wr *WalletRegistry) watchDkgMaliciousResultSlashed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgMaliciousResultSlashed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6657,7 +6657,7 @@ func (wr *WalletRegistry) watchDkgMaliciousResultSlashingFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgMaliciousResultSlashingFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6846,7 +6846,7 @@ func (wr *WalletRegistry) watchDkgParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7041,7 +7041,7 @@ func (wr *WalletRegistry) watchDkgResultApproved(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgResultApproved had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7242,7 +7242,7 @@ func (wr *WalletRegistry) watchDkgResultChallenged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgResultChallenged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7443,7 +7443,7 @@ func (wr *WalletRegistry) watchDkgResultSubmitted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgResultSubmitted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7624,7 +7624,7 @@ func (wr *WalletRegistry) watchDkgSeedTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgSeedTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7810,7 +7810,7 @@ func (wr *WalletRegistry) watchDkgStarted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgStarted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7989,7 +7989,7 @@ func (wr *WalletRegistry) watchDkgStateLocked(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgStateLocked had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8166,7 +8166,7 @@ func (wr *WalletRegistry) watchDkgTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event DkgTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8353,7 +8353,7 @@ func (wr *WalletRegistry) watchGasParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event GasParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8534,7 +8534,7 @@ func (wr *WalletRegistry) watchGovernanceTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event GovernanceTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8724,7 +8724,7 @@ func (wr *WalletRegistry) watchInactivityClaimed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event InactivityClaimed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8905,7 +8905,7 @@ func (wr *WalletRegistry) watchInitialized(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event Initialized had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9104,7 +9104,7 @@ func (wr *WalletRegistry) watchInvoluntaryAuthorizationDecreaseFailed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event InvoluntaryAuthorizationDecreaseFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9303,7 +9303,7 @@ func (wr *WalletRegistry) watchOperatorJoinedSortitionPool(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event OperatorJoinedSortitionPool had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9502,7 +9502,7 @@ func (wr *WalletRegistry) watchOperatorRegistered(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event OperatorRegistered had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9701,7 +9701,7 @@ func (wr *WalletRegistry) watchOperatorStatusUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event OperatorStatusUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9884,7 +9884,7 @@ func (wr *WalletRegistry) watchRandomBeaconUpgraded(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event RandomBeaconUpgraded had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10063,7 +10063,7 @@ func (wr *WalletRegistry) watchReimbursementPoolUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event ReimbursementPoolUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10244,7 +10244,7 @@ func (wr *WalletRegistry) watchRewardParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event RewardParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10432,7 +10432,7 @@ func (wr *WalletRegistry) watchRewardsWithdrawn(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event RewardsWithdrawn had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10613,7 +10613,7 @@ func (wr *WalletRegistry) watchSlashingParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event SlashingParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10799,7 +10799,7 @@ func (wr *WalletRegistry) watchWalletClosed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event WalletClosed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10996,7 +10996,7 @@ func (wr *WalletRegistry) watchWalletCreated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event WalletCreated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11179,7 +11179,7 @@ func (wr *WalletRegistry) watchWalletOwnerUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		wrLogger.Errorf(
+		wrLogger.Warnf(
 			"subscription to event WalletOwnerUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/pkg/chain/ethereum/tbtc/gen/contract/Bridge.go
+++ b/pkg/chain/ethereum/tbtc/gen/contract/Bridge.go
@@ -6064,7 +6064,7 @@ func (b *Bridge) watchDepositParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event DepositParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6273,7 +6273,7 @@ func (b *Bridge) watchDepositRevealed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event DepositRevealed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6458,7 +6458,7 @@ func (b *Bridge) watchDepositsSwept(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event DepositsSwept had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6646,7 +6646,7 @@ func (b *Bridge) watchFraudChallengeDefeatTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event FraudChallengeDefeatTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6836,7 +6836,7 @@ func (b *Bridge) watchFraudChallengeDefeated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event FraudChallengeDefeated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7032,7 +7032,7 @@ func (b *Bridge) watchFraudChallengeSubmitted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event FraudChallengeSubmitted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7219,7 +7219,7 @@ func (b *Bridge) watchFraudParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event FraudParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7400,7 +7400,7 @@ func (b *Bridge) watchGovernanceTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event GovernanceTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7579,7 +7579,7 @@ func (b *Bridge) watchInitialized(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event Initialized had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7769,7 +7769,7 @@ func (b *Bridge) watchMovedFundsSweepTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovedFundsSweepTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7959,7 +7959,7 @@ func (b *Bridge) watchMovedFundsSwept(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovedFundsSwept had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8147,7 +8147,7 @@ func (b *Bridge) watchMovingFundsBelowDustReported(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovingFundsBelowDustReported had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8339,7 +8339,7 @@ func (b *Bridge) watchMovingFundsCommitmentSubmitted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovingFundsCommitmentSubmitted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8529,7 +8529,7 @@ func (b *Bridge) watchMovingFundsCompleted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovingFundsCompleted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8730,7 +8730,7 @@ func (b *Bridge) watchMovingFundsParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovingFundsParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8916,7 +8916,7 @@ func (b *Bridge) watchMovingFundsTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovingFundsTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9104,7 +9104,7 @@ func (b *Bridge) watchMovingFundsTimeoutReset(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event MovingFundsTimeoutReset had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9301,7 +9301,7 @@ func (b *Bridge) watchNewWalletRegistered(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event NewWalletRegistered had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9482,7 +9482,7 @@ func (b *Bridge) watchNewWalletRequested(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event NewWalletRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9673,7 +9673,7 @@ func (b *Bridge) watchRedemptionParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event RedemptionParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9876,7 +9876,7 @@ func (b *Bridge) watchRedemptionRequested(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event RedemptionRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10068,7 +10068,7 @@ func (b *Bridge) watchRedemptionTimedOut(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event RedemptionTimedOut had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10258,7 +10258,7 @@ func (b *Bridge) watchRedemptionsCompleted(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event RedemptionsCompleted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10448,7 +10448,7 @@ func (b *Bridge) watchSpvMaintainerStatusUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event SpvMaintainerStatusUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10638,7 +10638,7 @@ func (b *Bridge) watchVaultStatusUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event VaultStatusUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10835,7 +10835,7 @@ func (b *Bridge) watchWalletClosed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event WalletClosed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11034,7 +11034,7 @@ func (b *Bridge) watchWalletClosing(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event WalletClosing had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11233,7 +11233,7 @@ func (b *Bridge) watchWalletMovingFunds(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event WalletMovingFunds had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11428,7 +11428,7 @@ func (b *Bridge) watchWalletParametersUpdated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event WalletParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -11623,7 +11623,7 @@ func (b *Bridge) watchWalletTerminated(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		bLogger.Errorf(
+		bLogger.Warnf(
 			"subscription to event WalletTerminated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/pkg/chain/ethereum/tbtc/gen/contract/LightRelay.go
+++ b/pkg/chain/ethereum/tbtc/gen/contract/LightRelay.go
@@ -1901,7 +1901,7 @@ func (lr *LightRelay) watchAuthorizationRequirementChanged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event AuthorizationRequirementChanged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2080,7 +2080,7 @@ func (lr *LightRelay) watchGenesis(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event Genesis had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2275,7 +2275,7 @@ func (lr *LightRelay) watchOwnershipTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event OwnershipTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2458,7 +2458,7 @@ func (lr *LightRelay) watchProofLengthChanged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event ProofLengthChanged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2639,7 +2639,7 @@ func (lr *LightRelay) watchRetarget(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event Retarget had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2818,7 +2818,7 @@ func (lr *LightRelay) watchSubmitterAuthorized(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event SubmitterAuthorized had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -2997,7 +2997,7 @@ func (lr *LightRelay) watchSubmitterDeauthorized(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		lrLogger.Errorf(
+		lrLogger.Warnf(
 			"subscription to event SubmitterDeauthorized had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",

--- a/pkg/chain/ethereum/threshold/gen/contract/TokenStaking.go
+++ b/pkg/chain/ethereum/threshold/gen/contract/TokenStaking.go
@@ -6243,7 +6243,7 @@ func (ts *TokenStaking) watchApplicationStatusChanged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event ApplicationStatusChanged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6426,7 +6426,7 @@ func (ts *TokenStaking) watchAuthorizationCeilingSet(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event AuthorizationCeilingSet had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6625,7 +6625,7 @@ func (ts *TokenStaking) watchAuthorizationDecreaseApproved(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event AuthorizationDecreaseApproved had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -6828,7 +6828,7 @@ func (ts *TokenStaking) watchAuthorizationDecreaseRequested(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event AuthorizationDecreaseRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7031,7 +7031,7 @@ func (ts *TokenStaking) watchAuthorizationIncreased(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event AuthorizationIncreased had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7243,7 +7243,7 @@ func (ts *TokenStaking) watchAuthorizationInvoluntaryDecreased(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event AuthorizationInvoluntaryDecreased had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7453,7 +7453,7 @@ func (ts *TokenStaking) watchDelegateChanged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event DelegateChanged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7649,7 +7649,7 @@ func (ts *TokenStaking) watchDelegateVotesChanged(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event DelegateVotesChanged had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -7832,7 +7832,7 @@ func (ts *TokenStaking) watchGovernanceTransferred(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event GovernanceTransferred had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8011,7 +8011,7 @@ func (ts *TokenStaking) watchMinimumStakeAmountSet(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event MinimumStakeAmountSet had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8190,7 +8190,7 @@ func (ts *TokenStaking) watchNotificationRewardPushed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event NotificationRewardPushed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8369,7 +8369,7 @@ func (ts *TokenStaking) watchNotificationRewardSet(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event NotificationRewardSet had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8550,7 +8550,7 @@ func (ts *TokenStaking) watchNotificationRewardWithdrawn(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event NotificationRewardWithdrawn had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8738,7 +8738,7 @@ func (ts *TokenStaking) watchNotifierRewarded(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event NotifierRewarded had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -8944,7 +8944,7 @@ func (ts *TokenStaking) watchOwnerRefreshed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event OwnerRefreshed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9145,7 +9145,7 @@ func (ts *TokenStaking) watchPanicButtonSet(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event PanicButtonSet had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9339,7 +9339,7 @@ func (ts *TokenStaking) watchSlashingProcessed(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event SlashingProcessed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9522,7 +9522,7 @@ func (ts *TokenStaking) watchStakeDiscrepancyPenaltySet(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event StakeDiscrepancyPenaltySet had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9732,7 +9732,7 @@ func (ts *TokenStaking) watchStaked(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event Staked had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -9935,7 +9935,7 @@ func (ts *TokenStaking) watchTokensSeized(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event TokensSeized had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10127,7 +10127,7 @@ func (ts *TokenStaking) watchToppedUp(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event ToppedUp had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
@@ -10317,7 +10317,7 @@ func (ts *TokenStaking) watchUnstaked(
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
-		tsLogger.Errorf(
+		tsLogger.Warnf(
 			"subscription to event Unstaked had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",


### PR DESCRIPTION
A client might experience some connectivity issues with Alchemy / Infura and will retry to reconnect. These attempts shouldn't be logged at the Error level as they don't require any actions from the operator.