### PR TITLE
Update version of `upload-artifact` and `dowload-artifact` to `v4`

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -123,7 +123,7 @@ jobs:
           docker save --output /tmp/go-build-env-image.tar go-build-env
 
       - name: Upload Docker Build Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: go-build-env-image
           path: /tmp/go-build-env-image.tar
@@ -189,7 +189,7 @@ jobs:
           context: .
 
       - name: Archive Client Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: |
@@ -309,7 +309,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Download Docker Build Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: go-build-env-image
           path: /tmp


### PR DESCRIPTION
The `v3` of the `actions/upload-artifact` and `actions/download-artifact` actions got
[deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) causing failure of workflow execution. We're upgrading to `v4` of the actions. Although there are some breaking changes in `v4` compared to `v3`, they do not affect our setup.