### PR TITLE
Logs for electrum connection

### DIFF
--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -21,10 +21,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/internal/byteutils"
 )
 
-// TODO: Some problems with Electrum re-connect were detected while developing
-//       integration tests: https://github.com/keep-network/keep-core/issues/3586.
-//       Make sure the problem is resolved soon.
-
 var (
 	supportedProtocolVersions = []string{"1.4"}
 	logger                    = log.Logger("keep-electrum")

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -82,6 +82,9 @@ func (c *Connection) GetTransaction(
 ) (*bitcoin.Transaction, error) {
 	txID := transactionHash.Hex(bitcoin.ReversedByteOrder)
 
+	logger.Infof("starting [%s] call to Electrum server", "GetRawTransaction")
+
+	startTime := time.Now()
 	rawTransaction, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
@@ -90,13 +93,20 @@ func (c *Connection) GetTransaction(
 			// See: https://github.com/Blockstream/electrs/pull/36
 			return client.GetRawTransaction(ctx, txID)
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to get raw transaction with ID [%s]: [%w]",
+			"failed to get raw transaction with ID [%s] after [%s]: [%w]",
 			txID,
+			elapsed,
 			err,
 		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetRawTransaction",
+		elapsed,
+	)
 
 	result, err := convertRawTransaction(rawTransaction)
 	if err != nil {
@@ -118,6 +128,9 @@ func (c *Connection) GetTransactionConfirmations(
 		zap.String("txID", txID),
 	)
 
+	logger.Infof("starting [%s] call to Electrum server", "GetRawTransaction")
+
+	startTime := time.Now()
 	rawTransaction, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
@@ -126,14 +139,21 @@ func (c *Connection) GetTransactionConfirmations(
 			// See: https://github.com/Blockstream/electrs/pull/36
 			return client.GetRawTransaction(ctx, txID)
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
 		return 0,
 			fmt.Errorf(
-				"failed to get raw transaction with ID [%s]: [%w]",
+				"failed to get raw transaction with ID [%s] after [%s]: [%w]",
 				txID,
+				elapsed,
 				err,
 			)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetRawTransaction",
+		elapsed,
+	)
 
 	tx, err := decodeTransaction(rawTransaction)
 	if err != nil {
@@ -167,6 +187,9 @@ txOutLoop:
 		reversedScriptHash := byteutils.Reverse(scriptHash[:])
 		reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
+		logger.Infof("starting [%s] call to Electrum server", "GetHistory")
+
+		startTime := time.Now()
 		scriptHashHistory, err := requestWithRetry(
 			c,
 			func(
@@ -175,11 +198,20 @@ txOutLoop:
 			) ([]*electrum.GetMempoolResult, error) {
 				return client.GetHistory(ctx, reversedScriptHashString)
 			})
+		elapsed := time.Since(startTime)
 		if err != nil {
 			// Don't return an error, but continue to the next TxOut entry.
-			txLogger.Errorf("failed to get history for script hash: [%v]", err)
+			txLogger.Errorf("failed to get history for script hash after [%s]: [%v]",
+				elapsed,
+				err,
+			)
 			continue txOutLoop
 		}
+
+		logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+			"GetHistory",
+			elapsed,
+		)
 
 		for _, transaction := range scriptHashHistory {
 			if transaction.Hash == txID {
@@ -233,16 +265,27 @@ func (c *Connection) BroadcastTransaction(
 	)
 	rawTxLogger.Debugf("broadcasting transaction")
 
+	logger.Infof("starting [%s] call to Electrum server", "BroadcastTransaction")
+
 	var response string
 
+	startTime := time.Now()
 	response, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
 			return client.BroadcastTransaction(ctx, rawTx)
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
-		return fmt.Errorf("failed to broadcast the transaction: [%w]", err)
+		return fmt.Errorf("failed to broadcast the transaction after [%s]: [%w]",
+			elapsed,
+			err,
+		)
 	}
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"BroadcastTransaction",
+		elapsed,
+	)
 
 	rawTxLogger.Infof("transaction broadcast successful: [%s]", response)
 
@@ -252,6 +295,9 @@ func (c *Connection) BroadcastTransaction(
 // GetLatestBlockHeight gets the height of the latest block (tip). If the
 // latest block was not determined, this function returns an error.
 func (c *Connection) GetLatestBlockHeight() (uint, error) {
+	logger.Infof("starting [%s] call to Electrum server", "SubscribeHeaders")
+
+	startTime := time.Now()
 	blockHeight, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (int32, error) {
@@ -262,9 +308,18 @@ func (c *Connection) GetLatestBlockHeight() (uint, error) {
 			tip := <-headersChan
 			return tip.Height, nil
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
-		return 0, fmt.Errorf("failed to subscribe for headers: [%w]", err)
+		return 0, fmt.Errorf("failed to subscribe for headers after [%s]: [%w]",
+			elapsed,
+			err,
+		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"SubscribeHeaders",
+		elapsed,
+	)
 
 	if blockHeight > 0 {
 		return uint(blockHeight), nil
@@ -279,6 +334,10 @@ func (c *Connection) GetLatestBlockHeight() (uint, error) {
 func (c *Connection) GetBlockHeader(
 	blockHeight uint,
 ) (*bitcoin.BlockHeader, error) {
+
+	logger.Infof("starting [%s] call to Electrum server", "GetBlockHeader")
+
+	startTime := time.Now()
 	getBlockHeaderResult, err := requestWithRetry(
 		c,
 		func(
@@ -288,9 +347,18 @@ func (c *Connection) GetBlockHeader(
 			return client.GetBlockHeader(ctx, uint32(blockHeight), 0)
 		},
 	)
+	elapsed := time.Since(startTime)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get block header: [%w]", err)
+		return nil, fmt.Errorf("failed to get block header after [%s]: [%w]",
+			elapsed,
+			err,
+		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetBlockHeader",
+		elapsed,
+	)
 
 	blockHeader, err := convertBlockHeader(getBlockHeaderResult)
 	if err != nil {
@@ -309,6 +377,9 @@ func (c *Connection) GetTransactionMerkleProof(
 ) (*bitcoin.TransactionMerkleProof, error) {
 	txID := transactionHash.Hex(bitcoin.ReversedByteOrder)
 
+	logger.Infof("starting [%s] call to Electrum server", "GetMerkleProof")
+
+	startTime := time.Now()
 	getMerkleProofResult, err := requestWithRetry(
 		c,
 		func(
@@ -322,9 +393,18 @@ func (c *Connection) GetTransactionMerkleProof(
 			)
 		},
 	)
+	elapsed := time.Since(startTime)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get merkle proof: [%w]", err)
+		return nil, fmt.Errorf("failed to get merkle proof after [%s]: [%w]",
+			"GetMerkleProof",
+			err,
+		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetMerkleProof",
+		elapsed,
+	)
 
 	return convertMerkleProof(getMerkleProofResult), nil
 }
@@ -423,6 +503,9 @@ func (c *Connection) getConfirmedScriptHistory(
 	reversedScriptHash := byteutils.Reverse(scriptHash[:])
 	reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
+	logger.Infof("starting [%s] call to Electrum server", "GetHistory")
+
+	startTime := time.Now()
 	items, err := requestWithRetry(
 		c,
 		func(
@@ -431,13 +514,20 @@ func (c *Connection) getConfirmedScriptHistory(
 		) ([]*electrum.GetMempoolResult, error) {
 			return client.GetHistory(ctx, reversedScriptHashString)
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to get history for script [0x%x]: [%v]",
+			"failed to get history for script [0x%x] after [%s]: [%v]",
 			script,
+			elapsed,
 			err,
 		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetHistory",
+		elapsed,
+	)
 
 	// According to https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history
 	// unconfirmed items living in the mempool are appended at the end of the
@@ -554,6 +644,9 @@ func (c *Connection) getScriptMempool(
 	reversedScriptHash := byteutils.Reverse(scriptHash[:])
 	reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
+	logger.Infof("starting [%s] call to Electrum server", "GetMempool")
+
+	startTime := time.Now()
 	items, err := requestWithRetry(
 		c,
 		func(
@@ -562,6 +655,7 @@ func (c *Connection) getScriptMempool(
 		) ([]*electrum.GetMempoolResult, error) {
 			return client.GetMempool(ctx, reversedScriptHashString)
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get mempool for script [0x%x]: [%v]",
@@ -569,6 +663,11 @@ func (c *Connection) getScriptMempool(
 			err,
 		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetMempool",
+		elapsed,
+	)
 
 	convertedItems := make([]*scriptMempoolItem, len(items))
 	for i, item := range items {
@@ -597,6 +696,9 @@ func (c *Connection) getScriptMempool(
 // EstimateSatPerVByteFee returns the estimated sat/vbyte fee for a
 // transaction to be confirmed within the given number of blocks.
 func (c *Connection) EstimateSatPerVByteFee(blocks uint32) (int64, error) {
+	logger.Infof("starting [%s] call to Electrum server", "GetFee")
+
+	startTime := time.Now()
 	// According to Electrum protocol docs, the returned fee is BTC/KB.
 	btcPerKbFee, err := requestWithRetry(
 		c,
@@ -611,9 +713,18 @@ func (c *Connection) EstimateSatPerVByteFee(blocks uint32) (int64, error) {
 			//       somehow once it disappears from Electrum implementations.
 			return client.GetFee(ctx, blocks)
 		})
+	elapsed := time.Since(startTime)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get fee: [%v]", err)
+		return 0, fmt.Errorf("failed to get fee after [%s]: [%v]",
+			elapsed,
+			err,
+		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"GetFee",
+		elapsed,
+	)
 
 	// According to Electrum protocol docs, if the daemon does not have
 	// enough information to make an estimate, the integer -1 is returned.
@@ -659,7 +770,9 @@ func (c *Connection) verifyServer() error {
 		version  string
 		protocol string
 	}
+	logger.Infof("starting [%s] call to Electrum server", "ServerVersion")
 
+	startTime := time.Now()
 	server, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (*Server, error) {
@@ -670,9 +783,18 @@ func (c *Connection) verifyServer() error {
 			return &Server{serverVersion, protocolVersion}, nil
 		},
 	)
+	elapsed := time.Since(startTime)
 	if err != nil {
-		return fmt.Errorf("failed to get server version: [%w]", err)
+		return fmt.Errorf("failed to get server version after [%s]: [%w]",
+			elapsed,
+			err,
+		)
 	}
+
+	logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+		"ServerVersion",
+		elapsed,
+	)
 
 	logger.Infof(
 		"connected to electrum server [version: [%s], protocol: [%s]]",
@@ -699,21 +821,30 @@ func (c *Connection) keepAlive() {
 	for {
 		select {
 		case <-ticker.C:
+			logger.Infof("starting [%s] call to Electrum server", "Ping")
+
+			startTime := time.Now()
 			_, err := requestWithRetry(
 				c,
 				func(ctx context.Context, client *electrum.Client) (interface{}, error) {
 					return nil, client.Ping(ctx)
 				},
 			)
+			elapsed := time.Since(startTime)
 			if err != nil {
 				logger.Errorf(
-					"failed to ping the electrum server; "+
+					"failed to ping the electrum server after [%s]; "+
 						"please verify health of the electrum server: [%v]",
+					elapsed,
 					err,
 				)
 			} else {
 				// Adjust ticker starting at the time of the latest successful ping.
 				ticker = time.NewTicker(c.config.KeepAliveInterval)
+				logger.Infof("successfully completed [%s] call to Electrum server after [%s]",
+					"Ping",
+					elapsed,
+				)
 			}
 		case <-c.parentCtx.Done():
 			ticker.Stop()

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -89,7 +89,9 @@ func (c *Connection) GetTransaction(
 			// as Esplora/Electrs doesn't support verbose transactions.
 			// See: https://github.com/Blockstream/electrs/pull/36
 			return client.GetRawTransaction(ctx, txID)
-		})
+		},
+		"GetRawTransaction",
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get raw transaction with ID [%s]: [%w]",
@@ -125,7 +127,9 @@ func (c *Connection) GetTransactionConfirmations(
 			// as Esplora/Electrs doesn't support verbose transactions.
 			// See: https://github.com/Blockstream/electrs/pull/36
 			return client.GetRawTransaction(ctx, txID)
-		})
+		},
+		"GetRawTransaction",
+	)
 	if err != nil {
 		return 0,
 			fmt.Errorf(
@@ -174,7 +178,9 @@ txOutLoop:
 				client *electrum.Client,
 			) ([]*electrum.GetMempoolResult, error) {
 				return client.GetHistory(ctx, reversedScriptHashString)
-			})
+			},
+			"GetHistory",
+		)
 		if err != nil {
 			// Don't return an error, but continue to the next TxOut entry.
 			txLogger.Errorf("failed to get history for script hash: [%v]", err)
@@ -239,7 +245,9 @@ func (c *Connection) BroadcastTransaction(
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
 			return client.BroadcastTransaction(ctx, rawTx)
-		})
+		},
+		"BroadcastTransaction",
+	)
 	if err != nil {
 		return fmt.Errorf("failed to broadcast the transaction: [%w]", err)
 	}
@@ -261,7 +269,9 @@ func (c *Connection) GetLatestBlockHeight() (uint, error) {
 			}
 			tip := <-headersChan
 			return tip.Height, nil
-		})
+		},
+		"SubscribeHeaders",
+	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to subscribe for headers: [%w]", err)
 	}
@@ -287,6 +297,7 @@ func (c *Connection) GetBlockHeader(
 		) (*electrum.GetBlockHeaderResult, error) {
 			return client.GetBlockHeader(ctx, uint32(blockHeight), 0)
 		},
+		"GetBlockHeader",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block header: [%w]", err)
@@ -321,6 +332,7 @@ func (c *Connection) GetTransactionMerkleProof(
 				uint32(blockHeight),
 			)
 		},
+		"GetMerkleProof",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get merkle proof: [%w]", err)
@@ -430,7 +442,9 @@ func (c *Connection) getConfirmedScriptHistory(
 			client *electrum.Client,
 		) ([]*electrum.GetMempoolResult, error) {
 			return client.GetHistory(ctx, reversedScriptHashString)
-		})
+		},
+		"GetHistory",
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get history for script [0x%x]: [%v]",
@@ -561,7 +575,9 @@ func (c *Connection) getScriptMempool(
 			client *electrum.Client,
 		) ([]*electrum.GetMempoolResult, error) {
 			return client.GetMempool(ctx, reversedScriptHashString)
-		})
+		},
+		"GetMempool",
+	)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get mempool for script [0x%x]: [%v]",
@@ -610,7 +626,9 @@ func (c *Connection) EstimateSatPerVByteFee(blocks uint32) (int64, error) {
 			//       since version 1.4.2 of the protocol. We need to replace it
 			//       somehow once it disappears from Electrum implementations.
 			return client.GetFee(ctx, blocks)
-		})
+		},
+		"GetFee",
+	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get fee: [%v]", err)
 	}
@@ -669,6 +687,7 @@ func (c *Connection) verifyServer() error {
 			}
 			return &Server{serverVersion, protocolVersion}, nil
 		},
+		"ServerVersion",
 	)
 	if err != nil {
 		return fmt.Errorf("failed to get server version: [%w]", err)
@@ -704,6 +723,7 @@ func (c *Connection) keepAlive() {
 				func(ctx context.Context, client *electrum.Client) (interface{}, error) {
 					return nil, client.Ping(ctx)
 				},
+				"Ping",
 			)
 			if err != nil {
 				logger.Errorf(
@@ -753,7 +773,11 @@ func connectWithRetry(
 func requestWithRetry[K interface{}](
 	c *Connection,
 	requestFn func(ctx context.Context, client *electrum.Client) (K, error),
+	requestName string,
 ) (K, error) {
+	startTime := time.Now()
+	logger.Infof("starting [%s] request to Electrum server", requestName)
+
 	var result K
 
 	err := wrappers.DoWithDefaultRetry(
@@ -778,6 +802,19 @@ func requestWithRetry[K interface{}](
 			result = r
 			return nil
 		})
+
+	solveRequestOutcome := func(err error) string {
+		if err != nil {
+			return fmt.Sprintf("error: [%v]", err)
+		}
+		return "success"
+	}
+
+	logger.Infof("[%s] request to Electrum server completed with [%s] after [%s]",
+		requestName,
+		solveRequestOutcome(err),
+		time.Since(startTime),
+	)
 
 	return result, err
 }


### PR DESCRIPTION
Refs the discussion https://github.com/keep-network/keep-core/pull/3701#discussion_r1324571809

Electrum client calls sometimes are prone to timeouts or other issues.
For debugging purposes we wrap electrum client calls with a logger and measure the time it takes to complete a call.