### PR TITLE
Increase maintainer's redemption request amount limit to 15 BTC

### DIFF
--- a/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
@@ -19,6 +19,7 @@ configMapGenerator:
     literals:
       - network=mainnet
       - electrum-api-url=ws://electrumx.bitcoin:8080
+      - redemption-request-amount-limit=1500000000 # 15 BTC in satoshi
     files:
       - .secret/keep-maintainer-keyfile
 

--- a/infrastructure/kube/keep-test/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-test/keep-maintainer/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
     literals:
       - network=testnet
       - electrum-api-url=ws://electrumx.bitcoin-testnet:8080
+      - redemption-request-amount-limit=0 # Use the default value
     files:
       - .secret/keep-maintainer-keyfile
 

--- a/infrastructure/kube/templates/keep-maintainer/maintainer-statefulset.yaml
+++ b/infrastructure/kube/templates/keep-maintainer/maintainer-statefulset.yaml
@@ -46,6 +46,11 @@ spec:
                 configMapKeyRef:
                   name: keep-maintainer-config
                   key: electrum-api-url
+            - name: REDEMPTION_REQUEST_AMOUNT_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: keep-maintainer-config
+                  key: redemption-request-amount-limit
           command:
             - keep-client
             - maintainer
@@ -57,6 +62,8 @@ spec:
             - /mnt/keep-maintainer/keyfile/keep-maintainer-keyfile
             - --bitcoin.electrum.url
             - $(ELECTRUM_API_URL)
+            - --walletCoordination.redemptionRequestAmountLimit
+            - $(REDEMPTION_REQUEST_AMOUNT_LIMIT)
           volumeMounts:
             - name: eth-account-keyfile
               mountPath: /mnt/keep-maintainer/keyfile


### PR DESCRIPTION
The wallet maintainer bot contains a safety net which forces it to not include requests exceeding 10 BTC in the automatically submitted redemption proposals. Such requests are processed manually after confirming they are not part of a broader malicious action. The redemption mechanism proved to perform well since its release so, we can increase the limit to 15 BTC and reduce the need of manual intervention.