### PR TITLE
Increase single DKG attempt timeout by 50 blocks

### DIFF
--- a/pkg/tbtc/dkg_loop.go
+++ b/pkg/tbtc/dkg_loop.go
@@ -26,7 +26,7 @@ const (
 	dkgAttemptAnnouncementActiveBlocks = 5
 	// dkgAttemptProtocolBlocks determines the maximum block duration of the
 	// actual protocol computations.
-	dkgAttemptMaximumProtocolBlocks = 150
+	dkgAttemptMaximumProtocolBlocks = 200
 	// dkgAttemptCoolDownBlocks determines the duration of the cool down
 	// period that is preserved between subsequent DKG attempts.
 	dkgAttemptCoolDownBlocks = 5

--- a/pkg/tbtc/dkg_loop_test.go
+++ b/pkg/tbtc/dkg_loop_test.go
@@ -80,7 +80,7 @@ func TestDkgRetryLoop(t *testing.T) {
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 1,
 				startBlock:             206,
-				timeoutBlock:           356, // start block + 150
+				timeoutBlock:           406, // start block + 200
 				excludedMembersIndexes: []group.MemberIndex{},
 			},
 		},
@@ -104,7 +104,7 @@ func TestDkgRetryLoop(t *testing.T) {
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 1,
 				startBlock:             206,
-				timeoutBlock:           356, // start block + 150
+				timeoutBlock:           406, // start block + 200
 				excludedMembersIndexes: []group.MemberIndex{9, 10},
 			},
 		},
@@ -130,8 +130,8 @@ func TestDkgRetryLoop(t *testing.T) {
 			// readiness.
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 2,
-				startBlock:             367, // 206 + 1 * (6 + 150 + 5)
-				timeoutBlock:           517, // start block + 150
+				startBlock:             417, // 206 + 1 * (6 + 200 + 5)
+				timeoutBlock:           617, // start block + 200
 				excludedMembersIndexes: []group.MemberIndex{2, 5},
 			},
 		},
@@ -155,8 +155,8 @@ func TestDkgRetryLoop(t *testing.T) {
 			// First attempt fails due to the announcer error.
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 2,
-				startBlock:             367, // 206 + 1 * (6 + 150 + 5)
-				timeoutBlock:           517, // start block + 150
+				startBlock:             417, // 206 + 1 * (6 + 200 + 5)
+				timeoutBlock:           617, // start block + 200
 				excludedMembersIndexes: []group.MemberIndex{2, 5},
 			},
 		},
@@ -183,8 +183,8 @@ func TestDkgRetryLoop(t *testing.T) {
 			// given seed.
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 2,
-				startBlock:             367, // 206 + 1 * (6 + 150 + 5)
-				timeoutBlock:           517, // start block + 150
+				startBlock:             417, // 206 + 1 * (6 + 200 + 5)
+				timeoutBlock:           617, // start block + 150
 				excludedMembersIndexes: []group.MemberIndex{2, 5},
 			},
 		},
@@ -211,8 +211,8 @@ func TestDkgRetryLoop(t *testing.T) {
 			// member 5 skips attempt 2 and succeeds on attempt 3.
 			expectedLastAttempt: &dkgAttemptParams{
 				number:                 3,
-				startBlock:             528, // 206 + 2 * (6 + 150 + 5)
-				timeoutBlock:           678, // start block + 150
+				startBlock:             628, // 206 + 2 * (6 + 200 + 5)
+				timeoutBlock:           828, // start block + 200
 				excludedMembersIndexes: []group.MemberIndex{9},
 			},
 		},

--- a/solidity/ecdsa/contracts/WalletRegistry.sol
+++ b/solidity/ecdsa/contracts/WalletRegistry.sol
@@ -323,9 +323,9 @@ contract WalletRegistry is
         //
         // DKG result submission timeout covers:
         // - 20 blocks required to confirm the DkgStarted event off-chain
-        // - 5 retries of the off-chain protocol that takes 161 blocks at most
+        // - 5 retries of the off-chain protocol that takes 211 blocks at most
         // - 15 blocks to submit the result for each of the 100 members
-        // That gives: 20 + (5 * 161) + (15 * 100) = 2325
+        // That gives: 20 + (5 * 211) + (15 * 100) = 2575
         //
         //
         // The original DKG result submitter has 20 blocks to approve it before
@@ -337,7 +337,7 @@ contract WalletRegistry is
         dkg.setSeedTimeout(11_520);
         dkg.setResultChallengePeriodLength(11_520);
         dkg.setResultChallengeExtraGas(50_000);
-        dkg.setResultSubmissionTimeout(2325);
+        dkg.setResultSubmissionTimeout(2575);
         dkg.setSubmitterPrecedencePeriodLength(20);
 
         // Gas parameters were adjusted based on Ethereum state in April 2022.


### PR DESCRIPTION
❗ This will require governance transaction to the `WalletRegistry` contract deployed on mainnet. This will be tracked in a separate issue.



Benchmarks with 4 clients on Applie M1 Max with 10 cores. Each client configured with key generation concurrency set to 2.

Before the recent changes

DKG duration | Round 2 duration
-- | --
0:17:24 | 0:15:32
0:16:51 | 0:14:38
0:17:46 | 0:15:34
0:17:18 | 0:15:38
0:17:39 | 0:15:42

After the recent changes

DKG duration | Round 2 duration
-- | --
0:28:38 | 0:25:39
0:28:31 | 0:25:24
0:29:26 | 0:26:05
0:29:06 | 0:25:45
0:28:47 | 0:25:19
0:28:10 | 0:25:09
0:28:30 | 0:25:22
0:29:06 | 0:25:16
0:28:21 | 0:25:18
0:28:55 | 0:25:29
0:28:06 | 0:25:12
0:29:20 | 0:26:15
0:29:22 | 0:26:31
0:29:19 | 0:26:09
