### PR TITLE
Embed Electrum configs for Bitcoin mainnet and testnet

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -83,6 +83,7 @@ func initGlobalEthereumFlags(cmd *cobra.Command) {
 		"Mainnet network",
 	)
 
+	// TODO: Rename `--goerli` flag to `--testnet` (see https://github.com/keep-network/keep-core/pull/3576#discussion_r1200216303).
 	cmd.PersistentFlags().Bool(
 		commonEthereum.Goerli.String(),
 		false,

--- a/config/_electrum_urls/mainnet
+++ b/config/_electrum_urls/mainnet
@@ -1,0 +1,1 @@
+ssl://electrum.blockstream.info:50002

--- a/config/_electrum_urls/testnet
+++ b/config/_electrum_urls/testnet
@@ -1,0 +1,1 @@
+ssl://electrum.blockstream.info:60002

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"embed"
+	"fmt"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
+	"math/rand"
+	neturl "net/url"
+	"strings"
+)
+
+//go:embed _electrum_urls/*
+var electrumURLs embed.FS
+
+// readElectrumConfigs reads Electrum configs from an embedded file for the
+// given Bitcoin network.
+func readElectrumConfigs(network bitcoin.Network) ([]electrum.Config, error) {
+	file, err := electrumURLs.ReadFile(fmt.Sprintf("_electrum_urls/%s", network))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read URLs file: [%v]", err)
+	}
+
+	urlsStrings := cleanStrings(strings.Split(string(file), "\n"))
+
+	configs := make([]electrum.Config, len(urlsStrings))
+
+	for i, urlString := range urlsStrings {
+		url, err := neturl.Parse(urlString)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"cannot parse URL with index [%v]: [%v]",
+				i,
+				err,
+			)
+		}
+
+		protocol, ok := electrum.ParseProtocol(url.Scheme)
+		if !ok {
+			return nil, fmt.Errorf(
+				"URL with index [%v] uses an unsupported Electrum protocol",
+				i,
+			)
+		}
+
+		configs[i] = electrum.Config{
+			URL:      url.Host,
+			Protocol: protocol,
+		}
+	}
+
+	return configs, nil
+}
+
+// resolveElectrum checks if Electrum is already configured. If the Electrum URL
+// is empty it reads the Electrum configs from the embedded list for the given
+// network and picks up one randomly.
+func (c *Config) resolveElectrum() error {
+	network := c.Bitcoin.Network
+
+	// Return if Electrum is already set.
+	if len(c.Bitcoin.Electrum.URL) > 0 {
+		return nil
+	}
+
+	// For unknown and regtest networks we don't expect the Electrum configs to be
+	// embedded in the client. The user should configure it in the config file.
+	if network == bitcoin.Regtest || network == bitcoin.Unknown {
+		logger.Warnf(
+			"Electrum configs were not configured for [%s] network; "+
+				"see bitcoin section in configuration",
+			network,
+		)
+		return nil
+	}
+
+	logger.Debugf(
+		"Electrum was not configured for [%s] bitcoin network; "+
+			"reading defaults",
+		network,
+	)
+
+	configs, err := readElectrumConfigs(network)
+	if err != nil {
+		return fmt.Errorf("failed to read default Electrum configs: [%v]", err)
+	}
+
+	// Pick a single Electrum config randomly.
+	config := configs[rand.Intn(len(configs))]
+
+	// Set only the URL and Protocol fields in the original config. Other
+	// fields may be already set, and we don't want to override them.
+	c.Bitcoin.Electrum.URL = config.URL
+	c.Bitcoin.Electrum.Protocol = config.Protocol
+
+	return nil
+}

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -85,7 +85,8 @@ func (c *Config) resolveElectrum() error {
 		return fmt.Errorf("failed to read default Electrum configs: [%v]", err)
 	}
 
-	// Pick a single Electrum config randomly.
+	// #nosec G404 (insecure random number source (rand))
+	// Picking up an Electrum server does not require secure randomness.
 	config := configs[rand.Intn(len(configs))]
 
 	// Set only the URL and Protocol fields in the original config. Other

--- a/config/electrum_test.go
+++ b/config/electrum_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
+	"golang.org/x/exp/slices"
+	"reflect"
+	"testing"
+)
+
+func TestResolveElectrum(t *testing.T) {
+	var tests = map[string]struct {
+		network         bitcoin.Network
+		expectedConfigs []electrum.Config
+		expectedError   error
+	}{
+		"mainnet network": {
+			network: bitcoin.Mainnet,
+			expectedConfigs: []electrum.Config{
+				{
+					URL:      "electrum.blockstream.info:50002",
+					Protocol: electrum.SSL,
+				},
+			},
+		},
+		"testnet network": {
+			network: bitcoin.Testnet,
+			expectedConfigs: []electrum.Config{
+				{
+					URL:      "electrum.blockstream.info:60002",
+					Protocol: electrum.SSL,
+				},
+			},
+		},
+		"regtest network": {
+			network: bitcoin.Regtest,
+			expectedConfigs: []electrum.Config{
+				{
+					URL:      "",
+					Protocol: electrum.Unknown,
+				},
+			},
+		},
+		"unknown network": {
+			network: bitcoin.Unknown,
+			expectedConfigs: []electrum.Config{
+				{
+					URL:      "",
+					Protocol: electrum.Unknown,
+				},
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.Bitcoin.Network = test.network
+
+			err := cfg.resolveElectrum()
+			if !reflect.DeepEqual(test.expectedError, err) {
+				t.Errorf(
+					"unexpected error\nexpected: %+v\nactual:   %+v\n",
+					test.expectedError,
+					err,
+				)
+			}
+
+			resolvedConfig := cfg.Bitcoin.Electrum
+			if !slices.Contains(test.expectedConfigs, resolvedConfig) {
+				t.Errorf(
+					"expected configs set doesn't contain resolved config\n"+
+						"expected: %+v\n"+
+						"actual:   %+v\n",
+					test.expectedConfigs,
+					resolvedConfig,
+				)
+			}
+		})
+	}
+}

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -48,6 +48,8 @@ KeyFile = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.20276
 
 [bitcoin.electrum]
 # URL to the Electrum server in format: `hostname:port`.
+# Should be uncommented only when using a custom Electrum server. Otherwise,
+# one of the default embedded servers is selected randomly at startup.
 URL = "electrumx.server.io:50001"
 
 # Electrum server connection protocol (`TCP` or `SSL`).

--- a/pkg/bitcoin/bitcoin.go
+++ b/pkg/bitcoin/bitcoin.go
@@ -43,3 +43,18 @@ const (
 	// Bitcoin specification.
 	ReversedByteOrder
 )
+
+// Network is a type used for Bitcoin networks enumeration.
+type Network int
+
+// Bitcoin networks enumeration.
+const (
+	Unknown Network = iota
+	Mainnet
+	Testnet
+	Regtest
+)
+
+func (n Network) String() string {
+	return []string{"unknown", "mainnet", "testnet", "regtest"}[n]
+}


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-core/issues/3565

Here we add some default Electrum configs that can be used for Bitcoin mainnet and testnet networks in case the Electrum `URL` is not explicitly provided in the `bitcoin.electrum` section of the configuration file. In such a case, one of the default embedded configs is picked up randomly.