### PR TITLE
Don't include stub contracts in NPM packages

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -175,7 +175,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Deploy contracts
-        run: yarn deploy:test
+        run: yarn deploy:local
 
       - name: Build Docker Image
         uses: ./.github/actions/docker-build-push

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -173,7 +173,7 @@ jobs:
         run: yarn install --network-concurrency 1 --frozen-lockfile
 
       - name: Deploy contracts
-        run: yarn deploy:test
+        run: yarn deploy:local
 
       - name: Build Docker Image
         uses: ./.github/actions/docker-build-push

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -38,9 +38,9 @@ jobs:
             @threshold-network/solidity-contracts
 
       # Deploy contracts to a local network to generate deployment artifacts that
-      # are required by dashboard and client compilation.
+      # are required by client compilation.
       - name: Deploy contracts
-        run: yarn deploy:test --network hardhat --write true
+        run: yarn deploy:local --network hardhat --write true
 
       - name: Bump up package version
         id: npm-version-bump

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -37,9 +37,9 @@ jobs:
             @threshold-network/solidity-contracts
 
       # Deploy contracts to a local network to generate deployment artifacts that
-      # are required by dashboard and client compilation.
+      # are required by client compilation.
       - name: Deploy contracts
-        run: yarn deploy:test --network hardhat --write true
+        run: yarn deploy:local --network hardhat --write true
 
       - name: Bump up package version
         id: npm-version-bump

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -29,7 +29,7 @@
     "build": "hardhat compile",
     "test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_ECDSA=true hardhat test",
     "deploy": "hardhat deploy --export export.json",
-    "deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_ECDSA=true hardhat deploy",
+    "deploy:local": "USE_EXTERNAL_DEPLOY=true hardhat deploy",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts --including-no-public-functions export/artifacts",
     "prepublishOnly": "hardhat prepare-artifacts --network $npm_config_network"
   },

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -18,7 +18,7 @@
     "build": "hardhat compile",
     "test": "hardhat check-accounts-count && USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_BEACON=true hardhat test",
     "deploy": "hardhat deploy --export export.json",
-    "deploy:test": "USE_EXTERNAL_DEPLOY=true hardhat deploy",
+    "deploy:local": "USE_EXTERNAL_DEPLOY=true hardhat deploy",
     "format": "npm run lint",
     "format:fix": "npm run lint:fix",
     "lint": "npm run lint:eslint && npm run lint:sol && npm run lint:config",


### PR DESCRIPTION
If `hardhat deploy` is run with `TEST_USE_STUBS_ECDSA` environment variable set to `true`, the deployment will include deployment of stub contracts, which are needed for testing purposes (execution of unit tests). So far we've been running `hardhat deploy TEST_USE_STUBS_ECDSA=true` together with `USE_EXTERNAL_DEPLOY=true` in `ecdsa` in the `deploy:test` script. The `USE_EXTERNAL_DEPLOY` variable specifies how the contracts of the dependencies should be deployed - whether to deploy them from scratch (`true`) or reuse the already deployed artifacts (`false`).
We were using the `deploy:test` script in `ecdsa` in two places - when running `contracts-deployment-dry-run` job (test of deployment on `hardhat` local network) and in `npm-compile-publish-contracts` job (publishing of `development`-tagged NPM package). This second use proved to be problematic, as the `development`-tagged package is used to generate the client bindings when running `make all`, resulting in the presence of unneeded (and unwanted) functionalities (like `forceAddWallet` and `getDkgData` from `WalletRegistryStub`). The first use is not causing such problems, but it should still be modified, as it's better to run the dry-run of deploy on the real contracts and not on the stubs.
What we decided to do is to replace
```
"deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_ECDSA=true hardhat deploy",
```
with
```
"deploy:local": "USE_EXTERNAL_DEPLOY=true hardhat deploy",
```
and use the new `deploy:local` script in both jobs that previously used `deploy:test`.
This way we'll no longer include stub functionalities in NPM packages (and hence in the clinet bindings) and we'll execute dry-run of the unmodified contracts. Scripts in `random-beacon` also got updated to follow the new naming.

Refs:
https://github.com/keep-network/keep-core/issues/3531
https://github.com/keep-network/tbtc-v2/pull/623