### PR TITLE
Add missing `BitcoinElectrum` flag category for `start` command

### DIFF
--- a/config/category.go
+++ b/config/category.go
@@ -18,6 +18,7 @@ const (
 var StartCmdCategories = []Category{
 	General,
 	Ethereum,
+	BitcoinElectrum,
 	Network,
 	Storage,
 	ClientInfo,


### PR DESCRIPTION
This is needed to pass the `bitcoin.electrum` config through flags. Without that, the client exists with the `unknown flag` error.