### PR TITLE
Wallet maintainer: Prevent against `requestTimeout` being `max(uint32)`

### DIFF
--- a/pkg/maintainer/wallet/redemptions.go
+++ b/pkg/maintainer/wallet/redemptions.go
@@ -365,7 +365,10 @@ func getPendingRedemptions(
 	// lesser than the assumed one, some events being on the edge of the block
 	// range may be omitted. To avoid that, we make the block range a little
 	// wider by using a constant factor of 1000 blocks.
-	filterStartBlock := currentBlockNumber - requestTimeoutBlocks - 1000
+	filterStartBlock := uint64(0)
+	if filterLookbackBlocks := requestTimeoutBlocks + 1000; currentBlockNumber > filterLookbackBlocks {
+		filterStartBlock = currentBlockNumber - filterLookbackBlocks
+	}
 
 	filter := &tbtc.RedemptionRequestedEventFilter{
 		StartBlock: filterStartBlock,


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3614

While running the redemption task, the wallet maintainer fetches past `RedemptionRequested` events using a filter whose start block is calculated as:
```
startBlock := currentBlock - requestTimeoutBlocks - 1000
```
where `requestTimeoutBlocks` is computed as:
```
requestTimeoutBlocks := uint64(requestTimeout) /
    uint64(chain.AverageBlockTime().Seconds())
```
However, the current `Bridge.requestTimeout` on mainnet is set to `max(uint32)` as redemptions are not yet enabled. That means the `requestTimeoutBlocks` is higher than `currentBlock` and produces a negative `startBlock` which is eventually set to `max(uint64)` due to being an unsigned type. The `startBlock` is then converted to `int64` within `go-ethereum` library which produces the `invalid argument 0: block number larger than int64` error as a result.

In order to fix this problem, we are introducing an additional check that ensures the minimum possible value of `startBlock` is `0`.