### PR TITLE
Maintainer optimizations around redemptions

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -342,6 +342,13 @@ func initMaintainerFlags(command *cobra.Command, cfg *config.Config) {
 		"The time interval in which pending redemptions requests are checked.",
 	)
 
+	command.Flags().Uint16Var(
+		&cfg.Maintainer.WalletCoordination.RedemptionWalletsLimit,
+		"walletCoordination.redemptionWalletsLimit",
+		wallet.DefaultRedemptionWalletsLimit,
+		"Limits the number of wallets that can receive a redemption proposal in the same time",
+	)
+
 	command.Flags().DurationVar(
 		&cfg.Maintainer.WalletCoordination.DepositSweepInterval,
 		"walletCoordination.depositSweepInterval",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -346,7 +346,14 @@ func initMaintainerFlags(command *cobra.Command, cfg *config.Config) {
 		&cfg.Maintainer.WalletCoordination.RedemptionWalletsLimit,
 		"walletCoordination.redemptionWalletsLimit",
 		wallet.DefaultRedemptionWalletsLimit,
-		"Limits the number of wallets that can receive a redemption proposal in the same time",
+		"Limits the number of wallets that can receive a redemption proposal in the same time.",
+	)
+
+	command.Flags().Uint64Var(
+		&cfg.Maintainer.WalletCoordination.RedemptionRequestAmountLimit,
+		"walletCoordination.redemptionRequestAmountLimit",
+		wallet.DefaultRedemptionRequestAmountLimit,
+		"Limits the redemption requests to the ones below the given satoshi value.",
 	)
 
 	command.Flags().DurationVar(

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -253,6 +253,13 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: 7 * time.Hour,
 		defaultValue:          3 * time.Hour,
 	},
+	"maintainer.walletCoordination.redemptionWalletsLimit": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.WalletCoordination.RedemptionWalletsLimit },
+		flagName:              "--walletCoordination.redemptionWalletsLimit",
+		flagValue:             "10",
+		expectedValueFromFlag: uint16(10),
+		defaultValue:          uint16(3),
+	},
 	"maintainer.walletCoordination.depositSweepInterval": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.WalletCoordination.DepositSweepInterval },
 		flagName:              "--walletCoordination.depositSweepInterval",

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -260,6 +260,15 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: uint16(10),
 		defaultValue:          uint16(3),
 	},
+	"maintainer.walletCoordination.redemptionRequestAmountLimit": {
+		readValueFunc: func(c *config.Config) interface{} {
+			return c.Maintainer.WalletCoordination.RedemptionRequestAmountLimit
+		},
+		flagName:              "--walletCoordination.redemptionRequestAmountLimit",
+		flagValue:             "500",
+		expectedValueFromFlag: uint64(500),
+		defaultValue:          uint64(10 * 1e8),
+	},
 	"maintainer.walletCoordination.depositSweepInterval": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.WalletCoordination.DepositSweepInterval },
 		flagName:              "--walletCoordination.depositSweepInterval",

--- a/cmd/maintainercli.go
+++ b/cmd/maintainercli.go
@@ -404,13 +404,14 @@ var proposeRedemptionCommand = cobra.Command{
 			return fmt.Errorf("could not connect to Electrum chain: [%v]", err)
 		}
 
-		var walletPublicKeyHash [20]byte
+		var walletPublicKeyHashes [][20]byte
 		if len(wallet) > 0 {
-			var err error
-			walletPublicKeyHash, err = newWalletPublicKeyHash(wallet)
+			walletPublicKeyHash, err := newWalletPublicKeyHash(wallet)
 			if err != nil {
 				return fmt.Errorf("failed extract wallet public key hash: %v", err)
 			}
+
+			walletPublicKeyHashes = append(walletPublicKeyHashes, walletPublicKeyHash)
 		}
 
 		if redemptionMaxSize == 0 {
@@ -420,31 +421,33 @@ var proposeRedemptionCommand = cobra.Command{
 			}
 		}
 
-		walletPublicKeyHash, redemptions, err := walletmtr.FindPendingRedemptions(
+		walletsPendingRedemptions, err := walletmtr.FindPendingRedemptions(
 			tbtcChain,
-			walletPublicKeyHash,
-			redemptionMaxSize,
+			walletmtr.PendingRedemptionsFilter{
+				WalletPublicKeyHashes:   walletPublicKeyHashes,
+				WalletsLimit:            1,
+				RedemptionRequestsLimit: redemptionMaxSize,
+			},
 		)
 		if err != nil {
-			return fmt.Errorf("failed to prepare redemption proposal: %v", err)
+			return fmt.Errorf("failed to find pending redemption requests: [%w]", err)
 		}
 
-		if len(redemptions) > int(redemptionMaxSize) {
-			return fmt.Errorf(
-				"redemptions number [%d] is greater than redemptions max size [%d]",
-				len(redemptions),
-				redemptionMaxSize,
+		for walletPublicKeyHash, redeemersOutputScripts := range walletsPendingRedemptions {
+			err := walletmtr.ProposeRedemption(
+				tbtcChain,
+				btcChain,
+				walletPublicKeyHash,
+				fee,
+				redeemersOutputScripts,
+				dryRun,
 			)
+			if err != nil {
+				return err
+			}
 		}
 
-		return walletmtr.ProposeRedemption(
-			tbtcChain,
-			btcChain,
-			walletPublicKeyHash,
-			fee,
-			redemptions,
-			dryRun,
-		)
+		return nil
 	},
 }
 

--- a/cmd/maintainercli.go
+++ b/cmd/maintainercli.go
@@ -427,6 +427,7 @@ var proposeRedemptionCommand = cobra.Command{
 				WalletPublicKeyHashes: walletPublicKeyHashes,
 				WalletsLimit:          1,
 				RequestsLimit:         redemptionMaxSize,
+				RequestAmountLimit:    0,
 			},
 		)
 		if err != nil {

--- a/cmd/maintainercli.go
+++ b/cmd/maintainercli.go
@@ -424,9 +424,9 @@ var proposeRedemptionCommand = cobra.Command{
 		walletsPendingRedemptions, err := walletmtr.FindPendingRedemptions(
 			tbtcChain,
 			walletmtr.PendingRedemptionsFilter{
-				WalletPublicKeyHashes:   walletPublicKeyHashes,
-				WalletsLimit:            1,
-				RedemptionRequestsLimit: redemptionMaxSize,
+				WalletPublicKeyHashes: walletPublicKeyHashes,
+				WalletsLimit:          1,
+				RequestsLimit:         redemptionMaxSize,
 			},
 		)
 		if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -215,6 +215,10 @@ func TestReadConfigFromFile(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.WalletCoordination.RedemptionInterval },
 			expectedValue: 13 * time.Hour,
 		},
+		"Maintainer.WalletCoordination.RedemptionWalletsLimit": {
+			readValueFunc: func(c *Config) interface{} { return c.Maintainer.WalletCoordination.RedemptionWalletsLimit },
+			expectedValue: uint16(10),
+		},
 		"Maintainer.WalletCoordination.DepositSweepInterval": {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.WalletCoordination.DepositSweepInterval },
 			expectedValue: 64 * time.Hour,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,6 +219,10 @@ func TestReadConfigFromFile(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.WalletCoordination.RedemptionWalletsLimit },
 			expectedValue: uint16(10),
 		},
+		"Maintainer.WalletCoordination.RedemptionRequestAmountLimit": {
+			readValueFunc: func(c *Config) interface{} { return c.Maintainer.WalletCoordination.RedemptionRequestAmountLimit },
+			expectedValue: uint64(500),
+		},
 		"Maintainer.WalletCoordination.DepositSweepInterval": {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.WalletCoordination.DepositSweepInterval },
 			expectedValue: 64 * time.Hour,

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -467,6 +467,10 @@ func closerBlock(timestamp uint64, b1, b2 *types.Block) *types.Block {
 	return b2
 }
 
+func (bc *baseChain) AverageBlockTime() time.Duration {
+	return 12 * time.Second
+}
+
 // wrapClientAddons wraps the client instance with add-ons like logging, rate
 // limiting and so on.
 func wrapClientAddons(

--- a/pkg/maintainer/wallet/chain.go
+++ b/pkg/maintainer/wallet/chain.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/chain"
 	"math/big"
 	"time"
 
@@ -141,4 +142,8 @@ type Chain interface {
 	GetWalletLock(
 		walletPublicKeyHash [20]byte,
 	) (time.Time, tbtc.WalletActionType, error)
+
+	BlockCounter() (chain.BlockCounter, error)
+
+	AverageBlockTime() time.Duration
 }

--- a/pkg/maintainer/wallet/chain_test.go
+++ b/pkg/maintainer/wallet/chain_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/chain"
 	"math/big"
 	"sync"
 	"time"
@@ -456,4 +457,12 @@ func (lc *LocalChain) ResetWalletLock(
 		lockExpiration: time.Unix(0, 0),
 		walletAction:   tbtc.Noop,
 	}
+}
+
+func (lc *LocalChain) BlockCounter() (chain.BlockCounter, error) {
+	panic("unsupported")
+}
+
+func (lc *LocalChain) AverageBlockTime() time.Duration {
+	panic("unsupported")
 }

--- a/pkg/maintainer/wallet/config.go
+++ b/pkg/maintainer/wallet/config.go
@@ -3,15 +3,17 @@ package wallet
 import "time"
 
 const (
-	DefaultRedemptionInterval     = 3 * time.Hour
-	DefaultRedemptionWalletsLimit = 3
-	DefaultDepositSweepInterval   = 48 * time.Hour
+	DefaultRedemptionInterval           = 3 * time.Hour
+	DefaultRedemptionWalletsLimit       = 3
+	DefaultRedemptionRequestAmountLimit = uint64(10 * 1e8) // 10 BTC
+	DefaultDepositSweepInterval         = 48 * time.Hour
 )
 
 // Config holds configurable properties.
 type Config struct {
-	Enabled                bool
-	RedemptionInterval     time.Duration
-	RedemptionWalletsLimit uint16
-	DepositSweepInterval   time.Duration
+	Enabled                      bool
+	RedemptionInterval           time.Duration
+	RedemptionWalletsLimit       uint16
+	RedemptionRequestAmountLimit uint64
+	DepositSweepInterval         time.Duration
 }

--- a/pkg/maintainer/wallet/config.go
+++ b/pkg/maintainer/wallet/config.go
@@ -3,13 +3,15 @@ package wallet
 import "time"
 
 const (
-	DefaultRedemptionInterval   = 3 * time.Hour
-	DefaultDepositSweepInterval = 48 * time.Hour
+	DefaultRedemptionInterval     = 3 * time.Hour
+	DefaultRedemptionWalletsLimit = 3
+	DefaultDepositSweepInterval   = 48 * time.Hour
 )
 
 // Config holds configurable properties.
 type Config struct {
-	Enabled              bool
-	RedemptionInterval   time.Duration
-	DepositSweepInterval time.Duration
+	Enabled                bool
+	RedemptionInterval     time.Duration
+	RedemptionWalletsLimit uint16
+	DepositSweepInterval   time.Duration
 }

--- a/pkg/maintainer/wallet/wallet.go
+++ b/pkg/maintainer/wallet/wallet.go
@@ -31,6 +31,9 @@ func Initialize(
 	if config.RedemptionInterval == 0 {
 		config.RedemptionInterval = DefaultRedemptionInterval
 	}
+	if config.RedemptionWalletsLimit == 0 {
+		config.RedemptionWalletsLimit = DefaultRedemptionWalletsLimit
+	}
 	if config.DepositSweepInterval == 0 {
 		config.DepositSweepInterval = DefaultDepositSweepInterval
 	}
@@ -115,7 +118,8 @@ func (wm *walletMaintainer) runIfWalletUnlocked(
 
 	if lockExpiration.After(time.Now()) {
 		logger.Infof(
-			"wallet is locked due to [%s] action until [%s]; skipping [%s] execution...",
+			"wallet [%s] is locked due to [%s] action until [%s]; skipping [%s] execution...",
+			hexutils.Encode(walletPublicKeyHash[:]),
 			lockWalletAction.String(),
 			lockExpiration.String(),
 			currentWalletAction.String(),

--- a/pkg/maintainer/wallet/wallet.go
+++ b/pkg/maintainer/wallet/wallet.go
@@ -34,6 +34,9 @@ func Initialize(
 	if config.RedemptionWalletsLimit == 0 {
 		config.RedemptionWalletsLimit = DefaultRedemptionWalletsLimit
 	}
+	if config.RedemptionRequestAmountLimit == 0 {
+		config.RedemptionRequestAmountLimit = DefaultRedemptionRequestAmountLimit
+	}
 	if config.DepositSweepInterval == 0 {
 		config.DepositSweepInterval = DefaultDepositSweepInterval
 	}

--- a/test/config.json
+++ b/test/config.json
@@ -47,6 +47,7 @@
         "WalletCoordination": {
           "Enabled": true,
           "RedemptionInterval": "13h",
+          "RedemptionWalletsLimit": 10,
           "DepositSweepInterval": "64h"
         },
         "Spv": {

--- a/test/config.json
+++ b/test/config.json
@@ -48,6 +48,7 @@
           "Enabled": true,
           "RedemptionInterval": "13h",
           "RedemptionWalletsLimit": 10,
+          "RedemptionRequestAmountLimit": 500,
           "DepositSweepInterval": "64h"
         },
         "Spv": {

--- a/test/config.toml
+++ b/test/config.toml
@@ -43,6 +43,7 @@ DisableProxy = true
 Enabled = true
 RedemptionInterval = "13h"
 RedemptionWalletsLimit = 10
+RedemptionRequestAmountLimit = 500
 DepositSweepInterval = "64h"
 
 [maintainer.Spv]

--- a/test/config.toml
+++ b/test/config.toml
@@ -42,6 +42,7 @@ DisableProxy = true
 [maintainer.WalletCoordination]
 Enabled = true
 RedemptionInterval = "13h"
+RedemptionWalletsLimit = 10
 DepositSweepInterval = "64h"
 
 [maintainer.Spv]

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -38,6 +38,7 @@ Maintainer:
     Enabled: true
     RedemptionInterval: "13h"
     RedemptionWalletsLimit: 10
+    RedemptionRequestAmountLimit: 500
     DepositSweepInterval: "64h"
   Spv:
     Enabled: true

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -37,6 +37,7 @@ Maintainer:
   WalletCoordination:
     Enabled: true
     RedemptionInterval: "13h"
+    RedemptionWalletsLimit: 10
     DepositSweepInterval: "64h"
   Spv:
     Enabled: true


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3614

Here we introduce a bunch of optimizations to the wallet maintainer. All of them are related to redemptions. I recommend reviewing commit by commit. Here is a brief description of the changes.

### Improve past `RedemptionRequested` events filtering

The wallet maintainer seeks past `RedemptionRequested` events in order to propose redemptions. So far, the events lookup was not constrained to any block range which could be problematic for several Ethereum providers. This can be improved as the wallet maintainer is only interested in pending requests that are not timed out yet. That means there is no sense to fetch events that were emitted before `now - redemptionRequestTimeout` block. We reflect that by narrowing the block range of the filter thus making the call more lightweight.

### Submit multiple redemption proposals for different wallets

Redemptions are time-sensitive so we must make sure all of them are handled in a reasonable time. So far, the maintainer iterated from the oldest wallet and proposed redemptions for the first wallet having pending redemptions. We can do it better and propose redemptions for multiple wallets at the same time. However, given the fact signing is computationally heavy and a lot of operator nodes have shares in multiple wallets, we need to set a reasonable limit on the maximum number of wallets performing redemptions at the same time. We achieve that by introducing the `RedemptionWalletsLimit` configurable parameter.

### Add an ability to limit the proposed redemptions value

We want to limit the risk for initial mainnet redemptions done shortly after the redemptions release. To achieve that, we need a way to limit the total amount of a single redemption proposal to a reasonable value. We address that indirectly, by introducing the `RedemptionRequestAmountLimit` for the wallet maintainer. This parameter guarantees that the redemption proposals submitted by the maintainer will consist of redemption requests whose amounts are below a certain satoshi value.
Combined with `WalletCoordinator.redemptionMaxSize` on-chain parameter, we obtain a tool to cap the total value of submitted redemption proposals to safe levels. All redemption requests exceeding the `RedemptionRequestAmountLimit` can be handled manually through the `maintainer-cli` tool after confirming everything is all right.
