### PR TITLE
Switch Electrum request logs to debug level

### DIFF
--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -1036,7 +1036,7 @@ func requestWithRetry[K interface{}](
 	requestName string,
 ) (K, error) {
 	startTime := time.Now()
-	logger.Infof("starting [%s] request to Electrum server", requestName)
+	logger.Debugf("starting [%s] request to Electrum server", requestName)
 
 	var result K
 
@@ -1070,7 +1070,7 @@ func requestWithRetry[K interface{}](
 		return "success"
 	}
 
-	logger.Infof("[%s] request to Electrum server completed with [%s] after [%s]",
+	logger.Debugf("[%s] request to Electrum server completed with [%s] after [%s]",
 		requestName,
 		solveRequestOutcome(err),
 		time.Since(startTime),


### PR DESCRIPTION
Some time ago, we did some major changes in the Electrum client implementation. Because of that, we added some `INFO` logging around Electrum requests in order to facilitate potential debugging. As Electrum-changes are now battle-tested, we can switch those request logs to `DEBUG` level to decrease the amount of logs produced on `INFO` level.