### PR TITLE
Electrum servers list updates

### DIFF
--- a/config/_electrum_urls/mainnet
+++ b/config/_electrum_urls/mainnet
@@ -1,1 +1,3 @@
+wss://electrumx-server.tbtc.network:8443
+wss://electrum.boar.network:2083
 ssl://electrum.blockstream.info:50002

--- a/config/_electrum_urls/mainnet
+++ b/config/_electrum_urls/mainnet
@@ -1,3 +1,4 @@
 wss://electrumx-server.tbtc.network:8443
 wss://electrum.boar.network:2083
+wss://bitcoin.threshold.p2p.org:50004
 ssl://electrum.blockstream.info:50002

--- a/config/_electrum_urls/testnet
+++ b/config/_electrum_urls/testnet
@@ -1,1 +1,2 @@
+wss://electrumx-server.test.tbtc.network:8443
 ssl://electrum.blockstream.info:60002

--- a/config/config.go
+++ b/config/config.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/keep-network/keep-core/config/network"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -148,7 +150,7 @@ func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categ
 	}
 
 	// Resolve Electrum server.
-	err = c.resolveElectrum()
+	err = c.resolveElectrum(rand.New(rand.NewSource(time.Now().UnixNano())))
 	if err != nil {
 		return fmt.Errorf("failed to resolve Electrum: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -150,6 +150,8 @@ func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categ
 	}
 
 	// Resolve Electrum server.
+	// #nosec G404 (insecure random number source (rand))
+	// Picking up an Electrum server does not require secure randomness.
 	err = c.resolveElectrum(rand.New(rand.NewSource(time.Now().UnixNano())))
 	if err != nil {
 		return fmt.Errorf("failed to resolve Electrum: %w", err)

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -38,7 +38,7 @@ func readElectrumUrls(network bitcoin.Network) (
 // resolveElectrum checks if Electrum is already configured. If the Electrum URL
 // is empty it reads the Electrum configs from the embedded list for the given
 // network and picks up one randomly.
-func (c *Config) resolveElectrum() error {
+func (c *Config) resolveElectrum(rng *rand.Rand) error {
 	network := c.Bitcoin.Network
 
 	// Return if Electrum is already set.
@@ -70,7 +70,7 @@ func (c *Config) resolveElectrum() error {
 
 	// #nosec G404 (insecure random number source (rand))
 	// Picking up an Electrum server does not require secure randomness.
-	selectedURL := urls[rand.Intn(len(urls))]
+	selectedURL := urls[rng.Intn(len(urls))]
 
 	// Set only the URL in the original config. Other fields may be already set,
 	// and we don't want to override them.

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 )
 
 //go:embed _electrum_urls/*
 var electrumURLs embed.FS
+
+// Keep Alive Interval value used for Blockstream's electrum connections.
+// This value is used only if a Blockstream's server is randomly selected from
+// the list of embedded Electrum servers. It does not apply if a Blockstream's
+// server connection is explicitly set in the client's configuration.
+var blockstreamKeepAliveInterval = 55 * time.Second
 
 // readElectrumUrls reads Electrum URLs from an embedded file for the
 // given Bitcoin network.
@@ -68,6 +75,15 @@ func (c *Config) resolveElectrum() error {
 	// Set only the URL in the original config. Other fields may be already set,
 	// and we don't want to override them.
 	c.Bitcoin.Electrum.URL = selectedURL
+
+	// Blockstream's servers timeout session after 60 seconds of inactivity which
+	// is much shorter than expected 600 seconds. To workaround connection drops
+	// and logs pollution with warning we reduce the KeepAliveInterval for the
+	// Blockstream's servers to less than 60 seconds.
+	if c.Bitcoin.Electrum.KeepAliveInterval == 0 &&
+		strings.Contains(selectedURL, "electrum.blockstream.info") {
+		c.Bitcoin.Electrum.KeepAliveInterval = blockstreamKeepAliveInterval
+	}
 
 	return nil
 }

--- a/config/electrum_integration_test.go
+++ b/config/electrum_integration_test.go
@@ -1,0 +1,38 @@
+// go:build integration
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
+)
+
+var testBitcoinNetworks = []bitcoin.Network{bitcoin.Testnet, bitcoin.Mainnet}
+
+func TestEmbeddedElectrumServerConnect_Integration(t *testing.T) {
+	for _, bitcoinNetwork := range testBitcoinNetworks {
+		urls, err := readElectrumUrls(bitcoinNetwork)
+		if err != nil {
+			t.Error(err)
+		}
+
+		for _, url := range urls {
+			t.Run(fmt.Sprintf("%s/%s", bitcoinNetwork, url), func(t *testing.T) {
+				newTestConnection(t, url)
+			})
+		}
+	}
+}
+
+func newTestConnection(t *testing.T, url string) bitcoin.Chain {
+	electrum, err := electrum.Connect(context.Background(), electrum.Config{URL: url})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return electrum
+}

--- a/config/electrum_test.go
+++ b/config/electrum_test.go
@@ -26,6 +26,9 @@ func TestResolveElectrum(t *testing.T) {
 					URL: "wss://electrum.boar.network:2083",
 				},
 				{
+					URL: "wss://bitcoin.threshold.p2p.org:50004",
+				},
+				{
 					URL:               "ssl://electrum.blockstream.info:50002",
 					KeepAliveInterval: 55 * time.Second,
 				},

--- a/config/electrum_test.go
+++ b/config/electrum_test.go
@@ -1,60 +1,98 @@
 package config
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/go-test/deep"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
 )
 
 func TestResolveElectrum(t *testing.T) {
-	var tests = map[string]struct {
-		network       bitcoin.Network
-		expectedURL   string
-		expectedError error
+	var tests = map[bitcoin.Network]struct {
+		expectedConfig []electrum.Config
+		expectedError  error
 	}{
-		"mainnet network": {
-			network:     bitcoin.Mainnet,
-			expectedURL: "ssl://electrum.blockstream.info:50002",
+		bitcoin.Mainnet: {
+			expectedConfig: []electrum.Config{
+				{
+					URL: "wss://electrumx-server.tbtc.network:8443",
+				},
+				{
+					URL: "wss://electrum.boar.network:2083",
+				},
+				{
+					URL:               "ssl://electrum.blockstream.info:50002",
+					KeepAliveInterval: 55 * time.Second,
+				},
+			},
 		},
-		"testnet network": {
-			network:     bitcoin.Testnet,
-			expectedURL: "ssl://electrum.blockstream.info:60002",
+		bitcoin.Testnet: {
+			expectedConfig: []electrum.Config{
+				{
+					URL: "wss://electrumx-server.test.tbtc.network:8443",
+				},
+				{
+					URL:               "ssl://electrum.blockstream.info:60002",
+					KeepAliveInterval: 55 * time.Second,
+				},
+			}},
+		bitcoin.Regtest: {
+			expectedConfig: []electrum.Config{
+				{
+					URL:               "",
+					KeepAliveInterval: 0,
+				},
+			},
 		},
-		"regtest network": {
-			network:     bitcoin.Regtest,
-			expectedURL: "",
-		},
-		"unknown network": {
-			network:     bitcoin.Unknown,
-			expectedURL: "",
+		bitcoin.Unknown: {
+			expectedConfig: []electrum.Config{
+				{
+					URL:               "",
+					KeepAliveInterval: 0,
+				},
+			},
 		},
 	}
 
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			cfg := &Config{}
-			cfg.Bitcoin.Network = test.network
+	for bitcoinNetwork, test := range tests {
+		t.Run(bitcoinNetwork.String(), func(t *testing.T) {
+			for i, expectedConfig := range test.expectedConfig {
+				rand := rand.New(&fakeRandSource{int64(i)})
 
-			err := cfg.resolveElectrum()
-			if !reflect.DeepEqual(test.expectedError, err) {
-				t.Errorf(
-					"unexpected error\nexpected: %+v\nactual:   %+v\n",
-					test.expectedError,
-					err,
-				)
-			}
+				cfg := &Config{}
+				cfg.Bitcoin.Network = bitcoinNetwork
 
-			resolvedConfig := cfg.Bitcoin.Electrum
-			if !reflect.DeepEqual(test.expectedURL, resolvedConfig.URL) {
-				t.Errorf(
-					"expected URL doesn't match resolved URL\n"+
-						"expected: %+v\n"+
-						"actual:   %+v\n",
-					test.expectedURL,
-					resolvedConfig.URL,
-				)
+				err := cfg.resolveElectrum(rand)
+				if !reflect.DeepEqual(test.expectedError, err) {
+					t.Errorf(
+						"unexpected error\nexpected: %+v\nactual:   %+v\n",
+						test.expectedError,
+						err,
+					)
+				}
+
+				resolvedConfig := cfg.Bitcoin.Electrum
+
+				if diff := deep.Equal(resolvedConfig, expectedConfig); diff != nil {
+					t.Errorf("compare failed: %v", diff)
+				}
 			}
 		})
 	}
+}
+
+type fakeRandSource struct {
+	expectedValue int64
+}
+
+func (s *fakeRandSource) Int63() int64 {
+	return s.expectedValue << 32
+}
+func (s *fakeRandSource) Seed(expectedValue int64) {
+	s.expectedValue = expectedValue
 }

--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -24,14 +24,6 @@ import (
 
 const timeout = 2 * time.Second
 
-type serverImplementation int
-
-const (
-	electrumX serverImplementation = iota
-	fulcrum
-	esploraElectrs
-)
-
 type testConfig struct {
 	clientConfig  Config
 	errorMessages expectedErrorMessages


### PR DESCRIPTION
### Blockstream's Servers Keep Alive Interval (ba416cedb989b0eebc8768ec7fc56de662647803)
Blockstream's servers timeout session after 60 seconds of inactivity which
is much shorter than the expected 600 seconds (see: [Electrum Protocol Docs](https://electrumx-spesmilo.readthedocs.io/en/latest/environment.html#envvar-SESSION_TIMEOUT)).
To workaround connection drops and logs pollution with warnings, we reduce the
`KeepAliveInterval` for Blockstream's servers to less than 60 seconds.
 
### Integration Tests for Embedded Electrum Servers (a288918fc657a779ec09b0b8b14a4bd1a80c4468)
We add an integration test to check the client can establish a connection to the embedded servers.

To run it execute:
```
go test -v -tags=integration ./config -run TestEmbeddedElectrumServerConnect_Integration
```

### Add Electrum Servers (e677fc312c87febe1080d69db3c11e5883dd6847)

We add more servers to the Electrum Servers list.