### PR TITLE
Handle SPV proofs spanning two epochs

### DIFF
--- a/pkg/bitcoin/spv_proof.go
+++ b/pkg/bitcoin/spv_proof.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 
 	"github.com/keep-network/keep-core/pkg/internal/byteutils"
 )
@@ -21,20 +20,6 @@ type SpvProof struct {
 	// BitcoinHeaders is a chain of block headers that form confirmations of
 	// blockchain inclusion.
 	BitcoinHeaders []byte
-}
-
-func (sp *SpvProof) FirstBlockHeaderDifficulty() *big.Int {
-	// Deserialize the first block header and return its difficulty.
-	rawBlockHeader := [BlockHeaderByteLength]byte{}
-	copy(
-		rawBlockHeader[:],
-		sp.BitcoinHeaders[:BlockHeaderByteLength],
-	)
-
-	firstBlockHeader := BlockHeader{}
-	firstBlockHeader.Deserialize(rawBlockHeader)
-
-	return firstBlockHeader.Difficulty()
 }
 
 // AssembleSpvProof assembles a proof that a given transaction was included in

--- a/pkg/bitcoin/spv_proof_test.go
+++ b/pkg/bitcoin/spv_proof_test.go
@@ -1,13 +1,10 @@
 package bitcoin
 
 import (
-	"math/big"
 	"reflect"
 	"testing"
 
 	"encoding/hex"
-
-	"github.com/keep-network/keep-core/internal/testutils"
 )
 
 // SpvProofData holds details of the transaction proof data used as a test
@@ -310,46 +307,6 @@ func decodeString(s string) []byte {
 	}
 
 	return bytes
-}
-
-func TestFirstBlockHeaderDifficulty(t *testing.T) {
-	spvProof := &SpvProof{
-		MerkleProof: decodeString(
-			"2ea95cfb5e8f0d4b4757368c95f5a1cfa1b98934e9086f7b59cf53caf3fd2c32d1d" +
-				"41ad3ebb735723098bf8a1fd243e1ccfe4057e2feef750367c9f6fedfae82a3b5ea" +
-				"f9ac6cfe8b05432e855818c6787a3b1e98f8fd5323b4f5a8b941a07f8377e397f5b" +
-				"ae83046e0c06cedc26d752ebedba66ad8a40358e957f8f3d31216a58686e7ba4b35" +
-				"ce0c41f0651ae65dc7e4755ebcd5d6a5071e8a4f0c0e650105a0",
-		),
-		TxIndexInBlock: 6,
-		BitcoinHeaders: decodeString(
-			"04000020642125b3910fdaead521b57955e28893d89f8ce7fd3ba1dd6d010000000" +
-				"00000f9e17a266a2267ee02d5ab82a75a76805db821a13abd2e80e0950d883311e5" +
-				"355dc21c62ed3e031adefc02c4040000205b6de55e069be71b21a62cd140dc70312" +
-				"25f7258dc758f19ea01000000000000139966d27d9ed0c0c1ed9162c2fea2ccf0ba" +
-				"212706f6bc421d0a2b6211de040d1ac41c62ed3e031a4726538f04e000208475e15" +
-				"e0314635d32abf04c761fee528d6a3f2db3b3d13798000000000000002a3fa06fec" +
-				"d9dd4bf2e25e22a95d4f65435d5c5b42bcf498b4e756f9f4ea67cea1c51c62ed3e0" +
-				"31a9d7bf3ac000000203f16d450c51853a4cd9569d225028aa08ab6139eee31f4f6" +
-				"7a010000000000004cda79bc48b970de2fb29c3f38626eb9d70d8bae7b92aad09f2" +
-				"a0ad2d2f334d35bca1c62ffff001d048fc21700000020687e487acbf5eb375c631a" +
-				"15127fbf7d80ca084461e7f26f92c509b6000000006fad33bd7c8d651bd6dc86c28" +
-				"6f0a99340b668f019b9e97a59fd392c36c4f46910cf1c62ffff001d407facaa0400" +
-				"002040f4c65610f26f06c4365305b956934501713e01c2fc08b919e0bc1b0000000" +
-				"0e401a6a884ba015e83c6fe2cd363e877ef03982e81eaff4e2c95af1e23a670f407" +
-				"d41c62ffff001d58c64d18",
-		),
-	}
-
-	actualDifficulty := spvProof.FirstBlockHeaderDifficulty()
-	expectedDifficulty := new(big.Int).SetUint64(5168815)
-
-	testutils.AssertBigIntsEqual(
-		t,
-		"difficulty",
-		expectedDifficulty,
-		actualDifficulty,
-	)
 }
 
 func TestAssembleTransactionProof(t *testing.T) {

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -17,6 +17,9 @@ import (
 
 var logger = log.Logger("keep-maintainer-spv")
 
+// The length of the Bitcoin difficulty epoch in blocks.
+const difficultyEpochLength = 2016
+
 func Initialize(
 	ctx context.Context,
 	config Config,
@@ -106,14 +109,6 @@ func (sm *spvMaintainer) proveDepositSweepTransactions() error {
 		len(depositSweepTransactions),
 	)
 
-	txProofDifficultyFactor, err := sm.spvChain.TxProofDifficultyFactor()
-	if err != nil {
-		return fmt.Errorf(
-			"failed to get transaction proof difficulty factor: [%v]",
-			err,
-		)
-	}
-
 	for _, transaction := range depositSweepTransactions {
 		// Print the transaction in the same endianness as block explorers do.
 		transactionHashStr := transaction.Hash().Hex(bitcoin.ReversedByteOrder)
@@ -123,99 +118,33 @@ func (sm *spvMaintainer) proveDepositSweepTransactions() error {
 			transactionHashStr,
 		)
 
-		latestBlockHeight, err := sm.btcChain.GetLatestBlockHeight()
-		if err != nil {
-			return err
-		}
-
 		accumulatedConfirmations, err := sm.btcChain.GetTransactionConfirmations(
 			transaction.Hash(),
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf(
+				"failed to get transaction confirmations: [%v]",
+				err,
+			)
 		}
 
-		proofStartBlock := uint64(latestBlockHeight - accumulatedConfirmations + 1)
-		proofStartEpoch := proofStartBlock / 2016
-
-		proofEndBlock := proofStartBlock + txProofDifficultyFactor.Uint64() - 1
-		proofEndEpoch := proofEndBlock / 2016
-
-		currentEpoch, err := sm.btcDiffChain.CurrentEpoch()
+		isProofWithinRelayRange, requiredConfirmations, err := sm.getProofInfo(
+			transaction.Hash(),
+		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get proof info: [%v]", err)
 		}
-		previousEpoch := currentEpoch - 1
 
-		requiredConfirmations := uint64(0)
-		if proofStartEpoch == currentEpoch &&
-			proofEndEpoch == currentEpoch {
-			// The proof is entirely within the current epoch.
-
-			requiredConfirmations = txProofDifficultyFactor.Uint64()
-		} else if proofStartEpoch == previousEpoch &&
-			proofEndEpoch == previousEpoch {
-			// The proof is entirely within the previous epoch.
-
-			requiredConfirmations = txProofDifficultyFactor.Uint64()
-		} else if proofStartEpoch == previousEpoch &&
-			proofEndEpoch == currentEpoch {
-			// The proof spans the previous and current difficulty epochs.
-
-			currentEpochDifficulty, previousEpochDifficulty, err :=
-				sm.btcDiffChain.GetCurrentAndPrevEpochDifficulty()
-			if err != nil {
-				return fmt.Errorf(
-					"failed to get Bitcoin epoch difficulties: [%v]",
-					err,
-				)
-			}
-
-			// Calculate the total difficulty that is required for the proof.
-			totalDifficultyRequired := new(big.Int).Mul(
-				txProofDifficultyFactor,
-				previousEpochDifficulty,
+		if !isProofWithinRelayRange {
+			// The required proof goes outside the previous and current
+			// difficulty epochs as seen by the relay. Skip the transaction. It
+			// will most likely be proven later.
+			logger.Warnf(
+				"skipped proving deposit sweep transaction [%s]; the range "+
+					"of the required proof goes outside the previous and "+
+					"current difficulty epochs as seen by the relay",
+				transactionHashStr,
 			)
-
-			// Calculate how much difficulty the blocks from the previous
-			// epoch part of the proof have in total.
-			numberOfBlocksPreviousEpoch := uint64(2016 - proofStartBlock%2016)
-			totalDifficultyPreviousEpoch := new(big.Int).Mul(
-				big.NewInt(int64(numberOfBlocksPreviousEpoch)),
-				previousEpochDifficulty,
-			)
-
-			// Calculate how much difficulty must come from the current epoch.
-			totalDifficultyCurrentEpoch := new(big.Int).Sub(
-				totalDifficultyRequired,
-				totalDifficultyPreviousEpoch,
-			)
-
-			// Calculate how many blocks from the current epoch we need.
-			remainder := new(big.Int)
-			numberOfBlocksCurrentEpoch, remainder := new(big.Int).DivMod(
-				totalDifficultyCurrentEpoch,
-				currentEpochDifficulty,
-				remainder,
-			)
-			if remainder.Cmp(big.NewInt(0)) > 0 {
-				numberOfBlocksCurrentEpoch.Add(
-					numberOfBlocksCurrentEpoch,
-					big.NewInt(1),
-				)
-			}
-
-			requiredConfirmations = numberOfBlocksPreviousEpoch +
-				numberOfBlocksCurrentEpoch.Uint64()
-		} else {
-			// Skip the transaction as the proof goes outside the previous or
-			// current epochs as seen by the relay. The reason for this is most
-			// likely that transaction entered the Bitcoin blockchain within the
-			// very new difficulty epoch that is not yet proven in the relay.
-			// In that case the transaction will be proven in the future. The
-			// other case could be that the transaction is older than the last
-			// two Bitcoin difficulty epochs. In that case the transaction will
-			// soon leave the sliding window of recent transactions.
 			continue
 		}
 
@@ -223,7 +152,7 @@ func (sm *spvMaintainer) proveDepositSweepTransactions() error {
 			// Skip the transaction as it has not accumulated enough
 			// confirmations. It will be proven later.
 			logger.Infof(
-				"Skipped proving deposit sweep transaction [%s]; transaction "+
+				"skipped proving deposit sweep transaction [%s]; transaction "+
 					"has [%v/%v] confirmations",
 				transactionHashStr,
 				accumulatedConfirmations,
@@ -476,6 +405,152 @@ func (sm *spvMaintainer) isInputCurrentWalletsMainUTXO(
 	}
 
 	return bytes.Equal(mainUtxoHash[:], wallet.MainUtxoHash[:]), nil
+}
+
+// getProofInfo returns information about the SPV proof. It includes the
+// information whether the transaction proof range is within the previous and
+// current difficulty epochs as seen by the relay and the required number of
+// confirmations.
+func (sm *spvMaintainer) getProofInfo(transactionHash bitcoin.Hash) (
+	bool, uint, error,
+) {
+	latestBlockHeight, err := sm.btcChain.GetLatestBlockHeight()
+	if err != nil {
+		return false, 0, fmt.Errorf(
+			"failed to get latest block height: [%v]",
+			err,
+		)
+	}
+
+	accumulatedConfirmations, err := sm.btcChain.GetTransactionConfirmations(
+		transactionHash,
+	)
+	if err != nil {
+		return false, 0, fmt.Errorf(
+			"failed to get transaction confirmations: [%v]",
+			err,
+		)
+	}
+
+	txProofDifficultyFactor, err := sm.spvChain.TxProofDifficultyFactor()
+	if err != nil {
+		return false, 0, fmt.Errorf(
+			"failed to get transaction proof difficulty factor: [%v]",
+			err,
+		)
+	}
+
+	// Calculate the starting block of the proof and the difficulty epoch number
+	// it belongs to.
+	proofStartBlock := uint64(latestBlockHeight - accumulatedConfirmations + 1)
+	proofStartEpoch := proofStartBlock / difficultyEpochLength
+
+	// Calculate the ending block of the proof and the difficulty epoch it
+	// belongs to.
+	proofEndBlock := proofStartBlock + txProofDifficultyFactor.Uint64() - 1
+	proofEndEpoch := proofEndBlock / difficultyEpochLength
+
+	// Get the current difficulty epoch number as seen by the relay. Subtract
+	// one to get the previous epoch number.
+	currentEpoch, err := sm.btcDiffChain.CurrentEpoch()
+	if err != nil {
+		return false, 0, fmt.Errorf("failed to get current epoch: [%v]", err)
+	}
+	previousEpoch := currentEpoch - 1
+
+	// There are only three possible valid combinations of the proof's block
+	// headers range: the proof must either be entirely in the previous epoch,
+	// must be entirely in the current epoch or must span the previous and
+	// current epochs.
+
+	// If the proof is entirely within the current epoch, required confirmations
+	// does not need to be adjusted.
+	if proofStartEpoch == currentEpoch &&
+		proofEndEpoch == currentEpoch {
+		return true, uint(txProofDifficultyFactor.Uint64()), nil
+	}
+
+	// If the proof is entirely within the previous epoch, required confirmations
+	// does not need to be adjusted.
+	if proofStartEpoch == previousEpoch &&
+		proofEndEpoch == previousEpoch {
+		return true, uint(txProofDifficultyFactor.Uint64()), nil
+	}
+
+	// If the proof spans the previous and current difficulty epochs, the
+	// required confirmations may have to be adjusted.
+	if proofStartEpoch == previousEpoch &&
+		proofEndEpoch == currentEpoch {
+		currentEpochDifficulty, previousEpochDifficulty, err :=
+			sm.btcDiffChain.GetCurrentAndPrevEpochDifficulty()
+		if err != nil {
+			return false, 0, fmt.Errorf(
+				"failed to get Bitcoin epoch difficulties: [%v]",
+				err,
+			)
+		}
+
+		// Calculate the total difficulty that is required for the proof. The
+		// proof begins in the previous difficulty epoch, therefore the total
+		// required difficulty will be the previous epoch difficulty times
+		// transaction proof difficulty factor
+		totalDifficultyRequired := new(big.Int).Mul(
+			previousEpochDifficulty,
+			txProofDifficultyFactor,
+		)
+
+		// Calculate the number of block headers in the proof that will come
+		// from the previous difficulty epoch.
+		numberOfBlocksPreviousEpoch :=
+			uint64(difficultyEpochLength - proofStartBlock%difficultyEpochLength)
+
+		// Calculate how much difficulty the blocks from the previous epoch part
+		// of the proof have in total.
+		totalDifficultyPreviousEpoch := new(big.Int).Mul(
+			big.NewInt(int64(numberOfBlocksPreviousEpoch)),
+			previousEpochDifficulty,
+		)
+
+		// Calculate how much difficulty must come from the current epoch.
+		totalDifficultyCurrentEpoch := new(big.Int).Sub(
+			totalDifficultyRequired,
+			totalDifficultyPreviousEpoch,
+		)
+
+		// Calculate how many blocks from the current epoch we need.
+		remainder := new(big.Int)
+		numberOfBlocksCurrentEpoch, remainder := new(big.Int).DivMod(
+			totalDifficultyCurrentEpoch,
+			currentEpochDifficulty,
+			remainder,
+		)
+		// If there is a remainder, it means there is still some amount of
+		// difficulty missing that is less than one block difficulty. We need to
+		// account for that by adding one additional block.
+		if remainder.Cmp(big.NewInt(0)) > 0 {
+			numberOfBlocksCurrentEpoch.Add(
+				numberOfBlocksCurrentEpoch,
+				big.NewInt(1),
+			)
+		}
+
+		// The total required number of confirmations is the sum of blocks from
+		// the previous and current epochs.
+		requiredConfirmations := numberOfBlocksPreviousEpoch +
+			numberOfBlocksCurrentEpoch.Uint64()
+
+		return true, uint(requiredConfirmations), nil
+	}
+
+	// If we entered here, it means that the proof's block headers range goes
+	// outside the previous or current difficulty epochs as seen by the relay.
+	// The reason for this is most likely that transaction entered the Bitcoin
+	// blockchain within the very new difficulty epoch that is not yet proven in
+	//  the relay. In that case the transaction will be proven in the future.
+	// The other case could be that the transaction is older than the last two
+	// Bitcoin difficulty epochs. In that case the transaction will soon leave
+	// the sliding window of recent transactions.
+	return false, 0, nil
 }
 
 // uniqueWalletPublicKeyHashes parses the list of events and returns a list of


### PR DESCRIPTION
This PR is a follow-up PR to https://github.com/keep-network/keep-core/pull/3649.
It adds calculations of the required number of confirmations if the proofs spans two epochs.