### PR TITLE
Retry upon coordination proposal failure

### DIFF
--- a/pkg/tbtc/coordination_test.go
+++ b/pkg/tbtc/coordination_test.go
@@ -306,6 +306,7 @@ func TestCoordinationExecutor_Coordinate(t *testing.T) {
 		func(
 			walletPublicKeyHash [20]byte,
 			actionsChecklist []WalletActionType,
+			_ uint,
 		) (CoordinationProposal, error) {
 			for _, action := range actionsChecklist {
 				if walletPublicKeyHash == publicKeyHash && action == ActionRedemption {
@@ -700,6 +701,7 @@ func TestCoordinationExecutor_ExecuteLeaderRoutine(t *testing.T) {
 		func(
 			walletPublicKeyHash [20]byte,
 			actionsChecklist []WalletActionType,
+			_ uint,
 		) (
 			CoordinationProposal,
 			error,
@@ -796,6 +798,97 @@ func TestCoordinationExecutor_ExecuteLeaderRoutine(t *testing.T) {
 			expectedMessage,
 			message,
 		)
+	}
+}
+
+func TestCoordinationExecutor_GenerateProposal(t *testing.T) {
+	var tests = map[string]struct {
+		proposalGenerator CoordinationProposalGenerator
+		expectedProposal  CoordinationProposal
+		expectedError     error
+	}{
+		"first attempt success": {
+			proposalGenerator: newMockCoordinationProposalGenerator(
+				func(
+					_ [20]byte,
+					_ []WalletActionType,
+					_ uint,
+				) (CoordinationProposal, error) {
+					return &NoopProposal{}, nil
+				},
+			),
+			expectedProposal: &NoopProposal{},
+			expectedError:    nil,
+		},
+		"last attempt success": {
+			proposalGenerator: newMockCoordinationProposalGenerator(
+				func(
+					_ [20]byte,
+					_ []WalletActionType,
+					call uint,
+				) (CoordinationProposal, error) {
+					if call == 1 {
+						return nil, fmt.Errorf("unexpected error")
+					} else if call == 2 {
+						return &NoopProposal{}, nil
+					} else {
+						panic("unexpected call")
+					}
+				},
+			),
+			expectedProposal: &NoopProposal{},
+			expectedError:    nil,
+		},
+		"all attempts failed": {
+			proposalGenerator: newMockCoordinationProposalGenerator(
+				func(
+					_ [20]byte,
+					_ []WalletActionType,
+					call uint,
+				) (CoordinationProposal, error) {
+					return nil, fmt.Errorf("unexpected error %v", call)
+				},
+			),
+			expectedProposal: nil,
+			expectedError: fmt.Errorf(
+				"all attempts failed: [attempt [1] error: [unexpected error 1]; attempt [2] error: [unexpected error 2]]",
+			),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			executor := &coordinationExecutor{
+				// Set only relevant fields.
+				proposalGenerator: test.proposalGenerator,
+			}
+
+			proposal, err := executor.generateProposal(
+				&CoordinationProposalRequest{}, // request fields not relevant
+				2,
+				1*time.Second,
+			)
+
+			if !reflect.DeepEqual(test.expectedError, err) {
+				t.Errorf(
+					"unexpected error\n"+
+						"expected: %v\n"+
+						"actual:   %v\n",
+					test.expectedError,
+					err,
+				)
+			}
+
+			if !reflect.DeepEqual(test.expectedProposal, proposal) {
+				t.Errorf(
+					"unexpected proposal\n"+
+						"expected: %v\n"+
+						"actual:   %v\n",
+					test.expectedProposal,
+					proposal,
+				)
+			}
+		})
 	}
 }
 
@@ -1171,9 +1264,11 @@ func TestCoordinationExecutor_ExecuteFollowerRoutine_WithIdleLeader(t *testing.T
 }
 
 type mockCoordinationProposalGenerator struct {
+	calls    uint
 	delegate func(
 		walletPublicKeyHash [20]byte,
 		actionsChecklist []WalletActionType,
+		call uint,
 	) (CoordinationProposal, error)
 }
 
@@ -1181,6 +1276,7 @@ func newMockCoordinationProposalGenerator(
 	delegate func(
 		walletPublicKeyHash [20]byte,
 		actionsChecklist []WalletActionType,
+		call uint,
 	) (CoordinationProposal, error),
 ) *mockCoordinationProposalGenerator {
 	return &mockCoordinationProposalGenerator{
@@ -1191,5 +1287,10 @@ func newMockCoordinationProposalGenerator(
 func (mcpg *mockCoordinationProposalGenerator) Generate(
 	request *CoordinationProposalRequest,
 ) (CoordinationProposal, error) {
-	return mcpg.delegate(request.WalletPublicKeyHash, request.ActionsChecklist)
+	mcpg.calls++
+	return mcpg.delegate(
+		request.WalletPublicKeyHash,
+		request.ActionsChecklist,
+		mcpg.calls,
+	)
 }


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3802

Here we attempt to harden proposal generation by retrying the process in case of failure. Proposal generation strongly relies on 3rd party services like Ethereum RPC and Electrum servers. Temporary disruption of those services can easily nuke proposal generation and cause a coordination window miss. Retrying proposal generation after a short delay should help overcome temporary problems and increase success chance of coordination windows.