### PR TITLE
Add redemption SPV proof submission to the maintainer-cli

### DIFF
--- a/pkg/maintainer/spv/redemptions.go
+++ b/pkg/maintainer/spv/redemptions.go
@@ -10,8 +10,6 @@ import (
 // SubmitRedemptionProof prepares redemption proof for the given transaction
 // and submits it to the on-chain contract. If the number of required
 // confirmations is `0`, an error is returned.
-//
-// TODO: Expose this function through the maintainer-cli tool.
 func SubmitRedemptionProof(
 	transactionHash bitcoin.Hash,
 	requiredConfirmations uint,


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3615

Here we expose the `submit-redemption-proof` command that allows to submit a redemption SPV proof manually.