### PR TITLE
Increase the gas limit for retarget with refund

### DIFF
--- a/pkg/chain/ethereum/bitcoin_difficulty.go
+++ b/pkg/chain/ethereum/bitcoin_difficulty.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/keep-network/keep-common/pkg/chain/ethereum"
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen/contract"
@@ -187,7 +188,12 @@ func (bdc *BitcoinDifficultyChain) RetargetWithRefund(headers []*bitcoin.BlockHe
 	}
 
 	// Update Bitcoin difficulty via LightRelayMaintainerProxy.
-	_, err := bdc.lightRelayMaintainerProxy.Retarget(serializedHeaders)
+	_, err := bdc.lightRelayMaintainerProxy.Retarget(
+		serializedHeaders,
+		ethutil.TransactionOptions{
+			GasLimit: 310000,
+		},
+	)
 	return err
 }
 


### PR DESCRIPTION
This PR increases the gas limit for calls to `LightRelayMaintainerProxy`'s `retarget` function.
The gas limit used is the gas estimate increased by 20%. 
The transactions would revert if the default limit was used.