### PR TITLE
Support deployment on Sepolia

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -28,7 +28,7 @@ on:
     inputs:
       environment:
         description: "Environment (network) for workflow execution, e.g. `sepolia`"
-        required: false
+        required: true
       upstream_builds:
         description: "Upstream builds"
         required: false

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (network) for workflow execution, e.g. `goerli`"
+        description: "Environment (network) for workflow execution, e.g. `sepolia`"
         required: false
       upstream_builds:
         description: "Upstream builds"
@@ -252,9 +252,24 @@ jobs:
 
       - name: Deploy contracts
         env:
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          # Use fake ternary expressions to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI...` credentials
+          # are empty, the expressions will be evaluated to the `SEPOLIA...`
+          # ones.
+          CHAIN_API_URL: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_HOSTNAME_HTTP
+              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
+          # two below envs?
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -340,9 +355,24 @@ jobs:
       
       - name: Deploy contracts
         env:
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          # Use fake ternary expressions to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI...` credentials
+          # are empty, the expressions will be evaluated to the `SEPOLIA...`
+          # ones.
+          CHAIN_API_URL: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_HOSTNAME_HTTP
+              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
+          # two below envs?
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.DAPP_DEV_SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -262,6 +262,7 @@ jobs:
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -357,6 +358,7 @@ jobs:
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -261,7 +261,6 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
@@ -357,7 +356,6 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -252,24 +252,16 @@ jobs:
 
       - name: Deploy contracts
         env:
-          # Use fake ternary expressions to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI...` credentials
-          # are empty, the expressions will be evaluated to the `SEPOLIA...`
-          # ones.
+          # Using fake ternary expression to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
+          # is empty, the expression will be evaluated to
+          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
           CHAIN_API_URL: |
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
-          # two below envs?
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -355,24 +347,16 @@ jobs:
       
       - name: Deploy contracts
         env:
-          # Use fake ternary expressions to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI...` credentials
-          # are empty, the expressions will be evaluated to the `SEPOLIA...`
-          # ones.
+          # Using fake ternary expression to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
+          # is empty, the expression will be evaluated to
+          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
           CHAIN_API_URL: |
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
-          # two below envs?
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.DAPP_DEV_SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -261,7 +261,7 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -356,7 +356,7 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -260,7 +260,7 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
@@ -356,7 +356,7 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -260,8 +260,8 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
@@ -356,8 +356,8 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -28,7 +28,7 @@ on:
     inputs:
       environment:
         description: "Environment (network) for workflow execution, e.g. `sepolia`"
-        required: false
+        required: true
       upstream_builds:
         description: "Upstream builds"
         required: false

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -248,24 +248,16 @@ jobs:
 
       - name: Deploy contracts
         env:
-          # Use fake ternary expressions to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI...` credentials
-          # are empty, the expressions will be evaluated to the `SEPOLIA...`
-          # ones.
+          # Using fake ternary expression to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
+          # is empty, the expression will be evaluated to
+          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
           CHAIN_API_URL: |
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
-          # two below envs?
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -349,24 +341,16 @@ jobs:
       
       - name: Deploy contracts
         env:
-          # Use fake ternary expressions to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI...` credentials
-          # are empty, the expressions will be evaluated to the `SEPOLIA...`
-          # ones.
+          # Using fake ternary expression to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
+          # is empty, the expression will be evaluated to
+          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
           CHAIN_API_URL: |
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
-          # two below envs?
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.DAPP_DEV_SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
-              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -258,6 +258,7 @@ jobs:
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -351,6 +352,7 @@ jobs:
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -256,8 +256,8 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
@@ -350,8 +350,8 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -256,7 +256,7 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
@@ -350,7 +350,7 @@ jobs:
             ${{ inputs.github.event.inputs.environment == 'goerli'
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (network) for workflow execution, e.g. `goerli`"
+        description: "Environment (network) for workflow execution, e.g. `sepolia`"
         required: false
       upstream_builds:
         description: "Upstream builds"
@@ -248,9 +248,24 @@ jobs:
 
       - name: Deploy contracts
         env:
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          # Use fake ternary expressions to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI...` credentials
+          # are empty, the expressions will be evaluated to the `SEPOLIA...`
+          # ones.
+          CHAIN_API_URL: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_HOSTNAME_HTTP
+              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
+          # two below envs?
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -334,9 +349,24 @@ jobs:
       
       - name: Deploy contracts
         env:
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          # Use fake ternary expressions to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI...` credentials
+          # are empty, the expressions will be evaluated to the `SEPOLIA...`
+          # ones.
+          CHAIN_API_URL: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_HOSTNAME_HTTP
+              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          # TODO: Shouldn't we use `ACCOUNTS_PRIVATE_KEYS` here instead of the
+          # two below envs?
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.DAPP_DEV_SEPOLIA_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+              || secrets.SEPOLIA_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -257,7 +257,6 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
@@ -351,7 +350,6 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -257,7 +257,7 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -350,7 +350,7 @@ jobs:
               && secrets.GOERLI_ETH_HOSTNAME_HTTP
               || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/solidity/ecdsa/deploy/09_deploy_wallet_registry_governance.ts
+++ b/solidity/ecdsa/deploy/09_deploy_wallet_registry_governance.ts
@@ -7,8 +7,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const WalletRegistry = await deployments.get("WalletRegistry")
 
-  // 60 seconds for Goerli. 1 week otherwise.
-  const GOVERNANCE_DELAY = hre.network.name === "goerli" ? 60 : 604800
+  // 60 seconds for Goerli/Sepolia. 1 week otherwise.
+  const GOVERNANCE_DELAY =
+    hre.network.name === "goerli" || hre.network.name === "sepolia"
+      ? 60
+      : 604800
 
   const WalletRegistryGovernance = await deployments.deploy(
     "WalletRegistryGovernance",

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -121,6 +121,14 @@ const config: HardhatUserConfig = {
         : undefined,
       tags: ["etherscan", "tenderly", "useRandomBeaconChaosnet"],
     },
+    sepolia: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 11155111,
+      accounts: process.env.ACCOUNTS_PRIVATE_KEYS
+        ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
+        : undefined,
+      tags: ["etherscan", "tenderly", "useRandomBeaconChaosnet"],
+    },
     mainnet: {
       url: process.env.CHAIN_API_URL || "",
       chainId: 1,
@@ -143,21 +151,25 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 1, // take the second account
       goerli: 0,
+      sepolia: 0,
       mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
       default: 2,
       goerli: 0,
+      sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
       goerli: 0,
+      sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     esdm: {
       default: 4,
       goerli: 0,
+      sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
   },
@@ -189,6 +201,10 @@ const config: HardhatUserConfig = {
         "node_modules/@keep-network/random-beacon/deployments/development",
       ],
       goerli: [
+        "node_modules/@threshold-network/solidity-contracts/artifacts",
+        "node_modules/@keep-network/random-beacon/artifacts",
+      ],
+      sepolia: [
         "node_modules/@threshold-network/solidity-contracts/artifacts",
         "node_modules/@keep-network/random-beacon/artifacts",
       ],

--- a/solidity/random-beacon/deploy/01_deploy_reimbursement_pool.ts
+++ b/solidity/random-beacon/deploy/01_deploy_reimbursement_pool.ts
@@ -16,6 +16,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   })
 
   if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(
+      ReimbursementPool.transactionHash,
+      2,
+      300000
+    )
     await helpers.etherscan.verify(ReimbursementPool)
   }
 

--- a/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
+++ b/solidity/random-beacon/deploy/02_deploy_beacon_sortition_pool.ts
@@ -27,6 +27,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   )
 
   if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(
+      BeaconSortitionPool.transactionHash,
+      2,
+      300000
+    )
     await helpers.etherscan.verify(BeaconSortitionPool)
   }
 

--- a/solidity/random-beacon/deploy/03_deploy_beacon_dkg_validator.ts
+++ b/solidity/random-beacon/deploy/03_deploy_beacon_dkg_validator.ts
@@ -15,6 +15,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   })
 
   if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(
+      BeaconDkgValidator.transactionHash,
+      2,
+      300000
+    )
     await helpers.etherscan.verify(BeaconDkgValidator)
   }
 

--- a/solidity/random-beacon/deploy/04_deploy_random_beacon.ts
+++ b/solidity/random-beacon/deploy/04_deploy_random_beacon.ts
@@ -59,6 +59,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   )
 
   if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(
+      RandomBeacon.transactionHash,
+      2,
+      300000
+    )
     await helpers.etherscan.verify(BLS)
     await helpers.etherscan.verify(BeaconAuthorization)
     await helpers.etherscan.verify(BeaconDkg)

--- a/solidity/random-beacon/deploy/07_deploy_random_beacon_governance.ts
+++ b/solidity/random-beacon/deploy/07_deploy_random_beacon_governance.ts
@@ -20,6 +20,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   )
 
   if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(
+      RandomBeaconGovernance.transactionHash,
+      2,
+      300000
+    )
     await helpers.etherscan.verify(RandomBeaconGovernance)
   }
 

--- a/solidity/random-beacon/deploy/09_deploy_random_beacon_chaosnet.ts
+++ b/solidity/random-beacon/deploy/09_deploy_random_beacon_chaosnet.ts
@@ -19,6 +19,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   )
 
   if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(
+      RandomBeaconChaosnet.transactionHash,
+      2,
+      300000
+    )
     await helpers.etherscan.verify(RandomBeaconChaosnet)
   }
 

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -109,6 +109,14 @@ const config: HardhatUserConfig = {
         : undefined,
       tags: ["etherscan", "tenderly"],
     },
+    sepolia: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 11155111,
+      accounts: process.env.ACCOUNTS_PRIVATE_KEYS
+        ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
+        : undefined,
+      tags: ["etherscan", "tenderly"],
+    },
     mainnet: {
       url: process.env.CHAIN_API_URL || "",
       chainId: 1,
@@ -131,16 +139,19 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 1,
       goerli: 0,
+      sepolia: 0,
       mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
       default: 2,
       goerli: 0,
+      sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
       goerli: 0,
+      sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
   },
@@ -166,6 +177,7 @@ const config: HardhatUserConfig = {
         "node_modules/@threshold-network/solidity-contracts/deployments/development",
       ],
       goerli: ["node_modules/@threshold-network/solidity-contracts/artifacts"],
+      sepolia: ["node_modules/@threshold-network/solidity-contracts/artifacts"],
       mainnet: ["./external/mainnet"],
     },
   },


### PR DESCRIPTION
The Görli testnet currently used by Threshold/Keep for development purposes is planned to become deprecated with the end of year 2023. The testnet that is planned to replace it is called
[Holešky](https://github.com/eth-clients/holesky), however it's not yet available - it's planned it will become widely accessible on Oct 1, 2023 ([source](https://everstake.one/blog/new-ethereum-testnet-holesky-all-you-need-to-know-now)). Switching our infrastructure to support new testnet is quite time consuming, so moving directly from Görli to Holešky may be quite risky, especially if there would be some delays in the date of Holešky genesis (not meeting the planned timelines is not a rare occurrence in the Ethereum space). As a solution, we decided to switch first to another testnet that is currently live - Sepolia. This testnet's EOL is planned for 2026, which gives us plenty of time to move to Holešky before Sepolia gets deprecated.

Refs:
https://github.com/threshold-network/solidity-contracts/issues/150
https://github.com/keep-network/ci/pull/48
https://github.com/threshold-network/solidity-contracts/pull/151
https://github.com/keep-network/tbtc-v2/pull/691
https://github.com/threshold-network/token-dashboard/pull/605

- [ ] Update `TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY` so that it is prefixed with `0x`