### PR TITLE
CLI for estimating deposit sweep Bitcoin fee

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -12,13 +12,14 @@ import (
 )
 
 var (
-	walletFlagName       = "wallet"
-	hideSweptFlagName    = "hide-swept"
-	sortByAmountFlagName = "sort-amount"
-	headFlagName         = "head"
-	tailFlagName         = "tail"
-	feeFlagName          = "fee"
-	dryRunFlagName       = "dry-run"
+	walletFlagName        = "wallet"
+	hideSweptFlagName     = "hide-swept"
+	sortByAmountFlagName  = "sort-amount"
+	headFlagName          = "head"
+	tailFlagName          = "tail"
+	feeFlagName           = "fee"
+	dryRunFlagName        = "dry-run"
+	depositsCountFlagName = "deposits-count"
 )
 
 // CoordinatorCommand contains the definition of tBTC Wallet Coordinator tools.
@@ -53,12 +54,12 @@ var listDepositsCommand = cobra.Command{
 
 		hideSwept, err := cmd.Flags().GetBool(hideSweptFlagName)
 		if err != nil {
-			return fmt.Errorf("failed to find show swept flag: %v", err)
+			return fmt.Errorf("failed to find hide swept flag: %v", err)
 		}
 
 		sortByAmount, err := cmd.Flags().GetBool(sortByAmountFlagName)
 		if err != nil {
-			return fmt.Errorf("failed to find show swept flag: %v", err)
+			return fmt.Errorf("failed to find sort by amount flag: %v", err)
 		}
 
 		head, err := cmd.Flags().GetInt(headFlagName)
@@ -132,7 +133,7 @@ var proposeDepositsSweepCommand = cobra.Command{
 
 		dryRun, err := cmd.Flags().GetBool(dryRunFlagName)
 		if err != nil {
-			return fmt.Errorf("failed to find fee flag: %v", err)
+			return fmt.Errorf("failed to find dry run flag: %v", err)
 		}
 
 		_, tbtcChain, _, _, _, err := ethereum.Connect(cmd.Context(), clientConfig.Ethereum)
@@ -158,6 +159,51 @@ Expects --wallet and --fee flags along with deposits to sweep provided
 as arguments.
 
 ` + coordinator.DepositsFormatDescription
+
+var estimateDepositsSweepFeeCommand = cobra.Command{
+	Use:              "estimate-deposits-sweep-fee",
+	Short:            "estimates deposits sweep fee",
+	Long:             estimateDepositsSweepFeeCommandDescription,
+	TraverseChildren: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		depositsCount, err := cmd.Flags().GetInt(depositsCountFlagName)
+		if err != nil {
+			return fmt.Errorf("failed to find deposits count flag: %v", err)
+		}
+
+		_, tbtcChain, _, _, _, err := ethereum.Connect(ctx, clientConfig.Ethereum)
+		if err != nil {
+			return fmt.Errorf(
+				"could not connect to Ethereum chain: [%v]",
+				err,
+			)
+		}
+
+		btcChain, err := electrum.Connect(ctx, clientConfig.Bitcoin.Electrum)
+		if err != nil {
+			return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
+		}
+
+		return coordinator.EstimateDepositsSweepFee(
+			tbtcChain,
+			btcChain,
+			depositsCount,
+		)
+	},
+}
+
+var estimateDepositsSweepFeeCommandDescription = "Estimates the satoshi fee for the entire Bitcoin deposits sweep " +
+	"transaction, based on the number of input deposits. By default, " +
+	"provides estimations for transactions containing a various number" +
+	"of input deposits, from 1 up to the maximum count allowed by the " +
+	"WalletCoordinator contract. The --deposits-count flag can be " +
+	"used to obtain a fee estimation for a Bitcoin sweep transaction" +
+	"containing a specific count of input deposits. All estimations" +
+	"assume the wallet main UTXO is used as one of the transaction's input" +
+	"so the estimation may be overpriced for the very first sweep " +
+	"transaction of each wallet."
 
 func init() {
 	initFlags(
@@ -224,4 +270,14 @@ func init() {
 	)
 
 	CoordinatorCommand.AddCommand(&proposeDepositsSweepCommand)
+
+	// Estimate Deposits Sweep Fee Subcommand.
+
+	estimateDepositsSweepFeeCommand.Flags().Int(
+		depositsCountFlagName,
+		0,
+		"get estimation for a specific count of input deposits",
+	)
+
+	CoordinatorCommand.AddCommand(&estimateDepositsSweepFeeCommand)
 }

--- a/pkg/bitcoin/chain.go
+++ b/pkg/bitcoin/chain.go
@@ -46,4 +46,8 @@ type Chain interface {
 	// that pays the given public key hash using either a P2PKH or P2WPKH script.
 	// The returned transactions are in an indefinite order.
 	GetMempoolForPublicKeyHash(publicKeyHash [20]byte) ([]*Transaction, error)
+
+	// EstimateSatPerVByteFee returns the estimated sat/vbyte fee for a
+	// transaction to be confirmed within the given number blocks.
+	EstimateSatPerVByteFee(blocks uint32) (int64, error)
 }

--- a/pkg/bitcoin/chain_test.go
+++ b/pkg/bitcoin/chain_test.go
@@ -1,9 +1,16 @@
 package bitcoin
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 type localChain struct {
-	transactions map[Hash]*Transaction
+	transactionsMutex sync.Mutex
+	transactions      map[Hash]*Transaction
+
+	satPerVByteFeeMutex sync.Mutex
+	satPerVByteFee      int64
 }
 
 func newLocalChain() *localChain {
@@ -15,6 +22,9 @@ func newLocalChain() *localChain {
 func (lc *localChain) GetTransaction(
 	transactionHash Hash,
 ) (*Transaction, error) {
+	lc.transactionsMutex.Lock()
+	defer lc.transactionsMutex.Unlock()
+
 	if transaction, exists := lc.transactions[transactionHash]; exists {
 		return transaction, nil
 	}
@@ -57,9 +67,30 @@ func (lc *localChain) GetMempoolForPublicKeyHash(
 	panic("not implemented")
 }
 
+func (lc *localChain) EstimateSatPerVByteFee(
+	blocks uint32,
+) (int64, error) {
+	lc.satPerVByteFeeMutex.Lock()
+	defer lc.satPerVByteFeeMutex.Unlock()
+
+	return lc.satPerVByteFee, nil
+}
+
+func (lc *localChain) setSatPerVByteFee(
+	satPerVByteFee int64,
+) {
+	lc.satPerVByteFeeMutex.Lock()
+	defer lc.satPerVByteFeeMutex.Unlock()
+
+	lc.satPerVByteFee = satPerVByteFee
+}
+
 func (lc *localChain) addTransaction(
 	transaction *Transaction,
 ) error {
+	lc.transactionsMutex.Lock()
+	defer lc.transactionsMutex.Unlock()
+
 	transactionHash := transaction.Hash()
 
 	if _, exists := lc.transactions[transactionHash]; exists {

--- a/pkg/bitcoin/estimator.go
+++ b/pkg/bitcoin/estimator.go
@@ -1,0 +1,218 @@
+package bitcoin
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/mempool"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
+
+// About half of all signatures generated with a random nonce are 72-byte, about
+// half are one byte smaller, and a small percentage are smaller than that.
+// For fee estimation purposes, we take the greatest possible value.
+var signaturePlaceholder = make([]byte, 72)
+
+// Compressed public keys have always 33 bytes.
+var publicKeyPlaceholder = make([]byte, 33)
+
+// TransactionSizeEstimator is a component allowing to estimate the size
+// of a Bitcoin transaction of the provided shape, without constructing it.
+type TransactionSizeEstimator struct {
+	internal *internalTransaction
+	err      error
+}
+
+func NewTransactionSizeEstimator() *TransactionSizeEstimator {
+	return &TransactionSizeEstimator{
+		internal: newInternalTransaction(),
+	}
+}
+
+// AddPublicKeyHashInputs adds the provided count of P2WPKH (isWitness is true)
+// or P2PKH (isWitness is false) inputs to the estimation. If the estimator
+// already errored out during previous actions, this method does nothing.
+func (tse *TransactionSizeEstimator) AddPublicKeyHashInputs(
+	count int,
+	isWitness bool,
+) *TransactionSizeEstimator {
+	if tse.err != nil {
+		return tse
+	}
+
+	var signatureScript []byte
+	var witness wire.TxWitness
+
+	if isWitness {
+		witness = wire.TxWitness{
+			signaturePlaceholder,
+			publicKeyPlaceholder,
+		}
+	} else {
+		var err error
+
+		signatureScript, err = txscript.NewScriptBuilder().
+			AddData(signaturePlaceholder).
+			AddData(publicKeyPlaceholder).
+			Script()
+		if err != nil {
+			tse.err = err
+			return tse
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		tse.internal.AddTxIn(
+			wire.NewTxIn(
+				wire.NewOutPoint((*chainhash.Hash)(&[32]byte{}), 0),
+				signatureScript,
+				witness,
+			),
+		)
+	}
+
+	return tse
+}
+
+// AddScriptHashInputs adds the provided count of P2WSH (isWitness is true)
+// or P2SH (isWitness is false) inputs to the estimation. The redeemScriptLength
+// argument should be used to pass the byte size of the plain-text redeem
+// script used to lock the inputs. If the estimator already errored out during
+// previous actions, this method does nothing.
+func (tse *TransactionSizeEstimator) AddScriptHashInputs(
+	count int,
+	redeemScriptLength int,
+	isWitness bool,
+) *TransactionSizeEstimator {
+	if tse.err != nil {
+		return tse
+	}
+
+	var signatureScript []byte
+	var witness wire.TxWitness
+
+	redeemScriptPlaceholder := make([]byte, redeemScriptLength)
+
+	if isWitness {
+		witness = wire.TxWitness{
+			signaturePlaceholder,
+			publicKeyPlaceholder,
+			redeemScriptPlaceholder,
+		}
+	} else {
+		var err error
+
+		signatureScript, err = txscript.NewScriptBuilder().
+			AddData(signaturePlaceholder).
+			AddData(publicKeyPlaceholder).
+			AddData(redeemScriptPlaceholder).
+			Script()
+		if err != nil {
+			tse.err = err
+			return tse
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		tse.internal.AddTxIn(
+			wire.NewTxIn(
+				wire.NewOutPoint((*chainhash.Hash)(&[32]byte{}), 0),
+				signatureScript,
+				witness,
+			),
+		)
+	}
+
+	return tse
+}
+
+// AddPublicKeyHashOutputs adds the provided count of P2WPKH (isWitness is true)
+// or P2PKH (isWitness is false) outputs to the estimation. If the estimator
+// already errored out during previous actions, this method does nothing.
+func (tse *TransactionSizeEstimator) AddPublicKeyHashOutputs(
+	count int,
+	isWitness bool,
+) *TransactionSizeEstimator {
+	if tse.err != nil {
+		return tse
+	}
+
+	var scriptPlaceholder []byte
+	var err error
+
+	if isWitness {
+		scriptPlaceholder, err = PayToWitnessPublicKeyHash([20]byte{})
+		if err != nil {
+			tse.err = err
+			return tse
+		}
+	} else {
+		scriptPlaceholder, err = PayToPublicKeyHash([20]byte{})
+		if err != nil {
+			tse.err = err
+			return tse
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		tse.internal.AddTxOut(
+			wire.NewTxOut(0, scriptPlaceholder),
+		)
+	}
+
+	return tse
+}
+
+// AddScriptHashOutputs adds the provided count of P2WSH (isWitness is true)
+// or P2SH (isWitness is false) outputs to the estimation. If the estimator
+// already errored out during previous actions, this method does nothing.
+func (tse *TransactionSizeEstimator) AddScriptHashOutputs(
+	count int,
+	isWitness bool,
+) *TransactionSizeEstimator {
+	if tse.err != nil {
+		return tse
+	}
+
+	var scriptPlaceholder []byte
+	var err error
+
+	if isWitness {
+		scriptPlaceholder, err = PayToWitnessScriptHash([32]byte{})
+		if err != nil {
+			tse.err = err
+			return tse
+		}
+	} else {
+		scriptPlaceholder, err = PayToScriptHash([20]byte{})
+		if err != nil {
+			tse.err = err
+			return tse
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		tse.internal.AddTxOut(
+			wire.NewTxOut(0, scriptPlaceholder),
+		)
+	}
+
+	return tse
+}
+
+// VirtualSize returns the virtual size of the transaction whose shape was
+// provided to the estimator. If any errors occurred while building the
+// transaction shape, the first error will be returned.
+//
+// Worth noting that the estimator can slightly overshoot the virtual size
+// estimation as it always assumes the greatest possible byte size of
+// signatures (72 bytes, see signaturePlaceholder docs) while actual
+// transactions can sometimes have shorter signatures (71 bytes or fewer in
+// very rare cases).
+func (tse *TransactionSizeEstimator) VirtualSize() (int64, error) {
+	if tse.err != nil {
+		return 0, tse.err
+	}
+
+	return mempool.GetTxVirtualSize(btcutil.NewTx(tse.internal.MsgTx)), nil
+}

--- a/pkg/bitcoin/estimator_test.go
+++ b/pkg/bitcoin/estimator_test.go
@@ -1,0 +1,87 @@
+package bitcoin
+
+import (
+	"github.com/keep-network/keep-core/pkg/internal/testutils"
+	"reflect"
+	"testing"
+)
+
+func TestTransactionSizeEstimator_VirtualSize(t *testing.T) {
+	var tests = map[string]struct {
+		estimator           *TransactionSizeEstimator
+		expectedVirtualSize int
+		expectedError       error
+	}{
+		// https://live.blockcypher.com/btc-testnet/tx/5b6d040eb06b3de1a819890d55d251112e55c31db4a3f5eb7cfacf519fad7adb
+		"1 P2WPKH input and 1 P2WSH input (92-byte redeem script) and 1 P2WPKH output": {
+			estimator: NewTransactionSizeEstimator().
+				AddPublicKeyHashInputs(1, true).
+				AddScriptHashInputs(1, 92, true).
+				AddPublicKeyHashOutputs(1, true),
+			expectedVirtualSize: 201,
+		},
+		// https://live.blockcypher.com/btc-testnet/tx/ef96519c30906e9a3aae45a1945777486c3bfc0426bf234704c688a60518425f
+		"1 P2WPKH input and 3 P2WSH inputs (92-byte redeem script) and 1 P2WPKH output": {
+			estimator: NewTransactionSizeEstimator().
+				AddPublicKeyHashInputs(1, true).
+				AddScriptHashInputs(3, 92, true).
+				AddPublicKeyHashOutputs(1, true),
+			expectedVirtualSize: 384,
+		},
+		// https://live.blockcypher.com/btc-testnet/tx/dc8e04cf284e1fd32d30d2874aba1227e82bb5678ee7c12dbb378442ce8dba9e
+		"1 P2WPKH input and 5 P2WSH inputs (92-byte redeem script) and 1 P2WPKH output": {
+			estimator: NewTransactionSizeEstimator().
+				AddPublicKeyHashInputs(1, true).
+				AddScriptHashInputs(5, 92, true).
+				AddPublicKeyHashOutputs(1, true),
+			expectedVirtualSize: 566,
+		},
+		// https://live.blockcypher.com/btc-testnet/tx/8751b14f847fe4b2b571b4b925f0faad09686b12a6da3fbadea9dcc9f2e299dc
+		"1 P2WPKH input and 10 P2WSH inputs (92-byte redeem script) and 1 P2WPKH output": {
+			estimator: NewTransactionSizeEstimator().
+				AddPublicKeyHashInputs(1, true).
+				AddScriptHashInputs(10, 92, true).
+				AddPublicKeyHashOutputs(1, true),
+			expectedVirtualSize: 1022,
+		},
+		// https://live.blockcypher.com/btc-testnet/tx/2a5d5f472e376dc28964e1b597b1ca5ee5ac042101b5199a3ca8dae2deec3538
+		"3 P2WSH inputs (92-byte redeem script) and 2 P2SH inputs (92-byte redeem script) and 1 P2WPKH output": {
+			estimator: NewTransactionSizeEstimator().
+				AddScriptHashInputs(3, 92, true).
+				AddScriptHashInputs(2, 92, false).
+				AddPublicKeyHashOutputs(1, true),
+			expectedVirtualSize: 800,
+		},
+		// https://live.blockcypher.com/btc-testnet/tx/2724545276df61f43f1e92c4b9f1dd3c9109595c022dbd9dc003efbad8ded38b
+		"1 P2WPKH input and 5 outputs (1 P2PKH, 2 P2WPKH, 1 P2SH, 1 P2WSH)": {
+			estimator: NewTransactionSizeEstimator().
+				AddPublicKeyHashInputs(1, true).
+				AddPublicKeyHashOutputs(1, false).
+				AddPublicKeyHashOutputs(2, true).
+				AddScriptHashOutputs(1, false).
+				AddScriptHashOutputs(1, true),
+			expectedVirtualSize: 250,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			virtualSize, err := test.estimator.VirtualSize()
+
+			if !reflect.DeepEqual(err, test.expectedError) {
+				t.Errorf(
+					"unexpected error\nexpected: [%v]\nactual:   [%v]\n",
+					test.expectedError,
+					err,
+				)
+			}
+
+			testutils.AssertIntsEqual(
+				t,
+				"virtual size",
+				test.expectedVirtualSize,
+				int(virtualSize),
+			)
+		})
+	}
+}

--- a/pkg/bitcoin/estimator_test.go
+++ b/pkg/bitcoin/estimator_test.go
@@ -85,3 +85,23 @@ func TestTransactionSizeEstimator_VirtualSize(t *testing.T) {
 		})
 	}
 }
+
+func TestTransactionFeeEstimator_EstimateFee(t *testing.T) {
+	chain := newLocalChain()
+
+	chain.setSatPerVByteFee(50)
+
+	estimator := NewTransactionFeeEstimator(chain)
+
+	fee, err := estimator.EstimateFee(250)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.AssertIntsEqual(
+		t,
+		"estimated fee",
+		12500,
+		int(fee),
+	)
+}

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1099,6 +1099,27 @@ func (tc *TbtcChain) BuildDepositKey(
 	return buildDepositKey(fundingTxHash, fundingOutputIndex)
 }
 
+func (tc *TbtcChain) GetDepositParameters() (
+	dustThreshold uint64,
+	treasuryFeeDivisor uint64,
+	txMaxFee uint64,
+	revealAheadPeriod uint32,
+	err error,
+) {
+	parameters, callErr := tc.bridge.DepositParameters()
+	if callErr != nil {
+		err = callErr
+		return
+	}
+
+	dustThreshold = parameters.DepositDustThreshold
+	treasuryFeeDivisor = parameters.DepositTreasuryFeeDivisor
+	txMaxFee = parameters.DepositTxMaxFee
+	revealAheadPeriod = parameters.DepositRevealAheadPeriod
+
+	return
+}
+
 func buildDepositKey(
 	fundingTxHash bitcoin.Hash,
 	fundingOutputIndex uint32,
@@ -1358,4 +1379,8 @@ func (tc *TbtcChain) SubmitDepositSweepProposalWithReimbursement(
 	)
 
 	return err
+}
+
+func (tc *TbtcChain) GetDepositSweepMaxSize() (uint16, error) {
+	return tc.walletCoordinator.DepositSweepMaxSize()
 }

--- a/pkg/maintainer/bitcoin_chain_test.go
+++ b/pkg/maintainer/bitcoin_chain_test.go
@@ -2,7 +2,6 @@ package maintainer
 
 import (
 	"fmt"
-
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 )
 
@@ -94,6 +93,12 @@ func (lc *localBitcoinChain) SetBlockHeaders(
 	blockHeaders map[uint]*bitcoin.BlockHeader,
 ) {
 	lc.blockHeaders = blockHeaders
+}
+
+func (lc *localBitcoinChain) EstimateSatPerVByteFee(
+	blocks uint32,
+) (int64, error) {
+	panic("unsupported")
 }
 
 // connectLocalBitcoinChain connects to the local Bitcoin chain and returns

--- a/pkg/tbtc/bitcoin_chain_test.go
+++ b/pkg/tbtc/bitcoin_chain_test.go
@@ -145,3 +145,9 @@ func (lbc *localBitcoinChain) GetMempoolForPublicKeyHash(
 
 	return matchingTransactions, nil
 }
+
+func (lbc *localBitcoinChain) EstimateSatPerVByteFee(
+	blocks uint32,
+) (int64, error) {
+	panic("unsupported")
+}

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -210,8 +210,18 @@ type BridgeChain interface {
 	ComputeMainUtxoHash(mainUtxo *bitcoin.UnspentTransactionOutput) [32]byte
 
 	// BuildDepositKey calculates a deposit key for the given funding transaction
-	// which is an unique identifier for a deposit on-chain.
+	// which is a unique identifier for a deposit on-chain.
 	BuildDepositKey(fundingTxHash bitcoin.Hash, fundingOutputIndex uint32) *big.Int
+
+	// GetDepositParameters gets the current value of parameters relevant
+	// for the depositing process.
+	GetDepositParameters() (
+		dustThreshold uint64,
+		treasuryFeeDivisor uint64,
+		txMaxFee uint64,
+		revealAheadPeriod uint32,
+		err error,
+	)
 }
 
 // HeartbeatRequestedEvent represents a Bridge heartbeat request event.
@@ -338,6 +348,10 @@ type WalletCoordinatorChain interface {
 	SubmitDepositSweepProposalWithReimbursement(
 		proposal *DepositSweepProposal,
 	) error
+
+	// GetDepositSweepMaxSize gets the maximum number of deposits that can
+	// be part of a deposit sweep proposal.
+	GetDepositSweepMaxSize() (uint16, error)
 }
 
 // HeartbeatRequestSubmittedEvent represents a wallet heartbeat request

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -563,6 +563,16 @@ func (lc *localChain) BuildDepositKey(
 	return new(big.Int).SetBytes(depositKeyBytes[:])
 }
 
+func (lc *localChain) GetDepositParameters() (
+	dustThreshold uint64,
+	treasuryFeeDivisor uint64,
+	txMaxFee uint64,
+	revealAheadPeriod uint32,
+	err error,
+) {
+	panic("unsupported")
+}
+
 func buildDepositRequestKey(
 	fundingTxHash bitcoin.Hash,
 	fundingOutputIndex uint32,
@@ -741,6 +751,10 @@ func buildDepositSweepProposalValidationKey(
 func (lc *localChain) SubmitDepositSweepProposalWithReimbursement(
 	proposal *DepositSweepProposal,
 ) error {
+	panic("unsupported")
+}
+
+func (lc *localChain) GetDepositSweepMaxSize() (uint16, error) {
 	panic("unsupported")
 }
 


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-core/issues/3562

Here we introduce the CLI command allowing us to estimate fees for deposit sweep Bitcoin transactions. 

To estimate fees for all possible deposit sweep transactions (from 1 deposit up to the maximum sweep size allowed by the `WalletCoordinator` contract), invoke:
```
keep-client coordinator estimate-deposits-sweep-fee
```
Following flags can be used with the command:

- `--deposits-count <number>` - get the fee estimate only for deposit sweep transaction containing the specific count of deposits inputs

The command requires `ethereum` and `bitcoin` node details to be provided in the config.

### Examples
Sample execution of the command for Goerli network:
```
 ./keep-client --config ./configs/config.toml \
    --goerli \
    coordinator \
    estimate-deposits-sweep-fee 
```
Output:
```
 deposits count fee (satoshis)
              1            201
              2            292
              3            384
              4            475
              5            566
              6            657
              7            749
              8            840
              9            931
             10           1022
             11           1114
             12           1205
             13           1296
             14           1387
             15           1479
             16           1570
             17           1661
             18           1752
             19           1844
             20           1935

```

Sample execution of the command with `--deposits-count` flag for Goerli network:
```
 ./keep-client --config ./configs/config.toml \
    --goerli \
    coordinator \
    estimate-deposits-sweep-fee \
    --deposits-count 5
```
Output:
```
 deposits count fee (satoshis)
              5            566
```