### PR TITLE
Fix broadcast function in Electrum implementation

### DIFF
--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -227,10 +227,10 @@ txOutLoop:
 func (c *Connection) BroadcastTransaction(
 	transaction *bitcoin.Transaction,
 ) error {
-	rawTx := transaction.Serialize()
+	rawTx := hex.EncodeToString(transaction.Serialize())
 
 	rawTxLogger := logger.With(
-		zap.String("rawTx", hex.EncodeToString(rawTx)),
+		zap.String("rawTx", rawTx),
 	)
 	rawTxLogger.Debugf("broadcasting transaction")
 
@@ -239,7 +239,7 @@ func (c *Connection) BroadcastTransaction(
 	response, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
-			return client.BroadcastTransaction(ctx, string(rawTx))
+			return client.BroadcastTransaction(ctx, rawTx)
 		})
 	if err != nil {
 		return fmt.Errorf("failed to broadcast the transaction: [%w]", err)


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

So far, the `Broadcast` method of our Electrum client tried to broadcast the transaction as a UTF string
(`client.BroadcastTransaction(ctx, string(rawTx))`). That was wrong as the client expects a hexadecimal string. Here we are fixing that by building `rawTx` as `hex.EncodeToString(transaction.Serialize())` which produces a proper hex of the raw transaction.