### PR TITLE
Increase disk size for testnet ElectrumX node

### DIFF
--- a/infrastructure/kube/keep-test/bitcoin/testnet/electrumx/electrumx-data-electrumx-1-pvc.yaml
+++ b/infrastructure/kube/keep-test/bitcoin/testnet/electrumx/electrumx-data-electrumx-1-pvc.yaml
@@ -18,4 +18,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 30Gi
+      storage: 40Gi

--- a/infrastructure/kube/keep-test/bitcoin/testnet/electrumx/kustomization.yaml
+++ b/infrastructure/kube/keep-test/bitcoin/testnet/electrumx/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 30Gi
+                  storage: 40Gi
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
ElectrumX on testnet started failing with `plyvel._plyvel.IOError: b'IO error: utxo/MANIFEST-7126373: No space left on device'` error. I edited PVC to increase disk size from 30Gi to 40Gi.