### PR TITLE
Use `keepnetwork/keep-client:v2.0.0-m5` for `keep-maintainer` on production

### DIFF
--- a/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
@@ -11,7 +11,7 @@ commonLabels:
 images:
   - name: keep-maintainer
     newName: keepnetwork/keep-client
-    newTag: v2.0.0-m4
+    newTag: v2.0.0-m5
 
 configMapGenerator:
   - name: keep-maintainer-config


### PR DESCRIPTION
Here we point the production instance of `keep-maintainer` to the latest public Docker image, i.e `keepnetwork/keep-client:v2.0.0-m5` which introduces some bug fixes and improvements.