### PR TITLE
Remove public Blockstream server from the list of auto-selected servers

### DIFF
--- a/config/_electrum_urls/mainnet
+++ b/config/_electrum_urls/mainnet
@@ -1,4 +1,3 @@
 wss://electrumx-server.tbtc.network:8443
 wss://electrum.boar.network:2083
 wss://bitcoin.threshold.p2p.org:50004
-ssl://electrum.blockstream.info:50002

--- a/config/_electrum_urls/testnet
+++ b/config/_electrum_urls/testnet
@@ -1,2 +1,1 @@
 wss://electrumx-server.test.tbtc.network:8443
-ssl://electrum.blockstream.info:60002

--- a/config/electrum.go
+++ b/config/electrum.go
@@ -5,19 +5,12 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 )
 
 //go:embed _electrum_urls/*
 var electrumURLs embed.FS
-
-// Keep Alive Interval value used for Blockstream's electrum connections.
-// This value is used only if a Blockstream's server is randomly selected from
-// the list of embedded Electrum servers. It does not apply if a Blockstream's
-// server connection is explicitly set in the client's configuration.
-var blockstreamKeepAliveInterval = 55 * time.Second
 
 // readElectrumUrls reads Electrum URLs from an embedded file for the
 // given Bitcoin network.
@@ -77,15 +70,6 @@ func (c *Config) resolveElectrum(rng *rand.Rand) error {
 	// Set only the URL in the original config. Other fields may be already set,
 	// and we don't want to override them.
 	c.Bitcoin.Electrum.URL = selectedURL
-
-	// Blockstream's servers timeout session after 60 seconds of inactivity which
-	// is much shorter than expected 600 seconds. To workaround connection drops
-	// and logs pollution with warning we reduce the KeepAliveInterval for the
-	// Blockstream's servers to less than 60 seconds.
-	if c.Bitcoin.Electrum.KeepAliveInterval == 0 &&
-		strings.Contains(selectedURL, "electrum.blockstream.info") {
-		c.Bitcoin.Electrum.KeepAliveInterval = blockstreamKeepAliveInterval
-	}
 
 	return nil
 }

--- a/config/electrum_test.go
+++ b/config/electrum_test.go
@@ -4,7 +4,6 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/go-test/deep"
 
@@ -28,20 +27,12 @@ func TestResolveElectrum(t *testing.T) {
 				{
 					URL: "wss://bitcoin.threshold.p2p.org:50004",
 				},
-				{
-					URL:               "ssl://electrum.blockstream.info:50002",
-					KeepAliveInterval: 55 * time.Second,
-				},
 			},
 		},
 		bitcoin.Testnet: {
 			expectedConfig: []electrum.Config{
 				{
 					URL: "wss://electrumx-server.test.tbtc.network:8443",
-				},
-				{
-					URL:               "ssl://electrum.blockstream.info:60002",
-					KeepAliveInterval: 55 * time.Second,
 				},
 			}},
 		bitcoin.Regtest: {


### PR DESCRIPTION
The blockstream's electrums servers seems very unstable and causes a lot of noise in the logs, even after our optimizations we did in ba416cedb989b0eebc8768ec7fc56de662647803.

Closes: https://github.com/keep-network/keep-core/issues/3612