### PR TITLE
Replace mentions of `GoerliLghtRelay` with `SepoliaLightRelay`

### DIFF
--- a/infrastructure/kube/keep-test/keep-maintainer-staging/README.md
+++ b/infrastructure/kube/keep-test/keep-maintainer-staging/README.md
@@ -1,12 +1,12 @@
 # Keep Maintainer Staging Mainnet
 
 Bitcoin Relay used by the tTBTC system on testnet environment is an optimized version
-of the Light Relay implemented by [GoerliLightRelay](https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/test/GoerliLightRelay.sol)
+of the Light Relay implemented by [SepoliaLightRelay](https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/test/SepoliaLightRelay.sol)
 contract. The reason the Light Relay had to be modified for testnet is that on
 Bitcoin testnet difficulty often drops to `1`, which makes the blocks validation
 on such change impossible to the regular Light Relay contract.
 
-The `GoerliLightRelay` version doesn't require a maintainer bot to submit block
+The `SepoliaLightRelay` version doesn't require a maintainer bot to submit block
 headers on difficulty change. It accepts ad-hoc difficulty alignment according to
 the tests needs.
 

--- a/infrastructure/kube/keep-test/keep-maintainer-staging/kustomization.yaml
+++ b/infrastructure/kube/keep-test/keep-maintainer-staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 namespace: default
 
 # Regular testnet maintainer doesn't run bitcoinDifficulty module due to specifics
-# of LightRelay running on testnet (GoerliLightRelay). This setup is running
+# of LightRelay running on testnet (SepoliaLightRelay). This setup is running
 # the `bitcoinDifficulty` module of maintainer connected to Bitcoin mainnet.
 nameSuffix: -staging
 

--- a/infrastructure/kube/keep-test/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-test/keep-maintainer/kustomization.yaml
@@ -32,7 +32,7 @@ secretGenerator:
 
 patches:
   # Testnet's maintainer shouldn't run `--bitcoinDifficulty` module, as the testnet
-  # uses modified version of LightRelay contract (GoerliLightRelay) that doesn't
+  # uses modified version of LightRelay contract (SepoliaLightRelay) that doesn't
   # require the bitcoin difficulty to be submitted. This patch defines manually
   # which modules should be started.
   - target:


### PR DESCRIPTION
As Goerli testnet becomes deprecated (with end of 2023) we're switching our testnet configuration to run on Sepolia testnet. As part of that work we've deployed a `SepoliaLightRelay` contract meant to relace `GoerliLightRelay`.