### PR TITLE
Switch btc-difficulty electrum api url

### DIFF
--- a/infrastructure/kube/keep-prd/btc-difficulty/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/btc-difficulty/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
       - .secret/btc-difficulty-maintainer-keyfile
   - name: electrum-api-mainnet
     literals:
-      - electrumx-url-tcp=electrum.blockstream.info:50001
+      - electrumx-url-ssl=electrumx.default.svc.cluster.local:443
 
 secretGenerator:
   - name: btc-difficulty-maintainer-eth-accounts-password

--- a/infrastructure/kube/keep-prd/btc-difficulty/maintainer-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/btc-difficulty/maintainer-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: electrum-api-mainnet
-                  key: electrumx-url-tcp
+                  key: electrumx-url-ssl
           volumeMounts:
             - name: eth-account-keyfile
               mountPath: /mnt/btc-difficulty-maintainer/keyfile
@@ -70,4 +70,4 @@ spec:
             - --bitcoin.electrum.url
             - $(ELECTRUM_API_URL)
             - --bitcoin.electrum.protocol
-            - "TCP"
+            - "SSL"


### PR DESCRIPTION
We update electrum url for keep-prod to the electrumx node that is running in our cluster.
The previous blockstream's server is very unstable and keeps dropping the connection which outputs a lot of warnings in logs.