### PR TITLE
Connect `keep-test` clients to testnet ElectrumX instance

### DIFF
--- a/infrastructure/kube/keep-test/keep-client/gen/template.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/template.yaml
@@ -90,6 +90,8 @@ spec:
             - $(ETH_WS_URL)
             - "--ethereum.keyFile"
             -  #@ "/mnt/keep-client/keyfile/" + account() + "-keyfile"
+            - --bitcoin.electrum.url
+            - $(ELECTRUM_TCP_URL)
             - "--storage.dir"
             - "/mnt/keep-client/data"
             - "--network.port"

--- a/infrastructure/kube/keep-test/keep-client/keep-client-config.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-client-config.yaml
@@ -7,3 +7,4 @@ data:
   LOG_LEVEL: "keep*=info tss-lib=warn"
   GOLOG_LOG_FMT: json
   # GOLOG_OUTPUT: stdout
+  ELECTRUM_TCP_URL: electrumx.default.svc.cluster.local:80

--- a/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
@@ -86,6 +86,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-0-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -291,6 +293,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-1-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -496,6 +500,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-2-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -699,6 +705,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-3-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -902,6 +910,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-4-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -1105,6 +1115,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-5-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -1308,6 +1320,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-6-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -1511,6 +1525,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-7-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -1714,6 +1730,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-8-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port
@@ -1917,6 +1935,8 @@ spec:
         - $(ETH_WS_URL)
         - --ethereum.keyFile
         - /mnt/keep-client/keyfile/account-9-keyfile
+        - --bitcoin.electrum.url
+        - $(ELECTRUM_TCP_URL)
         - --storage.dir
         - /mnt/keep-client/data
         - --network.port


### PR DESCRIPTION
This change points the `keep-test` clients to the testnet ElectrumX instance. This allows the clients to interact with the Bitcoin testnet.