### PR TITLE
Update Staticcheck action to v1.3.0

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -293,7 +293,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Staticcheck
-        uses: dominikh/staticcheck-action@v1.2.0
+        uses: dominikh/staticcheck-action@v1.3.0
         with:
           version: "2022.1.3"
           install-go: false


### PR DESCRIPTION
The previously used version `1.2.0` was internally using the `actions/cache@v2` action, which runs on Node 12. Node 12 has been out of support since April 2022, as a result GitHub has started the deprecation process of Node 12 for GitHub Actions. They plan to migrate all actions to run on Node16 by Summer 2023 and they show deprecation warnings in Annotations when actions are run on Node 12. Read more on
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. We're upgrading the `dominikh/staticcheck-action` to `1.3.0` version, which uses `actions/cache@v3`, which runs on Node 16.