### PR TITLE
Optimized signing retry loop by skipping retries that cannot succeed

### DIFF
--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -464,6 +464,9 @@ func (n *node) handleDepositSweepProposal(
 // block height.
 type waitForBlockFn func(context.Context, uint64) error
 
+// getCurrentBlockFn represents a function returning the current block height.
+type getCurrentBlockFn func() (uint64, error)
+
 // TODO: this should become a part of BlockHeightWaiter interface.
 func (n *node) waitForBlockHeight(ctx context.Context, blockHeight uint64) error {
 	blockCounter, err := n.chain.BlockCounter()

--- a/pkg/tbtc/signing_loop_test.go
+++ b/pkg/tbtc/signing_loop_test.go
@@ -3,6 +3,7 @@ package tbtc
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"testing"
@@ -55,6 +56,7 @@ func TestSigningRetryLoop(t *testing.T) {
 	var tests = map[string]struct {
 		signingGroupMemberIndex     group.MemberIndex
 		ctxFn                       func() (context.Context, context.CancelFunc)
+		currentBlockFn              getCurrentBlockFn
 		incomingAnnouncementsFn     func(sessionID string) ([]group.MemberIndex, error)
 		signingAttemptFn            signingAttemptFn
 		waitUntilAllDoneOutcomeFn   func(attemptNumber uint64) (*signing.Result, uint64, error)
@@ -68,6 +70,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			signingGroupMemberIndex: 1,
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
 			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
@@ -115,6 +120,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
 			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
+			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
 			) ([]group.MemberIndex, error) {
@@ -161,6 +169,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			signingGroupMemberIndex: 3,
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
 			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
@@ -216,6 +227,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
 			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
+			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
 			) ([]group.MemberIndex, error) {
@@ -268,6 +282,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			signingGroupMemberIndex: 4,
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
 			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
@@ -322,6 +339,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
 			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
+			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
 			) ([]group.MemberIndex, error) {
@@ -365,6 +385,9 @@ func TestSigningRetryLoop(t *testing.T) {
 			signingGroupMemberIndex: 4,
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
 			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
@@ -438,6 +461,9 @@ func TestSigningRetryLoop(t *testing.T) {
 				cancelCtx()
 				return ctx, cancelCtx
 			},
+			currentBlockFn: func() (uint64, error) {
+				return 200, nil // same as the initial start block
+			},
 			incomingAnnouncementsFn: func(
 				sessionID string,
 			) ([]group.MemberIndex, error) {
@@ -451,6 +477,87 @@ func TestSigningRetryLoop(t *testing.T) {
 			expectedErr:                 context.Canceled,
 			expectedResult:              nil,
 			expectedLastExecutedAttempt: nil,
+		},
+		"signing in the past": {
+			signingGroupMemberIndex: 1,
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 50*time.Millisecond)
+			},
+			currentBlockFn: func() (uint64, error) {
+				return math.MaxUint64, nil // all attempts should be skipped
+			},
+			incomingAnnouncementsFn: func(
+				sessionID string,
+			) ([]group.MemberIndex, error) {
+				return signingGroupMembersIndexes, nil
+			},
+			signingAttemptFn: func(
+				attempt *signingAttemptParams,
+			) (*signing.Result, uint64, error) {
+				return nil, 0, fmt.Errorf("invalid data")
+			},
+			// The retry loop keeps skipping all attempts because they are all
+			// ending announcement phase in the past block. It keeps retrying
+			// until the context deadline is exceeded.
+			expectedErr:                 context.DeadlineExceeded,
+			expectedResult:              nil,
+			expectedLastExecutedAttempt: nil,
+		},
+		"first attempt in the past": {
+			signingGroupMemberIndex: 3,
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 1*time.Second)
+			},
+			currentBlockFn: func() (uint64, error) {
+				// The initial start block is 200 and the announcement takes 6
+				// blocks; we are at the end of the announcement phase so the
+				// first attempt should be skipped.
+				return 206, nil
+			},
+			incomingAnnouncementsFn: func(
+				sessionID string,
+			) ([]group.MemberIndex, error) {
+				return signingGroupMembersIndexes, nil
+			},
+			signingAttemptFn: func(
+				attempt *signingAttemptParams,
+			) (*signing.Result, uint64, error) {
+				return testResult, 260, nil // an arbitrary end block
+			},
+			waitUntilAllDoneOutcomeFn: func(attemptNumber uint64) (*signing.Result, uint64, error) {
+				// Simulate that the done check phase determines the same
+				// end block as the executing signer.
+				return testResult, 260, nil
+			},
+			expectedOutgoingDoneChecks: []*signingDoneMessage{
+				{
+					senderID:      3,
+					message:       message,
+					attemptNumber: 2,
+					signature:     testResult.Signature,
+					endBlock:      260,
+				},
+			},
+			expectedErr: nil,
+			expectedResult: &signingRetryLoopResult{
+				result:              testResult,
+				latestEndBlock:      260, // the end block resolved by the done check phase
+				attemptTimeoutBlock: 277, // start block of the second attempt + 30
+			},
+			// Member 3 is the executing one. The first attempt's announcement
+			// is skipped and the signing random retry algorithm invoked with the
+			// test seed excludes 3 members (6 is the honest threshold) from the
+			// second attempt: 1, 2 and 5. The additional exclusion round that
+			// trims the included members list to the honest threshold size
+			// adds member 9 to the final excluded members list.
+			expectedLastExecutedAttempt: &signingAttemptParams{
+				number:                 2,
+				startBlock:             247, // 206 + 1 * (6 + 30 + 5)
+				timeoutBlock:           277, // start block of the second attempt + 30
+				excludedMembersIndexes: []group.MemberIndex{1, 2, 5, 9},
+			},
+			// just the second announcement, the first one was skipped
+			outgoingAnnouncementsCount: 1,
 		},
 	}
 
@@ -486,6 +593,7 @@ func TestSigningRetryLoop(t *testing.T) {
 				func(context.Context, uint64) error {
 					return nil
 				},
+				test.currentBlockFn,
 				func(params *signingAttemptParams) (*signing.Result, uint64, error) {
 					lastExecutedAttempt = params
 					return test.signingAttemptFn(params)


### PR DESCRIPTION
Depends on [#3541](https://github.com/keep-network/keep-core/pull/3541)

Think of this scenario:
1. There are three nodes: A, B, C. Each one has members in a wallet.
2. Only node A is up.
3. Request for signing is emitted on the chain (sweep or heartbeat).
4. Node A receives the event and activates the action and the signing retry loop.
5. Node A fails in the signing announcement phase. First retry, second retry, third retry. Nodes B and C are still offline.
6. B and C go up.
7. At this point, node A is at the fourth signing attempt.

What was happening: Nodes B and C kept executing retry attempts from 1 to 3. They were taking less than a second because the attempt start block and attempt and block were both in the past. We had a lot of warnings like:

> 2023-05-03T13:19:04.787+0200 WARN keep-tbtc tbtc/signing_loop.go:247 [member:41] completed announcement phase for attempt [1] with minority of [1] members ready to sign; starting next attempt (...)

Finally, they were able to catch up with node A and execute signing but we had a lot of warnings along the way that could mislead people not being super-familiar with how retry attempts were implemented. Also, it was not efficient to even try to execute the signing if there was no chance the announcement will go through.

The improvement is simple. If `announcementEndBlock` is in the past, we skip the signing attempt and go to the next one. This was implemented here.

This is how this situation manifests in the logs now:

> 2023-05-05T23:00:20.107+0200 INFO keep-tbtc	tbtc/signing_loop.go:215 [member:40] skipping attempt [1]; the current block is [24860] and the end block [24751] for the announcement phase is in the past	(...)


## Testing

I tested two scenarios locally. I had 3 nodes running  (A, B, C) with two wallets.

First, I executed a heartbeat request with all 3 nodes (A, B, C) running. It was handled with no problems.

Then, I disabled nodes B and C and requested heartbeat from another wallet. Node A could not handle it alone and 3 retries of the signing protocol failed. Then I restarted B and C and let it read the event from the past. Once they retrieved the event, they skipped the initial signing attempts that had no chance of succeeding and went straight to the most recent attempt.

Cheat sheet for heartbeat request:

```
KEEP_ETHEREUM_PASSWORD="password" ./keep-client ethereum tbtc wallet-coordinator request-heartbeat \
0xf64495333e81ee35e78ad1d042578870ab17c828 \ 
0xFFFFFFFFFFFFFFFF0000000000000001 \ 
--config configs/config.deployer.toml --submit
```