### PR TITLE
Print Electrum URL in the logs

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
 
 	"github.com/spf13/cobra"
@@ -58,11 +59,6 @@ Environment variables:
 // start starts a node
 func start(cmd *cobra.Command) error {
 	ctx := context.Background()
-
-	logger.Infof(
-		"Starting the client against [%s] ethereum network...",
-		clientConfig.Ethereum.Network,
-	)
 
 	beaconChain, tbtcChain, blockCounter, signing, operatorPrivateKey, err :=
 		ethereum.Connect(ctx, clientConfig.Ethereum)

--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,12 @@ func (c *Config) resolveNetworks(flagSet *pflag.FlagSet) (network.Type, error) {
 	c.Ethereum.Network = clientNetwork.Ethereum()
 	c.Bitcoin.Network = clientNetwork.Bitcoin()
 
+	logger.Infof(
+		"using [%v] Ethereum network and [%v] Bitcoin network",
+		c.Ethereum.Network,
+		c.Bitcoin.Network,
+	)
+
 	return clientNetwork, err
 }
 

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -65,6 +65,8 @@ func (c *Config) resolveElectrum() error {
 	// Picking up an Electrum server does not require secure randomness.
 	selectedURL := urls[rand.Intn(len(urls))]
 
+	logger.Infof("Auto-selecting Electrum server: [%v]", selectedURL)
+
 	// Set only the URL in the original config. Other fields may be already set,
 	// and we don't want to override them.
 	c.Bitcoin.Electrum.URL = selectedURL

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -72,7 +72,7 @@ func (c *Config) resolveElectrum(rng *rand.Rand) error {
 	// Picking up an Electrum server does not require secure randomness.
 	selectedURL := urls[rng.Intn(len(urls))]
 
-	logger.Infof("Auto-selecting Electrum server: [%v]", selectedURL)
+	logger.Infof("auto-selecting Electrum server: [%v]", selectedURL)
 
 	// Set only the URL in the original config. Other fields may be already set,
 	// and we don't want to override them.

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -679,7 +679,8 @@ func (c *Connection) verifyServer() error {
 	}
 
 	logger.Infof(
-		"connected to electrum server [version: [%s], protocol: [%s]]",
+		"connected to [%s] electrum server [version: [%s], protocol: [%s]]",
+		c.config.URL,
 		server.version,
 		server.protocol,
 	)

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -679,8 +679,7 @@ func (c *Connection) verifyServer() error {
 	}
 
 	logger.Infof(
-		"connected to [%s] electrum server [version: [%s], protocol: [%s]]",
-		c.config.URL,
+		"connected to electrum server [version: [%s], protocol: [%s]]",
 		server.version,
 		server.protocol,
 	)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ OPENZEPPELIN_MANIFEST=".openzeppelin/unknown-*.json"
 # This number should be no less than the highest index assigned to a named account
 # specified in `hardhat.config.ts` configs across all the used projects. Note that
 # account indices start from 0.
-REQUIRED_ACCOUNTS_NUMBER=8
+REQUIRED_ACCOUNTS_NUMBER=11
 
 # Defaults, can be overwritten by env variables/input parameters
 NETWORK_DEFAULT="development"


### PR DESCRIPTION
Unless specified in the config, mainnet client binary selects the Electrum server from one of the preconfigured nodes. It is nice to know which server was selected, even for debugging purposes. Additionally, we should log both Bitcoin and Ethereum networks used by the client. Electrum server URL is printed to the logs only if it has been auto-selected. This approach is consistent with not logging Ethereum server URL at all given we expect it is passed in the configuration.

I snaked one more change in this PR: fixed the number of accounts requirement in `scripts/install.sh`. Given the recent changes in tbtc-v2 project, at least 11 accounts are required in the local Ethereum client keystore to deploy and initialize contracts.

The `v1Redeemer` [set in tbtc-v2 `hardhat.config.ts`](https://github.com/keep-network/tbtc-v2/blob/7f48d6362f8bfc9a2931c4087e5eba28efee5370/solidity/hardhat.config.ts#L227) uses index 10 and indexes start from 0.

Example:
```
2023-06-05T08:54:24.185+0200    INFO    keep-config     config/config.go:95     using [mainnet] Ethereum network and [mainnet] Bitcoin network
2023-06-05T08:54:24.187+0200    INFO    keep-config     config/electrum.go:68   Auto-selecting Electrum server: [ssl://electrum.blockstream.info:50002]
```