### PR TITLE
Harden moving funds against edge cases

### DIFF
--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -223,6 +223,32 @@ type BridgeChain interface {
 		movingFundsTxHash bitcoin.Hash,
 		movingFundsTxOutpointIndex uint32,
 	) (*MovedFundsSweepRequest, bool, error)
+
+	// GetMovingFundsParameters gets the current value of parameters relevant
+	// for the moving funds process.
+	GetMovingFundsParameters() (
+		txMaxTotalFee uint64,
+		dustThreshold uint64,
+		timeoutResetDelay uint32,
+		timeout uint32,
+		timeoutSlashingAmount *big.Int,
+		timeoutNotifierRewardMultiplier uint32,
+		commitmentGasOffset uint16,
+		sweepTxMaxTotalFee uint64,
+		sweepTimeout uint32,
+		sweepTimeoutSlashingAmount *big.Int,
+		sweepTimeoutNotifierRewardMultiplier uint32,
+		err error,
+	)
+
+	// PastMovingFundsCommitmentSubmittedEvents fetches past moving funds
+	// commitment submitted events according to the provided filter or
+	// unfiltered if the filter is nil. Returned events are sorted by the block
+	// number in the ascending order, i.e. the latest event is at the end of the
+	// slice.
+	PastMovingFundsCommitmentSubmittedEvents(
+		filter *MovingFundsCommitmentSubmittedEventFilter,
+	) ([]*MovingFundsCommitmentSubmittedEvent, error)
 }
 
 // NewWalletRegisteredEvent represents a new wallet registered event.

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -1099,6 +1099,29 @@ func buildMovedFundsSweepProposalValidationKey(
 	return sha256.Sum256(buffer.Bytes()), nil
 }
 
+func (lc *localChain) GetMovingFundsParameters() (
+	txMaxTotalFee uint64,
+	dustThreshold uint64,
+	timeoutResetDelay uint32,
+	timeout uint32,
+	timeoutSlashingAmount *big.Int,
+	timeoutNotifierRewardMultiplier uint32,
+	commitmentGasOffset uint16,
+	sweepTxMaxTotalFee uint64,
+	sweepTimeout uint32,
+	sweepTimeoutSlashingAmount *big.Int,
+	sweepTimeoutNotifierRewardMultiplier uint32,
+	err error,
+) {
+	panic("unsupported")
+}
+
+func (lc *localChain) PastMovingFundsCommitmentSubmittedEvents(
+	filter *MovingFundsCommitmentSubmittedEventFilter,
+) ([]*MovingFundsCommitmentSubmittedEvent, error) {
+	panic("unsupported")
+}
+
 // Connect sets up the local chain.
 func Connect(blockTime ...time.Duration) *localChain {
 	operatorPrivateKey, _, err := operator.GenerateKeyPair(local_v1.DefaultCurve)

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -426,7 +426,7 @@ func ValidateMovingFundsSafetyMargin(
 	}
 
 	if isMovingFundsTarget {
-		safetyMargin = time.Duration(24) * 14 * time.Hour
+		safetyMargin = time.Duration(14*24) * time.Hour
 	}
 
 	// As the moving funds procedure is time constrained, we must ensure the

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -546,7 +546,7 @@ func isWalletPendingMovingFundsTarget(
 
 		// Our wallet is on the list of target wallets. If the state is moving
 		// funds, there is probably moving funds to our wallet in the process.
-		walletChainData, err := chain.GetWallet(walletPublicKeyHash)
+		walletChainData, err := chain.GetWallet(event.WalletPublicKeyHash)
 		if err != nil {
 			return false, fmt.Errorf(
 				"cannot get wallet's chain data: [%w]",

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -438,9 +438,7 @@ func ValidateMovingFundsSafetyMargin(
 		return fmt.Errorf("cannot get moving funds parameters: [%w]", err)
 	}
 
-	maxAllowedSafetyMargin := time.Duration(
-		float64(movingFundsTimeout) * 0.5 * float64(time.Second),
-	)
+	maxAllowedSafetyMargin := time.Duration(movingFundsTimeout/2) * time.Second
 
 	if safetyMargin > maxAllowedSafetyMargin {
 		safetyMargin = maxAllowedSafetyMargin

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -471,7 +471,6 @@ func (mfa *movingFundsAction) actionType() WalletActionType {
 
 func isWalletPendingMovingFundsTarget(
 	walletPublicKeyHash [20]byte,
-
 	chain interface {
 		BlockCounter() (chain.BlockCounter, error)
 
@@ -542,8 +541,9 @@ func isWalletPendingMovingFundsTarget(
 			continue
 		}
 
-		// Our wallet is on the list of target wallets. If the state is moving
-		// funds, there is probably moving funds to our wallet in the process.
+		// Our wallet is on the list of target wallets. If the state of the
+		// source wallet is still MovingFunds, the moving funds process
+		// targeting our wallet is likely in progress.
 		walletChainData, err := chain.GetWallet(event.WalletPublicKeyHash)
 		if err != nil {
 			return false, fmt.Errorf(

--- a/pkg/tbtc/moving_funds_test.go
+++ b/pkg/tbtc/moving_funds_test.go
@@ -2,7 +2,10 @@ package tbtc
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 
@@ -222,4 +225,211 @@ func TestAssembleMovingFundsTransaction(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestValidateMovingFundsSafetyMargin(t *testing.T) {
+	walletPublicKeyHash := hexToByte20(
+		"ffb3f7538bfa98a511495dd96027cfbd57baf2fa",
+	)
+
+	var tests = map[string]struct {
+		events           []*MovingFundsCommitmentSubmittedEvent
+		requestedAtDelta time.Duration
+		otherWallets     []struct {
+			publicKeyHash [20]byte
+			state         WalletState
+		}
+		movingFundsTimeout uint32
+		expectedError      error
+	}{
+		"wallet is not target and safety margin passed": {
+			events:             []*MovingFundsCommitmentSubmittedEvent{},
+			requestedAtDelta:   -25 * time.Hour,
+			movingFundsTimeout: 3628800, // 6 weeks
+			expectedError:      nil,
+		},
+		"wallet is not target and safety margin not passed": {
+			events:             []*MovingFundsCommitmentSubmittedEvent{},
+			requestedAtDelta:   -23 * time.Hour,
+			movingFundsTimeout: 3628800, // 6 weeks
+			expectedError:      fmt.Errorf("safety margin in force"),
+		},
+		"wallet is target and safety margin passed": {
+			events: []*MovingFundsCommitmentSubmittedEvent{
+				{
+					WalletPublicKeyHash: hexToByte20(
+						"3091d288521caec06ea912eacfd733edc5a36d6e",
+					),
+					TargetWallets: [][20]byte{
+						hexToByte20(
+							"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+						),
+						// wallet on the target wallets list
+						walletPublicKeyHash,
+					},
+				},
+			},
+			requestedAtDelta: -15 * 24 * time.Hour,
+			otherWallets: []struct {
+				publicKeyHash [20]byte
+				state         WalletState
+			}{
+				{
+					publicKeyHash: hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+					state:         StateMovingFunds,
+				},
+			},
+			movingFundsTimeout: 3628800, // 6 weeks
+			expectedError:      nil,
+		},
+		"wallet is target and safety margin not passed": {
+			events: []*MovingFundsCommitmentSubmittedEvent{
+				{
+					WalletPublicKeyHash: hexToByte20(
+						"3091d288521caec06ea912eacfd733edc5a36d6e",
+					),
+					TargetWallets: [][20]byte{
+						hexToByte20(
+							"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+						),
+						// wallet on the target wallets list
+						walletPublicKeyHash,
+					},
+				},
+			},
+			requestedAtDelta: -13 * 24 * time.Hour,
+			otherWallets: []struct {
+				publicKeyHash [20]byte
+				state         WalletState
+			}{
+				{
+					publicKeyHash: hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+					state:         StateMovingFunds,
+				},
+			},
+			movingFundsTimeout: 3628800, // 6 weeks
+			expectedError:      fmt.Errorf("safety margin in force"),
+		},
+		"wallet is target and safety margin limited and passed": {
+			events: []*MovingFundsCommitmentSubmittedEvent{
+				{
+					WalletPublicKeyHash: hexToByte20(
+						"3091d288521caec06ea912eacfd733edc5a36d6e",
+					),
+					TargetWallets: [][20]byte{
+						hexToByte20(
+							"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+						),
+						// wallet on the target wallets list
+						walletPublicKeyHash,
+					},
+				},
+			},
+			requestedAtDelta: -8 * 24 * time.Hour,
+			otherWallets: []struct {
+				publicKeyHash [20]byte
+				state         WalletState
+			}{
+				{
+					publicKeyHash: hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+					state:         StateMovingFunds,
+				},
+			},
+			// 2 weeks - it limits safety margin to 1 week (2 * 0.5)
+			movingFundsTimeout: 1209600,
+			expectedError:      nil,
+		},
+		"wallet is target and safety margin limited and not passed": {
+			events: []*MovingFundsCommitmentSubmittedEvent{
+				{
+					WalletPublicKeyHash: hexToByte20(
+						"3091d288521caec06ea912eacfd733edc5a36d6e",
+					),
+					TargetWallets: [][20]byte{
+						hexToByte20(
+							"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+						),
+						// wallet on the target wallets list
+						walletPublicKeyHash,
+					},
+				},
+			},
+			requestedAtDelta: -6 * 24 * time.Hour,
+			otherWallets: []struct {
+				publicKeyHash [20]byte
+				state         WalletState
+			}{
+				{
+					publicKeyHash: hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+					state:         StateMovingFunds,
+				},
+			},
+			// 2 weeks - it limits safety margin to 1 week (2 * 0.5)
+			movingFundsTimeout: 1209600,
+			expectedError:      fmt.Errorf("safety margin in force"),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			hostChain := Connect()
+
+			hostChain.SetMovingFundsParameters(
+				0,
+				0,
+				0,
+				test.movingFundsTimeout,
+				big.NewInt(0),
+				0,
+				0,
+				0,
+				0,
+				big.NewInt(0),
+				0,
+			)
+
+			hostChain.setPastMovingFundsCommitmentSubmittedEvents(
+				&MovingFundsCommitmentSubmittedEventFilter{
+					StartBlock: 0,
+				},
+				test.events,
+			)
+
+			hostChain.setWallet(walletPublicKeyHash, &WalletChainData{
+				MovingFundsRequestedAt: time.Now().Add(test.requestedAtDelta),
+			})
+
+			for _, wallet := range test.otherWallets {
+				hostChain.setWallet(wallet.publicKeyHash, &WalletChainData{
+					State: wallet.state,
+				})
+			}
+
+			err := ValidateMovingFundsSafetyMargin(
+				walletPublicKeyHash,
+				hostChain,
+			)
+
+			if !reflect.DeepEqual(test.expectedError, err) {
+				t.Errorf(
+					"unexpected error\nexpected: %v\nactual:   %v\n",
+					test.expectedError,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func hexToByte20(hexStr string) [20]byte {
+	if len(hexStr) != 40 {
+		panic("hex string length incorrect")
+	}
+	decoded, err := hex.DecodeString(hexStr)
+	if err != nil {
+		panic(err)
+	}
+	var result [20]byte
+	copy(result[:], decoded)
+	return result
 }

--- a/pkg/tbtc/moving_funds_test.go
+++ b/pkg/tbtc/moving_funds_test.go
@@ -48,6 +48,11 @@ func TestMovingFundsAction_Execute(t *testing.T) {
 			proposalExpiryBlock := proposalProcessingStartBlock +
 				movingFundsProposalValidityBlocks
 
+			// Set arbitrary moving funds timeout.
+			hostChain.SetMovingFundsParameters(
+				0, 0, 0, 604800, big.NewInt(0), 0, 0, 0, 0, big.NewInt(0), 0,
+			)
+
 			// Simulate the on-chain proposal validation passes with success.
 			err = hostChain.setMovingFundsProposalValidationResult(
 				walletPublicKeyHash,
@@ -58,6 +63,15 @@ func TestMovingFundsAction_Execute(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Simulate the wallet was not chosen as a target wallet for another
+			// moving funds wallet.
+			hostChain.setPastMovingFundsCommitmentSubmittedEvents(
+				&MovingFundsCommitmentSubmittedEventFilter{
+					StartBlock: 0,
+				},
+				[]*MovingFundsCommitmentSubmittedEvent{},
+			)
 
 			// Record the wallet main UTXO hash and moving funds commitment
 			// hash in the local host chain so the moving funds action can detect it.

--- a/pkg/tbtcpg/chain.go
+++ b/pkg/tbtcpg/chain.go
@@ -131,23 +131,6 @@ type Chain interface {
 		proposal *tbtc.HeartbeatProposal,
 	) error
 
-	// GetMovingFundsParameters gets the current value of parameters relevant
-	// for the moving funds process.
-	GetMovingFundsParameters() (
-		txMaxTotalFee uint64,
-		dustThreshold uint64,
-		timeoutResetDelay uint32,
-		timeout uint32,
-		timeoutSlashingAmount *big.Int,
-		timeoutNotifierRewardMultiplier uint32,
-		commitmentGasOffset uint16,
-		sweepTxMaxTotalFee uint64,
-		sweepTimeout uint32,
-		sweepTimeoutSlashingAmount *big.Int,
-		sweepTimeoutNotifierRewardMultiplier uint32,
-		err error,
-	)
-
 	// PastMovingFundsCommitmentSubmittedEvents fetches past moving funds
 	// commitment submitted events according to the provided filter or
 	// unfiltered if the filter is nil. Returned events are sorted by the block

--- a/pkg/tbtcpg/moving_funds.go
+++ b/pkg/tbtcpg/moving_funds.go
@@ -95,7 +95,7 @@ func (mft *MovingFundsTask) Run(request *tbtc.CoordinationProposalRequest) (
 
 	// Check the safety margin for moving funds early. This will prevent
 	// commitment submission if the wallet is not safe to move funds.
-	err = tbtc.ValidateMovingFundsSafetyMargin(walletChainData)
+	err = tbtc.ValidateMovingFundsSafetyMargin(walletPublicKeyHash, mft.chain)
 	if err != nil {
 		taskLogger.Infof("source wallet moving funds safety margin validation failed: [%v]", err)
 		return nil, false, nil

--- a/pkg/tbtcpg/moving_funds_test.go
+++ b/pkg/tbtcpg/moving_funds_test.go
@@ -579,6 +579,12 @@ func TestMovingFundsAction_ProposeMovingFunds(t *testing.T) {
 			tbtcChain := tbtcpg.NewLocalChain()
 			btcChain := tbtcpg.NewLocalBitcoinChain()
 
+			currentBlock := uint64(200000)
+
+			blockCounter := tbtcpg.NewMockBlockCounter()
+			blockCounter.SetCurrentBlock(currentBlock)
+			tbtcChain.SetBlockCounter(blockCounter)
+
 			btcChain.SetEstimateSatPerVByteFee(1, 25)
 
 			tbtcChain.SetWallet(
@@ -588,11 +594,20 @@ func TestMovingFundsAction_ProposeMovingFunds(t *testing.T) {
 				},
 			)
 
+			// Simulate the wallet was not chosen as a target wallet for another
+			// moving funds wallet.
+			tbtcChain.AddPastMovingFundsCommitmentSubmittedEvent(
+				&tbtc.MovingFundsCommitmentSubmittedEventFilter{
+					StartBlock: 0,
+				},
+				&tbtc.MovingFundsCommitmentSubmittedEvent{},
+			)
+
 			tbtcChain.SetMovingFundsParameters(
 				txMaxTotalFee,
 				0,
 				0,
-				0,
+				604800,
 				nil,
 				0,
 				0,


### PR DESCRIPTION
#Refs https://github.com/keep-network/keep-core/issues/3812.
This PR modifies the safety margin validation process used during moving funds.
It is possible that a wallet may receive deposits just before it changes states to `MovingFunds`.
It is also possible another wallets in `MovingFunds` state may commit to transfer their funds to it.  
To avoid a situation where a wallet ends up with additional funds after it has already moved their own funds we must apply a safety margin. 
In https://github.com/keep-network/keep-core/pull/3810 we already added a 24-hour safety margin. 
In this PR we add a longer 14-days safety margin when the wallet is a target of a moving funds process from another wallet. We also make sure the calculated safety margin is not greater than half of the `movingFundsTimeout`, so that a wallet has enough time to finish their moving funds process.
