### PR TITLE
Block header structure update

### DIFF
--- a/pkg/bitcoin/block.go
+++ b/pkg/bitcoin/block.go
@@ -122,7 +122,7 @@ func (bh *BlockHeader) Target() *big.Int {
 func (bh *BlockHeader) Difficulty() *big.Int {
 	maxTarget := new(big.Int)
 	maxTarget.SetString(
-		"00000000ffff0000000000000000000000000000000000000000000000000000",
+		"ffff0000000000000000000000000000000000000000000000000000",
 		16,
 	)
 

--- a/pkg/bitcoin/block.go
+++ b/pkg/bitcoin/block.go
@@ -42,11 +42,11 @@ func (bh *BlockHeader) Serialize() [BlockHeaderByteLength]byte {
 
 	// PreviousBlockHeaderHash
 	copy(result[offset:], bh.PreviousBlockHeaderHash[:])
-	offset += len(bh.PreviousBlockHeaderHash)
+	offset += HashByteLength
 
 	// MerkleRootHash
 	copy(result[offset:], bh.MerkleRootHash[:])
-	offset += len(bh.MerkleRootHash)
+	offset += HashByteLength
 
 	// Time
 	binary.LittleEndian.PutUint32(result[offset:], bh.Time)

--- a/pkg/bitcoin/block.go
+++ b/pkg/bitcoin/block.go
@@ -108,12 +108,17 @@ func (bh *BlockHeader) Hash() Hash {
 	return Hash{}
 }
 
-// Target calculates the difficulty target of a block header.
+// Target calculates the difficulty target of a block header. A Bitcoin block
+// must have its hash lower than or equal to the target calculated from the
+// `Bits` field.
 func (bh *BlockHeader) Target() *big.Int {
 	return blockchain.CompactToBig(bh.Bits)
 }
 
-// Difficulty calculates the difficulty of a block header.
+// Difficulty calculates the difficulty of a block header. The difficulty is the
+// measure of how hard it is to mine a valid Bitcoin block. It is calculated by
+// dividing the maximum possible target by the target calculated from the `Bits`
+// field.
 func (bh *BlockHeader) Difficulty() *big.Int {
 	maxTarget := new(big.Int)
 	maxTarget.SetString(

--- a/pkg/bitcoin/block.go
+++ b/pkg/bitcoin/block.go
@@ -1,6 +1,9 @@
 package bitcoin
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"math/big"
+)
 
 // BlockHeaderByteLength is the byte length of a serialized block header.
 const BlockHeaderByteLength = 80
@@ -68,4 +71,71 @@ func (bh *BlockHeader) Hash() Hash {
 	//       2. Compute the double SHA-256 over the serialized  block hash.
 	//       3. Construct the Hash instance appropriately.
 	return Hash{}
+}
+
+// Target calculates the difficulty target of a block header.
+func (bh *BlockHeader) Target() *big.Int {
+	// A serialized 80-byte block header stores the `bits` value as a 4-byte
+	// little-endian hexadecimal value in a slot including bytes 73, 74, 75, and
+	// 76. This function's input argument is expected to be a numerical
+	// representation of that 4-byte value reverted to the big-endian order.
+	// For example, if the `bits` little-endian value in the header is
+	// `0xcb04041b`, it must be reverted to the big-endian form `0x1b0404cb` and
+	// turned to a decimal number `453248203` in order to be used as this
+	// function's input.
+	//
+	// The `bits` 4-byte big-endian representation is a compact value that works
+	// like a base-256 version of scientific notation. It encodes the target
+	// exponent in the first byte and the target mantissa in the last three bytes.
+	// Referring to the previous example, if `bits = 453248203`, the hexadecimal
+	// representation is `0x1b0404cb` so the exponent is `0x1b` while the mantissa
+	// is `0x0404cb`.
+	//
+	// To extract the exponent, we need to shift right by 3 bytes (24 bits),
+	// extract the last byte of the result, and subtract 3 (because of the
+	// mantissa length):
+	// - 0x1b0404cb >>> 24 = 0x0000001b
+	// - 0x0000001b & 0xff = 0x1b
+	// - 0x1b - 3 = 24 (decimal)
+	//
+	// To extract the mantissa, we just need to take the last three bytes:
+	// - 0x1b0404cb & 0xffffff = 0x0404cb = 263371 (decimal)
+	//
+	// The final difficulty can be computed as mantissa * 256^exponent:
+	// - 263371 * 256^24 =
+	// 1653206561150525499452195696179626311675293455763937233695932416 (decimal)
+	//
+	// Sources:
+	// - https://developer.bitcoin.org/reference/block_chain.html#target-nbits
+	// - https://wiki.bitcoinsv.io/index.php/Target
+	exponent := (int(bh.Bits>>24) & 0xff) - 3
+	mantissa := bh.Bits & 0xffffff
+
+	// Compute 256^exponent.
+	pow := new(big.Int).Exp(
+		big.NewInt(256),
+		big.NewInt(int64(exponent)),
+		nil,
+	)
+
+	// Compute mantissa * (256^exponent).
+	target := new(big.Int).Mul(big.NewInt(int64(mantissa)), pow)
+
+	return target
+}
+
+// Difficulty calculates the difficulty of a block header.
+func (bh *BlockHeader) Difficulty() *big.Int {
+	maxTarget := new(big.Int)
+	maxTarget.SetString(
+		"00000000ffff0000000000000000000000000000000000000000000000000000",
+		16,
+	)
+
+	target := bh.Target()
+
+	difficulty := new(big.Int)
+	difficulty.Div(maxTarget, target)
+
+	return difficulty
 }

--- a/pkg/bitcoin/block.go
+++ b/pkg/bitcoin/block.go
@@ -62,6 +62,39 @@ func (bh *BlockHeader) Serialize() [BlockHeaderByteLength]byte {
 	return result
 }
 
+// Deserialize deserializes a byte array to a BlockHeader using the block header
+// serialization format:
+// [Version][PreviousBlockHeaderHash][MerkleRootHash][Time][Bits][Nonce].
+func (bh *BlockHeader) Deserialize(rawBlockHeader [BlockHeaderByteLength]byte) {
+	offset := 0
+
+	// Version
+	bh.Version = int32(binary.LittleEndian.Uint32(rawBlockHeader[offset:]))
+	offset += 4
+
+	// PreviousBlockHeaderHash
+	copy(
+		bh.PreviousBlockHeaderHash[:],
+		rawBlockHeader[offset:offset+HashByteLength],
+	)
+	offset += HashByteLength
+
+	// MerkleRootHash
+	copy(bh.MerkleRootHash[:], rawBlockHeader[offset:offset+HashByteLength])
+	offset += HashByteLength
+
+	// Time
+	bh.Time = binary.LittleEndian.Uint32(rawBlockHeader[offset:])
+	offset += 4
+
+	// Bits
+	bh.Bits = binary.LittleEndian.Uint32(rawBlockHeader[offset:])
+	offset += 4
+
+	// Nonce
+	bh.Nonce = binary.LittleEndian.Uint32(rawBlockHeader[offset:])
+}
+
 // Hash calculates the block header's hash as the double SHA-256 of the
 // block header serialization format:
 // [Version][PreviousBlockHeaderHash][MerkleRootHash][Time][Bits][Nonce].

--- a/pkg/bitcoin/block_test.go
+++ b/pkg/bitcoin/block_test.go
@@ -2,6 +2,7 @@ package bitcoin
 
 import (
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/keep-network/keep-core/internal/testutils"
@@ -51,5 +52,69 @@ func TestBlockHeaderSerialize(t *testing.T) {
 		t,
 		expectedSerializedHeader,
 		actualSerializedHeader[:],
+	)
+}
+
+func TestBlockHeaderTarget(t *testing.T) {
+	// Test data comes from a Bitcoin testnet block:
+	// https://live.blockcypher.com/btc-testnet/block/000000000000002af10911b8db32ed34dc6ea6515f84af5f7b82973c9a839e6d/
+
+	previousBlockHeaderHash, err := NewHashFromString(
+		"000000000066450030efdf72f233ed2495547a32295deea1e2f3a16b1e50a3a5",
+		ReversedByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merkleRootHash, err := NewHashFromString(
+		"1251774996b446f85462d5433f7a3e384ac1569072e617ab31e86da31c247de2",
+		ReversedByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockHeader := BlockHeader{
+		Version:                 536870916,
+		PreviousBlockHeaderHash: previousBlockHeaderHash,
+		MerkleRootHash:          merkleRootHash,
+		Time:                    1641914003,
+		Bits:                    436256810,
+		Nonce:                   778087099,
+	}
+
+	actualTarget := blockHeader.Target()
+	expectedTarget, _ := new(big.Int).SetString(
+		"1206233370197704583969288378458116959663044038027202007138304",
+		10,
+	)
+
+	testutils.AssertBigIntsEqual(
+		t,
+		"target",
+		expectedTarget,
+		actualTarget,
+	)
+}
+
+func TestBlockHeaderTarget_DifficultyOfOne(t *testing.T) {
+	// This is a special case, the difficulty bits represent a target of a
+	// difficulty of 1.
+	blockHeader := BlockHeader{
+		Bits: 486604799,
+	}
+
+	actualTarget := blockHeader.Target()
+	expectedTarget, _ := new(big.Int).SetString(
+		"26959535291011309493156476344723991336010898738574164086137773096960",
+		10,
+	)
+
+	testutils.AssertBigIntsEqual(
+		t,
+		"target",
+		expectedTarget,
+		actualTarget,
 	)
 }

--- a/pkg/bitcoin/block_test.go
+++ b/pkg/bitcoin/block_test.go
@@ -98,9 +98,9 @@ func TestBlockHeaderTarget(t *testing.T) {
 	)
 }
 
-func TestBlockHeaderTarget_DifficultyOfOne(t *testing.T) {
+func TestBlockHeaderTarget_LowestDifficulty(t *testing.T) {
 	// This is a special case, the difficulty bits represent a target of a
-	// difficulty of 1.
+	// difficulty of 1. Set just difficulty bits.
 	blockHeader := BlockHeader{
 		Bits: 486604799,
 	}
@@ -116,5 +116,63 @@ func TestBlockHeaderTarget_DifficultyOfOne(t *testing.T) {
 		"target",
 		expectedTarget,
 		actualTarget,
+	)
+}
+
+func TestBlockHeaderDifficulty(t *testing.T) {
+	// Test data comes from a Bitcoin testnet block:
+	// https://live.blockcypher.com/btc-testnet/block/000000000000002af10911b8db32ed34dc6ea6515f84af5f7b82973c9a839e6d/
+
+	previousBlockHeaderHash, err := NewHashFromString(
+		"000000000066450030efdf72f233ed2495547a32295deea1e2f3a16b1e50a3a5",
+		ReversedByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merkleRootHash, err := NewHashFromString(
+		"1251774996b446f85462d5433f7a3e384ac1569072e617ab31e86da31c247de2",
+		ReversedByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockHeader := BlockHeader{
+		Version:                 536870916,
+		PreviousBlockHeaderHash: previousBlockHeaderHash,
+		MerkleRootHash:          merkleRootHash,
+		Time:                    1641914003,
+		Bits:                    436256810,
+		Nonce:                   778087099,
+	}
+
+	actualDifficulty := blockHeader.Difficulty()
+	expectedDifficulty, _ := new(big.Int).SetString("22350181", 10)
+
+	testutils.AssertBigIntsEqual(
+		t,
+		"difficulty",
+		expectedDifficulty,
+		actualDifficulty,
+	)
+}
+
+func TestBlockHeaderDifficulty_LowestDifficulty(t *testing.T) {
+	// This is a special case, the difficulty bits represent a target of a
+	// difficulty of 1. Set just difficulty bits.
+	blockHeader := BlockHeader{
+		Bits: 486604799,
+	}
+
+	actualDifficulty := blockHeader.Difficulty()
+	expectedDifficulty, _ := new(big.Int).SetString("1", 10)
+
+	testutils.AssertBigIntsEqual(
+		t,
+		"difficulty",
+		expectedDifficulty,
+		actualDifficulty,
 	)
 }

--- a/pkg/bitcoin/block_test.go
+++ b/pkg/bitcoin/block_test.go
@@ -3,6 +3,7 @@ package bitcoin
 import (
 	"encoding/hex"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/keep-network/keep-core/internal/testutils"
@@ -11,7 +12,6 @@ import (
 func TestBlockHeaderSerialize(t *testing.T) {
 	// Test data comes from a Bitcoin testnet block:
 	// https://live.blockcypher.com/btc-testnet/block/000000000000002af10911b8db32ed34dc6ea6515f84af5f7b82973c9a839e6d/
-
 	previousBlockHeaderHash, err := NewHashFromString(
 		"000000000066450030efdf72f233ed2495547a32295deea1e2f3a16b1e50a3a5",
 		ReversedByteOrder,
@@ -55,10 +55,61 @@ func TestBlockHeaderSerialize(t *testing.T) {
 	)
 }
 
+func TestBlockHeaderDeserialize(t *testing.T) {
+	// Test data comes from a Bitcoin testnet block:
+	// https://live.blockcypher.com/btc-testnet/block/000000000000002af10911b8db32ed34dc6ea6515f84af5f7b82973c9a839e6d/
+	previousBlockHeaderHash, err := NewHashFromString(
+		"000000000066450030efdf72f233ed2495547a32295deea1e2f3a16b1e50a3a5",
+		ReversedByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merkleRootHash, err := NewHashFromString(
+		"1251774996b446f85462d5433f7a3e384ac1569072e617ab31e86da31c247de2",
+		ReversedByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedBlockHeader := BlockHeader{
+		Version:                 536870916,
+		PreviousBlockHeaderHash: previousBlockHeaderHash,
+		MerkleRootHash:          merkleRootHash,
+		Time:                    1641914003,
+		Bits:                    436256810,
+		Nonce:                   778087099,
+	}
+
+	rawBlockHeaderBytes, err := hex.DecodeString(
+		"04000020a5a3501e6ba1f3e2a1ee5d29327a549524ed33f272dfef30004566000000" +
+			"0000e27d241ca36de831ab17e6729056c14a383e7a3f43d56254f846b4964977" +
+			"5112939edd612ac0001abbaa602e",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rawBlockHeader [BlockHeaderByteLength]byte
+	copy(rawBlockHeader[:], rawBlockHeaderBytes)
+
+	actualBlockHeader := BlockHeader{}
+	actualBlockHeader.Deserialize(rawBlockHeader)
+
+	if !reflect.DeepEqual(expectedBlockHeader, actualBlockHeader) {
+		t.Errorf(
+			"\nexpected: %v\nactual:   %v",
+			expectedBlockHeader,
+			actualBlockHeader,
+		)
+	}
+}
+
 func TestBlockHeaderTarget(t *testing.T) {
 	// Test data comes from a Bitcoin testnet block:
 	// https://live.blockcypher.com/btc-testnet/block/000000000000002af10911b8db32ed34dc6ea6515f84af5f7b82973c9a839e6d/
-
 	previousBlockHeaderHash, err := NewHashFromString(
 		"000000000066450030efdf72f233ed2495547a32295deea1e2f3a16b1e50a3a5",
 		ReversedByteOrder,
@@ -122,7 +173,6 @@ func TestBlockHeaderTarget_LowestDifficulty(t *testing.T) {
 func TestBlockHeaderDifficulty(t *testing.T) {
 	// Test data comes from a Bitcoin testnet block:
 	// https://live.blockcypher.com/btc-testnet/block/000000000000002af10911b8db32ed34dc6ea6515f84af5f7b82973c9a839e6d/
-
 	previousBlockHeaderHash, err := NewHashFromString(
 		"000000000066450030efdf72f233ed2495547a32295deea1e2f3a16b1e50a3a5",
 		ReversedByteOrder,


### PR DESCRIPTION
This PR adds new functions to the `BlockHeader` structure:
- `Deserialize`
- `Target`
- `Difficulty`

These functions will be needed to verify if the difficulties of block headers in the SPV proof are consistent with the difficulties stored on-chain. They will be useful to detect a situation when the relay has not been updated yet with the current Bitcoin difficulties, but the proof already have block headers with those current difficulties. 