### PR TITLE
Remove deprecation notice for --mainnet flag

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -77,12 +77,10 @@ func initGlobalConfigFlags(cmd *cobra.Command, configFilePath *string) {
 // start command to run the client against test networks. Only one flag
 // from this set is allowed.
 func initGlobalNetworkFlags(cmd *cobra.Command) {
-	// TODO: Remove the mainnet flag.
-	// DEPRECATED
 	cmd.PersistentFlags().Bool(
 		network.Mainnet.String(),
 		false,
-		"Mainnet network (DEPRECATED)",
+		"Mainnet network",
 	)
 
 	cmd.PersistentFlags().Bool(

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -96,7 +96,7 @@ func initGlobalNetworkFlags(cmd *cobra.Command) {
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(
-		network.Mainnet.String(), // TODO: Remove the mainnet flag.
+		network.Mainnet.String(),
 		network.Testnet.String(),
 		network.Developer.String(),
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -119,15 +119,6 @@ func (c *Config) ReadConfig(configFilePath string, flagSet *pflag.FlagSet, categ
 		if err != nil {
 			return fmt.Errorf("unable to resolve networks: [%w]", err)
 		}
-
-		// TODO: Remove the mainnet flag.
-		// DEPRECATED
-		if isMainnet, err := flagSet.GetBool(network.Mainnet.String()); err == nil && isMainnet {
-			logger.Warnf(
-				"--%s flag is deprecated, to run the client against the mainnet don't provide any network flag",
-				network.Mainnet.String(),
-			)
-		}
 	}
 
 	// Read configuration from a file if the config file path is set.

--- a/docs/resources/client-start-help
+++ b/docs/resources/client-start-help
@@ -44,7 +44,7 @@ Flags:
 Global Flags:
   -c, --config string   Path to the configuration file. Supported formats: TOML, YAML, JSON.
       --developer       Developer network
-      --mainnet         Mainnet network (DEPRECATED)
+      --mainnet         Mainnet network
       --testnet         Testnet network
 
 Environment variables:


### PR DESCRIPTION
We planned to remove the `--mainnet` flag, as it seemed unnecessary, as the client running without any network flag runs for mainnet by default. But from an infrastructure administrator perspective, the flag may be actually useful when running the application on multiple environments. It's much easier to maintain a common template where the administrator will have to change the value of the flag rather than set the flag for some environments and remove it for mainnet.

When running the application for **mainnet** an administrator will have two possibilities:
- add `--mainnet` flag,
- don't define any network flag.

When running the application for **testnet** an administrator will have to add `--testnet` flag.