### PR TITLE
Fix name of argument `KeyGenerationConcurrency`

### DIFF
--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -226,7 +226,7 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: 2,
 		defaultValue:          1,
 	},
-	"tbtc.keyGenConcurrency": {
+	"tbtc.keyGenerationConcurrency": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.KeyGenerationConcurrency },
 		flagName:              "--tbtc.keyGenerationConcurrency",
 		flagValue:             "101",

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -117,7 +117,7 @@ Port = 9601
 # PreParamsGenerationTimeout = "2m"
 # PreParamsGenerationDelay = "10s"
 # PreParamsGenerationConcurrency = 1
-# KeyGenConcurrency = 1
+# KeyGenerationConcurrency = 1
 
 # Developer options to work with locally deployed contracts
 #


### PR DESCRIPTION
`KeyGenConcurrency` is not recognized properly when used in a configuration. The proper name is `KeyGenerationConcurrency`.

This commit replaces all occurrences of `KeyGenConcurrency` to `KeyGenerationConcurrency`.