### PR TITLE
Update `keep-maintainer` Kubernetes deployment on `keep-prd`

### DIFF
--- a/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
@@ -11,7 +11,7 @@ commonLabels:
 images:
   - name: keep-maintainer
     newName: keepnetwork/keep-client
-    newTag: v2.0.0-m5
+    newTag: v2.0.0
 
 configMapGenerator:
   - name: keep-maintainer-config
@@ -19,7 +19,6 @@ configMapGenerator:
     literals:
       - network=mainnet
       - electrum-api-url=ws://electrumx.bitcoin:8080
-      - redemption-request-amount-limit=1500000000 # 15 BTC in satoshi
     files:
       - .secret/keep-maintainer-keyfile
 


### PR DESCRIPTION
Here we update the `keep-maintainer` manifest according to the recent updates performed on the cluster.