### PR TITLE
Increase MovedFundsSweepLookBackBlocks from 30 to 50 days

### DIFF
--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -25,8 +25,8 @@ var ErrNoPendingMovedFundsSweepRequests = fmt.Errorf(
 
 // MovedFundsSweepLookBackBlocks is the look-back period in blocks used
 // when searching for submitted moving funds-related events. It's equal to
-// 30 days assuming 12 seconds per block.
-const MovedFundsSweepLookBackBlocks = uint64(216000)
+// 50 days assuming 12 seconds per block.
+const MovedFundsSweepLookBackBlocks = uint64(360000)
 
 // MovedFundsSweepTask is a task that may produce a moved funds sweep proposal.
 type MovedFundsSweepTask struct {


### PR DESCRIPTION
## Summary

- Increase `MovedFundsSweepLookBackBlocks` from `uint64(216000)` (30 days) to `uint64(360000)` (50 days)
- Fixes a production failure where 363.54 BTC became stuck because a `MovingFundsCompleted` event was ~38 days old (273,886 blocks), exceeding the current 216,000-block lookback by ~58,000 blocks
- The new 360,000-block lookback provides 32% headroom beyond the observed failure case

## Details

The constant is used in `FindMovingFundsTxData()` to compute `filterStartBlock = currentBlockNumber - MovedFundsSweepLookBackBlocks`, which determines how far back to search for `MovingFundsCommitmentSubmitted` and `MovingFundsCompleted` events.

**Arithmetic:**
- Old: `216,000 blocks × 12s = 30 days`
- New: `360,000 blocks × 12s = 50 days`

**RPC impact:** Negligible — `MovingFundsCompleted` events are rare (~10-15/year across all wallets), and log filtering is indexed by topic and contract address.

## Test plan

- [x] `go build ./pkg/tbtcpg/...` compiles
- [x] `go test ./pkg/tbtcpg/...` passes (all existing tests use symbolic reference to the constant)
- [x] `go test -race ./pkg/tbtcpg/...` passes
- [x] `go vet ./pkg/tbtcpg/...` passes