### PR TITLE
Moved funds sweep proposal handling

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1788,7 +1788,26 @@ func (tc *TbtcChain) ValidateMovedFundsSweepProposal(
 	walletPublicKeyHash [20]byte,
 	proposal *tbtc.MovedFundsSweepProposal,
 ) error {
-	// TODO: Implement
+	abiProposal := tbtcabi.WalletProposalValidatorMovedFundsSweepProposal{
+		WalletPubKeyHash:         walletPublicKeyHash,
+		MovingFundsTxHash:        proposal.MovingFundsTxHash,
+		MovingFundsTxOutputIndex: proposal.MovingFundsTxOutputIndex,
+		MovedFundsSweepTxFee:     proposal.SweepTxFee,
+	}
+
+	valid, err := tc.walletProposalValidator.ValidateMovedFundsSweepProposal(
+		abiProposal,
+	)
+	if err != nil {
+		return fmt.Errorf("validation failed: [%v]", err)
+	}
+
+	// Should never happen because `validateMovedFundsSweepProposal` returns
+	// true or reverts (returns an error) but do the check just in case.
+	if !valid {
+		return fmt.Errorf("unexpected validation result")
+	}
+
 	return nil
 }
 

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1730,6 +1730,14 @@ func (tc *TbtcChain) SubmitMovingFundsCommitment(
 	return err
 }
 
+func (tc *TbtcChain) ValidateMovedFundsSweepProposal(
+	walletPublicKeyHash [20]byte,
+	proposal *tbtc.MovedFundsSweepProposal,
+) error {
+	// TODO: Implement
+	return nil
+}
+
 func (tc *TbtcChain) ValidateRedemptionProposal(
 	walletPublicKeyHash [20]byte,
 	proposal *tbtc.RedemptionProposal,

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -428,3 +428,25 @@ func TestBuildRedemptionKey(t *testing.T) {
 		redemptionKey.Text(16),
 	)
 }
+
+func TestBuildMovedFundsKey(t *testing.T) {
+	fundingTxHash, err := bitcoin.NewHashFromString(
+		"7cff663e3e08847a5579913f6a66bc6c01f5f48c6ae1783be77418ed188021e6",
+		bitcoin.InternalByteOrder,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fundingOutputIndex := uint32(2)
+
+	movedFundsKey := buildMovedFundsKey(fundingTxHash, fundingOutputIndex)
+
+	expectedMovedFundsKey := "24509b8a853476ebe77af3707bd7ce017d527680e941b6eeaac2d5b712df4f8d"
+	testutils.AssertStringsEqual(
+		t,
+		"moved funds key",
+		expectedMovedFundsKey,
+		movedFundsKey.Text(16),
+	)
+}

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -400,6 +400,20 @@ type MovingFundsCommitmentSubmittedEventFilter struct {
 	WalletPublicKeyHash [][20]byte
 }
 
+// MovingFundsCompletedEvent represents a moving funds completed event.
+type MovingFundsCompletedEvent struct {
+	WalletPublicKeyHash [20]byte
+	MovingFundsTxHash   bitcoin.Hash
+	BlockNumber         uint64
+}
+
+// MovingFundsCompletedEventFilter is a component allowing to filter MovingFundsCompletedEvent.
+type MovingFundsCompletedEventFilter struct {
+	StartBlock          uint64
+	EndBlock            *uint64
+	WalletPublicKeyHash [][20]byte
+}
+
 // Chain represents the interface that the TBTC module expects to interact
 // with the anchoring blockchain on.
 type Chain interface {

--- a/pkg/tbtc/gen/pb/message.pb.go
+++ b/pkg/tbtc/gen/pb/message.pb.go
@@ -445,6 +445,69 @@ func (x *MovingFundsProposal) GetMovingFundsTxFee() []byte {
 	return nil
 }
 
+type MovedFundsSweepProposal struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	MovingFundsTxHash        []byte `protobuf:"bytes,1,opt,name=movingFundsTxHash,proto3" json:"movingFundsTxHash,omitempty"`
+	MovingFundsTxOutputIndex uint32 `protobuf:"varint,2,opt,name=movingFundsTxOutputIndex,proto3" json:"movingFundsTxOutputIndex,omitempty"`
+	SweepTxFee               []byte `protobuf:"bytes,3,opt,name=sweepTxFee,proto3" json:"sweepTxFee,omitempty"`
+}
+
+func (x *MovedFundsSweepProposal) Reset() {
+	*x = MovedFundsSweepProposal{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pkg_tbtc_gen_pb_message_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MovedFundsSweepProposal) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MovedFundsSweepProposal) ProtoMessage() {}
+
+func (x *MovedFundsSweepProposal) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_tbtc_gen_pb_message_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MovedFundsSweepProposal.ProtoReflect.Descriptor instead.
+func (*MovedFundsSweepProposal) Descriptor() ([]byte, []int) {
+	return file_pkg_tbtc_gen_pb_message_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *MovedFundsSweepProposal) GetMovingFundsTxHash() []byte {
+	if x != nil {
+		return x.MovingFundsTxHash
+	}
+	return nil
+}
+
+func (x *MovedFundsSweepProposal) GetMovingFundsTxOutputIndex() uint32 {
+	if x != nil {
+		return x.MovingFundsTxOutputIndex
+	}
+	return 0
+}
+
+func (x *MovedFundsSweepProposal) GetSweepTxFee() []byte {
+	if x != nil {
+		return x.SweepTxFee
+	}
+	return nil
+}
+
 type DepositSweepProposal_DepositKey struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -457,7 +520,7 @@ type DepositSweepProposal_DepositKey struct {
 func (x *DepositSweepProposal_DepositKey) Reset() {
 	*x = DepositSweepProposal_DepositKey{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_tbtc_gen_pb_message_proto_msgTypes[7]
+		mi := &file_pkg_tbtc_gen_pb_message_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -470,7 +533,7 @@ func (x *DepositSweepProposal_DepositKey) String() string {
 func (*DepositSweepProposal_DepositKey) ProtoMessage() {}
 
 func (x *DepositSweepProposal_DepositKey) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_tbtc_gen_pb_message_proto_msgTypes[7]
+	mi := &file_pkg_tbtc_gen_pb_message_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -568,8 +631,19 @@ var file_pkg_tbtc_gen_pb_message_proto_rawDesc = []byte{
 	0x0c, 0x52, 0x0d, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x57, 0x61, 0x6c, 0x6c, 0x65, 0x74, 0x73,
 	0x12, 0x2a, 0x0a, 0x10, 0x6d, 0x6f, 0x76, 0x69, 0x6e, 0x67, 0x46, 0x75, 0x6e, 0x64, 0x73, 0x54,
 	0x78, 0x46, 0x65, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x10, 0x6d, 0x6f, 0x76, 0x69,
-	0x6e, 0x67, 0x46, 0x75, 0x6e, 0x64, 0x73, 0x54, 0x78, 0x46, 0x65, 0x65, 0x42, 0x06, 0x5a, 0x04,
-	0x2e, 0x2f, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6e, 0x67, 0x46, 0x75, 0x6e, 0x64, 0x73, 0x54, 0x78, 0x46, 0x65, 0x65, 0x22, 0xa3, 0x01, 0x0a,
+	0x17, 0x4d, 0x6f, 0x76, 0x65, 0x64, 0x46, 0x75, 0x6e, 0x64, 0x73, 0x53, 0x77, 0x65, 0x65, 0x70,
+	0x50, 0x72, 0x6f, 0x70, 0x6f, 0x73, 0x61, 0x6c, 0x12, 0x2c, 0x0a, 0x11, 0x6d, 0x6f, 0x76, 0x69,
+	0x6e, 0x67, 0x46, 0x75, 0x6e, 0x64, 0x73, 0x54, 0x78, 0x48, 0x61, 0x73, 0x68, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0c, 0x52, 0x11, 0x6d, 0x6f, 0x76, 0x69, 0x6e, 0x67, 0x46, 0x75, 0x6e, 0x64, 0x73,
+	0x54, 0x78, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x18, 0x6d, 0x6f, 0x76, 0x69, 0x6e, 0x67,
+	0x46, 0x75, 0x6e, 0x64, 0x73, 0x54, 0x78, 0x4f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x49, 0x6e, 0x64,
+	0x65, 0x78, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x18, 0x6d, 0x6f, 0x76, 0x69, 0x6e, 0x67,
+	0x46, 0x75, 0x6e, 0x64, 0x73, 0x54, 0x78, 0x4f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x49, 0x6e, 0x64,
+	0x65, 0x78, 0x12, 0x1e, 0x0a, 0x0a, 0x73, 0x77, 0x65, 0x65, 0x70, 0x54, 0x78, 0x46, 0x65, 0x65,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0a, 0x73, 0x77, 0x65, 0x65, 0x70, 0x54, 0x78, 0x46,
+	0x65, 0x65, 0x42, 0x06, 0x5a, 0x04, 0x2e, 0x2f, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 }
 
 var (
@@ -584,7 +658,7 @@ func file_pkg_tbtc_gen_pb_message_proto_rawDescGZIP() []byte {
 	return file_pkg_tbtc_gen_pb_message_proto_rawDescData
 }
 
-var file_pkg_tbtc_gen_pb_message_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_pkg_tbtc_gen_pb_message_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_pkg_tbtc_gen_pb_message_proto_goTypes = []interface{}{
 	(*SigningDoneMessage)(nil),              // 0: tbtc.SigningDoneMessage
 	(*CoordinationProposal)(nil),            // 1: tbtc.CoordinationProposal
@@ -593,11 +667,12 @@ var file_pkg_tbtc_gen_pb_message_proto_goTypes = []interface{}{
 	(*DepositSweepProposal)(nil),            // 4: tbtc.DepositSweepProposal
 	(*RedemptionProposal)(nil),              // 5: tbtc.RedemptionProposal
 	(*MovingFundsProposal)(nil),             // 6: tbtc.MovingFundsProposal
-	(*DepositSweepProposal_DepositKey)(nil), // 7: tbtc.DepositSweepProposal.DepositKey
+	(*MovedFundsSweepProposal)(nil),         // 7: tbtc.MovedFundsSweepProposal
+	(*DepositSweepProposal_DepositKey)(nil), // 8: tbtc.DepositSweepProposal.DepositKey
 }
 var file_pkg_tbtc_gen_pb_message_proto_depIdxs = []int32{
 	1, // 0: tbtc.CoordinationMessage.proposal:type_name -> tbtc.CoordinationProposal
-	7, // 1: tbtc.DepositSweepProposal.depositsKeys:type_name -> tbtc.DepositSweepProposal.DepositKey
+	8, // 1: tbtc.DepositSweepProposal.depositsKeys:type_name -> tbtc.DepositSweepProposal.DepositKey
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -696,6 +771,18 @@ func file_pkg_tbtc_gen_pb_message_proto_init() {
 			}
 		}
 		file_pkg_tbtc_gen_pb_message_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MovedFundsSweepProposal); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_pkg_tbtc_gen_pb_message_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DepositSweepProposal_DepositKey); i {
 			case 0:
 				return &v.state
@@ -714,7 +801,7 @@ func file_pkg_tbtc_gen_pb_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_pkg_tbtc_gen_pb_message_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/tbtc/gen/pb/message.proto
+++ b/pkg/tbtc/gen/pb/message.proto
@@ -47,3 +47,9 @@ message MovingFundsProposal {
     repeated bytes targetWallets = 1;
     bytes movingFundsTxFee = 2;
 }
+
+message MovedFundsSweepProposal {
+    bytes movingFundsTxHash = 1;
+    uint32 movingFundsTxOutputIndex = 2;
+    bytes sweepTxFee = 3;
+}

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -1,6 +1,7 @@
 package tbtc
 
 import (
+	"fmt"
 	"math/big"
 	"time"
 
@@ -63,6 +64,18 @@ func ValidateMovedFundsSweepProposal(
 		) error
 	},
 ) error {
-	// TODO: Implement
+	validateProposalLogger.Infof("calling chain for proposal validation")
+
+	err := chain.ValidateMovedFundsSweepProposal(
+		walletPublicKeyHash,
+		proposal,
+	)
+
+	if err != nil {
+		return fmt.Errorf("moved funds sweep proposal is invalid: [%v]", err)
+	}
+
+	validateProposalLogger.Infof("moved funds sweep proposal is valid")
+
 	return nil
 }

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -18,6 +18,7 @@ const (
 	MovedFundsStateTimedOut
 )
 
+// MovedFundsSweepRequest represents a moved funds sweep request.
 type MovedFundsSweepRequest struct {
 	WalletPublicKeyHash [20]byte
 	Value               uint64
@@ -34,6 +35,8 @@ const (
 	movedFundsSweepProposalValidityBlocks = 600
 )
 
+// MovedFundsSweepProposal represents a moved funds sweep proposal issued by a
+// wallet's coordination leader.
 type MovedFundsSweepProposal struct {
 	MovingFundsTxHash        [32]byte
 	MovingFundsTxOutputIndex uint32

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -2,7 +2,25 @@ package tbtc
 
 import (
 	"math/big"
+	"time"
 )
+
+// MovedFundsSweepRequestState represents the state of a moved funds request.
+type MovedFundsSweepRequestState uint8
+
+const (
+	MovedFundsStateUnknown MovedFundsSweepRequestState = iota
+	MovedFundsStatePending
+	MovedFundsStateProcessed
+	MovedFundsStateTimedOut
+)
+
+type MovedFundsSweepRequest struct {
+	WalletPublicKeyHash [20]byte
+	Value               uint64
+	CreatedAt           time.Time
+	State               MovedFundsSweepRequestState
+}
 
 const (
 	// movedFundsSweepProposalValidityBlocks determines the moving funds

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -1,0 +1,28 @@
+package tbtc
+
+import (
+	"math/big"
+)
+
+const (
+	// movedFundsSweepProposalValidityBlocks determines the moving funds
+	// proposal validity time expressed in blocks. In other words, this is the
+	// worst-case time for a moving funds during which the wallet is busy and
+	// cannot take another actions. The value of 600 blocks is roughly 2 hours,
+	// assuming 12 seconds per block.
+	movedFundsSweepProposalValidityBlocks = 600
+)
+
+type MovedFundsSweepProposal struct {
+	MovingFundsTxHash        [32]byte
+	MovingFundsTxOutputIndex uint32
+	SweepTxFee               *big.Int
+}
+
+func (mfsp *MovedFundsSweepProposal) ActionType() WalletActionType {
+	return ActionMovedFundsSweep
+}
+
+func (mfsp *MovedFundsSweepProposal) ValidityBlocks() uint64 {
+	return movedFundsSweepProposalValidityBlocks
+}

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -3,6 +3,8 @@ package tbtc
 import (
 	"math/big"
 	"time"
+
+	"github.com/ipfs/go-log/v2"
 )
 
 // MovedFundsSweepRequestState represents the state of a moved funds request.
@@ -43,4 +45,24 @@ func (mfsp *MovedFundsSweepProposal) ActionType() WalletActionType {
 
 func (mfsp *MovedFundsSweepProposal) ValidityBlocks() uint64 {
 	return movedFundsSweepProposalValidityBlocks
+}
+
+// ValidateMovedFundsSweepProposal checks the moved funds sweep proposal with
+// on-chain validation rules.
+func ValidateMovedFundsSweepProposal(
+	validateProposalLogger log.StandardLogger,
+	walletPublicKeyHash [20]byte,
+	proposal *MovedFundsSweepProposal,
+	chain interface {
+		// ValidateMovedFundsSweepProposal validates the given moved funds sweep
+		// proposal against the chain. Returns an error if the proposal is not
+		// valid or nil otherwise.
+		ValidateMovedFundsSweepProposal(
+			walletPublicKeyHash [20]byte,
+			proposal *MovedFundsSweepProposal,
+		) error
+	},
+) error {
+	// TODO: Implement
+	return nil
 }

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -676,6 +676,17 @@ func (n *node) handleMovingFundsProposal(
 	walletActionLogger.Infof("wallet action dispatched successfully")
 }
 
+// handleMovedFundsSweepProposal handles an incoming moved funds sweep proposal
+// by orchestrating and dispatching an appropriate wallet action.
+func (n *node) handleMovedFundsSweepProposal(
+	wallet wallet,
+	proposal *MovedFundsSweepProposal,
+	startBlock uint64,
+	expiryBlock uint64,
+) {
+	// TODO: Implement
+}
+
 // coordinationLayerSettings represents settings for the coordination layer.
 type coordinationLayerSettings struct {
 	// executeCoordinationProcedureFn is a function executing the coordination
@@ -872,15 +883,15 @@ func processCoordinationResult(node *node, result *coordinationResult) {
 			)
 		}
 	// TODO: Uncomment when moving funds support is implemented.
-	// case ActionMovedFundsSweep:
-	//	 if proposal, ok := result.proposal.(*MovedFundsSweepProposal); ok {
-	//	 	 node.handleMovedFundsSweepProposal(
-	//	 	 	 result.wallet,
-	//	 	 	 proposal,
-	//	 	 	 startBlock,
-	//	 	 	 expiryBlock,
-	//	 	 )
-	//	 }
+	case ActionMovedFundsSweep:
+		if proposal, ok := result.proposal.(*MovedFundsSweepProposal); ok {
+			node.handleMovedFundsSweepProposal(
+				result.wallet,
+				proposal,
+				startBlock,
+				expiryBlock,
+			)
+		}
 	default:
 		logger.Errorf("no handler for coordination result [%s]", result)
 	}

--- a/pkg/tbtcpg/chain.go
+++ b/pkg/tbtcpg/chain.go
@@ -148,6 +148,11 @@ type Chain interface {
 		err error,
 	)
 
+	GetMovedFundsSweepRequest(
+		movingFundsTxHash bitcoin.Hash,
+		movingFundsTxOutpointIndex uint32,
+	) (*tbtc.MovedFundsSweepRequest, error)
+
 	// PastMovingFundsCommitmentSubmittedEvents fetches past moving funds
 	// commitment submitted events according to the provided filter or
 	// unfiltered if the filter is nil. Returned events are sorted by the block
@@ -156,6 +161,14 @@ type Chain interface {
 	PastMovingFundsCommitmentSubmittedEvents(
 		filter *tbtc.MovingFundsCommitmentSubmittedEventFilter,
 	) ([]*tbtc.MovingFundsCommitmentSubmittedEvent, error)
+
+	// PastMovingFundsCompletedEvents fetches past moving funds completed events
+	// according to the provided filter or unfiltered if the filter is nil.
+	// Returned events are sorted by the block number in the ascending order,
+	// i.e. the latest event is at the end of the slice.
+	PastMovingFundsCompletedEvents(
+		filter *tbtc.MovingFundsCompletedEventFilter,
+	) ([]*tbtc.MovingFundsCompletedEvent, error)
 
 	// ValidateMovingFundsProposal validates the given moving funds proposal
 	// against the chain. Returns an error if the proposal is not valid or

--- a/pkg/tbtcpg/chain.go
+++ b/pkg/tbtcpg/chain.go
@@ -188,6 +188,14 @@ type Chain interface {
 		targetWallets [][20]byte,
 	) error
 
+	// ValidateMovedFundsSweepProposal validates the given moved funds sweep
+	// proposal against the chain. Returns an error if the proposal is not valid
+	// or nil otherwise.
+	ValidateMovedFundsSweepProposal(
+		walletPublicKeyHash [20]byte,
+		proposal *tbtc.MovedFundsSweepProposal,
+	) error
+
 	// Computes the moving funds commitment hash from the provided public key
 	// hashes of target wallets.
 	ComputeMovingFundsCommitmentHash(targetWallets [][20]byte) [32]byte

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -1100,6 +1100,13 @@ func (lc *LocalChain) GetMovingFundsSubmissions() []*movingFundsCommitmentSubmis
 	return lc.movingFundsCommitmentSubmissions
 }
 
+func (lc *LocalChain) ValidateMovedFundsSweepProposal(
+	walletPublicKeyHash [20]byte,
+	proposal *tbtc.MovedFundsSweepProposal,
+) error {
+	panic("unsupported")
+}
+
 type MockBlockCounter struct {
 	mutex        sync.Mutex
 	currentBlock uint64

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -89,6 +89,8 @@ type LocalChain struct {
 	pastMovingFundsCommitmentSubmittedEvents map[[32]byte][]*tbtc.MovingFundsCommitmentSubmittedEvent
 	movingFundsProposalValidations           map[[32]byte]bool
 	movingFundsCommitmentSubmissions         []*movingFundsCommitmentSubmission
+	pastMovingFundsCompletedEvents           map[[32]byte][]*tbtc.MovingFundsCompletedEvent
+	movedFundsSweepRequests                  map[[32]byte]*tbtc.MovedFundsSweepRequest
 	operatorIDs                              map[chain.Address]uint32
 }
 
@@ -106,6 +108,8 @@ func NewLocalChain() *LocalChain {
 		pastMovingFundsCommitmentSubmittedEvents: make(map[[32]byte][]*tbtc.MovingFundsCommitmentSubmittedEvent),
 		movingFundsProposalValidations:           make(map[[32]byte]bool),
 		movingFundsCommitmentSubmissions:         make([]*movingFundsCommitmentSubmission, 0),
+		pastMovingFundsCompletedEvents:           make(map[[32]byte][]*tbtc.MovingFundsCompletedEvent),
+		movedFundsSweepRequests:                  make(map[[32]byte]*tbtc.MovedFundsSweepRequest),
 		operatorIDs:                              make(map[chain.Address]uint32),
 	}
 }
@@ -363,6 +367,32 @@ func buildPastRedemptionRequestedEventsKey(
 
 func buildPastMovingFundsCommitmentSubmittedEventsKey(
 	filter *tbtc.MovingFundsCommitmentSubmittedEventFilter,
+) ([32]byte, error) {
+	if filter == nil {
+		return [32]byte{}, nil
+	}
+
+	var buffer bytes.Buffer
+
+	startBlock := make([]byte, 8)
+	binary.BigEndian.PutUint64(startBlock, filter.StartBlock)
+	buffer.Write(startBlock)
+
+	if filter.EndBlock != nil {
+		endBlock := make([]byte, 8)
+		binary.BigEndian.PutUint64(startBlock, *filter.EndBlock)
+		buffer.Write(endBlock)
+	}
+
+	for _, walletPublicKeyHash := range filter.WalletPublicKeyHash {
+		buffer.Write(walletPublicKeyHash[:])
+	}
+
+	return sha256.Sum256(buffer.Bytes()), nil
+}
+
+func buildPastMovingFundsCompletedEventsKey(
+	filter *tbtc.MovingFundsCompletedEventFilter,
 ) ([32]byte, error) {
 	if filter == nil {
 		return [32]byte{}, nil
@@ -723,7 +753,51 @@ func (lc *LocalChain) GetMovedFundsSweepRequest(
 	movingFundsTxHash bitcoin.Hash,
 	movingFundsTxOutpointIndex uint32,
 ) (*tbtc.MovedFundsSweepRequest, error) {
-	panic("unsupported")
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	requestKey := buildMovedFundsSweepRequestKey(
+		movingFundsTxHash,
+		movingFundsTxOutpointIndex,
+	)
+
+	request, ok := lc.movedFundsSweepRequests[requestKey]
+	if !ok {
+		return nil, fmt.Errorf("request not found")
+	}
+
+	return request, nil
+}
+
+func (lc *LocalChain) SetMovedFundsSweepRequest(
+	movingFundsTxHash bitcoin.Hash,
+	movingFundsTxOutpointIndex uint32,
+	request *tbtc.MovedFundsSweepRequest,
+) {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	requestKey := buildMovedFundsSweepRequestKey(
+		movingFundsTxHash,
+		movingFundsTxOutpointIndex,
+	)
+
+	lc.movedFundsSweepRequests[requestKey] = request
+}
+
+func buildMovedFundsSweepRequestKey(
+	movingFundsTxHash bitcoin.Hash,
+	movingFundsTxOutpointIndex uint32,
+) [32]byte {
+	var buffer bytes.Buffer
+
+	buffer.Write(movingFundsTxHash[:])
+
+	outputIndex := make([]byte, 4)
+	binary.BigEndian.PutUint32(outputIndex, movingFundsTxOutpointIndex)
+	buffer.Write(outputIndex)
+
+	return sha256.Sum256(buffer.Bytes())
 }
 
 func (lc *LocalChain) SetMovingFundsParameters(
@@ -1063,10 +1137,47 @@ func (lc *LocalChain) PastMovingFundsCommitmentSubmittedEvents(
 	return events, nil
 }
 
+func (lc *LocalChain) AddPastMovingFundsCompletedEvent(
+	filter *tbtc.MovingFundsCompletedEventFilter,
+	event *tbtc.MovingFundsCompletedEvent,
+) error {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	eventsKey, err := buildPastMovingFundsCompletedEventsKey(filter)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := lc.pastMovingFundsCompletedEvents[eventsKey]; !ok {
+		lc.pastMovingFundsCompletedEvents[eventsKey] = []*tbtc.MovingFundsCompletedEvent{}
+	}
+
+	lc.pastMovingFundsCompletedEvents[eventsKey] = append(
+		lc.pastMovingFundsCompletedEvents[eventsKey],
+		event,
+	)
+
+	return nil
+}
+
 func (lc *LocalChain) PastMovingFundsCompletedEvents(
 	filter *tbtc.MovingFundsCompletedEventFilter,
 ) ([]*tbtc.MovingFundsCompletedEvent, error) {
-	panic("unsupported")
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	eventsKey, err := buildPastMovingFundsCompletedEventsKey(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	events, ok := lc.pastMovingFundsCompletedEvents[eventsKey]
+	if !ok {
+		return nil, fmt.Errorf("no events for given filter")
+	}
+
+	return events, nil
 }
 
 func (lc *LocalChain) SubmitMovingFundsCommitment(

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -719,6 +719,13 @@ func (lc *LocalChain) GetMovingFundsParameters() (
 		nil
 }
 
+func (lc *LocalChain) GetMovedFundsSweepRequest(
+	movingFundsTxHash bitcoin.Hash,
+	movingFundsTxOutpointIndex uint32,
+) (*tbtc.MovedFundsSweepRequest, error) {
+	panic("unsupported")
+}
+
 func (lc *LocalChain) SetMovingFundsParameters(
 	txMaxTotalFee uint64,
 	dustThreshold uint64,
@@ -1054,6 +1061,12 @@ func (lc *LocalChain) PastMovingFundsCommitmentSubmittedEvents(
 	}
 
 	return events, nil
+}
+
+func (lc *LocalChain) PastMovingFundsCompletedEvents(
+	filter *tbtc.MovingFundsCompletedEventFilter,
+) ([]*tbtc.MovingFundsCompletedEvent, error) {
+	panic("unsupported")
 }
 
 func (lc *LocalChain) SubmitMovingFundsCommitment(

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -17,6 +17,12 @@ var ErrSweepTxFeeTooHigh = fmt.Errorf(
 	"estimated fee exceeds the maximum fee",
 )
 
+// ErrNoPendingMovedFundsSweepRequests is the error returned when no pending
+// moved funds sweep requests.
+var ErrNoPendingMovedFundsSweepRequests = fmt.Errorf(
+	"could not find any pending moved funds sweep request",
+)
+
 // MovedFundsSweepLookBackBlocks is the look-back period in blocks used
 // when searching for submitted moving funds-related events. It's equal to
 // 30 days assuming 12 seconds per block.
@@ -183,9 +189,7 @@ func (mfst *MovedFundsSweepTask) FindMovingFundsTxData(
 	}
 
 	// No pending moved funds sweep request could be found.
-	return bitcoin.Hash{}, 0, fmt.Errorf(
-		"could not find any pending moved funds sweep request",
-	)
+	return bitcoin.Hash{}, 0, ErrNoPendingMovedFundsSweepRequests
 }
 
 func (mfst *MovedFundsSweepTask) findMovingFundsCommitmentData(

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -1,0 +1,110 @@
+package tbtcpg
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-log/v2"
+	"go.uber.org/zap"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+type MovedFundsSweepTask struct {
+	chain    Chain
+	btcChain bitcoin.Chain
+}
+
+func NewMovedFundsSweepTask(
+	chain Chain,
+	btcChain bitcoin.Chain,
+) *MovedFundsSweepTask {
+	return &MovedFundsSweepTask{
+		chain:    chain,
+		btcChain: btcChain,
+	}
+}
+
+func (mfst *MovedFundsSweepTask) Run(request *tbtc.CoordinationProposalRequest) (
+	tbtc.CoordinationProposal,
+	bool,
+	error,
+) {
+	walletPublicKeyHash := request.WalletPublicKeyHash
+
+	taskLogger := logger.With(
+		zap.String("task", mfst.ActionType().String()),
+		zap.String("walletPKH", fmt.Sprintf("0x%x", walletPublicKeyHash)),
+	)
+
+	walletChainData, err := mfst.chain.GetWallet(walletPublicKeyHash)
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"cannot get wallet's chain data: [%w]",
+			err,
+		)
+	}
+
+	if walletChainData.State != tbtc.StateLive &&
+		walletChainData.State != tbtc.StateMovingFunds {
+		taskLogger.Infof("wallet not in Live or MoveFunds state")
+		return nil, false, nil
+	}
+
+	if walletChainData.PendingMovedFundsSweepRequestsCount == 0 {
+		taskLogger.Infof("wallet has no pending moved funds sweep requests")
+		return nil, false, nil
+	}
+
+	movingFundsTxHash, movingFundsOutputIdx, err := mfst.FindMovingFundsTxData(
+		walletPublicKeyHash,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"cannot find moving funds transaction data: [%w]",
+			err,
+		)
+	}
+
+	proposal, err := mfst.ProposeMovedFundsSweep(
+		taskLogger,
+		walletPublicKeyHash,
+		movingFundsTxHash,
+		movingFundsOutputIdx,
+		0,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"cannot prepare moved funds sweep proposal: [%w]",
+			err,
+		)
+	}
+
+	return proposal, true, nil
+}
+
+func (mfst *MovedFundsSweepTask) FindMovingFundsTxData(
+	walletPublicKeyHash [20]byte,
+) (
+	txHash bitcoin.Hash,
+	txOutputIdx uint32,
+	err error,
+) {
+	// TODO: Implement
+	return bitcoin.Hash{}, 0, nil
+}
+
+func (mfst *MovedFundsSweepTask) ActionType() tbtc.WalletActionType {
+	return tbtc.ActionMovedFundsSweep
+}
+
+func (mfst *MovedFundsSweepTask) ProposeMovedFundsSweep(
+	taskLogger log.StandardLogger,
+	walletPublicKeyHash [20]byte,
+	movingFundsTxHash bitcoin.Hash,
+	movingFundsTxIndex uint32,
+	fee int64,
+) (*tbtc.MovedFundsSweepProposal, error) {
+	// TODO: Implement
+	return nil, nil
+}

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -28,6 +28,7 @@ var ErrNoPendingMovedFundsSweepRequests = fmt.Errorf(
 // 30 days assuming 12 seconds per block.
 const MovedFundsSweepLookBackBlocks = uint64(216000)
 
+// MovedFundsSweepTask is a task that may produce a moved funds sweep proposal.
 type MovedFundsSweepTask struct {
 	chain    Chain
 	btcChain bitcoin.Chain

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -194,7 +194,7 @@ func (mfst *MovedFundsSweepTask) FindMovingFundsTxData(
 }
 
 func (mfst *MovedFundsSweepTask) findMovingFundsCommitments(
-	walletPublicKeyHash [20]byte,
+	targetWalletPublicKeyHash [20]byte,
 	filterStartBlock uint64,
 ) ([]movingFundsCommitmentData, error) {
 	// Get all the recent moving funds commitment submitted events.
@@ -215,7 +215,7 @@ func (mfst *MovedFundsSweepTask) findMovingFundsCommitments(
 	commitmentData := []movingFundsCommitmentData{}
 	for _, event := range events {
 		for targetWalletIndex, targetWallet := range event.TargetWallets {
-			if targetWallet == walletPublicKeyHash {
+			if targetWallet == targetWalletPublicKeyHash {
 				// If our wallet has been found on the target wallet list save
 				// the committing wallet public key hash and the position of
 				// our wallet on the target wallet list.

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -17,6 +17,11 @@ var ErrSweepTxFeeTooHigh = fmt.Errorf(
 	"estimated fee exceeds the maximum fee",
 )
 
+// MovedFundsSweepLookBackBlocks is the look-back period in blocks used
+// when searching for submitted moving funds-related events. It's equal to
+// 30 days assuming 12 seconds per block.
+const MovedFundsSweepLookBackBlocks = uint64(216000)
+
 type MovedFundsSweepTask struct {
 	chain    Chain
 	btcChain bitcoin.Chain
@@ -118,8 +123,8 @@ func (mfst *MovedFundsSweepTask) FindMovingFundsTxData(
 	}
 
 	filterStartBlock := uint64(0)
-	if currentBlockNumber > MovingFundsCommitmentLookBackBlocks {
-		filterStartBlock = currentBlockNumber - MovingFundsCommitmentLookBackBlocks
+	if currentBlockNumber > MovedFundsSweepLookBackBlocks {
+		filterStartBlock = currentBlockNumber - MovedFundsSweepLookBackBlocks
 	}
 
 	movingFundsCommitmentData, err := mfst.findMovingFundsCommitmentData(

--- a/pkg/tbtcpg/moved_funds_sweep_test.go
+++ b/pkg/tbtcpg/moved_funds_sweep_test.go
@@ -4,8 +4,220 @@ import (
 	"testing"
 
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 )
+
+func TestFindMovingFundsTxData(t *testing.T) {
+	walletPublicKeyHash := hexToByte20(
+		"92a6ec889a8fa34f731e639edede4c75e184307c",
+	)
+
+	currentBlock := uint64(1000000)
+
+	tbtcChain := tbtcpg.NewLocalChain()
+
+	blockCounter := tbtcpg.NewMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	tbtcChain.SetBlockCounter(blockCounter)
+
+	startBlock := currentBlock - tbtcpg.MovedFundsSweepLookBackBlocks
+
+	// Test data on all the moving funds commitments.
+	movingFundsCommitments := []struct {
+		sourceWallet  [20]byte
+		targetWallets [][20]byte
+	}{
+		// Moving funds 1: transfers funds to the test wallet. The proof has
+		//                 not been submitted yet.
+		{
+			sourceWallet: hexToByte20(
+				"1e37ea706ec1300d518ac6e4f58d1f4390443566",
+			),
+			targetWallets: [][20]byte{
+				// unrelated wallet at index 0
+				hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
+				// test wallet at index 1
+				hexToByte20("92a6ec889a8fa34f731e639edede4c75e184307c"),
+			},
+		},
+
+		// Moving funds 2: transfers funds to the test wallet. The proof has
+		//                 been submitted but the moved funds sweep request is
+		//                 already processed.
+		{
+			sourceWallet: hexToByte20(
+				"d4162e0c6522eafac43650c78928910ceda4aef7",
+			),
+			targetWallets: [][20]byte{
+				// test wallet at index 0
+				hexToByte20("92a6ec889a8fa34f731e639edede4c75e184307c"),
+			},
+		},
+
+		// Moving funds 3: transfers funds to the test wallet. The proof has
+		//                 been submitted and the moved funds sweep request is
+		//                 pending.
+		{
+			sourceWallet: hexToByte20(
+				"ffb3f7538bfa98a511495dd96027cfbd57baf2fa",
+			),
+			targetWallets: [][20]byte{
+				// unrelated wallet at index 0
+				hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+				// test wallet at index 1
+				hexToByte20("92a6ec889a8fa34f731e639edede4c75e184307c"),
+				// unrelated wallet at index 2
+				hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
+			},
+		},
+
+		// Moving funds 4: transfers funds to unrelated wallet.
+		{
+			sourceWallet: hexToByte20(
+				"a37c0a3e56decce984e4e6ccda7394c09b507fb5",
+			),
+			targetWallets: [][20]byte{
+				// unrelated wallet at index 0
+				hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+			},
+		},
+	}
+
+	for _, movingFundsTx := range movingFundsCommitments {
+		err := tbtcChain.AddPastMovingFundsCommitmentSubmittedEvent(
+			&tbtc.MovingFundsCommitmentSubmittedEventFilter{
+				StartBlock: startBlock,
+			},
+			&tbtc.MovingFundsCommitmentSubmittedEvent{
+				WalletPublicKeyHash: movingFundsTx.sourceWallet,
+				TargetWallets:       movingFundsTx.targetWallets,
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The filter for moving funds completed events contains the starting block
+	// and the public key hashes of all the source wallets that committed to
+	// move funds to the test wallet.
+	movingFundsCompletedFilter := &tbtc.MovingFundsCompletedEventFilter{
+		StartBlock: startBlock,
+		WalletPublicKeyHash: [][20]byte{
+			hexToByte20("1e37ea706ec1300d518ac6e4f58d1f4390443566"),
+			hexToByte20("d4162e0c6522eafac43650c78928910ceda4aef7"),
+			hexToByte20("ffb3f7538bfa98a511495dd96027cfbd57baf2fa"),
+		},
+	}
+
+	// Tests data on all the completed moving funds transactions. Note it does
+	// not contain data from moving funds 1 as the transaction is not completed.
+	movingFundsTransactions := []struct {
+		sourceWallet [20]byte
+		txHash       bitcoin.Hash
+	}{
+		// Data from Moving funds 2.
+		{
+			sourceWallet: hexToByte20(
+				"d4162e0c6522eafac43650c78928910ceda4aef7",
+			),
+			txHash: hashFromString(
+				"722b27db8c84795a0eff3103394d0d34469dc79b822981eeb2ae0c023d7ce1e0",
+			),
+		},
+
+		// Data from Moving funds 3.
+		{
+			sourceWallet: hexToByte20(
+				"ffb3f7538bfa98a511495dd96027cfbd57baf2fa",
+			),
+			txHash: hashFromString(
+				"9a745afae8ad4e3a50f64da9ad23e6d14f9bd5e13ae6266d2099e6d16388161c",
+			),
+		},
+	}
+
+	for _, movingFundsTx := range movingFundsTransactions {
+		err := tbtcChain.AddPastMovingFundsCompletedEvent(
+			movingFundsCompletedFilter,
+			&tbtc.MovingFundsCompletedEvent{
+				WalletPublicKeyHash: movingFundsTx.sourceWallet,
+				MovingFundsTxHash:   movingFundsTx.txHash,
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Data to build moved funds sweep requests. Only the
+	movedFundsSweepRequests := []struct {
+		txHash      bitcoin.Hash
+		outputIndex uint32
+		state       tbtc.MovedFundsSweepRequestState
+	}{
+		// Data from Moving funds 2.
+		{
+			txHash: hashFromString(
+				"722b27db8c84795a0eff3103394d0d34469dc79b822981eeb2ae0c023d7ce1e0",
+			),
+			outputIndex: 0,
+			state:       tbtc.MovedFundsStateProcessed,
+		},
+
+		// Data from Moving funds 3.
+		{
+			txHash: hashFromString(
+				"9a745afae8ad4e3a50f64da9ad23e6d14f9bd5e13ae6266d2099e6d16388161c",
+			),
+			outputIndex: 1,
+			state:       tbtc.MovedFundsStatePending,
+		},
+	}
+
+	for _, request := range movedFundsSweepRequests {
+		tbtcChain.SetMovedFundsSweepRequest(
+			request.txHash,
+			request.outputIndex,
+			&tbtc.MovedFundsSweepRequest{
+				State: request.state,
+			},
+		)
+	}
+
+	task := tbtcpg.NewMovedFundsSweepTask(
+		tbtcChain,
+		nil,
+	)
+
+	movingFundsTxHash, movingFundsOutputIdx, err := task.FindMovingFundsTxData(
+		walletPublicKeyHash,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The expected result comes from the Moving funds 3.
+	expectedOutputIdx := uint32(1)
+	expectedTxHash := hashFromString(
+		"9a745afae8ad4e3a50f64da9ad23e6d14f9bd5e13ae6266d2099e6d16388161c",
+	)
+
+	testutils.AssertBytesEqual(
+		t,
+		expectedTxHash[:],
+		movingFundsTxHash[:],
+	)
+
+	testutils.AssertUintsEqual(
+		t,
+		"fee",
+		uint64(expectedOutputIdx),
+		uint64(movingFundsOutputIdx),
+	)
+}
 
 func TestEstimateMovedFundsSweepFee(t *testing.T) {
 	var tests = map[string]struct {
@@ -59,4 +271,16 @@ func TestEstimateMovedFundsSweepFee(t *testing.T) {
 			)
 		})
 	}
+}
+
+func hashFromString(str string) bitcoin.Hash {
+	hash, err := bitcoin.NewHashFromString(
+		str,
+		bitcoin.ReversedByteOrder,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return hash
 }

--- a/pkg/tbtcpg/moved_funds_sweep_test.go
+++ b/pkg/tbtcpg/moved_funds_sweep_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 )
 
-func TestFindMovingFundsTxData(t *testing.T) {
+func TestMovedFundsSweepAction_FindMovingFundsTxData(t *testing.T) {
 	walletPublicKeyHash := hexToByte20(
 		"92a6ec889a8fa34f731e639edede4c75e184307c",
 	)

--- a/pkg/tbtcpg/moved_funds_sweep_test.go
+++ b/pkg/tbtcpg/moved_funds_sweep_test.go
@@ -1,0 +1,62 @@
+package tbtcpg_test
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/tbtcpg"
+)
+
+func TestEstimateMovedFundsSweepFee(t *testing.T) {
+	var tests = map[string]struct {
+		sweepTxMaxTotalFee uint64
+		hasMainUtxo        bool
+		expectedFee        uint64
+		expectedError      error
+	}{
+		"estimated fee correct, one input": {
+			sweepTxMaxTotalFee: 3000,
+			hasMainUtxo:        false,
+			expectedFee:        1760,
+			expectedError:      nil,
+		},
+		"estimated fee correct, two inputs": {
+			sweepTxMaxTotalFee: 3000,
+			hasMainUtxo:        true,
+			expectedFee:        2848,
+			expectedError:      nil,
+		},
+		"estimated fee too high": {
+			sweepTxMaxTotalFee: 2500,
+			hasMainUtxo:        true,
+			expectedFee:        0,
+			expectedError:      tbtcpg.ErrSweepTxFeeTooHigh,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			btcChain := tbtcpg.NewLocalBitcoinChain()
+			btcChain.SetEstimateSatPerVByteFee(1, 16)
+
+			actualFee, err := tbtcpg.EstimateMovedFundsSweepFee(
+				btcChain,
+				test.hasMainUtxo,
+				test.sweepTxMaxTotalFee,
+			)
+
+			testutils.AssertUintsEqual(
+				t,
+				"fee",
+				test.expectedFee,
+				uint64(actualFee),
+			)
+
+			testutils.AssertAnyErrorInChainMatchesTarget(
+				t,
+				test.expectedError,
+				err,
+			)
+		})
+	}
+}

--- a/pkg/tbtcpg/tbtcpg.go
+++ b/pkg/tbtcpg/tbtcpg.go
@@ -41,8 +41,7 @@ func NewProposalGenerator(
 		NewRedemptionTask(chain, btcChain),
 		NewHeartbeatTask(chain),
 		NewMovingFundsTask(chain, btcChain),
-		// TODO: Uncomment when moving funds support is implemented.
-		// newMovedFundsSweepTask(),
+		NewMovedFundsSweepTask(chain, btcChain),
 	}
 
 	return &ProposalGenerator{


### PR DESCRIPTION
#Refs: https://github.com/keep-network/keep-core/issues/3736.
This PR introduces functionalities that lanuches the moved funds sweep procedure and produces a proposal for it.
Once the procedure is launched we check if the wallet in question needs to perform moved funds sweep.
If it does, we look for the data of a moving funds transaction that transferred the funds to the wallet in question.
In the end, we create a proposal containing the transaction hash, outpoint index and transaction fee. 
Based on ths data, a Bitcoin moved funds sweep transaction will be contructed.
  