### PR TITLE
Moving funds SPV proofs

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1687,6 +1687,60 @@ func (tc *TbtcChain) SubmitMovingFundsCommitment(
 	return err
 }
 
+func (tc *TbtcChain) SubmitMovingFundsProofWithReimbursement(
+	transaction *bitcoin.Transaction,
+	proof *bitcoin.SpvProof,
+	mainUTXO bitcoin.UnspentTransactionOutput,
+	walletPublicKeyHash [20]byte,
+) error {
+	bitcoinTxInfo := tbtcabi.BitcoinTxInfo3{
+		Version:      transaction.SerializeVersion(),
+		InputVector:  transaction.SerializeInputs(),
+		OutputVector: transaction.SerializeOutputs(),
+		Locktime:     transaction.SerializeLocktime(),
+	}
+	movingFundsProof := tbtcabi.BitcoinTxProof2{
+		MerkleProof:      proof.MerkleProof,
+		TxIndexInBlock:   big.NewInt(int64(proof.TxIndexInBlock)),
+		BitcoinHeaders:   proof.BitcoinHeaders,
+		CoinbasePreimage: proof.CoinbasePreimage,
+		CoinbaseProof:    proof.CoinbaseProof,
+	}
+	utxo := tbtcabi.BitcoinTxUTXO2{
+		TxHash:        mainUTXO.Outpoint.TransactionHash,
+		TxOutputIndex: mainUTXO.Outpoint.OutputIndex,
+		TxOutputValue: uint64(mainUTXO.Value),
+	}
+
+	gasEstimate, err := tc.maintainerProxy.SubmitMovingFundsProofGasEstimate(
+		bitcoinTxInfo,
+		movingFundsProof,
+		utxo,
+		walletPublicKeyHash,
+	)
+	if err != nil {
+		return err
+	}
+
+	// The original estimate for this contract call is too low and the call
+	// fails on reimbursing the submitter. Example:
+	// 0xe27a92883e0e64da8a3a54a15a260ea2f4d3d48470129ac5c09bfe9637d7e114
+	// Here we add a 20% margin to overcome the gas problems.
+	gasEstimateWithMargin := float64(gasEstimate) * float64(1.2)
+
+	_, err = tc.maintainerProxy.SubmitMovingFundsProof(
+		bitcoinTxInfo,
+		movingFundsProof,
+		utxo,
+		walletPublicKeyHash,
+		ethutil.TransactionOptions{
+			GasLimit: uint64(gasEstimateWithMargin),
+		},
+	)
+
+	return err
+}
+
 func (tc *TbtcChain) ValidateRedemptionProposal(
 	walletPublicKeyHash [20]byte,
 	proposal *tbtc.RedemptionProposal,

--- a/pkg/maintainer/spv/chain.go
+++ b/pkg/maintainer/spv/chain.go
@@ -81,4 +81,13 @@ type Chain interface {
 	PastRedemptionRequestedEvents(
 		filter *tbtc.RedemptionRequestedEventFilter,
 	) ([]*tbtc.RedemptionRequestedEvent, error)
+
+	// PastMovingFundsCommitmentSubmittedEvents fetches past moving funds
+	// commitment submitted events according to the provided filter or
+	// unfiltered if the filter is nil. Returned events are sorted by the block
+	// number in the ascending order, i.e. the latest event is at the end of the
+	// slice.
+	PastMovingFundsCommitmentSubmittedEvents(
+		filter *tbtc.MovingFundsCommitmentSubmittedEventFilter,
+	) ([]*tbtc.MovingFundsCommitmentSubmittedEvent, error)
 }

--- a/pkg/maintainer/spv/chain.go
+++ b/pkg/maintainer/spv/chain.go
@@ -66,6 +66,15 @@ type Chain interface {
 		walletPublicKeyHash [20]byte,
 	) error
 
+	// SubmitMovingFundsProofWithReimbursement submits the moving funds proof
+	// via MaintainerProxy. The caller is reimbursed.
+	SubmitMovingFundsProofWithReimbursement(
+		transaction *bitcoin.Transaction,
+		proof *bitcoin.SpvProof,
+		mainUTXO bitcoin.UnspentTransactionOutput,
+		walletPublicKeyHash [20]byte,
+	) error
+
 	// PastDepositRevealedEvents fetches past deposit reveal events according
 	// to the provided filter or unfiltered if the filter is nil. Returned
 	// events are sorted by the block number in the ascending order, i.e. the

--- a/pkg/maintainer/spv/chain_test.go
+++ b/pkg/maintainer/spv/chain_test.go
@@ -491,6 +491,12 @@ func buildPastRedemptionRequestedEventsKey(
 	return sha256.Sum256(buffer.Bytes()), nil
 }
 
+func (lc *localChain) PastMovingFundsCommitmentSubmittedEvents(
+	filter *tbtc.MovingFundsCommitmentSubmittedEventFilter,
+) ([]*tbtc.MovingFundsCommitmentSubmittedEvent, error) {
+	panic("unsupported")
+}
+
 type mockBlockCounter struct {
 	mutex        sync.Mutex
 	currentBlock uint64

--- a/pkg/maintainer/spv/chain_test.go
+++ b/pkg/maintainer/spv/chain_test.go
@@ -266,6 +266,15 @@ func (lc *localChain) getSubmittedRedemptionProofs() []*submittedRedemptionProof
 	return lc.submittedRedemptionProofs
 }
 
+func (lc *localChain) SubmitMovingFundsProofWithReimbursement(
+	transaction *bitcoin.Transaction,
+	proof *bitcoin.SpvProof,
+	mainUTXO bitcoin.UnspentTransactionOutput,
+	walletPublicKeyHash [20]byte,
+) error {
+	panic("unsupported")
+}
+
 func (lc *localChain) Ready() (bool, error) {
 	panic("unsupported")
 }

--- a/pkg/maintainer/spv/moving_funds.go
+++ b/pkg/maintainer/spv/moving_funds.go
@@ -1,0 +1,223 @@
+package spv
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+// SubmitMovingFundsProof prepares moving funds proof for the given
+// transaction and submits it to the on-chain contract. If the number of required
+// confirmations is `0`, an error is returned.
+func SubmitMovingFundsProof(
+	transactionHash bitcoin.Hash,
+	requiredConfirmations uint,
+	btcChain bitcoin.Chain,
+	spvChain Chain,
+) error {
+	return submitMovingFundsProof(
+		transactionHash,
+		requiredConfirmations,
+		btcChain,
+		spvChain,
+		bitcoin.AssembleSpvProof,
+	)
+}
+
+func submitMovingFundsProof(
+	transactionHash bitcoin.Hash,
+	requiredConfirmations uint,
+	btcChain bitcoin.Chain,
+	spvChain Chain,
+	spvProofAssembler spvProofAssembler,
+) error {
+	// TODO: Implement
+	return nil
+}
+
+func getUnprovenMovingFundsTransactions(
+	historyDepth uint64,
+	transactionLimit int,
+	btcChain bitcoin.Chain,
+	spvChain Chain,
+) (
+	[]*bitcoin.Transaction,
+	error,
+) {
+	blockCounter, err := spvChain.BlockCounter()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get block counter: [%v]", err)
+	}
+
+	currentBlock, err := blockCounter.CurrentBlock()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current block: [%v]", err)
+	}
+
+	// Calculate the starting block of the range in which the events will be
+	// searched for.
+	startBlock := currentBlock - historyDepth
+
+	events, err :=
+		spvChain.PastMovingFundsCommitmentSubmittedEvents(
+			&tbtc.MovingFundsCommitmentSubmittedEventFilter{
+				StartBlock: startBlock,
+			},
+		)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get past moving funds commitment submitted events: [%v]",
+			err,
+		)
+	}
+
+	unprovenMovingFundsTransactions := []*bitcoin.Transaction{}
+
+	for _, event := range events {
+		walletPublicKeyHash := event.WalletPublicKeyHash
+		targetWallets := event.TargetWallets
+
+		wallet, err := spvChain.GetWallet(walletPublicKeyHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get wallet: [%v]", err)
+		}
+
+		if wallet.State != tbtc.StateMovingFunds {
+			// The wallet can only submit moving funds proofs if it's in
+			//`MovingFunds` state. If the state is different skip it.
+			logger.Infof(
+				"skipped proving moving funds transactions for wallet [%x] "+
+					"because of wallet state [%v]",
+				walletPublicKeyHash,
+				wallet.State,
+			)
+			continue
+		}
+
+		// The moving funds transaction should be among the recent transactions that
+		// pay to any of the target wallets. When retrieving the recent transactions
+		// paying for the public key hash, we can use just one target wallet. Since
+		// the smart contract guarantees there is at least one target wallet, we can
+		// choose the one at index `0`. Notice that unlike in case of deposit sweeps
+		// or redemptions, we cannot use the source wallet public key hash when
+		// retrieving transactions. This is beacuse none of the transaction's outputs
+		// transafers funds to the source wallet.
+		targetWalletPublicKeyHash := targetWallets[0]
+
+		walletTransactions, err := btcChain.GetTransactionsForPublicKeyHash(
+			targetWalletPublicKeyHash,
+			transactionLimit,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to get transactions for wallet: [%v]",
+				err,
+			)
+		}
+
+		for _, transaction := range walletTransactions {
+			isUnproven, err :=
+				isUnprovenMovingFundsTransaction(
+					transaction,
+					walletPublicKeyHash,
+					targetWallets,
+					btcChain,
+					spvChain,
+				)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to check if transaction is an unproven moving funds "+
+						"transaction: [%v]",
+					err,
+				)
+			}
+
+			if isUnproven {
+				unprovenMovingFundsTransactions = append(
+					unprovenMovingFundsTransactions,
+					transaction,
+				)
+			}
+		}
+	}
+
+	return unprovenMovingFundsTransactions, nil
+}
+
+func isUnprovenMovingFundsTransaction(
+	transaction *bitcoin.Transaction,
+	walletPublicKeyHash [20]byte,
+	targetWalletsPublicKeyHashes [][20]byte,
+	btcChain bitcoin.Chain,
+	spvChain Chain,
+) (bool, error) {
+	// If the transaction does not have exactly one input, it cannot be a
+	// moving funds transaction.
+	if len(transaction.Inputs) != 1 {
+		return false, nil
+	}
+
+	fundingTransactionHash := transaction.Inputs[0].Outpoint.TransactionHash
+	fundingOutpointIndex := transaction.Inputs[0].Outpoint.OutputIndex
+
+	// The input must refer to the current wallet's main UTXO.
+	isMainUtxo, err := isInputCurrentWalletsMainUTXO(
+		fundingTransactionHash,
+		fundingOutpointIndex,
+		walletPublicKeyHash,
+		btcChain,
+		spvChain,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"failed to check if input is the main UTXO: [%v]",
+			err,
+		)
+	}
+
+	// The input is not the current main UTXO of the wallet.
+	// The transaction cannot be an unproven moving funds transaction.
+	if !isMainUtxo {
+		return false, nil
+	}
+
+	// If the number of transaction's outputs does not match the number of
+	// target walets from the commitment, the transaction cannot be a
+	// moving funds transaction.
+	if len(transaction.Outputs) != len(targetWalletsPublicKeyHashes) {
+		return false, nil
+	}
+
+	// Look at the transaction outputs. If the transaction is a moving funds
+	// transaction, each output must be transferring funds to the corresponding
+	// target wallets from the commitment.
+	for outputIndex, output := range transaction.Outputs {
+		// Assume that the outputs of moving funds trasnaction were added
+		// in the same order as target wallets on the list.
+		targetWalletPublicKeyHash := targetWalletsPublicKeyHashes[outputIndex]
+
+		p2pkh, err := bitcoin.PayToPublicKeyHash(targetWalletPublicKeyHash)
+		if err != nil {
+			return false, fmt.Errorf(
+				"failed to compute p2pkh script for transaction output: [%v]",
+				err,
+			)
+		}
+		p2wpkh, err := bitcoin.PayToWitnessPublicKeyHash(targetWalletPublicKeyHash)
+		if err != nil {
+			return false, fmt.Errorf(
+				"failed to compute p2wpkh script for transaction output: [%v]",
+				err,
+			)
+		}
+
+		if !bytes.Equal(output.PublicKeyScript, p2pkh) &&
+			!bytes.Equal(output.PublicKeyScript, p2wpkh) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/maintainer/spv/moving_funds_test.go
+++ b/pkg/maintainer/spv/moving_funds_test.go
@@ -1,0 +1,192 @@
+package spv
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/go-test/deep"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+func TestGetUnprovenMovingFundsTransactions(t *testing.T) {
+	bytesFromHex := func(str string) []byte {
+		value, err := hex.DecodeString(str)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return value
+	}
+
+	bytes20FromHex := func(str string) [20]byte {
+		var value [20]byte
+		copy(value[:], bytesFromHex(str))
+		return value
+	}
+
+	txFromHex := func(str string) *bitcoin.Transaction {
+		transaction := new(bitcoin.Transaction)
+		err := transaction.Deserialize(bytesFromHex(str))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return transaction
+	}
+
+	// Set an arbitrary history depth and transaction limit.
+	historyDepth := uint64(5)
+	transactionLimit := 10
+
+	btcChain := newLocalBitcoinChain()
+	spvChain := newLocalChain()
+
+	// Set a predictable current block.
+	currentBlock := uint64(1000)
+	blockCounter := newMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	spvChain.setBlockCounter(blockCounter)
+
+	mainUtxoHash := func(hashHex string, outputIndex uint32, value int64) [32]byte {
+		hash, err := bitcoin.NewHashFromString(hashHex, bitcoin.ReversedByteOrder)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return spvChain.ComputeMainUtxoHash(
+			&bitcoin.UnspentTransactionOutput{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: hash,
+					OutputIndex:     outputIndex,
+				},
+				Value: value,
+			},
+		)
+	}
+
+	// Define wallets being actors of this scenario:
+	wallets := []struct {
+		walletPublicKeyHash [20]byte
+		data                *tbtc.WalletChainData
+		transactions        []*bitcoin.Transaction
+	}{
+		{
+			// Wallet 1: https://live.blockcypher.com/btc-testnet/address/tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3
+			walletPublicKeyHash: bytes20FromHex("8db50eb52063ea9d98b3eac91489a90f738986f6"),
+			data: &tbtc.WalletChainData{
+				// Make the main UTXO point to Transaction 1.
+				MainUtxoHash: mainUtxoHash(
+					"11d27b4af5598bd0e5cea22c40f0ed8623278ad18f7fb2afc139ce99087aae44",
+					0,
+					40000,
+				),
+				State: tbtc.StateMovingFunds,
+			},
+			transactions: []*bitcoin.Transaction{
+				// Transaction 1: Creation of wallets main UTXO https://live.blockcypher.com/btc-testnet/tx/11d27b4af5598bd0e5cea22c40f0ed8623278ad18f7fb2afc139ce99087aae44/
+				txFromHex("02000000000101cf063c32da06ff5044f38220c61ee57ac5f3c31368a665bddb109d225d8b4d1a0100000000fdffffff02409c0000000000001600148db50eb52063ea9d98b3eac91489a90f738986f6df66000000000000160014be8347707d02375d1bd0c8f21a59f44c62990d8f024730440220166fbabc5d144d639e350826a04f1d2d148702312ce532da962076eb3859b81c02203d640f23f84a3792451539616432ffb07dc8ddac72047da56a22ecb842165bb4012103399de99c1d409735b7d20f46f616cd485f6b0442db13dfe4cd1b3772ae675fe024572700"),
+
+				// Transaction 2: MovingFunds: https://live.blockcypher.com/btc-testnet/tx/b6a67aeaf684b64b3506759c907a2d96e0891df32b4a7be0e9f8e05b5cd457b5/
+				txFromHex("0100000000010144ae7a0899ce39c1afb27f8fd18a272386edf0402ca2cee5d08b59f54a7bd2110000000000ffffffff037a310000000000001600143091d288521caec06ea912eacfd733edc5a36d6e7a3100000000000016001492a6ec889a8fa34f731e639edede4c75e184307c7c31000000000000160014c7302d75072d78be94eb8d36c4b77583c7abb06e0247304402200be4c3706674d848b09bee2c72c23a71832b5da98d8c4fb8ba7febcc4464e5c102207a8fbaea6f253727add9baa5adc0d53ca7eafc7493d937180959c82d9b3d69c9012103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d900000000"),
+
+				// Transaction 3: Some unrelated transaction that funded transaction 4: https://live.blockcypher.com/btc-testnet/tx/0ff42f0da4fa4afff6b1cda0ec08d45f3fc50a19eb487e853fb0c8abc9f1bb4b/
+				txFromHex("0200000000010198baf342676258d1fe06b44a9d421eac8568135f338f7b6e23d5ed8332affd190100000000fdffffff02b8880000000000001600148db50eb52063ea9d98b3eac91489a90f738986f69e94000000000000160014503af7f416e3ff1cdd5c43dd524d3cca2759d6b302473044022040ed8d5bc709fc8f14117c7090e66e7db945a860ec5011026252b61b102fce5e0220047d05c757c5092b9c43065e7b23b4f7d1054245bb31327f8cdcc02a4f163c620121038e17bbc2bf0bbdf61c25681fd6a003d40f3927c035a2ebd2944b0090afacebc8bd562700"),
+
+				// Transaction 4: Some unrelated transaction that pays to the first target wallet: https://live.blockcypher.com/btc-testnet/tx/bc124a83c29ad2f3ad09e9f61e96f94551dc618df311168139e8b8eb84416f76/
+				txFromHex("020000000001014bbbf1c9abc8b03f857e48eb190ac53f5fd408eca0cdb1f6ff4afaa40d2ff40f0100000000fdffffff020f270000000000001600143091d288521caec06ea912eacfd733edc5a36d6e026d000000000000160014edefac5962a46a02969879a7d232f37dbf0ac9f60247304402206941f2aaeb5561c6b58928ca4b0285e03ef0f8e36018c9b45c709e001ed0681a022052e50c1bb2f987dfaee251b70fe1eb6a1287c0723ff043880f46c82c09baacbe012103a9936dedbc8d585219d8daf1471e009253376cccb08f17561bad2ea09c2028bd04592700"),
+			},
+		},
+
+		{
+			// Wallet 2: https://live.blockcypher.com/btc-testnet/address/tb1q0tpdjdu2r3r7tzwlhqy4e2276g2q6fexsz4j0m/
+			walletPublicKeyHash: bytes20FromHex("7ac2d9378a1c47e589dfb8095ca95ed2140d2726"),
+			data: &tbtc.WalletChainData{
+				// Make the main UTXO point to Transaction 1.
+				MainUtxoHash: mainUtxoHash(
+					"89c1e51322878df5417652643a2cbc4bcc3b2ecaff371c3e03b7b9b285d5e3f8",
+					1,
+					1473114,
+				),
+				State: tbtc.StateMovingFunds,
+			},
+			transactions: []*bitcoin.Transaction{
+				// Transaction 1: Creation of wallet's main UTXO https://live.blockcypher.com/btc-testnet/tx/89c1e51322878df5417652643a2cbc4bcc3b2ecaff371c3e03b7b9b285d5e3f8/
+				txFromHex("02000000014ff17f9f98c5f9c516a94b1c08eabd0ad04fd04e1e3b9485493592e7fc76a7ab000000006a47304402202d3356f81c1d488ec7a9c2917bdb9c6060b9307eca2dcf5e876792e2ba6db85c022016dbb59e1104ef311c20235c1c1894be94ef0c317c4f3b0d13d31c67c592001301210291936829fd41e5217272a8141313ceb754d65787dc07ccb9a9e9a384ef243645feffffff025108ee16020000001600141ea512aa81a96d5ffa2f0d3e37803d9912c89e7e5a7a1600000000001600147ac2d9378a1c47e589dfb8095ca95ed2140d2726e2792100"),
+
+				// Transaction 2: MovingFunds: https://live.blockcypher.com/btc-testnet/tx/d078c00d7e78509062fccdecaf85580efe6e2826d8db77341fbc1097ca2955e5
+				txFromHex("01000000000101f8e3d585b2b9b7033e1c37ffca2e3bcc4bbc2c3a64527641f58d872213e5c1890100000000ffffffff0132571600000000001976a9142cd680318747b720d67bf4246eb7403b476adb3488ac024830450221008b6b3fa3eaf4b46268c3bfb718cf8391afc7879ec1949e465c04fa206235a3f202205f9d00ebba7cdb29414b0dad752cf489710ab60dc06c7b20a99c0d9d3fce8c3c012102ee067a0273f2e3ba88d23140a24fdb290f27bbcd0f94117a9c65be3911c5c04e00000000"),
+			},
+		},
+	}
+
+	// Record wallet data on both chains.
+	for _, wallet := range wallets {
+		spvChain.setWallet(wallet.walletPublicKeyHash, wallet.data)
+
+		for _, transaction := range wallet.transactions {
+			err := btcChain.BroadcastTransaction(transaction)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Add moving funds commitment submitted events for the wallets.
+	// The block number field is just to make them distinguishable while reading.
+	events := []*tbtc.MovingFundsCommitmentSubmittedEvent{
+		{
+			WalletPublicKeyHash: wallets[0].walletPublicKeyHash,
+			TargetWallets: [][20]byte{
+				bytes20FromHex("3091d288521caec06ea912eacfd733edc5a36d6e"),
+				bytes20FromHex("92a6ec889a8fa34f731e639edede4c75e184307c"),
+				bytes20FromHex("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
+			},
+			BlockNumber: 100,
+		},
+		{
+			WalletPublicKeyHash: wallets[1].walletPublicKeyHash,
+			TargetWallets: [][20]byte{
+				bytes20FromHex("2cd680318747b720d67bf4246eb7403b476adb34"),
+			},
+			BlockNumber: 200,
+		},
+	}
+
+	for _, event := range events {
+		err := spvChain.addPastMovingFundsCommitmentSubmittedEvent(
+			&tbtc.MovingFundsCommitmentSubmittedEventFilter{
+				StartBlock: currentBlock - historyDepth,
+			},
+			event,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	transactions, err := getUnprovenMovingFundsTransactions(
+		historyDepth,
+		transactionLimit,
+		btcChain,
+		spvChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transactionsHashes := make([]bitcoin.Hash, len(transactions))
+	for i, transaction := range transactions {
+		transactionsHashes[i] = transaction.Hash()
+	}
+
+	expectedTransactionsHashes := []bitcoin.Hash{
+		wallets[0].transactions[1].Hash(), // Wallet 1 - Transaction 2
+		wallets[1].transactions[1].Hash(), // Wallet 2 - Transaction 2
+	}
+
+	if diff := deep.Equal(expectedTransactionsHashes, transactionsHashes); diff != nil {
+		t.Errorf("invalid unproven transaction hashes: %v", diff)
+	}
+}

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -52,6 +52,10 @@ var proofTypes = map[tbtc.WalletActionType]struct {
 		unprovenTransactionsGetter: getUnprovenRedemptionTransactions,
 		transactionProofSubmitter:  SubmitRedemptionProof,
 	},
+	tbtc.ActionMovingFunds: {
+		unprovenTransactionsGetter: getUnprovenMovingFundsTransactions,
+		transactionProofSubmitter:  SubmitMovingFundsProof,
+	},
 }
 
 type spvMaintainer struct {

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -393,6 +393,14 @@ type MovingFundsCommitmentSubmittedEvent struct {
 	BlockNumber         uint64
 }
 
+func (mfcse *MovingFundsCommitmentSubmittedEvent) GetWalletPublicKeyHash() [20]byte {
+	return mfcse.WalletPublicKeyHash
+}
+
+func (mfcse *MovingFundsCommitmentSubmittedEvent) GetTargetWallets() [][20]byte {
+	return mfcse.TargetWallets
+}
+
 // MovingFundsCommitmentSubmittedEventFilter is a component allowing to filter MovingFundsCommitmentSubmittedEvent.
 type MovingFundsCommitmentSubmittedEventFilter struct {
 	StartBlock          uint64


### PR DESCRIPTION
#Refs: https://github.com/keep-network/keep-core/issues/3735.
This PR adds functionalities for creating and submitting moving funds transaction SPV proofs.

Finding the possible unproven moving funds transactions is done by retrieving `MovingFundsCommitmentSubmitted` events and looking at the recent transactions of target wallets from each event as well as the wallet public key hash from the event. It's enough to just look at one of the target wallets (e.g. the first one) and retrieve all the transactions that pay to that target wallet. The unproven moving funds transaction must match both the input - it must be the current wallet's main UTXO and all the outputs - they must match the target wallets.

Once the unproven moving funds transactions are found, they are proven.
