### PR TITLE
RFC 12 Implementation: Reduce heartbeat probability to 6.25%

### DIFF
--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -47,7 +47,7 @@ const (
 	// coordinationHeartbeatProbability is the probability of proposing a
 	// heartbeat action during the coordination procedure, assuming no other
 	// higher-priority action is proposed.
-	coordinationHeartbeatProbability = float64(0.125)
+	coordinationHeartbeatProbability = float64(0.0625)
 	// coordinationMessageReceiveBuffer is a buffer for messages received from
 	// the broadcast channel needed when the coordination follower is
 	// temporarily too slow to handle them. Keep in mind that although we

--- a/pkg/tbtc/coordination_test.go
+++ b/pkg/tbtc/coordination_test.go
@@ -568,7 +568,10 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 3600": {
 			coordinationBlock: 3600,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionHeartbeat,
+			},
 		},
 		"block 4500": {
 			coordinationBlock: 4500,
@@ -579,7 +582,6 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			coordinationBlock: 5400,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
-				ActionHeartbeat,
 			},
 		},
 		"block 6300": {
@@ -615,7 +617,6 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			coordinationBlock: 12600,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
-				ActionHeartbeat,
 			},
 		},
 		"block 13500": {
@@ -643,7 +644,7 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 
 				// Build an arbitrary seed based on the coordination block number.
 				seed := sha256.Sum256(
-					big.NewInt(int64(window.coordinationBlock) + 1).Bytes(),
+					big.NewInt(int64(window.coordinationBlock) + 2).Bytes(),
 				)
 
 				checklist := executor.getActionsChecklist(window.index(), seed)


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/737

The currently used probability of 12.5% means that a completely idle wallet will perform a heartbeat every 4 coordination windows on average (or 8 in the worst case) so, every 3600 blocks (~12 hours assuming a coordination every 900 blocks and 12 seconds per Ethereum block).

User acceptance tests executed on our Sepolia testnet (10 live wallets) show that such a value often leads to simultaneous heartbeats for several wallets at the same time. This, in turn, can cause increased resource consumption for individual nodes and harm some signing processes. Although nothing bad happens if those are just heartbeats, this may be problematic for redemptions and deposit sweeps. To lower the risk of signing failures, we are lowering the heartbeat probability to 6.25%.

The probability of 6.25% means that a completely idle wallet will perform a heartbeat every 8 coordination windows on average (or 16 in the worst case) so, every 7200 blocks (~24 hours assuming a coordination every 900 blocks and 12 seconds per Ethereum block).