### PR TITLE
Client initialization order juggle

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -114,7 +114,7 @@ func start(cmd *cobra.Command) error {
 	// Initialize beacon and tbtc only for non-bootstrap nodes.
 	// Skip initialization for bootstrap nodes as they are only used for network
 	// discovery.
-	if !clientConfig.LibP2P.Bootstrap {
+	if !isBootstrap() {
 		btcChain, err := electrum.Connect(ctx, clientConfig.Bitcoin.Electrum)
 		if err != nil {
 			return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
@@ -189,6 +189,9 @@ func start(cmd *cobra.Command) error {
 	return fmt.Errorf("shutting down the node because its context has ended")
 }
 
+func isBootstrap() bool {
+	return clientConfig.LibP2P.Bootstrap
+}
 func initializeClientInfo(
 	ctx context.Context,
 	config *config.Config,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,13 +80,6 @@ func start(cmd *cobra.Command) error {
 		return fmt.Errorf("cannot initialize network: [%v]", err)
 	}
 
-	nodeHeader(
-		netProvider.ConnectionManager().AddrStrings(),
-		beaconChain.Signing().Address().String(),
-		clientConfig.LibP2P.Port,
-		clientConfig.Ethereum,
-	)
-
 	clientInfoRegistry := initializeClientInfo(
 		ctx,
 		clientConfig,
@@ -140,6 +133,13 @@ func start(cmd *cobra.Command) error {
 			return fmt.Errorf("error initializing TBTC: [%v]", err)
 		}
 	}
+
+	nodeHeader(
+		netProvider.ConnectionManager().AddrStrings(),
+		beaconChain.Signing().Address().String(),
+		clientConfig.LibP2P.Port,
+		clientConfig.Ethereum,
+	)
 
 	<-ctx.Done()
 	return fmt.Errorf("shutting down the node because its context has ended")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,7 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+
+	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/storage"
 
 	"github.com/spf13/cobra"
 
@@ -18,7 +22,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
-	"github.com/keep-network/keep-core/pkg/storage"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -105,7 +105,7 @@ func start(cmd *cobra.Command) error {
 			tbtcDataPersistence,
 			err := initializePersistence()
 		if err != nil {
-			return fmt.Errorf("cannot initialize persistance: [%w]", err)
+			return fmt.Errorf("cannot initialize persistence: [%w]", err)
 		}
 
 		scheduler := generator.StartScheduler()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -104,40 +104,12 @@ func start(cmd *cobra.Command) error {
 			return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
 		}
 
-		storage, err := storage.Initialize(
-			clientConfig.Storage,
-			clientConfig.Ethereum.KeyFilePassword,
-		)
+		beaconKeyStorePersistence,
+			tbtcKeyStorePersistence,
+			tbtcDataPersistence,
+			err := initializePersistence()
 		if err != nil {
-			return fmt.Errorf("cannot initialize storage: [%w]", err)
-		}
-
-		beaconKeyStorePersistence, err := storage.InitializeKeyStorePersistence(
-			"beacon",
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"cannot initialize beacon keystore persistence: [%w]",
-				err,
-			)
-		}
-
-		tbtcKeyStorePersistence, err := storage.InitializeKeyStorePersistence(
-			"tbtc",
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"cannot initialize tbtc keystore persistence: [%w]",
-				err,
-			)
-		}
-
-		tbtcDataPersistence, err := storage.InitializeWorkPersistence("tbtc")
-		if err != nil {
-			return fmt.Errorf(
-				"cannot initialize tbtc data persistence: [%w]",
-				err,
-			)
+			return fmt.Errorf("cannot initialize persistance: [%w]", err)
 		}
 
 		scheduler := generator.StartScheduler()
@@ -257,4 +229,49 @@ func initializeClientInfo(
 	)
 
 	return registry
+}
+
+func initializePersistence() (
+	beaconKeyStorePersistence persistence.ProtectedHandle,
+	tbtcKeyStorePersistence persistence.ProtectedHandle,
+	tbtcDataPersistence persistence.BasicHandle,
+	err error,
+) {
+	storage, err := storage.Initialize(
+		clientConfig.Storage,
+		clientConfig.Ethereum.KeyFilePassword,
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("cannot initialize storage: [%w]", err)
+	}
+
+	beaconKeyStorePersistence, err = storage.InitializeKeyStorePersistence(
+		"beacon",
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf(
+			"cannot initialize beacon keystore persistence: [%w]",
+			err,
+		)
+	}
+
+	tbtcKeyStorePersistence, err = storage.InitializeKeyStorePersistence(
+		"tbtc",
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf(
+			"cannot initialize tbtc keystore persistence: [%w]",
+			err,
+		)
+	}
+
+	tbtcDataPersistence, err = storage.InitializeWorkPersistence("tbtc")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf(
+			"cannot initialize tbtc data persistence: [%w]",
+			err,
+		)
+	}
+
+	return
 }


### PR DESCRIPTION
In this PR we improve client initialization for the start command to reduce confusion.
The node header with the fancy ASCII art will print only after all the modules are initialized successfully.