### PR TITLE
Propose redemptions coordinator with CLI command

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -146,7 +146,7 @@ var proposeDepositsSweepCommand = cobra.Command{
 
 		depositSweepMaxSize, err := cmd.Flags().GetUint16(depositSweepMaxSizeFlagName)
 		if err != nil {
-			return fmt.Errorf("failed to find fee flag: %v", err)
+			return fmt.Errorf("failed to find deposit sweep max size flag: %v", err)
 		}
 
 		dryRun, err := cmd.Flags().GetBool(dryRunFlagName)
@@ -245,7 +245,7 @@ var proposeRedemptionCommand = cobra.Command{
 
 		redemptionMaxSize, err := cmd.Flags().GetUint16(redemptionMaxSizeFlagName)
 		if err != nil {
-			return fmt.Errorf("failed to find fee flag: %v", err)
+			return fmt.Errorf("failed to find redemption max size flag: %v", err)
 		}
 
 		dryRun, err := cmd.Flags().GetBool(dryRunFlagName)

--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -230,7 +230,7 @@ as arguments.
 var proposeRedemptionCommand = cobra.Command{
 	Use:              "propose-redemption",
 	Short:            "propose redemption",
-	Long:             proposeRedemptionCommandDescription,
+	Long:             "Submits a redemption proposal to the chain.",
 	TraverseChildren: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		wallet, err := cmd.Flags().GetString(walletFlagName)
@@ -303,8 +303,6 @@ var proposeRedemptionCommand = cobra.Command{
 		)
 	},
 }
-
-var proposeRedemptionCommandDescription = `Submits a redemption proposal to the chain.`
 
 var estimateDepositsSweepFeeCommand = cobra.Command{
 	Use:              "estimate-deposits-sweep-fee",

--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -233,8 +233,6 @@ var proposeRedemptionCommand = cobra.Command{
 	Long:             proposeRedemptionCommandDescription,
 	TraverseChildren: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// ctx := cmd.Context()
-
 		wallet, err := cmd.Flags().GetString(walletFlagName)
 		if err != nil {
 			return fmt.Errorf("failed to find wallet flag: %v", err)

--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -273,7 +273,7 @@ var proposeRedemptionCommand = cobra.Command{
 		if redemptionMaxSize == 0 {
 			redemptionMaxSize, err = tbtcChain.GetRedemptionMaxSize()
 			if err != nil {
-				return fmt.Errorf("failed to get deposit sweep max size: [%v]", err)
+				return fmt.Errorf("failed to get redemption max size: [%v]", err)
 			}
 		}
 
@@ -283,7 +283,7 @@ var proposeRedemptionCommand = cobra.Command{
 			redemptionMaxSize,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to prepare deposits sweep proposal: %v", err)
+			return fmt.Errorf("failed to prepare redemption proposal: %v", err)
 		}
 
 		if len(redemptions) > int(redemptionMaxSize) {

--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -230,7 +230,7 @@ as arguments.
 var proposeRedemptionCommand = cobra.Command{
 	Use:              "propose-redemption",
 	Short:            "propose redemption",
-	Long:             "aaaaa",
+	Long:             proposeRedemptionCommandDescription,
 	TraverseChildren: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// ctx := cmd.Context()
@@ -305,6 +305,8 @@ var proposeRedemptionCommand = cobra.Command{
 		)
 	},
 }
+
+var proposeRedemptionCommandDescription = `Submits a redemption proposal to the chain.`
 
 var estimateDepositsSweepFeeCommand = cobra.Command{
 	Use:              "estimate-deposits-sweep-fee",

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1055,9 +1055,16 @@ func (tc *TbtcChain) PastRedemptionRequestedEvents(
 
 	convertedEvents := make([]*tbtc.RedemptionRequestedEvent, 0)
 	for _, event := range events {
+		redeemerOutputScript, err := bitcoin.NewScriptFromVarLenData(
+			event.RedeemerOutputScript,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		convertedEvent := &tbtc.RedemptionRequestedEvent{
 			WalletPublicKeyHash:  event.WalletPubKeyHash,
-			RedeemerOutputScript: event.RedeemerOutputScript,
+			RedeemerOutputScript: redeemerOutputScript,
 			Redeemer:             chain.Address(event.Redeemer.Hex()),
 			RequestedAmount:      event.RequestedAmount,
 			TreasuryFee:          event.TreasuryFee,

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1283,10 +1283,7 @@ func (tc *TbtcChain) GetPendingRedemptionRequest(
 
 	// Redemption not found.
 	if redemptionRequest.RequestedAt == 0 {
-		return nil, fmt.Errorf(
-			"no pending redemption request for key [0x%x]",
-			redemptionKey.Text(16),
-		)
+		return nil, tbtc.ErrPendingRedemptionRequestNotFound
 	}
 
 	return &tbtc.RedemptionRequest{

--- a/pkg/coordinator/chain.go
+++ b/pkg/coordinator/chain.go
@@ -1,19 +1,9 @@
 package coordinator
 
 import (
-	"errors"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 	"math/big"
-)
-
-var (
-	// ErrPendingRedemptionRequestNotFound is an error that is returned if
-	// a pending redemption request was not found on-chain for the given redemption
-	// key.
-	ErrPendingRedemptionRequestNotFound = errors.New(
-		"no pending redemption requests for the given key",
-	)
 )
 
 // Chain represents the interface that the coordinator module expects to interact

--- a/pkg/coordinator/chain.go
+++ b/pkg/coordinator/chain.go
@@ -1,7 +1,21 @@
 package coordinator
 
 import (
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+var (
+	// ErrPendingRedemptionRequestNotFound is an error that is returned if
+	// a pending redemption request was not found on-chain for the given redemption
+	// key.
+	ErrPendingRedemptionRequestNotFound = errors.New(
+		"no pending redemption requests for the given key",
+	)
 )
 
 // Chain represents the interface that the coordinator module expects to interact
@@ -10,4 +24,89 @@ type Chain interface {
 	// TODO: Change to something more specific once https://github.com/keep-network/keep-core/issues/3632
 	// is handled.
 	tbtc.Chain
+
+	// PastRedemptionRequestedEvents fetches past redemption requested events according
+	// to the provided filter or unfiltered if the filter is nil. Returned
+	// events are sorted by the block number in the ascending order, i.e. the
+	// latest event is at the end of the slice.
+	PastRedemptionRequestedEvents(
+		filter *RedemptionRequestedEventFilter,
+	) ([]*RedemptionRequestedEvent, error)
+
+	// GetPendingRedemptionRequest gets the on-chain pending redemption request
+	// for the given redeemer output script and wallet public key hash.
+	// Returns an ErrPendingRedemptionRequestNotFound error if a redemption request
+	// was not found.
+	GetPendingRedemptionRequest(
+		redeemerOutputScript []byte,
+		walletPublicKeyHash [20]byte,
+	) (*RedemptionChainRequest, error)
+
+	// BuildRedemptionKey calculates a redemption key for the given redemption
+	// request which is an identifier for a redemption at the given time
+	// on-chain.
+	BuildRedemptionKey(redeemerOutputScript []byte, walletPublicKeyHash [20]byte) *big.Int
+
+	// GetRedemptionParameters gets the current value of parameters relevant
+	// for the redemption process.
+	GetRedemptionParameters() (
+		dustThreshold uint64,
+		treasuryFeeDivisor uint64,
+		txMaxFee uint64,
+		txMaxTotalFee uint64,
+		timeout uint32,
+		timeoutSlashingAmount *big.Int,
+		timeoutNotifierRewardMultiplier uint32,
+		err error,
+	)
+
+	// SubmitRedemptionProposalWithReimbursement submits a redemption proposal
+	// to the chain. It reimburses the gas cost to the caller.
+	SubmitRedemptionProposalWithReimbursement(
+		proposal *RedemptionProposal,
+	) error
+
+	// GetRedemptionMaxSize gets the maximum number of redemption requests that
+	// can be a part of a redemption sweep proposal.
+	GetRedemptionMaxSize() (uint16, error)
+
+	// GetRedemptionRequestMinAge get the  minimum time that must elapse since
+	// the redemption request creation before a request becomes eligible for
+	// a processing.
+	GetRedemptionRequestMinAge() (uint32, error)
+}
+
+// RedemptionRequestedEvent represents a redemption requested event.
+type RedemptionRequestedEvent struct {
+	WalletPublicKeyHash  [20]byte
+	RedeemerOutputScript []byte
+	Redeemer             chain.Address
+	RequestedAmount      uint64
+	TreasuryFee          uint64
+	TxMaxFee             uint64
+	BlockNumber          uint64
+}
+
+// RedemptionRequestedEventFilter is a component allowing to filter RedemptionRequestedEvent.
+type RedemptionRequestedEventFilter struct {
+	StartBlock          uint64
+	EndBlock            *uint64
+	WalletPublicKeyHash [][20]byte
+	Redeemer            []chain.Address
+}
+
+// RedemptionChainRequest represents a redemption request stored on-chain.
+type RedemptionChainRequest struct {
+	Redeemer        chain.Address
+	RequestedAmount uint64
+	TreasuryFee     uint64
+	TxMaxFee        uint64
+	RequestedAt     time.Time
+}
+
+// RedemptionProposal represents a redemption proposal submitted to the chain.
+type RedemptionProposal struct {
+	WalletPublicKeyHash    [20]byte
+	RedeemersOutputScripts [][]byte
+	RedemptionTxFee        *big.Int
 }

--- a/pkg/coordinator/redemptions.go
+++ b/pkg/coordinator/redemptions.go
@@ -175,7 +175,14 @@ func ProposeRedemption(
 	}
 
 	logger.Infof("validating the redemption proposal...")
-	// TODO: Use the same function that nodes will use to validate a proposal.
+
+	if _, err := tbtc.ValidateRedemptionProposal(
+		logger,
+		proposal,
+		chain,
+	); err != nil {
+		return fmt.Errorf("failed to verify redemption proposal: %v", err)
+	}
 
 	if !dryRun {
 		logger.Infof("submitting the deposit sweep proposal...")
@@ -214,7 +221,7 @@ func getPendingRedemptions(
 	)
 
 	// TODO: We should consider narrowing the block range in filter the fetch
-	// only events that are newer than `now - redemptionRequestTimeout`.
+	//       only events that are newer than `now - redemptionRequestTimeout`.
 
 	redemptionsRequested, err := chain.PastRedemptionRequestedEvents(filter)
 	if err != nil {

--- a/pkg/coordinator/redemptions.go
+++ b/pkg/coordinator/redemptions.go
@@ -1,0 +1,316 @@
+package coordinator
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/hexutils"
+)
+
+type redemptionEntry struct {
+	walletPublicKeyHash [20]byte
+
+	redemptionKey        string
+	redeemerOutputScript []byte
+	requestedAt          time.Time
+}
+
+// FindPendingRedemptions finds pending redemptions requests.
+func FindPendingRedemptions(
+	chain Chain,
+	walletPublicKeyHash [20]byte,
+	maxNumberOfDeposits uint16,
+) ([20]byte, [][]byte, error) {
+	logger.Infof("redemption max size: %d", maxNumberOfDeposits)
+
+	redemptionRequestMinAge, err := chain.GetRedemptionRequestMinAge()
+	if err != nil {
+		return [20]byte{}, nil, fmt.Errorf(
+			"failed to get redemption request minimum age: [%w]",
+			err,
+		)
+	}
+
+	_, _, _, _, redemptionTimeout, _, _, err := chain.GetRedemptionParameters()
+	if err != nil {
+		return [20]byte{}, nil, fmt.Errorf(
+			"failed to get redemption parameters: [%w]",
+			err,
+		)
+	}
+
+	getPendingRedemptionsFromWallet := func(walletToSweep [20]byte) ([]*redemptionEntry, error) {
+		pendingRedemptions, err := getPendingRedemptions(
+			chain,
+			walletToSweep,
+			int(maxNumberOfDeposits),
+			redemptionTimeout,
+			redemptionRequestMinAge,
+		)
+		if err != nil {
+			return nil,
+				fmt.Errorf(
+					"failed to get deposits for [%s] wallet: [%w]",
+					hexutils.Encode(walletToSweep[:]),
+					err,
+				)
+		}
+		return pendingRedemptions, nil
+	}
+
+	var redemptionsToPropose []*redemptionEntry
+	// If walletPublicKeyHash is not provided we need to find a wallet that has
+	// pending redemptions.
+	if walletPublicKeyHash == [20]byte{} {
+		walletRegisteredEvents, err := chain.PastNewWalletRegisteredEvents(nil)
+		if err != nil {
+			return [20]byte{}, nil, fmt.Errorf("failed to get registered wallets: [%w]", err)
+		}
+
+		// Take the oldest first
+		sort.SliceStable(walletRegisteredEvents, func(i, j int) bool {
+			return walletRegisteredEvents[i].BlockNumber < walletRegisteredEvents[j].BlockNumber
+		})
+
+		redeemingWallets := walletRegisteredEvents
+		// Only two the most recently created wallets are accepting redemptions.
+		if len(walletRegisteredEvents) >= 2 {
+			redeemingWallets = walletRegisteredEvents[len(walletRegisteredEvents)-2:]
+		}
+
+		for _, registeredWallet := range redeemingWallets {
+			logger.Infof(
+				"fetching pending redemption requests from wallet [%s]...",
+				hexutils.Encode(registeredWallet.WalletPublicKeyHash[:]),
+			)
+
+			pendingRedemptions, err := getPendingRedemptionsFromWallet(
+				registeredWallet.WalletPublicKeyHash,
+			)
+			if err != nil {
+				return [20]byte{}, nil, err
+			}
+
+			// Check if there are any unswept deposits in this wallet. If so
+			// sweep this wallet and don't check the other wallet.
+			if len(pendingRedemptions) > 0 {
+				walletPublicKeyHash = registeredWallet.WalletPublicKeyHash
+				redemptionsToPropose = pendingRedemptions
+				break
+			}
+		}
+	} else {
+		logger.Infof(
+			"fetching deposits from wallet [%s]...",
+			hexutils.Encode(walletPublicKeyHash[:]),
+		)
+		unsweptDeposits, err := getPendingRedemptionsFromWallet(
+			walletPublicKeyHash,
+		)
+		if err != nil {
+			return [20]byte{}, nil, err
+		}
+		redemptionsToPropose = unsweptDeposits
+	}
+
+	if len(redemptionsToPropose) == 0 {
+		return [20]byte{}, nil, nil
+	}
+
+	logger.Infof(
+		"found [%d] redemptions for wallet [%s]",
+		len(redemptionsToPropose),
+		hexutils.Encode(walletPublicKeyHash[:]),
+	)
+
+	redeemersOutputScripts := make([][]byte, len(redemptionsToPropose))
+
+	for i, redemption := range redemptionsToPropose {
+		logger.Infof(
+			"redemption [%d/%d] - %s",
+			i+1,
+			len(redemptionsToPropose),
+			fmt.Sprintf(
+				"redemptionKey: [%s], requested at: [%s]",
+				redemption.redemptionKey,
+				redemption.requestedAt,
+			))
+
+		redeemersOutputScripts[i] = redemption.redeemerOutputScript
+	}
+
+	return walletPublicKeyHash, redeemersOutputScripts, nil
+}
+
+// ProposeRedemption handles redemption proposal submission.
+func ProposeRedemption(
+	chain Chain,
+	walletPublicKeyHash [20]byte,
+	fee int64,
+	redeemersOutputScripts [][]byte,
+	dryRun bool,
+) error {
+	if len(redeemersOutputScripts) == 0 {
+		return fmt.Errorf("redemptions list is empty")
+	}
+
+	// Estimate fee if it's missing.
+	if fee <= 0 {
+		// TODO: implement fee estimation
+	}
+
+	logger.Infof("redemption transaction fee: [%d]", fee)
+
+	logger.Infof("preparing a redemption proposal...")
+
+	proposal := &RedemptionProposal{
+		WalletPublicKeyHash:    walletPublicKeyHash,
+		RedeemersOutputScripts: redeemersOutputScripts,
+		RedemptionTxFee:        big.NewInt(fee),
+	}
+
+	logger.Infof("validating the redemption proposal...")
+	// TODO: Use the same function that nodes will use to validate a proposal.
+
+	if !dryRun {
+		logger.Infof("submitting the deposit sweep proposal...")
+		if err := chain.SubmitRedemptionProposalWithReimbursement(proposal); err != nil {
+			return fmt.Errorf("failed to submit deposit sweep proposal: %v", err)
+		}
+	} else {
+		logger.Infof("skipping transaction submission in dry-run mode")
+	}
+
+	return nil
+}
+
+func getPendingRedemptions(
+	chain Chain,
+	walletPublicKeyHash [20]byte,
+	maxNumberOfRedemptions int,
+	redemptionRequestTimeout uint32,
+	redemptionRequestMinAge uint32,
+) ([]*redemptionEntry, error) {
+	logger.Infof("reading revealed deposits from chain...")
+
+	filter := &RedemptionRequestedEventFilter{}
+	if walletPublicKeyHash != [20]byte{} {
+		filter.WalletPublicKeyHash = [][20]byte{walletPublicKeyHash}
+	}
+
+	// Only redemption requests in range:
+	// [now - redemptionRequestTimeout, now - redemptionRequestMinAge]
+	// should be taken into consideration.
+	redemptionRequestsRangeStartTimestamp := time.Now().Add(
+		time.Duration(-redemptionRequestTimeout) * time.Second,
+	)
+	redemptionRequestsRangeEndTimestamp := time.Now().Add(
+		time.Duration(-redemptionRequestMinAge) * time.Second,
+	)
+
+	// TODO: We should consider narrowing the block range in filter the fetch
+	// only events that are newer than `now - redemptionRequestTimeout`.
+
+	redemptionsRequested, err := chain.PastRedemptionRequestedEvents(filter)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get past redemption requested events: [%w]",
+			err,
+		)
+	}
+	logger.Infof("found %d RedemptionRequested events", len(redemptionsRequested))
+
+	// Take the oldest first.
+	sort.SliceStable(redemptionsRequested, func(i, j int) bool {
+		return redemptionsRequested[i].BlockNumber < redemptionsRequested[j].BlockNumber
+	})
+
+	logger.Infof("checking pending redemptions details...")
+
+	pendingRedemptions := make([]*redemptionEntry, 0)
+
+redemptionRequestedLoop:
+	for i, event := range redemptionsRequested {
+		logger.Debugf("getting pending redemption details %d/%d", i+1, len(redemptionsRequested))
+
+		// Check if there is still a pending redemption for the given redemption
+		// requested event.
+		pendingRedemption, err := chain.GetPendingRedemptionRequest(
+			event.RedeemerOutputScript,
+			event.WalletPublicKeyHash,
+		)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrPendingRedemptionRequestNotFound):
+				logger.Debugf(
+					"redemption for request %d/%d is no longer pending",
+					i+1,
+					len(redemptionsRequested),
+				)
+
+				continue redemptionRequestedLoop
+			default:
+				return nil, fmt.Errorf(
+					"failed to get pending redemption request: [%w]",
+					err,
+				)
+			}
+		}
+
+		redemptionKey := chain.BuildRedemptionKey(
+			event.RedeemerOutputScript,
+			event.WalletPublicKeyHash,
+		)
+
+		pendingRedemptions = append(pendingRedemptions, &redemptionEntry{
+			walletPublicKeyHash:  event.WalletPublicKeyHash,
+			redemptionKey:        hexutils.Encode(redemptionKey.Bytes()),
+			redeemerOutputScript: event.RedeemerOutputScript,
+			requestedAt:          pendingRedemption.RequestedAt,
+		})
+	}
+
+	resultSliceCapacity := len(redemptionsRequested)
+	if maxNumberOfRedemptions > 0 {
+		resultSliceCapacity = maxNumberOfRedemptions
+	}
+
+	// Sort the pending redemptions.
+	sort.SliceStable(pendingRedemptions, func(i, j int) bool {
+		return pendingRedemptions[i].requestedAt.Before(pendingRedemptions[j].requestedAt)
+	})
+
+	result := make([]*redemptionEntry, 0, resultSliceCapacity)
+	for i, pendingRedemption := range pendingRedemptions {
+		if len(result) == cap(result) {
+			break
+		}
+
+		// Check if timeout passed for the redemption request.
+		if pendingRedemption.requestedAt.Before(redemptionRequestsRangeStartTimestamp) {
+			logger.Infof(
+				"redemption request %d/%d has already timed out",
+				i+1,
+				len(redemptionsRequested),
+			)
+			continue
+		}
+
+		// Check if enough time elapsed since the redemption request.
+		if pendingRedemption.requestedAt.After(redemptionRequestsRangeEndTimestamp) {
+			logger.Infof(
+				"redemption request %d/%d is not old enough",
+				i+1,
+				len(redemptionsRequested),
+			)
+			continue
+		}
+
+		result = append(result, pendingRedemption)
+	}
+
+	return result, nil
+}

--- a/pkg/coordinator/redemptions.go
+++ b/pkg/coordinator/redemptions.go
@@ -161,7 +161,7 @@ func ProposeRedemption(
 
 	// Estimate fee if it's missing.
 	if fee <= 0 {
-		// TODO: implement fee estimation
+		panic("fee estimation not implemented yet")
 	}
 
 	logger.Infof("redemption transaction fee: [%d]", fee)

--- a/pkg/coordinator/tbtc_chain_test.go
+++ b/pkg/coordinator/tbtc_chain_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
-	"github.com/keep-network/keep-core/pkg/coordinator"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/subscription"
@@ -371,8 +370,8 @@ func buildPastNewWalletRegisteredEventsKey(
 }
 
 func (lc *localTbtcChain) PastRedemptionRequestedEvents(
-	filter *coordinator.RedemptionRequestedEventFilter,
-) ([]*coordinator.RedemptionRequestedEvent, error) {
+	filter *tbtc.RedemptionRequestedEventFilter,
+) ([]*tbtc.RedemptionRequestedEvent, error) {
 	panic("unsupported")
 }
 
@@ -400,7 +399,10 @@ func buildDepositRequestKey(
 	return sha256.Sum256(append(fundingTxHash[:], fundingOutputIndexBytes...))
 }
 
-func (lc *localTbtcChain) BuildRedemptionKey(redeemerOutputScript []byte, walletPublicKeyHash [20]byte) *big.Int {
+func (lc *localTbtcChain) BuildRedemptionKey(
+	walletPublicKeyHash [20]byte,
+	redeemerOutputScript bitcoin.Script,
+) (*big.Int, error) {
 	panic("unsupported")
 }
 
@@ -562,7 +564,7 @@ func (lc *localTbtcChain) SubmitDepositSweepProposalWithReimbursement(
 }
 
 func (lc *localTbtcChain) SubmitRedemptionProposalWithReimbursement(
-	proposal *coordinator.RedemptionProposal,
+	proposal *tbtc.RedemptionProposal,
 ) error {
 	panic("unsupported")
 }

--- a/pkg/coordinator/tbtc_chain_test.go
+++ b/pkg/coordinator/tbtc_chain_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/coordinator"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/subscription"
@@ -369,6 +370,19 @@ func buildPastNewWalletRegisteredEventsKey(
 	return sha256.Sum256(buffer.Bytes()), nil
 }
 
+func (lc *localTbtcChain) PastRedemptionRequestedEvents(
+	filter *coordinator.RedemptionRequestedEventFilter,
+) ([]*coordinator.RedemptionRequestedEvent, error) {
+	panic("unsupported")
+}
+
+func (lc *localTbtcChain) GetPendingRedemptionRequest(
+	redeemerOutputScript []byte,
+	walletPublicKeyHash [20]byte,
+) (*coordinator.RedemptionChainRequest, error) {
+	panic("unsupported")
+}
+
 func (lc *localTbtcChain) GetWallet(walletPublicKeyHash [20]byte) (*tbtc.WalletChainData, error) {
 	panic("unsupported")
 }
@@ -391,6 +405,10 @@ func buildDepositRequestKey(
 	binary.BigEndian.PutUint32(fundingOutputIndexBytes, fundingOutputIndex)
 
 	return sha256.Sum256(append(fundingTxHash[:], fundingOutputIndexBytes...))
+}
+
+func (lc *localTbtcChain) BuildRedemptionKey(redeemerOutputScript []byte, walletPublicKeyHash [20]byte) *big.Int {
+	panic("unsupported")
 }
 
 func (lc *localTbtcChain) GetDepositParameters() (
@@ -425,6 +443,19 @@ func (lc *localTbtcChain) setDepositParameters(
 		txMaxFee:           txMaxFee,
 		revealAheadPeriod:  revealAheadPeriod,
 	}
+}
+
+func (lc *localTbtcChain) GetRedemptionParameters() (
+	dustThreshold uint64,
+	treasuryFeeDivisor uint64,
+	txMaxFee uint64,
+	txMaxTotalFee uint64,
+	timeout uint32,
+	timeoutSlashingAmount *big.Int,
+	timeoutNotifierRewardMultiplier uint32,
+	err error,
+) {
+	panic("unsupported")
 }
 
 func (lc *localTbtcChain) OnHeartbeatRequestSubmitted(
@@ -530,6 +561,20 @@ func (lc *localTbtcChain) SubmitDepositSweepProposalWithReimbursement(
 	return nil
 }
 
+func (lc *localTbtcChain) SubmitRedemptionProposalWithReimbursement(
+	proposal *coordinator.RedemptionProposal,
+) error {
+	panic("unsupported")
+}
+
 func (lc *localTbtcChain) GetDepositSweepMaxSize() (uint16, error) {
+	panic("unsupported")
+}
+
+func (lc *localTbtcChain) GetRedemptionMaxSize() (uint16, error) {
+	panic("unsupported")
+}
+
+func (lc *localTbtcChain) GetRedemptionRequestMinAge() (uint32, error) {
 	panic("unsupported")
 }

--- a/pkg/maintainer/wallet/local_chain_test.go
+++ b/pkg/maintainer/wallet/local_chain_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
-	"github.com/keep-network/keep-core/pkg/coordinator"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/subscription"
@@ -199,8 +198,8 @@ func (lc *localChain) PastNewWalletRegisteredEvents(
 }
 
 func (lc *localChain) PastRedemptionRequestedEvents(
-	filter *coordinator.RedemptionRequestedEventFilter,
-) ([]*coordinator.RedemptionRequestedEvent, error) {
+	filter *tbtc.RedemptionRequestedEventFilter,
+) ([]*tbtc.RedemptionRequestedEvent, error) {
 	panic("unsupported")
 }
 
@@ -216,7 +215,10 @@ func (lc *localChain) BuildDepositKey(fundingTxHash bitcoin.Hash, fundingOutputI
 	panic("unsupported")
 }
 
-func (lc *localChain) BuildRedemptionKey(redeemerOutputScript []byte, walletPublicKeyHash [20]byte) *big.Int {
+func (lc *localChain) BuildRedemptionKey(
+	walletPublicKeyHash [20]byte,
+	redeemerOutputScript bitcoin.Script,
+) (*big.Int, error) {
 	panic("unsupported")
 }
 
@@ -325,7 +327,7 @@ func (lc *localChain) SubmitDepositSweepProposalWithReimbursement(
 }
 
 func (lc *localChain) SubmitRedemptionProposalWithReimbursement(
-	proposal *coordinator.RedemptionProposal,
+	proposal *tbtc.RedemptionProposal,
 ) error {
 	panic("unsupported")
 }

--- a/pkg/maintainer/wallet/local_chain_test.go
+++ b/pkg/maintainer/wallet/local_chain_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/coordinator"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/subscription"
@@ -197,6 +198,19 @@ func (lc *localChain) PastNewWalletRegisteredEvents(
 	panic("unsupported")
 }
 
+func (lc *localChain) PastRedemptionRequestedEvents(
+	filter *coordinator.RedemptionRequestedEventFilter,
+) ([]*coordinator.RedemptionRequestedEvent, error) {
+	panic("unsupported")
+}
+
+func (lc *localChain) GetPendingRedemptionRequest(
+	redeemerOutputScript []byte,
+	walletPublicKeyHash [20]byte,
+) (*coordinator.RedemptionChainRequest, error) {
+	panic("unsupported")
+}
+
 func (lc *localChain) GetWallet(walletPublicKeyHash [20]byte) (*tbtc.WalletChainData, error) {
 	panic("unsupported")
 }
@@ -209,11 +223,28 @@ func (lc *localChain) BuildDepositKey(fundingTxHash bitcoin.Hash, fundingOutputI
 	panic("unsupported")
 }
 
+func (lc *localChain) BuildRedemptionKey(redeemerOutputScript []byte, walletPublicKeyHash [20]byte) *big.Int {
+	panic("unsupported")
+}
+
 func (lc *localChain) GetDepositParameters() (
 	dustThreshold uint64,
 	treasuryFeeDivisor uint64,
 	txMaxFee uint64,
 	revealAheadPeriod uint32,
+	err error,
+) {
+	panic("unsupported")
+}
+
+func (lc *localChain) GetRedemptionParameters() (
+	dustThreshold uint64,
+	treasuryFeeDivisor uint64,
+	txMaxFee uint64,
+	txMaxTotalFee uint64,
+	timeout uint32,
+	timeoutSlashingAmount *big.Int,
+	timeoutNotifierRewardMultiplier uint32,
 	err error,
 ) {
 	panic("unsupported")
@@ -293,6 +324,20 @@ func (lc *localChain) SubmitDepositSweepProposalWithReimbursement(
 	panic("unsupported")
 }
 
+func (lc *localChain) SubmitRedemptionProposalWithReimbursement(
+	proposal *coordinator.RedemptionProposal,
+) error {
+	panic("unsupported")
+}
+
 func (lc *localChain) GetDepositSweepMaxSize() (uint16, error) {
+	panic("unsupported")
+}
+
+func (lc *localChain) GetRedemptionMaxSize() (uint16, error) {
+	panic("unsupported")
+}
+
+func (lc *localChain) GetRedemptionRequestMinAge() (uint32, error) {
 	panic("unsupported")
 }

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -447,6 +447,25 @@ type RedemptionProposal struct {
 	RedemptionTxFee        *big.Int
 }
 
+// RedemptionRequestedEvent represents a redemption requested event.
+type RedemptionRequestedEvent struct {
+	WalletPublicKeyHash  [20]byte
+	RedeemerOutputScript bitcoin.Script
+	Redeemer             chain.Address
+	RequestedAmount      uint64
+	TreasuryFee          uint64
+	TxMaxFee             uint64
+	BlockNumber          uint64
+}
+
+// RedemptionRequestedEventFilter is a component allowing to filter RedemptionRequestedEvent.
+type RedemptionRequestedEventFilter struct {
+	StartBlock          uint64
+	EndBlock            *uint64
+	WalletPublicKeyHash [][20]byte
+	Redeemer            []chain.Address
+}
+
 // Chain represents the interface that the TBTC module expects to interact
 // with the anchoring blockchain on.
 type Chain interface {

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"math/big"
 	"time"
 
@@ -180,6 +181,15 @@ type DKGParameters struct {
 	ChallengePeriodBlocks         uint64
 	ApprovePrecedencePeriodBlocks uint64
 }
+
+var (
+	// ErrPendingRedemptionRequestNotFound is an error that is returned if
+	// a pending redemption request was not found on-chain for the given
+	// redemption key.
+	ErrPendingRedemptionRequestNotFound = errors.New(
+		"no pending redemption request for the given key",
+	)
+)
 
 // BridgeChain defines the subset of the TBTC chain interface that pertains
 // specifically to the tBTC Bridge operations.


### PR DESCRIPTION
We added a CLI command to submit a redemption proposal. 

To submit a redemptions proposal run:
```
keep-client coordinator propose-redemption --wallet <wallet_address> --fee <fee>
```

Following optional flags can be used with the command:
- `--wallet <address>` - target wallet
- `--fee` - fee to use for a bitcoin transaction

The command requires `ethereum` node details to be provided in the config.

## Testing

This feature can be tested against the updated Goerli `WalletCoordinator` whose address and ABI are provided by the https://www.npmjs.com/package/@keep-network/tbtc-v2/v/1.5.0-goerli.0 package.

Refs: https://github.com/keep-network/keep-core/issues/3614