### PR TITLE
Pinning OZ version to 4.7.3

### DIFF
--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@keep-network/sortition-pools": "^2.0.0-pre.16",
-    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts": "4.7.3",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
     "@threshold-network/solidity-contracts": "development"
   },

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -1095,7 +1095,12 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
 
-"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.6.0":
+"@openzeppelin/contracts@4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
+
+"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.3.2":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.1.tgz#afa804d2c68398704b0175acc94d91a54f203645"
   integrity sha512-aLDTLu/If1qYIFW5g4ZibuQaUsFGWQPBq1mZKp/txaebUnGHDmmiBhRLY1tDNedN0m+fJtKZ1zAODS9Yk+V6uA==


### PR DESCRIPTION
Upgrading OZ version might result in different gas consumption by Keep contracts which lead to failing unit tests that check the gas consumption in certain scenarios. We should pin the OZ contracts to a specific version in order to avoid randomly failing tests.

The upgrade of OZ that broke unit tests was done by our dependebot in the following commit https://github.com/keep-network/keep-core/commit/3a14b3a671a301d9de486be08b50560b623c1c1a