### PR TITLE
Passed base chain pointer into maintainer

### DIFF
--- a/pkg/chain/ethereum/bitcoin_difficulty.go
+++ b/pkg/chain/ethereum/bitcoin_difficulty.go
@@ -56,6 +56,7 @@ func NewBitcoinDifficultyChain(
 	}
 
 	return &BitcoinDifficultyChain{
+		baseChain:  baseChain,
 		lightRelay: lightRelay,
 	}, nil
 }


### PR DESCRIPTION
This PR fixes an error in the Bitcoin difficulty maintainer: the base chain pointer needs to be stored inside the Bitcoin difficulty chain.