### PR TITLE
Ensure wallet BTC state is reflected on the host chain before sweeping

### DIFF
--- a/pkg/bitcoin/chain.go
+++ b/pkg/bitcoin/chain.go
@@ -29,7 +29,7 @@ type Chain interface {
 	// returns an error.
 	GetBlockHeader(blockHeight uint) (*BlockHeader, error)
 
-	// GetTransactionsForPublicKeyHash get confirmed transactions that pays the
+	// GetTransactionsForPublicKeyHash gets the confirmed transactions that pays the
 	// given public key hash using either a P2PKH or P2WPKH script. The returned
 	// transactions are ordered by block height in the ascending order, i.e.
 	// the latest transaction is at the end of the list. The returned list does
@@ -41,4 +41,9 @@ type Chain interface {
 		publicKeyHash [20]byte,
 		limit int,
 	) ([]*Transaction, error)
+
+	// GetMempoolForPublicKeyHash gets the unconfirmed mempool transactions
+	// that pays the given public key hash using either a P2PKH or P2WPKH script.
+	// The returned transactions are in an indefinite order.
+	GetMempoolForPublicKeyHash(publicKeyHash [20]byte) ([]*Transaction, error)
 }

--- a/pkg/bitcoin/chain_test.go
+++ b/pkg/bitcoin/chain_test.go
@@ -51,6 +51,12 @@ func (lc *localChain) GetTransactionsForPublicKeyHash(
 	panic("not implemented")
 }
 
+func (lc *localChain) GetMempoolForPublicKeyHash(
+	publicKeyHash [20]byte,
+) ([]*Transaction, error) {
+	panic("not implemented")
+}
+
 func (lc *localChain) addTransaction(
 	transaction *Transaction,
 ) error {

--- a/pkg/maintainer/bitcoin_chain_test.go
+++ b/pkg/maintainer/bitcoin_chain_test.go
@@ -83,6 +83,12 @@ func (lc *localBitcoinChain) GetTransactionsForPublicKeyHash(
 	panic("unsupported")
 }
 
+func (lc *localBitcoinChain) GetMempoolForPublicKeyHash(
+	publicKeyHash [20]byte,
+) ([]*bitcoin.Transaction, error) {
+	panic("unsupported")
+}
+
 // SetBlockHeaders sets internal headers for testing purposes.
 func (lc *localBitcoinChain) SetBlockHeaders(
 	blockHeaders map[uint]*bitcoin.BlockHeader,

--- a/pkg/tbtc/bitcoin_chain_test.go
+++ b/pkg/tbtc/bitcoin_chain_test.go
@@ -110,3 +110,9 @@ func (lbc *localBitcoinChain) GetTransactionsForPublicKeyHash(
 
 	return matchingTransactions, nil
 }
+
+func (lbc *localBitcoinChain) GetMempoolForPublicKeyHash(
+	publicKeyHash [20]byte,
+) ([]*bitcoin.Transaction, error) {
+	panic("not implemented")
+}


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

### The problem

The `Bridge` contract enforces that all BTC transactions produced by the given wallet form a sequence and refer to each other. If a wallet violated this rule, such transactions would not be SPV-proved to the `Bridge` and would be used to create undefeatable fraud challenges against the wallet. That leads to funds loss and wallet punishment. The current state of things is vulnerable to this problem as there are several unlikely corner cases that are not covered on the client side. 

### The `ensureWalletSyncedBetweenChains` check

This changeset aims to fix the aforementioned problem by introducing the `ensureWalletSyncedBetweenChains` check at the beginning of the sweep action. This check allows for the sweep action only if the wallet state on the BTC chain is correctly reflected on the host chain `Bridge`. This way, we ensure the expected transaction sequence is preserved and produced sweep transaction will be proper from `Bridge`'s standpoint.

In detail, the `ensureWalletSyncedBetweenChains` function checks the following two conditions are met:
- The wallet main UTXO registered in the host chain Bridge comes from the latest BTC transaction OR wallet main UTXO is 
  unset and the wallet's BTC transaction history is empty. This condition ensures that all expected SPV proofs of confirmed 
  BTC transactions were submitted to the host chain Bridge thus the wallet state held known to the Bridge matches the 
  actual state on the BTC chain.
- There are no pending BTC transactions in the mempool. This condition ensures the wallet doesn't currently perform any 
  action on the BTC chain. Such transactions indicate a possible state change in the future but their outcome cannot be 
  determined at this stage so, the wallet should not perform new actions at the moment.

### Fetching the mempool items for given wallet 

We are also introducing the `GetMempoolForPublicKeyHash` function that allows fetching the mempool content for the given public key hash. Due to the volatile nature of the mempool, it is not trivial to cover this function with proper unit/integration tests. Correctness was ensured using an ad-hoc integration test that examined an example BTC testnet address and some manual actions that added a mempool transaction for that address. The code of the ad-hoc test looks as follows:
```
func TestGetMempoolForPublicKeyHash_Integration(t *testing.T) {
	for testName, config := range configs {
		electrum := newTestConnection(t, config)

		t.Run(testName, func(t *testing.T) {
			// PKH corresponding to address mpRZxxp5FtmQipEWJPa1NY9FmPsva3exUd
			pkhString := "61b469ada61f37c620010912a9d5d56646015f16"

			pkhBytes, err := hex.DecodeString(pkhString)
			if err != nil {
				t.Fatal(err)
			}

			pkh := [20]byte{}
			copy(pkh[:], pkhBytes)

			txs, err := electrum.GetMempoolForPublicKeyHash(pkh)
			if err != nil {
				t.Fatal(err)
			}

			txHashes := make([]string, len(txs))
			for i, tx := range txs {
				txHashes[i] = tx.Hash().Hex(bitcoin.ReversedByteOrder)
			}

			fmt.Printf("mempool txs: [%v]\n", txHashes)
		})
	}
}
```