### PR TITLE
Document contracts

### DIFF
--- a/docs/contracts.adoc
+++ b/docs/contracts.adoc
@@ -1,0 +1,5 @@
+= Keep Network Documentation
+
+== Contracts
+
+* link:https://docs.threshold.network/tbtc-v2-contracts[TBTC-v2 contracts]

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6,3 +6,4 @@
 * xref:./run-keep-node.adoc[Run Keep Client Node]
 * xref:./development/README.adoc[Developers]
 * xref:./dev-ops.adoc[DevOps]
+* xref:./contracts.adoc[Contracts]


### PR DESCRIPTION
We're modifying the index page of our documentation to link to the pages documenting contracts. So far we've got only TBTC-v2 contracts documentation in the works, but soon we'll document contracts from other projects.