### PR TITLE
Support deployment of v1 contracts on Sepolia

### DIFF
--- a/solidity-v1/migrations/2_deploy_contracts.js
+++ b/solidity-v1/migrations/2_deploy_contracts.js
@@ -49,7 +49,14 @@ const KeepVault = artifacts.require("./geyser/KeepVault.sol")
 
 let initializationPeriod = 43200 // ~12 hours
 const dkgContributionMargin = 1 // 1%
-const testNetworks = ["local", "ropsten", "keep_dev", "alfajores", "goerli"]
+const testNetworks = [
+  "local",
+  "ropsten",
+  "keep_dev",
+  "alfajores",
+  "goerli",
+  "sepolia",
+]
 
 module.exports = async function (deployer, network) {
   // Set the stake initialization period to 1 block for local development and testnet.

--- a/solidity-v1/truffle-config.js
+++ b/solidity-v1/truffle-config.js
@@ -32,20 +32,6 @@ module.exports = {
       network_id: 1101,
     },
 
-    ropsten: {
-      provider: function () {
-        return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
-          providerOrUrl: process.env.CHAIN_API_URL,
-        })
-      },
-      gas: 6000000,
-      network_id: 3,
-      skipDryRun: true,
-      networkCheckTimeout: 120000,
-      timeoutBlocks: 200, // # of blocks before a deployment times out  (minimum/default: 50)
-    },
-
     goerli: {
       provider: function () {
         return new HDWalletProvider({
@@ -55,6 +41,20 @@ module.exports = {
       },
       gas: 6000000,
       network_id: 5,
+      skipDryRun: true,
+      networkCheckTimeout: 120000,
+      timeoutBlocks: 200, // # of blocks before a deployment times out  (minimum/default: 50)
+    },
+
+    sepolia: {
+      provider: function () {
+        return new HDWalletProvider({
+          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
+          providerOrUrl: process.env.CHAIN_API_URL,
+        })
+      },
+      gas: 6000000,
+      network_id: 11155111,
       skipDryRun: true,
       networkCheckTimeout: 120000,
       timeoutBlocks: 200, // # of blocks before a deployment times out  (minimum/default: 50)


### PR DESCRIPTION
The Görli testnet currently used by Threshold/Keep for development purposes is planned to become deprecated with the end of year 2023. The testnet that is planned to replace it is called
[Holešky](https://github.com/eth-clients/holesky), however it's not yet available - it's planned it will become widely accessible on Sep 15, 2023 ([source](https://everstake.one/blog/new-ethereum-testnet-holesky-all-you-need-to-know-now)). Switching our infrastructure to support new testnet is quite time consuming, so moving directly from Görli to Holešky may be quite risky, especially if there would be some delays in the date of Holešky genesis (not meeting the planned timelines is not a rare occurrence in the Ethereum space). As a solution, we decided to switch first to another testnet that is currently live - Sepolia. This testnet's EOL is planned for 2026, which gives us plenty of time to move to Holešky before Sepolia gets deprecated.

As part of the process we need to deploy the legacy Keep contracts on Sepolia. This PR contains changes needed for such deployment of the `keep-core` contracts.
Package published using this code: https://www.npmjs.com/package/@keep-network/keep-core/v/1.8.1-sepolia.0.

Refs: https://github.com/threshold-network/solidity-contracts/issues/150