### PR TITLE
Rename `threshold` repo to `docs`

### DIFF
--- a/.github/workflows/contracts-ecdsa-docs.yml
+++ b/.github/workflows/contracts-ecdsa-docs.yml
@@ -63,10 +63,10 @@ jobs:
 
   # This job will be triggered for releases which name starts with
   # `refs/tags/solidity/`. It will generate contracts documentation in
-  # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
-  # a PR updating the docs will be created in the destination repository. The
-  # commit pushing the changes will be verified using GPG key.
+  # Markdown and sync it with a specific path of the `threshold-network/docs`
+  # repository. If changes will be detected, a PR updating the docs will be
+  # created in the destination repository. The commit pushing the changes will
+  # be verified using GPG key.
   contracts-docs-publish:
     name: Publish contracts documentation
     needs: contracts-docs-prepublish-wait
@@ -75,7 +75,7 @@ jobs:
       projectDir: /solidity/ecdsa
       publish: true
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/tbtc-v2/ecdsa-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com

--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -51,10 +51,10 @@ jobs:
 
   # This job will be triggered for releases which name starts with
   # `refs/tags/solidity/`. It will generate contracts documentation in
-  # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
-  # a PR updating the docs will be created in the destination repository. The
-  # commit pushing the changes will be verified using GPG key.
+  # Markdown and sync it with a specific path of the `threshold-network/docs`
+  # repository. If changes will be detected, a PR updating the docs will be
+  # created in the destination repository. The commit pushing the changes will
+  # be verified using GPG key.
   contracts-docs-publish:
     name: Publish contracts documentation
     needs: docs-detect-changes
@@ -64,7 +64,7 @@ jobs:
       projectDir: /solidity/random-beacon
       publish: true
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/random-beacon/random-beacon-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com


### PR DESCRIPTION
We're renaming some of the repositories in the `threshold-network` organization. One of them is `threshold` repo, which will be renamed to `docs`. We need to update the references of the old name.

⚠️ We should merge this PR roughly at the same time when we'll actually change the repo names in GitHub.