### PR TITLE
Update `tbtc-v2-maintainer` image name for `keep-test`

### DIFF
--- a/infrastructure/kube/keep-test/tbtc-v2-maintainer/guardian-statefulset.yaml
+++ b/infrastructure/kube/keep-test/tbtc-v2-maintainer/guardian-statefulset.yaml
@@ -40,7 +40,7 @@ spec:
                 path: tbtc-v2-guardian-0-keyfile
       containers:
         - name: maintainer
-          image: us-docker.pkg.dev/keep-test-f3e0/public/tbtc-v2-maintainer:latest
+          image: us-docker.pkg.dev/keep-test-f3e0/public/tbtc-mg:latest
           imagePullPolicy: Always
           resources:
             requests:

--- a/infrastructure/kube/keep-test/tbtc-v2-maintainer/minter-statefulset.yaml
+++ b/infrastructure/kube/keep-test/tbtc-v2-maintainer/minter-statefulset.yaml
@@ -40,7 +40,7 @@ spec:
                 path: tbtc-v2-minter-0-keyfile
       containers:
         - name: maintainer
-          image: us-docker.pkg.dev/keep-test-f3e0/public/tbtc-v2-maintainer:latest
+          image: us-docker.pkg.dev/keep-test-f3e0/public/tbtc-mg:latest
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Here we update the image name to the one actually used on the `keep-test` cluster.