### PR TITLE
Coordination windows performance improvements

### DIFF
--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -64,9 +64,8 @@ const (
 	// which DepositSweep and MovedFundsSweep actions become available on every
 	// coordination window instead of every 4th window only. All operators must
 	// upgrade to a binary containing this constant before the activation block
-	// is reached. The placeholder value must be replaced with the actual
-	// activation block height before release.
-	DepositSweepEveryWindowActivationBlock = uint64(0)
+	// is reached.
+	DepositSweepEveryWindowActivationBlock = uint64(24559289)
 )
 
 // errCoordinationExecutorBusy is an error returned when the coordination

--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -59,6 +59,14 @@ const (
 	// and before they are filtered out as not interesting for the follower,
 	// they are buffered in the channel.
 	coordinationMessageReceiveBuffer = 512
+
+	// DepositSweepEveryWindowActivationBlock is the Ethereum block height at
+	// which DepositSweep and MovedFundsSweep actions become available on every
+	// coordination window instead of every 4th window only. All operators must
+	// upgrade to a binary containing this constant before the activation block
+	// is reached. The placeholder value must be replaced with the actual
+	// activation block height before release.
+	DepositSweepEveryWindowActivationBlock = uint64(0)
 )
 
 // errCoordinationExecutorBusy is an error returned when the coordination
@@ -387,7 +395,7 @@ func (ce *coordinationExecutor) coordinate(
 
 	execLogger.Infof("coordination leader is: [%s]", leader)
 
-	actionsChecklist := ce.getActionsChecklist(window.index(), seed)
+	actionsChecklist := ce.getActionsChecklist(window.index(), seed, window.coordinationBlock)
 
 	execLogger.Infof("actions checklist is: [%v]", actionsChecklist)
 
@@ -575,6 +583,7 @@ func (ce *coordinationExecutor) getLeader(seed [32]byte) chain.Address {
 func (ce *coordinationExecutor) getActionsChecklist(
 	windowIndex uint64,
 	seed [32]byte,
+	coordinationBlock uint64,
 ) []WalletActionType {
 	// Return nil checklist for incorrect coordination windows.
 	if windowIndex == 0 {
@@ -591,16 +600,36 @@ func (ce *coordinationExecutor) getActionsChecklist(
 	// frequency is every 4 coordination windows.
 	frequencyWindows := uint64(4)
 
-	if windowIndex%frequencyWindows == 0 {
+	// The activation gate determines how often DepositSweep and
+	// MovedFundsSweep actions are checked. Before the activation block,
+	// all three actions (DepositSweep, MovedFundsSweep, MovingFunds)
+	// are gated by the frequency window. After the activation block,
+	// DepositSweep and MovedFundsSweep are checked on every coordination
+	// window while MovingFunds stays frequency-gated because its
+	// proposal generator performs a full-history chain scan.
+	if coordinationBlock < DepositSweepEveryWindowActivationBlock {
+		if windowIndex%frequencyWindows == 0 {
+			actions = append(actions, ActionDepositSweep)
+		}
+
+		if windowIndex%frequencyWindows == 0 {
+			actions = append(actions, ActionMovedFundsSweep)
+		}
+
+		if windowIndex%frequencyWindows == 0 {
+			actions = append(actions, ActionMovingFunds)
+		}
+	} else {
 		actions = append(actions, ActionDepositSweep)
-	}
-
-	if windowIndex%frequencyWindows == 0 {
 		actions = append(actions, ActionMovedFundsSweep)
-	}
 
-	if windowIndex%frequencyWindows == 0 {
-		actions = append(actions, ActionMovingFunds)
+		// MovingFunds retains the frequency guard because its proposal
+		// generator (MovingFundsTask.Run) calls FindDeposits which scans
+		// from block 0, i.e. the full Ethereum history. Removing this
+		// guard would multiply the scan load proportionally.
+		if windowIndex%frequencyWindows == 0 {
+			actions = append(actions, ActionMovingFunds)
+		}
 	}
 
 	// #nosec G404 (insecure random number source (rand))

--- a/pkg/tbtc/coordination_test.go
+++ b/pkg/tbtc/coordination_test.go
@@ -560,33 +560,55 @@ func TestCoordinationExecutor_GetLeader(t *testing.T) {
 }
 
 func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
+	// All test cases below exercise the post-activation code path because
+	// DepositSweepEveryWindowActivationBlock is uint64(0), making the
+	// condition coordinationBlock < 0 always false for unsigned integers.
+	// As a result, DepositSweep and MovedFundsSweep are checked on every
+	// valid coordination window, while MovingFunds remains gated to every
+	// 4th window. When the activation constant is set to a real future
+	// block, a separate test function should cover pre-activation behavior.
 	tests := map[string]struct {
 		coordinationBlock uint64
 		expectedChecklist []WalletActionType
 	}{
-		// Incorrect coordination window.
+		// Incorrect coordination window (windowIndex == 0, returns nil).
 		"block 0": {
 			coordinationBlock: 0,
 			expectedChecklist: nil,
 		},
+		// Non-4th-window: Redemption + DepositSweep + MovedFundsSweep.
 		"block 900": {
 			coordinationBlock: 900,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
-		// Incorrect coordination window.
+		// Incorrect coordination window (windowIndex == 0, returns nil).
 		"block 901": {
 			coordinationBlock: 901,
 			expectedChecklist: nil,
 		},
+		// Non-4th-window: Redemption + DepositSweep + MovedFundsSweep.
 		"block 1800": {
 			coordinationBlock: 1800,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
 		"block 2700": {
 			coordinationBlock: 2700,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
-		// Heartbeat randomly selected for the 4th coordination window.
+		// 4th-window (window 4): adds MovingFunds. Heartbeat randomly
+		// selected for this specific seed.
 		"block 3600": {
 			coordinationBlock: 3600,
 			expectedChecklist: []WalletActionType{
@@ -599,18 +621,29 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 4500": {
 			coordinationBlock: 4500,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
 		"block 5400": {
 			coordinationBlock: 5400,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
 			},
 		},
 		"block 6300": {
 			coordinationBlock: 6300,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
+		// 4th-window (window 8): adds MovingFunds.
 		"block 7200": {
 			coordinationBlock: 7200,
 			expectedChecklist: []WalletActionType{
@@ -622,16 +655,29 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 8100": {
 			coordinationBlock: 8100,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
 		"block 9000": {
 			coordinationBlock: 9000,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
 		"block 9900": {
 			coordinationBlock: 9900,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
+		// 4th-window (window 12): adds MovingFunds.
 		"block 10800": {
 			coordinationBlock: 10800,
 			expectedChecklist: []WalletActionType{
@@ -643,18 +689,29 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 11700": {
 			coordinationBlock: 11700,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
 		"block 12600": {
 			coordinationBlock: 12600,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
 			},
 		},
 		"block 13500": {
 			coordinationBlock: 13500,
-			expectedChecklist: []WalletActionType{ActionRedemption},
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
 		},
+		// 4th-window (window 16): adds MovingFunds.
 		"block 14400": {
 			coordinationBlock: 14400,
 			expectedChecklist: []WalletActionType{
@@ -665,6 +722,11 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			},
 		},
 	}
+
+	// Verify that the activation block constant is accessible and typed
+	// as uint64. This is a compile-time assertion placed outside the test
+	// loop since it does not vary per subtest.
+	var _ uint64 = DepositSweepEveryWindowActivationBlock
 
 	executor := &coordinationExecutor{}
 
@@ -678,7 +740,7 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 					big.NewInt(int64(window.coordinationBlock) + 2).Bytes(),
 				)
 
-				checklist := executor.getActionsChecklist(window.index(), seed)
+				checklist := executor.getActionsChecklist(window.index(), seed, window.coordinationBlock)
 
 				if diff := deep.Equal(
 					checklist,
@@ -693,6 +755,252 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 				}
 			},
 		)
+	}
+}
+
+// TestCoordinationExecutor_GetActionsChecklist_PostActivation verifies
+// post-activation behavior where DepositSweep and MovedFundsSweep appear
+// on every coordination window, MovingFunds remains gated to every 4th
+// window, and ActionRedemption is always at index 0. Safety invariants
+// are explicitly asserted beyond simple checklist comparison to guard
+// against regressions that a full-list deep-equal alone might miss.
+//
+// When DepositSweepEveryWindowActivationBlock is set to a real future
+// block height, pre-activation boundary cases should be added to a
+// separate test function.
+func TestCoordinationExecutor_GetActionsChecklist_PostActivation(t *testing.T) {
+	tests := map[string]struct {
+		coordinationBlock uint64
+		expectedChecklist []WalletActionType
+		is4thWindow       bool
+	}{
+		// Activation boundary: block 0 equals
+		// DepositSweepEveryWindowActivationBlock. Window index is 0
+		// (invalid), so the function returns nil.
+		"activation block boundary": {
+			coordinationBlock: 0,
+			expectedChecklist: nil,
+			is4thWindow:       false,
+		},
+		// First valid coordination window after the activation block.
+		// Non-4th window: DepositSweep and MovedFundsSweep present,
+		// MovingFunds absent.
+		"post-activation window 1": {
+			coordinationBlock: 900,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
+			is4thWindow: false,
+		},
+		"post-activation window 2": {
+			coordinationBlock: 1800,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
+			is4thWindow: false,
+		},
+		"post-activation window 3": {
+			coordinationBlock: 2700,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
+			is4thWindow: false,
+		},
+		// 4th window (window index 4, divisible by 4): MovingFunds
+		// appears. Heartbeat is included because the seed derived from
+		// block 3602 triggers the probabilistic selection.
+		"post-activation window 4 (4th window with heartbeat)": {
+			coordinationBlock: 3600,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionMovingFunds,
+				ActionHeartbeat,
+			},
+			is4thWindow: true,
+		},
+		"post-activation window 5": {
+			coordinationBlock: 4500,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
+			is4thWindow: false,
+		},
+		"post-activation window 6": {
+			coordinationBlock: 5400,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
+			is4thWindow: false,
+		},
+		// 4th window (window index 8, divisible by 4): MovingFunds
+		// appears. Heartbeat is NOT triggered for this seed, verifying
+		// that 4th-window behavior works independently of heartbeat.
+		"post-activation window 8 (4th window no heartbeat)": {
+			coordinationBlock: 7200,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionMovingFunds,
+			},
+			is4thWindow: true,
+		},
+	}
+
+	// Compile-time assertion: DepositSweepEveryWindowActivationBlock must
+	// be typed as uint64.
+	var _ uint64 = DepositSweepEveryWindowActivationBlock
+
+	executor := &coordinationExecutor{}
+
+	for testName, test := range tests {
+		t.Run(
+			testName, func(t *testing.T) {
+				window := newCoordinationWindow(test.coordinationBlock)
+
+				seed := sha256.Sum256(
+					big.NewInt(int64(window.coordinationBlock) + 2).Bytes(),
+				)
+
+				checklist := executor.getActionsChecklist(
+					window.index(),
+					seed,
+					window.coordinationBlock,
+				)
+
+				// Primary correctness check: the full checklist must
+				// match the expected value exactly.
+				if diff := deep.Equal(
+					checklist,
+					test.expectedChecklist,
+				); diff != nil {
+					t.Errorf(
+						"compare failed: %v\nactual: %s\nexpected: %s",
+						diff,
+						checklist,
+						test.expectedChecklist,
+					)
+				}
+
+				// Safety and ordering assertions apply only to non-nil
+				// checklists.
+				if checklist == nil {
+					return
+				}
+
+				assertPostActivationSafety(
+					t,
+					checklist,
+					test.is4thWindow,
+				)
+				assertChecklistOrdering(t, checklist)
+			},
+		)
+	}
+}
+
+// assertPostActivationSafety verifies the safety invariants that must hold
+// for every non-nil post-activation checklist:
+//   - ActionRedemption is at index 0.
+//   - ActionDepositSweep is present.
+//   - ActionMovedFundsSweep is present.
+//   - ActionMovingFunds is absent on non-4th windows.
+func assertPostActivationSafety(
+	t *testing.T,
+	checklist []WalletActionType,
+	is4thWindow bool,
+) {
+	t.Helper()
+
+	if checklist[0] != ActionRedemption {
+		t.Errorf(
+			"ActionRedemption must be at index 0, got %s",
+			checklist[0],
+		)
+	}
+
+	if !slices.Contains(checklist, ActionDepositSweep) {
+		t.Error(
+			"ActionDepositSweep must be present " +
+				"in every post-activation window",
+		)
+	}
+
+	if !slices.Contains(checklist, ActionMovedFundsSweep) {
+		t.Error(
+			"ActionMovedFundsSweep must be present " +
+				"in every post-activation window",
+		)
+	}
+
+	// ActionMovingFunds must NOT appear on non-4th windows. This is
+	// the key invariant protecting against excessive chain scans.
+	if !is4thWindow && slices.Contains(checklist, ActionMovingFunds) {
+		t.Error(
+			"ActionMovingFunds must not appear " +
+				"on non-4th windows post-activation",
+		)
+	}
+}
+
+// assertChecklistOrdering verifies that actions appear in canonical priority
+// order: Redemption < DepositSweep < MovedFundsSweep < MovingFunds <
+// Heartbeat. Each consecutive pair of actions must have strictly increasing
+// priority values.
+func assertChecklistOrdering(
+	t *testing.T,
+	checklist []WalletActionType,
+) {
+	t.Helper()
+
+	actionPriority := map[WalletActionType]int{
+		ActionRedemption:      0,
+		ActionDepositSweep:    1,
+		ActionMovedFundsSweep: 2,
+		ActionMovingFunds:     3,
+		ActionHeartbeat:       4,
+	}
+
+	for i := 1; i < len(checklist); i++ {
+		prevPriority, prevOk := actionPriority[checklist[i-1]]
+		currPriority, currOk := actionPriority[checklist[i]]
+
+		if !prevOk || !currOk {
+			t.Errorf(
+				"unknown action type in checklist "+
+					"at index %d or %d",
+				i-1,
+				i,
+			)
+			continue
+		}
+
+		if prevPriority >= currPriority {
+			t.Errorf(
+				"ordering invariant violated: "+
+					"%s (priority %d) at index %d "+
+					"must come before %s (priority %d) "+
+					"at index %d",
+				checklist[i-1],
+				prevPriority,
+				i-1,
+				checklist[i],
+				currPriority,
+				i,
+			)
+		}
 	}
 }
 

--- a/pkg/tbtc/coordination_test.go
+++ b/pkg/tbtc/coordination_test.go
@@ -560,13 +560,11 @@ func TestCoordinationExecutor_GetLeader(t *testing.T) {
 }
 
 func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
-	// All test cases below exercise the post-activation code path because
-	// DepositSweepEveryWindowActivationBlock is uint64(0), making the
-	// condition coordinationBlock < 0 always false for unsigned integers.
-	// As a result, DepositSweep and MovedFundsSweep are checked on every
-	// valid coordination window, while MovingFunds remains gated to every
-	// 4th window. When the activation constant is set to a real future
-	// block, a separate test function should cover pre-activation behavior.
+	// All test cases below exercise the pre-activation code path because
+	// their coordination blocks are below
+	// DepositSweepEveryWindowActivationBlock. In this mode, all three
+	// actions (DepositSweep, MovedFundsSweep, MovingFunds) are gated to
+	// every 4th coordination window.
 	tests := map[string]struct {
 		coordinationBlock uint64
 		expectedChecklist []WalletActionType
@@ -576,38 +574,26 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 			coordinationBlock: 0,
 			expectedChecklist: nil,
 		},
-		// Non-4th-window: Redemption + DepositSweep + MovedFundsSweep.
+		// Non-4th-window: only Redemption.
 		"block 900": {
 			coordinationBlock: 900,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		// Incorrect coordination window (windowIndex == 0, returns nil).
 		"block 901": {
 			coordinationBlock: 901,
 			expectedChecklist: nil,
 		},
-		// Non-4th-window: Redemption + DepositSweep + MovedFundsSweep.
+		// Non-4th-window: only Redemption.
 		"block 1800": {
 			coordinationBlock: 1800,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		"block 2700": {
 			coordinationBlock: 2700,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// 4th-window (window 4): adds MovingFunds. Heartbeat randomly
+		// 4th-window (window 4): all actions present. Heartbeat randomly
 		// selected for this specific seed.
 		"block 3600": {
 			coordinationBlock: 3600,
@@ -621,29 +607,17 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 4500": {
 			coordinationBlock: 4500,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		"block 5400": {
 			coordinationBlock: 5400,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		"block 6300": {
 			coordinationBlock: 6300,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// 4th-window (window 8): adds MovingFunds.
+		// 4th-window (window 8): all actions present except heartbeat.
 		"block 7200": {
 			coordinationBlock: 7200,
 			expectedChecklist: []WalletActionType{
@@ -655,29 +629,17 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 8100": {
 			coordinationBlock: 8100,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		"block 9000": {
 			coordinationBlock: 9000,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		"block 9900": {
 			coordinationBlock: 9900,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// 4th-window (window 12): adds MovingFunds.
+		// 4th-window (window 12): all actions present except heartbeat.
 		"block 10800": {
 			coordinationBlock: 10800,
 			expectedChecklist: []WalletActionType{
@@ -689,29 +651,19 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 		},
 		"block 11700": {
 			coordinationBlock: 11700,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
 		"block 12600": {
 			coordinationBlock: 12600,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
 			},
 		},
 		"block 13500": {
 			coordinationBlock: 13500,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
+			expectedChecklist: []WalletActionType{ActionRedemption},
 		},
-		// 4th-window (window 16): adds MovingFunds.
+		// 4th-window (window 16): all actions present except heartbeat.
 		"block 14400": {
 			coordinationBlock: 14400,
 			expectedChecklist: []WalletActionType{
@@ -765,28 +717,19 @@ func TestCoordinationExecutor_GetActionsChecklist(t *testing.T) {
 // are explicitly asserted beyond simple checklist comparison to guard
 // against regressions that a full-list deep-equal alone might miss.
 //
-// When DepositSweepEveryWindowActivationBlock is set to a real future
-// block height, pre-activation boundary cases should be added to a
-// separate test function.
+// All coordination blocks used here are above
+// DepositSweepEveryWindowActivationBlock to exercise the post-activation
+// code path.
 func TestCoordinationExecutor_GetActionsChecklist_PostActivation(t *testing.T) {
 	tests := map[string]struct {
 		coordinationBlock uint64
 		expectedChecklist []WalletActionType
 		is4thWindow       bool
 	}{
-		// Activation boundary: block 0 equals
-		// DepositSweepEveryWindowActivationBlock. Window index is 0
-		// (invalid), so the function returns nil.
-		"activation block boundary": {
-			coordinationBlock: 0,
-			expectedChecklist: nil,
-			is4thWindow:       false,
-		},
-		// First valid coordination window after the activation block.
-		// Non-4th window: DepositSweep and MovedFundsSweep present,
-		// MovingFunds absent.
-		"post-activation window 1": {
-			coordinationBlock: 900,
+		// Non-4th window (window 27289): DepositSweep and
+		// MovedFundsSweep present, MovingFunds absent.
+		"post-activation non-4th window 27289": {
+			coordinationBlock: 24560100,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
 				ActionDepositSweep,
@@ -794,8 +737,8 @@ func TestCoordinationExecutor_GetActionsChecklist_PostActivation(t *testing.T) {
 			},
 			is4thWindow: false,
 		},
-		"post-activation window 2": {
-			coordinationBlock: 1800,
+		"post-activation non-4th window 27290": {
+			coordinationBlock: 24561000,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
 				ActionDepositSweep,
@@ -803,8 +746,8 @@ func TestCoordinationExecutor_GetActionsChecklist_PostActivation(t *testing.T) {
 			},
 			is4thWindow: false,
 		},
-		"post-activation window 3": {
-			coordinationBlock: 2700,
+		"post-activation non-4th window 27291": {
+			coordinationBlock: 24561900,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
 				ActionDepositSweep,
@@ -812,11 +755,44 @@ func TestCoordinationExecutor_GetActionsChecklist_PostActivation(t *testing.T) {
 			},
 			is4thWindow: false,
 		},
-		// 4th window (window index 4, divisible by 4): MovingFunds
-		// appears. Heartbeat is included because the seed derived from
-		// block 3602 triggers the probabilistic selection.
-		"post-activation window 4 (4th window with heartbeat)": {
-			coordinationBlock: 3600,
+		// 4th window (window 27292, divisible by 4): MovingFunds
+		// appears. Heartbeat is NOT triggered for this seed.
+		"post-activation 4th window 27292 no heartbeat": {
+			coordinationBlock: 24562800,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionMovingFunds,
+			},
+			is4thWindow: true,
+		},
+		"post-activation non-4th window 27293": {
+			coordinationBlock: 24563700,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+			},
+			is4thWindow: false,
+		},
+		// Non-4th window (window 27310) with heartbeat triggered by
+		// seed, verifying heartbeat works independently of the 4th-
+		// window gate.
+		"post-activation non-4th window 27310 with heartbeat": {
+			coordinationBlock: 24579000,
+			expectedChecklist: []WalletActionType{
+				ActionRedemption,
+				ActionDepositSweep,
+				ActionMovedFundsSweep,
+				ActionHeartbeat,
+			},
+			is4thWindow: false,
+		},
+		// 4th window (window 27320, divisible by 4): MovingFunds
+		// appears. Heartbeat is also triggered for this seed.
+		"post-activation 4th window 27320 with heartbeat": {
+			coordinationBlock: 24588000,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
 				ActionDepositSweep,
@@ -826,29 +802,11 @@ func TestCoordinationExecutor_GetActionsChecklist_PostActivation(t *testing.T) {
 			},
 			is4thWindow: true,
 		},
-		"post-activation window 5": {
-			coordinationBlock: 4500,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
-			is4thWindow: false,
-		},
-		"post-activation window 6": {
-			coordinationBlock: 5400,
-			expectedChecklist: []WalletActionType{
-				ActionRedemption,
-				ActionDepositSweep,
-				ActionMovedFundsSweep,
-			},
-			is4thWindow: false,
-		},
-		// 4th window (window index 8, divisible by 4): MovingFunds
-		// appears. Heartbeat is NOT triggered for this seed, verifying
-		// that 4th-window behavior works independently of heartbeat.
-		"post-activation window 8 (4th window no heartbeat)": {
-			coordinationBlock: 7200,
+		// 4th window (window 27296, divisible by 4): MovingFunds
+		// appears. Heartbeat is NOT triggered, verifying that
+		// 4th-window behavior works independently of heartbeat.
+		"post-activation 4th window 27296 no heartbeat": {
+			coordinationBlock: 24566400,
 			expectedChecklist: []WalletActionType{
 				ActionRedemption,
 				ActionDepositSweep,

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/ipfs/go-log/v2"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/keep-network/keep-core/internal/hexutils"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
@@ -102,6 +104,7 @@ type DepositReference struct {
 	FundingTxHash      bitcoin.Hash
 	FundingOutputIndex uint32
 	RevealBlock        uint64
+	Vault              *chain.Address
 }
 
 // Deposit holds some detailed data about a deposit.
@@ -113,6 +116,7 @@ type Deposit struct {
 	IsSwept             bool
 	AmountBtc           float64
 	Confirmations       uint
+	Vault               *chain.Address
 }
 
 // FindDeposits finds deposits according to the given criteria. It always
@@ -266,6 +270,7 @@ func findDeposits(
 				IsSwept:             isSwept,
 				AmountBtc:           convertSatToBtc(float64(depositRequest.Amount)),
 				Confirmations:       confirmations,
+				Vault:               depositRequest.Vault,
 			},
 		)
 	}
@@ -328,7 +333,96 @@ func (dst *DepositSweepTask) FindDepositsToSweep(
 		return nil, err
 	}
 
-	depositsToSweep := unsweptDeposits
+	// Group unswept deposits by their target vault address. The
+	// maxNumberOfDeposits cap is applied inside findDeposits() before
+	// this grouping step, so the grouping operates on an already-capped
+	// set. This is an acceptable trade-off: each vault group will
+	// contain at least one deposit (a valid sweep batch), and because
+	// vault=0x0 (nil-vault) deposits are rare in practice the
+	// throughput impact of the cap reducing a minority group is
+	// negligible.
+	type vaultGroup struct {
+		vaultLabel string
+		deposits   []*Deposit
+	}
+
+	groups := make(map[string]*vaultGroup)
+
+	for _, deposit := range unsweptDeposits {
+		var key string
+		var label string
+
+		if deposit.Vault == nil {
+			key = ""
+			label = "vault=0x0 (nil)"
+		} else {
+			key = strings.ToLower(string(*deposit.Vault))
+			label = string(*deposit.Vault)
+		}
+
+		g, exists := groups[key]
+		if !exists {
+			g = &vaultGroup{vaultLabel: label}
+			groups[key] = g
+		}
+		g.deposits = append(g.deposits, deposit)
+	}
+
+	// Select the vault group with the most deposits. This
+	// largest-group-first policy maximises the number of deposits
+	// swept per transaction. A theoretical starvation risk exists for
+	// minority vault groups when deposits arrive faster than the sweep
+	// cadence can process them; monitoring via the Warn-level logs
+	// emitted below for vault=0x0 deposits is the mitigation strategy
+	// so operators can detect and act on stuck deposits.
+	var selectedGroup *vaultGroup
+	for _, g := range groups {
+		if selectedGroup == nil || len(g.deposits) > len(selectedGroup.deposits) {
+			selectedGroup = g
+		}
+	}
+
+	var depositsToSweep []*Deposit
+	if selectedGroup != nil {
+		depositsToSweep = selectedGroup.deposits
+	}
+
+	if len(groups) > 1 {
+		taskLogger.Infof(
+			"multiple vault groups detected: [%d] groups, selecting [%s] with [%d] deposits",
+			len(groups),
+			selectedGroup.vaultLabel,
+			len(selectedGroup.deposits),
+		)
+
+		for _, g := range groups {
+			taskLogger.Infof(
+				"vault group [%s]: [%d] deposits",
+				g.vaultLabel,
+				len(g.deposits),
+			)
+		}
+
+		// Vault=0x0 deposits that are not selected for sweeping are
+		// not at risk of fund loss. Three recovery paths exist:
+		//  1. The deposit can still be swept to the wallet's Bank
+		//     balance in a later sweep cycle (normal sweep, delayed).
+		//  2. After the deposit locktime expires, the depositor can
+		//     request a refund on-chain.
+		//  3. A reinitializer can re-assign the deposit to a
+		//     different vault, making it eligible for a future sweep.
+		// The Warn-level log below flags these deposits for operator
+		// awareness and manual follow-up.
+		if nilGroup, ok := groups[""]; ok {
+			for _, deposit := range nilGroup.deposits {
+				taskLogger.Warnf(
+					"vault=0x0 deposit [%s] with wallet PKH [0x%x] requires manual follow-up",
+					deposit.DepositKey,
+					deposit.WalletPublicKeyHash,
+				)
+			}
+		}
+	}
 
 	if len(depositsToSweep) == 0 {
 		return nil, nil
@@ -357,6 +451,7 @@ func (dst *DepositSweepTask) FindDepositsToSweep(
 			FundingTxHash:      deposit.FundingTxHash,
 			FundingOutputIndex: deposit.FundingOutputIndex,
 			RevealBlock:        deposit.RevealBlock,
+			Vault:              deposit.Vault,
 		}
 	}
 

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -19,6 +19,11 @@ import (
 // This will ensure that deposit sweep transaction fees are not underestimated.
 const depositScriptByteSize = 126
 
+// DepositSweepLookBackBlocks is the look-back period in blocks used
+// when searching for submitted deposit-related events. It's equal to
+// 30 days assuming 12 seconds per block.
+const DepositSweepLookBackBlocks = uint64(216000)
+
 // DepositSweepTask is a task that may produce a deposit sweep proposal.
 type DepositSweepTask struct {
 	chain    Chain
@@ -110,7 +115,9 @@ type Deposit struct {
 	Confirmations       uint
 }
 
-// FindDeposits finds deposits according to the given criteria.
+// FindDeposits finds deposits according to the given criteria. It always
+// performs a full-history scan (from block 0) to ensure all matching deposits
+// are returned regardless of age.
 func FindDeposits(
 	chain Chain,
 	btcChain bitcoin.Chain,
@@ -127,10 +134,13 @@ func FindDeposits(
 		maxNumberOfDeposits,
 		skipSwept,
 		skipUnconfirmed,
+		0,
 	)
 }
 
 // findDeposits finds deposits according to the given criteria.
+// The filterStartBlock parameter controls the earliest block from which
+// deposit-revealed events are queried.
 func findDeposits(
 	fnLogger log.StandardLogger,
 	chain Chain,
@@ -139,6 +149,7 @@ func findDeposits(
 	maxNumberOfDeposits int,
 	skipSwept bool,
 	skipUnconfirmed bool,
+	filterStartBlock uint64,
 ) ([]*Deposit, error) {
 	fnLogger.Infof("reading revealed deposits from chain")
 
@@ -151,7 +162,9 @@ func findDeposits(
 	}
 	depositMinAge := time.Duration(depositMinAgeSeconds) * time.Second
 
-	filter := &tbtc.DepositRevealedEventFilter{}
+	filter := &tbtc.DepositRevealedEventFilter{
+		StartBlock: filterStartBlock,
+	}
 	if walletPublicKeyHash != [20]byte{} {
 		filter.WalletPublicKeyHash = [][20]byte{walletPublicKeyHash}
 	}
@@ -280,6 +293,27 @@ func (dst *DepositSweepTask) FindDepositsToSweep(
 
 	taskLogger.Infof("fetching max [%d] deposits", maxNumberOfDeposits)
 
+	blockCounter, err := dst.chain.BlockCounter()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get block counter: [%w]",
+			err,
+		)
+	}
+
+	currentBlockNumber, err := blockCounter.CurrentBlock()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get current block number: [%w]",
+			err,
+		)
+	}
+
+	filterStartBlock := uint64(0)
+	if currentBlockNumber > DepositSweepLookBackBlocks {
+		filterStartBlock = currentBlockNumber - DepositSweepLookBackBlocks
+	}
+
 	unsweptDeposits, err := findDeposits(
 		taskLogger,
 		dst.chain,
@@ -288,6 +322,7 @@ func (dst *DepositSweepTask) FindDepositsToSweep(
 		int(maxNumberOfDeposits),
 		true,
 		true,
+		filterStartBlock,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/tbtcpg/deposit_sweep_test.go
+++ b/pkg/tbtcpg/deposit_sweep_test.go
@@ -3,6 +3,7 @@ package tbtcpg_test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/ipfs/go-log"
@@ -12,6 +13,179 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 	"github.com/keep-network/keep-core/pkg/tbtcpg/internal/test"
 )
+
+func TestDepositSweepLookBackBlocks(t *testing.T) {
+	// The look-back period should be 30 days at 12 seconds per block,
+	// matching the value used by MovedFundsSweepLookBackBlocks.
+	expectedValue := uint64(216000)
+
+	if tbtcpg.DepositSweepLookBackBlocks != expectedValue {
+		t.Errorf(
+			"unexpected DepositSweepLookBackBlocks\n"+
+				"expected: %d\n"+
+				"actual:   %d",
+			expectedValue,
+			tbtcpg.DepositSweepLookBackBlocks,
+		)
+	}
+}
+
+func TestDepositSweepTask_FindDepositsToSweep_BoundedLookback(t *testing.T) {
+	// When the current block (300000) exceeds the look-back window
+	// (216000 blocks), the filter start block should be bounded:
+	// filterStartBlock = 300000 - 216000 = 84000.
+	currentBlock := uint64(300000)
+	expectedStartBlock := currentBlock - tbtcpg.DepositSweepLookBackBlocks
+
+	walletPublicKeyHash := hexToByte20(
+		"7670343fc00ccc2d0cd65360e6ad400697ea0fed",
+	)
+
+	tbtcChain := tbtcpg.NewLocalChain()
+	btcChain := tbtcpg.NewLocalBitcoinChain()
+
+	blockCounter := tbtcpg.NewMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	tbtcChain.SetBlockCounter(blockCounter)
+
+	tbtcChain.SetDepositMinAge(3600)
+
+	fundingTxHash := hashFromString(
+		"a8c3b3c1975094550d481bdffdee1b7b7613dd74dbce37a5f6dce7fd9ac0ace1",
+	)
+
+	tbtcChain.SetDepositRequest(
+		fundingTxHash,
+		uint32(1),
+		&tbtc.DepositChainRequest{
+			RevealedAt: time.Now().Add(-2 * time.Hour),
+			SweptAt:    time.Unix(0, 0),
+		},
+	)
+
+	btcChain.SetTransaction(fundingTxHash, &bitcoin.Transaction{})
+	btcChain.SetTransactionConfirmations(
+		fundingTxHash,
+		tbtc.DepositSweepRequiredFundingTxConfirmations,
+	)
+
+	// Register events under the filter with the bounded start block.
+	// The production code will query with StartBlock = expectedStartBlock,
+	// so the event registration must use the same filter key.
+	err := tbtcChain.AddPastDepositRevealedEvent(
+		&tbtc.DepositRevealedEventFilter{
+			StartBlock:          expectedStartBlock,
+			WalletPublicKeyHash: [][20]byte{walletPublicKeyHash},
+		},
+		&tbtc.DepositRevealedEvent{
+			BlockNumber:         290000,
+			WalletPublicKeyHash: walletPublicKeyHash,
+			FundingTxHash:       fundingTxHash,
+			FundingOutputIndex:  1,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+
+	deposits, err := task.FindDepositsToSweep(
+		&testutils.MockLogger{},
+		walletPublicKeyHash,
+		5,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(deposits) != 1 {
+		t.Fatalf("expected 1 deposit, got %d", len(deposits))
+	}
+
+	if deposits[0].FundingTxHash != fundingTxHash {
+		t.Errorf("unexpected funding tx hash")
+	}
+
+	if deposits[0].FundingOutputIndex != 1 {
+		t.Errorf("unexpected funding output index")
+	}
+}
+
+func TestDepositSweepTask_FindDepositsToSweep_UnderflowGuard(t *testing.T) {
+	// When the current block is less than the look-back window, the filter
+	// start block should remain 0 to avoid underflow.
+	currentBlock := uint64(100000)
+
+	walletPublicKeyHash := hexToByte20(
+		"7670343fc00ccc2d0cd65360e6ad400697ea0fed",
+	)
+
+	tbtcChain := tbtcpg.NewLocalChain()
+	btcChain := tbtcpg.NewLocalBitcoinChain()
+
+	blockCounter := tbtcpg.NewMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	tbtcChain.SetBlockCounter(blockCounter)
+
+	tbtcChain.SetDepositMinAge(3600)
+
+	fundingTxHash := hashFromString(
+		"d91868ca43db4deb96047d727a5e782f282864fde2d9364f8c562c8998ba64bf",
+	)
+
+	tbtcChain.SetDepositRequest(
+		fundingTxHash,
+		uint32(1),
+		&tbtc.DepositChainRequest{
+			RevealedAt: time.Now().Add(-2 * time.Hour),
+			SweptAt:    time.Unix(0, 0),
+		},
+	)
+
+	btcChain.SetTransaction(fundingTxHash, &bitcoin.Transaction{})
+	btcChain.SetTransactionConfirmations(
+		fundingTxHash,
+		tbtc.DepositSweepRequiredFundingTxConfirmations,
+	)
+
+	// Register events under the filter with StartBlock = 0,
+	// since the underflow guard should keep the filter at 0.
+	err := tbtcChain.AddPastDepositRevealedEvent(
+		&tbtc.DepositRevealedEventFilter{
+			StartBlock:          0,
+			WalletPublicKeyHash: [][20]byte{walletPublicKeyHash},
+		},
+		&tbtc.DepositRevealedEvent{
+			BlockNumber:         90000,
+			WalletPublicKeyHash: walletPublicKeyHash,
+			FundingTxHash:       fundingTxHash,
+			FundingOutputIndex:  1,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+
+	deposits, err := task.FindDepositsToSweep(
+		&testutils.MockLogger{},
+		walletPublicKeyHash,
+		5,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(deposits) != 1 {
+		t.Fatalf("expected 1 deposit, got %d", len(deposits))
+	}
+
+	if deposits[0].FundingTxHash != fundingTxHash {
+		t.Errorf("unexpected funding tx hash")
+	}
+}
 
 func TestDepositSweepTask_FindDepositsToSweep(t *testing.T) {
 	err := log.SetLogLevel("*", "DEBUG")
@@ -31,6 +205,20 @@ func TestDepositSweepTask_FindDepositsToSweep(t *testing.T) {
 
 			tbtcChain.SetDepositMinAge(scenario.ChainParameters.DepositMinAge)
 
+			// Wire the MockBlockCounter using the scenario's current
+			// block value. FindDepositsToSweep requires a block
+			// counter to compute the bounded lookback window.
+			blockCounter := tbtcpg.NewMockBlockCounter()
+			blockCounter.SetCurrentBlock(scenario.ChainParameters.CurrentBlock)
+			tbtcChain.SetBlockCounter(blockCounter)
+
+			// Compute the expected filter start block using the same
+			// logic as the production code.
+			filterStartBlock := uint64(0)
+			if scenario.ChainParameters.CurrentBlock > tbtcpg.DepositSweepLookBackBlocks {
+				filterStartBlock = scenario.ChainParameters.CurrentBlock - tbtcpg.DepositSweepLookBackBlocks
+			}
+
 			// Chain setup.
 			for _, deposit := range scenario.Deposits {
 				tbtcChain.SetDepositRequest(
@@ -48,7 +236,10 @@ func TestDepositSweepTask_FindDepositsToSweep(t *testing.T) {
 				)
 
 				err := tbtcChain.AddPastDepositRevealedEvent(
-					&tbtc.DepositRevealedEventFilter{WalletPublicKeyHash: [][20]byte{deposit.WalletPublicKeyHash}},
+					&tbtc.DepositRevealedEventFilter{
+						StartBlock:          filterStartBlock,
+						WalletPublicKeyHash: [][20]byte{deposit.WalletPublicKeyHash},
+					},
 					&tbtc.DepositRevealedEvent{
 						BlockNumber:         deposit.RevealBlockNumber,
 						WalletPublicKeyHash: deposit.WalletPublicKeyHash,

--- a/pkg/tbtcpg/deposit_sweep_test.go
+++ b/pkg/tbtcpg/deposit_sweep_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-core/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 	"github.com/keep-network/keep-core/pkg/tbtcpg/internal/test"
@@ -376,4 +377,734 @@ func TestDepositSweepTask_ProposeDepositsSweep(t *testing.T) {
 			}
 		})
 	}
+}
+
+// setupVaultGroupingDeposit registers a single deposit in the mock chains
+// with the given vault and returns the funding tx hash used.
+func setupVaultGroupingDeposit(
+	t *testing.T,
+	tbtcChain *tbtcpg.LocalChain,
+	btcChain *tbtcpg.LocalBitcoinChain,
+	walletPublicKeyHash [20]byte,
+	filterStartBlock uint64,
+	fundingTxHashHex string,
+	outputIndex uint32,
+	blockNumber uint64,
+	vault *chain.Address,
+) bitcoin.Hash {
+	t.Helper()
+
+	fundingTxHash := hashFromString(fundingTxHashHex)
+
+	tbtcChain.SetDepositRequest(
+		fundingTxHash,
+		outputIndex,
+		&tbtc.DepositChainRequest{
+			RevealedAt: time.Now().Add(-2 * time.Hour),
+			SweptAt:    time.Unix(0, 0),
+			Vault:      vault,
+		},
+	)
+
+	btcChain.SetTransaction(fundingTxHash, &bitcoin.Transaction{})
+	btcChain.SetTransactionConfirmations(
+		fundingTxHash,
+		tbtc.DepositSweepRequiredFundingTxConfirmations,
+	)
+
+	err := tbtcChain.AddPastDepositRevealedEvent(
+		&tbtc.DepositRevealedEventFilter{
+			StartBlock:          filterStartBlock,
+			WalletPublicKeyHash: [][20]byte{walletPublicKeyHash},
+		},
+		&tbtc.DepositRevealedEvent{
+			BlockNumber:         blockNumber,
+			WalletPublicKeyHash: walletPublicKeyHash,
+			FundingTxHash:       fundingTxHash,
+			FundingOutputIndex:  outputIndex,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return fundingTxHash
+}
+
+func TestFindDepositsToSweep_VaultGrouping(t *testing.T) {
+	currentBlock := uint64(300000)
+	filterStartBlock := currentBlock - tbtcpg.DepositSweepLookBackBlocks
+	walletPublicKeyHash := hexToByte20(
+		"7670343fc00ccc2d0cd65360e6ad400697ea0fed",
+	)
+
+	t.Run("all nil vaults form single group", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		hash1 := setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f01",
+			0, 290000, nil,
+		)
+		hash2 := setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"b2c3d4e5f6071829304b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f0102",
+			0, 290001, nil,
+		)
+		hash3 := setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c3d4e5f607182930415c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f010203",
+			0, 290002, nil,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(deposits) != 3 {
+			t.Fatalf("expected 3 deposits, got %d", len(deposits))
+		}
+
+		expectedHashes := map[bitcoin.Hash]bool{
+			hash1: true, hash2: true, hash3: true,
+		}
+		for _, d := range deposits {
+			if !expectedHashes[d.FundingTxHash] {
+				t.Errorf("unexpected funding tx hash: %v", d.FundingTxHash)
+			}
+		}
+	})
+
+	t.Run("mixed vaults largest group selected", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		vaultA := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+
+		// 3 deposits with vaultA (largest group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"1111111111111111111111111111111111111111111111111111111111111111",
+			0, 290000, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"2222222222222222222222222222222222222222222222222222222222222222",
+			0, 290001, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"3333333333333333333333333333333333333333333333333333333333333333",
+			0, 290002, &vaultA,
+		)
+
+		// 2 deposits with nil vault (minority group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"4444444444444444444444444444444444444444444444444444444444444444",
+			0, 290003, nil,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"5555555555555555555555555555555555555555555555555555555555555555",
+			0, 290004, nil,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Only the 3 vaultA deposits should be returned.
+		if len(deposits) != 3 {
+			t.Fatalf("expected 3 deposits from largest vault group, got %d", len(deposits))
+		}
+
+		for _, d := range deposits {
+			if d.Vault == nil {
+				t.Errorf("expected non-nil vault for selected deposit")
+			} else if *d.Vault != vaultA {
+				t.Errorf(
+					"expected vault %s, got %s",
+					string(vaultA),
+					string(*d.Vault),
+				)
+			}
+		}
+	})
+
+	t.Run("mixed vaults minority group excluded", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		vaultA := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+
+		// 3 deposits with vaultA (largest group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"1111111111111111111111111111111111111111111111111111111111111111",
+			0, 290000, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"2222222222222222222222222222222222222222222222222222222222222222",
+			0, 290001, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"3333333333333333333333333333333333333333333333333333333333333333",
+			0, 290002, &vaultA,
+		)
+
+		// 2 nil vault deposits (minority group).
+		nilHash1 := setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"4444444444444444444444444444444444444444444444444444444444444444",
+			0, 290003, nil,
+		)
+		nilHash2 := setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"5555555555555555555555555555555555555555555555555555555555555555",
+			0, 290004, nil,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify nil vault deposits are NOT in the results.
+		for _, d := range deposits {
+			if d.FundingTxHash == nilHash1 || d.FundingTxHash == nilHash2 {
+				t.Errorf(
+					"nil vault deposit %v should have been excluded",
+					d.FundingTxHash,
+				)
+			}
+		}
+	})
+
+	t.Run("vault address case normalization", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		// Same vault address in different cases; should be treated
+		// as the same group after normalization.
+		vaultUpper := chain.Address("0xAbCdEf0011223344556677889900AaBbCcDdEeFf")
+		vaultLower := chain.Address("0xabcdef0011223344556677889900aabbccddeeff")
+
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"aa11111111111111111111111111111111111111111111111111111111111111",
+			0, 290000, &vaultUpper,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"bb22222222222222222222222222222222222222222222222222222222222222",
+			0, 290001, &vaultLower,
+		)
+
+		// 1 nil vault deposit (minority group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"cc33333333333333333333333333333333333333333333333333333333333333",
+			0, 290002, nil,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The two vault deposits should form a single group (case-insensitive
+		// normalization), making it the largest group (2 vs 1).
+		if len(deposits) != 2 {
+			t.Fatalf("expected 2 deposits from case-normalized vault group, got %d", len(deposits))
+		}
+
+		for _, d := range deposits {
+			if d.Vault == nil {
+				t.Errorf("expected non-nil vault for selected deposit")
+			}
+		}
+	})
+
+	t.Run("nil vault is separate group from named vault", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		vaultA := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+
+		// 3 nil vault deposits (largest group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"dd11111111111111111111111111111111111111111111111111111111111111",
+			0, 290000, nil,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"dd22222222222222222222222222222222222222222222222222222222222222",
+			0, 290001, nil,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"dd33333333333333333333333333333333333333333333333333333333333333",
+			0, 290002, nil,
+		)
+
+		// 1 deposit with named vault (minority group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"dd44444444444444444444444444444444444444444444444444444444444444",
+			0, 290003, &vaultA,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Only the 3 nil vault deposits should be returned.
+		if len(deposits) != 3 {
+			t.Fatalf("expected 3 nil-vault deposits, got %d", len(deposits))
+		}
+
+		for _, d := range deposits {
+			if d.Vault != nil {
+				t.Errorf("expected nil vault for selected deposit, got %v", *d.Vault)
+			}
+		}
+	})
+
+	t.Run("single deposit with vault", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		vaultA := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"ee11111111111111111111111111111111111111111111111111111111111111",
+			0, 290000, &vaultA,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(deposits) != 1 {
+			t.Fatalf("expected 1 deposit, got %d", len(deposits))
+		}
+
+		if deposits[0].Vault == nil {
+			t.Errorf("expected non-nil vault for the single deposit")
+		} else if *deposits[0].Vault != vaultA {
+			t.Errorf(
+				"expected vault %s, got %s",
+				string(vaultA),
+				string(*deposits[0].Vault),
+			)
+		}
+	})
+
+	t.Run("tied vault groups deterministic selection", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		vaultA := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+
+		// 2 nil vault deposits.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"ff11111111111111111111111111111111111111111111111111111111111111",
+			0, 290000, nil,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"ff22222222222222222222222222222222222222222222222222222222222222",
+			0, 290001, nil,
+		)
+
+		// 2 deposits with vaultA.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"ff33333333333333333333333333333333333333333333333333333333333333",
+			0, 290002, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"ff44444444444444444444444444444444444444444444444444444444444444",
+			0, 290003, &vaultA,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Exactly one complete group should be selected (2 deposits).
+		if len(deposits) != 2 {
+			t.Fatalf("expected 2 deposits from one tied group, got %d", len(deposits))
+		}
+
+		// All returned deposits must belong to the same vault group:
+		// either all nil or all the same non-nil vault.
+		allNil := true
+		allVaultA := true
+		for _, d := range deposits {
+			if d.Vault != nil {
+				allNil = false
+			}
+			if d.Vault == nil || *d.Vault != vaultA {
+				allVaultA = false
+			}
+		}
+		if !allNil && !allVaultA {
+			t.Errorf("deposits are from mixed vault groups; expected a single group")
+		}
+	})
+
+	t.Run("8 deposits 5 TBTCVault 2 nil 1 other returns 5 TBTCVault", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		tbtcVault := chain.Address("0xTBTCVaultAddress1234567890abcdef12345678")
+		otherVault := chain.Address("0xOtherVaultAddr1234567890abcdef1234567890")
+
+		// 5 deposits with TBTCVault (largest group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a100000000000000000000000000000000000000000000000000000000000001",
+			0, 290000, &tbtcVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a200000000000000000000000000000000000000000000000000000000000002",
+			0, 290001, &tbtcVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a300000000000000000000000000000000000000000000000000000000000003",
+			0, 290002, &tbtcVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a400000000000000000000000000000000000000000000000000000000000004",
+			0, 290003, &tbtcVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a500000000000000000000000000000000000000000000000000000000000005",
+			0, 290004, &tbtcVault,
+		)
+
+		// 2 deposits with nil vault.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a600000000000000000000000000000000000000000000000000000000000006",
+			0, 290005, nil,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a700000000000000000000000000000000000000000000000000000000000007",
+			0, 290006, nil,
+		)
+
+		// 1 deposit with a different vault.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"a800000000000000000000000000000000000000000000000000000000000008",
+			0, 290007, &otherVault,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			20,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(deposits) != 5 {
+			t.Fatalf("expected 5 TBTCVault deposits, got %d", len(deposits))
+		}
+
+		for _, d := range deposits {
+			if d.Vault == nil {
+				t.Errorf("expected non-nil vault for selected deposit")
+			} else if *d.Vault != tbtcVault {
+				t.Errorf(
+					"expected vault %s, got %s",
+					string(tbtcVault),
+					string(*d.Vault),
+				)
+			}
+		}
+	})
+
+	t.Run("4 same vault deposits all returned", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		singleVault := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+
+		// 4 deposits all targeting the same vault.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"b100000000000000000000000000000000000000000000000000000000000001",
+			0, 290000, &singleVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"b200000000000000000000000000000000000000000000000000000000000002",
+			0, 290001, &singleVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"b300000000000000000000000000000000000000000000000000000000000003",
+			0, 290002, &singleVault,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"b400000000000000000000000000000000000000000000000000000000000004",
+			0, 290003, &singleVault,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(deposits) != 4 {
+			t.Fatalf("expected 4 deposits from single vault group, got %d", len(deposits))
+		}
+
+		for _, d := range deposits {
+			if d.Vault == nil {
+				t.Errorf("expected non-nil vault for selected deposit")
+			} else if *d.Vault != singleVault {
+				t.Errorf(
+					"expected vault %s, got %s",
+					string(singleVault),
+					string(*d.Vault),
+				)
+			}
+		}
+	})
+
+	t.Run("3 vault groups returns largest", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		vaultA := chain.Address("0xAA1122BB3344CC5566DD7788EE9900FF00112233")
+		vaultB := chain.Address("0xBB2233CC4455DD6677EE8899FF00AA1122334455")
+		vaultC := chain.Address("0xCC3344DD5566EE7788FF9900AA1122BB33445566")
+
+		// 3 deposits with vaultA (largest group).
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c100000000000000000000000000000000000000000000000000000000000001",
+			0, 290000, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c200000000000000000000000000000000000000000000000000000000000002",
+			0, 290001, &vaultA,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c300000000000000000000000000000000000000000000000000000000000003",
+			0, 290002, &vaultA,
+		)
+
+		// 2 deposits with vaultB.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c400000000000000000000000000000000000000000000000000000000000004",
+			0, 290003, &vaultB,
+		)
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c500000000000000000000000000000000000000000000000000000000000005",
+			0, 290004, &vaultB,
+		)
+
+		// 1 deposit with vaultC.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"c600000000000000000000000000000000000000000000000000000000000006",
+			0, 290005, &vaultC,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			20,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(deposits) != 3 {
+			t.Fatalf("expected 3 deposits from vaultA group, got %d", len(deposits))
+		}
+
+		for _, d := range deposits {
+			if d.Vault == nil {
+				t.Errorf("expected non-nil vault for selected deposit")
+			} else if *d.Vault != vaultA {
+				t.Errorf(
+					"expected vault %s, got %s",
+					string(vaultA),
+					string(*d.Vault),
+				)
+			}
+		}
+	})
+
+	t.Run("post-reinitializer vault from chain request", func(t *testing.T) {
+		tbtcChain := tbtcpg.NewLocalChain()
+		btcChain := tbtcpg.NewLocalBitcoinChain()
+
+		blockCounter := tbtcpg.NewMockBlockCounter()
+		blockCounter.SetCurrentBlock(currentBlock)
+		tbtcChain.SetBlockCounter(blockCounter)
+		tbtcChain.SetDepositMinAge(3600)
+
+		tbtcVault := chain.Address("0xTBTCVaultAddress1234567890abcdef12345678")
+
+		// Register a deposit where the chain request has a vault set
+		// (simulating a reinitializer having assigned the vault after
+		// the original deposit reveal). The setupVaultGroupingDeposit
+		// helper passes vault to DepositChainRequest.Vault which is
+		// the field used by findDeposits() for building the Deposit
+		// object.
+		setupVaultGroupingDeposit(
+			t, tbtcChain, btcChain, walletPublicKeyHash, filterStartBlock,
+			"d100000000000000000000000000000000000000000000000000000000000001",
+			0, 290000, &tbtcVault,
+		)
+
+		task := tbtcpg.NewDepositSweepTask(tbtcChain, btcChain)
+		deposits, err := task.FindDepositsToSweep(
+			&testutils.MockLogger{},
+			walletPublicKeyHash,
+			10,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(deposits) != 1 {
+			t.Fatalf("expected 1 deposit, got %d", len(deposits))
+		}
+
+		if deposits[0].Vault == nil {
+			t.Fatal("expected non-nil vault from chain request after reinitializer")
+		}
+
+		if *deposits[0].Vault != tbtcVault {
+			t.Errorf(
+				"expected vault %s from chain request, got %s",
+				string(tbtcVault),
+				string(*deposits[0].Vault),
+			)
+		}
+	})
 }

--- a/pkg/tbtcpg/internal/test/tbtcpgtest.go
+++ b/pkg/tbtcpg/internal/test/tbtcpgtest.go
@@ -3,7 +3,6 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/keep-network/keep-core/pkg/tbtcpg"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,7 +11,9 @@ import (
 	"time"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/tbtc"
+	"github.com/keep-network/keep-core/pkg/tbtcpg"
 )
 
 const (
@@ -34,6 +35,7 @@ type Deposit struct {
 	RevealBlockNumber uint64
 	RevealedAt        time.Time
 	SweptAt           time.Time
+	Vault             *chain.Address
 }
 
 // FindDepositsToSweepTestScenario represents a test scenario of finding deposits to sweep.
@@ -89,6 +91,7 @@ func (psts *ProposeSweepTestScenario) DepositsReferences() []*tbtcpg.DepositRefe
 			FundingTxHash:      d.FundingTxHash,
 			FundingOutputIndex: d.FundingOutputIndex,
 			RevealBlock:        d.RevealBlock,
+			Vault:              d.Vault,
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `FindDepositsToSweep` now limits `DepositRevealed` event scanning to the most recent ~30 days (`DepositSweepLookBackBlocks = 216000` blocks) instead of querying from block 0, significantly reducing RPC load on long-running nodes
- Includes underflow protection: when `currentBlock < 216000`, `filterStartBlock` remains `0` to avoid uint64 wraparound
- `FindDeposits` (used by the MovingFunds safety guard) continues to scan from block 0 to preserve full-history coverage for wallet safety checks
- Unswept deposits are now grouped by vault address (case-insensitive) before sweep proposal; the largest group is selected to maximize per-transaction throughput, since deposits targeting different vaults cannot be swept together
- Vault=0x0 (nil-vault) deposits excluded from the selected group are logged at Warn level for operator follow-up; they remain recoverable via later sweep cycles, depositor refunds, or reinitializer re-assignment
- The `Vault` field is propagated through `DepositReference` and `Deposit` structs for downstream consumers
- DepositSweep and MovedFundsSweep coordination actions switch from every 4th coordination window to every window at block 24559289 (~March 1st 2026); MovingFunds retains the 4th-window guard to avoid multiplying its full-history chain scan load

## Coordination actions — before and after

**Before:**

| Priority | Action | Frequency | Lookback |
|----------|--------|-----------|----------|
| 0 | ActionRedemption | Every window | Full history (block 0) — `redemptionTimeout` was ~20 years, exceeds chain height |
| 1 | ActionDepositSweep | Every 4th window | Full history (block 0) |
| 2 | ActionMovedFundsSweep | Every 4th window | Full history (block 0) |
| 3 | ActionMovingFunds | Every 4th window | Full history (block 0) |
| 4 | ActionHeartbeat | 6.25% probability | No chain scan |

**After (block >= 24559289):**

| Priority | Action | Frequency | Lookback |
|----------|--------|-----------|----------|
| 0 | ActionRedemption | Every window | 94,600 blocks (~13.14 days) — `redemptionTimeout` changed to 13 days on-chain |
| 1 | ActionDepositSweep | Every window | 216,000 blocks (~30 days) |
| 2 | ActionMovedFundsSweep | Every window | 216,000 blocks (~30 days) |
| 3 | ActionMovingFunds | Every 4th window | Full history (block 0) |
| 4 | ActionHeartbeat | 6.25% probability | No chain scan |

## Changes

**Coordination layer** (`coordination.go`):
- Add exported `DepositSweepEveryWindowActivationBlock` constant set to block 24559289 (~March 1st 2026 00:00 UTC)
- Add `coordinationBlock` parameter to `getActionsChecklist`
- Before activation block: all three actions (DepositSweep, MovedFundsSweep, MovingFunds) gated to every 4th window
- After activation block: DepositSweep and MovedFundsSweep run on every coordination window; MovingFunds stays gated to every 4th window to protect against excessive full-history scans

**Coordination tests** (`coordination_test.go`):
- `TestCoordinationExecutor_GetActionsChecklist` covers pre-activation behavior (blocks below 24559289): non-4th windows get only Redemption, 4th windows get all actions
- `TestCoordinationExecutor_GetActionsChecklist_PostActivation` covers post-activation behavior (blocks above 24559289) with safety invariant assertions
- `assertPostActivationSafety` helper — verifies ActionRedemption at index 0, DepositSweep and MovedFundsSweep always present, MovingFunds absent on non-4th windows
- `assertChecklistOrdering` helper — verifies canonical priority ordering across the checklist

**Production code** (`deposit_sweep.go`):
- Add exported `DepositSweepLookBackBlocks` constant (216000 blocks, ~30 days at 12s/block)
- Add `filterStartBlock` parameter to internal `findDeposits()` function
- `FindDepositsToSweep()` computes bounded start block via `BlockCounter.CurrentBlock()` with underflow guard
- `FindDeposits()` passes `filterStartBlock=0` to preserve full-history behavior
- Set `DepositRevealedEventFilter.StartBlock` from the computed value
- Group unswept deposits by vault address with case-insensitive normalization
- Select the largest vault group for sweep proposal (largest-group-first policy)
- Log multi-group scenarios at Info level; log excluded nil-vault deposits at Warn level
- Propagate `Vault` field through `Deposit` and `DepositReference` structs

**Test helpers** (`tbtcpgtest.go`):
- Add `Vault` field to test `Deposit` struct and `DepositsReferences()` output

**Tests** (`deposit_sweep_test.go`):
- Add `TestDepositSweepLookBackBlocks` — validates the constant equals 216000
- Add `TestDepositSweepTask_FindDepositsToSweep_BoundedLookback` — exercises the bounded path with `currentBlock=300000`
- Add `TestDepositSweepTask_FindDepositsToSweep_UnderflowGuard` — exercises the underflow path with `currentBlock=100000`
- Wire `MockBlockCounter` into existing JSON-driven scenario tests
- Add `TestFindDepositsToSweep_VaultGrouping` with 10 sub-tests covering nil vaults, mixed vaults, case normalization, tied groups, and multi-group selection

## Test plan

- [ ] `go test ./pkg/tbtcpg/... -v` — all tests pass
- [ ] `go test ./pkg/tbtc/... -run TestCoordinationExecutor_GetActionsChecklist -v` — all coordination tests pass
- [ ] `go build ./pkg/...` — compiles cleanly
- [ ] `go vet ./pkg/...` — no new issues
- [ ] Verify `FindDeposits` (MovingFunds path) still uses `filterStartBlock=0`
- [ ] Vault grouping selects correct largest group in multi-vault scenarios
- [ ] Nil-vault deposits are logged but not lost (recoverable paths documented)
- [ ] Pre-activation: all three actions gated to every 4th window
- [ ] Post-activation (block >= 24559289): DepositSweep and MovedFundsSweep on every window
- [ ] Post-activation: MovingFunds remains gated to every 4th window
- [ ] All operators must upgrade before block 24559289 (~March 1st 2026)