### PR TITLE
Align keep-clients in keep-test with m3 changes

### DIFF
--- a/infrastructure/kube/keep-test/keep-client/gen/template.yaml
+++ b/infrastructure/kube/keep-test/keep-client/gen/template.yaml
@@ -85,7 +85,7 @@ spec:
               mountPath: /mnt/keep-client/keyfile
           command: ["keep-client", "start"]
           args:
-            - --goerli
+            - --testnet
             - --ethereum.url
             - $(ETH_WS_URL)
             - "--ethereum.keyFile"

--- a/infrastructure/kube/keep-test/keep-client/keep-client-config.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-client-config.yaml
@@ -7,4 +7,4 @@ data:
   LOG_LEVEL: "keep*=info tss-lib=warn"
   GOLOG_LOG_FMT: json
   # GOLOG_OUTPUT: stdout
-  ELECTRUM_TCP_URL: electrumx.default.svc.cluster.local:80
+  ELECTRUM_TCP_URL: tcp://electrumx.bitcoin-testnet:80

--- a/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
+++ b/infrastructure/kube/keep-test/keep-client/keep-clients.yaml
@@ -81,7 +81,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -288,7 +288,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -495,7 +495,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -700,7 +700,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -905,7 +905,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -1110,7 +1110,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -1315,7 +1315,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -1520,7 +1520,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -1725,7 +1725,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile
@@ -1930,7 +1930,7 @@ spec:
         - keep-client
         - start
         args:
-        - --goerli
+        - --testnet
         - --ethereum.url
         - $(ETH_WS_URL)
         - --ethereum.keyFile


### PR DESCRIPTION
We align the configuration of keep clients running in keep-test with the latest changes:
- replace `--goerli` with `--tesnet` (https://github.com/keep-network/keep-core/pull/3583)
- include protocol in electrum url (https://github.com/keep-network/keep-core/pull/3582)