### PR TITLE
Add 20% to the original gas estimate for the sweep proposal

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1450,8 +1450,25 @@ func (tc *TbtcChain) ValidateDepositSweepProposal(
 func (tc *TbtcChain) SubmitDepositSweepProposalWithReimbursement(
 	proposal *tbtc.DepositSweepProposal,
 ) error {
-	_, err := tc.walletCoordinator.SubmitDepositSweepProposalWithReimbursement(
+	gasEstimate, err := tc.walletCoordinator.SubmitDepositSweepProposalWithReimbursementGasEstimate(
 		convertDepositSweepProposalToAbiType(proposal),
+	)
+	if err != nil {
+		return err
+	}
+
+	// The original estimate for this contract call turned is low and the call
+	// fails on reimbursing the submitter. Examples:
+	// 0x5711df32d785140ca6b5b12c87f818a6c5d75d10445a12a7d3d75caadb40c0ac
+	// 0xf9a8c0b0ecceb673e19eed7af7c9963cdd929468fb3818e9a8c3b8c59dc6ef85
+	// Here we add a 20% margin to overcome the gas problems.
+	gasEstimateWithMargin := float64(gasEstimate) * float64(1.2)
+
+	_, err = tc.walletCoordinator.SubmitDepositSweepProposalWithReimbursement(
+		convertDepositSweepProposalToAbiType(proposal),
+		ethutil.TransactionOptions{
+			GasLimit: uint64(gasEstimateWithMargin),
+		},
 	)
 
 	return err


### PR DESCRIPTION
Closes #3610 

The original estimate for this contract call is too low and the call fails on reimbursing the submitter. Here we add a 20% margin to overcome the gas problem.

Examples of failures:
`0x5711df32d785140ca6b5b12c87f818a6c5d75d10445a12a7d3d75caadb40c0ac` `0xf9a8c0b0ecceb673e19eed7af7c9963cdd929468fb3818e9a8c3b8c59dc6ef85`

I stumbled upon this problem when submitting the very first sweep proposal manually, with CLI. I had to apply this change locally for all other sweep proposals I submitted. Then, I stumbled upon it again when using the automated version from #3635 on a fresh branch and again, had to apply this change to successfully submit proposals.