### PR TITLE
Temporarily exclude `LightRelayMaintainerProxy` from binding generation process

### DIFF
--- a/pkg/chain/ethereum/tbtc/gen/Makefile
+++ b/pkg/chain/ethereum/tbtc/gen/Makefile
@@ -1,7 +1,8 @@
 npm_package_name=@keep-network/tbtc-v2
 
 # Contracts for which the bindings should be generated.
-required_contracts := Bridge LightRelay LightRelayMaintainerProxy WalletCoordinator
+# TODO: Add LightRelayMaintainerProxy once it is deployed on goerli.
+required_contracts := Bridge LightRelay WalletCoordinator
 
 # There is a bug in the currently used abigen version (v1.10.19) that makes it
 # re-declaring structs used by multiple contracts


### PR DESCRIPTION
The `LightRelayMaintainerProxy` is not yet deployed on environments other than `development`. That means npm packages downloaded as part of non-development deployments do not contain their deployment info and the `make generate` process cannot extract the contract address from there which ends with an error. We temporarily exclude the `LightRelayMaintainerProxy` contract from the binding generation process to work around this problem.