### PR TITLE
Increase deposit sweep frequency

### DIFF
--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -540,10 +540,9 @@ func (ce *coordinationExecutor) getActionsChecklist(
 	actions = append(actions, ActionRedemption)
 
 	// Other actions should be checked with a lower frequency. The default
-	// frequency is every 16 coordination windows.
-	frequencyWindows := uint64(16)
+	// frequency is every 4 coordination windows.
+	frequencyWindows := uint64(4)
 
-	// TODO: Consider increasing frequency for the active wallet in the future.
 	if windowIndex%frequencyWindows == 0 {
 		actions = append(actions, ActionDepositSweep)
 	}
@@ -552,7 +551,6 @@ func (ce *coordinationExecutor) getActionsChecklist(
 		actions = append(actions, ActionMovedFundsSweep)
 	}
 
-	// TODO: Consider increasing frequency for old wallets in the future.
 	if windowIndex%frequencyWindows == 0 {
 		actions = append(actions, ActionMovingFunds)
 	}

--- a/pkg/tbtc/coordination_test.go
+++ b/pkg/tbtc/coordination_test.go
@@ -557,10 +557,14 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			coordinationBlock: 2700,
 			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
+		// Heartbeat randomly selected for the 4th coordination window.
 		"block 3600": {
 			coordinationBlock: 3600,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionMovingFunds,
 				ActionHeartbeat,
 			},
 		},
@@ -568,7 +572,6 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			coordinationBlock: 4500,
 			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// Heartbeat randomly selected for the 6th coordination window.
 		"block 5400": {
 			coordinationBlock: 5400,
 			expectedChecklist: []WalletActionType{
@@ -581,7 +584,12 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 7200": {
 			coordinationBlock: 7200,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionMovingFunds,
+			},
 		},
 		"block 8100": {
 			coordinationBlock: 8100,
@@ -597,13 +605,17 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 10800": {
 			coordinationBlock: 10800,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionMovingFunds,
+			},
 		},
 		"block 11700": {
 			coordinationBlock: 11700,
 			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// Heartbeat randomly selected for the 14th coordination window.
 		"block 12600": {
 			coordinationBlock: 12600,
 			expectedChecklist: []WalletActionType{
@@ -614,7 +626,6 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			coordinationBlock: 13500,
 			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// 16th coordination window so, all actions should be on the checklist.
 		"block 14400": {
 			coordinationBlock: 14400,
 			expectedChecklist: []WalletActionType{


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3802

So far, deposit sweeps were supposed to happen every 48 hours. This frequency was good for the early days of the system but starts to be insufficient now, when a significant number of deposits land every day. To optimize the deposit sweep process, we are increasing its frequency to 12 hours.