### PR TITLE
Modified retrieval of deposit request data

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1102,14 +1102,6 @@ func (tc *TbtcChain) GetDepositRequest(
 		)
 	}
 
-	// Deposit not found.
-	if depositRequest.RevealedAt == 0 {
-		return nil, fmt.Errorf(
-			"no deposit request for key [0x%x]",
-			depositKey.Text(16),
-		)
-	}
-
 	var vault *chain.Address
 	if depositRequest.Vault != [20]byte{} {
 		v := chain.Address(depositRequest.Vault.Hex())

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1090,16 +1090,21 @@ func (tc *TbtcChain) PastRedemptionRequestedEvents(
 func (tc *TbtcChain) GetDepositRequest(
 	fundingTxHash bitcoin.Hash,
 	fundingOutputIndex uint32,
-) (*tbtc.DepositChainRequest, error) {
+) (*tbtc.DepositChainRequest, bool, error) {
 	depositKey := buildDepositKey(fundingTxHash, fundingOutputIndex)
 
 	depositRequest, err := tc.bridge.Deposits(depositKey)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, false, fmt.Errorf(
 			"cannot get deposit request for key [0x%x]: [%v]",
 			depositKey.Text(16),
 			err,
 		)
+	}
+
+	// Deposit not found.
+	if depositRequest.RevealedAt == 0 {
+		return nil, false, nil
 	}
 
 	var vault *chain.Address
@@ -1115,7 +1120,7 @@ func (tc *TbtcChain) GetDepositRequest(
 		Vault:       vault,
 		TreasuryFee: depositRequest.TreasuryFee,
 		SweptAt:     time.Unix(int64(depositRequest.SweptAt), 0),
-	}, nil
+	}, true, nil
 }
 
 func (tc *TbtcChain) PastNewWalletRegisteredEvents(

--- a/pkg/coordinator/chain.go
+++ b/pkg/coordinator/chain.go
@@ -26,12 +26,18 @@ type NewWalletRegisteredEventFilter struct {
 // with the anchoring blockchain on.
 type Chain interface {
 	// GetDepositRequest gets the on-chain deposit request for the given
-	// funding transaction hash and output index. Returns an error if the
-	// deposit was not found.
+	// funding transaction hash and output index.The returned values represent:
+	// - deposit request which is non-nil only when the deposit request was
+	//   found,
+	// - boolean value which is true if the deposit request was found, false
+	//   otherwise,
+	// - error which is non-nil only when the function execution failed. It will
+	//   be nil if the deposit request was not found, but the function execution
+	//   succeeded.
 	GetDepositRequest(
 		fundingTxHash bitcoin.Hash,
 		fundingOutputIndex uint32,
-	) (*tbtc.DepositChainRequest, error)
+	) (*tbtc.DepositChainRequest, bool, error)
 
 	// PastNewWalletRegisteredEvents fetches past new wallet registered events
 	// according to the provided filter or unfiltered if the filter is nil. Returned

--- a/pkg/coordinator/chain_test.go
+++ b/pkg/coordinator/chain_test.go
@@ -118,7 +118,7 @@ func buildPastDepositRevealedEventsKey(
 func (lc *localChain) GetDepositRequest(
 	fundingTxHash bitcoin.Hash,
 	fundingOutputIndex uint32,
-) (*tbtc.DepositChainRequest, error) {
+) (*tbtc.DepositChainRequest, bool, error) {
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
@@ -126,10 +126,10 @@ func (lc *localChain) GetDepositRequest(
 
 	request, ok := lc.depositRequests[requestKey]
 	if !ok {
-		return nil, fmt.Errorf("no request for given key")
+		return nil, false, nil
 	}
 
-	return request, nil
+	return request, true, nil
 }
 
 func (lc *localChain) setDepositRequest(

--- a/pkg/coordinator/deposits.go
+++ b/pkg/coordinator/deposits.go
@@ -239,7 +239,10 @@ func getDeposits(
 
 		depositKey := chain.BuildDepositKey(event.FundingTxHash, event.FundingOutputIndex)
 
-		depositRequest, err := chain.GetDepositRequest(event.FundingTxHash, event.FundingOutputIndex)
+		depositRequest, found, err := chain.GetDepositRequest(
+			event.FundingTxHash,
+			event.FundingOutputIndex,
+		)
 		if err != nil {
 			return result, fmt.Errorf(
 				"failed to get deposit request: [%w]",
@@ -247,8 +250,7 @@ func getDeposits(
 			)
 		}
 
-		// Call successful, but deposit not found.
-		if depositRequest.RevealedAt.Unix() == 0 {
+		if !found {
 			return nil, fmt.Errorf(
 				"no deposit request for key [0x%x]",
 				depositKey.Text(16),

--- a/pkg/coordinator/deposits.go
+++ b/pkg/coordinator/deposits.go
@@ -247,6 +247,14 @@ func getDeposits(
 			)
 		}
 
+		// Call successful, but deposit not found.
+		if depositRequest.RevealedAt.Unix() == 0 {
+			return nil, fmt.Errorf(
+				"no deposit request for key [0x%x]",
+				depositKey.Text(16),
+			)
+		}
+
 		isSwept := depositRequest.SweptAt.Unix() != 0
 		if skipSwept && isSwept {
 			logger.Debugf("deposit %d/%d is already swept", i+1, len(depositRevealedEvents))

--- a/pkg/maintainer/spv/chain.go
+++ b/pkg/maintainer/spv/chain.go
@@ -20,8 +20,9 @@ type Chain interface {
 	) error
 
 	// GetDepositRequest gets the on-chain deposit request for the given
-	// funding transaction hash and output index. Returns an error if the
-	// deposit was not found.
+	// funding transaction hash and output index. If the deposit was not found
+	// a deposit object will still be returned, but the `RevealedAt` timestamp
+	// will be set to zero.
 	GetDepositRequest(
 		fundingTxHash bitcoin.Hash,
 		fundingOutputIndex uint32,

--- a/pkg/maintainer/spv/chain.go
+++ b/pkg/maintainer/spv/chain.go
@@ -20,13 +20,18 @@ type Chain interface {
 	) error
 
 	// GetDepositRequest gets the on-chain deposit request for the given
-	// funding transaction hash and output index. If the deposit was not found
-	// a deposit object will still be returned, but the `RevealedAt` timestamp
-	// will be set to zero.
+	// funding transaction hash and output index.The returned values represent:
+	// - deposit request which is non-nil only when the deposit request was
+	//   found,
+	// - boolean value which is true if the deposit request was found, false
+	//   otherwise,
+	// - error which is non-nil only when the function execution failed. It will
+	//   be nil if the deposit request was not found, but the function execution
+	//   succeeded.
 	GetDepositRequest(
 		fundingTxHash bitcoin.Hash,
 		fundingOutputIndex uint32,
-	) (*tbtc.DepositChainRequest, error)
+	) (*tbtc.DepositChainRequest, bool, error)
 
 	// TxProofDifficultyFactor returns the number of confirmations on the
 	// Bitcoin chain required to successfully evaluate an SPV proof.

--- a/pkg/maintainer/spv/deposit_sweep_proof.go
+++ b/pkg/maintainer/spv/deposit_sweep_proof.go
@@ -146,7 +146,7 @@ func parseTransactionInputs(
 			// the deposits should have the same vault set or no vault at all.
 			// If the vault if different than the vault from any previous
 			// deposit input, report an error.
-			deposit, err := spvChain.GetDepositRequest(
+			deposit, found, err := spvChain.GetDepositRequest(
 				outpointTransactionHash,
 				outpointIndex,
 			)
@@ -157,8 +157,7 @@ func parseTransactionInputs(
 				)
 			}
 
-			// Call successful, but deposit not found.
-			if deposit.RevealedAt.Unix() == 0 {
+			if !found {
 				return bitcoin.UnspentTransactionOutput{}, common.Address{}, fmt.Errorf(
 					"deposit not found: [%v]",
 					err,

--- a/pkg/maintainer/spv/deposit_sweep_proof.go
+++ b/pkg/maintainer/spv/deposit_sweep_proof.go
@@ -157,6 +157,14 @@ func parseTransactionInputs(
 				)
 			}
 
+			// Call successful, but deposit not found.
+			if deposit.RevealedAt.Unix() == 0 {
+				return bitcoin.UnspentTransactionOutput{}, common.Address{}, fmt.Errorf(
+					"deposit not found: [%v]",
+					err,
+				)
+			}
+
 			if depositAlreadyProcessed {
 				if vault != convertVaultAddress(deposit.Vault) {
 					return bitcoin.UnspentTransactionOutput{}, common.Address{}, fmt.Errorf(

--- a/pkg/maintainer/wallet/chain_test.go
+++ b/pkg/maintainer/wallet/chain_test.go
@@ -37,7 +37,7 @@ func (lc *localChain) PastDepositRevealedEvents(
 func (lc *localChain) GetDepositRequest(
 	fundingTxHash bitcoin.Hash,
 	fundingOutputIndex uint32,
-) (*tbtc.DepositChainRequest, error) {
+) (*tbtc.DepositChainRequest, bool, error) {
 	panic("unsupported")
 }
 


### PR DESCRIPTION
This PR modifies the `GetDepositRequest` function by adding a boolean value to the returned values.
The returned values represent: 
- deposit request which is non-nil only when the deposit request was found,
- boolean value which is true if the deposit request was found, false otherwise,
- error which is non-nil only when the function execution failed. It will be nil if the deposit request was not found, but the function execution succeeded.

This can be useful when we want to check if a deposit exists, but we do not want to issue an error when it does not
exist, i.e. we don't consider it an error.
 