### PR TITLE
Include extra data of deposits for sweep fee estimation

### DIFF
--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -14,7 +14,9 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
-const depositScriptByteSize = 92
+// Use the worst-case 126-byte deposit script with embedded extra data for estimation.
+// This will ensure that deposit sweep transaction fees are not underestimated.
+const depositScriptByteSize = 126
 
 // DepositSweepTask is a task that may produce a deposit sweep proposal.
 type DepositSweepTask struct {

--- a/pkg/tbtcpg/internal/test/testdata/propose_sweep_scenario_0.json
+++ b/pkg/tbtcpg/internal/test/testdata/propose_sweep_scenario_0.json
@@ -37,7 +37,7 @@
         "FundingOutputIndex": 3
       }
     ],
-    "SweepTxFee": 9984,
+    "SweepTxFee": 10634,
     "DepositsRevealBlocks": [11, 31, 32]
   }
 }


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/749

Bitcoin scripts of deposits embedding 32-byte extra data are longer (126 bytes) than the scripts of regular deposits not holding extra data (92 bytes). That means the actual virtual size of the resulting deposit sweep transaction is greater than the size assumed by the sweep fee estimator. Here we adjust the fee estimator to always take the longer script for calculations to avoid underestimation of the transaction fee. This approach is not ideal but is safe as it makes sure transactions are not rejected due to too low network fees.