### PR TITLE
Estimate redemption transaction fee during proposal

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -261,6 +261,11 @@ var proposeRedemptionCommand = cobra.Command{
 			)
 		}
 
+		btcChain, err := electrum.Connect(cmd.Context(), clientConfig.Bitcoin.Electrum)
+		if err != nil {
+			return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
+		}
+
 		var walletPublicKeyHash [20]byte
 		if len(wallet) > 0 {
 			var err error
@@ -296,6 +301,7 @@ var proposeRedemptionCommand = cobra.Command{
 
 		return coordinator.ProposeRedemption(
 			tbtcChain,
+			btcChain,
 			walletPublicKeyHash,
 			fee,
 			redemptions,

--- a/pkg/bitcoin/script.go
+++ b/pkg/bitcoin/script.go
@@ -9,6 +9,17 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
+// ScriptType represents the possible types of Script.
+type ScriptType uint8
+
+const (
+	NonStandardScript ScriptType = iota
+	P2PKHScript
+	P2WPKHScript
+	P2SHScript
+	P2WSHScript
+)
+
 // Script represents an arbitrary Bitcoin script, NOT prepended with the
 // byte-length of the script
 type Script []byte
@@ -118,4 +129,20 @@ func PayToScriptHash(scriptHash [20]byte) (Script, error) {
 		AddData(scriptHash[:]).
 		AddOp(txscript.OP_EQUAL).
 		Script()
+}
+
+// GetScriptType gets the ScriptType of the given Script.
+func GetScriptType(script Script) ScriptType {
+	switch txscript.GetScriptClass(script) {
+	case txscript.PubKeyHashTy:
+		return P2PKHScript
+	case txscript.WitnessV0PubKeyHashTy:
+		return P2WPKHScript
+	case txscript.ScriptHashTy:
+		return P2SHScript
+	case txscript.WitnessV0ScriptHashTy:
+		return P2WSHScript
+	default:
+		return NonStandardScript
+	}
 }

--- a/pkg/bitcoin/script_test.go
+++ b/pkg/bitcoin/script_test.go
@@ -333,3 +333,56 @@ func TestPayToScriptHash(t *testing.T) {
 
 	testutils.AssertBytesEqual(t, expectedResult, result[:])
 }
+
+func TestGetScriptType(t *testing.T) {
+	fromHex := func(hexString string) []byte {
+		bytes, err := hex.DecodeString(hexString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bytes
+	}
+
+	var tests = map[string]struct {
+		script       Script
+		expectedType ScriptType
+	}{
+		"p2pkh script": {
+			script:       fromHex("76a9148db50eb52063ea9d98b3eac91489a90f738986f688ac"),
+			expectedType: P2PKHScript,
+		},
+		"p2wpkh script": {
+			script:       fromHex("00148db50eb52063ea9d98b3eac91489a90f738986f6"),
+			expectedType: P2WPKHScript,
+		},
+		"p2sh script": {
+			script:       fromHex("a9143ec459d0f3c29286ae5df5fcc421e2786024277e87"),
+			expectedType: P2SHScript,
+		},
+		"p2wsh script": {
+			script:       fromHex("002086a303cdd2e2eab1d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca96"),
+			expectedType: P2WSHScript,
+		},
+		"non-standard script": {
+			script: fromHex(
+				"14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d0003" +
+					"95237576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a" +
+					"91428e081f285138ccbe389c1eb8985716230129f89880460bcea61b175ac68",
+			),
+			expectedType: NonStandardScript,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualType := GetScriptType(test.script)
+
+			testutils.AssertIntsEqual(
+				t,
+				"script type",
+				int(test.expectedType),
+				int(actualType),
+			)
+		})
+	}
+}

--- a/pkg/coordinator/redemptions.go
+++ b/pkg/coordinator/redemptions.go
@@ -158,7 +158,7 @@ func ProposeRedemption(
 	if fee <= 0 {
 		logger.Infof("estimating redemption transaction fee...")
 
-		estimatedFee, err := estimateRedemptionFee(
+		estimatedFee, err := EstimateRedemptionFee(
 			btcChain,
 			redeemersOutputScripts,
 		)
@@ -335,13 +335,15 @@ redemptionRequestedLoop:
 	return result, nil
 }
 
-func estimateRedemptionFee(
+func EstimateRedemptionFee(
 	btcChain bitcoin.Chain,
 	redeemersOutputScripts []bitcoin.Script,
 ) (int64, error) {
 	sizeEstimator := bitcoin.NewTransactionSizeEstimator().
 		// 1 P2WPKH main UTXO input.
-		AddPublicKeyHashInputs(1, true)
+		AddPublicKeyHashInputs(1, true).
+		// 1 P2WPKH change output.
+		AddPublicKeyHashOutputs(1, true)
 
 	for _, script := range redeemersOutputScripts {
 		switch bitcoin.GetScriptType(script) {

--- a/pkg/coordinator/redemptions.go
+++ b/pkg/coordinator/redemptions.go
@@ -356,7 +356,7 @@ func EstimateRedemptionFee(
 		case bitcoin.P2WSHScript:
 			sizeEstimator.AddScriptHashOutputs(1, true)
 		default:
-			panic("non-standard redeemer output script type")
+			return 0, fmt.Errorf("non-standard redeemer output script type")
 		}
 	}
 

--- a/pkg/coordinator/redemptions_test.go
+++ b/pkg/coordinator/redemptions_test.go
@@ -1,0 +1,39 @@
+package coordinator_test
+
+import (
+	"encoding/hex"
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/coordinator"
+	"testing"
+)
+
+// Test based on example testnet redemption transaction:
+// https://live.blockcypher.com/btc-testnet/tx/2724545276df61f43f1e92c4b9f1dd3c9109595c022dbd9dc003efbad8ded38b
+func TestEstimateRedemptionFee(t *testing.T) {
+	fromHex := func(hexString string) []byte {
+		bytes, err := hex.DecodeString(hexString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bytes
+	}
+
+	btcChain := newLocalBitcoinChain()
+	btcChain.setEstimateSatPerVByteFee(1, 16)
+
+	redeemersOutputScripts := []bitcoin.Script{
+		fromHex("76a9142cd680318747b720d67bf4246eb7403b476adb3488ac"),                   // P2PKH
+		fromHex("0014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0"),                         // P2WPKH
+		fromHex("a914011beb6fb8499e075a57027fb0a58384f2d3f78487"),                       // P2SH
+		fromHex("0020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"), // P2WSH
+	}
+
+	actualFee, err := coordinator.EstimateRedemptionFee(btcChain, redeemersOutputScripts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFee := 4000 // transactionVirtualSize * satPerVByteFee = 250 * 16 = 4000
+	testutils.AssertIntsEqual(t, "fee", expectedFee, int(actualFee))
+}


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3614

Here we add a function allowing us to estimate the redemption transaction total fee (`coordinator.EstimateRedemptionFee`) and we integrate it with the existing `coordinator.ProposeRedemption` function.