### PR TITLE
Don't add comments about API docs previews to PRs

### DIFF
--- a/.github/workflows/contracts-ecdsa-docs.yml
+++ b/.github/workflows/contracts-ecdsa-docs.yml
@@ -47,7 +47,7 @@ jobs:
       projectDir: /solidity/ecdsa
       publish: false
       addTOC: false
-      commentPR: true
+      commentPR: false
       exportAsGHArtifacts: true
 
   # This job is needed to avoid a clash of `contracts-docs-publish` jobs for

--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -47,7 +47,7 @@ jobs:
       projectDir: /solidity/random-beacon
       publish: false
       addTOC: false
-      commentPR: true
+      commentPR: false
       exportAsGHArtifacts: true
 
   # This job will be triggered for releases which name starts with


### PR DESCRIPTION
Previously we've been adding comments to PRs modifying Solidity contracts about available previews of the API documentation. As each push to the PR branch results in one such comment, PRs with a lot of pushes get quite busy with a lot of the similar comments. In the future it would be good to modify our commenting mechanism so that it would just leave one comment per PR and update it on each push. Until we do that we're turning off the PR commenting, to increase readability.

Ref:
https://github.com/keep-network/tbtc-v2/pull/793
https://github.com/threshold-network/solidity-contracts/pull/165