### PR TITLE
Increased number of attempts for signing integration tests

### DIFF
--- a/pkg/tbtc/signing_test.go
+++ b/pkg/tbtc/signing_test.go
@@ -185,7 +185,7 @@ func setupSigningExecutor(t *testing.T) *signingExecutor {
 
 	// Test block counter is much quicker than the real world one.
 	// Set more attempts to give more time for computations.
-	executor.signingAttemptsLimit *= 5
+	executor.signingAttemptsLimit *= 8
 
 	return executor
 }


### PR DESCRIPTION
This PR increases the number of attempts for signing during integration tests.
The reason for this change are occasional test failures. 