### PR TITLE
Return accumulated confirmations

### DIFF
--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -421,7 +421,7 @@ func getProofInfo(
 	// The other case could be that the transaction is older than the last two
 	// Bitcoin difficulty epochs. In that case the transaction will soon leave
 	// the sliding window of recent transactions.
-	return false, accumulatedConfirmations, 0, nil
+	return false, 0, 0, nil
 }
 
 // walletEvent is a type constraint representing wallet-related chain events.

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -166,10 +166,7 @@ func (sm *spvMaintainer) proveTransactions(
 			transactionHashStr,
 		)
 
-		isProofWithinRelayRange,
-			accumulatedConfirmations,
-			requiredConfirmations,
-			err := getProofInfo(
+		isProofWithinRelayRange, accumulatedConfirmations, requiredConfirmations, err := getProofInfo(
 			transaction.Hash(),
 			sm.btcChain,
 			sm.spvChain,

--- a/pkg/maintainer/spv/spv_test.go
+++ b/pkg/maintainer/spv/spv_test.go
@@ -106,12 +106,16 @@ func TestGetProofInfo(t *testing.T) {
 				test.previousEpochDifficulty,
 			)
 
-			isProofWithinRelayRange, requiredConfirmations, err := getProofInfo(
-				transactionHash,
-				btcChain,
-				localChain,
-				localChain,
-			)
+			isProofWithinRelayRange,
+				accumulatedConfirmations,
+				requiredConfirmations,
+				err :=
+				getProofInfo(
+					transactionHash,
+					btcChain,
+					localChain,
+					localChain,
+				)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -121,6 +125,13 @@ func TestGetProofInfo(t *testing.T) {
 				"is proof within range",
 				test.expectedIsProofWithinRelayRange,
 				isProofWithinRelayRange,
+			)
+
+			testutils.AssertUintsEqual(
+				t,
+				"accumulated confirmations",
+				uint64(test.transactionConfirmations),
+				uint64(accumulatedConfirmations),
 			)
 
 			testutils.AssertUintsEqual(

--- a/pkg/maintainer/spv/spv_test.go
+++ b/pkg/maintainer/spv/spv_test.go
@@ -13,67 +13,74 @@ import (
 
 func TestGetProofInfo(t *testing.T) {
 	tests := map[string]struct {
-		latestBlockHeight               uint
-		transactionConfirmations        uint
-		currentEpoch                    uint64
-		currentEpochDifficulty          *big.Int
-		previousEpochDifficulty         *big.Int
-		expectedIsProofWithinRelayRange bool
-		expectedRequiredConfirmations   uint
+		latestBlockHeight                uint
+		transactionConfirmations         uint
+		currentEpoch                     uint64
+		currentEpochDifficulty           *big.Int
+		previousEpochDifficulty          *big.Int
+		expectedIsProofWithinRelayRange  bool
+		expectedAccumulatedConfirmations uint
+		expectedRequiredConfirmations    uint
 	}{
 		"proof entirely within current epoch": {
-			latestBlockHeight:               790277,
-			transactionConfirmations:        3,
-			currentEpoch:                    392,
-			currentEpochDifficulty:          nil, // not needed
-			previousEpochDifficulty:         nil, // not needed
-			expectedIsProofWithinRelayRange: true,
-			expectedRequiredConfirmations:   6,
+			latestBlockHeight:                790277,
+			transactionConfirmations:         3,
+			currentEpoch:                     392,
+			currentEpochDifficulty:           nil, // not needed
+			previousEpochDifficulty:          nil, // not needed
+			expectedIsProofWithinRelayRange:  true,
+			expectedAccumulatedConfirmations: 3,
+			expectedRequiredConfirmations:    6,
 		},
 		"proof entirely within previous epoch": {
-			latestBlockHeight:               790300,
-			transactionConfirmations:        2041,
-			currentEpoch:                    392,
-			currentEpochDifficulty:          nil, // not needed
-			previousEpochDifficulty:         nil, // not needed
-			expectedIsProofWithinRelayRange: true,
-			expectedRequiredConfirmations:   6,
+			latestBlockHeight:                790300,
+			transactionConfirmations:         2041,
+			currentEpoch:                     392,
+			currentEpochDifficulty:           nil, // not needed
+			previousEpochDifficulty:          nil, // not needed
+			expectedAccumulatedConfirmations: 2041,
+			expectedIsProofWithinRelayRange:  true,
+			expectedRequiredConfirmations:    6,
 		},
 		"proof spans previous and current epochs and difficulty drops": {
-			latestBlockHeight:               790300,
-			transactionConfirmations:        31,
-			currentEpoch:                    392,
-			currentEpochDifficulty:          big.NewInt(50000000000000),
-			previousEpochDifficulty:         big.NewInt(30000000000000),
-			expectedIsProofWithinRelayRange: true,
-			expectedRequiredConfirmations:   9,
+			latestBlockHeight:                790300,
+			transactionConfirmations:         31,
+			currentEpoch:                     392,
+			currentEpochDifficulty:           big.NewInt(50000000000000),
+			previousEpochDifficulty:          big.NewInt(30000000000000),
+			expectedIsProofWithinRelayRange:  true,
+			expectedAccumulatedConfirmations: 31,
+			expectedRequiredConfirmations:    9,
 		},
 		"proof spans previous and current epochs and difficulty raises": {
-			latestBlockHeight:               790300,
-			transactionConfirmations:        31,
-			currentEpoch:                    392,
-			currentEpochDifficulty:          big.NewInt(30000000000000),
-			previousEpochDifficulty:         big.NewInt(60000000000000),
-			expectedIsProofWithinRelayRange: true,
-			expectedRequiredConfirmations:   4,
+			latestBlockHeight:                790300,
+			transactionConfirmations:         31,
+			currentEpoch:                     392,
+			currentEpochDifficulty:           big.NewInt(30000000000000),
+			previousEpochDifficulty:          big.NewInt(60000000000000),
+			expectedIsProofWithinRelayRange:  true,
+			expectedAccumulatedConfirmations: 31,
+			expectedRequiredConfirmations:    4,
 		},
 		"proof begins outside previous epoch": {
-			latestBlockHeight:               790300,
-			transactionConfirmations:        2048,
-			currentEpoch:                    392,
-			currentEpochDifficulty:          nil, // not needed
-			previousEpochDifficulty:         nil, // not needed
-			expectedIsProofWithinRelayRange: false,
-			expectedRequiredConfirmations:   0,
+			latestBlockHeight:                790300,
+			transactionConfirmations:         2048,
+			currentEpoch:                     392,
+			currentEpochDifficulty:           nil, // not needed
+			previousEpochDifficulty:          nil, // not needed
+			expectedIsProofWithinRelayRange:  false,
+			expectedAccumulatedConfirmations: 0,
+			expectedRequiredConfirmations:    0,
 		},
 		"proof ends outside current epoch": {
-			latestBlockHeight:               792285,
-			transactionConfirmations:        3,
-			currentEpoch:                    392,
-			currentEpochDifficulty:          nil, // not needed
-			previousEpochDifficulty:         nil, // not needed
-			expectedIsProofWithinRelayRange: false,
-			expectedRequiredConfirmations:   0,
+			latestBlockHeight:                792285,
+			transactionConfirmations:         3,
+			currentEpoch:                     392,
+			currentEpochDifficulty:           nil, // not needed
+			previousEpochDifficulty:          nil, // not needed
+			expectedIsProofWithinRelayRange:  false,
+			expectedAccumulatedConfirmations: 0,
+			expectedRequiredConfirmations:    0,
 		},
 	}
 
@@ -130,7 +137,7 @@ func TestGetProofInfo(t *testing.T) {
 			testutils.AssertUintsEqual(
 				t,
 				"accumulated confirmations",
-				uint64(test.transactionConfirmations),
+				uint64(test.expectedAccumulatedConfirmations),
 				uint64(accumulatedConfirmations),
 			)
 


### PR DESCRIPTION
#Depends on https://github.com/keep-network/keep-core/pull/3673.
This is a follow-up PR that handles a [review comment](https://github.com/keep-network/keep-core/pull/3667#discussion_r1253063238) from another PR.
Getting the number of accumulated confirmations of a transaction was moved into the `getProofInfo` function.