### PR TITLE
Tweak logs around network

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,10 @@ const (
 
 	// LogLevelEnvVariable can be used to define logging configuration.
 	LogLevelEnvVariable = "LOG_LEVEL"
+
+	// PubsubLogLevelEnvVariable can be used to define logging configuration
+	// for the pubsub implementation.
+	PubsubLogLevelEnvVariable = "PUBSUB_LOG_LEVEL"
 )
 
 // Config is the top level config structure.

--- a/main.go
+++ b/main.go
@@ -18,14 +18,34 @@ import (
 var logger = log.Logger("keep-main")
 
 func main() {
-	err := logging.Configure(os.Getenv(config.LogLevelEnvVariable))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to configure logging: [%v]\n", err)
-	}
+	configureLogging()
 
 	rootCmd := cmd.Initialize(build.Version, build.Revision)
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.Fatal(err)
+	}
+}
+
+func configureLogging() {
+	logLevel := "info"
+	if env := os.Getenv(config.LogLevelEnvVariable); len(env) > 0 {
+		logLevel = env
+	}
+
+	pubsubLogLevel := "warn"
+	if env := os.Getenv(config.PubsubLogLevelEnvVariable); len(env) > 0 {
+		pubsubLogLevel = env
+	}
+
+	levelDirective := fmt.Sprintf(
+		"%s pubsub=%s",
+		logLevel,
+		pubsubLogLevel,
+	)
+
+	err := logging.Configure(levelDirective)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to configure logging: [%v]\n", err)
 	}
 }

--- a/pkg/protocol/announcer/announcer.go
+++ b/pkg/protocol/announcer/announcer.go
@@ -172,3 +172,35 @@ loop:
 
 	return readyMembersIndexes, nil
 }
+
+// UnreadyMembers returns a list of member indexes that turned out to be unready
+// during the announcement. The list is sorted in ascending order.
+func UnreadyMembers(
+	readyMembers []group.MemberIndex,
+	groupSize int,
+) []group.MemberIndex {
+	if len(readyMembers) == groupSize {
+		return []group.MemberIndex{}
+	}
+
+	readyMembersSet := make(map[group.MemberIndex]bool)
+	for _, memberIndex := range readyMembers {
+		readyMembersSet[memberIndex] = true
+	}
+
+	unreadyMembers := make([]group.MemberIndex, 0)
+
+	for i := 0; i < groupSize; i++ {
+		memberIndex := group.MemberIndex(i + 1)
+
+		if _, isReady := readyMembersSet[memberIndex]; !isReady {
+			unreadyMembers = append(unreadyMembers, memberIndex)
+		}
+	}
+
+	sort.Slice(unreadyMembers, func(i, j int) bool {
+		return unreadyMembers[i] < unreadyMembers[j]
+	})
+
+	return unreadyMembers
+}

--- a/pkg/protocol/announcer/announcer_test.go
+++ b/pkg/protocol/announcer/announcer_test.go
@@ -227,3 +227,46 @@ func TestAnnouncer(t *testing.T) {
 		})
 	}
 }
+
+func TestUnreadyMembers(t *testing.T) {
+	tests := map[string]struct {
+		readyMembers []group.MemberIndex
+		groupSize    int
+		expected     []group.MemberIndex
+	}{
+		"all members are ready": {
+			readyMembers: []group.MemberIndex{1, 2, 3, 4, 5},
+			groupSize:    5,
+			expected:     []group.MemberIndex{},
+		},
+		"some members are not ready": {
+			readyMembers: []group.MemberIndex{1, 3, 5},
+			groupSize:    5,
+			expected:     []group.MemberIndex{2, 4},
+		},
+		"no members are ready": {
+			readyMembers: []group.MemberIndex{},
+			groupSize:    5,
+			expected:     []group.MemberIndex{1, 2, 3, 4, 5},
+		},
+		"group size is zero": {
+			readyMembers: []group.MemberIndex{},
+			groupSize:    0,
+			expected:     []group.MemberIndex{},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := UnreadyMembers(test.readyMembers, test.groupSize)
+
+			if !reflect.DeepEqual(test.expected, result) {
+				t.Errorf(
+					"unexpected result\nexpected: %v\nactual:   %v",
+					test.expected,
+					result,
+				)
+			}
+		})
+	}
+}

--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/exp/maps"
 	"math/big"
 	"sort"
 
@@ -181,8 +182,13 @@ func (de *dkgExecutor) checkEligibility(
 	}
 
 	dkgLogger.Infof(
-		"selected group members for DKG = %s",
+		"selected group members (seats) for DKG: [%s]",
 		groupSelectionResult.OperatorsAddresses,
+	)
+
+	dkgLogger.Infof(
+		"distinct operators participating in DKG: [%s]",
+		maps.Keys(groupSelectionResult.OperatorsAddresses.Set()),
 	)
 
 	if len(groupSelectionResult.OperatorsAddresses) > de.groupParameters.GroupSize {

--- a/pkg/tbtc/dkg_loop.go
+++ b/pkg/tbtc/dkg_loop.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"github.com/keep-network/keep-core/pkg/protocol/announcer"
 	"math/big"
 
 	"github.com/ipfs/go-log/v2"
@@ -209,6 +210,11 @@ func (drl *dkgRetryLoop) start(
 			continue
 		}
 
+		unreadyMembersIndexes := announcer.UnreadyMembers(
+			readyMembersIndexes,
+			drl.groupParameters.GroupSize,
+		)
+
 		// Check the loop stop signal.
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -217,19 +223,23 @@ func (drl *dkgRetryLoop) start(
 		if len(readyMembersIndexes) >= drl.groupParameters.GroupQuorum {
 			drl.logger.Infof(
 				"[member:%v] completed announcement phase for attempt [%v] "+
-					"with quorum of [%v] members ready to perform DKG",
+					"with quorum of [%v] members ready to perform DKG; "+
+					"following members are not ready: [%v]",
 				drl.memberIndex,
 				drl.attemptCounter,
 				len(readyMembersIndexes),
+				unreadyMembersIndexes,
 			)
 		} else {
 			drl.logger.Warnf(
 				"[member:%v] completed announcement phase for attempt [%v] "+
 					"with non-quorum of [%v] members ready to perform DKG; "+
-					"starting next attempt",
+					"following members are not ready: [%v]; "+
+					"moving to the next attempt",
 				drl.memberIndex,
 				drl.attemptCounter,
 				len(readyMembersIndexes),
+				unreadyMembersIndexes,
 			)
 			continue
 		}


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-core/issues/3770

Here we are tweaking some logs, mostly related to the network layer. The goal here is to make debugging easier. We are trying to achieve that by adding additional logs that may help during that process and limiting the unuseful ones. I recommend reviewing commit by commit. A short summary of changes:

- Set libp2p pubsub logs to `warn` by default and make that customizable using the `PUBSUB_LOG_LEVEL` environment variable (https://github.com/keep-network/keep-core/commit/b725e1c1650c57336355630a8803ac163c435304)
- Log members that are not ready during DKG/signing network announcement (https://github.com/keep-network/keep-core/commit/551e57a778fdd264e29e259d03125f6fb51a27ce)
- Log distinct operators participating in DKG (https://github.com/keep-network/keep-core/commit/980c85e1597a6bd3c6e8d80ee6d2779db2b37c48)
- Execute a ping test for freshly connected peers (https://github.com/keep-network/keep-core/commit/b3d97ffc43a9082fee1877ef875541ad8b428255)