### PR TITLE
Adding metric and diagnostics for the Bitcoin chain

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
-	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/build"
 	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/storage"
 
 	"github.com/spf13/cobra"
 
-	"github.com/keep-network/keep-core/build"
 	"github.com/keep-network/keep-core/config"
 	"github.com/keep-network/keep-core/pkg/beacon"
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -79,24 +78,23 @@ func start(cmd *cobra.Command) error {
 		return fmt.Errorf("cannot initialize network: [%v]", err)
 	}
 
-	btcChain, err := electrum.Connect(ctx, clientConfig.Bitcoin.Electrum)
-	if err != nil {
-		return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
-	}
-
 	clientInfoRegistry := initializeClientInfo(
 		ctx,
 		clientConfig,
 		netProvider,
 		signing,
 		blockCounter,
-		btcChain,
 	)
 
 	// Initialize beacon and tbtc only for non-bootstrap nodes.
 	// Skip initialization for bootstrap nodes as they are only used for network
 	// discovery.
 	if !isBootstrap() {
+		btcChain, err := electrum.Connect(ctx, clientConfig.Bitcoin.Electrum)
+		if err != nil {
+			return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
+		}
+
 		beaconKeyStorePersistence,
 			tbtcKeyStorePersistence,
 			tbtcDataPersistence,
@@ -106,6 +104,13 @@ func start(cmd *cobra.Command) error {
 		}
 
 		scheduler := generator.StartScheduler()
+
+		clientInfoRegistry.ObserveBtcConnectivity(
+			btcChain,
+			clientConfig.ClientInfo.BitcoinMetricsTick,
+		)
+
+		clientInfoRegistry.RegisterBtcChainInfoSource(btcChain)
 
 		err = beacon.Initialize(
 			ctx,
@@ -190,7 +195,6 @@ func initializeClientInfo(
 	netProvider net.Provider,
 	signing chain.Signing,
 	blockCounter chain.BlockCounter,
-	btcChain bitcoin.Chain,
 ) *clientinfo.Registry {
 	registry, isConfigured := clientinfo.Initialize(ctx, config.ClientInfo.Port)
 	if !isConfigured {
@@ -214,11 +218,6 @@ func initializeClientInfo(
 		config.ClientInfo.EthereumMetricsTick,
 	)
 
-	registry.ObserveBtcConnectivity(
-		btcChain,
-		clientConfig.ClientInfo.BitcoinMetricsTick,
-	)
-
 	registry.RegisterMetricClientInfo(build.Version)
 
 	registry.RegisterConnectedPeersSource(netProvider, signing)
@@ -230,7 +229,7 @@ func initializeClientInfo(
 		build.Revision,
 	)
 
-	registry.RegisterChainInfoSource(blockCounter, btcChain)
+	registry.RegisterEthChainInfoSource(blockCounter)
 
 	logger.Infof(
 		"enabled client info endpoint on port [%v]",

--- a/pkg/clientinfo/clientinfo.go
+++ b/pkg/clientinfo/clientinfo.go
@@ -16,6 +16,7 @@ type Config struct {
 	Port                int
 	NetworkMetricsTick  time.Duration
 	EthereumMetricsTick time.Duration
+	BitcoinMetricsTick  time.Duration
 }
 
 // Registry wraps keep-common clientinfo registry and exposes additional

--- a/pkg/clientinfo/diagnostics.go
+++ b/pkg/clientinfo/diagnostics.go
@@ -13,7 +13,8 @@ import (
 type Diagnostics struct {
 	ClientInfo     Client `json:"client_info"`
 	ConnectedPeers []Peer `json:"connected_peers"`
-	ChainInfo      Chain  `json:"chain_info"`
+	EthChainInfo   Chain  `json:"eth_chain_info"`
+	BtcChainInfo   Chain  `json:"btc_chain_info"`
 }
 
 // Client describes data structure of client information.
@@ -31,10 +32,9 @@ type Peer struct {
 	NetworkMultiAddresses []string `json:"multiaddrs"`
 }
 
-// Chain describes data structure of chains information.
+// Chain describes data structure of a chain information.
 type Chain struct {
-	EthBlockNumber uint64 `json:"latest_eth_block_number"`
-	BtcBlockNumber uint   `json:"latest_btc_block_number"`
+	LatestBlockNumber uint `json:"latest_block_number"`
 }
 
 // ApplicationInfo describes data structure of application information.
@@ -126,31 +126,47 @@ func (r *Registry) RegisterClientInfoSource(
 	})
 }
 
-// RegisterChainInfoSource registers the diagnostics source providing
-// information about chains.
-func (r *Registry) RegisterChainInfoSource(
-	blockCounter chain.BlockCounter,
+// RegisterBtcChainInfoSource registers the diagnostics source providing
+// information about btc chain.
+func (r *Registry) RegisterBtcChainInfoSource(
 	btcChain bitcoin.Chain,
 ) {
-	r.RegisterDiagnosticSource("chain_info", func() string {
-		ethCurrentBlock, err := blockCounter.CurrentBlock()
-		if err != nil {
-			logger.Errorf("error on getting Ethereum latest block number: [%v]", err)
-		}
-
-		btcCurrentBlock, err := btcChain.GetLatestBlockHeight()
+	r.RegisterDiagnosticSource("btc_chain_info", func() string {
+		btcLatestBlock, err := btcChain.GetLatestBlockHeight()
 		if err != nil {
 			logger.Errorf("error on getting Bitcoin latest block number: [%v]", err)
 		}
-
 		chainInfo := Chain{
-			EthBlockNumber: ethCurrentBlock,
-			BtcBlockNumber: btcCurrentBlock,
+			LatestBlockNumber: btcLatestBlock,
 		}
 
 		bytes, err := json.Marshal(chainInfo)
 		if err != nil {
-			logger.Errorf("error on serializing chain info to JSON: [%v]", err)
+			logger.Errorf("error on serializing btc chain info to JSON: [%v]", err)
+			return ""
+		}
+
+		return string(bytes)
+	})
+}
+
+// RegisterEthChainInfoSource registers the diagnostics source providing
+// information about eth chain.
+func (r *Registry) RegisterEthChainInfoSource(
+	blockCounter chain.BlockCounter,
+) {
+	r.RegisterDiagnosticSource("eth_chain_info", func() string {
+		ethLatestBlock, err := blockCounter.CurrentBlock()
+		if err != nil {
+			logger.Errorf("error on getting Ethereum latest block number: [%v]", err)
+		}
+		chainInfo := Chain{
+			LatestBlockNumber: uint(ethLatestBlock),
+		}
+
+		bytes, err := json.Marshal(chainInfo)
+		if err != nil {
+			logger.Errorf("error on serializing eth chain info to JSON: [%v]", err)
 			return ""
 		}
 

--- a/pkg/clientinfo/metrics.go
+++ b/pkg/clientinfo/metrics.go
@@ -88,7 +88,6 @@ func (r *Registry) ObserveEthConnectivity(
 ) {
 	input := func() float64 {
 		_, err := blockCounter.CurrentBlock()
-
 		if err != nil {
 			return 0
 		}
@@ -111,7 +110,6 @@ func (r *Registry) ObserveBtcConnectivity(
 ) {
 	input := func() float64 {
 		_, err := btcChain.GetLatestBlockHeight()
-
 		if err != nil {
 			return 0
 		}

--- a/pkg/clientinfo/metrics.go
+++ b/pkg/clientinfo/metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/keep-network/keep-common/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/net"
 )
@@ -16,6 +17,7 @@ const (
 	ConnectedPeersCountMetricName     = "connected_peers_count"
 	ConnectedBootstrapCountMetricName = "connected_bootstrap_count"
 	EthConnectivityMetricName         = "eth_connectivity"
+	BtcConnectivityMetricName         = "btc_connectivity"
 	ClientInfoMetricName              = "client_info"
 )
 
@@ -26,6 +28,9 @@ const (
 	// DefaultEthereumMetricsTick is the default duration of the
 	// observation tick for Ethereum metrics.
 	DefaultEthereumMetricsTick = 10 * time.Minute
+	// DefaultBitcoinMetricsTick is the default duration of the
+	// observation tick for Bitcoin metrics.
+	DefaultBitcoinMetricsTick = 10 * time.Minute
 	// The duration of the observation tick for all application-specific
 	// metrics.
 	ApplicationMetricsTick = 1 * time.Minute
@@ -95,6 +100,29 @@ func (r *Registry) ObserveEthConnectivity(
 		EthConnectivityMetricName,
 		input,
 		validateTick(tick, DefaultEthereumMetricsTick),
+	)
+}
+
+// ObserveBtcConnectivity triggers an observation process of the
+// btc_connectivity metric.
+func (r *Registry) ObserveBtcConnectivity(
+	btcChain bitcoin.Chain,
+	tick time.Duration,
+) {
+	input := func() float64 {
+		_, err := btcChain.GetLatestBlockHeight()
+
+		if err != nil {
+			return 0
+		}
+
+		return 1
+	}
+
+	r.observe(
+		BtcConnectivityMetricName,
+		input,
+		validateTick(tick, DefaultBitcoinMetricsTick),
 	)
 }
 


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3608

- Added `btc_connectivity` under the `/metrics`. It shows 1 or 0 - connected or not
- Added `latest_btc_block_number` `/diagnostics` that read the latest Bitcoin block

Example output:

http://192.168.1.8:9601/diagnostics

```
{
  "btc_chain_info": {
    "latest_block_number": 2438768
  },
  "client_info": {
    "chain_address": "0x04BdC8f5051f21CF6E788eA451bB81A75266b473",
    "network_id": "16Uiu2HAkzBpWcRgxEY8W4vuRYCJiSAzseEpVjFtHEawqow5xvTQw",
    "revision": "0f3c7b137",
    "version": "v2.0.0-m3-268-g0f3c7b137"
  },
  "connected_peers": [
    {
      "chain_address": "0x407190f04d838Ec47dad4C0e0D2a9c49d7737479",
      "multiaddrs": [
        "/ip6/::1/tcp/3920",
        "/ip4/192.168.1.8/tcp/3920",
        "/ip4/127.0.0.1/tcp/3920"
      ],
      "network_id": "16Uiu2HAm4WrMWq9Gc7WsymsqgrwbaD1KeW2eH8eY63DTZHXbRsuE"
    }
  ],
  "eth_chain_info": {
    "latest_block_number": 6073
  }
}
```

http://192.168.1.8:9601/metrics

```
# TYPE btc_connectivity gauge
btc_connectivity 1 1687513222959

client_info{version="v2.0.0-m3-268-g0f3c7b137"} 1

# TYPE connected_bootstrap_count gauge
connected_bootstrap_count 0 1687513282171

# TYPE connected_peers_count gauge
connected_peers_count 1 1687513282170

# TYPE eth_connectivity gauge
eth_connectivity 1 1687513222166

# TYPE tbtc_pre_params_count gauge
tbtc_pre_params_count 100 1687513282894
```