### PR TITLE
Use `keepnetwork/keep-client:v2.0.0-m4` for `keep-maintainer` on production

### DIFF
--- a/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
@@ -10,8 +10,8 @@ commonLabels:
 
 images:
   - name: keep-maintainer
-    newName: gcr.io/keep-prd-210b/keep-client
-    newTag: v2.0.0-m4-rc
+    newName: keepnetwork/keep-client
+    newTag: v2.0.0-m4
 
 configMapGenerator:
   - name: keep-maintainer-config


### PR DESCRIPTION
Here we point the production instance of `keep-maintainer` to the latest public Docker image, i.e `keepnetwork/keep-client:v2.0.0-m4` which enables support for redemptions.