### PR TITLE
Make prometheus internally exposed on keep-test

### DIFF
--- a/infrastructure/kube/keep-test/monitoring/monitoring-ingress.yaml
+++ b/infrastructure/kube/keep-test/monitoring/monitoring-ingress.yaml
@@ -25,20 +25,6 @@ spec:
                 name: grafana
                 port:
                   number: 3000
-          - path: "/prometheus"
-            pathType: Prefix
-            backend:
-              service:
-                name: trickster
-                port:
-                  number: 8480
-          - path: "/trickster"
-            pathType: Prefix
-            backend:
-              service:
-                name: trickster
-                port:
-                  number: 8480
 ---
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate


### PR DESCRIPTION
We don't need to expose the Prometheus instance publicly on keep-test. We use it as Grafana's data source.

https://monitoring.test.threshold.network/prometheus/ is no longer accessible.