### PR TITLE
Pin go-electrum dependency to master branch commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 	// here:
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.22.3
 	github.com/btcsuite/btcd/v2 => github.com/btcsuite/btcd v0.23.4
-	github.com/checksum0/go-electrum => github.com/keep-network/go-electrum v0.0.0-20230516120351-221d51b9fd27
+	github.com/checksum0/go-electrum => github.com/keep-network/go-electrum v0.0.0-20230516144526-567f2c1de4bc
 	// Temporary replacement until v1.28.2 is released containing `protodelim` package.
 	// See https://github.com/protocolbuffers/protobuf-go/commit/fb0abd915897428ccfdd6b03b48ad8219751ee54
 	google.golang.org/protobuf/dev => google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
-github.com/keep-network/go-electrum v0.0.0-20230516120351-221d51b9fd27 h1:eNCIY4D6NQ+X3bJKrSS2lXhZeJ2VqSmWNIqySiaJMlY=
-github.com/keep-network/go-electrum v0.0.0-20230516120351-221d51b9fd27/go.mod h1:EjLxYzaf/28gOdSRlifeLfjoOA6aUjtJZhwaZPnjL9c=
+github.com/keep-network/go-electrum v0.0.0-20230516144526-567f2c1de4bc h1:rOvDAL8wTaXBbg5WxrrNF2hwF2uvroFoAnh52rWaBtI=
+github.com/keep-network/go-electrum v0.0.0-20230516144526-567f2c1de4bc/go.mod h1:EjLxYzaf/28gOdSRlifeLfjoOA6aUjtJZhwaZPnjL9c=
 github.com/keep-network/keep-common v1.7.1-0.20230501122407-5cc3757ccf0d h1:6AiGKgOEmwO1Cri87bMfmxgF8ZgE5HIJOQUO7nZszh0=
 github.com/keep-network/keep-common v1.7.1-0.20230501122407-5cc3757ccf0d/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
This is a follow-up for https://github.com/keep-network/keep-core/pull/3567.
We pin go-electrum dependency to a commit hash from master after merging the https://github.com/keep-network/go-electrum/pull/1 PR.