### PR TITLE
Increasing signing attempts to perform all signing computations

### DIFF
--- a/pkg/tbtc/signing_test.go
+++ b/pkg/tbtc/signing_test.go
@@ -185,7 +185,7 @@ func setupSigningExecutor(t *testing.T) *signingExecutor {
 
 	// Test block counter is much quicker than the real world one.
 	// Set more attempts to give more time for computations.
-	executor.signingAttemptsLimit *= 3
+	executor.signingAttemptsLimit *= 5
 
 	return executor
 }


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3665

It turns out that the current number of attempts is not enough and we need to bump it up so the integration tests computation has enough time to perform signing. The reason why they started failing is because the local chain has block times much shorter than the real ones. This will give much shorter timeouts to perform all the signing computations.

Credits: The fix was suggested by @lukasz-zimnoch 