### PR TITLE
Redemption prototype: Validate proposal and broadcast Bitcoin transaction

### DIFF
--- a/pkg/bitcoin/bitcoin.go
+++ b/pkg/bitcoin/bitcoin.go
@@ -45,6 +45,18 @@ func readCompactSizeUint(varLenData []byte) (CompactSizeUint, int, error) {
 	return CompactSizeUint(csu), wire.VarIntSerializeSize(csu), nil
 }
 
+// writeCompactSizeUint writes the provided CompactSizeUint into a
+// byte slice.
+func writeCompactSizeUint(csu CompactSizeUint) ([]byte, error) {
+	var buffer bytes.Buffer
+	err := wire.WriteVarInt(&buffer, 0, uint64(csu))
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
 // ByteOrder represents the byte order used by the Bitcoin byte arrays. The
 // Bitcoin ecosystem is not totally consistent in this regard and different
 // byte orders are used depending on the purpose.

--- a/pkg/bitcoin/bitcoin.go
+++ b/pkg/bitcoin/bitcoin.go
@@ -23,6 +23,11 @@ import (
 // >= 0x10000 && <= 0xffffffff             |   5   | 0xfe followed by the number as uint32
 // >= 0x100000000 && <= 0xffffffffffffffff |   9   | 0xff followed by the number as uint64
 //
+// Worth noting, the encoded number value is represented using the little-endian
+// byte order. For example, to convert the compact size uint 0xfd0302, the
+// 0xfd prefix must be skipped and the 0x0302 must be reversed to 0x0203 and
+// then converted to a decimal number 515.
+//
 // For reference, see:
 // https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
 type CompactSizeUint uint64

--- a/pkg/bitcoin/bitcoin_test.go
+++ b/pkg/bitcoin/bitcoin_test.go
@@ -77,3 +77,46 @@ func TestReadCompactSizeUint(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteCompactSizeUint(t *testing.T) {
+	fromHex := func(hexString string) []byte {
+		bytes, err := hex.DecodeString(hexString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bytes
+	}
+
+	var tests = map[string]struct {
+		csu           CompactSizeUint
+		expectedBytes []byte
+	}{
+		"1-byte compact size uint": {
+			csu:           187,
+			expectedBytes: fromHex("bb"),
+		},
+		"3-byte compact size uint": {
+			csu:           515,
+			expectedBytes: fromHex("fd0302"),
+		},
+		"5-byte compact size uint": {
+			csu:           998000,
+			expectedBytes: fromHex("fe703a0f00"),
+		},
+		"9-byte compact size uint": {
+			csu:           198849843832919,
+			expectedBytes: fromHex("ff57284e56dab40000"),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			bytes, err := writeCompactSizeUint(test.csu)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testutils.AssertBytesEqual(t, test.expectedBytes, bytes)
+		})
+	}
+}

--- a/pkg/bitcoin/script.go
+++ b/pkg/bitcoin/script.go
@@ -34,6 +34,17 @@ func NewScriptFromVarLenData(varLenData []byte) (Script, error) {
 	return varLenData[compactByteLength:], nil
 }
 
+// ToVarLenData converts the Script to a byte array prepended with a
+// CompactSizeUint holding the script's byte length.
+func (s Script) ToVarLenData() ([]byte, error) {
+	compactBytes, err := writeCompactSizeUint(CompactSizeUint(len(s)))
+	if err != nil {
+		return nil, fmt.Errorf("cannot write compact size uint: [%v]", err)
+	}
+
+	return append(compactBytes, s...), nil
+}
+
 // PublicKeyHash constructs the 20-byte public key hash by applying SHA-256
 // then RIPEMD-160 on the provided ECDSA public key.
 func PublicKeyHash(publicKey *ecdsa.PublicKey) [20]byte {

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -360,3 +360,32 @@ func TestBuildDepositKey(t *testing.T) {
 		depositKey.Text(16),
 	)
 }
+
+func TestBuildRedemptionKey(t *testing.T) {
+	fromHex := func(hexString string) []byte {
+		b, err := hex.DecodeString(hexString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+
+	walletPublicKeyHashBytes := fromHex("8db50eb52063ea9d98b3eac91489a90f738986f6")
+	var walletPublicKeyHash [20]byte
+	copy(walletPublicKeyHash[:], walletPublicKeyHashBytes)
+
+	redeemerOutputScript := fromHex("76a9144130879211c54df460e484ddf9aac009cb38ee7488ac")
+
+	redemptionKey, err := buildRedemptionKey(walletPublicKeyHash, redeemerOutputScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRedemptionKey := "cb493004c645792101cfa4cc5da4c16aa3148065034371a6f1478b7df4b92d39"
+	testutils.AssertStringsEqual(
+		t,
+		"redemption key",
+		expectedRedemptionKey,
+		redemptionKey.Text(16),
+	)
+}

--- a/pkg/coordinator/tbtc_chain_test.go
+++ b/pkg/coordinator/tbtc_chain_test.go
@@ -410,6 +410,13 @@ func (lc *localTbtcChain) GetDepositParameters() (
 		nil
 }
 
+func (lc *localTbtcChain) GetPendingRedemptionRequest(
+	walletPublicKeyHash [20]byte,
+	redeemerOutputScript bitcoin.Script,
+) (*tbtc.RedemptionRequest, error) {
+	panic("unsupported")
+}
+
 func (lc *localTbtcChain) setDepositParameters(
 	dustThreshold uint64,
 	treasuryFeeDivisor uint64,

--- a/pkg/coordinator/tbtc_chain_test.go
+++ b/pkg/coordinator/tbtc_chain_test.go
@@ -539,3 +539,9 @@ func (lc *localTbtcChain) OnRedemptionProposalSubmitted(
 ) subscription.EventSubscription {
 	panic("unsupported")
 }
+
+func (lc *localTbtcChain) ValidateRedemptionProposal(
+	proposal *tbtc.RedemptionProposal,
+) error {
+	panic("unsupported")
+}

--- a/pkg/maintainer/wallet/local_chain_test.go
+++ b/pkg/maintainer/wallet/local_chain_test.go
@@ -219,6 +219,13 @@ func (lc *localChain) GetDepositParameters() (
 	panic("unsupported")
 }
 
+func (lc *localChain) GetPendingRedemptionRequest(
+	walletPublicKeyHash [20]byte,
+	redeemerOutputScript bitcoin.Script,
+) (*tbtc.RedemptionRequest, error) {
+	panic("unsupported")
+}
+
 func (lc *localChain) OnHeartbeatRequestSubmitted(
 	handler func(event *tbtc.HeartbeatRequestSubmittedEvent),
 ) subscription.EventSubscription {

--- a/pkg/maintainer/wallet/local_chain_test.go
+++ b/pkg/maintainer/wallet/local_chain_test.go
@@ -302,3 +302,9 @@ func (lc *localChain) OnRedemptionProposalSubmitted(
 ) subscription.EventSubscription {
 	panic("unsupported")
 }
+
+func (lc *localChain) ValidateRedemptionProposal(
+	proposal *tbtc.RedemptionProposal,
+) error {
+	panic("unsupported")
+}

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -380,6 +380,11 @@ type WalletCoordinatorChain interface {
 	OnRedemptionProposalSubmitted(
 		func(event *RedemptionProposalSubmittedEvent),
 	) subscription.EventSubscription
+
+	// ValidateRedemptionProposal validates the given redemption proposal
+	// against the chain. Returns an error if the proposal is not valid or
+	// nil otherwise.
+	ValidateRedemptionProposal(proposal *RedemptionProposal) error
 }
 
 // HeartbeatRequestSubmittedEvent represents a wallet heartbeat request

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -229,6 +229,14 @@ type BridgeChain interface {
 		revealAheadPeriod uint32,
 		err error,
 	)
+
+	// GetPendingRedemptionRequest gets the on-chain pending redemption request
+	// for the given wallet public key hash and redeemer output script.
+	// Returns an error if the request was not found.
+	GetPendingRedemptionRequest(
+		walletPublicKeyHash [20]byte,
+		redeemerOutputScript bitcoin.Script,
+	) (*RedemptionRequest, error)
 }
 
 // HeartbeatRequestedEvent represents a Bridge heartbeat request event.

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -579,6 +579,13 @@ func (lc *localChain) GetDepositParameters() (
 	panic("unsupported")
 }
 
+func (lc *localChain) GetPendingRedemptionRequest(
+	walletPublicKeyHash [20]byte,
+	redeemerOutputScript bitcoin.Script,
+) (*RedemptionRequest, error) {
+	panic("unsupported")
+}
+
 func buildDepositRequestKey(
 	fundingTxHash bitcoin.Hash,
 	fundingOutputIndex uint32,

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -770,6 +770,12 @@ func (lc *localChain) OnRedemptionProposalSubmitted(
 	panic("unsupported")
 }
 
+func (lc *localChain) ValidateRedemptionProposal(
+	proposal *RedemptionProposal,
+) error {
+	panic("unsupported")
+}
+
 // Connect sets up the local chain.
 func Connect() *localChain {
 	operatorPrivateKey, _, err := operator.GenerateKeyPair(local_v1.DefaultCurve)

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -114,8 +114,10 @@ func (dsa *depositSweepAction) execute() error {
 		return fmt.Errorf("validate proposal step failed: [%v]", err)
 	}
 
+	walletPublicKeyHash := bitcoin.PublicKeyHash(dsa.wallet().publicKey)
+
 	walletMainUtxo, err := DetermineWalletMainUtxo(
-		bitcoin.PublicKeyHash(dsa.wallet().publicKey),
+		walletPublicKeyHash,
 		dsa.chain,
 		dsa.btcChain,
 	)
@@ -126,7 +128,11 @@ func (dsa *depositSweepAction) execute() error {
 		)
 	}
 
-	err = dsa.ensureWalletSyncedBetweenChains(walletMainUtxo)
+	err = EnsureWalletSyncedBetweenChains(
+		walletPublicKeyHash,
+		walletMainUtxo,
+		dsa.btcChain,
+	)
 	if err != nil {
 		return fmt.Errorf(
 			"error while ensuring wallet state is synced between "+
@@ -318,92 +324,6 @@ func ValidateDepositSweepProposal(
 	}
 
 	return deposits, nil
-}
-
-// ensureWalletSyncedBetweenChains makes sure all actions taken by the wallet
-// on the Bitcoin chain are reflected in the host chain Bridge. This translates
-// to two conditions that must be met:
-// - The wallet main UTXO registered in the host chain Bridge comes from the
-//   latest BTC transaction OR wallet main UTXO is unset and wallet's BTC
-//   transaction history is empty. This condition ensures that all expected SPV
-//   proofs of confirmed BTC transactions were submitted to the host chain Bridge
-//   thus the wallet state held known to the Bridge matches the actual state
-//   on the BTC chain.
-// - There are no pending BTC transactions in the mempool. This condition
-//   ensures the wallet doesn't currently perform any action on the BTC chain.
-//   Such a transactions indicate a possible state change in the future
-//   but their outcome cannot be determined at this stage so, the wallet
-//   should not perform new actions at the moment.
-func (dsa *depositSweepAction) ensureWalletSyncedBetweenChains(
-	walletMainUtxo *bitcoin.UnspentTransactionOutput,
-) error {
-	walletPublicKeyHash := bitcoin.PublicKeyHash(dsa.wallet().publicKey)
-
-	// Take the recent transactions history for the wallet.
-	history, err := dsa.btcChain.GetTransactionsForPublicKeyHash(walletPublicKeyHash, 5)
-	if err != nil {
-		return fmt.Errorf("cannot get transactions history: [%v]", err)
-	}
-
-	if walletMainUtxo != nil {
-		// If the wallet main UTXO exists, the transaction history must
-		// contain at least one item. If it is empty, something went
-		// really wrong. This should never happen but check this scenario
-		// just in case.
-		if len(history) == 0 {
-			return fmt.Errorf(
-				"wallet main UTXO exists but there are no BTC " +
-					"transactions produced by the wallet",
-			)
-		}
-
-		// The transaction history is not empty for sure. Take the latest BTC
-		// transaction from the history.
-		latestTransaction := history[len(history)-1]
-
-		// Make sure the wallet main UTXO comes from the latest transaction.
-		// That means all expected SPV proofs were submitted to the Bridge.
-		// If the wallet main UTXO transaction hash doesn't match the latest
-		// transaction, that means the SPV proof for the latest transaction was
-		// not submitted to the Bridge yet.
-		//
-		// Note that it is enough to check that the wallet main UTXO transaction
-		// hash matches the latest transaction hash. There is no way the main
-		// UTXO changes and the transaction hash stays the same. The Bridge
-		// enforces that all wallet transactions form a sequence and refer
-		// each other.
-		if walletMainUtxo.Outpoint.TransactionHash != latestTransaction.Hash() {
-			return fmt.Errorf(
-				"wallet main UTXO doesn't come from the latest BTC transaction",
-			)
-		}
-	} else {
-		// If the wallet main UTXO doesn't exist, the transaction history must
-		// be empty. If it is not, that could mean there is a Bitcoin transaction
-		// produced by the wallet whose SPV proof was not submitted to
-		// the Bridge yet.
-		if len(history) != 0 {
-			return fmt.Errorf(
-				"wallet main UTXO doesn't exist but there are BTC " +
-					"transactions produced by the wallet",
-			)
-		}
-	}
-
-	// Regardless of the main UTXO state, we need to make sure that
-	// no pending wallet transactions exist in the mempool. That way,
-	// we are handling a plenty of corner cases like transactions races
-	// that could potentially lead to fraudulent transactions and funds loss.
-	mempool, err := dsa.btcChain.GetMempoolForPublicKeyHash(walletPublicKeyHash)
-	if err != nil {
-		return fmt.Errorf("cannot get mempool: [%v]", err)
-	}
-
-	if len(mempool) != 0 {
-		return fmt.Errorf("unconfirmed transactions exist in the mempool")
-	}
-
-	return nil
 }
 
 func (dsa *depositSweepAction) wallet() wallet {

--- a/pkg/tbtc/redemption_test.go
+++ b/pkg/tbtc/redemption_test.go
@@ -1,7 +1,10 @@
 package tbtc
 
 import (
+	"github.com/keep-network/keep-core/pkg/tecdsa"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 
@@ -9,6 +12,168 @@ import (
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/tbtc/internal/test"
 )
+
+// TODO: Think about covering unhappy paths for specific steps of the redemption action.
+func TestRedemptionAction_Execute(t *testing.T) {
+	scenarios, err := test.LoadRedemptionTestScenarios()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Title, func(t *testing.T) {
+			now := time.Now()
+
+			hostChain := Connect()
+			bitcoinChain := newLocalBitcoinChain()
+
+			wallet := wallet{
+				// Set only relevant fields.
+				publicKey: scenario.WalletPublicKey,
+			}
+			walletPublicKeyHash := bitcoin.PublicKeyHash(wallet.publicKey)
+
+			// Record the transaction that will serve as redemption transaction's
+			// input in the Bitcoin local chain.
+			err := bitcoinChain.BroadcastTransaction(scenario.InputTransaction)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// redeemersOutputScripts will be needed to build the proposal instance.
+			redeemersOutputScripts := make(
+				[]bitcoin.Script,
+				len(scenario.RedemptionRequests),
+			)
+
+			// Record all necessary requests' data on the local host chain.
+			for i, request := range scenario.RedemptionRequests {
+				hostChain.setPendingRedemptionRequest(
+					walletPublicKeyHash,
+					&RedemptionRequest{
+						Redeemer:             request.Redeemer,
+						RedeemerOutputScript: request.RedeemerOutputScript,
+						RequestedAmount:      request.RequestedAmount,
+						TreasuryFee:          request.TreasuryFee,
+						TxMaxFee:             request.TxMaxFee,
+						RequestedAt:          request.RequestedAt,
+					},
+				)
+
+				redeemersOutputScripts[i] = request.RedeemerOutputScript
+			}
+
+			totalFee := int64(0)
+			for _, feeShare := range scenario.FeeShares {
+				totalFee += feeShare
+			}
+
+			// Build the redemption proposal based on the scenario data.
+			proposal := &RedemptionProposal{
+				WalletPublicKeyHash:    walletPublicKeyHash,
+				RedeemersOutputScripts: redeemersOutputScripts,
+				RedemptionTxFee:        big.NewInt(totalFee),
+			}
+
+			// Choose an arbitrary start block and expiration time.
+			proposalProcessingStartBlock := uint64(100)
+			proposalExpiresAt := now.Add(4 * time.Hour)
+
+			// Simulate the on-chain proposal validation passes with success.
+			err = hostChain.setRedemptionProposalValidationResult(
+				proposal,
+				true,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Record the wallet main UTXO hash in the local host chain so
+			// the deposit action can detect it.
+			var walletMainUtxoHash [32]byte
+			if scenario.WalletMainUtxo != nil {
+				walletMainUtxoHash = hostChain.ComputeMainUtxoHash(
+					scenario.WalletMainUtxo,
+				)
+			}
+			hostChain.setWallet(walletPublicKeyHash, &WalletChainData{
+				MainUtxoHash: walletMainUtxoHash,
+			})
+
+			// Create a signing executor mock instance.
+			signingExecutor := newMockWalletSigningExecutor()
+
+			// The signature within the scenario fixture is in the format
+			// suitable for applying them directly to a Bitcoin transaction.
+			// However, the signing executor operates on raw tECDSA signatures
+			// so, we need to unpack it first.
+			rawSignature := &tecdsa.Signature{
+				R: scenario.Signature.R,
+				S: scenario.Signature.S,
+			}
+
+			// Set up the signing executor mock to return the signature from
+			// the test fixture when called with the expected parameters.
+			// Note that the start block is set based on the proposal
+			// processing start block as done within the action.
+			signingExecutor.setSignatures(
+				[]*big.Int{scenario.ExpectedSigHash},
+				proposalProcessingStartBlock,
+				[]*tecdsa.Signature{rawSignature},
+			)
+
+			action := newRedemptionAction(
+				logger.With(),
+				hostChain,
+				bitcoinChain,
+				wallet,
+				signingExecutor,
+				proposal,
+				proposalProcessingStartBlock,
+				proposalExpiresAt,
+			)
+
+			// Modify the default parameters of the action to make
+			// it possible to execute in the current test environment.
+			action.broadcastCheckDelay = 1 * time.Second
+
+			// Test scenarios use a different fee distribution than the
+			// default one used by the redemption action. Here we override
+			// the default distribution by using the one appropriate for
+			// test scenarios.
+			action.feeDistribution = func(requests []*RedemptionRequest) []int64 {
+				return scenario.FeeShares
+			}
+
+			// Test scenarios use the RedemptionChangeLast shape which is
+			// different from the default RedemptionChangeFirst shape used
+			// by the redemption action. We need to override it.
+			action.transactionShape = RedemptionChangeLast
+
+			err = action.execute()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Action execution that completes without an error is a sign of
+			// success. However, just in case, make an additional check that
+			// the expected redemption transaction was actually broadcasted
+			// on the local Bitcoin chain.
+			broadcastedRedemptionTransaction, err := bitcoinChain.GetTransaction(
+				scenario.ExpectedRedemptionTransactionHash,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testutils.AssertBytesEqual(
+				t,
+				scenario.ExpectedRedemptionTransaction.Serialize(),
+				broadcastedRedemptionTransaction.Serialize(),
+			)
+		})
+	}
+}
 
 func TestAssembleRedemptionTransaction(t *testing.T) {
 	scenarios, err := test.LoadRedemptionTestScenarios()

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -432,6 +432,92 @@ func DetermineWalletMainUtxo(
 	return nil, fmt.Errorf("main UTXO not found")
 }
 
+// EnsureWalletSyncedBetweenChains makes sure all actions taken by the wallet
+// on the Bitcoin chain are reflected in the host chain Bridge. This translates
+// to two conditions that must be met:
+// - The wallet main UTXO registered in the host chain Bridge comes from the
+//   latest BTC transaction OR wallet main UTXO is unset and wallet's BTC
+//   transaction history is empty. This condition ensures that all expected SPV
+//   proofs of confirmed BTC transactions were submitted to the host chain Bridge
+//   thus the wallet state held known to the Bridge matches the actual state
+//   on the BTC chain.
+// - There are no pending BTC transactions in the mempool. This condition
+//   ensures the wallet doesn't currently perform any action on the BTC chain.
+//   Such a transactions indicate a possible state change in the future
+//   but their outcome cannot be determined at this stage so, the wallet
+//   should not perform new actions at the moment.
+func EnsureWalletSyncedBetweenChains(
+	walletPublicKeyHash [20]byte,
+	walletMainUtxo *bitcoin.UnspentTransactionOutput,
+	btcChain bitcoin.Chain,
+) error {
+	// Take the recent transactions history for the wallet.
+	history, err := btcChain.GetTransactionsForPublicKeyHash(walletPublicKeyHash, 5)
+	if err != nil {
+		return fmt.Errorf("cannot get transactions history: [%v]", err)
+	}
+
+	if walletMainUtxo != nil {
+		// If the wallet main UTXO exists, the transaction history must
+		// contain at least one item. If it is empty, something went
+		// really wrong. This should never happen but check this scenario
+		// just in case.
+		if len(history) == 0 {
+			return fmt.Errorf(
+				"wallet main UTXO exists but there are no BTC " +
+					"transactions produced by the wallet",
+			)
+		}
+
+		// The transaction history is not empty for sure. Take the latest BTC
+		// transaction from the history.
+		latestTransaction := history[len(history)-1]
+
+		// Make sure the wallet main UTXO comes from the latest transaction.
+		// That means all expected SPV proofs were submitted to the Bridge.
+		// If the wallet main UTXO transaction hash doesn't match the latest
+		// transaction, that means the SPV proof for the latest transaction was
+		// not submitted to the Bridge yet.
+		//
+		// Note that it is enough to check that the wallet main UTXO transaction
+		// hash matches the latest transaction hash. There is no way the main
+		// UTXO changes and the transaction hash stays the same. The Bridge
+		// enforces that all wallet transactions form a sequence and refer
+		// each other.
+		if walletMainUtxo.Outpoint.TransactionHash != latestTransaction.Hash() {
+			return fmt.Errorf(
+				"wallet main UTXO doesn't come from the latest BTC transaction",
+			)
+		}
+	} else {
+		// If the wallet main UTXO doesn't exist, the transaction history must
+		// be empty. If it is not, that could mean there is a Bitcoin transaction
+		// produced by the wallet whose SPV proof was not submitted to
+		// the Bridge yet.
+		if len(history) != 0 {
+			return fmt.Errorf(
+				"wallet main UTXO doesn't exist but there are BTC " +
+					"transactions produced by the wallet",
+			)
+		}
+	}
+
+	// Regardless of the main UTXO state, we need to make sure that
+	// no pending wallet transactions exist in the mempool. That way,
+	// we are handling a plenty of corner cases like transactions races
+	// that could potentially lead to fraudulent transactions and funds loss.
+	mempool, err := btcChain.GetMempoolForPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		return fmt.Errorf("cannot get mempool: [%v]", err)
+	}
+
+	if len(mempool) != 0 {
+		return fmt.Errorf("unconfirmed transactions exist in the mempool")
+	}
+
+	return nil
+}
+
 // signer represents a threshold signer of a tBTC wallet. A signer holds
 // a wallet tECDSA private key share and is able to participate in the
 // signing process.


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/3609

Here we add the remaining part necessary to enable redemption support on the client side. Specific changes include:

### Extracting common components used across wallet actions

During the work on this PR, we identified that some code can be detached from the existing `depositSweepAction` and live as an independent being that can be reused across different wallet actions. Those components are:
- The `walletTransactionExecutor` which is a thin layer encapsulating some logic necessary to sign and broadcast wallet Bitcoin transactions
- The `EnsureWalletSyncedBetweenChains` function which allows to make sure the wallet is synced between the Bitcoin and host chain before starting an action

Thanks to that change, we avoid code duplication across wallet actions.

### Implementation of the `redemptionAction`

We introduce a dedicated `redemptionAction` that encapsulates everything that must be done to perform a successful redemption. Its structure is very similar to the existing `depositSweepAction`. It starts by making the proposal validation, then constructs, signs, and broadcasts the redemption transaction over the Bitcoin network.