### PR TITLE
Split contracts API doc into multiple files

### DIFF
--- a/.github/workflows/contracts-ecdsa-docs.yml
+++ b/.github/workflows/contracts-ecdsa-docs.yml
@@ -46,6 +46,7 @@ jobs:
     with:
       projectDir: /solidity/ecdsa
       publish: false
+      addTOC: false
       commentPR: true
       exportAsGHArtifacts: true
 
@@ -74,12 +75,14 @@ jobs:
     with:
       projectDir: /solidity/ecdsa
       publish: true
+      addTOC: false
       verifyCommits: true
       destinationRepo: threshold-network/threshold
       destinationFolder: ./docs/app-development/tbtc-v2/ecdsa-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com
       userName: Valkyrie
+      rsyncDelete: true
     secrets:
       githubToken: ${{ secrets.THRESHOLD_DOCS_GITHUB_TOKEN }}
       gpgPrivateKey: ${{ secrets.THRESHOLD_DOCS_GPG_PRIVATE_KEY_BASE64 }}

--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -46,6 +46,7 @@ jobs:
     with:
       projectDir: /solidity/random-beacon
       publish: false
+      addTOC: false
       commentPR: true
       exportAsGHArtifacts: true
 
@@ -63,12 +64,14 @@ jobs:
     with:
       projectDir: /solidity/random-beacon
       publish: true
+      addTOC: false
       verifyCommits: true
       destinationRepo: threshold-network/threshold
       destinationFolder: ./docs/app-development/random-beacon/random-beacon-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com
       userName: Valkyrie
+      rsyncDelete: true
     secrets:
       githubToken: ${{ secrets.THRESHOLD_DOCS_GITHUB_TOKEN }}
       gpgPrivateKey: ${{ secrets.THRESHOLD_DOCS_GPG_PRIVATE_KEY_BASE64 }}

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -225,7 +225,7 @@ const config: HardhatUserConfig = {
   docgen: {
     outputDir: "generated-docs",
     templates: "docgen-templates",
-    pages: "single", // `single`, `items` or `files`
+    pages: "files", // `single`, `items` or `files`
     exclude: ["./test"],
   },
 }

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -196,7 +196,7 @@ const config: HardhatUserConfig = {
   docgen: {
     outputDir: "generated-docs",
     templates: "docgen-templates",
-    pages: "single", // `single`, `items` or `files`
+    pages: "files", // `single`, `items` or `files`
     exclude: ["./test"],
   },
 }


### PR DESCRIPTION
Having all the contracts documented in one common file turned out to be hard to render by the GitBook. We're switching to documenting each contract file in a separate Markdown file.
As the generated files will be much smaller now and GitBook has its own file `ON THIS PAGE` section, we don't need to generate Table of Contents. The one thing that we also change as part of this PR is `rsyncDelete` setting - we'll have it set to `true`, in order to delete documentation of contracts which get removed from the repo. As we're not working directly on a `main` branch, this isn't dangerous (we'll see all the deletions in the PR diff).

Refs:
https://github.com/threshold-network/solidity-contracts/pull/149
https://github.com/keep-network/tbtc-v2/pull/640
https://github.com/threshold-network/threshold/pull/36