### PR TITLE
Set Node.js version to `18.15.0`

### DIFF
--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -25,7 +25,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 may cause issues with the
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877.
+          node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
           cache-dependency-path: solidity/ecdsa/yarn.lock

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -25,7 +25,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 may cause issues with the
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877.
+          node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
           cache-dependency-path: solidity/random-beacon/yarn.lock


### PR DESCRIPTION
We want to prevent the problem with generation of artifacts during execution of the `hardhat compile` command (part of `yarn deploy`). We saw in other project that sometimes command was not not generating expected artifacts. The problem is caused by the process silently quitting, which is related to the used version of Node (as described in https://github.com/NomicFoundation/hardhat/issues/3877). We've confirmed the problem is reproducible on `v18.16.0`, now we're downgrading to `v18.15.0` to fix the issue.

Refs:
https://github.com/keep-network/keep-core/pull/3595
https://github.com/threshold-network/solidity-contracts/pull/145