### PR TITLE
Adjustments to the moving funds proposal generator

### DIFF
--- a/pkg/tbtcpg/moving_funds.go
+++ b/pkg/tbtcpg/moving_funds.go
@@ -93,6 +93,14 @@ func (mft *MovingFundsTask) Run(request *tbtc.CoordinationProposalRequest) (
 		return nil, false, nil
 	}
 
+	// Check the safety margin for moving funds early. This will prevent
+	// commitment submission if the wallet is not safe to move funds.
+	err = tbtc.ValidateMovingFundsSafetyMargin(walletChainData)
+	if err != nil {
+		taskLogger.Infof("source wallet moving funds safety margin validation failed: [%v]", err)
+		return nil, false, nil
+	}
+
 	if walletChainData.PendingRedemptionsValue > 0 {
 		taskLogger.Infof("source wallet has pending redemptions")
 		return nil, false, nil
@@ -103,12 +111,14 @@ func (mft *MovingFundsTask) Run(request *tbtc.CoordinationProposalRequest) (
 		return nil, false, nil
 	}
 
-	// The wallet should not have any unswept deposits.
+	// The wallet should not have any unswept deposits. It's enough to find at
+	// least one unswept deposit. A single unswept deposit means that the wallet
+	// should not move funds yet.
 	unsweptDeposits, err := FindDeposits(
 		mft.chain,
 		mft.btcChain,
 		walletPublicKeyHash,
-		0,
+		1,
 		true,
 		true,
 	)

--- a/pkg/tbtcpg/moving_funds_test.go
+++ b/pkg/tbtcpg/moving_funds_test.go
@@ -581,6 +581,13 @@ func TestMovingFundsAction_ProposeMovingFunds(t *testing.T) {
 
 			btcChain.SetEstimateSatPerVByteFee(1, 25)
 
+			tbtcChain.SetWallet(
+				walletPublicKeyHash,
+				&tbtc.WalletChainData{
+					MovingFundsRequestedAt: time.Now().Add(-25 * time.Hour),
+				},
+			)
+
 			tbtcChain.SetMovingFundsParameters(
 				txMaxTotalFee,
 				0,


### PR DESCRIPTION
Here we introduce two adjustments to the moving funds proposal generator.

First, we introduce a moving funds safety margin of 24 hours. Wallets that just entered the `MovingFunds` state may have received some last minute deposits just before. Even though deposit sweep task typically occurs before the moving funds task, such deposits may not be mature enough or have enough confirmations to be swept. We know that `MovingFunds` wallets cannot receive new deposits so, it makes sense to preserve a safety margin before moving funds to give the last minute deposits a chance to become eligible for sweeping by the deposit sweep task.

Second, we slightly optimize the unswept deposit check at the beginning of the moving funds task. It's enough to find one unswept deposit to abort the moving funds task.