### PR TITLE
Set unmarshallers early during signing

### DIFF
--- a/pkg/protocol/announcer/announcer.go
+++ b/pkg/protocol/announcer/announcer.go
@@ -71,6 +71,12 @@ type Announcer struct {
 	membershipValidator *group.MembershipValidator
 }
 
+func RegisterUnmarshaller(channel net.BroadcastChannel) {
+	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &announcementMessage{}
+	})
+}
+
 // New creates a new instance of the Announcer. It expects a unique protocol
 // identifier, a broadcast channel configured to mediate between group members,
 // and a membership validator configured to validate the group membership of
@@ -80,10 +86,6 @@ func New(
 	broadcastChannel net.BroadcastChannel,
 	membershipValidator *group.MembershipValidator,
 ) *Announcer {
-	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
-		return &announcementMessage{}
-	})
-
 	return &Announcer{
 		protocolID:          protocolID,
 		broadcastChannel:    broadcastChannel,

--- a/pkg/protocol/announcer/announcer.go
+++ b/pkg/protocol/announcer/announcer.go
@@ -71,6 +71,8 @@ type Announcer struct {
 	membershipValidator *group.MembershipValidator
 }
 
+// RegisterUnmarshaller initializes the given broadcast channel to be able to
+// handle announcement messages by registering the required unmarshaller.
 func RegisterUnmarshaller(channel net.BroadcastChannel) {
 	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
 		return &announcementMessage{}

--- a/pkg/protocol/announcer/announcer_test.go
+++ b/pkg/protocol/announcer/announcer_test.go
@@ -150,6 +150,8 @@ func TestAnnouncer(t *testing.T) {
 				localChain.Signing(),
 			)
 
+			RegisterUnmarshaller(broadcastChannel)
+
 			announcer := New(
 				protocolID,
 				broadcastChannel,

--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -259,6 +259,8 @@ func (de *dkgExecutor) generateSigningGroup(
 		return
 	}
 
+	announcer.RegisterUnmarshaller(broadcastChannel)
+
 	dkgParameters, err := de.chain.DKGParameters()
 	if err != nil {
 		dkgLogger.Errorf("cannot get DKG parameters: [%v]", err)

--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -111,7 +111,7 @@ func (de *dkgExecutor) preParamsCount() int {
 // the result to the chain. The execution can be delayed by an arbitrary number
 // of blocks using the delayBlocks argument. This allows confirming the state
 // on-chain - e.g. wait for the required number of confirming blocks - before
-//executing the off-chain action.
+// executing the off-chain action.
 func (de *dkgExecutor) executeDkgIfEligible(
 	seed *big.Int,
 	startBlock uint64,
@@ -162,12 +162,12 @@ func (de *dkgExecutor) executeDkgIfEligible(
 
 // checkEligibility performs on-chain group selection and returns two pieces
 // of information:
-// - Indexes of members selected to the signing group and controlled by this
-//   operator. The indexes are in range [1, `groupSize`]. The slice is nil if
-//   none of the selected signing group members is controlled by this operator.
-// - Group selection result holding chain.OperatorID and chain.Address for
-//   operators selected to the signing group. There are always `groupSize`
-//   selected operators.
+//   - Indexes of members selected to the signing group and controlled by this
+//     operator. The indexes are in range [1, `groupSize`]. The slice is nil if
+//     none of the selected signing group members is controlled by this operator.
+//   - Group selection result holding chain.OperatorID and chain.Address for
+//     operators selected to the signing group. There are always `groupSize`
+//     selected operators.
 func (de *dkgExecutor) checkEligibility(
 	dkgLogger log.StandardLogger,
 ) ([]uint8, *GroupSelectionResult, error) {
@@ -218,6 +218,7 @@ func (de *dkgExecutor) setupBroadcastChannel(
 	}
 
 	dkg.RegisterUnmarshallers(broadcastChannel)
+	announcer.RegisterUnmarshaller(broadcastChannel)
 
 	err = broadcastChannel.SetFilter(membershipValidator.IsInGroup)
 	if err != nil {
@@ -258,8 +259,6 @@ func (de *dkgExecutor) generateSigningGroup(
 		dkgLogger.Errorf("could not set up a broadcast channel: [%v]", err)
 		return
 	}
-
-	announcer.RegisterUnmarshaller(broadcastChannel)
 
 	dkgParameters, err := de.chain.DKGParameters()
 	if err != nil {

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/pkg/generator"
 	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/announcer"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa/signing"
 )
@@ -241,6 +242,7 @@ func (n *node) getSigningExecutor(
 	}
 
 	signing.RegisterUnmarshallers(broadcastChannel)
+	announcer.RegisterUnmarshaller(broadcastChannel)
 
 	membershipValidator := group.NewMembershipValidator(
 		executorLogger,

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -241,7 +241,11 @@ func (n *node) getSigningExecutor(
 		return nil, false, fmt.Errorf("failed to get broadcast channel: [%v]", err)
 	}
 
-	registerSigningUnmarshallers(broadcastChannel)
+	signing.RegisterUnmarshallers(broadcastChannel)
+	announcer.RegisterUnmarshaller(broadcastChannel)
+	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &signingDoneMessage{}
+	})
 
 	membershipValidator := group.NewMembershipValidator(
 		executorLogger,
@@ -599,15 +603,4 @@ func withCancelOnBlock(
 	}()
 
 	return blockCtx, cancelBlockCtx
-}
-
-// registerSigningUnmarshallers initializes the given broadcast channel to be
-// able to perform the signing protocol interactions by registering all the
-// required protocol unmarshallers.
-func registerSigningUnmarshallers(channel net.BroadcastChannel) {
-	signing.RegisterUnmarshallers(channel)
-	announcer.RegisterUnmarshaller(channel)
-	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
-		return &signingDoneMessage{}
-	})
 }

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -241,8 +241,7 @@ func (n *node) getSigningExecutor(
 		return nil, false, fmt.Errorf("failed to get broadcast channel: [%v]", err)
 	}
 
-	signing.RegisterUnmarshallers(broadcastChannel)
-	announcer.RegisterUnmarshaller(broadcastChannel)
+	registerSigningUnmarshallers(broadcastChannel)
 
 	membershipValidator := group.NewMembershipValidator(
 		executorLogger,
@@ -600,4 +599,15 @@ func withCancelOnBlock(
 	}()
 
 	return blockCtx, cancelBlockCtx
+}
+
+// registerSigningUnmarshallers initializes the given broadcast channel to be
+// able to perform the signing protocol interactions by registering all the
+// required protocol unmarshallers.
+func registerSigningUnmarshallers(channel net.BroadcastChannel) {
+	signing.RegisterUnmarshallers(channel)
+	announcer.RegisterUnmarshaller(channel)
+	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &signingDoneMessage{}
+	})
 }

--- a/pkg/tbtc/signing_done.go
+++ b/pkg/tbtc/signing_done.go
@@ -62,10 +62,6 @@ func newSigningDoneCheck(
 	broadcastChannel net.BroadcastChannel,
 	membershipValidator *group.MembershipValidator,
 ) *signingDoneCheck {
-	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
-		return &signingDoneMessage{}
-	})
-
 	return &signingDoneCheck{
 		groupSize:           groupSize,
 		broadcastChannel:    broadcastChannel,

--- a/pkg/tbtc/signing_done_test.go
+++ b/pkg/tbtc/signing_done_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keep-network/keep-core/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/local"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -325,6 +326,10 @@ func setupSigningDoneCheck(
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &signingDoneMessage{}
+	})
 
 	membershipValidator := group.NewMembershipValidator(
 		&testutils.MockLogger{},


### PR DESCRIPTION
#Refs https://github.com/keep-network/keep-core/issues/3611.
This PR handles problems with unmarshallers not found errors during signing:
```
eep-libp2p	libp2p/channel.go:286	couldn't find unmarshaler for type [protocol_announcer/announcement_message]
keep-libp2p	libp2p/channel.go:286	couldn't find unmarshaler for type [tbtc/signing_done_message]
```
The solution is is to register the marshaller for those messages early, before the signing process begins.