### PR TITLE
Fix problem with missing `typechain`

### DIFF
--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "18.16.0"
           cache: "yarn"
           cache-dependency-path: solidity/random-beacon/yarn.lock
 


### PR DESCRIPTION
We want to fix problem with the `yarn build` (`hardhat compile`) command sometimes not generating expected artifacts (see for example [this](https://github.com/keep-network/keep-core/actions/runs/5116205979/jobs/9198133851) workflow). The problem is likely caused by the process silently quitting, which may be related to the used version of Node (as suggested in https://github.com/NomicFoundation/hardhat/issues/3877). We're verifying this by first setting the version to `18.16.0`, which is the version on which we observed the failure. If we make sure the problem is reproducible, we will try downgrading to see if it fixes the issue.