### PR TITLE
Remove support for Goerli testnet

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -252,14 +252,7 @@ jobs:
 
       - name: Deploy contracts
         env:
-          # Using fake ternary expression to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
-          # is empty, the expression will be evaluated to
-          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
-          CHAIN_API_URL: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_ETH_HOSTNAME_HTTP
-              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          CHAIN_API_URL: ${{ secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
@@ -347,14 +340,7 @@ jobs:
       
       - name: Deploy contracts
         env:
-          # Using fake ternary expression to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
-          # is empty, the expression will be evaluated to
-          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
-          CHAIN_API_URL: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_ETH_HOSTNAME_HTTP
-              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          CHAIN_API_URL: ${{ secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -248,14 +248,7 @@ jobs:
 
       - name: Deploy contracts
         env:
-          # Using fake ternary expression to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
-          # is empty, the expression will be evaluated to
-          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
-          CHAIN_API_URL: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_ETH_HOSTNAME_HTTP
-              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          CHAIN_API_URL: ${{ secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
@@ -341,14 +334,7 @@ jobs:
       
       - name: Deploy contracts
         env:
-          # Using fake ternary expression to decide which credentials to use,
-          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
-          # is empty, the expression will be evaluated to
-          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
-          CHAIN_API_URL: |
-            ${{ inputs.github.event.inputs.environment == 'goerli'
-              && secrets.GOERLI_ETH_HOSTNAME_HTTP
-              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          CHAIN_API_URL: ${{ secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
           ACCOUNTS_PRIVATE_KEYS: ${{ secrets.DAPP_DEV_TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}

--- a/solidity-v1/truffle-config.js
+++ b/solidity-v1/truffle-config.js
@@ -1,7 +1,7 @@
-require("babel-register")
-require("babel-polyfill")
-const HDWalletProvider = require("@truffle/hdwallet-provider")
-const Kit = require("@celo/contractkit")
+require("babel-register");
+require("babel-polyfill");
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+const Kit = require("@celo/contractkit");
 
 module.exports = {
   networks: {
@@ -15,7 +15,7 @@ module.exports = {
         return new HDWalletProvider({
           privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
           providerOrUrl: "http://localhost:8545",
-        })
+        });
       },
       gas: 6721975,
       network_id: 1101,
@@ -26,24 +26,10 @@ module.exports = {
         return new HDWalletProvider({
           privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
           providerOrUrl: "http://eth-tx-node.default.svc.cluster.local:8545",
-        })
+        });
       },
       gas: 6721975,
       network_id: 1101,
-    },
-
-    goerli: {
-      provider: function () {
-        return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
-          providerOrUrl: process.env.CHAIN_API_URL,
-        })
-      },
-      gas: 6000000,
-      network_id: 5,
-      skipDryRun: true,
-      networkCheckTimeout: 120000,
-      timeoutBlocks: 200, // # of blocks before a deployment times out  (minimum/default: 50)
     },
 
     sepolia: {
@@ -51,7 +37,7 @@ module.exports = {
         return new HDWalletProvider({
           privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
           providerOrUrl: process.env.CHAIN_API_URL,
-        })
+        });
       },
       gas: 6000000,
       network_id: 11155111,
@@ -62,9 +48,9 @@ module.exports = {
 
     alfajores: {
       provider: function () {
-        const kit = Kit.newKit(process.env.CHAIN_API_URL)
-        kit.addAccount(process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY)
-        return kit.web3.currentProvider
+        const kit = Kit.newKit(process.env.CHAIN_API_URL);
+        kit.addAccount(process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY);
+        return kit.web3.currentProvider;
       },
       network_id: 44787,
     },
@@ -95,4 +81,4 @@ module.exports = {
   api_keys: {
     etherscan: process.env.ETHERSCAN_API_KEY,
   },
-}
+};

--- a/solidity/ecdsa/deploy/09_deploy_wallet_registry_governance.ts
+++ b/solidity/ecdsa/deploy/09_deploy_wallet_registry_governance.ts
@@ -7,11 +7,8 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const WalletRegistry = await deployments.get("WalletRegistry")
 
-  // 60 seconds for Goerli/Sepolia. 1 week otherwise.
-  const GOVERNANCE_DELAY =
-    hre.network.name === "goerli" || hre.network.name === "sepolia"
-      ? 60
-      : 604800
+  // 60 seconds for Sepolia. 1 week otherwise.
+  const GOVERNANCE_DELAY = hre.network.name === "sepolia" ? 60 : 604800
 
   const WalletRegistryGovernance = await deployments.deploy(
     "WalletRegistryGovernance",

--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -113,14 +113,6 @@ const config: HardhatUserConfig = {
       chainId: 1101,
       tags: ["allowStubs", "useRandomBeaconChaosnet"],
     },
-    goerli: {
-      url: process.env.CHAIN_API_URL || "",
-      chainId: 5,
-      accounts: process.env.ACCOUNTS_PRIVATE_KEYS
-        ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["etherscan", "tenderly", "useRandomBeaconChaosnet"],
-    },
     sepolia: {
       url: process.env.CHAIN_API_URL || "",
       chainId: 11155111,
@@ -150,25 +142,21 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1, // take the second account
-      goerli: 0,
       sepolia: 0,
       mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
       default: 2,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     esdm: {
       default: 4,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
@@ -199,10 +187,6 @@ const config: HardhatUserConfig = {
       development: [
         "node_modules/@threshold-network/solidity-contracts/deployments/development",
         "node_modules/@keep-network/random-beacon/deployments/development",
-      ],
-      goerli: [
-        "node_modules/@threshold-network/solidity-contracts/artifacts",
-        "node_modules/@keep-network/random-beacon/artifacts",
       ],
       sepolia: [
         "node_modules/@threshold-network/solidity-contracts/artifacts",

--- a/solidity/random-beacon/hardhat.config.ts
+++ b/solidity/random-beacon/hardhat.config.ts
@@ -101,14 +101,6 @@ const config: HardhatUserConfig = {
       chainId: 1101,
       tags: ["allowStubs"],
     },
-    goerli: {
-      url: process.env.CHAIN_API_URL || "",
-      chainId: 5,
-      accounts: process.env.ACCOUNTS_PRIVATE_KEYS
-        ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["etherscan", "tenderly"],
-    },
     sepolia: {
       url: process.env.CHAIN_API_URL || "",
       chainId: 11155111,
@@ -138,19 +130,16 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1,
-      goerli: 0,
       sepolia: 0,
       mainnet: 0, // "0x123694886DBf5Ac94DDA07135349534536D14cAf"
     },
     governance: {
       default: 2,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
@@ -176,7 +165,6 @@ const config: HardhatUserConfig = {
       development: [
         "node_modules/@threshold-network/solidity-contracts/deployments/development",
       ],
-      goerli: ["node_modules/@threshold-network/solidity-contracts/artifacts"],
       sepolia: ["node_modules/@threshold-network/solidity-contracts/artifacts"],
       mainnet: ["./external/mainnet"],
     },


### PR DESCRIPTION
As the Goerli testnet will become deprecated with end of year 2023 and we've already migrated to Sepolia testnet, we'll no longer need the Goerli-related code past that date.

Ref: https://github.com/threshold-network/solidity-contracts/issues/150