### PR TITLE
Redemption prototype: Observe incoming proposals

### DIFF
--- a/pkg/bitcoin/bitcoin.go
+++ b/pkg/bitcoin/bitcoin.go
@@ -7,6 +7,11 @@
 // type should leak outside.
 package bitcoin
 
+import (
+	"bytes"
+	"github.com/btcsuite/btcd/wire"
+)
+
 // CompactSizeUint is a documentation type that is supposed to capture the
 // details of the Bitcoin's CompactSize Unsigned Integer. It represents a
 // number value encoded to bytes according to the following rules:
@@ -21,6 +26,19 @@ package bitcoin
 // For reference, see:
 // https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
 type CompactSizeUint uint64
+
+// readCompactSizeUint reads the leading CompactSizeUint from the provided
+// variable length data. Returns the value held by the CompactSizeUint as
+// the first argument and the byte length of the CompactSizeUint as the
+// second one.
+func readCompactSizeUint(varLenData []byte) (CompactSizeUint, int, error) {
+	csu, err := wire.ReadVarInt(bytes.NewReader(varLenData), 0)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return CompactSizeUint(csu), wire.VarIntSerializeSize(csu), nil
+}
 
 // ByteOrder represents the byte order used by the Bitcoin byte arrays. The
 // Bitcoin ecosystem is not totally consistent in this regard and different

--- a/pkg/bitcoin/bitcoin_test.go
+++ b/pkg/bitcoin/bitcoin_test.go
@@ -1,0 +1,79 @@
+package bitcoin
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/keep-network/keep-core/internal/testutils"
+	"reflect"
+	"testing"
+)
+
+func TestReadCompactSizeUint(t *testing.T) {
+	fromHex := func(hexString string) []byte {
+		bytes, err := hex.DecodeString(hexString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bytes
+	}
+
+	var tests = map[string]struct {
+		data               []byte
+		expectedValue      CompactSizeUint
+		expectedByteLength int
+		expectedErr        error
+	}{
+		"1-byte compact size uint": {
+			data:               fromHex("bb"),
+			expectedValue:      187,
+			expectedByteLength: 1,
+		},
+		"3-byte compact size uint": {
+			data:               fromHex("fd0302"),
+			expectedValue:      515,
+			expectedByteLength: 3,
+		},
+		"5-byte compact size uint": {
+			data:               fromHex("fe703a0f00"),
+			expectedValue:      998000,
+			expectedByteLength: 5,
+		},
+		"9-byte compact size uint": {
+			data:               fromHex("ff57284e56dab40000"),
+			expectedValue:      198849843832919,
+			expectedByteLength: 9,
+		},
+		"malformed compact size uint": {
+			data:        fromHex("fd01"),
+			expectedErr: fmt.Errorf("unexpected EOF"),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			value, byteLength, err := readCompactSizeUint(test.data)
+
+			if !reflect.DeepEqual(test.expectedErr, err) {
+				t.Errorf(
+					"unexpected error\nexpected: %+v\nactual:   %+v\n",
+					test.expectedErr,
+					err,
+				)
+			}
+
+			testutils.AssertIntsEqual(
+				t,
+				"value",
+				int(test.expectedValue),
+				int(value),
+			)
+
+			testutils.AssertIntsEqual(
+				t,
+				"byte length",
+				test.expectedByteLength,
+				byteLength,
+			)
+		})
+	}
+}

--- a/pkg/bitcoin/script.go
+++ b/pkg/bitcoin/script.go
@@ -8,6 +8,10 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
+// Script represents an arbitrary Bitcoin script, NOT prepended with the
+// byte-length of the script
+type Script []byte
+
 // PublicKeyHash constructs the 20-byte public key hash by applying SHA-256
 // then RIPEMD-160 on the provided ECDSA public key.
 func PublicKeyHash(publicKey *ecdsa.PublicKey) [20]byte {
@@ -28,7 +32,7 @@ func PublicKeyHash(publicKey *ecdsa.PublicKey) [20]byte {
 // PayToWitnessPublicKeyHash constructs a P2WPKH script for the provided
 // 20-byte public key hash. The function assumes the provided public key hash
 // is valid.
-func PayToWitnessPublicKeyHash(publicKeyHash [20]byte) ([]byte, error) {
+func PayToWitnessPublicKeyHash(publicKeyHash [20]byte) (Script, error) {
 	return txscript.NewScriptBuilder().
 		AddOp(txscript.OP_0).
 		AddData(publicKeyHash[:]).
@@ -37,7 +41,7 @@ func PayToWitnessPublicKeyHash(publicKeyHash [20]byte) ([]byte, error) {
 
 // PayToPublicKeyHash constructs a P2PKH script for the provided 20-byte public
 // key hash. The function assumes the provided public key hash is valid.
-func PayToPublicKeyHash(publicKeyHash [20]byte) ([]byte, error) {
+func PayToPublicKeyHash(publicKeyHash [20]byte) (Script, error) {
 	return txscript.NewScriptBuilder().
 		AddOp(txscript.OP_DUP).
 		AddOp(txscript.OP_HASH160).
@@ -46,9 +50,6 @@ func PayToPublicKeyHash(publicKeyHash [20]byte) ([]byte, error) {
 		AddOp(txscript.OP_CHECKSIG).
 		Script()
 }
-
-// Script represents an arbitrary Bitcoin script.
-type Script []byte
 
 // WitnessScriptHash constructs the 32-byte witness script hash by applying
 // single SHA-256 on the provided Script.
@@ -69,7 +70,7 @@ func ScriptHash(script Script) [20]byte {
 
 // PayToWitnessScriptHash constructs a P2WSH script for the provided 32-byte
 // witness script hash. The function assumes the provided script hash is valid.
-func PayToWitnessScriptHash(witnessScriptHash [32]byte) ([]byte, error) {
+func PayToWitnessScriptHash(witnessScriptHash [32]byte) (Script, error) {
 	return txscript.NewScriptBuilder().
 		AddOp(txscript.OP_0).
 		AddData(witnessScriptHash[:]).
@@ -78,7 +79,7 @@ func PayToWitnessScriptHash(witnessScriptHash [32]byte) ([]byte, error) {
 
 // PayToScriptHash constructs a P2SH script for the provided 20-byte script
 // hash. The function assumes the provided script hash is valid.
-func PayToScriptHash(scriptHash [20]byte) ([]byte, error) {
+func PayToScriptHash(scriptHash [20]byte) (Script, error) {
 	return txscript.NewScriptBuilder().
 		AddOp(txscript.OP_HASH160).
 		AddData(scriptHash[:]).

--- a/pkg/bitcoin/transaction.go
+++ b/pkg/bitcoin/transaction.go
@@ -226,9 +226,10 @@ type TransactionOutput struct {
 	// Value denotes the number of satoshis to spend. Zero is a valid value.
 	Value int64
 	// PublicKeyScript defines the conditions that must be satisfied to spend
-	// this output. This slice MUST NOT start with the byte-length of the script
-	// encoded as CompactSizeUint as this is done during transaction serialization.
-	PublicKeyScript []byte
+	// this output. As stated in the Script docstring, this field MUST NOT
+	// start with the byte-length of the script encoded as CompactSizeUint as
+	// this is done during transaction serialization.
+	PublicKeyScript Script
 }
 
 // UnspentTransactionOutput represents an unspent output (UTXO) of a Bitcoin

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1477,3 +1477,10 @@ func (tc *TbtcChain) SubmitDepositSweepProposalWithReimbursement(
 func (tc *TbtcChain) GetDepositSweepMaxSize() (uint16, error) {
 	return tc.walletCoordinator.DepositSweepMaxSize()
 }
+
+func (tc *TbtcChain) OnRedemptionProposalSubmitted(
+	func(event *tbtc.RedemptionProposalSubmittedEvent),
+) subscription.EventSubscription {
+	// TODO: Implementation.
+	panic("not implemented yet")
+}

--- a/pkg/chain/ethereum/tbtc/gen/abi/WalletCoordinator.go
+++ b/pkg/chain/ethereum/tbtc/gen/abi/WalletCoordinator.go
@@ -59,9 +59,16 @@ type WalletCoordinatorDepositSweepProposal struct {
 	DepositsRevealBlocks []*big.Int
 }
 
+// WalletCoordinatorRedemptionProposal is an auto generated low-level Go binding around an user-defined struct.
+type WalletCoordinatorRedemptionProposal struct {
+	WalletPubKeyHash       [20]byte
+	RedeemersOutputScripts [][]byte
+	RedemptionTxFee        *big.Int
+}
+
 // WalletCoordinatorMetaData contains all meta data concerning the WalletCoordinator contract.
 var WalletCoordinatorMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"CoordinatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"CoordinatorRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositMinAge\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositRefundSafetyMargin\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"depositSweepMaxSize\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"DepositSweepProposalParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"indexed\":false,\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"DepositSweepProposalSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"heartbeatRequestValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"heartbeatRequestGasOffset\",\"type\":\"uint32\"}],\"name\":\"HeartbeatRequestParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"HeartbeatRequestSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newReimbursementPool\",\"type\":\"address\"}],\"name\":\"ReimbursementPoolUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"WalletManuallyUnlocked\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"addCoordinator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"bridge\",\"outputs\":[{\"internalType\":\"contractBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositMinAge\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositRefundSafetyMargin\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepMaxSize\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalSubmissionGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeatRequestGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeatRequestValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractBridge\",\"name\":\"_bridge\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isCoordinator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"reimbursementPool\",\"outputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"removeCoordinator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"requestHeartbeat\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"requestHeartbeatWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposal\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposalWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"unlockWallet\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_depositMinAge\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_depositRefundSafetyMargin\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_depositSweepMaxSize\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateDepositSweepProposalParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_heartbeatRequestValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_heartbeatRequestGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateHeartbeatRequestParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"_reimbursementPool\",\"type\":\"address\"}],\"name\":\"updateReimbursementPool\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"bytes4\",\"name\":\"version\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"inputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"outputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes4\",\"name\":\"locktime\",\"type\":\"bytes4\"}],\"internalType\":\"structBitcoinTx.Info\",\"name\":\"fundingTx\",\"type\":\"tuple\"},{\"internalType\":\"bytes8\",\"name\":\"blindingFactor\",\"type\":\"bytes8\"},{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20\",\"name\":\"refundPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes4\",\"name\":\"refundLocktime\",\"type\":\"bytes4\"}],\"internalType\":\"structWalletCoordinator.DepositExtraInfo[]\",\"name\":\"depositsExtraInfo\",\"type\":\"tuple[]\"}],\"name\":\"validateDepositSweepProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"\",\"type\":\"bytes20\"}],\"name\":\"walletLock\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"expiresAt\",\"type\":\"uint32\"},{\"internalType\":\"enumWalletCoordinator.WalletAction\",\"name\":\"cause\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"CoordinatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"CoordinatorRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositMinAge\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositRefundSafetyMargin\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"depositSweepMaxSize\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"DepositSweepProposalParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"indexed\":false,\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"DepositSweepProposalSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"heartbeatRequestValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"heartbeatRequestGasOffset\",\"type\":\"uint32\"}],\"name\":\"HeartbeatRequestParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"HeartbeatRequestSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"redemptionProposalValidity\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"redemptionRequestMinAge\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"redemptionRequestTimeoutSafetyMargin\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"redemptionMaxSize\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"redemptionProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"RedemptionProposalParametersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes[]\",\"name\":\"redeemersOutputScripts\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256\",\"name\":\"redemptionTxFee\",\"type\":\"uint256\"}],\"indexed\":false,\"internalType\":\"structWalletCoordinator.RedemptionProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"RedemptionProposalSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newReimbursementPool\",\"type\":\"address\"}],\"name\":\"ReimbursementPoolUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"WalletManuallyUnlocked\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"addCoordinator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"bridge\",\"outputs\":[{\"internalType\":\"contractBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositMinAge\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositRefundSafetyMargin\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepMaxSize\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalSubmissionGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"depositSweepProposalValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeatRequestGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeatRequestValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractBridge\",\"name\":\"_bridge\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isCoordinator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"redemptionMaxSize\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"redemptionProposalSubmissionGasOffset\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"redemptionProposalValidity\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"redemptionRequestMinAge\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"redemptionRequestTimeoutSafetyMargin\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"reimbursementPool\",\"outputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"coordinator\",\"type\":\"address\"}],\"name\":\"removeCoordinator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"requestHeartbeat\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"name\":\"requestHeartbeatWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposal\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitDepositSweepProposalWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes[]\",\"name\":\"redeemersOutputScripts\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256\",\"name\":\"redemptionTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.RedemptionProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitRedemptionProposal\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes[]\",\"name\":\"redeemersOutputScripts\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256\",\"name\":\"redemptionTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.RedemptionProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"submitRedemptionProposalWithReimbursement\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"unlockWallet\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_depositMinAge\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_depositRefundSafetyMargin\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_depositSweepMaxSize\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"_depositSweepProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateDepositSweepProposalParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_heartbeatRequestValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_heartbeatRequestGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateHeartbeatRequestParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_redemptionProposalValidity\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_redemptionRequestMinAge\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_redemptionRequestTimeoutSafetyMargin\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_redemptionMaxSize\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"_redemptionProposalSubmissionGasOffset\",\"type\":\"uint32\"}],\"name\":\"updateRedemptionProposalParameters\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractReimbursementPool\",\"name\":\"_reimbursementPool\",\"type\":\"address\"}],\"name\":\"updateReimbursementPool\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletCoordinator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletCoordinator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"bytes4\",\"name\":\"version\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"inputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"outputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes4\",\"name\":\"locktime\",\"type\":\"bytes4\"}],\"internalType\":\"structBitcoinTx.Info\",\"name\":\"fundingTx\",\"type\":\"tuple\"},{\"internalType\":\"bytes8\",\"name\":\"blindingFactor\",\"type\":\"bytes8\"},{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20\",\"name\":\"refundPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes4\",\"name\":\"refundLocktime\",\"type\":\"bytes4\"}],\"internalType\":\"structWalletCoordinator.DepositExtraInfo[]\",\"name\":\"depositsExtraInfo\",\"type\":\"tuple[]\"}],\"name\":\"validateDepositSweepProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes[]\",\"name\":\"redeemersOutputScripts\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256\",\"name\":\"redemptionTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletCoordinator.RedemptionProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"validateRedemptionProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes20\",\"name\":\"\",\"type\":\"bytes20\"}],\"name\":\"walletLock\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"expiresAt\",\"type\":\"uint32\"},{\"internalType\":\"enumWalletCoordinator.WalletAction\",\"name\":\"cause\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // WalletCoordinatorABI is the input ABI used to generate the binding from.
@@ -520,6 +527,161 @@ func (_WalletCoordinator *WalletCoordinatorCallerSession) Owner() (common.Addres
 	return _WalletCoordinator.Contract.Owner(&_WalletCoordinator.CallOpts)
 }
 
+// RedemptionMaxSize is a free data retrieval call binding the contract method 0x6980f9fe.
+//
+// Solidity: function redemptionMaxSize() view returns(uint16)
+func (_WalletCoordinator *WalletCoordinatorCaller) RedemptionMaxSize(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "redemptionMaxSize")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// RedemptionMaxSize is a free data retrieval call binding the contract method 0x6980f9fe.
+//
+// Solidity: function redemptionMaxSize() view returns(uint16)
+func (_WalletCoordinator *WalletCoordinatorSession) RedemptionMaxSize() (uint16, error) {
+	return _WalletCoordinator.Contract.RedemptionMaxSize(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionMaxSize is a free data retrieval call binding the contract method 0x6980f9fe.
+//
+// Solidity: function redemptionMaxSize() view returns(uint16)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) RedemptionMaxSize() (uint16, error) {
+	return _WalletCoordinator.Contract.RedemptionMaxSize(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionProposalSubmissionGasOffset is a free data retrieval call binding the contract method 0x930b4898.
+//
+// Solidity: function redemptionProposalSubmissionGasOffset() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCaller) RedemptionProposalSubmissionGasOffset(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "redemptionProposalSubmissionGasOffset")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// RedemptionProposalSubmissionGasOffset is a free data retrieval call binding the contract method 0x930b4898.
+//
+// Solidity: function redemptionProposalSubmissionGasOffset() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorSession) RedemptionProposalSubmissionGasOffset() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionProposalSubmissionGasOffset(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionProposalSubmissionGasOffset is a free data retrieval call binding the contract method 0x930b4898.
+//
+// Solidity: function redemptionProposalSubmissionGasOffset() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) RedemptionProposalSubmissionGasOffset() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionProposalSubmissionGasOffset(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionProposalValidity is a free data retrieval call binding the contract method 0x300226ae.
+//
+// Solidity: function redemptionProposalValidity() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCaller) RedemptionProposalValidity(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "redemptionProposalValidity")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// RedemptionProposalValidity is a free data retrieval call binding the contract method 0x300226ae.
+//
+// Solidity: function redemptionProposalValidity() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorSession) RedemptionProposalValidity() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionProposalValidity(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionProposalValidity is a free data retrieval call binding the contract method 0x300226ae.
+//
+// Solidity: function redemptionProposalValidity() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) RedemptionProposalValidity() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionProposalValidity(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionRequestMinAge is a free data retrieval call binding the contract method 0x6511064d.
+//
+// Solidity: function redemptionRequestMinAge() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCaller) RedemptionRequestMinAge(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "redemptionRequestMinAge")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// RedemptionRequestMinAge is a free data retrieval call binding the contract method 0x6511064d.
+//
+// Solidity: function redemptionRequestMinAge() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorSession) RedemptionRequestMinAge() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionRequestMinAge(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionRequestMinAge is a free data retrieval call binding the contract method 0x6511064d.
+//
+// Solidity: function redemptionRequestMinAge() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) RedemptionRequestMinAge() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionRequestMinAge(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionRequestTimeoutSafetyMargin is a free data retrieval call binding the contract method 0x8aea2ac2.
+//
+// Solidity: function redemptionRequestTimeoutSafetyMargin() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCaller) RedemptionRequestTimeoutSafetyMargin(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "redemptionRequestTimeoutSafetyMargin")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// RedemptionRequestTimeoutSafetyMargin is a free data retrieval call binding the contract method 0x8aea2ac2.
+//
+// Solidity: function redemptionRequestTimeoutSafetyMargin() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorSession) RedemptionRequestTimeoutSafetyMargin() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionRequestTimeoutSafetyMargin(&_WalletCoordinator.CallOpts)
+}
+
+// RedemptionRequestTimeoutSafetyMargin is a free data retrieval call binding the contract method 0x8aea2ac2.
+//
+// Solidity: function redemptionRequestTimeoutSafetyMargin() view returns(uint32)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) RedemptionRequestTimeoutSafetyMargin() (uint32, error) {
+	return _WalletCoordinator.Contract.RedemptionRequestTimeoutSafetyMargin(&_WalletCoordinator.CallOpts)
+}
+
 // ReimbursementPool is a free data retrieval call binding the contract method 0xc09975cd.
 //
 // Solidity: function reimbursementPool() view returns(address)
@@ -580,6 +742,37 @@ func (_WalletCoordinator *WalletCoordinatorSession) ValidateDepositSweepProposal
 // Solidity: function validateDepositSweepProposal((bytes20,(bytes32,uint32)[],uint256,uint256[]) proposal, ((bytes4,bytes,bytes,bytes4),bytes8,bytes20,bytes20,bytes4)[] depositsExtraInfo) view returns(bool)
 func (_WalletCoordinator *WalletCoordinatorCallerSession) ValidateDepositSweepProposal(proposal WalletCoordinatorDepositSweepProposal, depositsExtraInfo []WalletCoordinatorDepositExtraInfo) (bool, error) {
 	return _WalletCoordinator.Contract.ValidateDepositSweepProposal(&_WalletCoordinator.CallOpts, proposal, depositsExtraInfo)
+}
+
+// ValidateRedemptionProposal is a free data retrieval call binding the contract method 0x0fde6c76.
+//
+// Solidity: function validateRedemptionProposal((bytes20,bytes[],uint256) proposal) view returns(bool)
+func (_WalletCoordinator *WalletCoordinatorCaller) ValidateRedemptionProposal(opts *bind.CallOpts, proposal WalletCoordinatorRedemptionProposal) (bool, error) {
+	var out []interface{}
+	err := _WalletCoordinator.contract.Call(opts, &out, "validateRedemptionProposal", proposal)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateRedemptionProposal is a free data retrieval call binding the contract method 0x0fde6c76.
+//
+// Solidity: function validateRedemptionProposal((bytes20,bytes[],uint256) proposal) view returns(bool)
+func (_WalletCoordinator *WalletCoordinatorSession) ValidateRedemptionProposal(proposal WalletCoordinatorRedemptionProposal) (bool, error) {
+	return _WalletCoordinator.Contract.ValidateRedemptionProposal(&_WalletCoordinator.CallOpts, proposal)
+}
+
+// ValidateRedemptionProposal is a free data retrieval call binding the contract method 0x0fde6c76.
+//
+// Solidity: function validateRedemptionProposal((bytes20,bytes[],uint256) proposal) view returns(bool)
+func (_WalletCoordinator *WalletCoordinatorCallerSession) ValidateRedemptionProposal(proposal WalletCoordinatorRedemptionProposal) (bool, error) {
+	return _WalletCoordinator.Contract.ValidateRedemptionProposal(&_WalletCoordinator.CallOpts, proposal)
 }
 
 // WalletLock is a free data retrieval call binding the contract method 0x2c259d2b.
@@ -795,6 +988,48 @@ func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitDepositSweep
 	return _WalletCoordinator.Contract.SubmitDepositSweepProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal)
 }
 
+// SubmitRedemptionProposal is a paid mutator transaction binding the contract method 0xe64007d0.
+//
+// Solidity: function submitRedemptionProposal((bytes20,bytes[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) SubmitRedemptionProposal(opts *bind.TransactOpts, proposal WalletCoordinatorRedemptionProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "submitRedemptionProposal", proposal)
+}
+
+// SubmitRedemptionProposal is a paid mutator transaction binding the contract method 0xe64007d0.
+//
+// Solidity: function submitRedemptionProposal((bytes20,bytes[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) SubmitRedemptionProposal(proposal WalletCoordinatorRedemptionProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitRedemptionProposal(&_WalletCoordinator.TransactOpts, proposal)
+}
+
+// SubmitRedemptionProposal is a paid mutator transaction binding the contract method 0xe64007d0.
+//
+// Solidity: function submitRedemptionProposal((bytes20,bytes[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitRedemptionProposal(proposal WalletCoordinatorRedemptionProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitRedemptionProposal(&_WalletCoordinator.TransactOpts, proposal)
+}
+
+// SubmitRedemptionProposalWithReimbursement is a paid mutator transaction binding the contract method 0x265a513e.
+//
+// Solidity: function submitRedemptionProposalWithReimbursement((bytes20,bytes[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) SubmitRedemptionProposalWithReimbursement(opts *bind.TransactOpts, proposal WalletCoordinatorRedemptionProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "submitRedemptionProposalWithReimbursement", proposal)
+}
+
+// SubmitRedemptionProposalWithReimbursement is a paid mutator transaction binding the contract method 0x265a513e.
+//
+// Solidity: function submitRedemptionProposalWithReimbursement((bytes20,bytes[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) SubmitRedemptionProposalWithReimbursement(proposal WalletCoordinatorRedemptionProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitRedemptionProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal)
+}
+
+// SubmitRedemptionProposalWithReimbursement is a paid mutator transaction binding the contract method 0x265a513e.
+//
+// Solidity: function submitRedemptionProposalWithReimbursement((bytes20,bytes[],uint256) proposal) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) SubmitRedemptionProposalWithReimbursement(proposal WalletCoordinatorRedemptionProposal) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.SubmitRedemptionProposalWithReimbursement(&_WalletCoordinator.TransactOpts, proposal)
+}
+
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
@@ -877,6 +1112,27 @@ func (_WalletCoordinator *WalletCoordinatorSession) UpdateHeartbeatRequestParame
 // Solidity: function updateHeartbeatRequestParameters(uint32 _heartbeatRequestValidity, uint32 _heartbeatRequestGasOffset) returns()
 func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateHeartbeatRequestParameters(_heartbeatRequestValidity uint32, _heartbeatRequestGasOffset uint32) (*types.Transaction, error) {
 	return _WalletCoordinator.Contract.UpdateHeartbeatRequestParameters(&_WalletCoordinator.TransactOpts, _heartbeatRequestValidity, _heartbeatRequestGasOffset)
+}
+
+// UpdateRedemptionProposalParameters is a paid mutator transaction binding the contract method 0x1b9783ff.
+//
+// Solidity: function updateRedemptionProposalParameters(uint32 _redemptionProposalValidity, uint32 _redemptionRequestMinAge, uint32 _redemptionRequestTimeoutSafetyMargin, uint16 _redemptionMaxSize, uint32 _redemptionProposalSubmissionGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactor) UpdateRedemptionProposalParameters(opts *bind.TransactOpts, _redemptionProposalValidity uint32, _redemptionRequestMinAge uint32, _redemptionRequestTimeoutSafetyMargin uint32, _redemptionMaxSize uint16, _redemptionProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.contract.Transact(opts, "updateRedemptionProposalParameters", _redemptionProposalValidity, _redemptionRequestMinAge, _redemptionRequestTimeoutSafetyMargin, _redemptionMaxSize, _redemptionProposalSubmissionGasOffset)
+}
+
+// UpdateRedemptionProposalParameters is a paid mutator transaction binding the contract method 0x1b9783ff.
+//
+// Solidity: function updateRedemptionProposalParameters(uint32 _redemptionProposalValidity, uint32 _redemptionRequestMinAge, uint32 _redemptionRequestTimeoutSafetyMargin, uint16 _redemptionMaxSize, uint32 _redemptionProposalSubmissionGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorSession) UpdateRedemptionProposalParameters(_redemptionProposalValidity uint32, _redemptionRequestMinAge uint32, _redemptionRequestTimeoutSafetyMargin uint32, _redemptionMaxSize uint16, _redemptionProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.UpdateRedemptionProposalParameters(&_WalletCoordinator.TransactOpts, _redemptionProposalValidity, _redemptionRequestMinAge, _redemptionRequestTimeoutSafetyMargin, _redemptionMaxSize, _redemptionProposalSubmissionGasOffset)
+}
+
+// UpdateRedemptionProposalParameters is a paid mutator transaction binding the contract method 0x1b9783ff.
+//
+// Solidity: function updateRedemptionProposalParameters(uint32 _redemptionProposalValidity, uint32 _redemptionRequestMinAge, uint32 _redemptionRequestTimeoutSafetyMargin, uint16 _redemptionMaxSize, uint32 _redemptionProposalSubmissionGasOffset) returns()
+func (_WalletCoordinator *WalletCoordinatorTransactorSession) UpdateRedemptionProposalParameters(_redemptionProposalValidity uint32, _redemptionRequestMinAge uint32, _redemptionRequestTimeoutSafetyMargin uint32, _redemptionMaxSize uint16, _redemptionProposalSubmissionGasOffset uint32) (*types.Transaction, error) {
+	return _WalletCoordinator.Contract.UpdateRedemptionProposalParameters(&_WalletCoordinator.TransactOpts, _redemptionProposalValidity, _redemptionRequestMinAge, _redemptionRequestTimeoutSafetyMargin, _redemptionMaxSize, _redemptionProposalSubmissionGasOffset)
 }
 
 // UpdateReimbursementPool is a paid mutator transaction binding the contract method 0x7b35b4e6.
@@ -2033,6 +2289,289 @@ func (_WalletCoordinator *WalletCoordinatorFilterer) WatchOwnershipTransferred(o
 func (_WalletCoordinator *WalletCoordinatorFilterer) ParseOwnershipTransferred(log types.Log) (*WalletCoordinatorOwnershipTransferred, error) {
 	event := new(WalletCoordinatorOwnershipTransferred)
 	if err := _WalletCoordinator.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// WalletCoordinatorRedemptionProposalParametersUpdatedIterator is returned from FilterRedemptionProposalParametersUpdated and is used to iterate over the raw logs and unpacked data for RedemptionProposalParametersUpdated events raised by the WalletCoordinator contract.
+type WalletCoordinatorRedemptionProposalParametersUpdatedIterator struct {
+	Event *WalletCoordinatorRedemptionProposalParametersUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *WalletCoordinatorRedemptionProposalParametersUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(WalletCoordinatorRedemptionProposalParametersUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(WalletCoordinatorRedemptionProposalParametersUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *WalletCoordinatorRedemptionProposalParametersUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *WalletCoordinatorRedemptionProposalParametersUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// WalletCoordinatorRedemptionProposalParametersUpdated represents a RedemptionProposalParametersUpdated event raised by the WalletCoordinator contract.
+type WalletCoordinatorRedemptionProposalParametersUpdated struct {
+	RedemptionProposalValidity            uint32
+	RedemptionRequestMinAge               uint32
+	RedemptionRequestTimeoutSafetyMargin  uint32
+	RedemptionMaxSize                     uint16
+	RedemptionProposalSubmissionGasOffset uint32
+	Raw                                   types.Log // Blockchain specific contextual infos
+}
+
+// FilterRedemptionProposalParametersUpdated is a free log retrieval operation binding the contract event 0xa16bb3cf10d251033dcfb3ff6f9601243766f6a3e397b30eb76d69f3fad339c2.
+//
+// Solidity: event RedemptionProposalParametersUpdated(uint32 redemptionProposalValidity, uint32 redemptionRequestMinAge, uint32 redemptionRequestTimeoutSafetyMargin, uint16 redemptionMaxSize, uint32 redemptionProposalSubmissionGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterRedemptionProposalParametersUpdated(opts *bind.FilterOpts) (*WalletCoordinatorRedemptionProposalParametersUpdatedIterator, error) {
+
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "RedemptionProposalParametersUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &WalletCoordinatorRedemptionProposalParametersUpdatedIterator{contract: _WalletCoordinator.contract, event: "RedemptionProposalParametersUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchRedemptionProposalParametersUpdated is a free log subscription operation binding the contract event 0xa16bb3cf10d251033dcfb3ff6f9601243766f6a3e397b30eb76d69f3fad339c2.
+//
+// Solidity: event RedemptionProposalParametersUpdated(uint32 redemptionProposalValidity, uint32 redemptionRequestMinAge, uint32 redemptionRequestTimeoutSafetyMargin, uint16 redemptionMaxSize, uint32 redemptionProposalSubmissionGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchRedemptionProposalParametersUpdated(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorRedemptionProposalParametersUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "RedemptionProposalParametersUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(WalletCoordinatorRedemptionProposalParametersUpdated)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "RedemptionProposalParametersUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRedemptionProposalParametersUpdated is a log parse operation binding the contract event 0xa16bb3cf10d251033dcfb3ff6f9601243766f6a3e397b30eb76d69f3fad339c2.
+//
+// Solidity: event RedemptionProposalParametersUpdated(uint32 redemptionProposalValidity, uint32 redemptionRequestMinAge, uint32 redemptionRequestTimeoutSafetyMargin, uint16 redemptionMaxSize, uint32 redemptionProposalSubmissionGasOffset)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseRedemptionProposalParametersUpdated(log types.Log) (*WalletCoordinatorRedemptionProposalParametersUpdated, error) {
+	event := new(WalletCoordinatorRedemptionProposalParametersUpdated)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "RedemptionProposalParametersUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// WalletCoordinatorRedemptionProposalSubmittedIterator is returned from FilterRedemptionProposalSubmitted and is used to iterate over the raw logs and unpacked data for RedemptionProposalSubmitted events raised by the WalletCoordinator contract.
+type WalletCoordinatorRedemptionProposalSubmittedIterator struct {
+	Event *WalletCoordinatorRedemptionProposalSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *WalletCoordinatorRedemptionProposalSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(WalletCoordinatorRedemptionProposalSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(WalletCoordinatorRedemptionProposalSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *WalletCoordinatorRedemptionProposalSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *WalletCoordinatorRedemptionProposalSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// WalletCoordinatorRedemptionProposalSubmitted represents a RedemptionProposalSubmitted event raised by the WalletCoordinator contract.
+type WalletCoordinatorRedemptionProposalSubmitted struct {
+	Proposal    WalletCoordinatorRedemptionProposal
+	Coordinator common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterRedemptionProposalSubmitted is a free log retrieval operation binding the contract event 0x315f9ad8d0b7518ff779e5acc7c069df04df94325d86b685227473ebd452bb70.
+//
+// Solidity: event RedemptionProposalSubmitted((bytes20,bytes[],uint256) proposal, address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) FilterRedemptionProposalSubmitted(opts *bind.FilterOpts, coordinator []common.Address) (*WalletCoordinatorRedemptionProposalSubmittedIterator, error) {
+
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
+	}
+
+	logs, sub, err := _WalletCoordinator.contract.FilterLogs(opts, "RedemptionProposalSubmitted", coordinatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &WalletCoordinatorRedemptionProposalSubmittedIterator{contract: _WalletCoordinator.contract, event: "RedemptionProposalSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchRedemptionProposalSubmitted is a free log subscription operation binding the contract event 0x315f9ad8d0b7518ff779e5acc7c069df04df94325d86b685227473ebd452bb70.
+//
+// Solidity: event RedemptionProposalSubmitted((bytes20,bytes[],uint256) proposal, address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) WatchRedemptionProposalSubmitted(opts *bind.WatchOpts, sink chan<- *WalletCoordinatorRedemptionProposalSubmitted, coordinator []common.Address) (event.Subscription, error) {
+
+	var coordinatorRule []interface{}
+	for _, coordinatorItem := range coordinator {
+		coordinatorRule = append(coordinatorRule, coordinatorItem)
+	}
+
+	logs, sub, err := _WalletCoordinator.contract.WatchLogs(opts, "RedemptionProposalSubmitted", coordinatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(WalletCoordinatorRedemptionProposalSubmitted)
+				if err := _WalletCoordinator.contract.UnpackLog(event, "RedemptionProposalSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRedemptionProposalSubmitted is a log parse operation binding the contract event 0x315f9ad8d0b7518ff779e5acc7c069df04df94325d86b685227473ebd452bb70.
+//
+// Solidity: event RedemptionProposalSubmitted((bytes20,bytes[],uint256) proposal, address indexed coordinator)
+func (_WalletCoordinator *WalletCoordinatorFilterer) ParseRedemptionProposalSubmitted(log types.Log) (*WalletCoordinatorRedemptionProposalSubmitted, error) {
+	event := new(WalletCoordinatorRedemptionProposalSubmitted)
+	if err := _WalletCoordinator.contract.UnpackLog(event, "RedemptionProposalSubmitted", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/pkg/chain/ethereum/tbtc/gen/cmd/WalletCoordinator.go
+++ b/pkg/chain/ethereum/tbtc/gen/cmd/WalletCoordinator.go
@@ -61,7 +61,13 @@ func init() {
 		wcHeartbeatRequestValidityCommand(),
 		wcIsCoordinatorCommand(),
 		wcOwnerCommand(),
+		wcRedemptionMaxSizeCommand(),
+		wcRedemptionProposalSubmissionGasOffsetCommand(),
+		wcRedemptionProposalValidityCommand(),
+		wcRedemptionRequestMinAgeCommand(),
+		wcRedemptionRequestTimeoutSafetyMarginCommand(),
 		wcReimbursementPoolCommand(),
+		wcValidateRedemptionProposalCommand(),
 		wcWalletLockCommand(),
 		wcAddCoordinatorCommand(),
 		wcInitializeCommand(),
@@ -71,10 +77,13 @@ func init() {
 		wcRequestHeartbeatWithReimbursementCommand(),
 		wcSubmitDepositSweepProposalCommand(),
 		wcSubmitDepositSweepProposalWithReimbursementCommand(),
+		wcSubmitRedemptionProposalCommand(),
+		wcSubmitRedemptionProposalWithReimbursementCommand(),
 		wcTransferOwnershipCommand(),
 		wcUnlockWalletCommand(),
 		wcUpdateDepositSweepProposalParametersCommand(),
 		wcUpdateHeartbeatRequestParametersCommand(),
+		wcUpdateRedemptionProposalParametersCommand(),
 		wcUpdateReimbursementPoolCommand(),
 	)
 
@@ -432,6 +441,176 @@ func wcOwner(c *cobra.Command, args []string) error {
 	return nil
 }
 
+func wcRedemptionMaxSizeCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "redemption-max-size",
+		Short:                 "Calls the view method redemptionMaxSize on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcRedemptionMaxSize,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcRedemptionMaxSize(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.RedemptionMaxSizeAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcRedemptionProposalSubmissionGasOffsetCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "redemption-proposal-submission-gas-offset",
+		Short:                 "Calls the view method redemptionProposalSubmissionGasOffset on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcRedemptionProposalSubmissionGasOffset,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcRedemptionProposalSubmissionGasOffset(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.RedemptionProposalSubmissionGasOffsetAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcRedemptionProposalValidityCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "redemption-proposal-validity",
+		Short:                 "Calls the view method redemptionProposalValidity on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcRedemptionProposalValidity,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcRedemptionProposalValidity(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.RedemptionProposalValidityAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcRedemptionRequestMinAgeCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "redemption-request-min-age",
+		Short:                 "Calls the view method redemptionRequestMinAge on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcRedemptionRequestMinAge,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcRedemptionRequestMinAge(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.RedemptionRequestMinAgeAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcRedemptionRequestTimeoutSafetyMarginCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "redemption-request-timeout-safety-margin",
+		Short:                 "Calls the view method redemptionRequestTimeoutSafetyMargin on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(0),
+		RunE:                  wcRedemptionRequestTimeoutSafetyMargin,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcRedemptionRequestTimeoutSafetyMargin(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	result, err := contract.RedemptionRequestTimeoutSafetyMarginAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
 func wcReimbursementPoolCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:                   "reimbursement-pool",
@@ -454,6 +633,46 @@ func wcReimbursementPool(c *cobra.Command, args []string) error {
 	}
 
 	result, err := contract.ReimbursementPoolAtBlock(
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wcValidateRedemptionProposalCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "validate-redemption-proposal [arg_proposal_json]",
+		Short:                 "Calls the view method validateRedemptionProposal on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(1),
+		RunE:                  wcValidateRedemptionProposal,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wcValidateRedemptionProposal(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	arg_proposal_json := abi.WalletCoordinatorRedemptionProposal{}
+	if err := json.Unmarshal([]byte(args[0]), &arg_proposal_json); err != nil {
+		return fmt.Errorf("failed to unmarshal arg_proposal_json to abi.WalletCoordinatorRedemptionProposal: %w", err)
+	}
+
+	result, err := contract.ValidateRedemptionProposalAtBlock(
+		arg_proposal_json,
 		cmd.BlockFlagValue.Int,
 	)
 
@@ -1032,6 +1251,130 @@ func wcSubmitDepositSweepProposalWithReimbursement(c *cobra.Command, args []stri
 	return nil
 }
 
+func wcSubmitRedemptionProposalCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "submit-redemption-proposal [arg_proposal_json]",
+		Short:                 "Calls the nonpayable method submitRedemptionProposal on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(1),
+		RunE:                  wcSubmitRedemptionProposal,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	c.PreRunE = cmd.NonConstArgsChecker
+	cmd.InitNonConstFlags(c)
+
+	return c
+}
+
+func wcSubmitRedemptionProposal(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	arg_proposal_json := abi.WalletCoordinatorRedemptionProposal{}
+	if err := json.Unmarshal([]byte(args[0]), &arg_proposal_json); err != nil {
+		return fmt.Errorf("failed to unmarshal arg_proposal_json to abi.WalletCoordinatorRedemptionProposal: %w", err)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.SubmitRedemptionProposal(
+			arg_proposal_json,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash())
+	} else {
+		// Do a call.
+		err = contract.CallSubmitRedemptionProposal(
+			arg_proposal_json,
+			cmd.BlockFlagValue.Int,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput("success")
+
+		cmd.PrintOutput(
+			"the transaction was not submitted to the chain; " +
+				"please add the `--submit` flag",
+		)
+	}
+
+	return nil
+}
+
+func wcSubmitRedemptionProposalWithReimbursementCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "submit-redemption-proposal-with-reimbursement [arg_proposal_json]",
+		Short:                 "Calls the nonpayable method submitRedemptionProposalWithReimbursement on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(1),
+		RunE:                  wcSubmitRedemptionProposalWithReimbursement,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	c.PreRunE = cmd.NonConstArgsChecker
+	cmd.InitNonConstFlags(c)
+
+	return c
+}
+
+func wcSubmitRedemptionProposalWithReimbursement(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	arg_proposal_json := abi.WalletCoordinatorRedemptionProposal{}
+	if err := json.Unmarshal([]byte(args[0]), &arg_proposal_json); err != nil {
+		return fmt.Errorf("failed to unmarshal arg_proposal_json to abi.WalletCoordinatorRedemptionProposal: %w", err)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.SubmitRedemptionProposalWithReimbursement(
+			arg_proposal_json,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash())
+	} else {
+		// Do a call.
+		err = contract.CallSubmitRedemptionProposalWithReimbursement(
+			arg_proposal_json,
+			cmd.BlockFlagValue.Int,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput("success")
+
+		cmd.PrintOutput(
+			"the transaction was not submitted to the chain; " +
+				"please add the `--submit` flag",
+		)
+	}
+
+	return nil
+}
+
 func wcTransferOwnershipCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:                   "transfer-ownership [arg_newOwner]",
@@ -1320,6 +1663,107 @@ func wcUpdateHeartbeatRequestParameters(c *cobra.Command, args []string) error {
 		err = contract.CallUpdateHeartbeatRequestParameters(
 			arg__heartbeatRequestValidity,
 			arg__heartbeatRequestGasOffset,
+			cmd.BlockFlagValue.Int,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput("success")
+
+		cmd.PrintOutput(
+			"the transaction was not submitted to the chain; " +
+				"please add the `--submit` flag",
+		)
+	}
+
+	return nil
+}
+
+func wcUpdateRedemptionProposalParametersCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "update-redemption-proposal-parameters [arg__redemptionProposalValidity] [arg__redemptionRequestMinAge] [arg__redemptionRequestTimeoutSafetyMargin] [arg__redemptionMaxSize] [arg__redemptionProposalSubmissionGasOffset]",
+		Short:                 "Calls the nonpayable method updateRedemptionProposalParameters on the WalletCoordinator contract.",
+		Args:                  cmd.ArgCountChecker(5),
+		RunE:                  wcUpdateRedemptionProposalParameters,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	c.PreRunE = cmd.NonConstArgsChecker
+	cmd.InitNonConstFlags(c)
+
+	return c
+}
+
+func wcUpdateRedemptionProposalParameters(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletCoordinator(c)
+	if err != nil {
+		return err
+	}
+
+	arg__redemptionProposalValidity, err := decode.ParseUint[uint32](args[0], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__redemptionProposalValidity, a uint32, from passed value %v",
+			args[0],
+		)
+	}
+	arg__redemptionRequestMinAge, err := decode.ParseUint[uint32](args[1], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__redemptionRequestMinAge, a uint32, from passed value %v",
+			args[1],
+		)
+	}
+	arg__redemptionRequestTimeoutSafetyMargin, err := decode.ParseUint[uint32](args[2], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__redemptionRequestTimeoutSafetyMargin, a uint32, from passed value %v",
+			args[2],
+		)
+	}
+	arg__redemptionMaxSize, err := decode.ParseUint[uint16](args[3], 16)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__redemptionMaxSize, a uint16, from passed value %v",
+			args[3],
+		)
+	}
+	arg__redemptionProposalSubmissionGasOffset, err := decode.ParseUint[uint32](args[4], 32)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't parse parameter arg__redemptionProposalSubmissionGasOffset, a uint32, from passed value %v",
+			args[4],
+		)
+	}
+
+	var (
+		transaction *types.Transaction
+	)
+
+	if shouldSubmit, _ := c.Flags().GetBool(cmd.SubmitFlag); shouldSubmit {
+		// Do a regular submission. Take payable into account.
+		transaction, err = contract.UpdateRedemptionProposalParameters(
+			arg__redemptionProposalValidity,
+			arg__redemptionRequestMinAge,
+			arg__redemptionRequestTimeoutSafetyMargin,
+			arg__redemptionMaxSize,
+			arg__redemptionProposalSubmissionGasOffset,
+		)
+		if err != nil {
+			return err
+		}
+
+		cmd.PrintOutput(transaction.Hash())
+	} else {
+		// Do a call.
+		err = contract.CallUpdateRedemptionProposalParameters(
+			arg__redemptionProposalValidity,
+			arg__redemptionRequestMinAge,
+			arg__redemptionRequestTimeoutSafetyMargin,
+			arg__redemptionMaxSize,
+			arg__redemptionProposalSubmissionGasOffset,
 			cmd.BlockFlagValue.Int,
 		)
 		if err != nil {

--- a/pkg/coordinator/tbtc_chain_test.go
+++ b/pkg/coordinator/tbtc_chain_test.go
@@ -533,3 +533,9 @@ func (lc *localTbtcChain) SubmitDepositSweepProposalWithReimbursement(
 func (lc *localTbtcChain) GetDepositSweepMaxSize() (uint16, error) {
 	panic("unsupported")
 }
+
+func (lc *localTbtcChain) OnRedemptionProposalSubmitted(
+	func(event *tbtc.RedemptionProposalSubmittedEvent),
+) subscription.EventSubscription {
+	panic("unsupported")
+}

--- a/pkg/maintainer/wallet/local_chain_test.go
+++ b/pkg/maintainer/wallet/local_chain_test.go
@@ -296,3 +296,9 @@ func (lc *localChain) SubmitDepositSweepProposalWithReimbursement(
 func (lc *localChain) GetDepositSweepMaxSize() (uint16, error) {
 	panic("unsupported")
 }
+
+func (lc *localChain) OnRedemptionProposalSubmitted(
+	func(event *tbtc.RedemptionProposalSubmittedEvent),
+) subscription.EventSubscription {
+	panic("unsupported")
+}

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -431,7 +431,7 @@ type RedemptionProposalSubmittedEvent struct {
 // RedemptionProposal represents a redemption proposal submitted to the chain.
 type RedemptionProposal struct {
 	WalletPublicKeyHash    [20]byte
-	RedeemersOutputScripts [][]byte
+	RedeemersOutputScripts []bitcoin.Script
 	RedemptionTxFee        *big.Int
 }
 

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -375,6 +375,12 @@ type WalletCoordinatorChain interface {
 	// GetDepositSweepMaxSize gets the maximum number of deposits that can
 	// be part of a deposit sweep proposal.
 	GetDepositSweepMaxSize() (uint16, error)
+
+	// OnRedemptionProposalSubmitted registers a callback that is invoked when
+	// an on-chain notification of the redemption proposal submission is seen.
+	OnRedemptionProposalSubmitted(
+		func(event *RedemptionProposalSubmittedEvent),
+	) subscription.EventSubscription
 }
 
 // HeartbeatRequestSubmittedEvent represents a wallet heartbeat request
@@ -412,6 +418,21 @@ type DepositSweepProposalSubmittedEventFilter struct {
 	EndBlock            *uint64
 	Coordinator         []chain.Address
 	WalletPublicKeyHash [20]byte
+}
+
+// RedemptionProposalSubmittedEvent represents a redemption proposal
+// submission event.
+type RedemptionProposalSubmittedEvent struct {
+	Proposal    *RedemptionProposal
+	Coordinator chain.Address
+	BlockNumber uint64
+}
+
+// RedemptionProposal represents a redemption proposal submitted to the chain.
+type RedemptionProposal struct {
+	WalletPublicKeyHash    [20]byte
+	RedeemersOutputScripts [][]byte
+	RedemptionTxFee        *big.Int
 }
 
 // Chain represents the interface that the TBTC module expects to interact

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -764,6 +764,12 @@ func (lc *localChain) GetDepositSweepMaxSize() (uint16, error) {
 	panic("unsupported")
 }
 
+func (lc *localChain) OnRedemptionProposalSubmitted(
+	func(event *RedemptionProposalSubmittedEvent),
+) subscription.EventSubscription {
+	panic("unsupported")
+}
+
 // Connect sets up the local chain.
 func Connect() *localChain {
 	operatorPrivateKey, _, err := operator.GenerateKeyPair(local_v1.DefaultCurve)

--- a/pkg/tbtc/deduplicator.go
+++ b/pkg/tbtc/deduplicator.go
@@ -42,6 +42,7 @@ const (
 // - DKG result submitted
 // - Heartbeat request submission
 // - Deposit sweep proposal submission
+// - Redemption proposal submission
 type deduplicator struct {
 	dkgSeedCache              *cache.TimeCache
 	dkgResultHashCache        *cache.TimeCache
@@ -175,4 +176,15 @@ func (d *deduplicator) notifyDepositSweepProposalSubmitted(
 	// Otherwise, the proposal is a duplicate and the client should not
 	// proceed with the execution.
 	return false
+}
+
+// notifyRedemptionProposalSubmitted notifies the client wants to start some
+// actions upon the redemption proposal submission. It returns boolean
+// indicating whether the client should proceed with the actions or ignore the
+// event as a duplicate.
+func (d *deduplicator) notifyRedemptionProposalSubmitted(
+	newProposal *RedemptionProposal,
+) bool {
+	// TODO: Implementation.
+	panic("not implemented yet")
 }

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -460,6 +460,20 @@ func (n *node) handleDepositSweepProposal(
 	walletActionLogger.Infof("wallet action dispatched successfully")
 }
 
+// handleRedemptionProposal handles an incoming redemption proposal.
+// First, it determines whether the node is supposed to do an action by checking
+// whether any of the proposal's target wallet signers are under node's control.
+// If so, this function orchestrates and dispatches an appropriate wallet action.
+func (n *node) handleRedemptionProposal(
+	proposal *RedemptionProposal,
+	proposalExpiresAt time.Time,
+	startBlock uint64,
+	delayBlocks uint64,
+) {
+	// TODO: Implementation.
+	panic("not implemented yet")
+}
+
 // waitForBlockFn represents a function blocking the execution until the given
 // block height.
 type waitForBlockFn func(context.Context, uint64) error

--- a/pkg/tbtc/redemption.go
+++ b/pkg/tbtc/redemption.go
@@ -36,8 +36,9 @@ type RedemptionRequest struct {
 	// Redeemer is the redeemer's address on the host chain.
 	Redeemer chain.Address
 	// RedeemerOutputScript is the output script the redeemed Bitcoin funds are
-	// locked to. This field is not prepended with the byte-length of the script.
-	RedeemerOutputScript []byte
+	// locked to. As stated in the bitcoin.Script docstring, this field is not
+	// prepended with the byte-length of the script.
+	RedeemerOutputScript bitcoin.Script
 	// RequestedAmount is the TBTC amount (in satoshi) requested for redemption.
 	RequestedAmount uint64
 	// TreasuryFee is the treasury TBTC fee (in satoshi) at the moment of

--- a/pkg/tbtc/redemption.go
+++ b/pkg/tbtc/redemption.go
@@ -9,6 +9,13 @@ import (
 	"github.com/keep-network/keep-core/pkg/chain"
 )
 
+const (
+	// redemptionProposalConfirmationBlocks determines the block length of the
+	// confirmation period on the host chain that is preserved after a
+	// redemption proposal submission.
+	redemptionProposalConfirmationBlocks = 20
+)
+
 // RedemptionTransactionShape is an enum describing the shape of
 // a Bitcoin redemption transaction.
 type RedemptionTransactionShape uint8

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -461,6 +461,106 @@ func Initialize(
 		}()
 	})
 
+	// Set up a handler of redemption proposals coming from the
+	// WalletCoordinator on-chain contract. Once an event is seen, a handler
+	// goroutine makes sure that the observed event is not a duplicate, waits
+	// a fixed confirmation period, and ensures the on-chain state justifies
+	// the occurrence of the event. Once done, the original event is used
+	// to trigger the redemption action. The handler does not care about
+	// possible subsequent events being result of chain reorgs. This is because
+	// the WalletCoordinator contract is just a coordination point based on
+	// the chain consensus. If enough clients received the event, they should
+	// follow it and execute a signature. All input parameters for that
+	// signature are validated, so even if there was a reorg and another event
+	// landed on the canonical chain later, the first signature will still be
+	// valid and approved by Bitcoin. The only reason the handler waits a
+	// fixed confirmation period after receiving the coordination event is to
+	// make sure the right type of action is executed given different types of
+	// actions may have different lock times. We do not want to run into a
+	// situation when the majority of clients execute redemption with N blocks
+	// wallet lock time and the chain has M < N blocks wallet lock time because
+	// the canonical chain - as a result of a reorg - is supposed to execute
+	// e.g. wallet heartbeat.
+	_ = chain.OnRedemptionProposalSubmitted(func(event *RedemptionProposalSubmittedEvent) {
+		go func() {
+			walletPublicKeyHash := event.Proposal.WalletPublicKeyHash
+
+			if ok := deduplicator.notifyRedemptionProposalSubmitted(
+				event.Proposal,
+			); !ok {
+				logger.Infof(
+					"redemption proposal for wallet PKH [0x%x] "+
+						"has been already processed",
+					walletPublicKeyHash,
+				)
+				return
+			}
+
+			confirmationBlock := event.BlockNumber +
+				redemptionProposalConfirmationBlocks
+
+			logger.Infof(
+				"observed redemption proposal for wallet PKH [0x%x] "+
+					"at block [%v]; waiting for block [%v] to confirm",
+				walletPublicKeyHash,
+				event.BlockNumber,
+				confirmationBlock,
+			)
+
+			err := node.waitForBlockHeight(ctx, confirmationBlock)
+			if err != nil {
+				logger.Errorf(
+					"failed to confirm redemption proposal for "+
+						"wallet PKH [0x%x]: [%v]",
+					walletPublicKeyHash,
+					err,
+				)
+				return
+			}
+
+			expiresAt, cause, err := chain.GetWalletLock(
+				walletPublicKeyHash,
+			)
+			if err != nil {
+				logger.Errorf(
+					"failed to get lock for wallet PKH [0x%x]: [%v]",
+					walletPublicKeyHash,
+					err,
+				)
+				return
+			}
+
+			// The event is confirmed if the wallet is locked due to a
+			// redemption action.
+			if time.Now().Before(expiresAt) && cause == Redemption {
+				logger.Infof(
+					"redemption proposal submitted for "+
+						"wallet PKH [0x%x] at block [%v] by [%v]",
+					walletPublicKeyHash,
+					event.BlockNumber,
+					event.Coordinator,
+				)
+
+				node.handleRedemptionProposal(
+					event.Proposal,
+					expiresAt,
+					event.BlockNumber,
+					redemptionProposalConfirmationBlocks,
+				)
+			} else {
+				logger.Infof(
+					"redemption proposal for wallet PKH [0x%x] "+
+						"at block [%v] was not confirmed; existing wallet lock "+
+						"has unexpected expiration time [%s] and/or cause [%v]",
+					walletPublicKeyHash,
+					event.BlockNumber,
+					expiresAt,
+					cause,
+				)
+			}
+		}()
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3609

Here is the first part of the client-side redemption support. In this PR, we are integrating with the recent changes introduced in the `WalletCoordinator` contract (https://github.com/keep-network/tbtc-v2/pull/633) and we are adding the ability to observe incoming redemption proposals. Here is a brief description of particular changes.

### `WalletCoordinator` contract integration code

We are adding all the boilerplate code required to see redemption proposals emitted by the `WalletCoordinator` contract. This work includes:
- Updates of contract bindings
- Integration with the `tbtc` package through the `tbtc.WalletCoordinatorChain` interface and `chain/ethereum` implementation
- Implementation of tools allowing to convert between length-prefixed redeemer output scripts used by the smart contracts and the prefixless form preferred in the off-chain client

### Observe incoming proposals

This part uses the code described in the previous section to:

- Handle incoming redemption proposals submitted to the `WalletCoordinator` contract
- De-duplicate incoming proposals
- Confirm the finality of the incoming proposals