### PR TITLE
Use non-privileged ports for ElectrumX

### DIFF
--- a/infrastructure/kube/templates/bitcoin/electrumx/electrumx-statefulset.yaml
+++ b/infrastructure/kube/templates/bitcoin/electrumx/electrumx-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   replicas: 1
   serviceName: electrumx
+  podManagementPolicy: Parallel
   template:
     spec:
       securityContext:

--- a/infrastructure/kube/templates/bitcoin/electrumx/electrumx-statefulset.yaml
+++ b/infrastructure/kube/templates/bitcoin/electrumx/electrumx-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
             - name: SSL_KEYFILE
               value: /mnt/electrum/cert/tls.key
             - name: SERVICES
-              value: tcp://:80,ssl://:443,ws://:8080,wss://:8443,rpc://0.0.0.0:8000
+              value: tcp://:50001,ssl://:50002,ws://:50003,wss://:50004,rpc://0.0.0.0:8000
             - name: COST_SOFT_LIMIT
               value: "0"
             - name: COST_HARD_LIMIT
@@ -57,13 +57,13 @@ spec:
               value: debug
           ports:
             - name: tcp
-              containerPort: 80
+              containerPort: 50001
             - name: ssl
-              containerPort: 443
+              containerPort: 50002
             - name: ws
-              containerPort: 8080
+              containerPort: 50003
             - name: wss
-              containerPort: 8443
+              containerPort: 50004
             - name: rpc
               containerPort: 8000
           livenessProbe:


### PR DESCRIPTION

### Use non-privileged ports for ElectrumX

The TCP/IP port numbers below 1024 are considered privileged ports. Normal users and processes are not allowed to use them for various security reasons.

We are running our container with non-root and after recent upgrades in the GCP cluster (Jul 7th), the ElectrumX instances stopped working due to failures in binding TCP and SSL ports:
```
ERROR:SessionManager:TCP server failed to listen on all_interfaces:80: [Errno 13] error while attempting to bind on address ('0.0.0.0', 80): permission denied
ERROR:SessionManager:SSL server failed to listen on all_interfaces:443: [Errno 13] error while attempting to bind on address ('0.0.0.0', 443): permission denied
INFO:SessionManager:WS server listening on all_interfaces:8080
INFO:SessionManager:WSS server listening on all_interfaces:8443
```

We updated the ports to use the defaults described in ElectrumX documentation: `50001-50004`.

The service is still exposed on ports `80`, `443`, `8080`, `8443`.

### Define podManagementPolicy: Parallel
    
The default podManagementPolicy is `OrderedReady`, which waits with spinning up subsequent replicas until the previous replica is ready.
In our use case, it's inaccurate, as we want to have three independent replicas. If the first one is broken, we still want to have a chance to
have another working.
    
Read more: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies

---

Changes were already introduced to the clusters.