### PR TITLE
Fix the wallets limit filter in the wallet maintainer redemptions code

### DIFF
--- a/pkg/maintainer/wallet/redemptions.go
+++ b/pkg/maintainer/wallet/redemptions.go
@@ -206,20 +206,10 @@ func FindPendingRedemptions(
 	}
 
 	logger.Infof(
-		"built an initial list of [%v] wallets that will be checked "+
+		"built a list of [%v] wallets that will be checked "+
 			"for pending redemption requests",
 		len(walletPublicKeyHashes),
 	)
-
-	// Apply the wallets number limit if needed.
-	if limit := int(filter.WalletsLimit); limit > 0 && len(walletPublicKeyHashes) > limit {
-		walletPublicKeyHashes = walletPublicKeyHashes[:limit]
-
-		logger.Infof(
-			"limited the initial wallets list to [%v] wallets",
-			len(walletPublicKeyHashes),
-		)
-	}
 
 	result := make(map[[20]byte][]bitcoin.Script)
 
@@ -264,6 +254,17 @@ func FindPendingRedemptions(
 				result[walletPublicKeyHash],
 				pendingRedemption.RedeemerOutputScript,
 			)
+		}
+
+		// Apply the wallets number limit if needed.
+		if limit := int(filter.WalletsLimit); limit > 0 && len(result) == limit {
+			logger.Infof(
+				"aborting pending redemptions checks due to the "+
+					"configured wallets limit; [%v] wallets with pending "+
+					"redemptions were found so far",
+				len(result),
+			)
+			break
 		}
 	}
 


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-core/issues/3682

As described in #3682, the current logic is wrong. If the `WalletsLimit` filter is on, always the same oldest wallets will be taken into account so redemption requests targeting newer wallets can be missed by the wallet maintainer. We are fixing that by applying the `WalletsLimit` filter at a later stage.