### PR TITLE
Inform in API docs about contracts not being deployed to Mainnet

### DIFF
--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -45,7 +45,7 @@ jobs:
     uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
     with:
       projectDir: /solidity/random-beacon
-      postProcessingCommand: find ./generated-docs -name "*.md" -type f -exec sed -i '5i {% hint style="warning" %}\nThis file documents a code which is not yet deployed to Mainnet.\n{% endhint %}\n' {} +
+      postProcessingCommand: find ./generated-docs -name "*.md" -type f -exec sed -i '5i {% hint style="warning" %}\nThis file documents a contract which is not yet deployed to Mainnet.\n{% endhint %}\n' {} +
       publish: false
       addTOC: false
       commentPR: true
@@ -65,7 +65,7 @@ jobs:
     uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
     with:
       projectDir: /solidity/random-beacon
-      postProcessingCommand: find ./generated-docs -name "*.md" -type f -exec sed -i '5i {% hint style="warning" %}\nThis file documents a code which is not yet deployed to Mainnet.\n{% endhint %}\n' {} +
+      postProcessingCommand: find ./generated-docs -name "*.md" -type f -exec sed -i '5i {% hint style="warning" %}\nThis file documents a contract which is not yet deployed to Mainnet.\n{% endhint %}\n' {} +
       publish: true
       addTOC: false
       verifyCommits: true

--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -45,6 +45,7 @@ jobs:
     uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
     with:
       projectDir: /solidity/random-beacon
+      postProcessingCommand: find ./generated-docs -name "*.md" -type f -exec sed -i '5i {% hint style="warning" %}\nThis file documents a code which is not yet deployed to Mainnet.\n{% endhint %}\n' {} +
       publish: false
       addTOC: false
       commentPR: true
@@ -59,10 +60,12 @@ jobs:
   contracts-docs-publish:
     name: Publish contracts documentation
     needs: docs-detect-changes
-    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/solidity/')
+    # TODO: Remove alternative condition before merge
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/solidity/')) || github.ref == 'refs/pull/3671/merge'
     uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
     with:
       projectDir: /solidity/random-beacon
+      postProcessingCommand: find ./generated-docs -name "*.md" -type f -exec sed -i '5i {% hint style="warning" %}\nThis file documents a code which is not yet deployed to Mainnet.\n{% endhint %}\n' {} +
       publish: true
       addTOC: false
       verifyCommits: true


### PR DESCRIPTION
We want to add a note to each generated API doc for Random Beacon that informs
about contracts not being deployed on Mainnet. The note is in style used by
GitBook to highlight important information (read more:
https://docs.gitbook.com/content-creation/blocks/hint#git-sync-representation-in-markdown).
The note is inserted between 5th and 6th line of each generated doc.

Note: This commit contains a temporary change of the triggering conditions for
the publish job. We need to remove this change before merging to `main`.

Before merging this PR we must:

- [x] merge the https://github.com/keep-network/ci/pull/47 first
- [x] re-run the https://github.com/keep-network/keep-core/actions/runs/5472175032 check
- [ ] verify if the PR with the updated docs will be created in the `threshold` repo and merge it
- [ ] verify if the documentation in API section for Random-Beacon in docs.threshold.network displays as we wish
- [ ] remove the testing configuration from the current PR (marked by TODO in code)