### PR TITLE
[Backport] Fix a memory leak in Electrum client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 	// here:
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.22.3
 	github.com/btcsuite/btcd/v2 => github.com/btcsuite/btcd v0.23.4
-	github.com/checksum0/go-electrum => github.com/keep-network/go-electrum v0.0.0-20230524074410-befe891c2f8c
+	github.com/checksum0/go-electrum => github.com/keep-network/go-electrum v0.0.0-20240206170935-6038cb594daa
 	// Temporary replacement until v1.28.2 is released containing `protodelim` package.
 	// See https://github.com/protocolbuffers/protobuf-go/commit/fb0abd915897428ccfdd6b03b48ad8219751ee54
 	google.golang.org/protobuf/dev => google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/go-electrum v0.0.0-20230524074410-befe891c2f8c h1:wBBb0rIOnYpOqH+QkwEQ/2LT6n7v+ELJlDePvoR7pQY=
-github.com/keep-network/go-electrum v0.0.0-20230524074410-befe891c2f8c/go.mod h1:eiMFzdvS+x8Voi0bmiZtVfJ3zMNRUnPNDnhCQR0tudo=
+github.com/keep-network/go-electrum v0.0.0-20240206170935-6038cb594daa h1:AKTJr+STc4rP9NcN2ppP9Zft3GbYechFW8q/S8UNQrQ=
+github.com/keep-network/go-electrum v0.0.0-20240206170935-6038cb594daa/go.mod h1:eiMFzdvS+x8Voi0bmiZtVfJ3zMNRUnPNDnhCQR0tudo=
 github.com/keep-network/keep-common v1.7.1-0.20230501122407-5cc3757ccf0d h1:6AiGKgOEmwO1Cri87bMfmxgF8ZgE5HIJOQUO7nZszh0=
 github.com/keep-network/keep-common v1.7.1-0.20230501122407-5cc3757ccf0d/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/kilic/bls12-381 v0.1.0/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -263,11 +263,11 @@ func (c *Connection) GetLatestBlockHeight() (uint, error) {
 	blockHeight, err := requestWithRetry(
 		c,
 		func(ctx context.Context, client *electrum.Client) (int32, error) {
-			headersChan, err := client.SubscribeHeaders(ctx)
+			tip, err := client.SubscribeHeadersSingle(ctx)
 			if err != nil {
 				return 0, fmt.Errorf("failed to get the blocks tip height: [%w]", err)
 			}
-			tip := <-headersChan
+
 			return tip.Height, nil
 		},
 		"SubscribeHeaders",


### PR DESCRIPTION
This pull request backports https://github.com/keep-network/keep-core/pull/3775 to the `releases/mainnet/v2.0.0-m7` branch.