### PR TITLE
Deposit sweep log tweaks

### DIFF
--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -160,7 +160,7 @@ func (dsa *depositSweepAction) execute() error {
 
 	broadcastTxLogger := actionLogger.With(
 		zap.String("step", "broadcastTransaction"),
-		zap.String("sweepTxHash", fmt.Sprintf("0x%x", sweepTx.Hash())),
+		zap.String("sweepTxHash", sweepTx.Hash().Hex(bitcoin.ReversedByteOrder)),
 	)
 
 	err = dsa.broadcastTransaction(broadcastTxLogger, sweepTx)

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -126,7 +126,7 @@ func (se *signingExecutor) signBatch(
 
 	signingBatchLogger := logger.With(
 		zap.String("wallet", fmt.Sprintf("0x%x", walletPublicKeyBytes)),
-		zap.String("signingMessages", strings.Join(messagesDigests, ", ")),
+		zap.String("signedMessages", strings.Join(messagesDigests, ", ")),
 	)
 
 	signingStartBlock := startBlock // start block for the first signing
@@ -135,7 +135,7 @@ func (se *signingExecutor) signBatch(
 
 	for i, message := range messages {
 		signingBatchMessageLogger := signingBatchLogger.With(
-			zap.String("signingMessage", fmt.Sprintf("0x%x", message)),
+			zap.String("signedMessage", fmt.Sprintf("0x%x", message)),
 			zap.String("index", fmt.Sprintf("%v/%v", i+1, len(messages))),
 		)
 
@@ -191,7 +191,7 @@ func (se *signingExecutor) sign(
 
 	signingLogger := logger.With(
 		zap.String("wallet", fmt.Sprintf("0x%x", walletPublicKeyBytes)),
-		zap.String("signingMessage", fmt.Sprintf("0x%x", message)),
+		zap.String("signedMessage", fmt.Sprintf("0x%x", message)),
 		zap.Uint64("signingStartBlock", startBlock),
 		zap.Uint64("signingTimeoutBlock", loopTimeoutBlock),
 	)

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -126,7 +126,7 @@ func (se *signingExecutor) signBatch(
 
 	signingBatchLogger := logger.With(
 		zap.String("wallet", fmt.Sprintf("0x%x", walletPublicKeyBytes)),
-		zap.String("messages", strings.Join(messagesDigests, ", ")),
+		zap.String("signingMessages", strings.Join(messagesDigests, ", ")),
 	)
 
 	signingStartBlock := startBlock // start block for the first signing
@@ -135,7 +135,7 @@ func (se *signingExecutor) signBatch(
 
 	for i, message := range messages {
 		signingBatchMessageLogger := signingBatchLogger.With(
-			zap.String("message", fmt.Sprintf("0x%x", message)),
+			zap.String("signingMessage", fmt.Sprintf("0x%x", message)),
 			zap.String("index", fmt.Sprintf("%v/%v", i+1, len(messages))),
 		)
 
@@ -191,7 +191,7 @@ func (se *signingExecutor) sign(
 
 	signingLogger := logger.With(
 		zap.String("wallet", fmt.Sprintf("0x%x", walletPublicKeyBytes)),
-		zap.String("message", fmt.Sprintf("0x%x", message)),
+		zap.String("signingMessage", fmt.Sprintf("0x%x", message)),
 		zap.Uint64("signingStartBlock", startBlock),
 		zap.Uint64("signingTimeoutBlock", loopTimeoutBlock),
 	)


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

Here we tweak some loggers used during the deposit sweep process.