### PR TITLE
Remove pre-signing delay from deposit sweep action

### DIFF
--- a/pkg/tbtc/deposit_sweep_test.go
+++ b/pkg/tbtc/deposit_sweep_test.go
@@ -179,12 +179,10 @@ func TestDepositSweepAction_Execute(t *testing.T) {
 			// Set up the signing executor mock to return the signatures from
 			// the test fixture when called with the expected parameters.
 			// Note that the start block is set based on the proposal
-			// processing start block incremented by the same delay value
-			// as done within the action.
+			// processing start block as done within the action.
 			signingExecutor.setSignatures(
 				scenario.ExpectedSigHashes,
-				proposalProcessingStartBlock+
-					uint64(len(depositsKeys)*depositSweepSigningDelayBlocks),
+				proposalProcessingStartBlock,
 				rawSignatures,
 			)
 


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

The pre-signing delay was introduced to compensate the time spent for proposal validation. However, during testing, it turned out the time spent for validation is negligible thus the delay can be safely removed. Potential anomalies are supposed to be handled by the signing announcement phase so, an additional pre-signing delay is redundant. This change should speed up the deposit sweep action by approximately `2 min * N`, where `N` is the number of swept deposits.