### PR TITLE
Update btc difficulty maintainer k8s config

### DIFF
--- a/infrastructure/kube/keep-prd/btc-difficulty/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/btc-difficulty/kustomization.yaml
@@ -12,9 +12,9 @@ configMapGenerator:
   - name: btc-difficulty-maintainer-eth-accounts-info
     files:
       - .secret/btc-difficulty-maintainer-keyfile
-  - name: electrum-api-mainnet
+  - name: btc-difficulty-maintainer
     literals:
-      - electrumx-url-ssl=electrumx.default.svc.cluster.local:443
+      - electrum-url=tcp://electrumx.bitcoin:80
 
 secretGenerator:
   - name: btc-difficulty-maintainer-eth-accounts-password

--- a/infrastructure/kube/keep-prd/btc-difficulty/maintainer-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/btc-difficulty/maintainer-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
                 path: btc-difficulty-maintainer-keyfile
       containers:
         - name: btc-difficulty-maintainer
-          image: gcr.io/keep-prd-210b/keep-client:latest
+          image: gcr.io/keep-prd-210b/keep-client:v2.0.0-m3
           imagePullPolicy: Always
           resources:
             requests:
@@ -52,8 +52,8 @@ spec:
             - name: ELECTRUM_API_URL
               valueFrom:
                 configMapKeyRef:
-                  name: electrum-api-mainnet
-                  key: electrumx-url-ssl
+                  name: btc-difficulty-maintainer
+                  key: electrum-url
           volumeMounts:
             - name: eth-account-keyfile
               mountPath: /mnt/btc-difficulty-maintainer/keyfile
@@ -62,12 +62,9 @@ spec:
             - maintainer
           args:
             - --bitcoinDifficulty
-            - --mainnet
             - --ethereum.url
             - $(ETH_WS_URL)
             - --ethereum.keyFile
             - /mnt/btc-difficulty-maintainer/keyfile/btc-difficulty-maintainer-keyfile
             - --bitcoin.electrum.url
             - $(ELECTRUM_API_URL)
-            - --bitcoin.electrum.protocol
-            - "SSL"


### PR DESCRIPTION
Switch to the latest version of the keep-client released under `v2.0.0-m3` tag.

This version has two changes affecting the k8s configuration:
- `--mainnet` flag got deprecated,
- electrum protocol is now included in the URL.

We also took a chance to define the electrum url in a dedicated config map, and simplified the URL to `electrumx.bitcoin` which is how kubernetes exposes the service internally.

We switched to tcp URL, as SSL is not working due to outdated certificate.