### PR TITLE
Kubernetes deployment for tBTC v2 chain events monitoring tool

### DIFF
--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/.env.secret
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/.env.secret
@@ -1,0 +1,3 @@
+ethereum-url=
+sentry-dsn=
+discord-webhook-url=

--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/.env.secret
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/.env.secret
@@ -1,3 +1,4 @@
 ethereum-url=
+electrum-url=
 sentry-dsn=
 discord-webhook-url=

--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/README.md
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/README.md
@@ -1,0 +1,10 @@
+# TBTCv2 system events monitoring
+
+Configuration to run TBTCv2 system events monitoring. It is a production 
+overlay of the [base `tbtc-v2-monitoring` configuration](../../templates/tbtc-v2-monitoring)
+
+To apply the configuration execute:
+
+```sh
+kubectl apply -k ./
+```

--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/kustomization.yaml
@@ -1,0 +1,24 @@
+bases:
+  - ../../templates/tbtc-v2-monitoring
+
+images:
+  - name: tbtc-v2-monitoring
+    newName: gcr.io/keep-prd-210b/tbtc-v2-monitoring
+    newTag: latest
+
+configMapGenerator:
+  - name: tbtc-v2-monitoring-config
+    literals:
+      - environment=mainnet
+      - large-deposit-threshold-sat=1000000000 # 10 BTC
+
+secretGenerator:
+  - name: tbtc-v2-monitoring-config
+    envs:
+      - .env.secret
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    note: generated
+

--- a/infrastructure/kube/keep-test/tbtc-v2-monitoring/.env.secret
+++ b/infrastructure/kube/keep-test/tbtc-v2-monitoring/.env.secret
@@ -1,0 +1,3 @@
+ethereum-url=
+sentry-dsn=
+discord-webhook-url=

--- a/infrastructure/kube/keep-test/tbtc-v2-monitoring/.env.secret
+++ b/infrastructure/kube/keep-test/tbtc-v2-monitoring/.env.secret
@@ -1,3 +1,4 @@
 ethereum-url=
+electrum-url=
 sentry-dsn=
 discord-webhook-url=

--- a/infrastructure/kube/keep-test/tbtc-v2-monitoring/README.md
+++ b/infrastructure/kube/keep-test/tbtc-v2-monitoring/README.md
@@ -1,0 +1,10 @@
+# TBTCv2 system events monitoring
+
+Configuration to run TBTCv2 system events monitoring. It is a test
+overlay of the [base `tbtc-v2-monitoring` configuration](../../templates/tbtc-v2-monitoring)
+
+To apply the configuration execute:
+
+```sh
+kubectl apply -k ./
+```

--- a/infrastructure/kube/keep-test/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/keep-test/tbtc-v2-monitoring/kustomization.yaml
@@ -1,0 +1,24 @@
+bases:
+  - ../../templates/tbtc-v2-monitoring
+
+images:
+  - name: tbtc-v2-monitoring
+    newName: gcr.io/keep-test-f3e0/tbtc-v2-monitoring
+    newTag: latest
+
+configMapGenerator:
+  - name: tbtc-v2-monitoring-config
+    literals:
+      - environment=testnet
+      - large-deposit-threshold-sat=10000000 # 0.1 BTC for testing purposes
+
+secretGenerator:
+  - name: tbtc-v2-monitoring-config
+    envs:
+      - .env.secret
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    note: generated
+

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/README.md
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/README.md
@@ -1,0 +1,6 @@
+# TBTCv2 system events monitoring
+
+Base configuration to run [TBTCv2 system events monitoring](https://github.com/keep-network/tbtc-v2/tree/main/monitoring).
+It is referenced by environment-specific overlays:
+- [`keep-prd` production overlay](../../keep-prd/tbtc-v2-monitoring)
+- [`keep-test` test overlay](../../keep-test/tbtc-v2-monitoring)

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - tbtc-v2-monitoring-cronjob.yaml

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
@@ -33,6 +33,11 @@ spec:
                     secretKeyRef:
                       name: tbtc-v2-monitoring-config
                       key: ethereum-url
+                - name: ELECTRUM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: electrum-url
                 - name: LARGE_DEPOSIT_THRESHOLD_SAT
                   valueFrom:
                     configMapKeyRef:

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tbtc-v2-monitoring
+  namespace: default
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 240
+      backoffLimit: 0
+      template:
+        spec:
+          volumes:
+            - name: tbtc-v2-monitoring-data
+              persistentVolumeClaim:
+                claimName: tbtc-v2-monitoring-data
+          restartPolicy: Never
+          containers:
+            - name: tbtc-v2-monitoring
+              image: tbtc-v2-monitoring:latest
+              imagePullPolicy: Always
+              env:
+                - name: ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: environment
+                - name: ETHEREUM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: ethereum-url
+                - name: LARGE_DEPOSIT_THRESHOLD_SAT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: large-deposit-threshold-sat
+                - name: DATA_DIR_PATH
+                  value: /mnt/tbtc-v2-monitoring/data
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: sentry-dsn
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: discord-webhook-url
+              volumeMounts:
+                - name: tbtc-v2-monitoring-data
+                  mountPath: /mnt/tbtc-v2-monitoring/data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tbtc-v2-monitoring-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Refs: https://github.com/keep-network/pm/issues/33
Depends on: https://github.com/keep-network/tbtc-v2/pull/535

Here we introduce Kubernetes deployment for `tbtc-v2-monitoring` component introduced in https://github.com/keep-network/tbtc-v2/pull/526. We are deploying it as a cronjob triggered every 5 minutes. The configuration structure leverages [Kustomize's bases and overlays](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) in order to keep a clear structure and avoid duplication. That means we have:
- A base configuration of the cronjob defined in `infrastructure/kube/templates/tbtc-v2-monitoring` that is referenced by environment-specific configurations (overlays)
- A `keep-prd` production overlay defined in `infrastructure/kube/keep-prd/tbtc-v2-monitoring` that refers to the aforementioned base
- A `keep-test` test overlay defined in `infrastructure/kube/keep-test/tbtc-v2-monitoring` that refers to the aforementioned base