### PR TITLE
Optimize deposit sweep proposal generator

### DIFF
--- a/cmd/maintainercli.go
+++ b/cmd/maintainercli.go
@@ -132,13 +132,12 @@ var listDepositsCommand = cobra.Command{
 
 func printDepositsTable(deposits []*tbtcpg.Deposit) error {
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 1, ' ', tabwriter.AlignRight)
-	fmt.Fprintf(w, "index\twallet\ttype\tvalue (BTC)\tdeposit key\trevealed deposit data\tconfirmations\tswept\t\n")
+	fmt.Fprintf(w, "index\twallet\tvalue (BTC)\tdeposit key\trevealed deposit data\tconfirmations\tswept\t\n")
 
 	for i, deposit := range deposits {
-		fmt.Fprintf(w, "%d\t%s\t%s\t%.5f\t%s\t%s\t%d\t%t\t\n",
+		fmt.Fprintf(w, "%d\t%s\t%.5f\t%s\t%s\t%d\t%t\t\n",
 			i,
 			hexutils.Encode(deposit.WalletPublicKeyHash[:]),
-			deposit.ScriptType,
 			deposit.AmountBtc,
 			deposit.DepositKey,
 			fmt.Sprintf(

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -104,7 +104,6 @@ type Deposit struct {
 	DepositReference
 
 	WalletPublicKeyHash [20]byte
-	ScriptType          bitcoin.ScriptType
 	DepositKey          string
 	IsSwept             bool
 	AmountBtc           float64
@@ -241,20 +240,6 @@ func findDeposits(
 			continue
 		}
 
-		var scriptType bitcoin.ScriptType
-		depositTransaction, err := btcChain.GetTransaction(
-			event.FundingTxHash,
-		)
-		if err != nil {
-			fnLogger.Errorf(
-				"failed to get deposit transaction data: [%v]",
-				err,
-			)
-		} else {
-			publicKeyScript := depositTransaction.Outputs[event.FundingOutputIndex].PublicKeyScript
-			scriptType = bitcoin.GetScriptType(publicKeyScript)
-		}
-
 		result = append(
 			result,
 			&Deposit{
@@ -264,7 +249,6 @@ func findDeposits(
 					RevealBlock:        event.BlockNumber,
 				},
 				WalletPublicKeyHash: event.WalletPublicKeyHash,
-				ScriptType:          scriptType,
 				DepositKey:          hexutils.Encode(depositKey.Bytes()),
 				IsSwept:             isSwept,
 				AmountBtc:           convertSatToBtc(float64(depositRequest.Amount)),


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-core/issues/3802

Fetching deposit script type is not needed for sweep proposal generation. Doing so means making an additional Electrum call for each deposit. This makes proposal generation longer and more prone to failure.

At the same time, the script type is used only for Maintainer CLI which is not so important since we have tbtcscan and there is no way to manually trigger sweeps due to the introduction of RFC 12.

That said, we are removing script type fetch from the process.