### PR TITLE
Heartbea(s)t part I: The new event listener

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1047,42 +1047,6 @@ func buildDepositKey(
 	return depositKey.Big()
 }
 
-func (tc *TbtcChain) activeWalletPublicKey() ([]byte, bool, error) {
-	walletPublicKeyHash, err := tc.bridge.ActiveWalletPubKeyHash()
-	if err != nil {
-		return nil, false, fmt.Errorf(
-			"cannot get active wallet public key hash: [%v]",
-			err,
-		)
-	}
-
-	if walletPublicKeyHash == [20]byte{} {
-		return nil, false, nil
-	}
-
-	bridgeWalletData, err := tc.bridge.Wallets(walletPublicKeyHash)
-	if err != nil {
-		return nil, false, fmt.Errorf(
-			"cannot get active wallet data from Bridge: [%v]",
-			err,
-		)
-	}
-
-	registryWalletData, err := tc.walletRegistry.GetWallet(bridgeWalletData.EcdsaWalletID)
-	if err != nil {
-		return nil, false, fmt.Errorf(
-			"cannot get active wallet data from WalletRegistry: [%v]",
-			err,
-		)
-	}
-
-	publicKeyBytes := []byte{0x04} // pre-fill with uncompressed ECDSA public key prefix
-	publicKeyBytes = append(publicKeyBytes, registryWalletData.PublicKeyX[:]...)
-	publicKeyBytes = append(publicKeyBytes, registryWalletData.PublicKeyY[:]...)
-
-	return publicKeyBytes, true, nil
-}
-
 func (tc *TbtcChain) OnHeartbeatRequestSubmitted(
 	handler func(event *tbtc.HeartbeatRequestSubmittedEvent),
 ) subscription.EventSubscription {

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1152,6 +1152,24 @@ func (tc *TbtcChain) activeWalletPublicKey() ([]byte, bool, error) {
 	return publicKeyBytes, true, nil
 }
 
+func (tc *TbtcChain) OnHeartbeatRequestedSubmitted(
+	handler func(event *tbtc.HeartbeatRequestedSubmittedEvent),
+) subscription.EventSubscription {
+	onEvent := func(
+		walletPubKeyHash [20]byte,
+		message []byte,
+		blockNumber uint64,
+	) {
+		handler(&tbtc.HeartbeatRequestedSubmittedEvent{
+			WalletPublicKeyHash: walletPubKeyHash,
+			Message:             message,
+			BlockNumber:         blockNumber,
+		})
+	}
+
+	return tc.walletCoordinator.HeartbeatRequestSubmittedEvent(nil).OnEvent(onEvent)
+}
+
 func (tc *TbtcChain) OnDepositSweepProposalSubmitted(
 	handler func(event *tbtc.DepositSweepProposalSubmittedEvent),
 ) subscription.EventSubscription {

--- a/pkg/chain/ethereum/tbtc/gen/abi/WalletCoordinator.go
+++ b/pkg/chain/ethereum/tbtc/gen/abi/WalletCoordinator.go
@@ -58,15 +58,9 @@ type WalletCoordinatorDepositSweepProposal struct {
 	SweepTxFee       *big.Int
 }
 
-// WalletCoordinatorWalletMemberContext is an auto generated low-level Go binding around an user-defined struct.
-type WalletCoordinatorWalletMemberContext struct {
-	WalletMembersIDs  []uint32
-	WalletMemberIndex *big.Int
-}
-
 // WalletCoordinatorMetaData contains all meta data concerning the WalletCoordinator contract.
 var WalletCoordinatorMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositMinAge\",\"type\":\"uint32\"}],\"name\":\"DepositMinAgeUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositRefundSafetyMargin\",\"type\":\"uint32\"}],\"name\":\"DepositRefundSafetyMarginUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"depositSweepMaxSize\",\"type\":\"uint16\"}],\"name\":\"DepositSweepMaxSizeUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"DepositSweepProposalSubmissionGasOffsetUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"indexed\":false,\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"proposalSubmitter\",\"type\":\"address\"}],\"name\":\"DepositSweepProposalSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalValidity\",\"type\":\"uint32\"}],\"name\":\"DepositSweepProposalValidityUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"proposalSubmitter\",\"type\":\"address\"}],\"name\":\"ProposalSubmitterAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"proposalSubmitter\",\"type\":\"address\"}],\"name\":\"ProposalSubmitterRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newReimbursementPool\",\"type\":\"address\"}],\"name\":\"ReimbursementPoolUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"WalletManuallyUnlocked\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"proposalSubmitter\",\"type\":\"address\"}],\"name\":\"addProposalSubmitter\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"bridge\",\"outputs\":[{\"internalType\":\"contractBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositMinAge\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositRefundSafetyMargin\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepMaxSize\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalSubmissionGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractBridge\",\"name\":\"_bridge\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isProposalSubmitter\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"reimbursementPool\",\"outputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"proposalSubmitter\",\"type\":\"address\"}],\"name\":\"removeProposalSubmitter\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint32[]\",\"name\":\"walletMembersIDs\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256\",\"name\":\"walletMemberIndex\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.WalletMemberContext\",\"name\":\"walletMemberContext\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposal\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint32[]\",\"name\":\"walletMembersIDs\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256\",\"name\":\"walletMemberIndex\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.WalletMemberContext\",\"name\":\"walletMemberContext\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposalWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"unlockWallet\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositMinAge\",\"type\":\"uint32\"}],\"name\":\"updateDepositMinAge\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositRefundSafetyMargin\",\"type\":\"uint32\"}],\"name\":\"updateDepositRefundSafetyMargin\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"_depositSweepMaxSize\",\"type\":\"uint16\"}],\"name\":\"updateDepositSweepMaxSize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateDepositSweepProposalSubmissionGasOffset\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalValidity\",\"type\":\"uint32\"}],\"name\":\"updateDepositSweepProposalValidity\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"_reimbursementPool\",\"type\":\"address\"}],\"name\":\"updateReimbursementPool\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"bytes4\",\"name\":\"version\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"inputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"outputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes4\",\"name\":\"locktime\",\"type\":\"bytes4\"}],\"internalType\":\"structBitcoinTx.Info\",\"name\":\"fundingTx\",\"type\":\"tuple\"},{\"internalType\":\"bytes8\",\"name\":\"blindingFactor\",\"type\":\"bytes8\"},{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20\",\"name\":\"refundPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes4\",\"name\":\"refundLocktime\",\"type\":\"bytes4\"}],\"internalType\":\"structWalletCoordinator.DepositExtraInfo[]\",\"name\":\"depositsExtraInfo\",\"type\":\"tuple[]\"}],\"name\":\"validateDepositSweepProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"\",\"type\":\"bytes20\"}],\"name\":\"walletLock\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"expiresAt\",\"type\":\"uint32\"},{\"internalType\":\"enumWalletCoordinator.WalletAction\",\"name\":\"cause\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"walletRegistry\",\"outputs\":[{\"internalType\":\"contractIWalletRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"CoordinatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"CoordinatorRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositMinAge\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositRefundSafetyMargin\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"depositSweepMaxSize\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"DepositSweepProposalParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"indexed\":false,\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"DepositSweepProposalSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"heartbeatRequestValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"heartbeatRequestGasOffset\",\"type\":\"uint32\"}],\"name\":\"HeartbeatRequestParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"HeartbeatRequestSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newReimbursementPool\",\"type\":\"address\"}],\"name\":\"ReimbursementPoolUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"WalletManuallyUnlocked\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"addCoordinator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"bridge\",\"outputs\":[{\"internalType\":\"contractBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositMinAge\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositRefundSafetyMargin\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepMaxSize\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalSubmissionGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeatRequestGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeatRequestValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractBridge\",\"name\":\"_bridge\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isCoordinator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"reimbursementPool\",\"outputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"removeCoordinator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"requestHeartbeat\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"requestHeartbeatWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposal\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposalWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"unlockWallet\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_depositMinAge\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_depositRefundSafetyMargin\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_depositSweepMaxSize\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateDepositSweepProposalParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_heartbeatRequestValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_heartbeatRequestGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateHeartbeatRequestParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"_reimbursementPool\",\"type\":\"address\"}],\"name\":\"updateReimbursementPool\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"bytes4\",\"name\":\"version\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"inputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"outputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes4\",\"name\":\"locktime\",\"type\":\"bytes4\"}],\"internalType\":\"structBitcoinTx.Info\",\"name\":\"fundingTx\",\"type\":\"tuple\"},{\"internalType\":\"bytes8\",\"name\":\"blindingFactor\",\"type\":\"bytes8\"},{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20\",\"name\":\"refundPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes4\",\"name\":\"refundLocktime\",\"type\":\"bytes4\"}],\"internalType\":\"structWalletCoordinator.DepositExtraInfo[]\",\"name\":\"depositsExtraInfo\",\"type\":\"tuple[]\"}],\"name\":\"validateDepositSweepProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"\",\"type\":\"bytes20\"}],\"name\":\"walletLock\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"expiresAt\",\"type\":\"uint32\"},{\"internalType\":\"enumWalletCoordinator.WalletAction\",\"name\":\"cause\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // WalletCoordinatorABI is the input ABI used to generate the binding from.
@@ -401,12 +395,74 @@ func (_WalletCoordinator *WalletCoordinatorCallerSession) DepositSweepProposalVa
 	return _WalletCoordinator.Contract.DepositSweepProposalValidity(&_WalletCoordinator.CallOpts)
 }
 
-// IsProposalSubmitter is a free data retrieval call binding the contract method 0x213f7df7.
+// HeartbeatRequestGasOffset is a free data retrieval call binding the contract method 0xa34fff59.
 //
-// Solidity: function isProposalSubmitter(address ) view returns(bool)
-func (_WalletCoordinator *WalletCoordinatorCaller) IsProposalSubmitter(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+// Solidity: function heartbeatRequestGasOffset() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCaller) HeartbeatRequestGasOffset(opts *bind.CallOpts) (uint32, error) {
 	var out []interface{}
-	err := _WalletCoordinator.contract.Call(opts, &out, "isProposalSubmitter", arg0)
+	err := _WalletCoordinator.contract.Call(opts, &out, "heartbeatRequestGasOffset")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// HeartbeatRequestGasOffset is a free data retrieval call binding the contract method 0xa34fff59.
+//
+// Solidity: function heartbeatRequestGasOffset() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorSession) HeartbeatRequestGasOffset() (uint32, error) {
+	return _WalletCoordinator.Contract.HeartbeatRequestGasOffset(&_WalletCoordinator.CallOpts)
+}
+
+// HeartbeatRequestGasOffset is a free data retrieval call binding the contract method 0xa34fff59.
+//
+// Solidity: function heartbeatRequestGasOffset() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) HeartbeatRequestGasOffset() (uint32, error) {
+	return _WalletCoordinator.Contract.HeartbeatRequestGasOffset(&_WalletCoordinator.CallOpts)
+}
+
+// HeartbeatRequestValidity is a free data retrieval call binding the contract method 0x7fbf9b39.
+//
+// Solidity: function heartbeatRequestValidity() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCaller) HeartbeatRequestValidity(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "heartbeatRequestValidity")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// HeartbeatRequestValidity is a free data retrieval call binding the contract method 0x7fbf9b39.
+//
+// Solidity: function heartbeatRequestValidity() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorSession) HeartbeatRequestValidity() (uint32, error) {
+	return _WalletCoordinator.Contract.HeartbeatRequestValidity(&_WalletCoordinator.CallOpts)
+}
+
+// HeartbeatRequestValidity is a free data retrieval call binding the contract method 0x7fbf9b39.
+//
+// Solidity: function heartbeatRequestValidity() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) HeartbeatRequestValidity() (uint32, error) {
+	return _WalletCoordinator.Contract.HeartbeatRequestValidity(&_WalletCoordinator.CallOpts)
+}
+
+// IsCoordinator is a free data retrieval call binding the contract method 0xaec32099.
+//
+// Solidity: function isCoordinator(address ) view returns(bool)
+func (_WalletCoordinator *WalletCoordinatorCaller) IsCoordinator(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "isCoordinator", arg0)
 
 	if err != nil {
 		return *new(bool), err
@@ -418,18 +474,18 @@ func (_WalletCoordinator *WalletCoordinatorCaller) IsProposalSubmitter(opts *bin
 
 }
 
-// IsProposalSubmitter is a free data retrieval call binding the contract method 0x213f7df7.
+// IsCoordinator is a free data retrieval call binding the contract method 0xaec32099.
 //
-// Solidity: function isProposalSubmitter(address ) view returns(bool)
-func (_WalletCoordinator *WalletCoordinatorSession) IsProposalSubmitter(arg0 common.Address) (bool, error) {
-	return _WalletCoordinator.Contract.IsProposalSubmitter(&_WalletCoordinator.CallOpts, arg0)
+// Solidity: function isCoordinator(address ) view returns(bool)
+func (_WalletCoordinator *WalletCoordinatorSession) IsCoordinator(arg0 common.Address) (bool, error) {
+	return _WalletCoordinator.Contract.IsCoordinator(&_WalletCoordinator.CallOpts, arg0)
 }
 
-// IsProposalSubmitter is a free data retrieval call binding the contract method 0x213f7df7.
+// IsCoordinator is a free data retrieval call binding the contract method 0xaec32099.
 //
-// Solidity: function isProposalSubmitter(address ) view returns(bool)
-func (_WalletCoordinator *WalletCoordinatorCallerSession) IsProposalSubmitter(arg0 common.Address) (bool, error) {
-	return _WalletCoordinator.Contract.IsProposalSubmitter(&_WalletCoordinator.CallOpts, arg0)
+// Solidity: function isCoordinator(address ) view returns(bool)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) IsCoordinator(arg0 common.Address) (bool, error) {
+	return _WalletCoordinator.Contract.IsCoordinator(&_WalletCoordinator.CallOpts, arg0)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
@@ -570,56 +626,25 @@ func (_WalletCoordinator *WalletCoordinatorCallerSession) WalletLock(arg0 [20]by
 	return _WalletCoordinator.Contract.WalletLock(&_WalletCoordinator.CallOpts, arg0)
 }
 
-// WalletRegistry is a free data retrieval call binding the contract method 0xab7aa6ad.
+// AddCoordinator is a paid mutator transaction binding the contract method 0xfbd6d77e.
 //
-// Solidity: function walletRegistry() view returns(address)
-func (_WalletCoordinator *WalletCoordinatorCaller) WalletRegistry(opts *bind.CallOpts) (common.Address, error) {
-	var out []interface{}
-	err := _WalletCoordinator.contract.Call(opts, &out, "walletRegistry")
-
-	if err != nil {
-		return *new(common.Address), err
-	}
-
-	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
-
-	return out0, err
-
+// Solidity: function addCoordinator(address coordinator) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) AddCoordinator(opts *bind.TransactOpts, coordinator common.Address) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "addCoordinator", coordinator)
 }
 
-// WalletRegistry is a free data retrieval call binding the contract method 0xab7aa6ad.
+// AddCoordinator is a paid mutator transaction binding the contract method 0xfbd6d77e.
 //
-// Solidity: function walletRegistry() view returns(address)
-func (_WalletCoordinator *WalletCoordinatorSession) WalletRegistry() (common.Address, error) {
-	return _WalletCoordinator.Contract.WalletRegistry(&_WalletCoordinator.CallOpts)
+// Solidity: function addCoordinator(address coordinator) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) AddCoordinator(coordinator common.Address) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.AddCoordinator(&_WalletCoordinator.TransactOpts, coordinator)
 }
 
-// WalletRegistry is a free data retrieval call binding the contract method 0xab7aa6ad.
+// AddCoordinator is a paid mutator transaction binding the contract method 0xfbd6d77e.
 //
-// Solidity: function walletRegistry() view returns(address)
-func (_WalletCoordinator *WalletCoordinatorCallerSession) WalletRegistry() (common.Address, error) {
-	return _WalletCoordinator.Contract.WalletRegistry(&_WalletCoordinator.CallOpts)
-}
-
-// AddProposalSubmitter is a paid mutator transaction binding the contract method 0x8e323a99.
-//
-// Solidity: function addProposalSubmitter(address proposalSubmitter) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) AddProposalSubmitter(opts *bind.TransactOpts, proposalSubmitter common.Address) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "addProposalSubmitter", proposalSubmitter)
-}
-
-// AddProposalSubmitter is a paid mutator transaction binding the contract method 0x8e323a99.
-//
-// Solidity: function addProposalSubmitter(address proposalSubmitter) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) AddProposalSubmitter(proposalSubmitter common.Address) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.AddProposalSubmitter(&_WalletCoordinator.TransactOpts, proposalSubmitter)
-}
-
-// AddProposalSubmitter is a paid mutator transaction binding the contract method 0x8e323a99.
-//
-// Solidity: function addProposalSubmitter(address proposalSubmitter) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) AddProposalSubmitter(proposalSubmitter common.Address) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.AddProposalSubmitter(&_WalletCoordinator.TransactOpts, proposalSubmitter)
+// Solidity: function addCoordinator(address coordinator) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) AddCoordinator(coordinator common.Address) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.AddCoordinator(&_WalletCoordinator.TransactOpts, coordinator)
 }
 
 // Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
@@ -643,25 +668,25 @@ func (_WalletCoordinator *WalletCoordinatorTransactorSession) Initialize(_bridge
 	return _WalletCoordinator.Contract.Initialize(&_WalletCoordinator.TransactOpts, _bridge)
 }
 
-// RemoveProposalSubmitter is a paid mutator transaction binding the contract method 0x3a4159c8.
+// RemoveCoordinator is a paid mutator transaction binding the contract method 0x8cb5a0c0.
 //
-// Solidity: function removeProposalSubmitter(address proposalSubmitter) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) RemoveProposalSubmitter(opts *bind.TransactOpts, proposalSubmitter common.Address) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "removeProposalSubmitter", proposalSubmitter)
+// Solidity: function removeCoordinator(address coordinator) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) RemoveCoordinator(opts *bind.TransactOpts, coordinator common.Address) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "removeCoordinator", coordinator)
 }
 
-// RemoveProposalSubmitter is a paid mutator transaction binding the contract method 0x3a4159c8.
+// RemoveCoordinator is a paid mutator transaction binding the contract method 0x8cb5a0c0.
 //
-// Solidity: function removeProposalSubmitter(address proposalSubmitter) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) RemoveProposalSubmitter(proposalSubmitter common.Address) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.RemoveProposalSubmitter(&_WalletCoordinator.TransactOpts, proposalSubmitter)
+// Solidity: function removeCoordinator(address coordinator) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) RemoveCoordinator(coordinator common.Address) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.RemoveCoordinator(&_WalletCoordinator.TransactOpts, coordinator)
 }
 
-// RemoveProposalSubmitter is a paid mutator transaction binding the contract method 0x3a4159c8.
+// RemoveCoordinator is a paid mutator transaction binding the contract method 0x8cb5a0c0.
 //
-// Solidity: function removeProposalSubmitter(address proposalSubmitter) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) RemoveProposalSubmitter(proposalSubmitter common.Address) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.RemoveProposalSubmitter(&_WalletCoordinator.TransactOpts, proposalSubmitter)
+// Solidity: function removeCoordinator(address coordinator) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) RemoveCoordinator(coordinator common.Address) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.RemoveCoordinator(&_WalletCoordinator.TransactOpts, coordinator)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
@@ -685,46 +710,88 @@ func (_WalletCoordinator *WalletCoordinatorTransactorSession) RenounceOwnership(
 	return _WalletCoordinator.Contract.RenounceOwnership(&_WalletCoordinator.TransactOpts)
 }
 
-// SubmitDepositSweepProposal is a paid mutator transaction binding the contract method 0x1c6710dd.
+// RequestHeartbeat is a paid mutator transaction binding the contract method 0x6348c439.
 //
-// Solidity: function submitDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256) proposal, (uint32[],uint256) walletMemberContext) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) SubmitDepositSweepProposal(opts *bind.TransactOpts, proposal WalletCoordinatorDepositSweepProposal, walletMemberContext WalletCoordinatorWalletMemberContext) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "submitDepositSweepProposal", proposal, walletMemberContext)
+// Solidity: function requestHeartbeat(bytes20 walletPubKeyHash, bytes message) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) RequestHeartbeat(opts *bind.TransactOpts, walletPubKeyHash [20]byte, message []byte) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "requestHeartbeat", walletPubKeyHash, message)
 }
 
-// SubmitDepositSweepProposal is a paid mutator transaction binding the contract method 0x1c6710dd.
+// RequestHeartbeat is a paid mutator transaction binding the contract method 0x6348c439.
 //
-// Solidity: function submitDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256) proposal, (uint32[],uint256) walletMemberContext) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) SubmitDepositSweepProposal(proposal WalletCoordinatorDepositSweepProposal, walletMemberContext WalletCoordinatorWalletMemberContext) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.SubmitDepositSweepProposal(&_WalletCoordinator.TransactOpts, proposal, walletMemberContext)
+// Solidity: function requestHeartbeat(bytes20 walletPubKeyHash, bytes message) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) RequestHeartbeat(walletPubKeyHash [20]byte, message []byte) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.RequestHeartbeat(&_WalletCoordinator.TransactOpts, walletPubKeyHash, message)
 }
 
-// SubmitDepositSweepProposal is a paid mutator transaction binding the contract method 0x1c6710dd.
+// RequestHeartbeat is a paid mutator transaction binding the contract method 0x6348c439.
 //
-// Solidity: function submitDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256) proposal, (uint32[],uint256) walletMemberContext) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitDepositSweepProposal(proposal WalletCoordinatorDepositSweepProposal, walletMemberContext WalletCoordinatorWalletMemberContext) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.SubmitDepositSweepProposal(&_WalletCoordinator.TransactOpts, proposal, walletMemberContext)
+// Solidity: function requestHeartbeat(bytes20 walletPubKeyHash, bytes message) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) RequestHeartbeat(walletPubKeyHash [20]byte, message []byte) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.RequestHeartbeat(&_WalletCoordinator.TransactOpts, walletPubKeyHash, message)
 }
 
-// SubmitDepositSweepProposalWithReimbursement is a paid mutator transaction binding the contract method 0xc1790d77.
+// RequestHeartbeatWithReimbursement is a paid mutator transaction binding the contract method 0x34173c2d.
 //
-// Solidity: function submitDepositSweepProposalWithReimbursement((bytes20,(bytes32,uint32)[],uint256) proposal, (uint32[],uint256) walletMemberContext) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) SubmitDepositSweepProposalWithReimbursement(opts *bind.TransactOpts, proposal WalletCoordinatorDepositSweepProposal, walletMemberContext WalletCoordinatorWalletMemberContext) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "submitDepositSweepProposalWithReimbursement", proposal, walletMemberContext)
+// Solidity: function requestHeartbeatWithReimbursement(bytes20 walletPubKeyHash, bytes message) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) RequestHeartbeatWithReimbursement(opts *bind.TransactOpts, walletPubKeyHash [20]byte, message []byte) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "requestHeartbeatWithReimbursement", walletPubKeyHash, message)
 }
 
-// SubmitDepositSweepProposalWithReimbursement is a paid mutator transaction binding the contract method 0xc1790d77.
+// RequestHeartbeatWithReimbursement is a paid mutator transaction binding the contract method 0x34173c2d.
 //
-// Solidity: function submitDepositSweepProposalWithReimbursement((bytes20,(bytes32,uint32)[],uint256) proposal, (uint32[],uint256) walletMemberContext) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) SubmitDepositSweepProposalWithReimbursement(proposal WalletCoordinatorDepositSweepProposal, walletMemberContext WalletCoordinatorWalletMemberContext) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.SubmitDepositSweepProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal, walletMemberContext)
+// Solidity: function requestHeartbeatWithReimbursement(bytes20 walletPubKeyHash, bytes message) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) RequestHeartbeatWithReimbursement(walletPubKeyHash [20]byte, message []byte) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.RequestHeartbeatWithReimbursement(&_WalletCoordinator.TransactOpts, walletPubKeyHash, message)
 }
 
-// SubmitDepositSweepProposalWithReimbursement is a paid mutator transaction binding the contract method 0xc1790d77.
+// RequestHeartbeatWithReimbursement is a paid mutator transaction binding the contract method 0x34173c2d.
 //
-// Solidity: function submitDepositSweepProposalWithReimbursement((bytes20,(bytes32,uint32)[],uint256) proposal, (uint32[],uint256) walletMemberContext) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitDepositSweepProposalWithReimbursement(proposal WalletCoordinatorDepositSweepProposal, walletMemberContext WalletCoordinatorWalletMemberContext) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.SubmitDepositSweepProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal, walletMemberContext)
+// Solidity: function requestHeartbeatWithReimbursement(bytes20 walletPubKeyHash, bytes message) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) RequestHeartbeatWithReimbursement(walletPubKeyHash [20]byte, message []byte) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.RequestHeartbeatWithReimbursement(&_WalletCoordinator.TransactOpts, walletPubKeyHash, message)
+}
+
+// SubmitDepositSweepProposal is a paid mutator transaction binding the contract method 0x742b386b.
+//
+// Solidity: function submitDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) SubmitDepositSweepProposal(opts *bind.TransactOpts, proposal WalletCoordinatorDepositSweepProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "submitDepositSweepProposal", proposal)
+}
+
+// SubmitDepositSweepProposal is a paid mutator transaction binding the contract method 0x742b386b.
+//
+// Solidity: function submitDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) SubmitDepositSweepProposal(proposal WalletCoordinatorDepositSweepProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitDepositSweepProposal(&_WalletCoordinator.TransactOpts, proposal)
+}
+
+// SubmitDepositSweepProposal is a paid mutator transaction binding the contract method 0x742b386b.
+//
+// Solidity: function submitDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitDepositSweepProposal(proposal WalletCoordinatorDepositSweepProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitDepositSweepProposal(&_WalletCoordinator.TransactOpts, proposal)
+}
+
+// SubmitDepositSweepProposalWithReimbursement is a paid mutator transaction binding the contract method 0x6ed6405f.
+//
+// Solidity: function submitDepositSweepProposalWithReimbursement((bytes20,(bytes32,uint32)[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) SubmitDepositSweepProposalWithReimbursement(opts *bind.TransactOpts, proposal WalletCoordinatorDepositSweepProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "submitDepositSweepProposalWithReimbursement", proposal)
+}
+
+// SubmitDepositSweepProposalWithReimbursement is a paid mutator transaction binding the contract method 0x6ed6405f.
+//
+// Solidity: function submitDepositSweepProposalWithReimbursement((bytes20,(bytes32,uint32)[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) SubmitDepositSweepProposalWithReimbursement(proposal WalletCoordinatorDepositSweepProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitDepositSweepProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal)
+}
+
+// SubmitDepositSweepProposalWithReimbursement is a paid mutator transaction binding the contract method 0x6ed6405f.
+//
+// Solidity: function submitDepositSweepProposalWithReimbursement((bytes20,(bytes32,uint32)[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitDepositSweepProposalWithReimbursement(proposal WalletCoordinatorDepositSweepProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitDepositSweepProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
@@ -769,109 +836,46 @@ func (_WalletCoordinator *WalletCoordinatorTransactorSession) UnlockWallet(walle
 	return _WalletCoordinator.Contract.UnlockWallet(&_WalletCoordinator.TransactOpts, walletPubKeyHash)
 }
 
-// UpdateDepositMinAge is a paid mutator transaction binding the contract method 0x0dc1b8df.
+// UpdateDepositSweepProposalParameters is a paid mutator transaction binding the contract method 0x5486032e.
 //
-// Solidity: function updateDepositMinAge(uint32 _depositMinAge) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateDepositMinAge(opts *bind.TransactOpts, _depositMinAge uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "updateDepositMinAge", _depositMinAge)
+// Solidity: function updateDepositSweepProposalParameters(uint32 _depositSweepProposalValidity, uint32 _depositMinAge, uint32 _depositRefundSafetyMargin, uint16 _depositSweepMaxSize, uint32 _depositSweepProposalSubmissionGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateDepositSweepProposalParameters(opts *bind.TransactOpts, _depositSweepProposalValidity uint32, _depositMinAge uint32, _depositRefundSafetyMargin uint32, _depositSweepMaxSize uint16, _depositSweepProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "updateDepositSweepProposalParameters", _depositSweepProposalValidity, _depositMinAge, _depositRefundSafetyMargin, _depositSweepMaxSize, _depositSweepProposalSubmissionGasOffset)
 }
 
-// UpdateDepositMinAge is a paid mutator transaction binding the contract method 0x0dc1b8df.
+// UpdateDepositSweepProposalParameters is a paid mutator transaction binding the contract method 0x5486032e.
 //
-// Solidity: function updateDepositMinAge(uint32 _depositMinAge) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) UpdateDepositMinAge(_depositMinAge uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositMinAge(&_WalletCoordinator.TransactOpts, _depositMinAge)
+// Solidity: function updateDepositSweepProposalParameters(uint32 _depositSweepProposalValidity, uint32 _depositMinAge, uint32 _depositRefundSafetyMargin, uint16 _depositSweepMaxSize, uint32 _depositSweepProposalSubmissionGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) UpdateDepositSweepProposalParameters(_depositSweepProposalValidity uint32, _depositMinAge uint32, _depositRefundSafetyMargin uint32, _depositSweepMaxSize uint16, _depositSweepProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.UpdateDepositSweepProposalParameters(&_WalletCoordinator.TransactOpts, _depositSweepProposalValidity, _depositMinAge, _depositRefundSafetyMargin, _depositSweepMaxSize, _depositSweepProposalSubmissionGasOffset)
 }
 
-// UpdateDepositMinAge is a paid mutator transaction binding the contract method 0x0dc1b8df.
+// UpdateDepositSweepProposalParameters is a paid mutator transaction binding the contract method 0x5486032e.
 //
-// Solidity: function updateDepositMinAge(uint32 _depositMinAge) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateDepositMinAge(_depositMinAge uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositMinAge(&_WalletCoordinator.TransactOpts, _depositMinAge)
+// Solidity: function updateDepositSweepProposalParameters(uint32 _depositSweepProposalValidity, uint32 _depositMinAge, uint32 _depositRefundSafetyMargin, uint16 _depositSweepMaxSize, uint32 _depositSweepProposalSubmissionGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateDepositSweepProposalParameters(_depositSweepProposalValidity uint32, _depositMinAge uint32, _depositRefundSafetyMargin uint32, _depositSweepMaxSize uint16, _depositSweepProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.UpdateDepositSweepProposalParameters(&_WalletCoordinator.TransactOpts, _depositSweepProposalValidity, _depositMinAge, _depositRefundSafetyMargin, _depositSweepMaxSize, _depositSweepProposalSubmissionGasOffset)
 }
 
-// UpdateDepositRefundSafetyMargin is a paid mutator transaction binding the contract method 0x6ff913c3.
+// UpdateHeartbeatRequestParameters is a paid mutator transaction binding the contract method 0x85a0924c.
 //
-// Solidity: function updateDepositRefundSafetyMargin(uint32 _depositRefundSafetyMargin) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateDepositRefundSafetyMargin(opts *bind.TransactOpts, _depositRefundSafetyMargin uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "updateDepositRefundSafetyMargin", _depositRefundSafetyMargin)
+// Solidity: function updateHeartbeatRequestParameters(uint32 _heartbeatRequestValidity, uint32 _heartbeatRequestGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateHeartbeatRequestParameters(opts *bind.TransactOpts, _heartbeatRequestValidity uint32, _heartbeatRequestGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "updateHeartbeatRequestParameters", _heartbeatRequestValidity, _heartbeatRequestGasOffset)
 }
 
-// UpdateDepositRefundSafetyMargin is a paid mutator transaction binding the contract method 0x6ff913c3.
+// UpdateHeartbeatRequestParameters is a paid mutator transaction binding the contract method 0x85a0924c.
 //
-// Solidity: function updateDepositRefundSafetyMargin(uint32 _depositRefundSafetyMargin) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) UpdateDepositRefundSafetyMargin(_depositRefundSafetyMargin uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositRefundSafetyMargin(&_WalletCoordinator.TransactOpts, _depositRefundSafetyMargin)
+// Solidity: function updateHeartbeatRequestParameters(uint32 _heartbeatRequestValidity, uint32 _heartbeatRequestGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) UpdateHeartbeatRequestParameters(_heartbeatRequestValidity uint32, _heartbeatRequestGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.UpdateHeartbeatRequestParameters(&_WalletCoordinator.TransactOpts, _heartbeatRequestValidity, _heartbeatRequestGasOffset)
 }
 
-// UpdateDepositRefundSafetyMargin is a paid mutator transaction binding the contract method 0x6ff913c3.
+// UpdateHeartbeatRequestParameters is a paid mutator transaction binding the contract method 0x85a0924c.
 //
-// Solidity: function updateDepositRefundSafetyMargin(uint32 _depositRefundSafetyMargin) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateDepositRefundSafetyMargin(_depositRefundSafetyMargin uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositRefundSafetyMargin(&_WalletCoordinator.TransactOpts, _depositRefundSafetyMargin)
-}
-
-// UpdateDepositSweepMaxSize is a paid mutator transaction binding the contract method 0x9f41e13b.
-//
-// Solidity: function updateDepositSweepMaxSize(uint16 _depositSweepMaxSize) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateDepositSweepMaxSize(opts *bind.TransactOpts, _depositSweepMaxSize uint16) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "updateDepositSweepMaxSize", _depositSweepMaxSize)
-}
-
-// UpdateDepositSweepMaxSize is a paid mutator transaction binding the contract method 0x9f41e13b.
-//
-// Solidity: function updateDepositSweepMaxSize(uint16 _depositSweepMaxSize) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) UpdateDepositSweepMaxSize(_depositSweepMaxSize uint16) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositSweepMaxSize(&_WalletCoordinator.TransactOpts, _depositSweepMaxSize)
-}
-
-// UpdateDepositSweepMaxSize is a paid mutator transaction binding the contract method 0x9f41e13b.
-//
-// Solidity: function updateDepositSweepMaxSize(uint16 _depositSweepMaxSize) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateDepositSweepMaxSize(_depositSweepMaxSize uint16) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositSweepMaxSize(&_WalletCoordinator.TransactOpts, _depositSweepMaxSize)
-}
-
-// UpdateDepositSweepProposalSubmissionGasOffset is a paid mutator transaction binding the contract method 0xb82bc399.
-//
-// Solidity: function updateDepositSweepProposalSubmissionGasOffset(uint32 _depositSweepProposalSubmissionGasOffset) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateDepositSweepProposalSubmissionGasOffset(opts *bind.TransactOpts, _depositSweepProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "updateDepositSweepProposalSubmissionGasOffset", _depositSweepProposalSubmissionGasOffset)
-}
-
-// UpdateDepositSweepProposalSubmissionGasOffset is a paid mutator transaction binding the contract method 0xb82bc399.
-//
-// Solidity: function updateDepositSweepProposalSubmissionGasOffset(uint32 _depositSweepProposalSubmissionGasOffset) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) UpdateDepositSweepProposalSubmissionGasOffset(_depositSweepProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositSweepProposalSubmissionGasOffset(&_WalletCoordinator.TransactOpts, _depositSweepProposalSubmissionGasOffset)
-}
-
-// UpdateDepositSweepProposalSubmissionGasOffset is a paid mutator transaction binding the contract method 0xb82bc399.
-//
-// Solidity: function updateDepositSweepProposalSubmissionGasOffset(uint32 _depositSweepProposalSubmissionGasOffset) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateDepositSweepProposalSubmissionGasOffset(_depositSweepProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositSweepProposalSubmissionGasOffset(&_WalletCoordinator.TransactOpts, _depositSweepProposalSubmissionGasOffset)
-}
-
-// UpdateDepositSweepProposalValidity is a paid mutator transaction binding the contract method 0x23a1c307.
-//
-// Solidity: function updateDepositSweepProposalValidity(uint32 _depositSweepProposalValidity) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateDepositSweepProposalValidity(opts *bind.TransactOpts, _depositSweepProposalValidity uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.contract.Transact(opts, "updateDepositSweepProposalValidity", _depositSweepProposalValidity)
-}
-
-// UpdateDepositSweepProposalValidity is a paid mutator transaction binding the contract method 0x23a1c307.
-//
-// Solidity: function updateDepositSweepProposalValidity(uint32 _depositSweepProposalValidity) returns()
-func (_WalletCoordinator *WalletCoordinatorSession) UpdateDepositSweepProposalValidity(_depositSweepProposalValidity uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositSweepProposalValidity(&_WalletCoordinator.TransactOpts, _depositSweepProposalValidity)
-}
-
-// UpdateDepositSweepProposalValidity is a paid mutator transaction binding the contract method 0x23a1c307.
-//
-// Solidity: function updateDepositSweepProposalValidity(uint32 _depositSweepProposalValidity) returns()
-func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateDepositSweepProposalValidity(_depositSweepProposalValidity uint32) (*types.Transaction, error) {
-	return _WalletCoordinator.Contract.UpdateDepositSweepProposalValidity(&_WalletCoordinator.TransactOpts, _depositSweepProposalValidity)
+// Solidity: function updateHeartbeatRequestParameters(uint32 _heartbeatRequestValidity, uint32 _heartbeatRequestGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateHeartbeatRequestParameters(_heartbeatRequestValidity uint32, _heartbeatRequestGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.UpdateHeartbeatRequestParameters(&_WalletCoordinator.TransactOpts, _heartbeatRequestValidity, _heartbeatRequestGasOffset)
 }
 
 // UpdateReimbursementPool is a paid mutator transaction binding the contract method 0x7b35b4e6.
@@ -895,9 +899,9 @@ func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateReimbursemen
 	return _WalletCoordinator.Contract.UpdateReimbursementPool(&_WalletCoordinator.TransactOpts, _reimbursementPool)
 }
 
-// WalletCoordinatorDepositMinAgeUpdatedIterator is returned from FilterDepositMinAgeUpdated and is used to iterate over the raw logs and unpacked data for DepositMinAgeUpdated events raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositMinAgeUpdatedIterator struct {
-	Event *WalletCoordinatorDepositMinAgeUpdated // Event containing the contract specifics and raw log
+// WalletCoordinatorCoordinatorAddedIterator is returned from FilterCoordinatorAdded and is used to iterate over the raw logs and unpacked data for CoordinatorAdded events raised by the WalletCoordinator contract.
+type WalletCoordinatorCoordinatorAddedIterator struct {
+	Event *WalletCoordinatorCoordinatorAdded // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -911,7 +915,7 @@ type WalletCoordinatorDepositMinAgeUpdatedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorDepositMinAgeUpdatedIterator) Next() bool {
+func (it *WalletCoordinatorCoordinatorAddedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -920,7 +924,7 @@ func (it *WalletCoordinatorDepositMinAgeUpdatedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorDepositMinAgeUpdated)
+			it.Event = new(WalletCoordinatorCoordinatorAdded)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -935,7 +939,7 @@ func (it *WalletCoordinatorDepositMinAgeUpdatedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorDepositMinAgeUpdated)
+		it.Event = new(WalletCoordinatorCoordinatorAdded)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -951,41 +955,51 @@ func (it *WalletCoordinatorDepositMinAgeUpdatedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorDepositMinAgeUpdatedIterator) Error() error {
+func (it *WalletCoordinatorCoordinatorAddedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *WalletCoordinatorDepositMinAgeUpdatedIterator) Close() error {
+func (it *WalletCoordinatorCoordinatorAddedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// WalletCoordinatorDepositMinAgeUpdated represents a DepositMinAgeUpdated event raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositMinAgeUpdated struct {
-	DepositMinAge uint32
-	Raw           types.Log // Blockchain specific contextual infos
+// WalletCoordinatorCoordinatorAdded represents a CoordinatorAdded event raised by the WalletCoordinator contract.
+type WalletCoordinatorCoordinatorAdded struct {
+	Coordinator common.Address
+	Raw         types.Log // Blockchain specific contextual infos
 }
 
-// FilterDepositMinAgeUpdated is a free log retrieval operation binding the contract event 0xeda69d960fc800ae7f67255cd8b42b338c24e1a655053127fff8bf88a2480d3f.
+// FilterCoordinatorAdded is a free log retrieval operation binding the contract event 0x56e6c5206d2baab7a01569b19d84b5963ca9f96e10f55076b5e5987fbf780cf5.
 //
-// Solidity: event DepositMinAgeUpdated(uint32 depositMinAge)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositMinAgeUpdated(opts *bind.FilterOpts) (*WalletCoordinatorDepositMinAgeUpdatedIterator, error) {
+// Solidity: event CoordinatorAdded(address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterCoordinatorAdded(opts *bind.FilterOpts, coordinator []common.Address) (*WalletCoordinatorCoordinatorAddedIterator, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositMinAgeUpdated")
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
+	}
+
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "CoordinatorAdded", coordinatorRule)
 	if err != nil {
 		return nil, err
 	}
-	return &WalletCoordinatorDepositMinAgeUpdatedIterator{contract: _WalletCoordinator.contract, event: "DepositMinAgeUpdated", logs: logs, sub: sub}, nil
+	return &WalletCoordinatorCoordinatorAddedIterator{contract: _WalletCoordinator.contract, event: "CoordinatorAdded", logs: logs, sub: sub}, nil
 }
 
-// WatchDepositMinAgeUpdated is a free log subscription operation binding the contract event 0xeda69d960fc800ae7f67255cd8b42b338c24e1a655053127fff8bf88a2480d3f.
+// WatchCoordinatorAdded is a free log subscription operation binding the contract event 0x56e6c5206d2baab7a01569b19d84b5963ca9f96e10f55076b5e5987fbf780cf5.
 //
-// Solidity: event DepositMinAgeUpdated(uint32 depositMinAge)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositMinAgeUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositMinAgeUpdated) (event.Subscription, error) {
+// Solidity: event CoordinatorAdded(address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchCoordinatorAdded(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorCoordinatorAdded, coordinator []common.Address) (event.Subscription, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositMinAgeUpdated")
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
+	}
+
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "CoordinatorAdded", coordinatorRule)
 	if err != nil {
 		return nil, err
 	}
@@ -995,8 +1009,8 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositMinAgeUpdated(o
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorDepositMinAgeUpdated)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "DepositMinAgeUpdated", log); err != nil {
+				event := new(WalletCoordinatorCoordinatorAdded)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "CoordinatorAdded", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1017,21 +1031,21 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositMinAgeUpdated(o
 	}), nil
 }
 
-// ParseDepositMinAgeUpdated is a log parse operation binding the contract event 0xeda69d960fc800ae7f67255cd8b42b338c24e1a655053127fff8bf88a2480d3f.
+// ParseCoordinatorAdded is a log parse operation binding the contract event 0x56e6c5206d2baab7a01569b19d84b5963ca9f96e10f55076b5e5987fbf780cf5.
 //
-// Solidity: event DepositMinAgeUpdated(uint32 depositMinAge)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositMinAgeUpdated(log types.Log) (*WalletCoordinatorDepositMinAgeUpdated, error) {
-	event := new(WalletCoordinatorDepositMinAgeUpdated)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositMinAgeUpdated", log); err != nil {
+// Solidity: event CoordinatorAdded(address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseCoordinatorAdded(log types.Log) (*WalletCoordinatorCoordinatorAdded, error) {
+	event := new(WalletCoordinatorCoordinatorAdded)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "CoordinatorAdded", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator is returned from FilterDepositRefundSafetyMarginUpdated and is used to iterate over the raw logs and unpacked data for DepositRefundSafetyMarginUpdated events raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator struct {
-	Event *WalletCoordinatorDepositRefundSafetyMarginUpdated // Event containing the contract specifics and raw log
+// WalletCoordinatorCoordinatorRemovedIterator is returned from FilterCoordinatorRemoved and is used to iterate over the raw logs and unpacked data for CoordinatorRemoved events raised by the WalletCoordinator contract.
+type WalletCoordinatorCoordinatorRemovedIterator struct {
+	Event *WalletCoordinatorCoordinatorRemoved // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1045,7 +1059,7 @@ type WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator) Next() bool {
+func (it *WalletCoordinatorCoordinatorRemovedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1054,7 +1068,7 @@ func (it *WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator) Next() bool
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorDepositRefundSafetyMarginUpdated)
+			it.Event = new(WalletCoordinatorCoordinatorRemoved)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1069,7 +1083,7 @@ func (it *WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator) Next() bool
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorDepositRefundSafetyMarginUpdated)
+		it.Event = new(WalletCoordinatorCoordinatorRemoved)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1085,41 +1099,51 @@ func (it *WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator) Next() bool
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator) Error() error {
+func (it *WalletCoordinatorCoordinatorRemovedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator) Close() error {
+func (it *WalletCoordinatorCoordinatorRemovedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// WalletCoordinatorDepositRefundSafetyMarginUpdated represents a DepositRefundSafetyMarginUpdated event raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositRefundSafetyMarginUpdated struct {
-	DepositRefundSafetyMargin uint32
-	Raw                       types.Log // Blockchain specific contextual infos
+// WalletCoordinatorCoordinatorRemoved represents a CoordinatorRemoved event raised by the WalletCoordinator contract.
+type WalletCoordinatorCoordinatorRemoved struct {
+	Coordinator common.Address
+	Raw         types.Log // Blockchain specific contextual infos
 }
 
-// FilterDepositRefundSafetyMarginUpdated is a free log retrieval operation binding the contract event 0xcb0c11e4086618176ceab0afd46b7fa25688cf2a6566ed4845f1fb530571faee.
+// FilterCoordinatorRemoved is a free log retrieval operation binding the contract event 0xcf15831020102bbbe0547b0c3460aa49715f2646e0911760d2b069e0fb2f62a1.
 //
-// Solidity: event DepositRefundSafetyMarginUpdated(uint32 depositRefundSafetyMargin)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositRefundSafetyMarginUpdated(opts *bind.FilterOpts) (*WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator, error) {
+// Solidity: event CoordinatorRemoved(address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterCoordinatorRemoved(opts *bind.FilterOpts, coordinator []common.Address) (*WalletCoordinatorCoordinatorRemovedIterator, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositRefundSafetyMarginUpdated")
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
+	}
+
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "CoordinatorRemoved", coordinatorRule)
 	if err != nil {
 		return nil, err
 	}
-	return &WalletCoordinatorDepositRefundSafetyMarginUpdatedIterator{contract: _WalletCoordinator.contract, event: "DepositRefundSafetyMarginUpdated", logs: logs, sub: sub}, nil
+	return &WalletCoordinatorCoordinatorRemovedIterator{contract: _WalletCoordinator.contract, event: "CoordinatorRemoved", logs: logs, sub: sub}, nil
 }
 
-// WatchDepositRefundSafetyMarginUpdated is a free log subscription operation binding the contract event 0xcb0c11e4086618176ceab0afd46b7fa25688cf2a6566ed4845f1fb530571faee.
+// WatchCoordinatorRemoved is a free log subscription operation binding the contract event 0xcf15831020102bbbe0547b0c3460aa49715f2646e0911760d2b069e0fb2f62a1.
 //
-// Solidity: event DepositRefundSafetyMarginUpdated(uint32 depositRefundSafetyMargin)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositRefundSafetyMarginUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositRefundSafetyMarginUpdated) (event.Subscription, error) {
+// Solidity: event CoordinatorRemoved(address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchCoordinatorRemoved(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorCoordinatorRemoved, coordinator []common.Address) (event.Subscription, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositRefundSafetyMarginUpdated")
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
+	}
+
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "CoordinatorRemoved", coordinatorRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1129,8 +1153,8 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositRefundSafetyMar
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorDepositRefundSafetyMarginUpdated)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "DepositRefundSafetyMarginUpdated", log); err != nil {
+				event := new(WalletCoordinatorCoordinatorRemoved)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "CoordinatorRemoved", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1151,21 +1175,21 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositRefundSafetyMar
 	}), nil
 }
 
-// ParseDepositRefundSafetyMarginUpdated is a log parse operation binding the contract event 0xcb0c11e4086618176ceab0afd46b7fa25688cf2a6566ed4845f1fb530571faee.
+// ParseCoordinatorRemoved is a log parse operation binding the contract event 0xcf15831020102bbbe0547b0c3460aa49715f2646e0911760d2b069e0fb2f62a1.
 //
-// Solidity: event DepositRefundSafetyMarginUpdated(uint32 depositRefundSafetyMargin)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositRefundSafetyMarginUpdated(log types.Log) (*WalletCoordinatorDepositRefundSafetyMarginUpdated, error) {
-	event := new(WalletCoordinatorDepositRefundSafetyMarginUpdated)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositRefundSafetyMarginUpdated", log); err != nil {
+// Solidity: event CoordinatorRemoved(address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseCoordinatorRemoved(log types.Log) (*WalletCoordinatorCoordinatorRemoved, error) {
+	event := new(WalletCoordinatorCoordinatorRemoved)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "CoordinatorRemoved", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// WalletCoordinatorDepositSweepMaxSizeUpdatedIterator is returned from FilterDepositSweepMaxSizeUpdated and is used to iterate over the raw logs and unpacked data for DepositSweepMaxSizeUpdated events raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositSweepMaxSizeUpdatedIterator struct {
-	Event *WalletCoordinatorDepositSweepMaxSizeUpdated // Event containing the contract specifics and raw log
+// WalletCoordinatorDepositSweepProposalParametersUpdatedIterator is returned from FilterDepositSweepProposalParametersUpdated and is used to iterate over the raw logs and unpacked data for DepositSweepProposalParametersUpdated events raised by the WalletCoordinator contract.
+type WalletCoordinatorDepositSweepProposalParametersUpdatedIterator struct {
+	Event *WalletCoordinatorDepositSweepProposalParametersUpdated // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1179,7 +1203,7 @@ type WalletCoordinatorDepositSweepMaxSizeUpdatedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorDepositSweepMaxSizeUpdatedIterator) Next() bool {
+func (it *WalletCoordinatorDepositSweepProposalParametersUpdatedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1188,7 +1212,7 @@ func (it *WalletCoordinatorDepositSweepMaxSizeUpdatedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorDepositSweepMaxSizeUpdated)
+			it.Event = new(WalletCoordinatorDepositSweepProposalParametersUpdated)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1203,7 +1227,7 @@ func (it *WalletCoordinatorDepositSweepMaxSizeUpdatedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorDepositSweepMaxSizeUpdated)
+		it.Event = new(WalletCoordinatorDepositSweepProposalParametersUpdated)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1219,175 +1243,45 @@ func (it *WalletCoordinatorDepositSweepMaxSizeUpdatedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorDepositSweepMaxSizeUpdatedIterator) Error() error {
+func (it *WalletCoordinatorDepositSweepProposalParametersUpdatedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *WalletCoordinatorDepositSweepMaxSizeUpdatedIterator) Close() error {
+func (it *WalletCoordinatorDepositSweepProposalParametersUpdatedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// WalletCoordinatorDepositSweepMaxSizeUpdated represents a DepositSweepMaxSizeUpdated event raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositSweepMaxSizeUpdated struct {
-	DepositSweepMaxSize uint16
-	Raw                 types.Log // Blockchain specific contextual infos
-}
-
-// FilterDepositSweepMaxSizeUpdated is a free log retrieval operation binding the contract event 0xcc7b63f885d59808f386320218caf8e6bdaa095b61927dea4e59f9cf6954beab.
-//
-// Solidity: event DepositSweepMaxSizeUpdated(uint16 depositSweepMaxSize)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepMaxSizeUpdated(opts *bind.FilterOpts) (*WalletCoordinatorDepositSweepMaxSizeUpdatedIterator, error) {
-
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositSweepMaxSizeUpdated")
-	if err != nil {
-		return nil, err
-	}
-	return &WalletCoordinatorDepositSweepMaxSizeUpdatedIterator{contract: _WalletCoordinator.contract, event: "DepositSweepMaxSizeUpdated", logs: logs, sub: sub}, nil
-}
-
-// WatchDepositSweepMaxSizeUpdated is a free log subscription operation binding the contract event 0xcc7b63f885d59808f386320218caf8e6bdaa095b61927dea4e59f9cf6954beab.
-//
-// Solidity: event DepositSweepMaxSizeUpdated(uint16 depositSweepMaxSize)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepMaxSizeUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositSweepMaxSizeUpdated) (event.Subscription, error) {
-
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositSweepMaxSizeUpdated")
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorDepositSweepMaxSizeUpdated)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepMaxSizeUpdated", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseDepositSweepMaxSizeUpdated is a log parse operation binding the contract event 0xcc7b63f885d59808f386320218caf8e6bdaa095b61927dea4e59f9cf6954beab.
-//
-// Solidity: event DepositSweepMaxSizeUpdated(uint16 depositSweepMaxSize)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositSweepMaxSizeUpdated(log types.Log) (*WalletCoordinatorDepositSweepMaxSizeUpdated, error) {
-	event := new(WalletCoordinatorDepositSweepMaxSizeUpdated)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepMaxSizeUpdated", log); err != nil {
-		return nil, err
-	}
-	event.Raw = log
-	return event, nil
-}
-
-// WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator is returned from FilterDepositSweepProposalSubmissionGasOffsetUpdated and is used to iterate over the raw logs and unpacked data for DepositSweepProposalSubmissionGasOffsetUpdated events raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator struct {
-	Event *WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log        // Log channel receiving the found contract events
-	sub  ethereum.Subscription // Subscription for errors, completion and termination
-	done bool                  // Whether the subscription completed delivering logs
-	fail error                 // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated represents a DepositSweepProposalSubmissionGasOffsetUpdated event raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated struct {
+// WalletCoordinatorDepositSweepProposalParametersUpdated represents a DepositSweepProposalParametersUpdated event raised by the WalletCoordinator contract.
+type WalletCoordinatorDepositSweepProposalParametersUpdated struct {
+	DepositSweepProposalValidity            uint32
+	DepositMinAge                           uint32
+	DepositRefundSafetyMargin               uint32
+	DepositSweepMaxSize                     uint16
 	DepositSweepProposalSubmissionGasOffset uint32
 	Raw                                     types.Log // Blockchain specific contextual infos
 }
 
-// FilterDepositSweepProposalSubmissionGasOffsetUpdated is a free log retrieval operation binding the contract event 0xafb79fa073ff248ba2f1cd9798891f4ee776a03c9f860eccdebcb1837305a197.
+// FilterDepositSweepProposalParametersUpdated is a free log retrieval operation binding the contract event 0xc36fe6b9d74f864b5e345edc3435eb451a80669ec78c8357cc15e3a1d3897a73.
 //
-// Solidity: event DepositSweepProposalSubmissionGasOffsetUpdated(uint32 depositSweepProposalSubmissionGasOffset)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepProposalSubmissionGasOffsetUpdated(opts *bind.FilterOpts) (*WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator, error) {
+// Solidity: event DepositSweepProposalParametersUpdated(uint32 depositSweepProposalValidity, uint32 depositMinAge, uint32 depositRefundSafetyMargin, uint16 depositSweepMaxSize, uint32 depositSweepProposalSubmissionGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepProposalParametersUpdated(opts *bind.FilterOpts) (*WalletCoordinatorDepositSweepProposalParametersUpdatedIterator, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositSweepProposalSubmissionGasOffsetUpdated")
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositSweepProposalParametersUpdated")
 	if err != nil {
 		return nil, err
 	}
-	return &WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedIterator{contract: _WalletCoordinator.contract, event: "DepositSweepProposalSubmissionGasOffsetUpdated", logs: logs, sub: sub}, nil
+	return &WalletCoordinatorDepositSweepProposalParametersUpdatedIterator{contract: _WalletCoordinator.contract, event: "DepositSweepProposalParametersUpdated", logs: logs, sub: sub}, nil
 }
 
-// WatchDepositSweepProposalSubmissionGasOffsetUpdated is a free log subscription operation binding the contract event 0xafb79fa073ff248ba2f1cd9798891f4ee776a03c9f860eccdebcb1837305a197.
+// WatchDepositSweepProposalParametersUpdated is a free log subscription operation binding the contract event 0xc36fe6b9d74f864b5e345edc3435eb451a80669ec78c8357cc15e3a1d3897a73.
 //
-// Solidity: event DepositSweepProposalSubmissionGasOffsetUpdated(uint32 depositSweepProposalSubmissionGasOffset)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalSubmissionGasOffsetUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated) (event.Subscription, error) {
+// Solidity: event DepositSweepProposalParametersUpdated(uint32 depositSweepProposalValidity, uint32 depositMinAge, uint32 depositRefundSafetyMargin, uint16 depositSweepMaxSize, uint32 depositSweepProposalSubmissionGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalParametersUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositSweepProposalParametersUpdated) (event.Subscription, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositSweepProposalSubmissionGasOffsetUpdated")
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositSweepProposalParametersUpdated")
 	if err != nil {
 		return nil, err
 	}
@@ -1397,8 +1291,8 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalSu
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalSubmissionGasOffsetUpdated", log); err != nil {
+				event := new(WalletCoordinatorDepositSweepProposalParametersUpdated)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalParametersUpdated", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1419,12 +1313,12 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalSu
 	}), nil
 }
 
-// ParseDepositSweepProposalSubmissionGasOffsetUpdated is a log parse operation binding the contract event 0xafb79fa073ff248ba2f1cd9798891f4ee776a03c9f860eccdebcb1837305a197.
+// ParseDepositSweepProposalParametersUpdated is a log parse operation binding the contract event 0xc36fe6b9d74f864b5e345edc3435eb451a80669ec78c8357cc15e3a1d3897a73.
 //
-// Solidity: event DepositSweepProposalSubmissionGasOffsetUpdated(uint32 depositSweepProposalSubmissionGasOffset)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositSweepProposalSubmissionGasOffsetUpdated(log types.Log) (*WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated, error) {
-	event := new(WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalSubmissionGasOffsetUpdated", log); err != nil {
+// Solidity: event DepositSweepProposalParametersUpdated(uint32 depositSweepProposalValidity, uint32 depositMinAge, uint32 depositRefundSafetyMargin, uint16 depositSweepMaxSize, uint32 depositSweepProposalSubmissionGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositSweepProposalParametersUpdated(log types.Log) (*WalletCoordinatorDepositSweepProposalParametersUpdated, error) {
+	event := new(WalletCoordinatorDepositSweepProposalParametersUpdated)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalParametersUpdated", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -1500,22 +1394,22 @@ func (it *WalletCoordinatorDepositSweepProposalSubmittedIterator) Close() error 
 
 // WalletCoordinatorDepositSweepProposalSubmitted represents a DepositSweepProposalSubmitted event raised by the WalletCoordinator contract.
 type WalletCoordinatorDepositSweepProposalSubmitted struct {
-	Proposal          WalletCoordinatorDepositSweepProposal
-	ProposalSubmitter common.Address
-	Raw               types.Log // Blockchain specific contextual infos
+	Proposal    WalletCoordinatorDepositSweepProposal
+	Coordinator common.Address
+	Raw         types.Log // Blockchain specific contextual infos
 }
 
 // FilterDepositSweepProposalSubmitted is a free log retrieval operation binding the contract event 0xe17b4ed4828b9f018ca549cfd5f662e5551408093b1db16d94b9cd242e6df171.
 //
-// Solidity: event DepositSweepProposalSubmitted((bytes20,(bytes32,uint32)[],uint256) proposal, address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepProposalSubmitted(opts *bind.FilterOpts, proposalSubmitter []common.Address) (*WalletCoordinatorDepositSweepProposalSubmittedIterator, error) {
+// Solidity: event DepositSweepProposalSubmitted((bytes20,(bytes32,uint32)[],uint256) proposal, address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepProposalSubmitted(opts *bind.FilterOpts, coordinator []common.Address) (*WalletCoordinatorDepositSweepProposalSubmittedIterator, error) {
 
-	var proposalSubmitterRule []interface{}
-	for _, proposalSubmitterItem := range proposalSubmitter {
-		proposalSubmitterRule = append(proposalSubmitterRule, proposalSubmitterItem)
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
 	}
 
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositSweepProposalSubmitted", proposalSubmitterRule)
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositSweepProposalSubmitted", coordinatorRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1524,15 +1418,15 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepProposalS
 
 // WatchDepositSweepProposalSubmitted is a free log subscription operation binding the contract event 0xe17b4ed4828b9f018ca549cfd5f662e5551408093b1db16d94b9cd242e6df171.
 //
-// Solidity: event DepositSweepProposalSubmitted((bytes20,(bytes32,uint32)[],uint256) proposal, address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalSubmitted(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositSweepProposalSubmitted, proposalSubmitter []common.Address) (event.Subscription, error) {
+// Solidity: event DepositSweepProposalSubmitted((bytes20,(bytes32,uint32)[],uint256) proposal, address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalSubmitted(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositSweepProposalSubmitted, coordinator []common.Address) (event.Subscription, error) {
 
-	var proposalSubmitterRule []interface{}
-	for _, proposalSubmitterItem := range proposalSubmitter {
-		proposalSubmitterRule = append(proposalSubmitterRule, proposalSubmitterItem)
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
 	}
 
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositSweepProposalSubmitted", proposalSubmitterRule)
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositSweepProposalSubmitted", coordinatorRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1566,7 +1460,7 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalSu
 
 // ParseDepositSweepProposalSubmitted is a log parse operation binding the contract event 0xe17b4ed4828b9f018ca549cfd5f662e5551408093b1db16d94b9cd242e6df171.
 //
-// Solidity: event DepositSweepProposalSubmitted((bytes20,(bytes32,uint32)[],uint256) proposal, address indexed proposalSubmitter)
+// Solidity: event DepositSweepProposalSubmitted((bytes20,(bytes32,uint32)[],uint256) proposal, address indexed coordinator)
 func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositSweepProposalSubmitted(log types.Log) (*WalletCoordinatorDepositSweepProposalSubmitted, error) {
 	event := new(WalletCoordinatorDepositSweepProposalSubmitted)
 	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalSubmitted", log); err != nil {
@@ -1576,9 +1470,9 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositSweepProposalSu
 	return event, nil
 }
 
-// WalletCoordinatorDepositSweepProposalValidityUpdatedIterator is returned from FilterDepositSweepProposalValidityUpdated and is used to iterate over the raw logs and unpacked data for DepositSweepProposalValidityUpdated events raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositSweepProposalValidityUpdatedIterator struct {
-	Event *WalletCoordinatorDepositSweepProposalValidityUpdated // Event containing the contract specifics and raw log
+// WalletCoordinatorHeartbeatRequestParametersUpdatedIterator is returned from FilterHeartbeatRequestParametersUpdated and is used to iterate over the raw logs and unpacked data for HeartbeatRequestParametersUpdated events raised by the WalletCoordinator contract.
+type WalletCoordinatorHeartbeatRequestParametersUpdatedIterator struct {
+	Event *WalletCoordinatorHeartbeatRequestParametersUpdated // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1592,7 +1486,7 @@ type WalletCoordinatorDepositSweepProposalValidityUpdatedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorDepositSweepProposalValidityUpdatedIterator) Next() bool {
+func (it *WalletCoordinatorHeartbeatRequestParametersUpdatedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1601,7 +1495,7 @@ func (it *WalletCoordinatorDepositSweepProposalValidityUpdatedIterator) Next() b
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorDepositSweepProposalValidityUpdated)
+			it.Event = new(WalletCoordinatorHeartbeatRequestParametersUpdated)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1616,7 +1510,7 @@ func (it *WalletCoordinatorDepositSweepProposalValidityUpdatedIterator) Next() b
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorDepositSweepProposalValidityUpdated)
+		it.Event = new(WalletCoordinatorHeartbeatRequestParametersUpdated)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1632,41 +1526,42 @@ func (it *WalletCoordinatorDepositSweepProposalValidityUpdatedIterator) Next() b
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorDepositSweepProposalValidityUpdatedIterator) Error() error {
+func (it *WalletCoordinatorHeartbeatRequestParametersUpdatedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *WalletCoordinatorDepositSweepProposalValidityUpdatedIterator) Close() error {
+func (it *WalletCoordinatorHeartbeatRequestParametersUpdatedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// WalletCoordinatorDepositSweepProposalValidityUpdated represents a DepositSweepProposalValidityUpdated event raised by the WalletCoordinator contract.
-type WalletCoordinatorDepositSweepProposalValidityUpdated struct {
-	DepositSweepProposalValidity uint32
-	Raw                          types.Log // Blockchain specific contextual infos
+// WalletCoordinatorHeartbeatRequestParametersUpdated represents a HeartbeatRequestParametersUpdated event raised by the WalletCoordinator contract.
+type WalletCoordinatorHeartbeatRequestParametersUpdated struct {
+	HeartbeatRequestValidity  uint32
+	HeartbeatRequestGasOffset uint32
+	Raw                       types.Log // Blockchain specific contextual infos
 }
 
-// FilterDepositSweepProposalValidityUpdated is a free log retrieval operation binding the contract event 0x085a81d11ac3cf6033d185eccdfc414b8a20da29a555406c068a0a1fdac8afea.
+// FilterHeartbeatRequestParametersUpdated is a free log retrieval operation binding the contract event 0xe67c0a182190bf283264290d7208533d5936483c98baee174eeac036b081360a.
 //
-// Solidity: event DepositSweepProposalValidityUpdated(uint32 depositSweepProposalValidity)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterDepositSweepProposalValidityUpdated(opts *bind.FilterOpts) (*WalletCoordinatorDepositSweepProposalValidityUpdatedIterator, error) {
+// Solidity: event HeartbeatRequestParametersUpdated(uint32 heartbeatRequestValidity, uint32 heartbeatRequestGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterHeartbeatRequestParametersUpdated(opts *bind.FilterOpts) (*WalletCoordinatorHeartbeatRequestParametersUpdatedIterator, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "DepositSweepProposalValidityUpdated")
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "HeartbeatRequestParametersUpdated")
 	if err != nil {
 		return nil, err
 	}
-	return &WalletCoordinatorDepositSweepProposalValidityUpdatedIterator{contract: _WalletCoordinator.contract, event: "DepositSweepProposalValidityUpdated", logs: logs, sub: sub}, nil
+	return &WalletCoordinatorHeartbeatRequestParametersUpdatedIterator{contract: _WalletCoordinator.contract, event: "HeartbeatRequestParametersUpdated", logs: logs, sub: sub}, nil
 }
 
-// WatchDepositSweepProposalValidityUpdated is a free log subscription operation binding the contract event 0x085a81d11ac3cf6033d185eccdfc414b8a20da29a555406c068a0a1fdac8afea.
+// WatchHeartbeatRequestParametersUpdated is a free log subscription operation binding the contract event 0xe67c0a182190bf283264290d7208533d5936483c98baee174eeac036b081360a.
 //
-// Solidity: event DepositSweepProposalValidityUpdated(uint32 depositSweepProposalValidity)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalValidityUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorDepositSweepProposalValidityUpdated) (event.Subscription, error) {
+// Solidity: event HeartbeatRequestParametersUpdated(uint32 heartbeatRequestValidity, uint32 heartbeatRequestGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchHeartbeatRequestParametersUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorHeartbeatRequestParametersUpdated) (event.Subscription, error) {
 
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "DepositSweepProposalValidityUpdated")
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "HeartbeatRequestParametersUpdated")
 	if err != nil {
 		return nil, err
 	}
@@ -1676,8 +1571,8 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalVa
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorDepositSweepProposalValidityUpdated)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalValidityUpdated", log); err != nil {
+				event := new(WalletCoordinatorHeartbeatRequestParametersUpdated)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "HeartbeatRequestParametersUpdated", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1698,12 +1593,147 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchDepositSweepProposalVa
 	}), nil
 }
 
-// ParseDepositSweepProposalValidityUpdated is a log parse operation binding the contract event 0x085a81d11ac3cf6033d185eccdfc414b8a20da29a555406c068a0a1fdac8afea.
+// ParseHeartbeatRequestParametersUpdated is a log parse operation binding the contract event 0xe67c0a182190bf283264290d7208533d5936483c98baee174eeac036b081360a.
 //
-// Solidity: event DepositSweepProposalValidityUpdated(uint32 depositSweepProposalValidity)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseDepositSweepProposalValidityUpdated(log types.Log) (*WalletCoordinatorDepositSweepProposalValidityUpdated, error) {
-	event := new(WalletCoordinatorDepositSweepProposalValidityUpdated)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "DepositSweepProposalValidityUpdated", log); err != nil {
+// Solidity: event HeartbeatRequestParametersUpdated(uint32 heartbeatRequestValidity, uint32 heartbeatRequestGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseHeartbeatRequestParametersUpdated(log types.Log) (*WalletCoordinatorHeartbeatRequestParametersUpdated, error) {
+	event := new(WalletCoordinatorHeartbeatRequestParametersUpdated)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "HeartbeatRequestParametersUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// WalletCoordinatorHeartbeatRequestSubmittedIterator is returned from FilterHeartbeatRequestSubmitted and is used to iterate over the raw logs and unpacked data for HeartbeatRequestSubmitted events raised by the WalletCoordinator contract.
+type WalletCoordinatorHeartbeatRequestSubmittedIterator struct {
+	Event *WalletCoordinatorHeartbeatRequestSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *WalletCoordinatorHeartbeatRequestSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(WalletCoordinatorHeartbeatRequestSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(WalletCoordinatorHeartbeatRequestSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *WalletCoordinatorHeartbeatRequestSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *WalletCoordinatorHeartbeatRequestSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// WalletCoordinatorHeartbeatRequestSubmitted represents a HeartbeatRequestSubmitted event raised by the WalletCoordinator contract.
+type WalletCoordinatorHeartbeatRequestSubmitted struct {
+	WalletPubKeyHash [20]byte
+	Message          []byte
+	Raw              types.Log // Blockchain specific contextual infos
+}
+
+// FilterHeartbeatRequestSubmitted is a free log retrieval operation binding the contract event 0x4dd09cf8f23ce69b68c7dc12fe74c2172499ca3168ea632bd03e5b62838d6130.
+//
+// Solidity: event HeartbeatRequestSubmitted(bytes20 walletPubKeyHash, bytes message)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterHeartbeatRequestSubmitted(opts *bind.FilterOpts) (*WalletCoordinatorHeartbeatRequestSubmittedIterator, error) {
+
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "HeartbeatRequestSubmitted")
+	if err != nil {
+		return nil, err
+	}
+	return &WalletCoordinatorHeartbeatRequestSubmittedIterator{contract: _WalletCoordinator.contract, event: "HeartbeatRequestSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchHeartbeatRequestSubmitted is a free log subscription operation binding the contract event 0x4dd09cf8f23ce69b68c7dc12fe74c2172499ca3168ea632bd03e5b62838d6130.
+//
+// Solidity: event HeartbeatRequestSubmitted(bytes20 walletPubKeyHash, bytes message)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchHeartbeatRequestSubmitted(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorHeartbeatRequestSubmitted) (event.Subscription, error) {
+
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "HeartbeatRequestSubmitted")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(WalletCoordinatorHeartbeatRequestSubmitted)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "HeartbeatRequestSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHeartbeatRequestSubmitted is a log parse operation binding the contract event 0x4dd09cf8f23ce69b68c7dc12fe74c2172499ca3168ea632bd03e5b62838d6130.
+//
+// Solidity: event HeartbeatRequestSubmitted(bytes20 walletPubKeyHash, bytes message)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseHeartbeatRequestSubmitted(log types.Log) (*WalletCoordinatorHeartbeatRequestSubmitted, error) {
+	event := new(WalletCoordinatorHeartbeatRequestSubmitted)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "HeartbeatRequestSubmitted", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -1991,294 +2021,6 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchOwnershipTransferred(o
 func (_WalletCoordinator *WalletCoordinatorFilterer) ParseOwnershipTransferred(log types.Log) (*WalletCoordinatorOwnershipTransferred, error) {
 	event := new(WalletCoordinatorOwnershipTransferred)
 	if err := _WalletCoordinator.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
-		return nil, err
-	}
-	event.Raw = log
-	return event, nil
-}
-
-// WalletCoordinatorProposalSubmitterAddedIterator is returned from FilterProposalSubmitterAdded and is used to iterate over the raw logs and unpacked data for ProposalSubmitterAdded events raised by the WalletCoordinator contract.
-type WalletCoordinatorProposalSubmitterAddedIterator struct {
-	Event *WalletCoordinatorProposalSubmitterAdded // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log        // Log channel receiving the found contract events
-	sub  ethereum.Subscription // Subscription for errors, completion and termination
-	done bool                  // Whether the subscription completed delivering logs
-	fail error                 // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorProposalSubmitterAddedIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorProposalSubmitterAdded)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorProposalSubmitterAdded)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorProposalSubmitterAddedIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *WalletCoordinatorProposalSubmitterAddedIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// WalletCoordinatorProposalSubmitterAdded represents a ProposalSubmitterAdded event raised by the WalletCoordinator contract.
-type WalletCoordinatorProposalSubmitterAdded struct {
-	ProposalSubmitter common.Address
-	Raw               types.Log // Blockchain specific contextual infos
-}
-
-// FilterProposalSubmitterAdded is a free log retrieval operation binding the contract event 0xe7005265f76a2d6482aaa3a0e969edd45868e3210ff126216a0425f83af1ef20.
-//
-// Solidity: event ProposalSubmitterAdded(address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterProposalSubmitterAdded(opts *bind.FilterOpts, proposalSubmitter []common.Address) (*WalletCoordinatorProposalSubmitterAddedIterator, error) {
-
-	var proposalSubmitterRule []interface{}
-	for _, proposalSubmitterItem := range proposalSubmitter {
-		proposalSubmitterRule = append(proposalSubmitterRule, proposalSubmitterItem)
-	}
-
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "ProposalSubmitterAdded", proposalSubmitterRule)
-	if err != nil {
-		return nil, err
-	}
-	return &WalletCoordinatorProposalSubmitterAddedIterator{contract: _WalletCoordinator.contract, event: "ProposalSubmitterAdded", logs: logs, sub: sub}, nil
-}
-
-// WatchProposalSubmitterAdded is a free log subscription operation binding the contract event 0xe7005265f76a2d6482aaa3a0e969edd45868e3210ff126216a0425f83af1ef20.
-//
-// Solidity: event ProposalSubmitterAdded(address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchProposalSubmitterAdded(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorProposalSubmitterAdded, proposalSubmitter []common.Address) (event.Subscription, error) {
-
-	var proposalSubmitterRule []interface{}
-	for _, proposalSubmitterItem := range proposalSubmitter {
-		proposalSubmitterRule = append(proposalSubmitterRule, proposalSubmitterItem)
-	}
-
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "ProposalSubmitterAdded", proposalSubmitterRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorProposalSubmitterAdded)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "ProposalSubmitterAdded", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseProposalSubmitterAdded is a log parse operation binding the contract event 0xe7005265f76a2d6482aaa3a0e969edd45868e3210ff126216a0425f83af1ef20.
-//
-// Solidity: event ProposalSubmitterAdded(address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseProposalSubmitterAdded(log types.Log) (*WalletCoordinatorProposalSubmitterAdded, error) {
-	event := new(WalletCoordinatorProposalSubmitterAdded)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "ProposalSubmitterAdded", log); err != nil {
-		return nil, err
-	}
-	event.Raw = log
-	return event, nil
-}
-
-// WalletCoordinatorProposalSubmitterRemovedIterator is returned from FilterProposalSubmitterRemoved and is used to iterate over the raw logs and unpacked data for ProposalSubmitterRemoved events raised by the WalletCoordinator contract.
-type WalletCoordinatorProposalSubmitterRemovedIterator struct {
-	Event *WalletCoordinatorProposalSubmitterRemoved // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log        // Log channel receiving the found contract events
-	sub  ethereum.Subscription // Subscription for errors, completion and termination
-	done bool                  // Whether the subscription completed delivering logs
-	fail error                 // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *WalletCoordinatorProposalSubmitterRemovedIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(WalletCoordinatorProposalSubmitterRemoved)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(WalletCoordinatorProposalSubmitterRemoved)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *WalletCoordinatorProposalSubmitterRemovedIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *WalletCoordinatorProposalSubmitterRemovedIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// WalletCoordinatorProposalSubmitterRemoved represents a ProposalSubmitterRemoved event raised by the WalletCoordinator contract.
-type WalletCoordinatorProposalSubmitterRemoved struct {
-	ProposalSubmitter common.Address
-	Raw               types.Log // Blockchain specific contextual infos
-}
-
-// FilterProposalSubmitterRemoved is a free log retrieval operation binding the contract event 0x4017c4f3f844d24f56ade93af205a7ed01bf7f858b90f4b62206be460af2d226.
-//
-// Solidity: event ProposalSubmitterRemoved(address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) FilterProposalSubmitterRemoved(opts *bind.FilterOpts, proposalSubmitter []common.Address) (*WalletCoordinatorProposalSubmitterRemovedIterator, error) {
-
-	var proposalSubmitterRule []interface{}
-	for _, proposalSubmitterItem := range proposalSubmitter {
-		proposalSubmitterRule = append(proposalSubmitterRule, proposalSubmitterItem)
-	}
-
-	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "ProposalSubmitterRemoved", proposalSubmitterRule)
-	if err != nil {
-		return nil, err
-	}
-	return &WalletCoordinatorProposalSubmitterRemovedIterator{contract: _WalletCoordinator.contract, event: "ProposalSubmitterRemoved", logs: logs, sub: sub}, nil
-}
-
-// WatchProposalSubmitterRemoved is a free log subscription operation binding the contract event 0x4017c4f3f844d24f56ade93af205a7ed01bf7f858b90f4b62206be460af2d226.
-//
-// Solidity: event ProposalSubmitterRemoved(address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) WatchProposalSubmitterRemoved(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorProposalSubmitterRemoved, proposalSubmitter []common.Address) (event.Subscription, error) {
-
-	var proposalSubmitterRule []interface{}
-	for _, proposalSubmitterItem := range proposalSubmitter {
-		proposalSubmitterRule = append(proposalSubmitterRule, proposalSubmitterItem)
-	}
-
-	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "ProposalSubmitterRemoved", proposalSubmitterRule)
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(WalletCoordinatorProposalSubmitterRemoved)
-				if err := _WalletCoordinator.contract.UnpackLog(event, "ProposalSubmitterRemoved", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseProposalSubmitterRemoved is a log parse operation binding the contract event 0x4017c4f3f844d24f56ade93af205a7ed01bf7f858b90f4b62206be460af2d226.
-//
-// Solidity: event ProposalSubmitterRemoved(address indexed proposalSubmitter)
-func (_WalletCoordinator *WalletCoordinatorFilterer) ParseProposalSubmitterRemoved(log types.Log) (*WalletCoordinatorProposalSubmitterRemoved, error) {
-	event := new(WalletCoordinatorProposalSubmitterRemoved)
-	if err := _WalletCoordinator.contract.UnpackLog(event, "ProposalSubmitterRemoved", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/pkg/chain/ethereum/tbtc/gen/cmd/WalletCoordinator.go
+++ b/pkg/chain/ethereum/tbtc/gen/cmd/WalletCoordinator.go
@@ -56,22 +56,20 @@ func init() {
 		wcDepositSweepMaxSizeCommand(),
 		wcDepositSweepProposalSubmissionGasOffsetCommand(),
 		wcDepositSweepProposalValidityCommand(),
-		wcIsProposalSubmitterCommand(),
+		wcHeartbeatRequestGasOffsetCommand(),
+		wcHeartbeatRequestValidityCommand(),
+		wcIsCoordinatorCommand(),
 		wcOwnerCommand(),
 		wcReimbursementPoolCommand(),
-		wcWalletRegistryCommand(),
-		wcAddProposalSubmitterCommand(),
+		wcAddCoordinatorCommand(),
 		wcInitializeCommand(),
-		wcRemoveProposalSubmitterCommand(),
+		wcRemoveCoordinatorCommand(),
 		wcRenounceOwnershipCommand(),
 		wcSubmitDepositSweepProposalCommand(),
 		wcSubmitDepositSweepProposalWithReimbursementCommand(),
 		wcTransferOwnershipCommand(),
-		wcUpdateDepositMinAgeCommand(),
-		wcUpdateDepositRefundSafetyMarginCommand(),
-		wcUpdateDepositSweepMaxSizeCommand(),
-		wcUpdateDepositSweepProposalSubmissionGasOffsetCommand(),
-		wcUpdateDepositSweepProposalValidityCommand(),
+		wcUpdateDepositSweepProposalParametersCommand(),
+		wcUpdateHeartbeatRequestParametersCommand(),
 		wcUpdateReimbursementPoolCommand(),
 	)
 
@@ -284,12 +282,12 @@ func wcDepositSweepProposalValidity(c *cobra.Command, args []string) error {
 	return nil
 }
 
-func wcIsProposalSubmitterCommand() *cobra.Command {
+func wcHeartbeatRequestGasOffsetCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "is-proposal-submitter [arg0]",
-		Short:                 "Calls the view method isProposalSubmitter on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcIsProposalSubmitter,
+		Use:                   "heartbeat-request-gas-offset",
+		Short:                 "Calls the view method heartbeatRequestGasOffset on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcHeartbeatRequestGasOffset,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
 	}
@@ -299,7 +297,75 @@ func wcIsProposalSubmitterCommand() *cobra.Command {
 	return c
 }
 
-func wcIsProposalSubmitter(c *cobra.Command, args []string) error {
+func wcHeartbeatRequestGasOffset(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.HeartbeatRequestGasOffsetAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcHeartbeatRequestValidityCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "heartbeat-request-validity",
+		Short:                 "Calls the view method heartbeatRequestValidity on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcHeartbeatRequestValidity,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcHeartbeatRequestValidity(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.HeartbeatRequestValidityAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcIsCoordinatorCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "is-coordinator [arg0]",
+		Short:                 "Calls the view method isCoordinator on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(1),
+		RunE:                  wcIsCoordinator,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcIsCoordinator(c *cobra.Command, args []string) error {
 	contract, err := initializeWalletCoordinator(c)
 	if err != nil {
 		return err
@@ -313,7 +379,7 @@ func wcIsProposalSubmitter(c *cobra.Command, args []string) error {
 		)
 	}
 
-	result, err := contract.IsProposalSubmitterAtBlock(
+	result, err := contract.IsCoordinatorAtBlock(
 		arg0,
 		cmd.BlockFlagValue.Int,
 	)
@@ -395,48 +461,14 @@ func wcReimbursementPool(c *cobra.Command, args []string) error {
 	return nil
 }
 
-func wcWalletRegistryCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:                   "wallet-registry",
-		Short:                 "Calls the view method walletRegistry on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(0),
-		RunE:                  wcWalletRegistry,
-		SilenceUsage:          true,
-		DisableFlagsInUseLine: true,
-	}
-
-	cmd.InitConstFlags(c)
-
-	return c
-}
-
-func wcWalletRegistry(c *cobra.Command, args []string) error {
-	contract, err := initializeWalletCoordinator(c)
-	if err != nil {
-		return err
-	}
-
-	result, err := contract.WalletRegistryAtBlock(
-		cmd.BlockFlagValue.Int,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	cmd.PrintOutput(result)
-
-	return nil
-}
-
 /// ------------------- Non-const methods -------------------
 
-func wcAddProposalSubmitterCommand() *cobra.Command {
+func wcAddCoordinatorCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "add-proposal-submitter [arg_proposalSubmitter]",
-		Short:                 "Calls the nonpayable method addProposalSubmitter on the WalletCoordinator contract.",
+		Use:                   "add-coordinator [arg_coordinator]",
+		Short:                 "Calls the nonpayable method addCoordinator on the WalletCoordinator contract.",
 		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcAddProposalSubmitter,
+		RunE:                  wcAddCoordinator,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
 	}
@@ -447,16 +479,16 @@ func wcAddProposalSubmitterCommand() *cobra.Command {
 	return c
 }
 
-func wcAddProposalSubmitter(c *cobra.Command, args []string) error {
+func wcAddCoordinator(c *cobra.Command, args []string) error {
 	contract, err := initializeWalletCoordinator(c)
 	if err != nil {
 		return err
 	}
 
-	arg_proposalSubmitter, err := chainutil.AddressFromHex(args[0])
+	arg_coordinator, err := chainutil.AddressFromHex(args[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter arg_proposalSubmitter, a address, from passed value %v",
+			"couldn't parse parameter arg_coordinator, a address, from passed value %v",
 			args[0],
 		)
 	}
@@ -467,8 +499,8 @@ func wcAddProposalSubmitter(c *cobra.Command, args []string) error {
 
 	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.AddProposalSubmitter(
-			arg_proposalSubmitter,
+		transaction, err = contract.AddCoordinator(
+			arg_coordinator,
 		)
 		if err != nil {
 			return err
@@ -477,8 +509,8 @@ func wcAddProposalSubmitter(c *cobra.Command, args []string) error {
 		cmd.PrintOutput(transaction.Hash())
 	} else {
 		// Do a call.
-		err = contract.CallAddProposalSubmitter(
-			arg_proposalSubmitter,
+		err = contract.CallAddCoordinator(
+			arg_coordinator,
 			cmd.BlockFlagValue.Int,
 		)
 		if err != nil {
@@ -561,12 +593,12 @@ func wcInitialize(c *cobra.Command, args []string) error {
 	return nil
 }
 
-func wcRemoveProposalSubmitterCommand() *cobra.Command {
+func wcRemoveCoordinatorCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "remove-proposal-submitter [arg_proposalSubmitter]",
-		Short:                 "Calls the nonpayable method removeProposalSubmitter on the WalletCoordinator contract.",
+		Use:                   "remove-coordinator [arg_coordinator]",
+		Short:                 "Calls the nonpayable method removeCoordinator on the WalletCoordinator contract.",
 		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcRemoveProposalSubmitter,
+		RunE:                  wcRemoveCoordinator,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
 	}
@@ -577,16 +609,16 @@ func wcRemoveProposalSubmitterCommand() *cobra.Command {
 	return c
 }
 
-func wcRemoveProposalSubmitter(c *cobra.Command, args []string) error {
+func wcRemoveCoordinator(c *cobra.Command, args []string) error {
 	contract, err := initializeWalletCoordinator(c)
 	if err != nil {
 		return err
 	}
 
-	arg_proposalSubmitter, err := chainutil.AddressFromHex(args[0])
+	arg_coordinator, err := chainutil.AddressFromHex(args[0])
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't parse parameter arg_proposalSubmitter, a address, from passed value %v",
+			"couldn't parse parameter arg_coordinator, a address, from passed value %v",
 			args[0],
 		)
 	}
@@ -597,8 +629,8 @@ func wcRemoveProposalSubmitter(c *cobra.Command, args []string) error {
 
 	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.RemoveProposalSubmitter(
-			arg_proposalSubmitter,
+		transaction, err = contract.RemoveCoordinator(
+			arg_coordinator,
 		)
 		if err != nil {
 			return err
@@ -607,8 +639,8 @@ func wcRemoveProposalSubmitter(c *cobra.Command, args []string) error {
 		cmd.PrintOutput(transaction.Hash())
 	} else {
 		// Do a call.
-		err = contract.CallRemoveProposalSubmitter(
-			arg_proposalSubmitter,
+		err = contract.CallRemoveCoordinator(
+			arg_coordinator,
 			cmd.BlockFlagValue.Int,
 		)
 		if err != nil {
@@ -682,9 +714,9 @@ func wcRenounceOwnership(c *cobra.Command, args []string) error {
 
 func wcSubmitDepositSweepProposalCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "submit-deposit-sweep-proposal [arg_proposal_json] [arg_walletMemberContext_json]",
+		Use:                   "submit-deposit-sweep-proposal [arg_proposal_json]",
 		Short:                 "Calls the nonpayable method submitDepositSweepProposal on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(2),
+		Args:                  cmd.ArgCountChecker(1),
 		RunE:                  wcSubmitDepositSweepProposal,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
@@ -707,11 +739,6 @@ func wcSubmitDepositSweepProposal(c *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to unmarshal arg_proposal_json to abi.WalletCoordinatorDepositSweepProposal: %w", err)
 	}
 
-	arg_walletMemberContext_json := abi.WalletCoordinatorWalletMemberContext{}
-	if err := json.Unmarshal([]byte(args[1]), &arg_walletMemberContext_json); err != nil {
-		return fmt.Errorf("failed to unmarshal arg_walletMemberContext_json to abi.WalletCoordinatorWalletMemberContext: %w", err)
-	}
-
 	var (
 		transaction *types.Transaction
 	)
@@ -720,7 +747,6 @@ func wcSubmitDepositSweepProposal(c *cobra.Command, args []string) error {
 		// Do a regular submission. Take payable into account.
 		transaction, err = contract.SubmitDepositSweepProposal(
 			arg_proposal_json,
-			arg_walletMemberContext_json,
 		)
 		if err != nil {
 			return err
@@ -731,7 +757,6 @@ func wcSubmitDepositSweepProposal(c *cobra.Command, args []string) error {
 		// Do a call.
 		err = contract.CallSubmitDepositSweepProposal(
 			arg_proposal_json,
-			arg_walletMemberContext_json,
 			cmd.BlockFlagValue.Int,
 		)
 		if err != nil {
@@ -751,9 +776,9 @@ func wcSubmitDepositSweepProposal(c *cobra.Command, args []string) error {
 
 func wcSubmitDepositSweepProposalWithReimbursementCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "submit-deposit-sweep-proposal-with-reimbursement [arg_proposal_json] [arg_walletMemberContext_json]",
+		Use:                   "submit-deposit-sweep-proposal-with-reimbursement [arg_proposal_json]",
 		Short:                 "Calls the nonpayable method submitDepositSweepProposalWithReimbursement on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(2),
+		Args:                  cmd.ArgCountChecker(1),
 		RunE:                  wcSubmitDepositSweepProposalWithReimbursement,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
@@ -776,11 +801,6 @@ func wcSubmitDepositSweepProposalWithReimbursement(c *cobra.Command, args []stri
 		return fmt.Errorf("failed to unmarshal arg_proposal_json to abi.WalletCoordinatorDepositSweepProposal: %w", err)
 	}
 
-	arg_walletMemberContext_json := abi.WalletCoordinatorWalletMemberContext{}
-	if err := json.Unmarshal([]byte(args[1]), &arg_walletMemberContext_json); err != nil {
-		return fmt.Errorf("failed to unmarshal arg_walletMemberContext_json to abi.WalletCoordinatorWalletMemberContext: %w", err)
-	}
-
 	var (
 		transaction *types.Transaction
 	)
@@ -789,7 +809,6 @@ func wcSubmitDepositSweepProposalWithReimbursement(c *cobra.Command, args []stri
 		// Do a regular submission. Take payable into account.
 		transaction, err = contract.SubmitDepositSweepProposalWithReimbursement(
 			arg_proposal_json,
-			arg_walletMemberContext_json,
 		)
 		if err != nil {
 			return err
@@ -800,7 +819,6 @@ func wcSubmitDepositSweepProposalWithReimbursement(c *cobra.Command, args []stri
 		// Do a call.
 		err = contract.CallSubmitDepositSweepProposalWithReimbursement(
 			arg_proposal_json,
-			arg_walletMemberContext_json,
 			cmd.BlockFlagValue.Int,
 		)
 		if err != nil {
@@ -883,12 +901,12 @@ func wcTransferOwnership(c *cobra.Command, args []string) error {
 	return nil
 }
 
-func wcUpdateDepositMinAgeCommand() *cobra.Command {
+func wcUpdateDepositSweepProposalParametersCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:                   "update-deposit-min-age [arg__depositMinAge]",
-		Short:                 "Calls the nonpayable method updateDepositMinAge on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcUpdateDepositMinAge,
+		Use:                   "update-deposit-sweep-proposal-parameters [arg__depositSweepProposalValidity] [arg__depositMinAge] [arg__depositRefundSafetyMargin] [arg__depositSweepMaxSize] [arg__depositSweepProposalSubmissionGasOffset]",
+		Short:                 "Calls the nonpayable method updateDepositSweepProposalParameters on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(5),
+		RunE:                  wcUpdateDepositSweepProposalParameters,
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
 	}
@@ -899,267 +917,7 @@ func wcUpdateDepositMinAgeCommand() *cobra.Command {
 	return c
 }
 
-func wcUpdateDepositMinAge(c *cobra.Command, args []string) error {
-	contract, err := initializeWalletCoordinator(c)
-	if err != nil {
-		return err
-	}
-
-	arg__depositMinAge, err := decode.ParseUint[uint32](args[0], 32)
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg__depositMinAge, a uint32, from passed value %v",
-			args[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UpdateDepositMinAge(
-			arg__depositMinAge,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash())
-	} else {
-		// Do a call.
-		err = contract.CallUpdateDepositMinAge(
-			arg__depositMinAge,
-			cmd.BlockFlagValue.Int,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput("success")
-
-		cmd.PrintOutput(
-			"the transaction was not submitted to the chain; " +
-				"please add the `--submit` flag",
-		)
-	}
-
-	return nil
-}
-
-func wcUpdateDepositRefundSafetyMarginCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:                   "update-deposit-refund-safety-margin [arg__depositRefundSafetyMargin]",
-		Short:                 "Calls the nonpayable method updateDepositRefundSafetyMargin on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcUpdateDepositRefundSafetyMargin,
-		SilenceUsage:          true,
-		DisableFlagsInUseLine: true,
-	}
-
-	c.PreRunE = cmd.NonConstArgsChecker
-	cmd.InitNonConstFlags(c)
-
-	return c
-}
-
-func wcUpdateDepositRefundSafetyMargin(c *cobra.Command, args []string) error {
-	contract, err := initializeWalletCoordinator(c)
-	if err != nil {
-		return err
-	}
-
-	arg__depositRefundSafetyMargin, err := decode.ParseUint[uint32](args[0], 32)
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg__depositRefundSafetyMargin, a uint32, from passed value %v",
-			args[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UpdateDepositRefundSafetyMargin(
-			arg__depositRefundSafetyMargin,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash())
-	} else {
-		// Do a call.
-		err = contract.CallUpdateDepositRefundSafetyMargin(
-			arg__depositRefundSafetyMargin,
-			cmd.BlockFlagValue.Int,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput("success")
-
-		cmd.PrintOutput(
-			"the transaction was not submitted to the chain; " +
-				"please add the `--submit` flag",
-		)
-	}
-
-	return nil
-}
-
-func wcUpdateDepositSweepMaxSizeCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:                   "update-deposit-sweep-max-size [arg__depositSweepMaxSize]",
-		Short:                 "Calls the nonpayable method updateDepositSweepMaxSize on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcUpdateDepositSweepMaxSize,
-		SilenceUsage:          true,
-		DisableFlagsInUseLine: true,
-	}
-
-	c.PreRunE = cmd.NonConstArgsChecker
-	cmd.InitNonConstFlags(c)
-
-	return c
-}
-
-func wcUpdateDepositSweepMaxSize(c *cobra.Command, args []string) error {
-	contract, err := initializeWalletCoordinator(c)
-	if err != nil {
-		return err
-	}
-
-	arg__depositSweepMaxSize, err := decode.ParseUint[uint16](args[0], 16)
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg__depositSweepMaxSize, a uint16, from passed value %v",
-			args[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UpdateDepositSweepMaxSize(
-			arg__depositSweepMaxSize,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash())
-	} else {
-		// Do a call.
-		err = contract.CallUpdateDepositSweepMaxSize(
-			arg__depositSweepMaxSize,
-			cmd.BlockFlagValue.Int,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput("success")
-
-		cmd.PrintOutput(
-			"the transaction was not submitted to the chain; " +
-				"please add the `--submit` flag",
-		)
-	}
-
-	return nil
-}
-
-func wcUpdateDepositSweepProposalSubmissionGasOffsetCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:                   "update-deposit-sweep-proposal-submission-gas-offset [arg__depositSweepProposalSubmissionGasOffset]",
-		Short:                 "Calls the nonpayable method updateDepositSweepProposalSubmissionGasOffset on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcUpdateDepositSweepProposalSubmissionGasOffset,
-		SilenceUsage:          true,
-		DisableFlagsInUseLine: true,
-	}
-
-	c.PreRunE = cmd.NonConstArgsChecker
-	cmd.InitNonConstFlags(c)
-
-	return c
-}
-
-func wcUpdateDepositSweepProposalSubmissionGasOffset(c *cobra.Command, args []string) error {
-	contract, err := initializeWalletCoordinator(c)
-	if err != nil {
-		return err
-	}
-
-	arg__depositSweepProposalSubmissionGasOffset, err := decode.ParseUint[uint32](args[0], 32)
-	if err != nil {
-		return fmt.Errorf(
-			"couldn't parse parameter arg__depositSweepProposalSubmissionGasOffset, a uint32, from passed value %v",
-			args[0],
-		)
-	}
-
-	var (
-		transaction *types.Transaction
-	)
-
-	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
-		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UpdateDepositSweepProposalSubmissionGasOffset(
-			arg__depositSweepProposalSubmissionGasOffset,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput(transaction.Hash())
-	} else {
-		// Do a call.
-		err = contract.CallUpdateDepositSweepProposalSubmissionGasOffset(
-			arg__depositSweepProposalSubmissionGasOffset,
-			cmd.BlockFlagValue.Int,
-		)
-		if err != nil {
-			return err
-		}
-
-		cmd.PrintOutput("success")
-
-		cmd.PrintOutput(
-			"the transaction was not submitted to the chain; " +
-				"please add the `--submit` flag",
-		)
-	}
-
-	return nil
-}
-
-func wcUpdateDepositSweepProposalValidityCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:                   "update-deposit-sweep-proposal-validity [arg__depositSweepProposalValidity]",
-		Short:                 "Calls the nonpayable method updateDepositSweepProposalValidity on the WalletCoordinator contract.",
-		Args:                  cmd.ArgCountChecker(1),
-		RunE:                  wcUpdateDepositSweepProposalValidity,
-		SilenceUsage:          true,
-		DisableFlagsInUseLine: true,
-	}
-
-	c.PreRunE = cmd.NonConstArgsChecker
-	cmd.InitNonConstFlags(c)
-
-	return c
-}
-
-func wcUpdateDepositSweepProposalValidity(c *cobra.Command, args []string) error {
+func wcUpdateDepositSweepProposalParameters(c *cobra.Command, args []string) error {
 	contract, err := initializeWalletCoordinator(c)
 	if err != nil {
 		return err
@@ -1172,6 +930,34 @@ func wcUpdateDepositSweepProposalValidity(c *cobra.Command, args []string) error
 			args[0],
 		)
 	}
+	arg__depositMinAge, err := decode.ParseUint[uint32](args[1], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__depositMinAge, a uint32, from passed value %v",
+			args[1],
+		)
+	}
+	arg__depositRefundSafetyMargin, err := decode.ParseUint[uint32](args[2], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__depositRefundSafetyMargin, a uint32, from passed value %v",
+			args[2],
+		)
+	}
+	arg__depositSweepMaxSize, err := decode.ParseUint[uint16](args[3], 16)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__depositSweepMaxSize, a uint16, from passed value %v",
+			args[3],
+		)
+	}
+	arg__depositSweepProposalSubmissionGasOffset, err := decode.ParseUint[uint32](args[4], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__depositSweepProposalSubmissionGasOffset, a uint32, from passed value %v",
+			args[4],
+		)
+	}
 
 	var (
 		transaction *types.Transaction
@@ -1179,8 +965,12 @@ func wcUpdateDepositSweepProposalValidity(c *cobra.Command, args []string) error
 
 	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
 		// Do a regular submission. Take payable into account.
-		transaction, err = contract.UpdateDepositSweepProposalValidity(
+		transaction, err = contract.UpdateDepositSweepProposalParameters(
 			arg__depositSweepProposalValidity,
+			arg__depositMinAge,
+			arg__depositRefundSafetyMargin,
+			arg__depositSweepMaxSize,
+			arg__depositSweepProposalSubmissionGasOffset,
 		)
 		if err != nil {
 			return err
@@ -1189,8 +979,86 @@ func wcUpdateDepositSweepProposalValidity(c *cobra.Command, args []string) error
 		cmd.PrintOutput(transaction.Hash())
 	} else {
 		// Do a call.
-		err = contract.CallUpdateDepositSweepProposalValidity(
+		err = contract.CallUpdateDepositSweepProposalParameters(
 			arg__depositSweepProposalValidity,
+			arg__depositMinAge,
+			arg__depositRefundSafetyMargin,
+			arg__depositSweepMaxSize,
+			arg__depositSweepProposalSubmissionGasOffset,
+			cmd.BlockFlagValue.Int,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput("success")
+
+		cmd.PrintOutput(
+			"the transaction was not submitted to the chain; " +
+				"please add the `--submit` flag",
+		)
+	}
+
+	return nil
+}
+
+func wcUpdateHeartbeatRequestParametersCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "update-heartbeat-request-parameters [arg__heartbeatRequestValidity] [arg__heartbeatRequestGasOffset]",
+		Short:                 "Calls the nonpayable method updateHeartbeatRequestParameters on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(2),
+		RunE:                  wcUpdateHeartbeatRequestParameters,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	c.PreRunE = cmd.NonConstArgsChecker
+	cmd.InitNonConstFlags(c)
+
+	return c
+}
+
+func wcUpdateHeartbeatRequestParameters(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	arg__heartbeatRequestValidity, err := decode.ParseUint[uint32](args[0], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__heartbeatRequestValidity, a uint32, from passed value %v",
+			args[0],
+		)
+	}
+	arg__heartbeatRequestGasOffset, err := decode.ParseUint[uint32](args[1], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__heartbeatRequestGasOffset, a uint32, from passed value %v",
+			args[1],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.UpdateHeartbeatRequestParameters(
+			arg__heartbeatRequestValidity,
+			arg__heartbeatRequestGasOffset,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash())
+	} else {
+		// Do a call.
+		err = contract.CallUpdateHeartbeatRequestParameters(
+			arg__heartbeatRequestValidity,
+			arg__heartbeatRequestGasOffset,
 			cmd.BlockFlagValue.Int,
 		)
 		if err != nil {

--- a/pkg/chain/ethereum/tbtc/gen/contract/WalletCoordinator.go
+++ b/pkg/chain/ethereum/tbtc/gen/contract/WalletCoordinator.go
@@ -105,16 +105,16 @@ func NewWalletCoordinator(
 // ----- Non-const Methods ------
 
 // Transaction submission.
-func (wc *WalletCoordinator) AddProposalSubmitter(
-	arg_proposalSubmitter common.Address,
+func (wc *WalletCoordinator) AddCoordinator(
+	arg_coordinator common.Address,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	wcLogger.Debug(
-		"submitting transaction addProposalSubmitter",
+		"submitting transaction addCoordinator",
 		" params: ",
 		fmt.Sprint(
-			arg_proposalSubmitter,
+			arg_coordinator,
 		),
 	)
 
@@ -140,22 +140,22 @@ func (wc *WalletCoordinator) AddProposalSubmitter(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := wc.contract.AddProposalSubmitter(
+	transaction, err := wc.contract.AddCoordinator(
 		transactorOptions,
-		arg_proposalSubmitter,
+		arg_coordinator,
 	)
 	if err != nil {
 		return transaction, wc.errorResolver.ResolveError(
 			err,
 			wc.transactorOptions.From,
 			nil,
-			"addProposalSubmitter",
-			arg_proposalSubmitter,
+			"addCoordinator",
+			arg_coordinator,
 		)
 	}
 
 	wcLogger.Infof(
-		"submitted transaction addProposalSubmitter with id: [%s] and nonce [%v]",
+		"submitted transaction addCoordinator with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
@@ -174,22 +174,22 @@ func (wc *WalletCoordinator) AddProposalSubmitter(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := wc.contract.AddProposalSubmitter(
+			transaction, err := wc.contract.AddCoordinator(
 				newTransactorOptions,
-				arg_proposalSubmitter,
+				arg_coordinator,
 			)
 			if err != nil {
 				return nil, wc.errorResolver.ResolveError(
 					err,
 					wc.transactorOptions.From,
 					nil,
-					"addProposalSubmitter",
-					arg_proposalSubmitter,
+					"addCoordinator",
+					arg_coordinator,
 				)
 			}
 
 			wcLogger.Infof(
-				"submitted transaction addProposalSubmitter with id: [%s] and nonce [%v]",
+				"submitted transaction addCoordinator with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
 			)
@@ -204,8 +204,8 @@ func (wc *WalletCoordinator) AddProposalSubmitter(
 }
 
 // Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallAddProposalSubmitter(
-	arg_proposalSubmitter common.Address,
+func (wc *WalletCoordinator) CallAddCoordinator(
+	arg_coordinator common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -217,26 +217,26 @@ func (wc *WalletCoordinator) CallAddProposalSubmitter(
 		wc.caller,
 		wc.errorResolver,
 		wc.contractAddress,
-		"addProposalSubmitter",
+		"addCoordinator",
 		&result,
-		arg_proposalSubmitter,
+		arg_coordinator,
 	)
 
 	return err
 }
 
-func (wc *WalletCoordinator) AddProposalSubmitterGasEstimate(
-	arg_proposalSubmitter common.Address,
+func (wc *WalletCoordinator) AddCoordinatorGasEstimate(
+	arg_coordinator common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
 		wc.callerOptions.From,
 		wc.contractAddress,
-		"addProposalSubmitter",
+		"addCoordinator",
 		wc.contractABI,
 		wc.transactor,
-		arg_proposalSubmitter,
+		arg_coordinator,
 	)
 
 	return result, err
@@ -381,16 +381,16 @@ func (wc *WalletCoordinator) InitializeGasEstimate(
 }
 
 // Transaction submission.
-func (wc *WalletCoordinator) RemoveProposalSubmitter(
-	arg_proposalSubmitter common.Address,
+func (wc *WalletCoordinator) RemoveCoordinator(
+	arg_coordinator common.Address,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	wcLogger.Debug(
-		"submitting transaction removeProposalSubmitter",
+		"submitting transaction removeCoordinator",
 		" params: ",
 		fmt.Sprint(
-			arg_proposalSubmitter,
+			arg_coordinator,
 		),
 	)
 
@@ -416,22 +416,22 @@ func (wc *WalletCoordinator) RemoveProposalSubmitter(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := wc.contract.RemoveProposalSubmitter(
+	transaction, err := wc.contract.RemoveCoordinator(
 		transactorOptions,
-		arg_proposalSubmitter,
+		arg_coordinator,
 	)
 	if err != nil {
 		return transaction, wc.errorResolver.ResolveError(
 			err,
 			wc.transactorOptions.From,
 			nil,
-			"removeProposalSubmitter",
-			arg_proposalSubmitter,
+			"removeCoordinator",
+			arg_coordinator,
 		)
 	}
 
 	wcLogger.Infof(
-		"submitted transaction removeProposalSubmitter with id: [%s] and nonce [%v]",
+		"submitted transaction removeCoordinator with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
@@ -450,22 +450,22 @@ func (wc *WalletCoordinator) RemoveProposalSubmitter(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := wc.contract.RemoveProposalSubmitter(
+			transaction, err := wc.contract.RemoveCoordinator(
 				newTransactorOptions,
-				arg_proposalSubmitter,
+				arg_coordinator,
 			)
 			if err != nil {
 				return nil, wc.errorResolver.ResolveError(
 					err,
 					wc.transactorOptions.From,
 					nil,
-					"removeProposalSubmitter",
-					arg_proposalSubmitter,
+					"removeCoordinator",
+					arg_coordinator,
 				)
 			}
 
 			wcLogger.Infof(
-				"submitted transaction removeProposalSubmitter with id: [%s] and nonce [%v]",
+				"submitted transaction removeCoordinator with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
 			)
@@ -480,8 +480,8 @@ func (wc *WalletCoordinator) RemoveProposalSubmitter(
 }
 
 // Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallRemoveProposalSubmitter(
-	arg_proposalSubmitter common.Address,
+func (wc *WalletCoordinator) CallRemoveCoordinator(
+	arg_coordinator common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -493,26 +493,26 @@ func (wc *WalletCoordinator) CallRemoveProposalSubmitter(
 		wc.caller,
 		wc.errorResolver,
 		wc.contractAddress,
-		"removeProposalSubmitter",
+		"removeCoordinator",
 		&result,
-		arg_proposalSubmitter,
+		arg_coordinator,
 	)
 
 	return err
 }
 
-func (wc *WalletCoordinator) RemoveProposalSubmitterGasEstimate(
-	arg_proposalSubmitter common.Address,
+func (wc *WalletCoordinator) RemoveCoordinatorGasEstimate(
+	arg_coordinator common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
 		wc.callerOptions.From,
 		wc.contractAddress,
-		"removeProposalSubmitter",
+		"removeCoordinator",
 		wc.contractABI,
 		wc.transactor,
-		arg_proposalSubmitter,
+		arg_coordinator,
 	)
 
 	return result, err
@@ -643,9 +643,304 @@ func (wc *WalletCoordinator) RenounceOwnershipGasEstimate() (uint64, error) {
 }
 
 // Transaction submission.
+func (wc *WalletCoordinator) RequestHeartbeat(
+	arg_walletPubKeyHash [20]byte,
+	arg_message []byte,
+
+	transactionOptions ...chainutil.TransactionOptions,
+) (*types.Transaction, error) {
+	wcLogger.Debug(
+		"submitting transaction requestHeartbeat",
+		" params: ",
+		fmt.Sprint(
+			arg_walletPubKeyHash,
+			arg_message,
+		),
+	)
+
+	wc.transactionMutex.Lock()
+	defer wc.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *wc.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := wc.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := wc.contract.RequestHeartbeat(
+		transactorOptions,
+		arg_walletPubKeyHash,
+		arg_message,
+	)
+	if err != nil {
+		return transaction, wc.errorResolver.ResolveError(
+			err,
+			wc.transactorOptions.From,
+			nil,
+			"requestHeartbeat",
+			arg_walletPubKeyHash,
+			arg_message,
+		)
+	}
+
+	wcLogger.Infof(
+		"submitted transaction requestHeartbeat with id: [%s] and nonce [%v]",
+		transaction.Hash(),
+		transaction.Nonce(),
+	)
+
+	go wc.miningWaiter.ForceMining(
+		transaction,
+		transactorOptions,
+		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
+			// If original transactor options has a non-zero gas limit, that
+			// means the client code set it on their own. In that case, we
+			// should rewrite the gas limit from the original transaction
+			// for each resubmission. If the gas limit is not set by the client
+			// code, let the the submitter re-estimate the gas limit on each
+			// resubmission.
+			if transactorOptions.GasLimit != 0 {
+				newTransactorOptions.GasLimit = transactorOptions.GasLimit
+			}
+
+			transaction, err := wc.contract.RequestHeartbeat(
+				newTransactorOptions,
+				arg_walletPubKeyHash,
+				arg_message,
+			)
+			if err != nil {
+				return nil, wc.errorResolver.ResolveError(
+					err,
+					wc.transactorOptions.From,
+					nil,
+					"requestHeartbeat",
+					arg_walletPubKeyHash,
+					arg_message,
+				)
+			}
+
+			wcLogger.Infof(
+				"submitted transaction requestHeartbeat with id: [%s] and nonce [%v]",
+				transaction.Hash(),
+				transaction.Nonce(),
+			)
+
+			return transaction, nil
+		},
+	)
+
+	wc.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (wc *WalletCoordinator) CallRequestHeartbeat(
+	arg_walletPubKeyHash [20]byte,
+	arg_message []byte,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := chainutil.CallAtBlock(
+		wc.transactorOptions.From,
+		blockNumber, nil,
+		wc.contractABI,
+		wc.caller,
+		wc.errorResolver,
+		wc.contractAddress,
+		"requestHeartbeat",
+		&result,
+		arg_walletPubKeyHash,
+		arg_message,
+	)
+
+	return err
+}
+
+func (wc *WalletCoordinator) RequestHeartbeatGasEstimate(
+	arg_walletPubKeyHash [20]byte,
+	arg_message []byte,
+) (uint64, error) {
+	var result uint64
+
+	result, err := chainutil.EstimateGas(
+		wc.callerOptions.From,
+		wc.contractAddress,
+		"requestHeartbeat",
+		wc.contractABI,
+		wc.transactor,
+		arg_walletPubKeyHash,
+		arg_message,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (wc *WalletCoordinator) RequestHeartbeatWithReimbursement(
+	arg_walletPubKeyHash [20]byte,
+	arg_message []byte,
+
+	transactionOptions ...chainutil.TransactionOptions,
+) (*types.Transaction, error) {
+	wcLogger.Debug(
+		"submitting transaction requestHeartbeatWithReimbursement",
+		" params: ",
+		fmt.Sprint(
+			arg_walletPubKeyHash,
+			arg_message,
+		),
+	)
+
+	wc.transactionMutex.Lock()
+	defer wc.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *wc.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := wc.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := wc.contract.RequestHeartbeatWithReimbursement(
+		transactorOptions,
+		arg_walletPubKeyHash,
+		arg_message,
+	)
+	if err != nil {
+		return transaction, wc.errorResolver.ResolveError(
+			err,
+			wc.transactorOptions.From,
+			nil,
+			"requestHeartbeatWithReimbursement",
+			arg_walletPubKeyHash,
+			arg_message,
+		)
+	}
+
+	wcLogger.Infof(
+		"submitted transaction requestHeartbeatWithReimbursement with id: [%s] and nonce [%v]",
+		transaction.Hash(),
+		transaction.Nonce(),
+	)
+
+	go wc.miningWaiter.ForceMining(
+		transaction,
+		transactorOptions,
+		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
+			// If original transactor options has a non-zero gas limit, that
+			// means the client code set it on their own. In that case, we
+			// should rewrite the gas limit from the original transaction
+			// for each resubmission. If the gas limit is not set by the client
+			// code, let the the submitter re-estimate the gas limit on each
+			// resubmission.
+			if transactorOptions.GasLimit != 0 {
+				newTransactorOptions.GasLimit = transactorOptions.GasLimit
+			}
+
+			transaction, err := wc.contract.RequestHeartbeatWithReimbursement(
+				newTransactorOptions,
+				arg_walletPubKeyHash,
+				arg_message,
+			)
+			if err != nil {
+				return nil, wc.errorResolver.ResolveError(
+					err,
+					wc.transactorOptions.From,
+					nil,
+					"requestHeartbeatWithReimbursement",
+					arg_walletPubKeyHash,
+					arg_message,
+				)
+			}
+
+			wcLogger.Infof(
+				"submitted transaction requestHeartbeatWithReimbursement with id: [%s] and nonce [%v]",
+				transaction.Hash(),
+				transaction.Nonce(),
+			)
+
+			return transaction, nil
+		},
+	)
+
+	wc.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (wc *WalletCoordinator) CallRequestHeartbeatWithReimbursement(
+	arg_walletPubKeyHash [20]byte,
+	arg_message []byte,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := chainutil.CallAtBlock(
+		wc.transactorOptions.From,
+		blockNumber, nil,
+		wc.contractABI,
+		wc.caller,
+		wc.errorResolver,
+		wc.contractAddress,
+		"requestHeartbeatWithReimbursement",
+		&result,
+		arg_walletPubKeyHash,
+		arg_message,
+	)
+
+	return err
+}
+
+func (wc *WalletCoordinator) RequestHeartbeatWithReimbursementGasEstimate(
+	arg_walletPubKeyHash [20]byte,
+	arg_message []byte,
+) (uint64, error) {
+	var result uint64
+
+	result, err := chainutil.EstimateGas(
+		wc.callerOptions.From,
+		wc.contractAddress,
+		"requestHeartbeatWithReimbursement",
+		wc.contractABI,
+		wc.transactor,
+		arg_walletPubKeyHash,
+		arg_message,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
 func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 	arg_proposal abi.WalletCoordinatorDepositSweepProposal,
-	arg_walletMemberContext abi.WalletCoordinatorWalletMemberContext,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
@@ -654,7 +949,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 		" params: ",
 		fmt.Sprint(
 			arg_proposal,
-			arg_walletMemberContext,
 		),
 	)
 
@@ -683,7 +977,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 	transaction, err := wc.contract.SubmitDepositSweepProposal(
 		transactorOptions,
 		arg_proposal,
-		arg_walletMemberContext,
 	)
 	if err != nil {
 		return transaction, wc.errorResolver.ResolveError(
@@ -692,7 +985,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 			nil,
 			"submitDepositSweepProposal",
 			arg_proposal,
-			arg_walletMemberContext,
 		)
 	}
 
@@ -719,7 +1011,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 			transaction, err := wc.contract.SubmitDepositSweepProposal(
 				newTransactorOptions,
 				arg_proposal,
-				arg_walletMemberContext,
 			)
 			if err != nil {
 				return nil, wc.errorResolver.ResolveError(
@@ -728,7 +1019,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 					nil,
 					"submitDepositSweepProposal",
 					arg_proposal,
-					arg_walletMemberContext,
 				)
 			}
 
@@ -750,7 +1040,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposal(
 // Non-mutating call, not a transaction submission.
 func (wc *WalletCoordinator) CallSubmitDepositSweepProposal(
 	arg_proposal abi.WalletCoordinatorDepositSweepProposal,
-	arg_walletMemberContext abi.WalletCoordinatorWalletMemberContext,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -765,7 +1054,6 @@ func (wc *WalletCoordinator) CallSubmitDepositSweepProposal(
 		"submitDepositSweepProposal",
 		&result,
 		arg_proposal,
-		arg_walletMemberContext,
 	)
 
 	return err
@@ -773,7 +1061,6 @@ func (wc *WalletCoordinator) CallSubmitDepositSweepProposal(
 
 func (wc *WalletCoordinator) SubmitDepositSweepProposalGasEstimate(
 	arg_proposal abi.WalletCoordinatorDepositSweepProposal,
-	arg_walletMemberContext abi.WalletCoordinatorWalletMemberContext,
 ) (uint64, error) {
 	var result uint64
 
@@ -784,7 +1071,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalGasEstimate(
 		wc.contractABI,
 		wc.transactor,
 		arg_proposal,
-		arg_walletMemberContext,
 	)
 
 	return result, err
@@ -793,7 +1079,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalGasEstimate(
 // Transaction submission.
 func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 	arg_proposal abi.WalletCoordinatorDepositSweepProposal,
-	arg_walletMemberContext abi.WalletCoordinatorWalletMemberContext,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
@@ -802,7 +1087,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 		" params: ",
 		fmt.Sprint(
 			arg_proposal,
-			arg_walletMemberContext,
 		),
 	)
 
@@ -831,7 +1115,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 	transaction, err := wc.contract.SubmitDepositSweepProposalWithReimbursement(
 		transactorOptions,
 		arg_proposal,
-		arg_walletMemberContext,
 	)
 	if err != nil {
 		return transaction, wc.errorResolver.ResolveError(
@@ -840,7 +1123,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 			nil,
 			"submitDepositSweepProposalWithReimbursement",
 			arg_proposal,
-			arg_walletMemberContext,
 		)
 	}
 
@@ -867,7 +1149,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 			transaction, err := wc.contract.SubmitDepositSweepProposalWithReimbursement(
 				newTransactorOptions,
 				arg_proposal,
-				arg_walletMemberContext,
 			)
 			if err != nil {
 				return nil, wc.errorResolver.ResolveError(
@@ -876,7 +1157,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 					nil,
 					"submitDepositSweepProposalWithReimbursement",
 					arg_proposal,
-					arg_walletMemberContext,
 				)
 			}
 
@@ -898,7 +1178,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursement(
 // Non-mutating call, not a transaction submission.
 func (wc *WalletCoordinator) CallSubmitDepositSweepProposalWithReimbursement(
 	arg_proposal abi.WalletCoordinatorDepositSweepProposal,
-	arg_walletMemberContext abi.WalletCoordinatorWalletMemberContext,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -913,7 +1192,6 @@ func (wc *WalletCoordinator) CallSubmitDepositSweepProposalWithReimbursement(
 		"submitDepositSweepProposalWithReimbursement",
 		&result,
 		arg_proposal,
-		arg_walletMemberContext,
 	)
 
 	return err
@@ -921,7 +1199,6 @@ func (wc *WalletCoordinator) CallSubmitDepositSweepProposalWithReimbursement(
 
 func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursementGasEstimate(
 	arg_proposal abi.WalletCoordinatorDepositSweepProposal,
-	arg_walletMemberContext abi.WalletCoordinatorWalletMemberContext,
 ) (uint64, error) {
 	var result uint64
 
@@ -932,7 +1209,6 @@ func (wc *WalletCoordinator) SubmitDepositSweepProposalWithReimbursementGasEstim
 		wc.contractABI,
 		wc.transactor,
 		arg_proposal,
-		arg_walletMemberContext,
 	)
 
 	return result, err
@@ -1215,429 +1491,23 @@ func (wc *WalletCoordinator) UnlockWalletGasEstimate(
 }
 
 // Transaction submission.
-func (wc *WalletCoordinator) UpdateDepositMinAge(
+func (wc *WalletCoordinator) UpdateDepositSweepProposalParameters(
+	arg__depositSweepProposalValidity uint32,
 	arg__depositMinAge uint32,
-
-	transactionOptions ...chainutil.TransactionOptions,
-) (*types.Transaction, error) {
-	wcLogger.Debug(
-		"submitting transaction updateDepositMinAge",
-		" params: ",
-		fmt.Sprint(
-			arg__depositMinAge,
-		),
-	)
-
-	wc.transactionMutex.Lock()
-	defer wc.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *wc.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := wc.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := wc.contract.UpdateDepositMinAge(
-		transactorOptions,
-		arg__depositMinAge,
-	)
-	if err != nil {
-		return transaction, wc.errorResolver.ResolveError(
-			err,
-			wc.transactorOptions.From,
-			nil,
-			"updateDepositMinAge",
-			arg__depositMinAge,
-		)
-	}
-
-	wcLogger.Infof(
-		"submitted transaction updateDepositMinAge with id: [%s] and nonce [%v]",
-		transaction.Hash(),
-		transaction.Nonce(),
-	)
-
-	go wc.miningWaiter.ForceMining(
-		transaction,
-		transactorOptions,
-		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
-			// If original transactor options has a non-zero gas limit, that
-			// means the client code set it on their own. In that case, we
-			// should rewrite the gas limit from the original transaction
-			// for each resubmission. If the gas limit is not set by the client
-			// code, let the the submitter re-estimate the gas limit on each
-			// resubmission.
-			if transactorOptions.GasLimit != 0 {
-				newTransactorOptions.GasLimit = transactorOptions.GasLimit
-			}
-
-			transaction, err := wc.contract.UpdateDepositMinAge(
-				newTransactorOptions,
-				arg__depositMinAge,
-			)
-			if err != nil {
-				return nil, wc.errorResolver.ResolveError(
-					err,
-					wc.transactorOptions.From,
-					nil,
-					"updateDepositMinAge",
-					arg__depositMinAge,
-				)
-			}
-
-			wcLogger.Infof(
-				"submitted transaction updateDepositMinAge with id: [%s] and nonce [%v]",
-				transaction.Hash(),
-				transaction.Nonce(),
-			)
-
-			return transaction, nil
-		},
-	)
-
-	wc.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallUpdateDepositMinAge(
-	arg__depositMinAge uint32,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := chainutil.CallAtBlock(
-		wc.transactorOptions.From,
-		blockNumber, nil,
-		wc.contractABI,
-		wc.caller,
-		wc.errorResolver,
-		wc.contractAddress,
-		"updateDepositMinAge",
-		&result,
-		arg__depositMinAge,
-	)
-
-	return err
-}
-
-func (wc *WalletCoordinator) UpdateDepositMinAgeGasEstimate(
-	arg__depositMinAge uint32,
-) (uint64, error) {
-	var result uint64
-
-	result, err := chainutil.EstimateGas(
-		wc.callerOptions.From,
-		wc.contractAddress,
-		"updateDepositMinAge",
-		wc.contractABI,
-		wc.transactor,
-		arg__depositMinAge,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (wc *WalletCoordinator) UpdateDepositRefundSafetyMargin(
 	arg__depositRefundSafetyMargin uint32,
-
-	transactionOptions ...chainutil.TransactionOptions,
-) (*types.Transaction, error) {
-	wcLogger.Debug(
-		"submitting transaction updateDepositRefundSafetyMargin",
-		" params: ",
-		fmt.Sprint(
-			arg__depositRefundSafetyMargin,
-		),
-	)
-
-	wc.transactionMutex.Lock()
-	defer wc.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *wc.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := wc.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := wc.contract.UpdateDepositRefundSafetyMargin(
-		transactorOptions,
-		arg__depositRefundSafetyMargin,
-	)
-	if err != nil {
-		return transaction, wc.errorResolver.ResolveError(
-			err,
-			wc.transactorOptions.From,
-			nil,
-			"updateDepositRefundSafetyMargin",
-			arg__depositRefundSafetyMargin,
-		)
-	}
-
-	wcLogger.Infof(
-		"submitted transaction updateDepositRefundSafetyMargin with id: [%s] and nonce [%v]",
-		transaction.Hash(),
-		transaction.Nonce(),
-	)
-
-	go wc.miningWaiter.ForceMining(
-		transaction,
-		transactorOptions,
-		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
-			// If original transactor options has a non-zero gas limit, that
-			// means the client code set it on their own. In that case, we
-			// should rewrite the gas limit from the original transaction
-			// for each resubmission. If the gas limit is not set by the client
-			// code, let the the submitter re-estimate the gas limit on each
-			// resubmission.
-			if transactorOptions.GasLimit != 0 {
-				newTransactorOptions.GasLimit = transactorOptions.GasLimit
-			}
-
-			transaction, err := wc.contract.UpdateDepositRefundSafetyMargin(
-				newTransactorOptions,
-				arg__depositRefundSafetyMargin,
-			)
-			if err != nil {
-				return nil, wc.errorResolver.ResolveError(
-					err,
-					wc.transactorOptions.From,
-					nil,
-					"updateDepositRefundSafetyMargin",
-					arg__depositRefundSafetyMargin,
-				)
-			}
-
-			wcLogger.Infof(
-				"submitted transaction updateDepositRefundSafetyMargin with id: [%s] and nonce [%v]",
-				transaction.Hash(),
-				transaction.Nonce(),
-			)
-
-			return transaction, nil
-		},
-	)
-
-	wc.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallUpdateDepositRefundSafetyMargin(
-	arg__depositRefundSafetyMargin uint32,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := chainutil.CallAtBlock(
-		wc.transactorOptions.From,
-		blockNumber, nil,
-		wc.contractABI,
-		wc.caller,
-		wc.errorResolver,
-		wc.contractAddress,
-		"updateDepositRefundSafetyMargin",
-		&result,
-		arg__depositRefundSafetyMargin,
-	)
-
-	return err
-}
-
-func (wc *WalletCoordinator) UpdateDepositRefundSafetyMarginGasEstimate(
-	arg__depositRefundSafetyMargin uint32,
-) (uint64, error) {
-	var result uint64
-
-	result, err := chainutil.EstimateGas(
-		wc.callerOptions.From,
-		wc.contractAddress,
-		"updateDepositRefundSafetyMargin",
-		wc.contractABI,
-		wc.transactor,
-		arg__depositRefundSafetyMargin,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (wc *WalletCoordinator) UpdateDepositSweepMaxSize(
 	arg__depositSweepMaxSize uint16,
-
-	transactionOptions ...chainutil.TransactionOptions,
-) (*types.Transaction, error) {
-	wcLogger.Debug(
-		"submitting transaction updateDepositSweepMaxSize",
-		" params: ",
-		fmt.Sprint(
-			arg__depositSweepMaxSize,
-		),
-	)
-
-	wc.transactionMutex.Lock()
-	defer wc.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *wc.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := wc.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := wc.contract.UpdateDepositSweepMaxSize(
-		transactorOptions,
-		arg__depositSweepMaxSize,
-	)
-	if err != nil {
-		return transaction, wc.errorResolver.ResolveError(
-			err,
-			wc.transactorOptions.From,
-			nil,
-			"updateDepositSweepMaxSize",
-			arg__depositSweepMaxSize,
-		)
-	}
-
-	wcLogger.Infof(
-		"submitted transaction updateDepositSweepMaxSize with id: [%s] and nonce [%v]",
-		transaction.Hash(),
-		transaction.Nonce(),
-	)
-
-	go wc.miningWaiter.ForceMining(
-		transaction,
-		transactorOptions,
-		func(newTransactorOptions *bind.TransactOpts) (*types.Transaction, error) {
-			// If original transactor options has a non-zero gas limit, that
-			// means the client code set it on their own. In that case, we
-			// should rewrite the gas limit from the original transaction
-			// for each resubmission. If the gas limit is not set by the client
-			// code, let the the submitter re-estimate the gas limit on each
-			// resubmission.
-			if transactorOptions.GasLimit != 0 {
-				newTransactorOptions.GasLimit = transactorOptions.GasLimit
-			}
-
-			transaction, err := wc.contract.UpdateDepositSweepMaxSize(
-				newTransactorOptions,
-				arg__depositSweepMaxSize,
-			)
-			if err != nil {
-				return nil, wc.errorResolver.ResolveError(
-					err,
-					wc.transactorOptions.From,
-					nil,
-					"updateDepositSweepMaxSize",
-					arg__depositSweepMaxSize,
-				)
-			}
-
-			wcLogger.Infof(
-				"submitted transaction updateDepositSweepMaxSize with id: [%s] and nonce [%v]",
-				transaction.Hash(),
-				transaction.Nonce(),
-			)
-
-			return transaction, nil
-		},
-	)
-
-	wc.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallUpdateDepositSweepMaxSize(
-	arg__depositSweepMaxSize uint16,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := chainutil.CallAtBlock(
-		wc.transactorOptions.From,
-		blockNumber, nil,
-		wc.contractABI,
-		wc.caller,
-		wc.errorResolver,
-		wc.contractAddress,
-		"updateDepositSweepMaxSize",
-		&result,
-		arg__depositSweepMaxSize,
-	)
-
-	return err
-}
-
-func (wc *WalletCoordinator) UpdateDepositSweepMaxSizeGasEstimate(
-	arg__depositSweepMaxSize uint16,
-) (uint64, error) {
-	var result uint64
-
-	result, err := chainutil.EstimateGas(
-		wc.callerOptions.From,
-		wc.contractAddress,
-		"updateDepositSweepMaxSize",
-		wc.contractABI,
-		wc.transactor,
-		arg__depositSweepMaxSize,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffset(
 	arg__depositSweepProposalSubmissionGasOffset uint32,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	wcLogger.Debug(
-		"submitting transaction updateDepositSweepProposalSubmissionGasOffset",
+		"submitting transaction updateDepositSweepProposalParameters",
 		" params: ",
 		fmt.Sprint(
+			arg__depositSweepProposalValidity,
+			arg__depositMinAge,
+			arg__depositRefundSafetyMargin,
+			arg__depositSweepMaxSize,
 			arg__depositSweepProposalSubmissionGasOffset,
 		),
 	)
@@ -1664,8 +1534,12 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffset(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := wc.contract.UpdateDepositSweepProposalSubmissionGasOffset(
+	transaction, err := wc.contract.UpdateDepositSweepProposalParameters(
 		transactorOptions,
+		arg__depositSweepProposalValidity,
+		arg__depositMinAge,
+		arg__depositRefundSafetyMargin,
+		arg__depositSweepMaxSize,
 		arg__depositSweepProposalSubmissionGasOffset,
 	)
 	if err != nil {
@@ -1673,13 +1547,17 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffset(
 			err,
 			wc.transactorOptions.From,
 			nil,
-			"updateDepositSweepProposalSubmissionGasOffset",
+			"updateDepositSweepProposalParameters",
+			arg__depositSweepProposalValidity,
+			arg__depositMinAge,
+			arg__depositRefundSafetyMargin,
+			arg__depositSweepMaxSize,
 			arg__depositSweepProposalSubmissionGasOffset,
 		)
 	}
 
 	wcLogger.Infof(
-		"submitted transaction updateDepositSweepProposalSubmissionGasOffset with id: [%s] and nonce [%v]",
+		"submitted transaction updateDepositSweepProposalParameters with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
@@ -1698,8 +1576,12 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffset(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := wc.contract.UpdateDepositSweepProposalSubmissionGasOffset(
+			transaction, err := wc.contract.UpdateDepositSweepProposalParameters(
 				newTransactorOptions,
+				arg__depositSweepProposalValidity,
+				arg__depositMinAge,
+				arg__depositRefundSafetyMargin,
+				arg__depositSweepMaxSize,
 				arg__depositSweepProposalSubmissionGasOffset,
 			)
 			if err != nil {
@@ -1707,13 +1589,17 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffset(
 					err,
 					wc.transactorOptions.From,
 					nil,
-					"updateDepositSweepProposalSubmissionGasOffset",
+					"updateDepositSweepProposalParameters",
+					arg__depositSweepProposalValidity,
+					arg__depositMinAge,
+					arg__depositRefundSafetyMargin,
+					arg__depositSweepMaxSize,
 					arg__depositSweepProposalSubmissionGasOffset,
 				)
 			}
 
 			wcLogger.Infof(
-				"submitted transaction updateDepositSweepProposalSubmissionGasOffset with id: [%s] and nonce [%v]",
+				"submitted transaction updateDepositSweepProposalParameters with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
 			)
@@ -1728,7 +1614,11 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffset(
 }
 
 // Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallUpdateDepositSweepProposalSubmissionGasOffset(
+func (wc *WalletCoordinator) CallUpdateDepositSweepProposalParameters(
+	arg__depositSweepProposalValidity uint32,
+	arg__depositMinAge uint32,
+	arg__depositRefundSafetyMargin uint32,
+	arg__depositSweepMaxSize uint16,
 	arg__depositSweepProposalSubmissionGasOffset uint32,
 	blockNumber *big.Int,
 ) error {
@@ -1741,15 +1631,23 @@ func (wc *WalletCoordinator) CallUpdateDepositSweepProposalSubmissionGasOffset(
 		wc.caller,
 		wc.errorResolver,
 		wc.contractAddress,
-		"updateDepositSweepProposalSubmissionGasOffset",
+		"updateDepositSweepProposalParameters",
 		&result,
+		arg__depositSweepProposalValidity,
+		arg__depositMinAge,
+		arg__depositRefundSafetyMargin,
+		arg__depositSweepMaxSize,
 		arg__depositSweepProposalSubmissionGasOffset,
 	)
 
 	return err
 }
 
-func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffsetGasEstimate(
+func (wc *WalletCoordinator) UpdateDepositSweepProposalParametersGasEstimate(
+	arg__depositSweepProposalValidity uint32,
+	arg__depositMinAge uint32,
+	arg__depositRefundSafetyMargin uint32,
+	arg__depositSweepMaxSize uint16,
 	arg__depositSweepProposalSubmissionGasOffset uint32,
 ) (uint64, error) {
 	var result uint64
@@ -1757,9 +1655,13 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffsetGasEst
 	result, err := chainutil.EstimateGas(
 		wc.callerOptions.From,
 		wc.contractAddress,
-		"updateDepositSweepProposalSubmissionGasOffset",
+		"updateDepositSweepProposalParameters",
 		wc.contractABI,
 		wc.transactor,
+		arg__depositSweepProposalValidity,
+		arg__depositMinAge,
+		arg__depositRefundSafetyMargin,
+		arg__depositSweepMaxSize,
 		arg__depositSweepProposalSubmissionGasOffset,
 	)
 
@@ -1767,16 +1669,18 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalSubmissionGasOffsetGasEst
 }
 
 // Transaction submission.
-func (wc *WalletCoordinator) UpdateDepositSweepProposalValidity(
-	arg__depositSweepProposalValidity uint32,
+func (wc *WalletCoordinator) UpdateHeartbeatRequestParameters(
+	arg__heartbeatRequestValidity uint32,
+	arg__heartbeatRequestGasOffset uint32,
 
 	transactionOptions ...chainutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	wcLogger.Debug(
-		"submitting transaction updateDepositSweepProposalValidity",
+		"submitting transaction updateHeartbeatRequestParameters",
 		" params: ",
 		fmt.Sprint(
-			arg__depositSweepProposalValidity,
+			arg__heartbeatRequestValidity,
+			arg__heartbeatRequestGasOffset,
 		),
 	)
 
@@ -1802,22 +1706,24 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalValidity(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := wc.contract.UpdateDepositSweepProposalValidity(
+	transaction, err := wc.contract.UpdateHeartbeatRequestParameters(
 		transactorOptions,
-		arg__depositSweepProposalValidity,
+		arg__heartbeatRequestValidity,
+		arg__heartbeatRequestGasOffset,
 	)
 	if err != nil {
 		return transaction, wc.errorResolver.ResolveError(
 			err,
 			wc.transactorOptions.From,
 			nil,
-			"updateDepositSweepProposalValidity",
-			arg__depositSweepProposalValidity,
+			"updateHeartbeatRequestParameters",
+			arg__heartbeatRequestValidity,
+			arg__heartbeatRequestGasOffset,
 		)
 	}
 
 	wcLogger.Infof(
-		"submitted transaction updateDepositSweepProposalValidity with id: [%s] and nonce [%v]",
+		"submitted transaction updateHeartbeatRequestParameters with id: [%s] and nonce [%v]",
 		transaction.Hash(),
 		transaction.Nonce(),
 	)
@@ -1836,22 +1742,24 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalValidity(
 				newTransactorOptions.GasLimit = transactorOptions.GasLimit
 			}
 
-			transaction, err := wc.contract.UpdateDepositSweepProposalValidity(
+			transaction, err := wc.contract.UpdateHeartbeatRequestParameters(
 				newTransactorOptions,
-				arg__depositSweepProposalValidity,
+				arg__heartbeatRequestValidity,
+				arg__heartbeatRequestGasOffset,
 			)
 			if err != nil {
 				return nil, wc.errorResolver.ResolveError(
 					err,
 					wc.transactorOptions.From,
 					nil,
-					"updateDepositSweepProposalValidity",
-					arg__depositSweepProposalValidity,
+					"updateHeartbeatRequestParameters",
+					arg__heartbeatRequestValidity,
+					arg__heartbeatRequestGasOffset,
 				)
 			}
 
 			wcLogger.Infof(
-				"submitted transaction updateDepositSweepProposalValidity with id: [%s] and nonce [%v]",
+				"submitted transaction updateHeartbeatRequestParameters with id: [%s] and nonce [%v]",
 				transaction.Hash(),
 				transaction.Nonce(),
 			)
@@ -1866,8 +1774,9 @@ func (wc *WalletCoordinator) UpdateDepositSweepProposalValidity(
 }
 
 // Non-mutating call, not a transaction submission.
-func (wc *WalletCoordinator) CallUpdateDepositSweepProposalValidity(
-	arg__depositSweepProposalValidity uint32,
+func (wc *WalletCoordinator) CallUpdateHeartbeatRequestParameters(
+	arg__heartbeatRequestValidity uint32,
+	arg__heartbeatRequestGasOffset uint32,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -1879,26 +1788,29 @@ func (wc *WalletCoordinator) CallUpdateDepositSweepProposalValidity(
 		wc.caller,
 		wc.errorResolver,
 		wc.contractAddress,
-		"updateDepositSweepProposalValidity",
+		"updateHeartbeatRequestParameters",
 		&result,
-		arg__depositSweepProposalValidity,
+		arg__heartbeatRequestValidity,
+		arg__heartbeatRequestGasOffset,
 	)
 
 	return err
 }
 
-func (wc *WalletCoordinator) UpdateDepositSweepProposalValidityGasEstimate(
-	arg__depositSweepProposalValidity uint32,
+func (wc *WalletCoordinator) UpdateHeartbeatRequestParametersGasEstimate(
+	arg__heartbeatRequestValidity uint32,
+	arg__heartbeatRequestGasOffset uint32,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := chainutil.EstimateGas(
 		wc.callerOptions.From,
 		wc.contractAddress,
-		"updateDepositSweepProposalValidity",
+		"updateHeartbeatRequestParameters",
 		wc.contractABI,
 		wc.transactor,
-		arg__depositSweepProposalValidity,
+		arg__heartbeatRequestValidity,
+		arg__heartbeatRequestGasOffset,
 	)
 
 	return result, err
@@ -2266,10 +2178,84 @@ func (wc *WalletCoordinator) DepositSweepProposalValidityAtBlock(
 	return result, err
 }
 
-func (wc *WalletCoordinator) IsProposalSubmitter(
+func (wc *WalletCoordinator) HeartbeatRequestGasOffset() (uint32, error) {
+	result, err := wc.contract.HeartbeatRequestGasOffset(
+		wc.callerOptions,
+	)
+
+	if err != nil {
+		return result, wc.errorResolver.ResolveError(
+			err,
+			wc.callerOptions.From,
+			nil,
+			"heartbeatRequestGasOffset",
+		)
+	}
+
+	return result, err
+}
+
+func (wc *WalletCoordinator) HeartbeatRequestGasOffsetAtBlock(
+	blockNumber *big.Int,
+) (uint32, error) {
+	var result uint32
+
+	err := chainutil.CallAtBlock(
+		wc.callerOptions.From,
+		blockNumber,
+		nil,
+		wc.contractABI,
+		wc.caller,
+		wc.errorResolver,
+		wc.contractAddress,
+		"heartbeatRequestGasOffset",
+		&result,
+	)
+
+	return result, err
+}
+
+func (wc *WalletCoordinator) HeartbeatRequestValidity() (uint32, error) {
+	result, err := wc.contract.HeartbeatRequestValidity(
+		wc.callerOptions,
+	)
+
+	if err != nil {
+		return result, wc.errorResolver.ResolveError(
+			err,
+			wc.callerOptions.From,
+			nil,
+			"heartbeatRequestValidity",
+		)
+	}
+
+	return result, err
+}
+
+func (wc *WalletCoordinator) HeartbeatRequestValidityAtBlock(
+	blockNumber *big.Int,
+) (uint32, error) {
+	var result uint32
+
+	err := chainutil.CallAtBlock(
+		wc.callerOptions.From,
+		blockNumber,
+		nil,
+		wc.contractABI,
+		wc.caller,
+		wc.errorResolver,
+		wc.contractAddress,
+		"heartbeatRequestValidity",
+		&result,
+	)
+
+	return result, err
+}
+
+func (wc *WalletCoordinator) IsCoordinator(
 	arg0 common.Address,
 ) (bool, error) {
-	result, err := wc.contract.IsProposalSubmitter(
+	result, err := wc.contract.IsCoordinator(
 		wc.callerOptions,
 		arg0,
 	)
@@ -2279,7 +2265,7 @@ func (wc *WalletCoordinator) IsProposalSubmitter(
 			err,
 			wc.callerOptions.From,
 			nil,
-			"isProposalSubmitter",
+			"isCoordinator",
 			arg0,
 		)
 	}
@@ -2287,7 +2273,7 @@ func (wc *WalletCoordinator) IsProposalSubmitter(
 	return result, err
 }
 
-func (wc *WalletCoordinator) IsProposalSubmitterAtBlock(
+func (wc *WalletCoordinator) IsCoordinatorAtBlock(
 	arg0 common.Address,
 	blockNumber *big.Int,
 ) (bool, error) {
@@ -2301,7 +2287,7 @@ func (wc *WalletCoordinator) IsProposalSubmitterAtBlock(
 		wc.caller,
 		wc.errorResolver,
 		wc.contractAddress,
-		"isProposalSubmitter",
+		"isCoordinator",
 		&result,
 		arg0,
 	)
@@ -2479,48 +2465,12 @@ func (wc *WalletCoordinator) WalletLockAtBlock(
 	return result, err
 }
 
-func (wc *WalletCoordinator) WalletRegistry() (common.Address, error) {
-	result, err := wc.contract.WalletRegistry(
-		wc.callerOptions,
-	)
-
-	if err != nil {
-		return result, wc.errorResolver.ResolveError(
-			err,
-			wc.callerOptions.From,
-			nil,
-			"walletRegistry",
-		)
-	}
-
-	return result, err
-}
-
-func (wc *WalletCoordinator) WalletRegistryAtBlock(
-	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
-
-	err := chainutil.CallAtBlock(
-		wc.callerOptions.From,
-		blockNumber,
-		nil,
-		wc.contractABI,
-		wc.caller,
-		wc.errorResolver,
-		wc.contractAddress,
-		"walletRegistry",
-		&result,
-	)
-
-	return result, err
-}
-
 // ------ Events -------
 
-func (wc *WalletCoordinator) DepositMinAgeUpdatedEvent(
+func (wc *WalletCoordinator) CoordinatorAddedEvent(
 	opts *ethereum.SubscribeOpts,
-) *WcDepositMinAgeUpdatedSubscription {
+	coordinatorFilter []common.Address,
+) *WcCoordinatorAddedSubscription {
 	if opts == nil {
 		opts = new(ethereum.SubscribeOpts)
 	}
@@ -2531,563 +2481,405 @@ func (wc *WalletCoordinator) DepositMinAgeUpdatedEvent(
 		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &WcDepositMinAgeUpdatedSubscription{
+	return &WcCoordinatorAddedSubscription{
+		wc,
+		opts,
+		coordinatorFilter,
+	}
+}
+
+type WcCoordinatorAddedSubscription struct {
+	contract          *WalletCoordinator
+	opts              *ethereum.SubscribeOpts
+	coordinatorFilter []common.Address
+}
+
+type walletCoordinatorCoordinatorAddedFunc func(
+	Coordinator common.Address,
+	blockNumber uint64,
+)
+
+func (cas *WcCoordinatorAddedSubscription) OnEvent(
+	handler walletCoordinatorCoordinatorAddedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.WalletCoordinatorCoordinatorAdded)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.Coordinator,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := cas.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (cas *WcCoordinatorAddedSubscription) Pipe(
+	sink chan *abi.WalletCoordinatorCoordinatorAdded,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(cas.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := cas.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					wcLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - cas.opts.PastBlocks
+
+				wcLogger.Infof(
+					"subscription monitoring fetching past CoordinatorAdded events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := cas.contract.PastCoordinatorAddedEvents(
+					fromBlock,
+					nil,
+					cas.coordinatorFilter,
+				)
+				if err != nil {
+					wcLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				wcLogger.Infof(
+					"subscription monitoring fetched [%v] past CoordinatorAdded events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := cas.contract.watchCoordinatorAdded(
+		sink,
+		cas.coordinatorFilter,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (wc *WalletCoordinator) watchCoordinatorAdded(
+	sink chan *abi.WalletCoordinatorCoordinatorAdded,
+	coordinatorFilter []common.Address,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return wc.contract.WatchCoordinatorAdded(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			coordinatorFilter,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		wcLogger.Warnf(
+			"subscription to event CoordinatorAdded had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"host chain connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		wcLogger.Errorf(
+			"subscription to event CoordinatorAdded failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return chainutil.WithResubscription(
+		chainutil.SubscriptionBackoffMax,
+		subscribeFn,
+		chainutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (wc *WalletCoordinator) PastCoordinatorAddedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+	coordinatorFilter []common.Address,
+) ([]*abi.WalletCoordinatorCoordinatorAdded, error) {
+	iterator, err := wc.contract.FilterCoordinatorAdded(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		coordinatorFilter,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past CoordinatorAdded events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.WalletCoordinatorCoordinatorAdded, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (wc *WalletCoordinator) CoordinatorRemovedEvent(
+	opts *ethereum.SubscribeOpts,
+	coordinatorFilter []common.Address,
+) *WcCoordinatorRemovedSubscription {
+	if opts == nil {
+		opts = new(ethereum.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = chainutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &WcCoordinatorRemovedSubscription{
+		wc,
+		opts,
+		coordinatorFilter,
+	}
+}
+
+type WcCoordinatorRemovedSubscription struct {
+	contract          *WalletCoordinator
+	opts              *ethereum.SubscribeOpts
+	coordinatorFilter []common.Address
+}
+
+type walletCoordinatorCoordinatorRemovedFunc func(
+	Coordinator common.Address,
+	blockNumber uint64,
+)
+
+func (crs *WcCoordinatorRemovedSubscription) OnEvent(
+	handler walletCoordinatorCoordinatorRemovedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.WalletCoordinatorCoordinatorRemoved)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.Coordinator,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := crs.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (crs *WcCoordinatorRemovedSubscription) Pipe(
+	sink chan *abi.WalletCoordinatorCoordinatorRemoved,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(crs.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := crs.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					wcLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - crs.opts.PastBlocks
+
+				wcLogger.Infof(
+					"subscription monitoring fetching past CoordinatorRemoved events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := crs.contract.PastCoordinatorRemovedEvents(
+					fromBlock,
+					nil,
+					crs.coordinatorFilter,
+				)
+				if err != nil {
+					wcLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				wcLogger.Infof(
+					"subscription monitoring fetched [%v] past CoordinatorRemoved events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := crs.contract.watchCoordinatorRemoved(
+		sink,
+		crs.coordinatorFilter,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (wc *WalletCoordinator) watchCoordinatorRemoved(
+	sink chan *abi.WalletCoordinatorCoordinatorRemoved,
+	coordinatorFilter []common.Address,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return wc.contract.WatchCoordinatorRemoved(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			coordinatorFilter,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		wcLogger.Warnf(
+			"subscription to event CoordinatorRemoved had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"host chain connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		wcLogger.Errorf(
+			"subscription to event CoordinatorRemoved failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return chainutil.WithResubscription(
+		chainutil.SubscriptionBackoffMax,
+		subscribeFn,
+		chainutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (wc *WalletCoordinator) PastCoordinatorRemovedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+	coordinatorFilter []common.Address,
+) ([]*abi.WalletCoordinatorCoordinatorRemoved, error) {
+	iterator, err := wc.contract.FilterCoordinatorRemoved(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		coordinatorFilter,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past CoordinatorRemoved events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.WalletCoordinatorCoordinatorRemoved, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (wc *WalletCoordinator) DepositSweepProposalParametersUpdatedEvent(
+	opts *ethereum.SubscribeOpts,
+) *WcDepositSweepProposalParametersUpdatedSubscription {
+	if opts == nil {
+		opts = new(ethereum.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = chainutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &WcDepositSweepProposalParametersUpdatedSubscription{
 		wc,
 		opts,
 	}
 }
 
-type WcDepositMinAgeUpdatedSubscription struct {
+type WcDepositSweepProposalParametersUpdatedSubscription struct {
 	contract *WalletCoordinator
 	opts     *ethereum.SubscribeOpts
 }
 
-type walletCoordinatorDepositMinAgeUpdatedFunc func(
+type walletCoordinatorDepositSweepProposalParametersUpdatedFunc func(
+	DepositSweepProposalValidity uint32,
 	DepositMinAge uint32,
-	blockNumber uint64,
-)
-
-func (dmaus *WcDepositMinAgeUpdatedSubscription) OnEvent(
-	handler walletCoordinatorDepositMinAgeUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorDepositMinAgeUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.DepositMinAge,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := dmaus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (dmaus *WcDepositMinAgeUpdatedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorDepositMinAgeUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(dmaus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := dmaus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - dmaus.opts.PastBlocks
-
-				wcLogger.Infof(
-					"subscription monitoring fetching past DepositMinAgeUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := dmaus.contract.PastDepositMinAgeUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past DepositMinAgeUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := dmaus.contract.watchDepositMinAgeUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (wc *WalletCoordinator) watchDepositMinAgeUpdated(
-	sink chan *abi.WalletCoordinatorDepositMinAgeUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchDepositMinAgeUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		wcLogger.Warnf(
-			"subscription to event DepositMinAgeUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"host chain connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		wcLogger.Errorf(
-			"subscription to event DepositMinAgeUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return chainutil.WithResubscription(
-		chainutil.SubscriptionBackoffMax,
-		subscribeFn,
-		chainutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (wc *WalletCoordinator) PastDepositMinAgeUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.WalletCoordinatorDepositMinAgeUpdated, error) {
-	iterator, err := wc.contract.FilterDepositMinAgeUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past DepositMinAgeUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.WalletCoordinatorDepositMinAgeUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (wc *WalletCoordinator) DepositRefundSafetyMarginUpdatedEvent(
-	opts *ethereum.SubscribeOpts,
-) *WcDepositRefundSafetyMarginUpdatedSubscription {
-	if opts == nil {
-		opts = new(ethereum.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = chainutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &WcDepositRefundSafetyMarginUpdatedSubscription{
-		wc,
-		opts,
-	}
-}
-
-type WcDepositRefundSafetyMarginUpdatedSubscription struct {
-	contract *WalletCoordinator
-	opts     *ethereum.SubscribeOpts
-}
-
-type walletCoordinatorDepositRefundSafetyMarginUpdatedFunc func(
 	DepositRefundSafetyMargin uint32,
-	blockNumber uint64,
-)
-
-func (drsmus *WcDepositRefundSafetyMarginUpdatedSubscription) OnEvent(
-	handler walletCoordinatorDepositRefundSafetyMarginUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorDepositRefundSafetyMarginUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.DepositRefundSafetyMargin,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := drsmus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (drsmus *WcDepositRefundSafetyMarginUpdatedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorDepositRefundSafetyMarginUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(drsmus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := drsmus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - drsmus.opts.PastBlocks
-
-				wcLogger.Infof(
-					"subscription monitoring fetching past DepositRefundSafetyMarginUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := drsmus.contract.PastDepositRefundSafetyMarginUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past DepositRefundSafetyMarginUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := drsmus.contract.watchDepositRefundSafetyMarginUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (wc *WalletCoordinator) watchDepositRefundSafetyMarginUpdated(
-	sink chan *abi.WalletCoordinatorDepositRefundSafetyMarginUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchDepositRefundSafetyMarginUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		wcLogger.Warnf(
-			"subscription to event DepositRefundSafetyMarginUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"host chain connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		wcLogger.Errorf(
-			"subscription to event DepositRefundSafetyMarginUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return chainutil.WithResubscription(
-		chainutil.SubscriptionBackoffMax,
-		subscribeFn,
-		chainutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (wc *WalletCoordinator) PastDepositRefundSafetyMarginUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.WalletCoordinatorDepositRefundSafetyMarginUpdated, error) {
-	iterator, err := wc.contract.FilterDepositRefundSafetyMarginUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past DepositRefundSafetyMarginUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.WalletCoordinatorDepositRefundSafetyMarginUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (wc *WalletCoordinator) DepositSweepMaxSizeUpdatedEvent(
-	opts *ethereum.SubscribeOpts,
-) *WcDepositSweepMaxSizeUpdatedSubscription {
-	if opts == nil {
-		opts = new(ethereum.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = chainutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &WcDepositSweepMaxSizeUpdatedSubscription{
-		wc,
-		opts,
-	}
-}
-
-type WcDepositSweepMaxSizeUpdatedSubscription struct {
-	contract *WalletCoordinator
-	opts     *ethereum.SubscribeOpts
-}
-
-type walletCoordinatorDepositSweepMaxSizeUpdatedFunc func(
 	DepositSweepMaxSize uint16,
-	blockNumber uint64,
-)
-
-func (dsmsus *WcDepositSweepMaxSizeUpdatedSubscription) OnEvent(
-	handler walletCoordinatorDepositSweepMaxSizeUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorDepositSweepMaxSizeUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.DepositSweepMaxSize,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := dsmsus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (dsmsus *WcDepositSweepMaxSizeUpdatedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorDepositSweepMaxSizeUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(dsmsus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := dsmsus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - dsmsus.opts.PastBlocks
-
-				wcLogger.Infof(
-					"subscription monitoring fetching past DepositSweepMaxSizeUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := dsmsus.contract.PastDepositSweepMaxSizeUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past DepositSweepMaxSizeUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := dsmsus.contract.watchDepositSweepMaxSizeUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (wc *WalletCoordinator) watchDepositSweepMaxSizeUpdated(
-	sink chan *abi.WalletCoordinatorDepositSweepMaxSizeUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchDepositSweepMaxSizeUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		wcLogger.Warnf(
-			"subscription to event DepositSweepMaxSizeUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"host chain connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		wcLogger.Errorf(
-			"subscription to event DepositSweepMaxSizeUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return chainutil.WithResubscription(
-		chainutil.SubscriptionBackoffMax,
-		subscribeFn,
-		chainutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (wc *WalletCoordinator) PastDepositSweepMaxSizeUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.WalletCoordinatorDepositSweepMaxSizeUpdated, error) {
-	iterator, err := wc.contract.FilterDepositSweepMaxSizeUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past DepositSweepMaxSizeUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.WalletCoordinatorDepositSweepMaxSizeUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (wc *WalletCoordinator) DepositSweepProposalSubmissionGasOffsetUpdatedEvent(
-	opts *ethereum.SubscribeOpts,
-) *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription {
-	if opts == nil {
-		opts = new(ethereum.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = chainutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription{
-		wc,
-		opts,
-	}
-}
-
-type WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription struct {
-	contract *WalletCoordinator
-	opts     *ethereum.SubscribeOpts
-}
-
-type walletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedFunc func(
 	DepositSweepProposalSubmissionGasOffset uint32,
 	blockNumber uint64,
 )
 
-func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) OnEvent(
-	handler walletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdatedFunc,
+func (dsppus *WcDepositSweepProposalParametersUpdatedSubscription) OnEvent(
+	handler walletCoordinatorDepositSweepProposalParametersUpdatedFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated)
+	eventChan := make(chan *abi.WalletCoordinatorDepositSweepProposalParametersUpdated)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -3097,6 +2889,10 @@ func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) On
 				return
 			case event := <-eventChan:
 				handler(
+					event.DepositSweepProposalValidity,
+					event.DepositMinAge,
+					event.DepositRefundSafetyMargin,
+					event.DepositSweepMaxSize,
 					event.DepositSweepProposalSubmissionGasOffset,
 					event.Raw.BlockNumber,
 				)
@@ -3104,40 +2900,40 @@ func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) On
 		}
 	}()
 
-	sub := dspsgous.Pipe(eventChan)
+	sub := dsppus.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated,
+func (dsppus *WcDepositSweepProposalParametersUpdatedSubscription) Pipe(
+	sink chan *abi.WalletCoordinatorDepositSweepProposalParametersUpdated,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(dspsgous.opts.Tick)
+		ticker := time.NewTicker(dsppus.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := dspsgous.contract.blockCounter.CurrentBlock()
+				lastBlock, err := dsppus.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					wcLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - dspsgous.opts.PastBlocks
+				fromBlock := lastBlock - dsppus.opts.PastBlocks
 
 				wcLogger.Infof(
-					"subscription monitoring fetching past DepositSweepProposalSubmissionGasOffsetUpdated events "+
+					"subscription monitoring fetching past DepositSweepProposalParametersUpdated events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := dspsgous.contract.PastDepositSweepProposalSubmissionGasOffsetUpdatedEvents(
+				events, err := dsppus.contract.PastDepositSweepProposalParametersUpdatedEvents(
 					fromBlock,
 					nil,
 				)
@@ -3149,7 +2945,7 @@ func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) Pi
 					continue
 				}
 				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past DepositSweepProposalSubmissionGasOffsetUpdated events",
+					"subscription monitoring fetched [%v] past DepositSweepProposalParametersUpdated events",
 					len(events),
 				)
 
@@ -3160,7 +2956,7 @@ func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) Pi
 		}
 	}()
 
-	sub := dspsgous.contract.watchDepositSweepProposalSubmissionGasOffsetUpdated(
+	sub := dsppus.contract.watchDepositSweepProposalParametersUpdated(
 		sink,
 	)
 
@@ -3170,11 +2966,11 @@ func (dspsgous *WcDepositSweepProposalSubmissionGasOffsetUpdatedSubscription) Pi
 	})
 }
 
-func (wc *WalletCoordinator) watchDepositSweepProposalSubmissionGasOffsetUpdated(
-	sink chan *abi.WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated,
+func (wc *WalletCoordinator) watchDepositSweepProposalParametersUpdated(
+	sink chan *abi.WalletCoordinatorDepositSweepProposalParametersUpdated,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchDepositSweepProposalSubmissionGasOffsetUpdated(
+		return wc.contract.WatchDepositSweepProposalParametersUpdated(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 		)
@@ -3182,7 +2978,7 @@ func (wc *WalletCoordinator) watchDepositSweepProposalSubmissionGasOffsetUpdated
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		wcLogger.Warnf(
-			"subscription to event DepositSweepProposalSubmissionGasOffsetUpdated had to be "+
+			"subscription to event DepositSweepProposalParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
 			elapsed,
@@ -3191,7 +2987,7 @@ func (wc *WalletCoordinator) watchDepositSweepProposalSubmissionGasOffsetUpdated
 
 	subscriptionFailedFn := func(err error) {
 		wcLogger.Errorf(
-			"subscription to event DepositSweepProposalSubmissionGasOffsetUpdated failed "+
+			"subscription to event DepositSweepProposalParametersUpdated failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -3207,11 +3003,11 @@ func (wc *WalletCoordinator) watchDepositSweepProposalSubmissionGasOffsetUpdated
 	)
 }
 
-func (wc *WalletCoordinator) PastDepositSweepProposalSubmissionGasOffsetUpdatedEvents(
+func (wc *WalletCoordinator) PastDepositSweepProposalParametersUpdatedEvents(
 	startBlock uint64,
 	endBlock *uint64,
-) ([]*abi.WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated, error) {
-	iterator, err := wc.contract.FilterDepositSweepProposalSubmissionGasOffsetUpdated(
+) ([]*abi.WalletCoordinatorDepositSweepProposalParametersUpdated, error) {
+	iterator, err := wc.contract.FilterDepositSweepProposalParametersUpdated(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
@@ -3219,12 +3015,12 @@ func (wc *WalletCoordinator) PastDepositSweepProposalSubmissionGasOffsetUpdatedE
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past DepositSweepProposalSubmissionGasOffsetUpdated events: [%v]",
+			"error retrieving past DepositSweepProposalParametersUpdated events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.WalletCoordinatorDepositSweepProposalSubmissionGasOffsetUpdated, 0)
+	events := make([]*abi.WalletCoordinatorDepositSweepProposalParametersUpdated, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -3236,7 +3032,7 @@ func (wc *WalletCoordinator) PastDepositSweepProposalSubmissionGasOffsetUpdatedE
 
 func (wc *WalletCoordinator) DepositSweepProposalSubmittedEvent(
 	opts *ethereum.SubscribeOpts,
-	proposalSubmitterFilter []common.Address,
+	coordinatorFilter []common.Address,
 ) *WcDepositSweepProposalSubmittedSubscription {
 	if opts == nil {
 		opts = new(ethereum.SubscribeOpts)
@@ -3251,19 +3047,19 @@ func (wc *WalletCoordinator) DepositSweepProposalSubmittedEvent(
 	return &WcDepositSweepProposalSubmittedSubscription{
 		wc,
 		opts,
-		proposalSubmitterFilter,
+		coordinatorFilter,
 	}
 }
 
 type WcDepositSweepProposalSubmittedSubscription struct {
-	contract                *WalletCoordinator
-	opts                    *ethereum.SubscribeOpts
-	proposalSubmitterFilter []common.Address
+	contract          *WalletCoordinator
+	opts              *ethereum.SubscribeOpts
+	coordinatorFilter []common.Address
 }
 
 type walletCoordinatorDepositSweepProposalSubmittedFunc func(
 	Proposal abi.WalletCoordinatorDepositSweepProposal,
-	ProposalSubmitter common.Address,
+	Coordinator common.Address,
 	blockNumber uint64,
 )
 
@@ -3281,7 +3077,7 @@ func (dspss *WcDepositSweepProposalSubmittedSubscription) OnEvent(
 			case event := <-eventChan:
 				handler(
 					event.Proposal,
-					event.ProposalSubmitter,
+					event.Coordinator,
 					event.Raw.BlockNumber,
 				)
 			}
@@ -3324,7 +3120,7 @@ func (dspss *WcDepositSweepProposalSubmittedSubscription) Pipe(
 				events, err := dspss.contract.PastDepositSweepProposalSubmittedEvents(
 					fromBlock,
 					nil,
-					dspss.proposalSubmitterFilter,
+					dspss.coordinatorFilter,
 				)
 				if err != nil {
 					wcLogger.Errorf(
@@ -3347,7 +3143,7 @@ func (dspss *WcDepositSweepProposalSubmittedSubscription) Pipe(
 
 	sub := dspss.contract.watchDepositSweepProposalSubmitted(
 		sink,
-		dspss.proposalSubmitterFilter,
+		dspss.coordinatorFilter,
 	)
 
 	return subscription.NewEventSubscription(func() {
@@ -3358,13 +3154,13 @@ func (dspss *WcDepositSweepProposalSubmittedSubscription) Pipe(
 
 func (wc *WalletCoordinator) watchDepositSweepProposalSubmitted(
 	sink chan *abi.WalletCoordinatorDepositSweepProposalSubmitted,
-	proposalSubmitterFilter []common.Address,
+	coordinatorFilter []common.Address,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
 		return wc.contract.WatchDepositSweepProposalSubmitted(
 			&bind.WatchOpts{Context: ctx},
 			sink,
-			proposalSubmitterFilter,
+			coordinatorFilter,
 		)
 	}
 
@@ -3398,14 +3194,14 @@ func (wc *WalletCoordinator) watchDepositSweepProposalSubmitted(
 func (wc *WalletCoordinator) PastDepositSweepProposalSubmittedEvents(
 	startBlock uint64,
 	endBlock *uint64,
-	proposalSubmitterFilter []common.Address,
+	coordinatorFilter []common.Address,
 ) ([]*abi.WalletCoordinatorDepositSweepProposalSubmitted, error) {
 	iterator, err := wc.contract.FilterDepositSweepProposalSubmitted(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
 		},
-		proposalSubmitterFilter,
+		coordinatorFilter,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -3424,9 +3220,9 @@ func (wc *WalletCoordinator) PastDepositSweepProposalSubmittedEvents(
 	return events, nil
 }
 
-func (wc *WalletCoordinator) DepositSweepProposalValidityUpdatedEvent(
+func (wc *WalletCoordinator) HeartbeatRequestParametersUpdatedEvent(
 	opts *ethereum.SubscribeOpts,
-) *WcDepositSweepProposalValidityUpdatedSubscription {
+) *WcHeartbeatRequestParametersUpdatedSubscription {
 	if opts == nil {
 		opts = new(ethereum.SubscribeOpts)
 	}
@@ -3437,26 +3233,27 @@ func (wc *WalletCoordinator) DepositSweepProposalValidityUpdatedEvent(
 		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &WcDepositSweepProposalValidityUpdatedSubscription{
+	return &WcHeartbeatRequestParametersUpdatedSubscription{
 		wc,
 		opts,
 	}
 }
 
-type WcDepositSweepProposalValidityUpdatedSubscription struct {
+type WcHeartbeatRequestParametersUpdatedSubscription struct {
 	contract *WalletCoordinator
 	opts     *ethereum.SubscribeOpts
 }
 
-type walletCoordinatorDepositSweepProposalValidityUpdatedFunc func(
-	DepositSweepProposalValidity uint32,
+type walletCoordinatorHeartbeatRequestParametersUpdatedFunc func(
+	HeartbeatRequestValidity uint32,
+	HeartbeatRequestGasOffset uint32,
 	blockNumber uint64,
 )
 
-func (dspvus *WcDepositSweepProposalValidityUpdatedSubscription) OnEvent(
-	handler walletCoordinatorDepositSweepProposalValidityUpdatedFunc,
+func (hrpus *WcHeartbeatRequestParametersUpdatedSubscription) OnEvent(
+	handler walletCoordinatorHeartbeatRequestParametersUpdatedFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorDepositSweepProposalValidityUpdated)
+	eventChan := make(chan *abi.WalletCoordinatorHeartbeatRequestParametersUpdated)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -3466,47 +3263,48 @@ func (dspvus *WcDepositSweepProposalValidityUpdatedSubscription) OnEvent(
 				return
 			case event := <-eventChan:
 				handler(
-					event.DepositSweepProposalValidity,
+					event.HeartbeatRequestValidity,
+					event.HeartbeatRequestGasOffset,
 					event.Raw.BlockNumber,
 				)
 			}
 		}
 	}()
 
-	sub := dspvus.Pipe(eventChan)
+	sub := hrpus.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (dspvus *WcDepositSweepProposalValidityUpdatedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorDepositSweepProposalValidityUpdated,
+func (hrpus *WcHeartbeatRequestParametersUpdatedSubscription) Pipe(
+	sink chan *abi.WalletCoordinatorHeartbeatRequestParametersUpdated,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(dspvus.opts.Tick)
+		ticker := time.NewTicker(hrpus.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := dspvus.contract.blockCounter.CurrentBlock()
+				lastBlock, err := hrpus.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					wcLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - dspvus.opts.PastBlocks
+				fromBlock := lastBlock - hrpus.opts.PastBlocks
 
 				wcLogger.Infof(
-					"subscription monitoring fetching past DepositSweepProposalValidityUpdated events "+
+					"subscription monitoring fetching past HeartbeatRequestParametersUpdated events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := dspvus.contract.PastDepositSweepProposalValidityUpdatedEvents(
+				events, err := hrpus.contract.PastHeartbeatRequestParametersUpdatedEvents(
 					fromBlock,
 					nil,
 				)
@@ -3518,7 +3316,7 @@ func (dspvus *WcDepositSweepProposalValidityUpdatedSubscription) Pipe(
 					continue
 				}
 				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past DepositSweepProposalValidityUpdated events",
+					"subscription monitoring fetched [%v] past HeartbeatRequestParametersUpdated events",
 					len(events),
 				)
 
@@ -3529,7 +3327,7 @@ func (dspvus *WcDepositSweepProposalValidityUpdatedSubscription) Pipe(
 		}
 	}()
 
-	sub := dspvus.contract.watchDepositSweepProposalValidityUpdated(
+	sub := hrpus.contract.watchHeartbeatRequestParametersUpdated(
 		sink,
 	)
 
@@ -3539,11 +3337,11 @@ func (dspvus *WcDepositSweepProposalValidityUpdatedSubscription) Pipe(
 	})
 }
 
-func (wc *WalletCoordinator) watchDepositSweepProposalValidityUpdated(
-	sink chan *abi.WalletCoordinatorDepositSweepProposalValidityUpdated,
+func (wc *WalletCoordinator) watchHeartbeatRequestParametersUpdated(
+	sink chan *abi.WalletCoordinatorHeartbeatRequestParametersUpdated,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchDepositSweepProposalValidityUpdated(
+		return wc.contract.WatchHeartbeatRequestParametersUpdated(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 		)
@@ -3551,7 +3349,7 @@ func (wc *WalletCoordinator) watchDepositSweepProposalValidityUpdated(
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		wcLogger.Warnf(
-			"subscription to event DepositSweepProposalValidityUpdated had to be "+
+			"subscription to event HeartbeatRequestParametersUpdated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"host chain connectivity",
 			elapsed,
@@ -3560,7 +3358,7 @@ func (wc *WalletCoordinator) watchDepositSweepProposalValidityUpdated(
 
 	subscriptionFailedFn := func(err error) {
 		wcLogger.Errorf(
-			"subscription to event DepositSweepProposalValidityUpdated failed "+
+			"subscription to event HeartbeatRequestParametersUpdated failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -3576,11 +3374,11 @@ func (wc *WalletCoordinator) watchDepositSweepProposalValidityUpdated(
 	)
 }
 
-func (wc *WalletCoordinator) PastDepositSweepProposalValidityUpdatedEvents(
+func (wc *WalletCoordinator) PastHeartbeatRequestParametersUpdatedEvents(
 	startBlock uint64,
 	endBlock *uint64,
-) ([]*abi.WalletCoordinatorDepositSweepProposalValidityUpdated, error) {
-	iterator, err := wc.contract.FilterDepositSweepProposalValidityUpdated(
+) ([]*abi.WalletCoordinatorHeartbeatRequestParametersUpdated, error) {
+	iterator, err := wc.contract.FilterHeartbeatRequestParametersUpdated(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
@@ -3588,12 +3386,193 @@ func (wc *WalletCoordinator) PastDepositSweepProposalValidityUpdatedEvents(
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past DepositSweepProposalValidityUpdated events: [%v]",
+			"error retrieving past HeartbeatRequestParametersUpdated events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.WalletCoordinatorDepositSweepProposalValidityUpdated, 0)
+	events := make([]*abi.WalletCoordinatorHeartbeatRequestParametersUpdated, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (wc *WalletCoordinator) HeartbeatRequestSubmittedEvent(
+	opts *ethereum.SubscribeOpts,
+) *WcHeartbeatRequestSubmittedSubscription {
+	if opts == nil {
+		opts = new(ethereum.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = chainutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &WcHeartbeatRequestSubmittedSubscription{
+		wc,
+		opts,
+	}
+}
+
+type WcHeartbeatRequestSubmittedSubscription struct {
+	contract *WalletCoordinator
+	opts     *ethereum.SubscribeOpts
+}
+
+type walletCoordinatorHeartbeatRequestSubmittedFunc func(
+	WalletPubKeyHash [20]byte,
+	Message []byte,
+	blockNumber uint64,
+)
+
+func (hrss *WcHeartbeatRequestSubmittedSubscription) OnEvent(
+	handler walletCoordinatorHeartbeatRequestSubmittedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.WalletCoordinatorHeartbeatRequestSubmitted)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.WalletPubKeyHash,
+					event.Message,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := hrss.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (hrss *WcHeartbeatRequestSubmittedSubscription) Pipe(
+	sink chan *abi.WalletCoordinatorHeartbeatRequestSubmitted,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(hrss.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := hrss.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					wcLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - hrss.opts.PastBlocks
+
+				wcLogger.Infof(
+					"subscription monitoring fetching past HeartbeatRequestSubmitted events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := hrss.contract.PastHeartbeatRequestSubmittedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					wcLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				wcLogger.Infof(
+					"subscription monitoring fetched [%v] past HeartbeatRequestSubmitted events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := hrss.contract.watchHeartbeatRequestSubmitted(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (wc *WalletCoordinator) watchHeartbeatRequestSubmitted(
+	sink chan *abi.WalletCoordinatorHeartbeatRequestSubmitted,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return wc.contract.WatchHeartbeatRequestSubmitted(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		wcLogger.Warnf(
+			"subscription to event HeartbeatRequestSubmitted had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"host chain connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		wcLogger.Errorf(
+			"subscription to event HeartbeatRequestSubmitted failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return chainutil.WithResubscription(
+		chainutil.SubscriptionBackoffMax,
+		subscribeFn,
+		chainutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (wc *WalletCoordinator) PastHeartbeatRequestSubmittedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.WalletCoordinatorHeartbeatRequestSubmitted, error) {
+	iterator, err := wc.contract.FilterHeartbeatRequestSubmitted(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past HeartbeatRequestSubmitted events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.WalletCoordinatorHeartbeatRequestSubmitted, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -3972,382 +3951,6 @@ func (wc *WalletCoordinator) PastOwnershipTransferredEvents(
 	}
 
 	events := make([]*abi.WalletCoordinatorOwnershipTransferred, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (wc *WalletCoordinator) ProposalSubmitterAddedEvent(
-	opts *ethereum.SubscribeOpts,
-	proposalSubmitterFilter []common.Address,
-) *WcProposalSubmitterAddedSubscription {
-	if opts == nil {
-		opts = new(ethereum.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = chainutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &WcProposalSubmitterAddedSubscription{
-		wc,
-		opts,
-		proposalSubmitterFilter,
-	}
-}
-
-type WcProposalSubmitterAddedSubscription struct {
-	contract                *WalletCoordinator
-	opts                    *ethereum.SubscribeOpts
-	proposalSubmitterFilter []common.Address
-}
-
-type walletCoordinatorProposalSubmitterAddedFunc func(
-	ProposalSubmitter common.Address,
-	blockNumber uint64,
-)
-
-func (psas *WcProposalSubmitterAddedSubscription) OnEvent(
-	handler walletCoordinatorProposalSubmitterAddedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorProposalSubmitterAdded)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.ProposalSubmitter,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := psas.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (psas *WcProposalSubmitterAddedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorProposalSubmitterAdded,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(psas.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := psas.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - psas.opts.PastBlocks
-
-				wcLogger.Infof(
-					"subscription monitoring fetching past ProposalSubmitterAdded events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := psas.contract.PastProposalSubmitterAddedEvents(
-					fromBlock,
-					nil,
-					psas.proposalSubmitterFilter,
-				)
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past ProposalSubmitterAdded events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := psas.contract.watchProposalSubmitterAdded(
-		sink,
-		psas.proposalSubmitterFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (wc *WalletCoordinator) watchProposalSubmitterAdded(
-	sink chan *abi.WalletCoordinatorProposalSubmitterAdded,
-	proposalSubmitterFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchProposalSubmitterAdded(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			proposalSubmitterFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		wcLogger.Warnf(
-			"subscription to event ProposalSubmitterAdded had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"host chain connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		wcLogger.Errorf(
-			"subscription to event ProposalSubmitterAdded failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return chainutil.WithResubscription(
-		chainutil.SubscriptionBackoffMax,
-		subscribeFn,
-		chainutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (wc *WalletCoordinator) PastProposalSubmitterAddedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	proposalSubmitterFilter []common.Address,
-) ([]*abi.WalletCoordinatorProposalSubmitterAdded, error) {
-	iterator, err := wc.contract.FilterProposalSubmitterAdded(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		proposalSubmitterFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past ProposalSubmitterAdded events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.WalletCoordinatorProposalSubmitterAdded, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (wc *WalletCoordinator) ProposalSubmitterRemovedEvent(
-	opts *ethereum.SubscribeOpts,
-	proposalSubmitterFilter []common.Address,
-) *WcProposalSubmitterRemovedSubscription {
-	if opts == nil {
-		opts = new(ethereum.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = chainutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = chainutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &WcProposalSubmitterRemovedSubscription{
-		wc,
-		opts,
-		proposalSubmitterFilter,
-	}
-}
-
-type WcProposalSubmitterRemovedSubscription struct {
-	contract                *WalletCoordinator
-	opts                    *ethereum.SubscribeOpts
-	proposalSubmitterFilter []common.Address
-}
-
-type walletCoordinatorProposalSubmitterRemovedFunc func(
-	ProposalSubmitter common.Address,
-	blockNumber uint64,
-)
-
-func (psrs *WcProposalSubmitterRemovedSubscription) OnEvent(
-	handler walletCoordinatorProposalSubmitterRemovedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.WalletCoordinatorProposalSubmitterRemoved)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.ProposalSubmitter,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := psrs.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (psrs *WcProposalSubmitterRemovedSubscription) Pipe(
-	sink chan *abi.WalletCoordinatorProposalSubmitterRemoved,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(psrs.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := psrs.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - psrs.opts.PastBlocks
-
-				wcLogger.Infof(
-					"subscription monitoring fetching past ProposalSubmitterRemoved events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := psrs.contract.PastProposalSubmitterRemovedEvents(
-					fromBlock,
-					nil,
-					psrs.proposalSubmitterFilter,
-				)
-				if err != nil {
-					wcLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				wcLogger.Infof(
-					"subscription monitoring fetched [%v] past ProposalSubmitterRemoved events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := psrs.contract.watchProposalSubmitterRemoved(
-		sink,
-		psrs.proposalSubmitterFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (wc *WalletCoordinator) watchProposalSubmitterRemoved(
-	sink chan *abi.WalletCoordinatorProposalSubmitterRemoved,
-	proposalSubmitterFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return wc.contract.WatchProposalSubmitterRemoved(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			proposalSubmitterFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		wcLogger.Warnf(
-			"subscription to event ProposalSubmitterRemoved had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"host chain connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		wcLogger.Errorf(
-			"subscription to event ProposalSubmitterRemoved failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return chainutil.WithResubscription(
-		chainutil.SubscriptionBackoffMax,
-		subscribeFn,
-		chainutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (wc *WalletCoordinator) PastProposalSubmitterRemovedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	proposalSubmitterFilter []common.Address,
-) ([]*abi.WalletCoordinatorProposalSubmitterRemoved, error) {
-	iterator, err := wc.contract.FilterProposalSubmitterRemoved(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		proposalSubmitterFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past ProposalSubmitterRemoved events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.WalletCoordinatorProposalSubmitterRemoved, 0)
 
 	for iterator.Next() {
 		event := iterator.Event

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -185,12 +185,6 @@ type DKGParameters struct {
 // BridgeChain defines the subset of the TBTC chain interface that pertains
 // specifically to the tBTC Bridge operations.
 type BridgeChain interface {
-	// OnHeartbeatRequested registers a callback that is invoked when an
-	// on-chain notification of the Bridge heartbeat request is seen.
-	OnHeartbeatRequested(
-		func(event *HeartbeatRequestedEvent),
-	) subscription.EventSubscription
-
 	// PastDepositRevealedEvents fetches past deposit reveal events according
 	// to the provided filter or unfiltered if the filter is nil. Returned
 	// events are sorted by the block number in the ascending order, i.e. the
@@ -274,10 +268,10 @@ type DepositChainRequest struct {
 // WalletCoordinatorChain defines the subset of the TBTC chain interface that
 // pertains specifically to the tBTC wallet coordination.
 type WalletCoordinatorChain interface {
-	// OnHeartbeatRequestedSubmitted registers a callback that is invoked when
+	// OnHeartbeatRequestSubmitted registers a callback that is invoked when
 	// an on-chain notification of the wallet heartbeat request is seen.
-	OnHeartbeatRequestedSubmitted(
-		handler func(event *HeartbeatRequestedSubmittedEvent),
+	OnHeartbeatRequestSubmitted(
+		handler func(event *HeartbeatRequestSubmittedEvent),
 	) subscription.EventSubscription
 
 	// OnDepositSweepProposalSubmitted registers a callback that is invoked when
@@ -315,9 +309,9 @@ type WalletCoordinatorChain interface {
 	) error
 }
 
-// HeartbeatRequestedSubmittedEvent represents a wallet heartbeat request
+// HeartbeatRequestSubmittedEvent represents a wallet heartbeat request
 // submitted to the chain.
-type HeartbeatRequestedSubmittedEvent struct {
+type HeartbeatRequestSubmittedEvent struct {
 	WalletPublicKeyHash [20]byte
 	Message             []byte
 	BlockNumber         uint64

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -322,9 +322,9 @@ type DepositSweepProposal struct {
 // DepositSweepProposalSubmittedEvent represents a deposit sweep proposal
 // submission event.
 type DepositSweepProposalSubmittedEvent struct {
-	Proposal          *DepositSweepProposal
-	ProposalSubmitter chain.Address
-	BlockNumber       uint64
+	Proposal    *DepositSweepProposal
+	Coordinator chain.Address
+	BlockNumber uint64
 }
 
 // DepositSweepProposalSubmittedEventFilter is a component allowing to
@@ -332,7 +332,7 @@ type DepositSweepProposalSubmittedEvent struct {
 type DepositSweepProposalSubmittedEventFilter struct {
 	StartBlock          uint64
 	EndBlock            *uint64
-	ProposalSubmitter   []chain.Address
+	Coordinator         []chain.Address
 	WalletPublicKeyHash [20]byte
 }
 

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -274,6 +274,12 @@ type DepositChainRequest struct {
 // WalletCoordinatorChain defines the subset of the TBTC chain interface that
 // pertains specifically to the tBTC wallet coordination.
 type WalletCoordinatorChain interface {
+	// OnHeartbeatRequestedSubmitted registers a callback that is invoked when
+	// an on-chain notification of the wallet heartbeat request is seen.
+	OnHeartbeatRequestedSubmitted(
+		handler func(event *HeartbeatRequestedSubmittedEvent),
+	) subscription.EventSubscription
+
 	// OnDepositSweepProposalSubmitted registers a callback that is invoked when
 	// an on-chain notification of the deposit sweep proposal submission is seen.
 	OnDepositSweepProposalSubmitted(
@@ -307,6 +313,14 @@ type WalletCoordinatorChain interface {
 			FundingTx *bitcoin.Transaction
 		},
 	) error
+}
+
+// HeartbeatRequestedSubmittedEvent represents a wallet heartbeat request
+// submitted to the chain.
+type HeartbeatRequestedSubmittedEvent struct {
+	WalletPublicKeyHash [20]byte
+	Message             []byte
+	BlockNumber         uint64
 }
 
 // DepositSweepProposal represents a deposit sweep proposal submitted to the chain.

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -421,12 +421,6 @@ func (lc *localChain) DKGParameters() (*DKGParameters, error) {
 	}, nil
 }
 
-func (lc *localChain) OnHeartbeatRequested(
-	handler func(event *HeartbeatRequestedEvent),
-) subscription.EventSubscription {
-	panic("unsupported")
-}
-
 func (lc *localChain) PastDepositRevealedEvents(
 	filter *DepositRevealedEventFilter,
 ) ([]*DepositRevealedEvent, error) {
@@ -449,8 +443,8 @@ func (lc *localChain) operatorAddress() (chain.Address, error) {
 	return lc.Signing().PublicKeyToAddress(operatorPublicKey)
 }
 
-func (lc *localChain) OnHeartbeatRequestedSubmitted(
-	handler func(event *HeartbeatRequestedSubmittedEvent),
+func (lc *localChain) OnHeartbeatRequestSubmitted(
+	handler func(event *HeartbeatRequestSubmittedEvent),
 ) subscription.EventSubscription {
 	panic("unsupported")
 }

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -5,6 +5,12 @@ import (
 	"crypto/elliptic"
 	"encoding/binary"
 	"fmt"
+	"math/big"
+	"math/rand"
+	"reflect"
+	"sync"
+	"time"
+
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
@@ -13,11 +19,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/subscription"
 	"github.com/keep-network/keep-core/pkg/tecdsa/dkg"
 	"golang.org/x/crypto/sha3"
-	"math/big"
-	"math/rand"
-	"reflect"
-	"sync"
-	"time"
 )
 
 const localChainOperatorID = chain.OperatorID(1)
@@ -446,6 +447,12 @@ func (lc *localChain) operatorAddress() (chain.Address, error) {
 	}
 
 	return lc.Signing().PublicKeyToAddress(operatorPublicKey)
+}
+
+func (lc *localChain) OnHeartbeatRequestedSubmitted(
+	handler func(event *HeartbeatRequestedSubmittedEvent),
+) subscription.EventSubscription {
+	panic("unsupported")
 }
 
 func (lc *localChain) OnDepositSweepProposalSubmitted(

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -254,66 +253,6 @@ func Initialize(
 				event.BlockNumber,
 				event.Result,
 				event.ResultHash,
-			)
-		}()
-	})
-
-	// TODO: Make heartbeats a proper walletAction managed by the WalletCoordinator
-	//       contract and do not use signingExecutor directly.
-	_ = chain.OnHeartbeatRequested(func(event *HeartbeatRequestedEvent) {
-		go func() {
-			// There is no need to deduplicate. Test loop events are unique.
-			messagesDigests := make([]string, len(event.Messages))
-			for i, message := range event.Messages {
-				bytes := message.Bytes()
-				messagesDigests[i] = fmt.Sprintf(
-					"0x%x...%x",
-					bytes[:2],
-					bytes[len(bytes)-2:],
-				)
-			}
-
-			logger.Infof(
-				"heartbeat [%s] requested from "+
-					"wallet [0x%x] at block [%v]",
-				strings.Join(messagesDigests, ", "),
-				event.WalletPublicKey,
-				event.BlockNumber,
-			)
-
-			executor, ok, err := node.getSigningExecutor(
-				unmarshalPublicKey(event.WalletPublicKey),
-			)
-			if err != nil {
-				logger.Errorf("cannot get signing executor: [%v]", err)
-				return
-			}
-			if !ok {
-				logger.Infof(
-					"node does not control signers of wallet "+
-						"with public key [0x%x]",
-					event.WalletPublicKey,
-				)
-				return
-			}
-
-			signatures, err := executor.signBatch(
-				context.TODO(),
-				event.Messages,
-				event.BlockNumber,
-			)
-			if err != nil {
-				logger.Errorf("cannot sign batch: [%v]", err)
-				return
-			}
-
-			logger.Infof(
-				"generated [%v] signatures for heartbeat [%s] as "+
-					"requested from wallet [0x%x] at block [%v]",
-				len(signatures),
-				strings.Join(messagesDigests, ", "),
-				event.WalletPublicKey,
-				event.BlockNumber,
 			)
 		}()
 	})

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -3,10 +3,11 @@ package tbtc
 import (
 	"context"
 	"fmt"
-	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 
 	"github.com/ipfs/go-log"
 
@@ -394,7 +395,7 @@ func Initialize(
 						"wallet PKH [0x%x] at block [%v] by [%v]",
 					walletPublicKeyHash,
 					event.BlockNumber,
-					event.ProposalSubmitter,
+					event.Coordinator,
 				)
 
 				node.handleDepositSweepProposal(

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -5,11 +5,12 @@ import (
 	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
+	"sync"
+
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 	"go.uber.org/zap"
-	"sync"
 )
 
 // WalletActionType represents actions types that can be performed by a wallet.
@@ -17,6 +18,7 @@ type WalletActionType uint8
 
 const (
 	Noop WalletActionType = iota
+	Heartbeat
 	DepositSweep
 	Redemption
 	MovingFunds
@@ -27,6 +29,8 @@ func (wat WalletActionType) String() string {
 	switch wat {
 	case Noop:
 		return "Noop"
+	case Heartbeat:
+		return "Heartbeat"
 	case DepositSweep:
 		return "DepositSweep"
 	case Redemption:


### PR DESCRIPTION
Refs #3512 

With the existing, pretty computationally-expensive tECDSA signing algorithm, [we would prefer](https://github.com/keep-network/keep-core/pull/3521#discussion_r1173652203) not to execute heartbeats at the same time as other wallet actions (sweeping, redemptions, moving funds). Moreover, we would prefer not to execute heartbeats from multiple wallets at the same time.

Such coordination is complicated off-chain for the same reason as the coordination of sweeps and redemptions. We could - as we do now - execute heartbeats at fixed hours but it does not help with coordination between heartbeats and sweeps. Also, it does not solve the problem of multiple heartbeats simultaneously.

For this reason, in https://github.com/keep-network/tbtc-v2/pull/609, the heartbeat has been made a first-class wallet action coordinated in the on-chain contract just like the rest of the wallet actions.

In this PR we regenerate `WalletRegistry` contract bindings after the changes from https://github.com/keep-network/tbtc-v2/pull/607 and https://github.com/keep-network/tbtc-v2/pull/609. We add the `OnHeartbeatRequestSubmitted` event listener and remove the old, stubbed `OnHeartbeatRequested` implementation.

In the next PRs, we will implement event deduplication and the off-chain action for heartbeats.