### PR TITLE
Compilation error fix due to duplicated generated types

### DIFF
--- a/pkg/chain/ethereum/tbtc/gen/Makefile
+++ b/pkg/chain/ethereum/tbtc/gen/Makefile
@@ -25,6 +25,7 @@ define after_abi_hook
 endef
 define fix_wallet_proposal_validator_collision
 	@perl -pi -e s,BitcoinTxInfo,BitcoinTxInfo2,g ./abi/WalletProposalValidator.go
+	@perl -pi -e s,BitcoinTxUTXO,BitcoinTxUTXO3,g ./abi/WalletProposalValidator.go
 endef
 define fix_maintainer_proxy_collision
 	@perl -pi -e s,BitcoinTxUTXO,BitcoinTxUTXO2,g ./abi/MaintainerProxy.go
@@ -35,7 +36,12 @@ endef
 # See explanation in https://github.com/keep-network/keep-common/issues/117.
 define after_contract_hook
 	$(eval type := $(1))
+	$(if $(filter $(type),WalletProposalValidator),$(call fix_wallet_proposal_validator_contract_collision))
 	$(if $(filter $(type),MaintainerProxy),$(call fix_maintainer_proxy_contract_collision))
+endef
+define fix_wallet_proposal_validator_contract_collision
+	@perl -pi -e s,BitcoinTxUTXO,BitcoinTxUTXO3,g ./contract/WalletProposalValidator.go
+	@perl -pi -e s,BitcoinTxUTXO,BitcoinTxUTXO3,g ./cmd/WalletProposalValidator.go
 endef
 define fix_maintainer_proxy_contract_collision
 	@perl -pi -e s,BitcoinTxUTXO,BitcoinTxUTXO2,g ./contract/MaintainerProxy.go

--- a/pkg/chain/ethereum/tbtc/gen/abi/WalletProposalValidator.go
+++ b/pkg/chain/ethereum/tbtc/gen/abi/WalletProposalValidator.go
@@ -36,6 +36,13 @@ type BitcoinTxInfo2 struct {
 	Locktime     [4]byte
 }
 
+// BitcoinTxUTXO3 is an auto generated low-level Go binding around an user-defined struct.
+type BitcoinTxUTXO3 struct {
+	TxHash        [32]byte
+	TxOutputIndex uint32
+	TxOutputValue uint64
+}
+
 // WalletProposalValidatorDepositExtraInfo is an auto generated low-level Go binding around an user-defined struct.
 type WalletProposalValidatorDepositExtraInfo struct {
 	FundingTx        BitcoinTxInfo2
@@ -65,6 +72,13 @@ type WalletProposalValidatorHeartbeatProposal struct {
 	Message          []byte
 }
 
+// WalletProposalValidatorMovingFundsProposal is an auto generated low-level Go binding around an user-defined struct.
+type WalletProposalValidatorMovingFundsProposal struct {
+	WalletPubKeyHash [20]byte
+	TargetWallets    [][20]byte
+	MovingFundsTxFee *big.Int
+}
+
 // WalletProposalValidatorRedemptionProposal is an auto generated low-level Go binding around an user-defined struct.
 type WalletProposalValidatorRedemptionProposal struct {
 	WalletPubKeyHash       [20]byte
@@ -74,7 +88,7 @@ type WalletProposalValidatorRedemptionProposal struct {
 
 // WalletProposalValidatorMetaData contains all meta data concerning the WalletProposalValidator contract.
 var WalletProposalValidatorMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[{\"internalType\":\"contractBridge\",\"name\":\"_bridge\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"DEPOSIT_MIN_AGE\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEPOSIT_REFUND_SAFETY_MARGIN\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEPOSIT_SWEEP_MAX_SIZE\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REDEMPTION_MAX_SIZE\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REDEMPTION_REQUEST_MIN_AGE\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"bridge\",\"outputs\":[{\"internalType\":\"contractBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletProposalValidator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletProposalValidator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"bytes4\",\"name\":\"version\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"inputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"outputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes4\",\"name\":\"locktime\",\"type\":\"bytes4\"}],\"internalType\":\"structBitcoinTx.Info\",\"name\":\"fundingTx\",\"type\":\"tuple\"},{\"internalType\":\"bytes8\",\"name\":\"blindingFactor\",\"type\":\"bytes8\"},{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20\",\"name\":\"refundPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes4\",\"name\":\"refundLocktime\",\"type\":\"bytes4\"}],\"internalType\":\"structWalletProposalValidator.DepositExtraInfo[]\",\"name\":\"depositsExtraInfo\",\"type\":\"tuple[]\"}],\"name\":\"validateDepositSweepProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"internalType\":\"structWalletProposalValidator.HeartbeatProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"validateHeartbeatProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes[]\",\"name\":\"redeemersOutputScripts\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256\",\"name\":\"redemptionTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletProposalValidator.RedemptionProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"validateRedemptionProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[{\"internalType\":\"contractBridge\",\"name\":\"_bridge\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"DEPOSIT_MIN_AGE\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEPOSIT_REFUND_SAFETY_MARGIN\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"DEPOSIT_SWEEP_MAX_SIZE\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REDEMPTION_MAX_SIZE\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REDEMPTION_REQUEST_MIN_AGE\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"bridge\",\"outputs\":[{\"internalType\":\"contractBridge\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"fundingTxHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"fundingOutputIndex\",\"type\":\"uint32\"}],\"internalType\":\"structWalletProposalValidator.DepositKey[]\",\"name\":\"depositsKeys\",\"type\":\"tuple[]\"},{\"internalType\":\"uint256\",\"name\":\"sweepTxFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"depositsRevealBlocks\",\"type\":\"uint256[]\"}],\"internalType\":\"structWalletProposalValidator.DepositSweepProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"bytes4\",\"name\":\"version\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"inputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"outputVector\",\"type\":\"bytes\"},{\"internalType\":\"bytes4\",\"name\":\"locktime\",\"type\":\"bytes4\"}],\"internalType\":\"structBitcoinTx.Info\",\"name\":\"fundingTx\",\"type\":\"tuple\"},{\"internalType\":\"bytes8\",\"name\":\"blindingFactor\",\"type\":\"bytes8\"},{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20\",\"name\":\"refundPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes4\",\"name\":\"refundLocktime\",\"type\":\"bytes4\"}],\"internalType\":\"structWalletProposalValidator.DepositExtraInfo[]\",\"name\":\"depositsExtraInfo\",\"type\":\"tuple[]\"}],\"name\":\"validateDepositSweepProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"}],\"internalType\":\"structWalletProposalValidator.HeartbeatProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"validateHeartbeatProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes20[]\",\"name\":\"targetWallets\",\"type\":\"bytes20[]\"},{\"internalType\":\"uint256\",\"name\":\"movingFundsTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletProposalValidator.MovingFundsProposal\",\"name\":\"proposal\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"txHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"txOutputIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint64\",\"name\":\"txOutputValue\",\"type\":\"uint64\"}],\"internalType\":\"structBitcoinTx.UTXO\",\"name\":\"walletMainUtxo\",\"type\":\"tuple\"}],\"name\":\"validateMovingFundsProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes20\",\"name\":\"walletPubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"bytes[]\",\"name\":\"redeemersOutputScripts\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256\",\"name\":\"redemptionTxFee\",\"type\":\"uint256\"}],\"internalType\":\"structWalletProposalValidator.RedemptionProposal\",\"name\":\"proposal\",\"type\":\"tuple\"}],\"name\":\"validateRedemptionProposal\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // WalletProposalValidatorABI is the input ABI used to generate the binding from.
@@ -500,6 +514,37 @@ func (_WalletProposalValidator *WalletProposalValidatorSession) ValidateHeartbea
 // Solidity: function validateHeartbeatProposal((bytes20,bytes) proposal) view returns(bool)
 func (_WalletProposalValidator *WalletProposalValidatorCallerSession) ValidateHeartbeatProposal(proposal WalletProposalValidatorHeartbeatProposal) (bool, error) {
 	return _WalletProposalValidator.Contract.ValidateHeartbeatProposal(&_WalletProposalValidator.CallOpts, proposal)
+}
+
+// ValidateMovingFundsProposal is a free data retrieval call binding the contract method 0x9b337db2.
+//
+// Solidity: function validateMovingFundsProposal((bytes20,bytes20[],uint256) proposal, (bytes32,uint32,uint64) walletMainUtxo) view returns(bool)
+func (_WalletProposalValidator *WalletProposalValidatorCaller) ValidateMovingFundsProposal(opts *bind.CallOpts, proposal WalletProposalValidatorMovingFundsProposal, walletMainUtxo BitcoinTxUTXO3) (bool, error) {
+	var out []interface{}
+	err := _WalletProposalValidator.contract.Call(opts, &out, "validateMovingFundsProposal", proposal, walletMainUtxo)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateMovingFundsProposal is a free data retrieval call binding the contract method 0x9b337db2.
+//
+// Solidity: function validateMovingFundsProposal((bytes20,bytes20[],uint256) proposal, (bytes32,uint32,uint64) walletMainUtxo) view returns(bool)
+func (_WalletProposalValidator *WalletProposalValidatorSession) ValidateMovingFundsProposal(proposal WalletProposalValidatorMovingFundsProposal, walletMainUtxo BitcoinTxUTXO3) (bool, error) {
+	return _WalletProposalValidator.Contract.ValidateMovingFundsProposal(&_WalletProposalValidator.CallOpts, proposal, walletMainUtxo)
+}
+
+// ValidateMovingFundsProposal is a free data retrieval call binding the contract method 0x9b337db2.
+//
+// Solidity: function validateMovingFundsProposal((bytes20,bytes20[],uint256) proposal, (bytes32,uint32,uint64) walletMainUtxo) view returns(bool)
+func (_WalletProposalValidator *WalletProposalValidatorCallerSession) ValidateMovingFundsProposal(proposal WalletProposalValidatorMovingFundsProposal, walletMainUtxo BitcoinTxUTXO3) (bool, error) {
+	return _WalletProposalValidator.Contract.ValidateMovingFundsProposal(&_WalletProposalValidator.CallOpts, proposal, walletMainUtxo)
 }
 
 // ValidateRedemptionProposal is a free data retrieval call binding the contract method 0x0fde6c76.

--- a/pkg/chain/ethereum/tbtc/gen/cmd/WalletProposalValidator.go
+++ b/pkg/chain/ethereum/tbtc/gen/cmd/WalletProposalValidator.go
@@ -56,6 +56,7 @@ func init() {
 		wpvREDEMPTIONREQUESTMINAGECommand(),
 		wpvREDEMPTIONREQUESTTIMEOUTSAFETYMARGINCommand(),
 		wpvValidateHeartbeatProposalCommand(),
+		wpvValidateMovingFundsProposalCommand(),
 		wpvValidateRedemptionProposalCommand(),
 	)
 
@@ -330,6 +331,52 @@ func wpvValidateHeartbeatProposal(c *cobra.Command, args []string) error {
 
 	result, err := contract.ValidateHeartbeatProposalAtBlock(
 		arg_proposal_json,
+		cmd.BlockFlagValue.Int,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	cmd.PrintOutput(result)
+
+	return nil
+}
+
+func wpvValidateMovingFundsProposalCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "validate-moving-funds-proposal [arg_proposal_json] [arg_walletMainUtxo_json]",
+		Short:                 "Calls the view method validateMovingFundsProposal on the WalletProposalValidator contract.",
+		Args:                  cmd.ArgCountChecker(2),
+		RunE:                  wpvValidateMovingFundsProposal,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.InitConstFlags(c)
+
+	return c
+}
+
+func wpvValidateMovingFundsProposal(c *cobra.Command, args []string) error {
+	contract, err := initializeWalletProposalValidator(c)
+	if err != nil {
+		return err
+	}
+
+	arg_proposal_json := abi.WalletProposalValidatorMovingFundsProposal{}
+	if err := json.Unmarshal([]byte(args[0]), &arg_proposal_json); err != nil {
+		return fmt.Errorf("failed to unmarshal arg_proposal_json to abi.WalletProposalValidatorMovingFundsProposal: %w", err)
+	}
+
+	arg_walletMainUtxo_json := abi.BitcoinTxUTXO3{}
+	if err := json.Unmarshal([]byte(args[1]), &arg_walletMainUtxo_json); err != nil {
+		return fmt.Errorf("failed to unmarshal arg_walletMainUtxo_json to abi.BitcoinTxUTXO3: %w", err)
+	}
+
+	result, err := contract.ValidateMovingFundsProposalAtBlock(
+		arg_proposal_json,
+		arg_walletMainUtxo_json,
 		cmd.BlockFlagValue.Int,
 	)
 

--- a/pkg/chain/ethereum/tbtc/gen/contract/WalletProposalValidator.go
+++ b/pkg/chain/ethereum/tbtc/gen/contract/WalletProposalValidator.go
@@ -451,6 +451,54 @@ func (wpv *WalletProposalValidator) ValidateHeartbeatProposalAtBlock(
 	return result, err
 }
 
+func (wpv *WalletProposalValidator) ValidateMovingFundsProposal(
+	arg_proposal abi.WalletProposalValidatorMovingFundsProposal,
+	arg_walletMainUtxo abi.BitcoinTxUTXO3,
+) (bool, error) {
+	result, err := wpv.contract.ValidateMovingFundsProposal(
+		wpv.callerOptions,
+		arg_proposal,
+		arg_walletMainUtxo,
+	)
+
+	if err != nil {
+		return result, wpv.errorResolver.ResolveError(
+			err,
+			wpv.callerOptions.From,
+			nil,
+			"validateMovingFundsProposal",
+			arg_proposal,
+			arg_walletMainUtxo,
+		)
+	}
+
+	return result, err
+}
+
+func (wpv *WalletProposalValidator) ValidateMovingFundsProposalAtBlock(
+	arg_proposal abi.WalletProposalValidatorMovingFundsProposal,
+	arg_walletMainUtxo abi.BitcoinTxUTXO3,
+	blockNumber *big.Int,
+) (bool, error) {
+	var result bool
+
+	err := chainutil.CallAtBlock(
+		wpv.callerOptions.From,
+		blockNumber,
+		nil,
+		wpv.contractABI,
+		wpv.caller,
+		wpv.errorResolver,
+		wpv.contractAddress,
+		"validateMovingFundsProposal",
+		&result,
+		arg_proposal,
+		arg_walletMainUtxo,
+	)
+
+	return result, err
+}
+
 func (wpv *WalletProposalValidator) ValidateRedemptionProposal(
 	arg_proposal abi.WalletProposalValidatorRedemptionProposal,
 ) (bool, error) {


### PR DESCRIPTION
This PR fixes a compilation problem due to duplicated types that were generated by the `abigen`.
The problem is due to an error in the version of `abigen` that we use for contract code generation. 
See https://github.com/keep-network/keep-common/issues/117 for explanation.