### PR TITLE
Change large deposit/redemption threshold for `tbtc-v2-monitoring`

### DIFF
--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/kustomization.yaml
@@ -10,7 +10,8 @@ configMapGenerator:
   - name: tbtc-v2-monitoring-config
     literals:
       - environment=mainnet
-      - large-deposit-threshold-sat=1000000000 # 10 BTC
+      - large-deposit-threshold-sat=10000000000 # 100 BTC
+      - large-redemption-threshold-sat=10000000000 # 100 BTC
 
 secretGenerator:
   - name: tbtc-v2-monitoring-config

--- a/infrastructure/kube/keep-test/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/keep-test/tbtc-v2-monitoring/kustomization.yaml
@@ -10,7 +10,8 @@ configMapGenerator:
   - name: tbtc-v2-monitoring-config
     literals:
       - environment=testnet
-      - large-deposit-threshold-sat=10000000 # 0.1 BTC for testing purposes
+      - large-deposit-threshold-sat=1000000000 # 10 BTC
+      - large-redemption-threshold-sat=1000000000 # 10 BTC
 
 secretGenerator:
   - name: tbtc-v2-monitoring-config

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
@@ -43,6 +43,11 @@ spec:
                     configMapKeyRef:
                       name: tbtc-v2-monitoring-config
                       key: large-deposit-threshold-sat
+                - name: LARGE_REDEMPTION_THRESHOLD_SAT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: large-redemption-threshold-sat
                 - name: DATA_DIR_PATH
                   value: /mnt/tbtc-v2-monitoring/data
                 - name: SENTRY_DSN


### PR DESCRIPTION
New values are
- 100 BTC for mainnet deposits and redemptions
- 10 BTC for testnet deposits and redemptions