### PR TITLE
Remove bootstrap nodes from peer discovery

### DIFF
--- a/config/_peers/mainnet
+++ b/config/_peers/mainnet
@@ -3,5 +3,3 @@
 /dns4/keep-validator-0.prod-eks-eu-west-1.staked.cloud/tcp/3919/ipfs/16Uiu2HAm6Fs6Fn71n7PqRmpHMbfMkZUCGYhW5RL81MSMg57AANkZ
 /dns4/keep-validator-1.prod-eks-ap-northeast-2.staked.cloud/tcp/3919/ipfs/16Uiu2HAm5UzZb1TTYBjb2959h4z4VHzjt585SQqZnJPBrDnJuob7
 /dns4/keep-validator-2.prod-eks-eu-north-1.staked.cloud/tcp/3919/ipfs/16Uiu2HAmJvbYNhzY6a8kiG2zzrqXGnYWax7CQTbiMHoAvY4qLvg7
-/dns4/bootstrap-b1.threshold.p2p.org/tcp/3919/ipfs/16Uiu2HAmG7kjmp4D3C9jkvA8s59tfJzPfJSVqQJkhG6tEvVhJW68
-/dns4/bootstrap-b2.threshold.p2p.org/tcp/3919/ipfs/16Uiu2HAmSuXryEFqeDaMmRZ7KeUdQmHCt3PiWVNpe37q2xR3VT5n

--- a/config/_peers/testnet
+++ b/config/_peers/testnet
@@ -1,5 +1,2 @@
-/dns4/bootstrap-0.test.keep.network/tcp/3919/ipfs/16Uiu2HAmCcfVpHwfBKNFbQuhvGuFXHVLQ65gB4sJm7HyrcZuLttH
-/dns4/bootstrap-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
 /dns4/bst-a01.test.keep.boar.network/tcp/6001/ipfs/16Uiu2HAmSLDSahiKyTbCNNu8wJmZAsiKF7wuYJ8mogY8ZuAG1jhu
-/dns4/bootstrap-alpha.test.threshold.p2p.org/tcp/3919/ipfs/16Uiu2HAky2Y4Tyq5vTA1CxikcDes6o5EH11i2qcg5dBV9W3Lks5c
 /dns4/keep-validator-0.eks-ap-northeast-2-secure.staging.staked.cloud/tcp/3919/ipfs/16Uiu2HAm77eSvRq5ioD4J8VFPkq3bJHBEHkssCuiFkgAoABwjo2S


### PR DESCRIPTION
## Summary
Remove bootstrap node entries from embedded peer lists. Network will rely on existing participant nodes for peer discovery.

## Changes
- **Mainnet**: Remove 2 bootstrap nodes (`bootstrap-b1.threshold.p2p.org`, `bootstrap-b2.threshold.p2p.org`)  
- **Testnet**: Remove 3 bootstrap nodes (`bootstrap-0.test.keep.network`, `bootstrap-1.test.keep.network`, `bootstrap-alpha.test.threshold.p2p.org`)

## Remaining Peers
- **Mainnet**: 5 participant nodes (2 Boar + 3 Staked)
- **Testnet**: 2 participant nodes (1 Boar + 1 Staked)

## Technical Notes
- No code changes - existing libp2p implementation handles any peer type
- Participant nodes provide sufficient connectivity for network operation
- DNS-based addressing preserved for operational flexibility