### PR TITLE
Bitcoin difficulty maintainer logic update

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -332,10 +332,10 @@ func initMaintainerFlags(command *cobra.Command, cfg *config.Config) {
 	)
 
 	command.Flags().BoolVar(
-		&cfg.Maintainer.UseBitcoinDifficultyProxy,
-		"useBitcoinDifficultyProxy",
+		&cfg.Maintainer.DisableBitcoinDifficultyProxy,
+		"disableBitcoinDifficultyProxy",
 		false,
-		"use Bitcoin difficulty proxy",
+		"disable Bitcoin difficulty proxy",
 	)
 }
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -330,6 +330,13 @@ func initMaintainerFlags(command *cobra.Command, cfg *config.Config) {
 		false,
 		"start Bitcoin difficulty maintainer",
 	)
+
+	command.Flags().BoolVar(
+		&cfg.Maintainer.UseBitcoinDifficultyProxy,
+		"useBitcoinDifficultyProxy",
+		false,
+		"use Bitcoin difficulty proxy",
+	)
 }
 
 // Initialize flags for Developer configuration.

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -240,6 +240,13 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: true,
 		defaultValue:          false,
 	},
+	"maintainer.useBitcoinDifficultyProxy": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.UseBitcoinDifficultyProxy },
+		flagName:              "--useBitcoinDifficultyProxy",
+		flagValue:             "", // don't provide any value
+		expectedValueFromFlag: true,
+		defaultValue:          false,
+	},
 	"developer.randomBeaconAddress": {
 		readValueFunc: func(c *config.Config) interface{} {
 			address, _ := c.Ethereum.ContractAddress(chainEthereum.RandomBeaconContractName)

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -240,9 +240,9 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: true,
 		defaultValue:          false,
 	},
-	"maintainer.useBitcoinDifficultyProxy": {
-		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.UseBitcoinDifficultyProxy },
-		flagName:              "--useBitcoinDifficultyProxy",
+	"maintainer.disableBitcoinDifficultyProxy": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.DisableBitcoinDifficultyProxy },
+		flagName:              "--disableBitcoinDifficultyProxy",
 		flagValue:             "", // don't provide any value
 		expectedValueFromFlag: true,
 		defaultValue:          false,

--- a/cmd/maintainer.go
+++ b/cmd/maintainer.go
@@ -49,7 +49,11 @@ func maintainers(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
 	}
 
-	chain, err := ethereum.ConnectBitcoinDifficulty(ctx, clientConfig.Ethereum)
+	chain, err := ethereum.ConnectBitcoinDifficulty(
+		ctx,
+		clientConfig.Ethereum,
+		clientConfig.Maintainer,
+	)
 	if err != nil {
 		return fmt.Errorf(
 			"could not connect to Bitcoin difficulty chain: [%v]",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -199,8 +199,8 @@ func TestReadConfigFromFile(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.BitcoinDifficulty },
 			expectedValue: true,
 		},
-		"Maintainer.UseBitcoinDifficultyProxy": {
-			readValueFunc: func(c *Config) interface{} { return c.Maintainer.UseBitcoinDifficultyProxy },
+		"Maintainer.DisableBitcoinDifficultyProxy": {
+			readValueFunc: func(c *Config) interface{} { return c.Maintainer.DisableBitcoinDifficultyProxy },
 			expectedValue: true,
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -199,6 +199,10 @@ func TestReadConfigFromFile(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.BitcoinDifficulty },
 			expectedValue: true,
 		},
+		"Maintainer.UseBitcoinDifficultyProxy": {
+			readValueFunc: func(c *Config) interface{} { return c.Maintainer.UseBitcoinDifficultyProxy },
+			expectedValue: true,
+		},
 	}
 
 	for _, filePath := range filePaths {

--- a/pkg/chain/ethereum/bitcoin_difficulty.go
+++ b/pkg/chain/ethereum/bitcoin_difficulty.go
@@ -63,7 +63,7 @@ func NewBitcoinDifficultyChain(
 
 	// If the Bitcoin difficulty should be updated directly via LightRelay,
 	// quit early without creating a handle to LightRelayMaintainerProxy.
-	if !maintainerConfig.UseBitcoinDifficultyProxy {
+	if maintainerConfig.DisableBitcoinDifficultyProxy {
 		return &BitcoinDifficultyChain{
 			baseChain:                 baseChain,
 			lightRelay:                lightRelay,

--- a/pkg/chain/ethereum/bitcoin_difficulty.go
+++ b/pkg/chain/ethereum/bitcoin_difficulty.go
@@ -115,16 +115,12 @@ func (bdc *BitcoinDifficultyChain) Ready() (bool, error) {
 	return bdc.lightRelay.Ready()
 }
 
-// AuthorizationRequired checks whether the relay requires the address
-// submitting a retarget to be authorised in advance by governance.
-func (bdc *BitcoinDifficultyChain) AuthorizationRequired() (bool, error) {
-	return bdc.lightRelay.AuthorizationRequired()
-}
-
 // IsAuthorized checks whether the given address has been authorised by
 // governance to submit a retarget.
 func (bdc *BitcoinDifficultyChain) IsAuthorized(address chain.Address) (bool, error) {
-	return bdc.lightRelay.IsAuthorized(common.HexToAddress(address.String()))
+	return bdc.LightRelayMaintainerProxy.IsAuthorized(
+		common.HexToAddress(address.String()),
+	)
 }
 
 // Retarget adds a new epoch to the relay by providing a proof of the difficulty

--- a/pkg/chain/ethereum/bitcoin_difficulty.go
+++ b/pkg/chain/ethereum/bitcoin_difficulty.go
@@ -85,6 +85,21 @@ func NewBitcoinDifficultyChain(
 		)
 	}
 
+	retrievedLightRelayAddress, err := lightRelayMaintainerProxy.LightRelay()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to retrieve the relay address from LightRelayMaintainerProxy "+
+				"contract: [%v]",
+			err,
+		)
+	}
+
+	// Verify the LightRelay set in LightRelayMaintainerProxy is the same
+	// instance as the one set in the client via configuration.
+	if lightRelayAddress != retrievedLightRelayAddress {
+		return nil, fmt.Errorf("mismatch between LightRelay addresses")
+	}
+
 	return &BitcoinDifficultyChain{
 		baseChain:                 baseChain,
 		lightRelay:                lightRelay,
@@ -120,7 +135,7 @@ func (bdc *BitcoinDifficultyChain) Retarget(headers []*bitcoin.BlockHeader) erro
 		serializedHeader := header.Serialize()
 		serializedHeaders = append(serializedHeaders, serializedHeader[:]...)
 	}
-	_, err := bdc.lightRelay.Retarget(serializedHeaders)
+	_, err := bdc.LightRelayMaintainerProxy.Retarget(serializedHeaders)
 	return err
 }
 

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -3,11 +3,12 @@ package ethereum
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/hashicorp/go-multierror"
 	"math/big"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -18,6 +19,7 @@ import (
 	"github.com/keep-network/keep-common/pkg/rate"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen/contract"
+	"github.com/keep-network/keep-core/pkg/maintainer"
 	"github.com/keep-network/keep-core/pkg/operator"
 )
 
@@ -127,21 +129,22 @@ func Connect(
 // ConnectBitcoinDifficulty creates Bitcoin difficulty chain handle.
 func ConnectBitcoinDifficulty(
 	ctx context.Context,
-	config ethereum.Config,
+	ethereumConfig ethereum.Config,
+	maintainerConfig maintainer.Config,
 ) (
 	*BitcoinDifficultyChain,
 	error,
 ) {
-	client, err := ethclient.Dial(config.URL)
+	client, err := ethclient.Dial(ethereumConfig.URL)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error Connecting to Ethereum Server: %s [%v]",
-			config.URL,
+			ethereumConfig.URL,
 			err,
 		)
 	}
 
-	baseChain, err := newBaseChain(ctx, config, client)
+	baseChain, err := newBaseChain(ctx, ethereumConfig, client)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"could not create base chain handle: [%v]",
@@ -149,7 +152,11 @@ func ConnectBitcoinDifficulty(
 		)
 	}
 
-	bitcoinDifficultyChain, err := NewBitcoinDifficultyChain(config, baseChain)
+	bitcoinDifficultyChain, err := NewBitcoinDifficultyChain(
+		ethereumConfig,
+		maintainerConfig,
+		baseChain,
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"could not create Bitcoin difficulty chain handle: [%v]",

--- a/pkg/maintainer/bitcoin_difficulty.go
+++ b/pkg/maintainer/bitcoin_difficulty.go
@@ -257,7 +257,7 @@ func (bdm *bitcoinDifficultyMaintainer) proveNextEpoch(ctx context.Context) (
 			if err := bdm.chain.Retarget(headers); err != nil {
 				return false, fmt.Errorf(
 					"failed to submit block headers from range [%d:%d] via "+
-						"via Retarget: [%w]",
+						"Retarget: [%w]",
 					firstBlockHeaderHeight,
 					lastBlockHeaderHeight,
 					err,
@@ -267,7 +267,7 @@ func (bdm *bitcoinDifficultyMaintainer) proveNextEpoch(ctx context.Context) (
 			if err := bdm.chain.RetargetWithRefund(headers); err != nil {
 				return false, fmt.Errorf(
 					"failed to submit block headers from range [%d:%d] via "+
-						"via RetargetWithRefund: [%w]",
+						"RetargetWithRefund: [%w]",
 					firstBlockHeaderHeight,
 					lastBlockHeaderHeight,
 					err,

--- a/pkg/maintainer/bitcoin_difficulty.go
+++ b/pkg/maintainer/bitcoin_difficulty.go
@@ -162,8 +162,8 @@ func (bdm *bitcoinDifficultyMaintainer) verifySubmissionEligibility() error {
 		return nil
 	}
 
-	// Retargetting will be done via `LightRelayMaintainerProxy`` with refunding.
-	isAuthorizedForRefunding, err := bdm.chain.IsAuthorizedForRefund(
+	// Retargetting will be done via `LightRelayMaintainerProxy` with refunding.
+	isAuthorizedForRefund, err := bdm.chain.IsAuthorizedForRefund(
 		maintainerAddress,
 	)
 	if err != nil {
@@ -174,7 +174,7 @@ func (bdm *bitcoinDifficultyMaintainer) verifySubmissionEligibility() error {
 		)
 	}
 
-	if !isAuthorizedForRefunding {
+	if !isAuthorizedForRefund {
 		return errNotAuthorized
 	}
 

--- a/pkg/maintainer/bitcoin_difficulty.go
+++ b/pkg/maintainer/bitcoin_difficulty.go
@@ -138,19 +138,6 @@ func (bdm *bitcoinDifficultyMaintainer) verifySubmissionEligibility() error {
 		return errNoGenesis
 	}
 
-	authorizationRequired, err := bdm.chain.AuthorizationRequired()
-	if err != nil {
-		return fmt.Errorf(
-			"cannot check whether authorization is required to submit "+
-				"block headers: [%w]",
-			err,
-		)
-	}
-
-	if !authorizationRequired {
-		return nil
-	}
-
 	maintainerAddress := bdm.chain.Signing().Address()
 
 	isAuthorized, err := bdm.chain.IsAuthorized(maintainerAddress)

--- a/pkg/maintainer/bitcoin_difficulty.go
+++ b/pkg/maintainer/bitcoin_difficulty.go
@@ -42,12 +42,14 @@ func initializeBitcoinDifficultyMaintainer(
 	ctx context.Context,
 	btcChain bitcoin.Chain,
 	chain BitcoinDifficultyChain,
+	disableProxy bool,
 	idleBackOffTime time.Duration,
 	restartBackOffTime time.Duration,
 ) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           btcChain,
 		chain:              chain,
+		disableProxy:       disableProxy,
 		idleBackOffTime:    idleBackOffTime,
 		restartBackOffTime: restartBackOffTime,
 	}

--- a/pkg/maintainer/bitcoin_difficulty_test.go
+++ b/pkg/maintainer/bitcoin_difficulty_test.go
@@ -469,6 +469,7 @@ func TestBitcoinDifficultyMaintainer_Integration(t *testing.T) {
 		ctx,
 		btcChain,
 		difficultyChain,
+		false,
 		idleBackOffTime,
 		restartBackOffTime,
 	)

--- a/pkg/maintainer/bitcoin_difficulty_test.go
+++ b/pkg/maintainer/bitcoin_difficulty_test.go
@@ -12,34 +12,24 @@ import (
 
 func TestVerifySubmissionEligibility(t *testing.T) {
 	tests := map[string]struct {
-		ready                 bool
-		authorizationRequired bool
-		operatorAuthorized    bool
-		expectedError         error
+		ready              bool
+		operatorAuthorized bool
+		expectedError      error
 	}{
 		"chain not ready": {
-			ready:                 false,
-			authorizationRequired: false,
-			operatorAuthorized:    false,
-			expectedError:         errNoGenesis,
-		},
-		"authorization not required": {
-			ready:                 true,
-			authorizationRequired: false,
-			operatorAuthorized:    false,
-			expectedError:         nil,
+			ready:              false,
+			operatorAuthorized: false,
+			expectedError:      errNoGenesis,
 		},
 		"operator not authorized": {
-			ready:                 true,
-			authorizationRequired: true,
-			operatorAuthorized:    false,
-			expectedError:         errNotAuthorized,
+			ready:              true,
+			operatorAuthorized: false,
+			expectedError:      errNotAuthorized,
 		},
 		"operator authorized": {
-			ready:                 true,
-			authorizationRequired: true,
-			operatorAuthorized:    true,
-			expectedError:         nil,
+			ready:              true,
+			operatorAuthorized: true,
+			expectedError:      nil,
 		},
 	}
 
@@ -49,7 +39,6 @@ func TestVerifySubmissionEligibility(t *testing.T) {
 			operatorAddress := difficultyChain.Signing().Address()
 
 			difficultyChain.SetReady(test.ready)
-			difficultyChain.SetAuthorizationRequired(test.authorizationRequired)
 			difficultyChain.SetAuthorizedOperator(
 				operatorAddress,
 				test.operatorAuthorized,

--- a/pkg/maintainer/bitcoin_difficulty_test.go
+++ b/pkg/maintainer/bitcoin_difficulty_test.go
@@ -163,6 +163,7 @@ func TestProveNextEpoch(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           btcChain,
 		chain:              difficultyChain,
+		disableProxy:       true,
 		idleBackOffTime:    bitcoinDifficultyDefaultIdleBackOffTime,
 		restartBackOffTime: bitcoinDifficultyDefaultRestartBackoffTime,
 	}
@@ -263,6 +264,7 @@ func TestGetBlockHeaders(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           btcChain,
 		chain:              nil,
+		disableProxy:       true,
 		idleBackOffTime:    bitcoinDifficultyDefaultIdleBackOffTime,
 		restartBackOffTime: bitcoinDifficultyDefaultRestartBackoffTime,
 	}
@@ -294,6 +296,7 @@ func TestWaitForCurrentEpochUpdate_Successful(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           nil,
 		chain:              difficultyChain,
+		disableProxy:       true,
 		idleBackOffTime:    2 * time.Second,
 		restartBackOffTime: 2 * time.Second,
 	}
@@ -342,6 +345,7 @@ func TestWaitForCurrentEpochUpdate_Cancelled(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           nil,
 		chain:              difficultyChain,
+		disableProxy:       true,
 		idleBackOffTime:    2 * time.Second,
 		restartBackOffTime: 2 * time.Second,
 	}
@@ -383,6 +387,7 @@ func TestProveEpochs_ErrorVerifyingSubmissionEligibility(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           nil,
 		chain:              difficultyChain,
+		disableProxy:       true,
 		idleBackOffTime:    bitcoinDifficultyDefaultIdleBackOffTime,
 		restartBackOffTime: bitcoinDifficultyDefaultRestartBackoffTime,
 	}
@@ -410,6 +415,7 @@ func TestProveEpochs_ErrorProvingSingleEpoch(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           btcChain,
 		chain:              difficultyChain,
+		disableProxy:       true,
 		idleBackOffTime:    bitcoinDifficultyDefaultIdleBackOffTime,
 		restartBackOffTime: bitcoinDifficultyDefaultRestartBackoffTime,
 	}
@@ -460,6 +466,7 @@ func TestProveEpochs_Successful(t *testing.T) {
 	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
 		btcChain:           btcChain,
 		chain:              difficultyChain,
+		disableProxy:       true,
 		idleBackOffTime:    2 * time.Second,
 		restartBackOffTime: 2 * time.Second,
 	}
@@ -499,7 +506,7 @@ func TestBitcoinDifficultyMaintainer_Integration(t *testing.T) {
 		ctx,
 		btcChain,
 		difficultyChain,
-		false,
+		true,
 		idleBackOffTime,
 		restartBackOffTime,
 	)

--- a/pkg/maintainer/bitcoin_difficulty_test.go
+++ b/pkg/maintainer/bitcoin_difficulty_test.go
@@ -96,137 +96,177 @@ func TestVerifySubmissionEligibility(t *testing.T) {
 }
 
 func TestProveNextEpoch(t *testing.T) {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
-
-	btcChain := connectLocalBitcoinChain()
-
-	// Set three block headers on each side of the retarget. The old epoch
-	// number is 299, the new epoch number is 300.
-	blockHeaders := map[uint]*bitcoin.BlockHeader{
-		604797: {
-			Version:                 0,
-			PreviousBlockHeaderHash: bitcoin.Hash{},
-			MerkleRootHash:          bitcoin.Hash{},
-			Time:                    1000000,
-			Bits:                    1111111,
-			Nonce:                   10,
+	tests := []struct {
+		name         string
+		disableProxy bool
+	}{
+		{
+			name:         "proxy disabled",
+			disableProxy: true,
 		},
-		604798: {
-			Version:                 0,
-			PreviousBlockHeaderHash: bitcoin.Hash{},
-			MerkleRootHash:          bitcoin.Hash{},
-			Time:                    1000100,
-			Bits:                    1111111,
-			Nonce:                   20,
-		},
-		604799: { // Last block of the old epoch (epoch 299)
-			Version:                 0,
-			PreviousBlockHeaderHash: bitcoin.Hash{},
-			MerkleRootHash:          bitcoin.Hash{},
-			Time:                    1000200,
-			Bits:                    1111111,
-			Nonce:                   30,
-		},
-		604800: { // First block of the new epoch (epoch 300)
-			Version:                 0,
-			PreviousBlockHeaderHash: bitcoin.Hash{},
-			MerkleRootHash:          bitcoin.Hash{},
-			Time:                    1000300,
-			Bits:                    2222222,
-			Nonce:                   40,
-		},
-		604801: {
-			Version:                 0,
-			PreviousBlockHeaderHash: bitcoin.Hash{},
-			MerkleRootHash:          bitcoin.Hash{},
-			Time:                    1000400,
-			Bits:                    2222222,
-			Nonce:                   50,
-		},
-		604802: {
-			Version:                 0,
-			PreviousBlockHeaderHash: bitcoin.Hash{},
-			MerkleRootHash:          bitcoin.Hash{},
-			Time:                    1000500,
-			Bits:                    2222222,
-			Nonce:                   60,
+		{
+			name:         "proxy enabled",
+			disableProxy: false,
 		},
 	}
-	btcChain.SetBlockHeaders(blockHeaders)
 
-	difficultyChain := connectLocalBitcoinDifficultyChain()
-
-	difficultyChain.SetCurrentEpoch(299)
-	difficultyChain.SetProofLength(3)
-
-	bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
-		btcChain:           btcChain,
-		chain:              difficultyChain,
-		disableProxy:       true,
-		idleBackOffTime:    bitcoinDifficultyDefaultIdleBackOffTime,
-		restartBackOffTime: bitcoinDifficultyDefaultRestartBackoffTime,
+	createBlockHeaders := func() map[uint]*bitcoin.BlockHeader {
+		return map[uint]*bitcoin.BlockHeader{
+			604797: {
+				Version:                 0,
+				PreviousBlockHeaderHash: bitcoin.Hash{},
+				MerkleRootHash:          bitcoin.Hash{},
+				Time:                    1000000,
+				Bits:                    1111111,
+				Nonce:                   10,
+			},
+			604798: {
+				Version:                 0,
+				PreviousBlockHeaderHash: bitcoin.Hash{},
+				MerkleRootHash:          bitcoin.Hash{},
+				Time:                    1000100,
+				Bits:                    1111111,
+				Nonce:                   20,
+			},
+			604799: { // Last block of the old epoch (epoch 299)
+				Version:                 0,
+				PreviousBlockHeaderHash: bitcoin.Hash{},
+				MerkleRootHash:          bitcoin.Hash{},
+				Time:                    1000200,
+				Bits:                    1111111,
+				Nonce:                   30,
+			},
+			604800: { // First block of the new epoch (epoch 300)
+				Version:                 0,
+				PreviousBlockHeaderHash: bitcoin.Hash{},
+				MerkleRootHash:          bitcoin.Hash{},
+				Time:                    1000300,
+				Bits:                    2222222,
+				Nonce:                   40,
+			},
+			604801: {
+				Version:                 0,
+				PreviousBlockHeaderHash: bitcoin.Hash{},
+				MerkleRootHash:          bitcoin.Hash{},
+				Time:                    1000400,
+				Bits:                    2222222,
+				Nonce:                   50,
+			},
+			604802: {
+				Version:                 0,
+				PreviousBlockHeaderHash: bitcoin.Hash{},
+				MerkleRootHash:          bitcoin.Hash{},
+				Time:                    1000500,
+				Bits:                    2222222,
+				Nonce:                   60,
+			},
+		}
 	}
 
-	result, err := bitcoinDifficultyMaintainer.proveNextEpoch(ctx)
-	if err != nil {
-		t.Fatal(err)
+	runProveNextEpochAssertions := func(
+		t *testing.T,
+		ctx context.Context,
+		bitcoinDifficultyMaintainer *bitcoinDifficultyMaintainer,
+		blockHeaders map[uint]*bitcoin.BlockHeader,
+		difficultyChain *localBitcoinDifficultyChain,
+	) {
+		result, err := bitcoinDifficultyMaintainer.proveNextEpoch(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedResult := true
+		if result != expectedResult {
+			t.Fatalf(
+				"unexpected result returned\nexpected: %v\nactual:   %v\n",
+				expectedResult,
+				result,
+			)
+		}
+
+		var retargetEvents []*RetargetEvent
+		if bitcoinDifficultyMaintainer.disableProxy {
+			retargetEvents = difficultyChain.RetargetEvents()
+		} else {
+			retargetEvents = difficultyChain.RetargetWithRefundEvents()
+		}
+
+		expectedNumberOfRetargetEvents := 1
+		if len(retargetEvents) != expectedNumberOfRetargetEvents {
+			t.Fatalf(
+				"unexpected number of retarget events\nexpected: %v\nactual:   %v\n",
+				expectedNumberOfRetargetEvents,
+				len(retargetEvents),
+			)
+		}
+
+		eventsOldDifficulty := retargetEvents[0].oldDifficulty
+		expectedOldDifficulty := blockHeaders[604799].Bits
+		if eventsOldDifficulty != expectedOldDifficulty {
+			t.Fatalf(
+				"unexpected old difficulty of the retarget event \n"+
+					"expected: %v\nactual:   %v\n",
+				expectedOldDifficulty,
+				eventsOldDifficulty,
+			)
+		}
+
+		eventsNewDifficulty := retargetEvents[0].newDifficulty
+		expectedNewDifficulty := blockHeaders[604800].Bits
+		if eventsNewDifficulty != expectedNewDifficulty {
+			t.Fatalf(
+				"unexpected new difficulty of the retarget event \n"+
+					"expected: %v\nactual:   %v\n",
+				expectedNewDifficulty,
+				eventsNewDifficulty,
+			)
+		}
+
+		// Call once more, this time without any new epoch to prove
+		result, err = bitcoinDifficultyMaintainer.proveNextEpoch(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedResult = false
+		if result != expectedResult {
+			t.Fatalf(
+				"unexpected result returned\nexpected: %v\nactual:   %v\n",
+				expectedResult,
+				result,
+			)
+		}
 	}
 
-	expectedResult := true
-	if result != expectedResult {
-		t.Fatalf(
-			"unexpected result returned\nexpected: %v\nactual:   %v\n",
-			expectedResult,
-			result,
-		)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancelCtx := context.WithCancel(context.Background())
+			defer cancelCtx()
 
-	expectedNumberOfRetargetEvents := 1
-	retargetEvents := difficultyChain.RetargetEvents()
-	if len(retargetEvents) != expectedNumberOfRetargetEvents {
-		t.Fatalf(
-			"unexpected number of retarget events\nexpected: %v\nactual:   %v\n",
-			expectedNumberOfRetargetEvents,
-			len(retargetEvents),
-		)
-	}
+			btcChain := connectLocalBitcoinChain()
+			blockHeaders := createBlockHeaders()
+			btcChain.SetBlockHeaders(blockHeaders)
 
-	eventsOldDifficulty := retargetEvents[0].oldDifficulty
-	expectedOldDifficulty := blockHeaders[604799].Bits
-	if eventsOldDifficulty != expectedOldDifficulty {
-		t.Fatalf(
-			"unexpected old difficulty of the retarget event \n"+
-				"expected: %v\nactual:   %v\n",
-			expectedOldDifficulty,
-			eventsOldDifficulty,
-		)
-	}
+			difficultyChain := connectLocalBitcoinDifficultyChain()
+			difficultyChain.SetCurrentEpoch(299)
+			difficultyChain.SetProofLength(3)
 
-	eventsNewDifficulty := retargetEvents[0].newDifficulty
-	expectedNewDifficulty := blockHeaders[604800].Bits
-	if eventsNewDifficulty != expectedNewDifficulty {
-		t.Fatalf(
-			"unexpected new difficulty of the retarget event \n"+
-				"expected: %v\nactual:   %v\n",
-			expectedNewDifficulty,
-			eventsNewDifficulty,
-		)
-	}
+			bitcoinDifficultyMaintainer := &bitcoinDifficultyMaintainer{
+				btcChain:           btcChain,
+				chain:              difficultyChain,
+				disableProxy:       tc.disableProxy,
+				idleBackOffTime:    bitcoinDifficultyDefaultIdleBackOffTime,
+				restartBackOffTime: bitcoinDifficultyDefaultRestartBackoffTime,
+			}
 
-	// Call once more, this time without any new epoch to prove
-	result, err = bitcoinDifficultyMaintainer.proveNextEpoch(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedResult = false
-	if result != expectedResult {
-		t.Fatalf(
-			"unexpected result returned\nexpected: %v\nactual:   %v\n",
-			expectedResult,
-			result,
-		)
+			runProveNextEpochAssertions(
+				t,
+				ctx,
+				bitcoinDifficultyMaintainer,
+				blockHeaders,
+				difficultyChain,
+			)
+		})
 	}
 }
 

--- a/pkg/maintainer/chain.go
+++ b/pkg/maintainer/chain.go
@@ -14,10 +14,6 @@ type BitcoinDifficultyChain interface {
 	// otherwise the prevEpochDifficulty will be uninitialized and zero.
 	Ready() (bool, error)
 
-	// AuthorizationRequired checks whether the relay requires the address
-	// submitting a retarget to be authorised in advance by governance.
-	AuthorizationRequired() (bool, error)
-
 	// IsAuthorized checks whether the given address has been authorized by
 	// governance to submit a retarget.
 	IsAuthorized(address chain.Address) (bool, error)

--- a/pkg/maintainer/chain.go
+++ b/pkg/maintainer/chain.go
@@ -14,16 +14,29 @@ type BitcoinDifficultyChain interface {
 	// otherwise the prevEpochDifficulty will be uninitialized and zero.
 	Ready() (bool, error)
 
-	// IsAuthorized checks whether the given address has been authorized by
-	// governance to submit a retarget.
+	// IsAuthorized checks whether the given address has been authorized to
+	// submit a retarget directly to LightRelay. This function should be used
+	// when retargetting via LightRelayMaintainerProxy is disabled.
 	IsAuthorized(address chain.Address) (bool, error)
+
+	// IsAuthorizedForRefund checks whether the given address has been
+	// authorized to submit a retarget via LightRelayMaintainerProxy. This
+	// function should be used when retargetting via LightRelayMaintainerProxy
+	// is not disabled.
+	IsAuthorizedForRefund(address chain.Address) (bool, error)
 
 	// Signing returns the signing associated with the chain.
 	Signing() chain.Signing
 
-	// Retarget adds a new epoch to the relay by providing a proof
-	// of the difficulty before and after the retarget.
+	// Retarget adds a new epoch to the relay by providing a proof of the
+	// difficulty before and after the retarget. The cost of calling this
+	// function is not refunded to the caller.
 	Retarget(headers []*bitcoin.BlockHeader) error
+
+	// RetargetWithRefund adds a new epoch to the relay by providing a proof of
+	// the difficulty before and after the retarget. The cost of calling this
+	// function is refunded to the caller.
+	RetargetWithRefund(headers []*bitcoin.BlockHeader) error
 
 	// CurrentEpoch returns the number of the latest difficulty epoch which is
 	// proven to the relay. If the genesis epoch's number is set correctly, and

--- a/pkg/maintainer/chain_test.go
+++ b/pkg/maintainer/chain_test.go
@@ -37,9 +37,20 @@ func (lbdc *localBitcoinDifficultyChain) AuthorizationRequired() (bool, error) {
 	return lbdc.authorizationRequired, nil
 }
 
-// IsAuthorized checks whether the given address has been authorized by
-// governance to submit a retarget.
+// IsAuthorized checks whether the given address has been authorized to
+// submit a retarget directly to LightRelay. This function should be used
+// when retargetting via LightRelayMaintainerProxy is disabled.
 func (lbdc *localBitcoinDifficultyChain) IsAuthorized(
+	address chain.Address,
+) (bool, error) {
+	return lbdc.authorizedOperators[address], nil
+}
+
+// IsAuthorizedForRefund checks whether the given address has been
+// authorized to submit a retarget via LightRelayMaintainerProxy. This
+// function should be used when retargetting via LightRelayMaintainerProxy
+// is not disabled.
+func (lbdc *localBitcoinDifficultyChain) IsAuthorizedForRefund(
 	address chain.Address,
 ) (bool, error) {
 	return lbdc.authorizedOperators[address], nil
@@ -66,6 +77,15 @@ func (lbdc *localBitcoinDifficultyChain) Retarget(
 	lbdc.currentEpoch++
 
 	return nil
+}
+
+// RetargetWithRefund adds a new epoch to the relay by providing a proof of
+// the difficulty before and after the retarget. The cost of calling this
+// function is refunded to the caller.
+func (lbdc *localBitcoinDifficultyChain) RetargetWithRefund(
+	headers []*bitcoin.BlockHeader,
+) error {
+	return lbdc.Retarget(headers)
 }
 
 // CurrentEpoch returns the number of the latest difficulty epoch which is

--- a/pkg/maintainer/chain_test.go
+++ b/pkg/maintainer/chain_test.go
@@ -19,9 +19,9 @@ type localBitcoinDifficultyChain struct {
 	currentEpoch uint64
 	proofLength  uint64
 
-	ready                 bool
-	authorizationRequired bool
-	authorizedOperators   map[chain.Address]bool
+	ready                        bool
+	authorizedOperators          map[chain.Address]bool
+	authorizedForRefundOperators map[chain.Address]bool
 
 	retargetEvents []*RetargetEvent
 }
@@ -29,12 +29,6 @@ type localBitcoinDifficultyChain struct {
 // Ready checks whether the relay is active (i.e. genesis has been performed).
 func (lbdc *localBitcoinDifficultyChain) Ready() (bool, error) {
 	return lbdc.ready, nil
-}
-
-// AuthorizationRequired checks whether the relay requires the address
-// submitting a retarget to be authorised in advance by governance.
-func (lbdc *localBitcoinDifficultyChain) AuthorizationRequired() (bool, error) {
-	return lbdc.authorizationRequired, nil
 }
 
 // IsAuthorized checks whether the given address has been authorized to
@@ -53,7 +47,7 @@ func (lbdc *localBitcoinDifficultyChain) IsAuthorized(
 func (lbdc *localBitcoinDifficultyChain) IsAuthorizedForRefund(
 	address chain.Address,
 ) (bool, error) {
-	return lbdc.authorizedOperators[address], nil
+	return lbdc.authorizedForRefundOperators[address], nil
 }
 
 // Signing returns the signing associated with the chain.
@@ -107,12 +101,6 @@ func (lbdc *localBitcoinDifficultyChain) SetReady(ready bool) {
 	lbdc.ready = ready
 }
 
-// SetAuthorizationRequired sets chain's authorization requirement to true
-// or false.
-func (lbdc *localBitcoinDifficultyChain) SetAuthorizationRequired(required bool) {
-	lbdc.authorizationRequired = required
-}
-
 // SetAuthorizedOperator sets the given operator address as either authorized or
 // unauthorized.
 func (lbdc *localBitcoinDifficultyChain) SetAuthorizedOperator(
@@ -120,6 +108,15 @@ func (lbdc *localBitcoinDifficultyChain) SetAuthorizedOperator(
 	authorized bool,
 ) {
 	lbdc.authorizedOperators[operatorAddress] = authorized
+}
+
+// SetAuthorizedForRefundOperator sets the given operator address as either
+// authorized or unauthorized for refund.
+func (lbdc *localBitcoinDifficultyChain) SetAuthorizedForRefundOperator(
+	operatorAddress chain.Address,
+	authorized bool,
+) {
+	lbdc.authorizedForRefundOperators[operatorAddress] = authorized
 }
 
 // SetCurrentEpoch sets the current proven epoch in the chain.
@@ -146,7 +143,8 @@ func connectLocalBitcoinDifficultyChain() *localBitcoinDifficultyChain {
 	}
 
 	return &localBitcoinDifficultyChain{
-		operatorPrivateKey:  operatorPrivateKey,
-		authorizedOperators: make(map[chain.Address]bool),
+		operatorPrivateKey:           operatorPrivateKey,
+		authorizedOperators:          make(map[chain.Address]bool),
+		authorizedForRefundOperators: make(map[chain.Address]bool),
 	}
 }

--- a/pkg/maintainer/config.go
+++ b/pkg/maintainer/config.go
@@ -6,5 +6,9 @@ type Config struct {
 	// should be started.
 	BitcoinDifficulty bool
 
+	// UseBitcoinDifficultyProxy indicates whether the Bitcoin difficulty
+	// maintainer should submit difficulty information via proxy.
+	UseBitcoinDifficultyProxy bool
+
 	// TODO: Add options for other maintainer tasks, e.g. spv
 }

--- a/pkg/maintainer/config.go
+++ b/pkg/maintainer/config.go
@@ -6,9 +6,12 @@ type Config struct {
 	// should be started.
 	BitcoinDifficulty bool
 
-	// UseBitcoinDifficultyProxy indicates whether the Bitcoin difficulty
-	// maintainer should submit difficulty information via proxy.
-	UseBitcoinDifficultyProxy bool
+	// DisableBitcoinDifficultyProxy indicates whether the Bitcoin difficulty
+	// maintainer proxy should be disabled. By default, the Bitcoin difficulty
+	// maintainer submits the epoch headers to the relay via the proxy. If this
+	// option is set to true, the epoch headers will be submitted directly to
+	// the relay.
+	DisableBitcoinDifficultyProxy bool
 
 	// TODO: Add options for other maintainer tasks, e.g. spv
 }

--- a/pkg/maintainer/maintainer.go
+++ b/pkg/maintainer/maintainer.go
@@ -21,6 +21,7 @@ func Initialize(
 			ctx,
 			btcChain,
 			chain,
+			config.DisableBitcoinDifficultyProxy,
 			bitcoinDifficultyDefaultIdleBackOffTime,
 			bitcoinDifficultyDefaultRestartBackoffTime,
 		)

--- a/test/config.json
+++ b/test/config.json
@@ -42,7 +42,7 @@
     },
     "Maintainer": {
         "BitcoinDifficulty": true,
-        "UseBitcoinDifficultyProxy": true
+        "DisableBitcoinDifficultyProxy": true
     },
     "Developer": {
         "RandomBeaconAddress": "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb",

--- a/test/config.json
+++ b/test/config.json
@@ -41,7 +41,8 @@
         "EthereumMetricsTick": "1m27s"
     },
     "Maintainer": {
-        "BitcoinDifficulty": true
+        "BitcoinDifficulty": true,
+        "UseBitcoinDifficultyProxy": true
     },
     "Developer": {
         "RandomBeaconAddress": "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb",

--- a/test/config.toml
+++ b/test/config.toml
@@ -38,6 +38,7 @@ EthereumMetricsTick = "1m27s"
 
 [maintainer]
 BitcoinDifficulty = true
+UseBitcoinDifficultyProxy = true
 
 [developer]
 RandomBeaconAddress = "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb"

--- a/test/config.toml
+++ b/test/config.toml
@@ -38,7 +38,7 @@ EthereumMetricsTick = "1m27s"
 
 [maintainer]
 BitcoinDifficulty = true
-UseBitcoinDifficultyProxy = true
+DisableBitcoinDifficultyProxy = true
 
 [developer]
 RandomBeaconAddress = "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb"

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -33,6 +33,7 @@ ClientInfo:
   EthereumMetricsTick: "1m27s"
 Maintainer:
     BitcoinDifficulty: true
+    UseBitcoinDifficultyProxy: true
 Developer:
   RandomBeaconAddress: "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb"
   WalletRegistryAddress: "0x143ba24e66fce8bca22f7d739f9a932c519b1c76"

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -33,7 +33,7 @@ ClientInfo:
   EthereumMetricsTick: "1m27s"
 Maintainer:
     BitcoinDifficulty: true
-    UseBitcoinDifficultyProxy: true
+    DisableBitcoinDifficultyProxy: true
 Developer:
   RandomBeaconAddress: "0xcf64c2a367341170cb4e09cf8c0ed137d8473ceb"
   WalletRegistryAddress: "0x143ba24e66fce8bca22f7d739f9a932c519b1c76"


### PR DESCRIPTION
This PR updates the logic of the Bitcoin difficulty maintainer, so that relay retargetting can be performed either via  `LightRelayMaintainerProxy` or directly via `LightRelay`. The decision if based on the value of the  `disableBitcoinDifficultyProxy ` flag. 

By default, this flag is set to false and `LightRelayMaintainerProxy` is used. If set to true, retargets are done directly via `LightRelay`.