### PR TITLE
RFC 12 Implementation: Do not handle no-op proposals

### DIFF
--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -365,15 +365,15 @@ func (ce *coordinationExecutor) coordinate(
 		return nil, fmt.Errorf("failed to compute coordination seed: [%v]", err)
 	}
 
-	execLogger.Info("coordination seed is: [0x%x]", seed)
+	execLogger.Infof("coordination seed is: [0x%x]", seed)
 
 	leader := ce.getLeader(seed)
 
-	execLogger.Info("coordination leader is: [%s]", leader)
+	execLogger.Infof("coordination leader is: [%s]", leader)
 
 	actionsChecklist := ce.getActionsChecklist(window.index(), seed)
 
-	execLogger.Info("actions checklist is: [%v]", actionsChecklist)
+	execLogger.Infof("actions checklist is: [%v]", actionsChecklist)
 
 	// Set up a context that is automatically cancelled when the active phase
 	// of the coordination window ends.
@@ -414,7 +414,7 @@ func (ce *coordinationExecutor) coordinate(
 			)
 		}
 
-		execLogger.Info("broadcasted proposal: [%s]", proposal.ActionType())
+		execLogger.Infof("broadcasted proposal: [%s]", proposal.ActionType())
 	} else {
 		execLogger.Info("executing follower's routine")
 
@@ -434,7 +434,7 @@ func (ce *coordinationExecutor) coordinate(
 			)
 		}
 
-		execLogger.Info(
+		execLogger.Infof(
 			"received proposal: [%s]; observed faults: [%v]",
 			proposal.ActionType(),
 			faults,
@@ -454,7 +454,7 @@ func (ce *coordinationExecutor) coordinate(
 		faults:   faults,
 	}
 
-	execLogger.Info("coordination completed with result: [%s]", result)
+	execLogger.Infof("coordination completed with result: [%s]", result)
 
 	return result, nil
 }

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -755,10 +755,18 @@ func processCoordinationResult(node *node, result *coordinationResult) {
 	// TODO: In the future, create coordination faults cache and
 	//       record faults from the processed results there.
 
+	proposedAction := result.proposal.ActionType()
+
+	if proposedAction == ActionNoop {
+		// No-op proposal cannot be processed so return early to avoid
+		// panicking on the ValidityBlocks call.
+		return
+	}
+
 	startBlock := result.window.endBlock()
 	expiryBlock := startBlock + result.proposal.ValidityBlocks()
 
-	switch result.proposal.ActionType() {
+	switch proposedAction {
 	case ActionHeartbeat:
 		if proposal, ok := result.proposal.(*HeartbeatProposal); ok {
 			node.handleHeartbeatProposal(


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/737

Here we add the missing case that stops coordination result processing in case a no-op proposal is issued. The no-op proposals cannot be processed as they lead to panic. By the way, we are fixing some problems with log displaying discovered during testing.