### PR TITLE
Adding Ethereum latest block number diagnostic

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -211,11 +211,6 @@ func initializeClientInfo(
 		config.ClientInfo.EthereumMetricsTick,
 	)
 
-	registry.ObserveEthBlockNumber(
-		blockCounter,
-		config.ClientInfo.EthereumMetricsTick,
-	)
-
 	registry.RegisterMetricClientInfo(build.Version)
 
 	registry.RegisterConnectedPeersSource(netProvider, signing)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -214,6 +214,7 @@ func initializeClientInfo(
 	registry.RegisterMetricClientInfo(build.Version)
 
 	registry.RegisterConnectedPeersSource(netProvider, signing)
+
 	registry.RegisterClientInfoSource(
 		netProvider,
 		signing,
@@ -221,7 +222,7 @@ func initializeClientInfo(
 		build.Revision,
 	)
 
-	registry.RegisterChainInfo(blockCounter)
+	registry.RegisterChainInfoSource(blockCounter)
 
 	logger.Infof(
 		"enabled client info endpoint on port [%v]",

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -211,6 +211,11 @@ func initializeClientInfo(
 		config.ClientInfo.EthereumMetricsTick,
 	)
 
+	registry.ObserveEthBlockNumber(
+		blockCounter,
+		config.ClientInfo.EthereumMetricsTick,
+	)
+
 	registry.RegisterMetricClientInfo(build.Version)
 
 	registry.RegisterConnectedPeersSource(netProvider, signing)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -226,6 +226,8 @@ func initializeClientInfo(
 		build.Revision,
 	)
 
+	registry.RegisterChainInfo(blockCounter)
+
 	logger.Infof(
 		"enabled client info endpoint on port [%v]",
 		config.ClientInfo.Port,

--- a/pkg/clientinfo/diagnostics.go
+++ b/pkg/clientinfo/diagnostics.go
@@ -52,7 +52,7 @@ func (r *Registry) RegisterConnectedPeersSource(
 		for peerNetworkID, multiaddrs := range connectedPeersAddrInfo {
 			peerPublicKey, err := connectionManager.GetPeerPublicKey(peerNetworkID)
 			if err != nil {
-				logger.Error("error on getting peer public key: [%v]", err)
+				logger.Errorf("error on getting peer public key: [%v]", err)
 				continue
 			}
 
@@ -60,7 +60,7 @@ func (r *Registry) RegisterConnectedPeersSource(
 				peerPublicKey,
 			)
 			if err != nil {
-				logger.Error("error on getting peer chain address: [%v]", err)
+				logger.Errorf("error on getting peer chain address: [%v]", err)
 				continue
 			}
 
@@ -73,7 +73,7 @@ func (r *Registry) RegisterConnectedPeersSource(
 
 		bytes, err := json.Marshal(peersList)
 		if err != nil {
-			logger.Error("error on serializing peers list to JSON: [%v]", err)
+			logger.Errorf("error on serializing peers list to JSON: [%v]", err)
 			return ""
 		}
 
@@ -95,7 +95,7 @@ func (r *Registry) RegisterClientInfoSource(
 		clientID := netProvider.ID().String()
 		clientPublicKey, err := connectionManager.GetPeerPublicKey(clientID)
 		if err != nil {
-			logger.Error("error on getting client public key: [%v]", err)
+			logger.Errorf("error on getting client public key: [%v]", err)
 			return ""
 		}
 
@@ -103,7 +103,7 @@ func (r *Registry) RegisterClientInfoSource(
 			clientPublicKey,
 		)
 		if err != nil {
-			logger.Error("error on getting peer chain address: [%v]", err)
+			logger.Errorf("error on getting peer chain address: [%v]", err)
 			return ""
 		}
 
@@ -116,7 +116,7 @@ func (r *Registry) RegisterClientInfoSource(
 
 		bytes, err := json.Marshal(clientInfo)
 		if err != nil {
-			logger.Error("error on serializing client info to JSON: [%v]", err)
+			logger.Errorf("error on serializing client info to JSON: [%v]", err)
 			return ""
 		}
 
@@ -124,15 +124,15 @@ func (r *Registry) RegisterClientInfoSource(
 	})
 }
 
-// RegisterChainInfo registers the diagnostics source providing
+// RegisterChainInfoSource registers the diagnostics source providing
 // information about chains.
-func (r *Registry) RegisterChainInfo(
+func (r *Registry) RegisterChainInfoSource(
 	blockCounter chain.BlockCounter,
 ) {
 	r.RegisterDiagnosticSource("chain_info", func() string {
 		currentBlock, err := blockCounter.CurrentBlock()
-
 		if err != nil {
+			logger.Errorf("error on getting Ethereum latest block number: [%v]", err)
 			return ""
 		}
 
@@ -142,7 +142,7 @@ func (r *Registry) RegisterChainInfo(
 
 		bytes, err := json.Marshal(chainInfo)
 		if err != nil {
-			logger.Error("error on serializing chain info to JSON: [%v]", err)
+			logger.Errorf("error on serializing chain info to JSON: [%v]", err)
 			return ""
 		}
 
@@ -159,7 +159,7 @@ func (r *Registry) RegisterApplicationSource(
 	r.RegisterDiagnosticSource(application, func() string {
 		bytes, err := json.Marshal(fetchApplicationDiagnostics())
 		if err != nil {
-			logger.Error("error on serializing peers list to JSON: [%v]", err)
+			logger.Errorf("error on serializing peers list to JSON: [%v]", err)
 			return ""
 		}
 

--- a/pkg/clientinfo/diagnostics.go
+++ b/pkg/clientinfo/diagnostics.go
@@ -12,6 +12,7 @@ import (
 type Diagnostics struct {
 	ClientInfo     Client `json:"client_info"`
 	ConnectedPeers []Peer `json:"connected_peers"`
+	ChainInfo      Chain  `json:"chain_info"`
 }
 
 // Client describes data structure of client information.
@@ -27,6 +28,11 @@ type Peer struct {
 	ChainAddress          string   `json:"chain_address"`
 	NetworkID             string   `json:"network_id"`
 	NetworkMultiAddresses []string `json:"multiaddrs"`
+}
+
+// Chain describes data structure of chains information.
+type Chain struct {
+	EthBlockNumber uint64 `json:"latest_eth_block_number"`
 }
 
 // ApplicationInfo describes data structure of application information.
@@ -111,6 +117,32 @@ func (r *Registry) RegisterClientInfoSource(
 		bytes, err := json.Marshal(clientInfo)
 		if err != nil {
 			logger.Error("error on serializing client info to JSON: [%v]", err)
+			return ""
+		}
+
+		return string(bytes)
+	})
+}
+
+// RegisterChainInfo registers the diagnostics source providing
+// information about chains.
+func (r *Registry) RegisterChainInfo(
+	blockCounter chain.BlockCounter,
+) {
+	r.RegisterDiagnosticSource("chain_info", func() string {
+		currentBlock, err := blockCounter.CurrentBlock()
+
+		if err != nil {
+			return ""
+		}
+
+		chainInfo := Chain{
+			EthBlockNumber: currentBlock,
+		}
+
+		bytes, err := json.Marshal(chainInfo)
+		if err != nil {
+			logger.Error("error on serializing chain info to JSON: [%v]", err)
 			return ""
 		}
 

--- a/pkg/clientinfo/metrics.go
+++ b/pkg/clientinfo/metrics.go
@@ -16,7 +16,6 @@ const (
 	ConnectedPeersCountMetricName     = "connected_peers_count"
 	ConnectedBootstrapCountMetricName = "connected_bootstrap_count"
 	EthConnectivityMetricName         = "eth_connectivity"
-	EthLatestBlockNumberMetricName    = "eth_latest_block_number"
 	ClientInfoMetricName              = "client_info"
 )
 
@@ -94,29 +93,6 @@ func (r *Registry) ObserveEthConnectivity(
 
 	r.observe(
 		EthConnectivityMetricName,
-		input,
-		validateTick(tick, DefaultEthereumMetricsTick),
-	)
-}
-
-// ObserveEthBlockNumber triggers an observation process of the
-// eth_latest_block_number metric.
-func (r *Registry) ObserveEthBlockNumber(
-	blockCounter chain.BlockCounter,
-	tick time.Duration,
-) {
-	input := func() float64 {
-		currentBlock, err := blockCounter.CurrentBlock()
-
-		if err != nil {
-			return 0
-		}
-
-		return float64(currentBlock)
-	}
-
-	r.observe(
-		EthLatestBlockNumberMetricName,
 		input,
 		validateTick(tick, DefaultEthereumMetricsTick),
 	)

--- a/pkg/clientinfo/metrics.go
+++ b/pkg/clientinfo/metrics.go
@@ -16,6 +16,7 @@ const (
 	ConnectedPeersCountMetricName     = "connected_peers_count"
 	ConnectedBootstrapCountMetricName = "connected_bootstrap_count"
 	EthConnectivityMetricName         = "eth_connectivity"
+	EthLatestBlockNumberMetricName    = "eth_latest_block_number"
 	ClientInfoMetricName              = "client_info"
 )
 
@@ -93,6 +94,29 @@ func (r *Registry) ObserveEthConnectivity(
 
 	r.observe(
 		EthConnectivityMetricName,
+		input,
+		validateTick(tick, DefaultEthereumMetricsTick),
+	)
+}
+
+// ObserveEthBlockNumber triggers an observation process of the
+// eth_latest_block_number metric.
+func (r *Registry) ObserveEthBlockNumber(
+	blockCounter chain.BlockCounter,
+	tick time.Duration,
+) {
+	input := func() float64 {
+		currentBlock, err := blockCounter.CurrentBlock()
+
+		if err != nil {
+			return 0
+		}
+
+		return float64(currentBlock)
+	}
+
+	r.observe(
+		EthLatestBlockNumberMetricName,
 		input,
 		validateTick(tick, DefaultEthereumMetricsTick),
 	)


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3608

Exposing the latest block number diagnostic can be helpful to diagnose some of the problems with a node connectivity and determine if a node is catching up with the global Ethereum state.

Example output:
```
{
  "chain_info": {
    "latest_eth_block_number": 3525
  },
  "client_info": {
    "chain_address": "0x407190f04d838Ec47dad4C0e0D2a9c49d7737479",
    "network_id": "16Uiu2HAm4WrMWq9Gc7WsymsqgrwbaD1KeW2eH8eY63DTZHXbRsuE",
    "revision": "8c444b4b9",
    "version": "v2.0.0-m3-70-g8c444b4b9"
  },
  "connected_peers": null
}
```