### PR TITLE
Update the `WalletRegistry` deployment artifact for mainnet

### DIFF
--- a/solidity/ecdsa/.openzeppelin/mainnet.json
+++ b/solidity/ecdsa/.openzeppelin/mainnet.json
@@ -480,6 +480,475 @@
           }
         }
       }
+    },
+    "441ecc118d56b371f5d6b87b26da6d1b8263d448ac7854ac6d9e08db3325236e": {
+      "address": "0x08D7e8ce124921CAaFd7670502379Ced0065c832",
+      "txHash": "0xfa6c2128843843db8dd0ecc6fa823ae54c3ca37e1bdf7111c867b39418ae9c65",
+      "layout": {
+        "storage": [
+          {
+            "label": "governance",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "Governable",
+            "src": "@keep-network/random-beacon/contracts/Governable.sol:56"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "Governable",
+            "src": "@keep-network/random-beacon/contracts/Governable.sol:59"
+          },
+          {
+            "label": "reimbursementPool",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(ReimbursementPool)405",
+            "contract": "Reimbursable",
+            "src": "@keep-network/random-beacon/contracts/Reimbursable.sol:51"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "Reimbursable",
+            "src": "@keep-network/random-beacon/contracts/Reimbursable.sol:51"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "100",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "100",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "authorization",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_struct(Data)17205_storage",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:69"
+          },
+          {
+            "label": "dkg",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_struct(Data)18158_storage",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:69"
+          },
+          {
+            "label": "wallets",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_struct(Data)19462_storage",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:71"
+          },
+          {
+            "label": "_maliciousDkgResultSlashingAmount",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_uint96",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:78"
+          },
+          {
+            "label": "_maliciousDkgResultNotificationRewardMultiplier",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:88"
+          },
+          {
+            "label": "_sortitionPoolRewardsBanDuration",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:93"
+          },
+          {
+            "label": "_dkgResultSubmissionGas",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:101"
+          },
+          {
+            "label": "_dkgResultApprovalGasOffset",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:106"
+          },
+          {
+            "label": "_notifyOperatorInactivityGasOffset",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:111"
+          },
+          {
+            "label": "_notifySeedTimeoutGasOffset",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:118"
+          },
+          {
+            "label": "_notifyDkgTimeoutNegativeGasOffset",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_uint256",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:135"
+          },
+          {
+            "label": "inactivityClaimNonce",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:149"
+          },
+          {
+            "label": "walletOwner",
+            "offset": 0,
+            "slot": "261",
+            "type": "t_contract(IWalletOwner)17102",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:158"
+          },
+          {
+            "label": "randomBeacon",
+            "offset": 0,
+            "slot": "262",
+            "type": "t_contract(IRandomBeacon)417",
+            "contract": "WalletRegistry",
+            "src": "contracts/WalletRegistry.sol:169"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)38_storage": {
+            "label": "uint256[38]",
+            "numberOfBytes": "1216"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(EcdsaDkgValidator)13288": {
+            "label": "contract EcdsaDkgValidator",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IRandomBeacon)417": {
+            "label": "contract IRandomBeacon",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWalletOwner)17102": {
+            "label": "contract IWalletOwner",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ReimbursementPool)405": {
+            "label": "contract ReimbursementPool",
+            "numberOfBytes": "20"
+          },
+          "t_contract(SortitionPool)2722": {
+            "label": "contract SortitionPool",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(AuthorizationDecrease)17184_storage)": {
+            "label": "mapping(address => struct EcdsaAuthorization.AuthorizationDecrease)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Wallet)19452_storage)": {
+            "label": "mapping(bytes32 => struct Wallets.Wallet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AuthorizationDecrease)17184_storage": {
+            "label": "struct EcdsaAuthorization.AuthorizationDecrease",
+            "members": [
+              {
+                "label": "decreasingBy",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "decreasingAt",
+                "type": "t_uint64",
+                "offset": 12,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Data)17205_storage": {
+            "label": "struct EcdsaAuthorization.Data",
+            "members": [
+              {
+                "label": "parameters",
+                "type": "t_struct(Parameters)17179_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "stakingProviderToOperator",
+                "type": "t_mapping(t_address,t_address)",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "operatorToStakingProvider",
+                "type": "t_mapping(t_address,t_address)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "pendingDecreases",
+                "type": "t_mapping(t_address,t_struct(AuthorizationDecrease)17184_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "__gap",
+                "type": "t_array(t_uint256)46_storage",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "1600"
+          },
+          "t_struct(Data)18158_storage": {
+            "label": "struct EcdsaDkg.Data",
+            "members": [
+              {
+                "label": "sortitionPool",
+                "type": "t_contract(SortitionPool)2722",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "dkgValidator",
+                "type": "t_contract(EcdsaDkgValidator)13288",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "parameters",
+                "type": "t_struct(Parameters)18132_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "stateLockBlock",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "startBlock",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "seed",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "resultSubmissionStartBlockOffset",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "submittedResultHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "11"
+              },
+              {
+                "label": "submittedResultBlock",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "12"
+              },
+              {
+                "label": "__gap",
+                "type": "t_array(t_uint256)38_storage",
+                "offset": 0,
+                "slot": "13"
+              }
+            ],
+            "numberOfBytes": "1632"
+          },
+          "t_struct(Data)19462_storage": {
+            "label": "struct Wallets.Data",
+            "members": [
+              {
+                "label": "registry",
+                "type": "t_mapping(t_bytes32,t_struct(Wallet)19452_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "__gap",
+                "type": "t_array(t_uint256)49_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "1600"
+          },
+          "t_struct(Parameters)17179_storage": {
+            "label": "struct EcdsaAuthorization.Parameters",
+            "members": [
+              {
+                "label": "minimumAuthorization",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "authorizationDecreaseDelay",
+                "type": "t_uint64",
+                "offset": 12,
+                "slot": "0"
+              },
+              {
+                "label": "authorizationDecreaseChangePeriod",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Parameters)18132_storage": {
+            "label": "struct EcdsaDkg.Parameters",
+            "members": [
+              {
+                "label": "seedTimeout",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "resultChallengePeriodLength",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "resultChallengeExtraGas",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "resultSubmissionTimeout",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "submitterPrecedencePeriodLength",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(Wallet)19452_storage": {
+            "label": "struct Wallets.Wallet",
+            "members": [
+              {
+                "label": "membersIdsHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "publicKeyX",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "publicKeyY",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
     }
   }
 }

--- a/solidity/ecdsa/deployments/mainnet/WalletRegistry.json
+++ b/solidity/ecdsa/deployments/mainnet/WalletRegistry.json
@@ -1953,10 +1953,10 @@
     "0xc2731fb2823af3Efc2694c9bC86F444d5c5bb4Dc",
     "0x01B67b1194C75264d06F808A921228a95C765dd7"
   ],
-  "numDeployments": 1,
+  "numDeployments": 2,
   "libraries": {
     "EcdsaInactivity": "0x8263eFCb8F28246697585c89Fed0501Cd946F764"
   },
-  "implementation": "0xFbaE130e06Bbc8CA198861BEeCae6e2B830398fb",
+  "implementation": "0x08D7e8ce124921CAaFd7670502379Ced0065c832",
   "devdoc": "Contract deployed as upgradable proxy"
 }


### PR DESCRIPTION
The `WalletRegistry` proxy has been upgraded to the new implementation in order to include changes from https://github.com/keep-network/keep-core/pull/3756. Here we are pushing relevant artifact updates.