### PR TITLE
Use the path filter when triggering `contracts-docs-publish-preview`

### DIFF
--- a/.github/workflows/contracts-ecdsa-docs.yml
+++ b/.github/workflows/contracts-ecdsa-docs.yml
@@ -39,7 +39,7 @@ jobs:
     name: Publish preview of contracts documentation
     needs: docs-detect-changes
     if: |
-      github.event_name == 'pull_request'
+      needs.docs-detect-changes.outputs.path-filter == 'true'
         || github.event_name == 'push'
         || github.event_name == 'workflow_dispatch'
     uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main

--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -39,7 +39,7 @@ jobs:
     name: Publish preview of contracts documentation
     needs: docs-detect-changes
     if: |
-      github.event_name == 'pull_request'
+      needs.docs-detect-changes.outputs.path-filter == 'true'
         || github.event_name == 'push'
         || github.event_name == 'workflow_dispatch'
     uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main


### PR DESCRIPTION
Instead of running the `contracts-docs-publish-preview` job on update of every PR, we want to run it only when PR modifies contracts or the workflow itself.

Refs:
https://github.com/keep-network/ci/pull/43
https://github.com/keep-network/keep-core/pull/3534
https://github.com/keep-network/tbtc-v2/pull/584
https://github.com/threshold-network/solidity-contracts/pull/138