### PR TITLE
Update auto-generated contract docs destination

### DIFF
--- a/.github/workflows/contracts-ecdsa-docs.yml
+++ b/.github/workflows/contracts-ecdsa-docs.yml
@@ -78,7 +78,7 @@ jobs:
       addTOC: false
       verifyCommits: true
       destinationRepo: threshold-network/threshold
-      destinationFolder: ./docs/app-development/tbtc-v2/ecdsa-api
+      destinationFolder: ./docs/app-development/tbtc-v2/tbtc-contracts-api/ecdsa-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com
       userName: Valkyrie


### PR DESCRIPTION
As auto-generated contract API reference has been moved under https://docs.threshold.network/app-development/tbtc-v2/tbtc-contracts-api, we need to update the CI job that publishes those docs to take the new destination into account