### PR TITLE
Invoke automated redemptions periodically by maintainer

### DIFF
--- a/pkg/maintainer/wallet/redemptions.go
+++ b/pkg/maintainer/wallet/redemptions.go
@@ -261,10 +261,10 @@ func getPendingRedemptions(
 	// [now - redemptionRequestTimeout, now - redemptionRequestMinAge]
 	// should be taken into consideration.
 	redemptionRequestsRangeStartTimestamp := time.Now().Add(
-		time.Duration(-redemptionRequestTimeout) * time.Second,
+		-time.Duration(redemptionRequestTimeout) * time.Second,
 	)
 	redemptionRequestsRangeEndTimestamp := time.Now().Add(
-		time.Duration(-redemptionRequestMinAge) * time.Second,
+		-time.Duration(redemptionRequestMinAge) * time.Second,
 	)
 
 	// TODO: We should consider narrowing the block range in filter the fetch

--- a/pkg/maintainer/wallet/redemptions.go
+++ b/pkg/maintainer/wallet/redemptions.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/keep-network/keep-core/internal/hexutils"
-	"github.com/keep-network/keep-core/pkg/bitcoin"
-	"github.com/keep-network/keep-core/pkg/tbtc"
 	"math/big"
 	"sort"
 	"time"
+
+	"github.com/keep-network/keep-core/internal/hexutils"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
 func (wm *walletMaintainer) runRedemptionTask(ctx context.Context) error {
 	redemptionMaxSize, err := wm.chain.GetRedemptionMaxSize()
 	if err != nil {
-		return fmt.Errorf("failed to get deposit sweep max size: [%w]", err)
+		return fmt.Errorf("failed to get redemption max size: [%w]", err)
 	}
 
 	walletPublicKeyHash, redeemersOutputScripts, err := FindPendingRedemptions(

--- a/pkg/maintainer/wallet/wallet.go
+++ b/pkg/maintainer/wallet/wallet.go
@@ -72,7 +72,9 @@ func (wm *walletMaintainer) startControlLoop(ctx context.Context) {
 
 			logger.Info("starting redemption task execution...")
 
-			// TODO: Implement
+			if err := wm.runRedemptionTask(ctx); err != nil {
+				logger.Errorf("failed to run redemption task: [%v]", err)
+			}
 
 			logger.Infof(
 				"redemption task run completed; next run in [%s]",


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3614
Depends on: https://github.com/keep-network/keep-core/pull/3659

Here we add automation for the redemption proposal submission logic. Every 3 hours, the maintainer will check for pending redemptions starting from the oldest wallet and will propose them for redemption by submitting a proposal to the `WalletCoordinator` contract. 