### PR TITLE
Archive key material on wallet closure

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1453,6 +1453,21 @@ func (tc *TbtcChain) GetWallet(
 	}, nil
 }
 
+func (tc *TbtcChain) OnWalletClosed(
+	handler func(event *tbtc.WalletClosedEvent),
+) subscription.EventSubscription {
+	onEvent := func(
+		walletID [32]byte,
+		blockNumber uint64,
+	) {
+		handler(&tbtc.WalletClosedEvent{
+			WalletID:    walletID,
+			BlockNumber: blockNumber,
+		})
+	}
+	return tc.walletRegistry.WalletClosedEvent(nil, nil).OnEvent(onEvent)
+}
+
 func (tc *TbtcChain) ComputeMainUtxoHash(
 	mainUtxo *bitcoin.UnspentTransactionOutput,
 ) [32]byte {

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1415,6 +1415,21 @@ func (tc *TbtcChain) PastNewWalletRegisteredEvents(
 	return convertedEvents, err
 }
 
+func (tc *TbtcChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
+	isWalletRegistered, err := tc.walletRegistry.IsWalletRegistered(
+		EcdsaWalletID,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"cannot check if wallet with ECDSA ID [0x%x] is registered: [%v]",
+			EcdsaWalletID,
+			err,
+		)
+	}
+
+	return isWalletRegistered, nil
+}
+
 func (tc *TbtcChain) GetWallet(
 	walletPublicKeyHash [20]byte,
 ) (*tbtc.WalletChainData, error) {

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1415,6 +1415,24 @@ func (tc *TbtcChain) PastNewWalletRegisteredEvents(
 	return convertedEvents, err
 }
 
+func (tc *TbtcChain) CalculateWalletID(
+	walletPublicKey *ecdsa.PublicKey,
+) ([32]byte, error) {
+	return calculateWalletID(walletPublicKey)
+}
+
+func calculateWalletID(walletPublicKey *ecdsa.PublicKey) ([32]byte, error) {
+	walletPublicKeyBytes, err := convertPubKeyToChainFormat(walletPublicKey)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf(
+			"error while converting wallet public key to chain format: [%v]",
+			err,
+		)
+	}
+
+	return crypto.Keccak256Hash(walletPublicKeyBytes[:]), nil
+}
+
 func (tc *TbtcChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
 	isWalletRegistered, err := tc.walletRegistry.IsWalletRegistered(
 		EcdsaWalletID,

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -277,6 +278,49 @@ func TestCalculateInactivityClaimHash(t *testing.T) {
 		expectedHash,
 		hex.EncodeToString(hash[:]),
 	)
+}
+
+func TestCalculateWalletID(t *testing.T) {
+	hexToByte32 := func(hexStr string) [32]byte {
+		if len(hexStr) != 64 {
+			t.Fatal("hex string length incorrect")
+		}
+
+		decoded, err := hex.DecodeString(hexStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var result [32]byte
+		copy(result[:], decoded)
+
+		return result
+	}
+
+	xBytes := hexToByte32(
+		"9a0544440cc47779235ccb76d669590c2cd20c7e431f97e17a1093faf03291c4",
+	)
+
+	yBytes := hexToByte32(
+		"73e661a208a8a565ca1e384059bd2ff7ff6886df081ff1229250099d388c83df",
+	)
+
+	walletPublicKey := &ecdsa.PublicKey{
+		Curve: local_v1.DefaultCurve,
+		X:     new(big.Int).SetBytes(xBytes[:]),
+		Y:     new(big.Int).SetBytes(yBytes[:]),
+	}
+
+	actualWalletID, err := calculateWalletID(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedWalletID := hexToByte32(
+		"a6602e554b8cf7c23538fd040e4ff3520ec680e5e5ce9a075259e613a3e5aa79",
+	)
+
+	testutils.AssertBytesEqual(t, expectedWalletID[:], actualWalletID[:])
 }
 
 func TestParseDkgResultValidationOutcome(t *testing.T) {

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -262,6 +262,14 @@ type BridgeChain interface {
 	// according to the on-chain Bridge rules.
 	ComputeMainUtxoHash(mainUtxo *bitcoin.UnspentTransactionOutput) [32]byte
 
+	// PastNewWalletRegisteredEvents fetches past new wallet registered events
+	// according to the provided filter or unfiltered if the filter is nil.
+	// Returned events are sorted by the block number in the ascending order,
+	// i.e. the latest event is at the end of the slice.
+	PastNewWalletRegisteredEvents(
+		filter *NewWalletRegisteredEventFilter,
+	) ([]*NewWalletRegisteredEvent, error)
+
 	// PastDepositRevealedEvents fetches past deposit reveal events according
 	// to the provided filter or unfiltered if the filter is nil. Returned
 	// events are sorted by the block number in the ascending order, i.e. the

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -245,6 +245,10 @@ type WalletClosedEvent struct {
 // BridgeChain defines the subset of the TBTC chain interface that pertains
 // specifically to the tBTC Bridge operations.
 type BridgeChain interface {
+	// CalculateWalletID calculates the wallet's ECDSA ID based on the provided
+	// wallet public key.
+	CalculateWalletID(walletPublicKey *ecdsa.PublicKey) ([32]byte, error)
+
 	// IsWalletRegistered checks whether the given wallet is registered in the
 	// ECDSA wallet registry.
 	IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error)

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -268,14 +268,6 @@ type BridgeChain interface {
 	// according to the on-chain Bridge rules.
 	ComputeMainUtxoHash(mainUtxo *bitcoin.UnspentTransactionOutput) [32]byte
 
-	// PastNewWalletRegisteredEvents fetches past new wallet registered events
-	// according to the provided filter or unfiltered if the filter is nil.
-	// Returned events are sorted by the block number in the ascending order,
-	// i.e. the latest event is at the end of the slice.
-	PastNewWalletRegisteredEvents(
-		filter *NewWalletRegisteredEventFilter,
-	) ([]*NewWalletRegisteredEvent, error)
-
 	// PastDepositRevealedEvents fetches past deposit reveal events according
 	// to the provided filter or unfiltered if the filter is nil. Returned
 	// events are sorted by the block number in the ascending order, i.e. the

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -245,6 +245,8 @@ type WalletClosedEvent struct {
 // BridgeChain defines the subset of the TBTC chain interface that pertains
 // specifically to the tBTC Bridge operations.
 type BridgeChain interface {
+	IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error)
+
 	// GetWallet gets the on-chain data for the given wallet. Returns an error
 	// if the wallet was not found.
 	GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -235,8 +235,8 @@ type DKGParameters struct {
 	ApprovePrecedencePeriodBlocks uint64
 }
 
-// WalletClosedEvent represents a wallet closed. It is emitted when the wallet
-// is closed in the wallet registry.
+// WalletClosedEvent represents a wallet closed event. It is emitted when the
+// wallet is closed in the wallet registry.
 type WalletClosedEvent struct {
 	WalletID    [32]byte
 	BlockNumber uint64

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -245,6 +245,8 @@ type WalletClosedEvent struct {
 // BridgeChain defines the subset of the TBTC chain interface that pertains
 // specifically to the tBTC Bridge operations.
 type BridgeChain interface {
+	// IsWalletRegistered checks whether the given wallet is registered in the
+	// ECDSA wallet registry.
 	IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error)
 
 	// GetWallet gets the on-chain data for the given wallet. Returns an error

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -235,12 +235,26 @@ type DKGParameters struct {
 	ApprovePrecedencePeriodBlocks uint64
 }
 
+// WalletClosedEvent represents a wallet closed. It is emitted when the wallet
+// is closed in the wallet registry.
+type WalletClosedEvent struct {
+	WalletID    [32]byte
+	BlockNumber uint64
+}
+
 // BridgeChain defines the subset of the TBTC chain interface that pertains
 // specifically to the tBTC Bridge operations.
 type BridgeChain interface {
 	// GetWallet gets the on-chain data for the given wallet. Returns an error
 	// if the wallet was not found.
 	GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)
+
+	// OnWalletClosed registers a callback that is invoked when an on-chain
+	// notification of the wallet closed is seen. The notification occurs when
+	// the wallet is closed or terminated.
+	OnWalletClosed(
+		func(event *WalletClosedEvent),
+	) subscription.EventSubscription
 
 	// ComputeMainUtxoHash computes the hash of the provided main UTXO
 	// according to the on-chain Bridge rules.

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -843,6 +843,10 @@ func buildDepositRequestKey(
 	return sha256.Sum256(append(fundingTxHash[:], buffer...))
 }
 
+func (lc *localChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
+	panic("unsupported")
+}
+
 func (lc *localChain) GetWallet(walletPublicKeyHash [20]byte) (
 	*WalletChainData,
 	error,

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -697,6 +697,12 @@ func (lc *localChain) GetInactivityClaimNonce(walletID [32]byte) (*big.Int, erro
 	return big.NewInt(int64(nonce)), nil
 }
 
+func (lc *localChain) PastNewWalletRegisteredEvents(
+	filter *NewWalletRegisteredEventFilter,
+) ([]*NewWalletRegisteredEvent, error) {
+	panic("unsupported")
+}
+
 func (lc *localChain) PastDepositRevealedEvents(
 	filter *DepositRevealedEventFilter,
 ) ([]*DepositRevealedEvent, error) {

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -853,6 +853,12 @@ func (lc *localChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
 	panic("unsupported")
 }
 
+func (lc *localChain) CalculateWalletID(
+	walletPublicKey *ecdsa.PublicKey,
+) ([32]byte, error) {
+	panic("unsupported")
+}
+
 func (lc *localChain) GetWallet(walletPublicKeyHash [20]byte) (
 	*WalletChainData,
 	error,

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -868,6 +868,12 @@ func (lc *localChain) setWallet(
 	lc.wallets[walletPublicKeyHash] = walletChainData
 }
 
+func (lc *localChain) OnWalletClosed(
+	handler func(event *WalletClosedEvent),
+) subscription.EventSubscription {
+	panic("unsupported")
+}
+
 func (lc *localChain) ComputeMainUtxoHash(
 	mainUtxo *bitcoin.UnspentTransactionOutput,
 ) [32]byte {

--- a/pkg/tbtc/deduplicator.go
+++ b/pkg/tbtc/deduplicator.go
@@ -16,8 +16,8 @@ const (
 	// DKGResultHashCachePeriod is the time period the cache maintains
 	// the given DKG result hash.
 	DKGResultHashCachePeriod = 7 * 24 * time.Hour
-	// WalletClosedCachePeriod is the time period the cache maintains
-	// the given wallet closed hash.
+	// WalletClosedCachePeriod is the time period the cache maintains the ID of
+	// a closed wallet.
 	WalletClosedCachePeriod = 7 * 24 * time.Hour
 )
 

--- a/pkg/tbtc/dkg_test.go
+++ b/pkg/tbtc/dkg_test.go
@@ -89,7 +89,14 @@ func TestDkgExecutor_RegisterSigner(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			persistenceHandle := &mockPersistenceHandle{}
-			walletRegistry := newWalletRegistry(persistenceHandle)
+			chain := Connect()
+			walletRegistry, err := newWalletRegistry(
+				persistenceHandle,
+				chain.CalculateWalletID,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			dkgExecutor := &dkgExecutor{
 				// setting only the fields really needed for this test

--- a/pkg/tbtc/inactivity_test.go
+++ b/pkg/tbtc/inactivity_test.go
@@ -157,12 +157,16 @@ func setupInactivityClaimExecutorScenario(t *testing.T) (
 	keyStorePersistence := createMockKeyStorePersistence(t, signers...)
 
 	walletPublicKeyHash := bitcoin.PublicKeyHash(signers[0].wallet.publicKey)
-	ecdsaWalletID := [32]byte{1, 2, 3}
+	walletID, err := localChain.CalculateWalletID(signers[0].wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	localChain.setWallet(
 		walletPublicKeyHash,
 		&WalletChainData{
-			EcdsaWalletID: ecdsaWalletID,
+			EcdsaWalletID: walletID,
+			State:         StateLive,
 		},
 	)
 
@@ -191,7 +195,7 @@ func setupInactivityClaimExecutorScenario(t *testing.T) (
 		t.Fatal("node is supposed to control wallet signers")
 	}
 
-	return executor, ecdsaWalletID, localChain
+	return executor, walletID, localChain
 }
 
 func TestSignClaim_SigningSuccessful(t *testing.T) {

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -1210,7 +1210,7 @@ func (n *node) handleWalletClosure(walletID [32]byte) error {
 	}
 
 	logger.Infof(
-		"Successfully archived wallet with wallet ID [0x%x] and public key "+
+		"successfully archived wallet with wallet ID [0x%x] and public key "+
 			"hash [0x%x]",
 		walletID,
 		walletPublicKeyHash,

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -1089,6 +1089,7 @@ func processCoordinationResult(node *node, result *coordinationResult) {
 	}
 }
 
+// archiveClosedWallets archives closed or terminated wallets.
 func (n *node) archiveClosedWallets() error {
 	getClosedWallets := func(walletPublicKeyHashes [][20]byte) (
 		closedWallets [][20]byte,

--- a/pkg/tbtc/node_test.go
+++ b/pkg/tbtc/node_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/generator"
 	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
@@ -30,6 +31,20 @@ func TestNode_GetSigningExecutor(t *testing.T) {
 	localProvider := local.Connect()
 
 	signer := createMockSigner(t)
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
+	walletID, err := localChain.CalculateWalletID(signer.wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain.setWallet(
+		walletPublicKeyHash,
+		&WalletChainData{
+			EcdsaWalletID: walletID,
+			State:         StateLive,
+		},
+	)
 
 	// Populate the mock keystore with the mock signer's data. This is
 	// required to make the node controlling the signer's wallet.
@@ -148,6 +163,20 @@ func TestNode_GetCoordinationExecutor(t *testing.T) {
 	localProvider := local.Connect()
 
 	signer := createMockSigner(t)
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
+	walletID, err := localChain.CalculateWalletID(signer.wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain.setWallet(
+		walletPublicKeyHash,
+		&WalletChainData{
+			EcdsaWalletID: walletID,
+			State:         StateLive,
+		},
+	)
 
 	// Populate the mock keystore with the mock signer's data. This is
 	// required to make the node controlling the signer's wallet.
@@ -271,6 +300,20 @@ func TestNode_RunCoordinationLayer(t *testing.T) {
 	localProvider := local.Connect()
 
 	signer := createMockSigner(t)
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
+	walletID, err := localChain.CalculateWalletID(signer.wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain.setWallet(
+		walletPublicKeyHash,
+		&WalletChainData{
+			EcdsaWalletID: walletID,
+			State:         StateLive,
+		},
+	)
 
 	// Populate the mock keystore with the mock signer's data. This is
 	// required to make the node controlling the signer's wallet.

--- a/pkg/tbtc/registry.go
+++ b/pkg/tbtc/registry.go
@@ -156,6 +156,9 @@ func (wr *walletRegistry) getWalletByPublicKeyHash(
 	return wallet{}, false
 }
 
+// archiveWallet archives the wallet with the given public key hash. The wallet
+// data is removed from the wallet cache and the entire wallet storage directory
+// is moved to the archive directory.
 func (wr *walletRegistry) archiveWallet(
 	walletPublicKeyHash [20]byte,
 ) error {
@@ -233,6 +236,8 @@ func (ws *walletStorage) saveSigner(signer *signer) error {
 	return nil
 }
 
+// archiveWallet archives the given wallet data in the underlying persistence
+// layer of the walletStorage.
 func (ws *walletStorage) archiveWallet(walletStoragePath string) error {
 	err := ws.persistence.Archive(walletStoragePath)
 	if err != nil {

--- a/pkg/tbtc/registry.go
+++ b/pkg/tbtc/registry.go
@@ -12,6 +12,10 @@ import (
 	"github.com/keep-network/keep-common/pkg/persistence"
 )
 
+// CalculateWalletIDFunc calculates the ECDSA wallet ID based on the provided
+// wallet public key.
+type CalculateWalletIdFunc func(walletPublicKey *ecdsa.PublicKey) ([32]byte, error)
+
 // walletRegistry is the component that holds the data of the wallets managed
 // by the given node. All functions of the registry are safe for concurrent use.
 type walletRegistry struct {
@@ -26,18 +30,28 @@ type walletRegistry struct {
 	// walletStorage is the handle to the wallet storage responsible for
 	// wallet persistence.
 	walletStorage *walletStorage
+
+	// calculateWalletIdFunc calculates the ECDSA wallet ID based on the
+	// provided wallet public key.
+	calculateWalletIdFunc CalculateWalletIdFunc
 }
 
 type walletCacheValue struct {
 	// SHA-256+RIPEMD-160 hash computed over the compressed ECDSA public key of
 	// the wallet.
 	walletPublicKeyHash [20]byte
+	// ECDSA wallet ID calculated as the keccak256 of the 64-byte-long
+	// concatenation of the X and Y coordinates of the wallet's public key.
+	walletID [32]byte
 	// Array of wallet signers controlled by this node.
 	signers []*signer
 }
 
 // newWalletRegistry creates a new instance of the walletRegistry.
-func newWalletRegistry(persistence persistence.ProtectedHandle) *walletRegistry {
+func newWalletRegistry(
+	persistence persistence.ProtectedHandle,
+	calculateWalletIdFunc CalculateWalletIdFunc,
+) (*walletRegistry, error) {
 	walletStorage := newWalletStorage(persistence)
 
 	// Pre-populate the wallet cache using the wallet storage.
@@ -53,9 +67,19 @@ func newWalletRegistry(persistence persistence.ProtectedHandle) *walletRegistry 
 			// them.
 			wallet := signers[0].wallet
 			walletPublicKeyHash := bitcoin.PublicKeyHash(wallet.publicKey)
+			walletID, err := calculateWalletIdFunc(wallet.publicKey)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"error while calculating wallet ID for wallet with public "+
+						"key hash [0x%x]: [%v]",
+					walletPublicKeyHash,
+					err,
+				)
+			}
 
 			walletCache[walletStorageKey] = &walletCacheValue{
 				walletPublicKeyHash: walletPublicKeyHash,
+				walletID:            walletID,
 				signers:             signers,
 			}
 
@@ -72,9 +96,10 @@ func newWalletRegistry(persistence persistence.ProtectedHandle) *walletRegistry 
 	}
 
 	return &walletRegistry{
-		walletCache:   walletCache,
-		walletStorage: walletStorage,
-	}
+		walletCache:           walletCache,
+		walletStorage:         walletStorage,
+		calculateWalletIdFunc: calculateWalletIdFunc,
+	}, nil
 }
 
 // getWalletsPublicKeys returns public keys of all registered wallets.
@@ -105,12 +130,18 @@ func (wr *walletRegistry) registerSigner(signer *signer) error {
 	walletStorageKey := getWalletStorageKey(signer.wallet.publicKey)
 
 	// If the wallet cache does not have the given entry yet, initialize
-	// the value and compute the wallet public key hash. This way, the hash
-	// is computed only once. No need to initialize signers slice as
+	// the value and compute the wallet ID and wallet public key hash. This way,
+	// the hashes are computed only once. No need to initialize signers slice as
 	// appending works with nil values.
 	if _, ok := wr.walletCache[walletStorageKey]; !ok {
+		walletID, err := wr.calculateWalletIdFunc(signer.wallet.publicKey)
+		if err != nil {
+			return fmt.Errorf("cannot calculate wallet ID: [%v]", err)
+		}
+
 		wr.walletCache[walletStorageKey] = &walletCacheValue{
 			walletPublicKeyHash: bitcoin.PublicKeyHash(signer.wallet.publicKey),
+			walletID:            walletID,
 		}
 	}
 
@@ -156,6 +187,23 @@ func (wr *walletRegistry) getWalletByPublicKeyHash(
 	return wallet{}, false
 }
 
+// getWalletByID gets the given wallet by its 32-byte wallet ID. Second boolean
+// return value denotes whether the wallet was found in the registry or not.
+func (wr *walletRegistry) getWalletByID(walletID [32]byte) (wallet, bool) {
+	wr.mutex.Lock()
+	defer wr.mutex.Unlock()
+
+	for _, value := range wr.walletCache {
+		if value.walletID == walletID {
+			// All signers belong to one wallet. Take that wallet from the
+			// first signer.
+			return value.signers[0].wallet, true
+		}
+	}
+
+	return wallet{}, false
+}
+
 // archiveWallet archives the wallet with the given public key hash. The wallet
 // data is removed from the wallet cache and the entire wallet storage directory
 // is moved to the archive directory.
@@ -176,12 +224,7 @@ func (wr *walletRegistry) archiveWallet(
 	}
 
 	if walletPublicKey == nil {
-		logger.Infof(
-			"node does not control wallet with public key hash [0x%x]; "+
-				"quitting wallet archiving",
-			walletPublicKeyHash,
-		)
-		return nil
+		return fmt.Errorf("wallet not found in the wallet cache")
 	}
 
 	walletStorageKey := getWalletStorageKey(walletPublicKey)

--- a/pkg/tbtc/registry.go
+++ b/pkg/tbtc/registry.go
@@ -238,8 +238,8 @@ func (ws *walletStorage) saveSigner(signer *signer) error {
 
 // archiveWallet archives the given wallet data in the underlying persistence
 // layer of the walletStorage.
-func (ws *walletStorage) archiveWallet(walletStoragePath string) error {
-	err := ws.persistence.Archive(walletStoragePath)
+func (ws *walletStorage) archiveWallet(walletStorageKey string) error {
+	err := ws.persistence.Archive(walletStorageKey)
 	if err != nil {
 		return fmt.Errorf(
 			"could not archive wallet storage using the "+

--- a/pkg/tbtc/registry.go
+++ b/pkg/tbtc/registry.go
@@ -220,6 +220,7 @@ func (wr *walletRegistry) archiveWallet(
 			// All signers belong to one wallet. Take the wallet public key from
 			//  the first signer.
 			walletPublicKey = value.signers[0].wallet.publicKey
+			break
 		}
 	}
 

--- a/pkg/tbtc/registry_test.go
+++ b/pkg/tbtc/registry_test.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -15,14 +16,21 @@ import (
 
 func TestWalletRegistry_RegisterSigner(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
 	walletStorageKey := getWalletStorageKey(signer.wallet.publicKey)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,12 +70,19 @@ func TestWalletRegistry_RegisterSigner(t *testing.T) {
 
 func TestWalletRegistry_GetSigners(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,12 +103,19 @@ func TestWalletRegistry_GetSigners(t *testing.T) {
 
 func TestWalletRegistry_getWalletByPublicKeyHash(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,12 +132,19 @@ func TestWalletRegistry_getWalletByPublicKeyHash(t *testing.T) {
 
 func TestWalletRegistry_getWalletByPublicKeyHash_NotFound(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,6 +158,75 @@ func TestWalletRegistry_getWalletByPublicKeyHash_NotFound(t *testing.T) {
 	})
 
 	_, ok := walletRegistry.getWalletByPublicKeyHash(walletPublicKeyHash)
+	if ok {
+		t.Error("should not return a wallet")
+	}
+}
+
+func TestWalletRegistry_getWalletByID(t *testing.T) {
+	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
+
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signer := createMockSigner(t)
+
+	err = walletRegistry.registerSigner(signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
+	walletID, err := chain.CalculateWalletID(signer.wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wallet, ok := walletRegistry.getWalletByID(walletID)
+	if !ok {
+		t.Error("should return a wallet")
+	}
+
+	testutils.AssertStringsEqual(t, "wallet", signer.wallet.String(), wallet.String())
+}
+
+func TestWalletRegistry_getWalletByID_NotFound(t *testing.T) {
+	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
+
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signer := createMockSigner(t)
+
+	err = walletRegistry.registerSigner(signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x, y := tecdsa.Curve.ScalarBaseMult(big.NewInt(100).Bytes())
+
+	walletID, err := chain.CalculateWalletID(&ecdsa.PublicKey{
+		Curve: tecdsa.Curve,
+		X:     x,
+		Y:     y,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := walletRegistry.getWalletByID(walletID)
 	if ok {
 		t.Error("should not return a wallet")
 	}
@@ -153,8 +251,16 @@ func TestWalletRegistry_PrePopulateWalletCache(t *testing.T) {
 		},
 	}
 
+	chain := Connect()
+
 	// Cache pre-population happens within newWalletRegistry.
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testutils.AssertIntsEqual(
 		t,
@@ -184,12 +290,19 @@ func TestWalletRegistry_PrePopulateWalletCache(t *testing.T) {
 
 func TestWalletRegistry_GetWalletsPublicKeys(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,15 +320,22 @@ func TestWalletRegistry_GetWalletsPublicKeys(t *testing.T) {
 
 func TestWalletRegistry_ArchiveWallet(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
 	walletStorageKey := getWalletStorageKey(signer.wallet.publicKey)
 	walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,12 +369,19 @@ func TestWalletRegistry_ArchiveWallet(t *testing.T) {
 
 func TestWalletRegistry_ArchiveWallet_NotFound(t *testing.T) {
 	persistenceHandle := &mockPersistenceHandle{}
+	chain := Connect()
 
-	walletRegistry := newWalletRegistry(persistenceHandle)
+	walletRegistry, err := newWalletRegistry(
+		persistenceHandle,
+		chain.CalculateWalletID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	signer := createMockSigner(t)
 
-	err := walletRegistry.registerSigner(signer)
+	err = walletRegistry.registerSigner(signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,23 +390,16 @@ func TestWalletRegistry_ArchiveWallet_NotFound(t *testing.T) {
 	anotherWalletPublicKeyHash := [20]byte{1, 1, 2, 2, 3, 3}
 
 	err = walletRegistry.archiveWallet(anotherWalletPublicKeyHash)
-	if err != nil {
-		t.Fatal(err)
+
+	expectedErr := fmt.Errorf("wallet not found in the wallet cache")
+
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Fatalf(
+			"unexpected error\nexpected: %v\nactual:   %v",
+			expectedErr,
+			err,
+		)
 	}
-
-	testutils.AssertIntsEqual(
-		t,
-		"registered wallets count",
-		1,
-		len(walletRegistry.walletCache),
-	)
-
-	testutils.AssertIntsEqual(
-		t,
-		"archived wallets count",
-		0,
-		len(persistenceHandle.archived),
-	)
 }
 
 func TestWalletStorage_SaveSigner(t *testing.T) {

--- a/pkg/tbtc/signing_test.go
+++ b/pkg/tbtc/signing_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
 	"github.com/keep-network/keep-core/pkg/generator"
@@ -158,6 +159,20 @@ func setupSigningExecutor(t *testing.T) *signingExecutor {
 			privateKeyShare:         privateKeyShare,
 		}
 	}
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signers[0].wallet.publicKey)
+	walletID, err := localChain.CalculateWalletID(signers[0].wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain.setWallet(
+		walletPublicKeyHash,
+		&WalletChainData{
+			EcdsaWalletID: walletID,
+			State:         StateLive,
+		},
+	)
 
 	keyStorePersistence := createMockKeyStorePersistence(t, signers...)
 

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -270,8 +270,8 @@ func Initialize(
 				event.WalletID,
 			); !ok {
 				logger.Warnf(
-					"Wallet closure for wallet with ID [0x%x] at block [%v] has"+
-						"been already processed",
+					"Wallet closure for wallet with ID [0x%x] at block [%v] "+
+						"has been already processed",
 					event.WalletID,
 					event.BlockNumber,
 				)
@@ -279,7 +279,8 @@ func Initialize(
 			}
 
 			logger.Infof(
-				"Wallet with ID [0x%x] has been closed at block [%v]",
+				"Wallet with ID [0x%x] has been closed at block [%v]; "+
+					"proceeding with handling wallet closure",
 				event.WalletID,
 				event.BlockNumber,
 			)
@@ -289,7 +290,7 @@ func Initialize(
 			)
 			if err != nil {
 				logger.Errorf(
-					"Failure while handling wallet with ID [0x%x]: [%v]",
+					"Failure while handling wallet closure with ID [0x%x]: [%v]",
 					event.WalletID,
 					err,
 				)

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -264,6 +264,22 @@ func Initialize(
 		}()
 	})
 
+	_ = chain.OnWalletClosed(func(event *WalletClosedEvent) {
+		go func() {
+			// TODO: Most likely event deduplication is needed.
+
+			logger.Infof(
+				"Wallet with ID [0x%x] has been closed at block [%v]",
+				event.WalletID,
+				event.BlockNumber,
+			)
+
+			node.handleWalletClosure(
+				event.WalletID,
+			)
+		}()
+	})
+
 	return nil
 }
 

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -274,9 +274,16 @@ func Initialize(
 				event.BlockNumber,
 			)
 
-			node.handleWalletClosure(
+			err := node.handleWalletClosure(
 				event.WalletID,
 			)
+			if err != nil {
+				logger.Errorf(
+					"Failure while handling wallet with ID [0x%x]: [%v]",
+					event.WalletID,
+					err,
+				)
+			}
 		}()
 	})
 

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -266,7 +266,17 @@ func Initialize(
 
 	_ = chain.OnWalletClosed(func(event *WalletClosedEvent) {
 		go func() {
-			// TODO: Most likely event deduplication is needed.
+			if ok := deduplicator.notifyWalletClosed(
+				event.WalletID,
+			); !ok {
+				logger.Warnf(
+					"Wallet closure for wallet with ID [0x%x] at block [%v] has"+
+						"been already processed",
+					event.WalletID,
+					event.BlockNumber,
+				)
+				return
+			}
 
 			logger.Infof(
 				"Wallet with ID [0x%x] has been closed at block [%v]",

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -3,6 +3,7 @@ package tbtcpg
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -1021,6 +1022,12 @@ func (lc *LocalChain) SetAverageBlockTime(averageBlockTime time.Duration) {
 }
 
 func (lc *LocalChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
+	panic("unsupported")
+}
+
+func (lc *LocalChain) CalculateWalletID(
+	walletPublicKey *ecdsa.PublicKey,
+) ([32]byte, error) {
 	panic("unsupported")
 }
 

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -1020,6 +1020,10 @@ func (lc *LocalChain) SetAverageBlockTime(averageBlockTime time.Duration) {
 	lc.averageBlockTime = averageBlockTime
 }
 
+func (lc *LocalChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
+	panic("unsupported")
+}
+
 func (lc *LocalChain) GetWallet(walletPublicKeyHash [20]byte) (
 	*tbtc.WalletChainData,
 	error,

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/subscription"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
@@ -1043,6 +1044,12 @@ func (lc *LocalChain) SetWallet(
 	defer lc.mutex.Unlock()
 
 	lc.walletChainData[walletPublicKeyHash] = data
+}
+
+func (lc *LocalChain) OnWalletClosed(
+	handler func(event *tbtc.WalletClosedEvent),
+) subscription.EventSubscription {
+	panic("unsupported")
 }
 
 func (lc *LocalChain) GetWalletParameters() (


### PR DESCRIPTION
#Refs: https://github.com/keep-network/keep-core/issues/3797.
This PR handles archiving key material on wallet closures.
Archiving the wallet data happens in two situations:
- when the `WalletClosed` event is received
- on node start, if there are closed wallets in the node's wallet registry.

Archiving wallet's key material causes the wallet data to be moved to the `archive` directory and the wallet is removed
form the registry's cache..
Such wallets will no longer participate in the RFC-12 coordination.