### PR TITLE
Scaffold frost_tbtc_signer native engine registration

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1467,21 +1467,46 @@ func pastNewWalletRegisteredV2Events(
 	walletPublicKeyHash [][20]byte,
 	bridge any,
 ) ([]*tbtc.NewWalletRegisteredEvent, error) {
+	if bridge == nil {
+		return nil, nil
+	}
+
 	bridgeValue := reflect.ValueOf(bridge)
 	pastV2Events := bridgeValue.MethodByName("PastNewWalletRegisteredV2Events")
 	if !pastV2Events.IsValid() {
 		return nil, nil
 	}
 
-	results := pastV2Events.Call(
-		[]reflect.Value{
-			reflect.ValueOf(startBlock),
-			reflect.ValueOf(endBlock),
-			reflect.ValueOf(walletID),
-			reflect.ValueOf(ecdsaWalletID),
-			reflect.ValueOf(walletPublicKeyHash),
-		},
+	var (
+		results []reflect.Value
+		callErr error
 	)
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				callErr = fmt.Errorf(
+					"panic calling PastNewWalletRegisteredV2Events: [%v]",
+					recovered,
+				)
+			}
+		}()
+
+		results = pastV2Events.Call(
+			[]reflect.Value{
+				reflect.ValueOf(startBlock),
+				reflect.ValueOf(endBlock),
+				reflect.ValueOf(walletID),
+				reflect.ValueOf(ecdsaWalletID),
+				reflect.ValueOf(walletPublicKeyHash),
+			},
+		)
+	}()
+
+	if callErr != nil {
+		return nil, callErr
+	}
+
 	if len(results) != 2 {
 		return nil, fmt.Errorf(
 			"unexpected PastNewWalletRegisteredV2Events result count: [%v]",
@@ -1534,6 +1559,13 @@ func pastNewWalletRegisteredV2Events(
 			walletPubKeyHashField = eventValue.FieldByName("WalletPublicKeyHash")
 		}
 		rawField := eventValue.FieldByName("Raw")
+		if !rawField.IsValid() {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 raw event payload at index [%v]",
+				i,
+			)
+		}
+
 		if rawField.Kind() == reflect.Pointer {
 			if rawField.IsNil() {
 				return nil, fmt.Errorf("unexpected nil raw event payload")
@@ -1541,6 +1573,15 @@ func pastNewWalletRegisteredV2Events(
 
 			rawField = rawField.Elem()
 		}
+
+		if rawField.Kind() != reflect.Struct {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 raw event payload kind at index [%v]: [%v]",
+				i,
+				rawField.Kind(),
+			)
+		}
+
 		blockNumberField := rawField.FieldByName("BlockNumber")
 
 		if !walletIDField.IsValid() ||
@@ -1686,13 +1727,10 @@ func resolveWalletPublicKeyHashForWalletID(
 	bridge any,
 ) ([20]byte, error) {
 	resolveCanonical, ok := bridge.(walletPublicKeyHashForWalletIDFn)
-	if !ok {
-		resolveCanonical = nil
-	}
 
 	var walletPublicKeyHash [20]byte
 	var err error
-	if resolveCanonical != nil {
+	if ok {
 		walletPublicKeyHash, err = resolveCanonical.WalletPubKeyHashForWalletID(walletID)
 	} else {
 		err = fmt.Errorf("wallet public key hash accessor unavailable")
@@ -1706,6 +1744,14 @@ func resolveWalletPublicKeyHashForWalletID(
 
 	legacyWalletPublicKeyHash, ok := tbtc.WalletPublicKeyHashFromLegacyWalletID(walletID)
 	if ok {
+		if err != nil {
+			logger.Infof(
+				"canonical wallet public key hash resolution failed for wallet ID [0x%x]; using legacy derivation: [%v]",
+				walletID,
+				err,
+			)
+		}
+
 		return legacyWalletPublicKeyHash, nil
 	}
 

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1392,18 +1392,10 @@ func (tc *TbtcChain) PastNewWalletRegisteredEvents(
 		walletID,
 		ecdsaWalletID,
 		walletPublicKeyHash,
-		tc.bridge.PastNewWalletRegisteredV2Events,
+		tc.bridge,
 		tc.bridge.PastNewWalletRegisteredEvents,
 	)
 }
-
-type pastNewWalletRegisteredV2EventsFn func(
-	startBlock uint64,
-	endBlock *uint64,
-	walletID [][32]byte,
-	ecdsaWalletID [][32]byte,
-	walletPubKeyHash [][20]byte,
-) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error)
 
 type pastNewWalletRegisteredEventsFn func(
 	startBlock uint64,
@@ -1418,30 +1410,19 @@ func pastNewWalletRegisteredEvents(
 	walletID [][32]byte,
 	ecdsaWalletID [][32]byte,
 	walletPublicKeyHash [][20]byte,
-	pastV2Events pastNewWalletRegisteredV2EventsFn,
+	bridge any,
 	pastLegacyEvents pastNewWalletRegisteredEventsFn,
 ) ([]*tbtc.NewWalletRegisteredEvent, error) {
-	v2Events, err := pastV2Events(
+	convertedEvents, err := pastNewWalletRegisteredV2Events(
 		startBlock,
 		endBlock,
 		walletID,
 		ecdsaWalletID,
 		walletPublicKeyHash,
+		bridge,
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	convertedEvents := make([]*tbtc.NewWalletRegisteredEvent, 0, len(v2Events))
-	for _, event := range v2Events {
-		convertedEvent := &tbtc.NewWalletRegisteredEvent{
-			WalletID:            event.WalletID,
-			EcdsaWalletID:       event.EcdsaWalletID,
-			WalletPublicKeyHash: event.WalletPubKeyHash,
-			BlockNumber:         event.Raw.BlockNumber,
-		}
-
-		convertedEvents = append(convertedEvents, convertedEvent)
 	}
 
 	// Fallback for legacy deployments that do not emit NewWalletRegisteredV2.
@@ -1474,6 +1455,118 @@ func pastNewWalletRegisteredEvents(
 			return convertedEvents[i].BlockNumber < convertedEvents[j].BlockNumber
 		},
 	)
+
+	return convertedEvents, nil
+}
+
+func pastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+	bridge any,
+) ([]*tbtc.NewWalletRegisteredEvent, error) {
+	bridgeValue := reflect.ValueOf(bridge)
+	pastV2Events := bridgeValue.MethodByName("PastNewWalletRegisteredV2Events")
+	if !pastV2Events.IsValid() {
+		return nil, nil
+	}
+
+	results := pastV2Events.Call(
+		[]reflect.Value{
+			reflect.ValueOf(startBlock),
+			reflect.ValueOf(endBlock),
+			reflect.ValueOf(walletID),
+			reflect.ValueOf(ecdsaWalletID),
+			reflect.ValueOf(walletPublicKeyHash),
+		},
+	)
+	if len(results) != 2 {
+		return nil, fmt.Errorf(
+			"unexpected PastNewWalletRegisteredV2Events result count: [%v]",
+			len(results),
+		)
+	}
+
+	if !results[1].IsNil() {
+		err, ok := results[1].Interface().(error)
+		if !ok {
+			return nil, fmt.Errorf(
+				"unexpected PastNewWalletRegisteredV2Events error type: [%T]",
+				results[1].Interface(),
+			)
+		}
+
+		return nil, err
+	}
+
+	eventsValue := results[0]
+	if eventsValue.Kind() != reflect.Slice {
+		return nil, fmt.Errorf(
+			"unexpected PastNewWalletRegisteredV2Events events type: [%v]",
+			eventsValue.Kind(),
+		)
+	}
+
+	convertedEvents := make([]*tbtc.NewWalletRegisteredEvent, 0, eventsValue.Len())
+	for i := 0; i < eventsValue.Len(); i++ {
+		eventValue := eventsValue.Index(i)
+		if eventValue.Kind() == reflect.Pointer {
+			if eventValue.IsNil() {
+				continue
+			}
+
+			eventValue = eventValue.Elem()
+		}
+
+		if eventValue.Kind() != reflect.Struct {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 event kind: [%v]",
+				eventValue.Kind(),
+			)
+		}
+
+		walletIDField := eventValue.FieldByName("WalletID")
+		ecdsaWalletIDField := eventValue.FieldByName("EcdsaWalletID")
+		walletPubKeyHashField := eventValue.FieldByName("WalletPubKeyHash")
+		if !walletPubKeyHashField.IsValid() {
+			walletPubKeyHashField = eventValue.FieldByName("WalletPublicKeyHash")
+		}
+		rawField := eventValue.FieldByName("Raw")
+		if rawField.Kind() == reflect.Pointer {
+			if rawField.IsNil() {
+				return nil, fmt.Errorf("unexpected nil raw event payload")
+			}
+
+			rawField = rawField.Elem()
+		}
+		blockNumberField := rawField.FieldByName("BlockNumber")
+
+		if !walletIDField.IsValid() ||
+			walletIDField.Type() != reflect.TypeOf([32]byte{}) ||
+			!ecdsaWalletIDField.IsValid() ||
+			ecdsaWalletIDField.Type() != reflect.TypeOf([32]byte{}) ||
+			!walletPubKeyHashField.IsValid() ||
+			walletPubKeyHashField.Type() != reflect.TypeOf([20]byte{}) ||
+			!blockNumberField.IsValid() ||
+			blockNumberField.Kind() != reflect.Uint64 {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 event shape at index [%v]",
+				i,
+			)
+		}
+
+		convertedEvents = append(
+			convertedEvents,
+			&tbtc.NewWalletRegisteredEvent{
+				WalletID:            walletIDField.Interface().([32]byte),
+				EcdsaWalletID:       ecdsaWalletIDField.Interface().([32]byte),
+				WalletPublicKeyHash: walletPubKeyHashField.Interface().([20]byte),
+				BlockNumber:         blockNumberField.Uint(),
+			},
+		)
+	}
 
 	return convertedEvents, nil
 }
@@ -1536,7 +1629,10 @@ func (tc *TbtcChain) GetWallet(
 		return nil, fmt.Errorf("cannot parse wallet state: [%v]", err)
 	}
 
-	walletID, err := tc.bridge.WalletID(walletPublicKeyHash)
+	walletID, err := walletIDForWalletPublicKeyHash(
+		tc.bridge,
+		walletPublicKeyHash,
+	)
 	if err != nil {
 		// Fallback for legacy deployments where walletID accessor may not exist.
 		walletID = tbtc.DeriveLegacyWalletID(walletPublicKeyHash)
@@ -1561,19 +1657,47 @@ func (tc *TbtcChain) WalletPublicKeyHashForWalletID(
 ) ([20]byte, error) {
 	return resolveWalletPublicKeyHashForWalletID(
 		walletID,
-		tc.bridge.WalletPubKeyHashForWalletID,
+		tc.bridge,
 	)
 }
 
-type walletPublicKeyHashForWalletIDFn func(
-	walletID [32]byte,
-) ([20]byte, error)
+type walletIDForWalletPublicKeyHashFn interface {
+	WalletID(walletPublicKeyHash [20]byte) ([32]byte, error)
+}
+
+func walletIDForWalletPublicKeyHash(
+	bridge any,
+	walletPublicKeyHash [20]byte,
+) ([32]byte, error) {
+	resolver, ok := bridge.(walletIDForWalletPublicKeyHashFn)
+	if !ok {
+		return [32]byte{}, fmt.Errorf("wallet ID accessor unavailable")
+	}
+
+	return resolver.WalletID(walletPublicKeyHash)
+}
+
+type walletPublicKeyHashForWalletIDFn interface {
+	WalletPubKeyHashForWalletID(walletID [32]byte) ([20]byte, error)
+}
 
 func resolveWalletPublicKeyHashForWalletID(
 	walletID [32]byte,
-	resolveCanonical walletPublicKeyHashForWalletIDFn,
+	bridge any,
 ) ([20]byte, error) {
-	walletPublicKeyHash, err := resolveCanonical(walletID)
+	resolveCanonical, ok := bridge.(walletPublicKeyHashForWalletIDFn)
+	if !ok {
+		resolveCanonical = nil
+	}
+
+	var walletPublicKeyHash [20]byte
+	var err error
+	if resolveCanonical != nil {
+		walletPublicKeyHash, err = resolveCanonical.WalletPubKeyHashForWalletID(walletID)
+	} else {
+		err = fmt.Errorf("wallet public key hash accessor unavailable")
+	}
+
 	if err == nil {
 		if walletPublicKeyHash != [20]byte{} {
 			return walletPublicKeyHash, nil

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -328,6 +328,105 @@ func TestCalculateWalletID(t *testing.T) {
 	testutils.AssertBytesEqual(t, expectedWalletID[:], actualWalletID[:])
 }
 
+type pastNewWalletRegisteredV2EventsBridgeMock struct {
+	pastEvents func(
+		startBlock uint64,
+		endBlock *uint64,
+		walletID [][32]byte,
+		ecdsaWalletID [][32]byte,
+		walletPublicKeyHash [][20]byte,
+	) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error)
+}
+
+func (m *pastNewWalletRegisteredV2EventsBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+	return m.pastEvents(
+		startBlock,
+		endBlock,
+		walletID,
+		ecdsaWalletID,
+		walletPublicKeyHash,
+	)
+}
+
+type pastNewWalletRegisteredV2EventsAltFieldBridgeMock struct {
+	pastEvents func(
+		startBlock uint64,
+		endBlock *uint64,
+		walletID [][32]byte,
+		ecdsaWalletID [][32]byte,
+		walletPublicKeyHash [][20]byte,
+	) ([]*pastNewWalletRegisteredV2EventsAltFieldEvent, error)
+}
+
+type pastNewWalletRegisteredV2EventsAltFieldEvent struct {
+	WalletID            [32]byte
+	EcdsaWalletID       [32]byte
+	WalletPublicKeyHash [20]byte
+	Raw                 types.Log
+}
+
+func (m *pastNewWalletRegisteredV2EventsAltFieldBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+) ([]*pastNewWalletRegisteredV2EventsAltFieldEvent, error) {
+	return m.pastEvents(
+		startBlock,
+		endBlock,
+		walletID,
+		ecdsaWalletID,
+		walletPublicKeyHash,
+	)
+}
+
+type pastNewWalletRegisteredV2EventsMissingRawBridgeMock struct {
+	pastEvents func(
+		startBlock uint64,
+		endBlock *uint64,
+		walletID [][32]byte,
+		ecdsaWalletID [][32]byte,
+		walletPublicKeyHash [][20]byte,
+	) ([]*pastNewWalletRegisteredV2EventsMissingRawEvent, error)
+}
+
+type pastNewWalletRegisteredV2EventsMissingRawEvent struct {
+	WalletID         [32]byte
+	EcdsaWalletID    [32]byte
+	WalletPubKeyHash [20]byte
+}
+
+func (m *pastNewWalletRegisteredV2EventsMissingRawBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+) ([]*pastNewWalletRegisteredV2EventsMissingRawEvent, error) {
+	return m.pastEvents(
+		startBlock,
+		endBlock,
+		walletID,
+		ecdsaWalletID,
+		walletPublicKeyHash,
+	)
+}
+
+type pastNewWalletRegisteredV2EventsWrongSignatureBridgeMock struct{}
+
+func (m *pastNewWalletRegisteredV2EventsWrongSignatureBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+	return nil, nil
+}
+
 func TestPastNewWalletRegisteredEvents_UsesV2EventsWhenAvailable(t *testing.T) {
 	startBlock := uint64(500)
 	endBlock := uint64(700)
@@ -349,36 +448,38 @@ func TestPastNewWalletRegisteredEvents_UsesV2EventsWhenAvailable(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		func(
-			actualStartBlock uint64,
-			actualEndBlock *uint64,
-			_ [][32]byte,
-			_ [][32]byte,
-			_ [][20]byte,
-		) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
-			if actualStartBlock != startBlock {
-				t.Fatalf("unexpected start block: [%v]", actualStartBlock)
-			}
+		&pastNewWalletRegisteredV2EventsBridgeMock{
+			pastEvents: func(
+				actualStartBlock uint64,
+				actualEndBlock *uint64,
+				_ [][32]byte,
+				_ [][32]byte,
+				_ [][20]byte,
+			) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+				if actualStartBlock != startBlock {
+					t.Fatalf("unexpected start block: [%v]", actualStartBlock)
+				}
 
-			if actualEndBlock == nil || *actualEndBlock != endBlock {
-				t.Fatalf("unexpected end block: [%v]", actualEndBlock)
-			}
+				if actualEndBlock == nil || *actualEndBlock != endBlock {
+					t.Fatalf("unexpected end block: [%v]", actualEndBlock)
+				}
 
-			// Provide events out of order to verify post-conversion sort.
-			return []*tbtcabi.BridgeNewWalletRegisteredV2{
-				{
-					WalletID:         expectedWalletIDB,
-					EcdsaWalletID:    expectedECDSAWalletIDB,
-					WalletPubKeyHash: expectedWalletPublicKeyHashB,
-					Raw:              types.Log{BlockNumber: 650},
-				},
-				{
-					WalletID:         expectedWalletIDA,
-					EcdsaWalletID:    expectedECDSAWalletIDA,
-					WalletPubKeyHash: expectedWalletPublicKeyHashA,
-					Raw:              types.Log{BlockNumber: 600},
-				},
-			}, nil
+				// Provide events out of order to verify post-conversion sort.
+				return []*tbtcabi.BridgeNewWalletRegisteredV2{
+					{
+						WalletID:         expectedWalletIDB,
+						EcdsaWalletID:    expectedECDSAWalletIDB,
+						WalletPubKeyHash: expectedWalletPublicKeyHashB,
+						Raw:              types.Log{BlockNumber: 650},
+					},
+					{
+						WalletID:         expectedWalletIDA,
+						EcdsaWalletID:    expectedECDSAWalletIDA,
+						WalletPubKeyHash: expectedWalletPublicKeyHashA,
+						Raw:              types.Log{BlockNumber: 600},
+					},
+				}, nil
+			},
 		},
 		func(uint64, *uint64, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegistered, error) {
 			legacyFallbackCalled = true
@@ -424,8 +525,16 @@ func TestPastNewWalletRegisteredEvents_FallsBackToLegacyWhenV2Empty(t *testing.T
 		nil, // no canonical wallet-ID filter -> fallback path enabled
 		nil,
 		nil,
-		func(uint64, *uint64, [][32]byte, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
-			return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+		&pastNewWalletRegisteredV2EventsBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+				return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+			},
 		},
 		func(uint64, *uint64, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegistered, error) {
 			legacyFallbackCalled = true
@@ -473,8 +582,16 @@ func TestPastNewWalletRegisteredEvents_DoesNotFallbackWithWalletIDFilter(t *test
 		walletIDFilter,
 		nil,
 		nil,
-		func(uint64, *uint64, [][32]byte, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
-			return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+		&pastNewWalletRegisteredV2EventsBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+				return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+			},
 		},
 		func(uint64, *uint64, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegistered, error) {
 			legacyFallbackCalled = true
@@ -494,6 +611,133 @@ func TestPastNewWalletRegisteredEvents_DoesNotFallbackWithWalletIDFilter(t *test
 	}
 }
 
+func TestPastNewWalletRegisteredV2Events_ReturnsEmptyWhenMethodUnavailable(t *testing.T) {
+	actualEvents, err := pastNewWalletRegisteredV2Events(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		struct{}{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+
+	if len(actualEvents) != 0 {
+		t.Fatalf("unexpected events count: [%v]", len(actualEvents))
+	}
+}
+
+func TestPastNewWalletRegisteredV2Events_UsesWalletPublicKeyHashFallbackField(t *testing.T) {
+	expectedWalletID := [32]byte{0x01}
+	expectedECDSAWalletID := [32]byte{0x02}
+	expectedWalletPublicKeyHash := [20]byte{0x03}
+
+	actualEvents, err := pastNewWalletRegisteredV2Events(
+		11,
+		nil,
+		nil,
+		nil,
+		nil,
+		&pastNewWalletRegisteredV2EventsAltFieldBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*pastNewWalletRegisteredV2EventsAltFieldEvent, error) {
+				return []*pastNewWalletRegisteredV2EventsAltFieldEvent{
+					{
+						WalletID:            expectedWalletID,
+						EcdsaWalletID:       expectedECDSAWalletID,
+						WalletPublicKeyHash: expectedWalletPublicKeyHash,
+						Raw:                 types.Log{BlockNumber: 121},
+					},
+				}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+
+	if len(actualEvents) != 1 {
+		t.Fatalf("unexpected events count: [%v]", len(actualEvents))
+	}
+
+	if actualEvents[0].WalletPublicKeyHash != expectedWalletPublicKeyHash {
+		t.Fatalf(
+			"unexpected wallet public key hash\nexpected: [%x]\nactual:   [%x]",
+			expectedWalletPublicKeyHash,
+			actualEvents[0].WalletPublicKeyHash,
+		)
+	}
+}
+
+func TestPastNewWalletRegisteredV2Events_ReturnsErrorOnCallPanic(t *testing.T) {
+	_, err := pastNewWalletRegisteredV2Events(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		&pastNewWalletRegisteredV2EventsWrongSignatureBridgeMock{},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "panic calling PastNewWalletRegisteredV2Events") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestPastNewWalletRegisteredV2Events_ReturnsErrorWhenRawMissing(t *testing.T) {
+	_, err := pastNewWalletRegisteredV2Events(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		&pastNewWalletRegisteredV2EventsMissingRawBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*pastNewWalletRegisteredV2EventsMissingRawEvent, error) {
+				return []*pastNewWalletRegisteredV2EventsMissingRawEvent{
+					{
+						WalletID:         [32]byte{0x05},
+						EcdsaWalletID:    [32]byte{0x06},
+						WalletPubKeyHash: [20]byte{0x07},
+					},
+				}, nil
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "raw event payload") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+type walletPublicKeyHashForWalletIDBridgeMock struct {
+	resolve func(walletID [32]byte) ([20]byte, error)
+}
+
+func (m *walletPublicKeyHashForWalletIDBridgeMock) WalletPubKeyHashForWalletID(
+	walletID [32]byte,
+) ([20]byte, error) {
+	return m.resolve(walletID)
+}
+
 func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 	t.Run("returns canonical mapping when non-zero", func(t *testing.T) {
 		walletID := [32]byte{0x01}
@@ -501,12 +745,14 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		actualWalletPublicKeyHash, err := resolveWalletPublicKeyHashForWalletID(
 			walletID,
-			func(actualWalletID [32]byte) ([20]byte, error) {
-				if actualWalletID != walletID {
-					t.Fatalf("unexpected wallet ID: [%x]", actualWalletID)
-				}
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func(actualWalletID [32]byte) ([20]byte, error) {
+					if actualWalletID != walletID {
+						t.Fatalf("unexpected wallet ID: [%x]", actualWalletID)
+					}
 
-				return expectedWalletPublicKeyHash, nil
+					return expectedWalletPublicKeyHash, nil
+				},
 			},
 		)
 		if err != nil {
@@ -528,8 +774,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		actualWalletPublicKeyHash, err := resolveWalletPublicKeyHashForWalletID(
 			legacyWalletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, errors.New("canonical lookup unavailable")
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, errors.New("canonical lookup unavailable")
+				},
 			},
 		)
 		if err != nil {
@@ -551,8 +799,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		actualWalletPublicKeyHash, err := resolveWalletPublicKeyHashForWalletID(
 			legacyWalletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, nil
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, nil
+				},
 			},
 		)
 		if err != nil {
@@ -574,8 +824,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		_, err := resolveWalletPublicKeyHashForWalletID(
 			walletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, canonicalErr
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, canonicalErr
+				},
 			},
 		)
 		if err == nil {
@@ -595,8 +847,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		_, err := resolveWalletPublicKeyHashForWalletID(
 			walletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, nil
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, nil
+				},
 			},
 		)
 		if err == nil {

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -107,6 +107,7 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricSigningSuccessTotal,
 		MetricSigningFailedTotal,
 		MetricSigningTimeoutsTotal,
+		MetricSigningNativeTBTCSignerFallbackTotal,
 		MetricWalletActionsTotal,
 		MetricWalletActionSuccessTotal,
 		MetricWalletActionFailedTotal,
@@ -125,9 +126,11 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 	}
 
 	// First, initialize all counters in the map
+	pm.countersMutex.Lock()
 	for _, name := range counters {
 		pm.counters[name] = &counter{value: 0}
 	}
+	pm.countersMutex.Unlock()
 
 	// Then, register observers (this prevents concurrent map read/write)
 	for _, name := range counters {
@@ -151,39 +154,59 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 	}
 
 	// Register per-action type wallet metrics
-	// For each action type, register: total, success_total, failed_total, duration_seconds
+	// For each action type, register: total, success_total, failed_total, duration_seconds.
+	// Collect first, then initialize all maps, and only then register observers to
+	// avoid concurrent map writes while observers are reading.
+	perActionCounters := []string{}
+	perActionDurations := []string{}
 	for _, actionType := range GetAllWalletActionTypes() {
-		actionCounters := []string{
+		perActionCounters = append(
+			perActionCounters,
 			WalletActionMetricName(actionType, "total"),
 			WalletActionMetricName(actionType, "success_total"),
 			WalletActionMetricName(actionType, "failed_total"),
-		}
-		for _, name := range actionCounters {
-			pm.counters[name] = &counter{value: 0}
-			metricName := name // Capture for closure
-			pm.registry.ObserveApplicationSource(
-				"performance",
-				map[string]Source{
-					metricName: func() float64 {
-						pm.countersMutex.RLock()
-						c, exists := pm.counters[metricName]
-						pm.countersMutex.RUnlock()
-						if !exists {
-							return 0
-						}
-						c.mutex.RLock()
-						defer c.mutex.RUnlock()
-						return c.value
-					},
-				},
-			)
-		}
+		)
+		perActionDurations = append(
+			perActionDurations,
+			WalletActionMetricName(actionType, "duration_seconds"),
+		)
+	}
 
-		// Register duration metric for this action type
-		durationName := WalletActionMetricName(actionType, "duration_seconds")
+	pm.countersMutex.Lock()
+	for _, name := range perActionCounters {
+		pm.counters[name] = &counter{value: 0}
+	}
+	pm.countersMutex.Unlock()
+
+	for _, name := range perActionCounters {
+		metricName := name // Capture for closure
+		pm.registry.ObserveApplicationSource(
+			"performance",
+			map[string]Source{
+				metricName: func() float64 {
+					pm.countersMutex.RLock()
+					c, exists := pm.counters[metricName]
+					pm.countersMutex.RUnlock()
+					if !exists {
+						return 0
+					}
+					c.mutex.RLock()
+					defer c.mutex.RUnlock()
+					return c.value
+				},
+			},
+		)
+	}
+
+	pm.histogramsMutex.Lock()
+	for _, durationName := range perActionDurations {
 		pm.histograms[durationName] = &histogram{
 			buckets: make(map[float64]float64),
 		}
+	}
+	pm.histogramsMutex.Unlock()
+
+	for _, durationName := range perActionDurations {
 		durationMetricName := durationName // Capture for closure
 		pm.registry.ObserveApplicationSource(
 			"performance",
@@ -218,11 +241,13 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 	}
 
 	// First, initialize all histograms in the map
+	pm.histogramsMutex.Lock()
 	for _, name := range durationMetrics {
 		pm.histograms[name] = &histogram{
 			buckets: make(map[float64]float64),
 		}
 	}
+	pm.histogramsMutex.Unlock()
 
 	// Then, register observers (this prevents concurrent map read/write)
 	for _, name := range durationMetrics {
@@ -273,9 +298,11 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 	}
 
 	// First, initialize all gauges in the map
+	pm.gaugesMutex.Lock()
 	for _, name := range gauges {
 		pm.gauges[name] = &gauge{value: 0}
 	}
+	pm.gaugesMutex.Unlock()
 
 	// Then, register observers (this prevents concurrent map read/write)
 	for _, name := range gauges {
@@ -549,6 +576,9 @@ const (
 	MetricSigningDurationSeconds      = "signing_duration_seconds"
 	MetricSigningAttemptsPerOperation = "signing_attempts_per_operation"
 	MetricSigningTimeoutsTotal        = "signing_timeouts_total"
+	// MetricSigningNativeTBTCSignerFallbackTotal counts the number of times the
+	// frost_tbtc_signer path fell back to legacy tECDSA execution.
+	MetricSigningNativeTBTCSignerFallbackTotal = "signing_native_tbtc_signer_fallback_total"
 
 	// Wallet Action Metrics (aggregate)
 	MetricWalletActionsTotal           = "wallet_actions_total"

--- a/pkg/clientinfo/performance_test.go
+++ b/pkg/clientinfo/performance_test.go
@@ -306,6 +306,7 @@ func TestMetricsInitialization(t *testing.T) {
 		MetricDKGJoinedTotal,
 		MetricSigningOperationsTotal,
 		MetricSigningSuccessTotal,
+		MetricSigningNativeTBTCSignerFallbackTotal,
 	}
 
 	for _, counterName := range counters {

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -37,7 +37,8 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // is wired end-to-end.
 type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
 
-const buildTaggedTBTCSignerBootstrapVersionToken = "bootstrap"
+const buildTaggedTBTCSignerVersionPrefix = "tbtc-signer/"
+const buildTaggedTBTCSignerBootstrapVersionPrerelease = "bootstrap"
 const buildTaggedTBTCSignerSyntheticContributionDomain = "tbtc-signer-bootstrap-contribution-v1"
 
 type nativeTBTCSignerVersionedEngine interface {
@@ -146,7 +147,7 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			logger,
 			request,
 			legacyPrivateKeyShare,
-			"tbtc-signer RunDKG failed",
+			fmt.Sprintf("tbtc-signer RunDKG failed: [%v]", err),
 			payload.KeyGroupSource,
 		)
 	}
@@ -173,7 +174,7 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	keyGroupForRound, err := buildTaggedTBTCSignerRoundKeyGroup(
+	keyGroupForRound, keyGroupSubstituted, err := buildTaggedTBTCSignerRoundKeyGroup(
 		payload,
 		dkgResult,
 	)
@@ -185,6 +186,15 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			legacyPrivateKeyShare,
 			err.Error(),
 			payload.KeyGroupSource,
+		)
+	}
+
+	if keyGroupSubstituted && logger != nil {
+		logger.Debugf(
+			"substituting scaffold key group from payload source [%s]: payload [%s] -> RunDKG [%s]",
+			payload.KeyGroupSource,
+			payload.KeyGroup,
+			dkgResult.KeyGroup,
 		)
 	}
 
@@ -207,15 +217,15 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			logger,
 			request,
 			legacyPrivateKeyShare,
-			"cannot query tbtc-signer version; coarse round scaffold skipped",
+			fmt.Sprintf(
+				"cannot query tbtc-signer version; coarse round scaffold skipped: [%v]",
+				err,
+			),
 			payload.KeyGroupSource,
 		)
 	}
 
-	if !strings.Contains(
-		strings.ToLower(engineVersion),
-		buildTaggedTBTCSignerBootstrapVersionToken,
-	) {
+	if !isBuildTaggedTBTCSignerBootstrapVersion(engineVersion) {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
 			logger,
@@ -239,7 +249,7 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			logger,
 			request,
 			legacyPrivateKeyShare,
-			"tbtc-signer bootstrap coarse round failed",
+			fmt.Sprintf("tbtc-signer bootstrap coarse round failed: [%v]", err),
 			payload.KeyGroupSource,
 		)
 	}
@@ -313,30 +323,75 @@ func buildTaggedTBTCSignerDKGPlaceholderPublicKeyHex(identifier uint16) string {
 func buildTaggedTBTCSignerRoundKeyGroup(
 	payload *NativeTBTCSignerMaterialPayload,
 	dkgResult *NativeTBTCSignerDKGResult,
-) (string, error) {
+) (string, bool, error) {
 	if payload == nil {
-		return "", fmt.Errorf("tbtc-signer payload is nil")
+		return "", false, fmt.Errorf("tbtc-signer payload is nil")
 	}
 
 	if dkgResult == nil {
-		return "", fmt.Errorf("tbtc-signer RunDKG result is nil")
+		return "", false, fmt.Errorf("tbtc-signer RunDKG result is nil")
 	}
 
 	if dkgResult.KeyGroup == "" {
-		return "", fmt.Errorf("tbtc-signer RunDKG key group is empty")
+		return "", false, fmt.Errorf("tbtc-signer RunDKG key group is empty")
 	}
 
 	if payload.KeyGroup == dkgResult.KeyGroup {
-		return payload.KeyGroup, nil
+		return payload.KeyGroup, false, nil
 	}
 
 	if payload.KeyGroupSource == NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey {
 		// Scaffold compatibility: legacy-wallet-pubkey key groups are
 		// placeholder-only and expected to diverge from coarse RunDKG output.
-		return dkgResult.KeyGroup, nil
+		return dkgResult.KeyGroup, true, nil
 	}
 
-	return "", fmt.Errorf("tbtc-signer key group does not match RunDKG result")
+	return "", false, fmt.Errorf("tbtc-signer key group does not match RunDKG result")
+}
+
+func isBuildTaggedTBTCSignerBootstrapVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	if !strings.HasPrefix(version, buildTaggedTBTCSignerVersionPrefix) {
+		return false
+	}
+
+	version = strings.TrimPrefix(version, buildTaggedTBTCSignerVersionPrefix)
+	coreVersion, prerelease, hasPrerelease := strings.Cut(version, "-")
+	if !hasPrerelease {
+		return false
+	}
+
+	if prerelease != buildTaggedTBTCSignerBootstrapVersionPrerelease &&
+		!strings.HasPrefix(
+			prerelease,
+			buildTaggedTBTCSignerBootstrapVersionPrerelease+".",
+		) {
+		return false
+	}
+
+	coreSegments := strings.Split(coreVersion, ".")
+	if len(coreSegments) != 3 {
+		return false
+	}
+
+	// Bootstrap scaffold must be enabled only on 0.x.y pre-release builds.
+	if coreSegments[0] != "0" {
+		return false
+	}
+
+	for _, segment := range coreSegments {
+		if segment == "" {
+			return false
+		}
+
+		for _, character := range segment {
+			if character < '0' || character > '9' {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func executeBuildTaggedTBTCSignerBootstrapCoarseRound(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -122,6 +122,7 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			"tbtc-signer coarse session flow is not wired (keyGroupSource=%s)",
 			payload.KeyGroupSource,
 		),
+		payload.KeyGroupSource,
 	)
 }
 
@@ -186,7 +187,17 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	request *NativeExecutionFFISigningRequest,
 	legacyPrivateKeyShare *tecdsa.PrivateKeyShare,
 	reason string,
+	keyGroupSource string,
 ) (*frost.Signature, error) {
+	emitNativeTBTCSignerFallbackEvent(
+		NativeTBTCSignerFallbackEvent{
+			SessionID:                   request.SessionID,
+			Reason:                      reason,
+			KeyGroupSource:              keyGroupSource,
+			LegacyPrivateKeyShareExists: legacyPrivateKeyShare != nil,
+		},
+	)
+
 	if legacyPrivateKeyShare == nil {
 		return nil, fmt.Errorf("%w: %s", ErrNativeCryptographyUnavailable, reason)
 	}

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/frost"
@@ -34,6 +35,12 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // routes through a temporary legacy fallback until coarse session finalize flow
 // is wired end-to-end.
 type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
+
+const buildTaggedTBTCSignerBootstrapVersionToken = "bootstrap"
+
+type nativeTBTCSignerVersionedEngine interface {
+	Version() (string, error)
+}
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) Sign(
 	ctx context.Context,
@@ -175,21 +182,74 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	if logger != nil {
-		logger.Debugf(
-			"validated tbtc-signer key-group contract via RunDKG; using legacy fallback until finalize flow is wired",
+	versionedEngine, isVersioned := nativeEngine.(nativeTBTCSignerVersionedEngine)
+	if !isVersioned {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"tbtc-signer version API is unavailable; coarse round scaffold skipped",
+			payload.KeyGroupSource,
 		)
 	}
 
-	// The coarse-session flow is intentionally deferred until keep-core
-	// orchestration is migrated from round-level message exchange. Use a Go-side
-	// legacy fallback while this migration is in progress.
+	engineVersion, err := versionedEngine.Version()
+	if err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"cannot query tbtc-signer version; coarse round scaffold skipped",
+			payload.KeyGroupSource,
+		)
+	}
+
+	if !strings.Contains(
+		strings.ToLower(engineVersion),
+		buildTaggedTBTCSignerBootstrapVersionToken,
+	) {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			fmt.Sprintf(
+				"tbtc-signer version [%s] is not bootstrap; coarse round scaffold skipped",
+				engineVersion,
+			),
+			payload.KeyGroupSource,
+		)
+	}
+
+	if err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+		request,
+		payload.KeyGroup,
+		nativeEngine,
+	); err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"tbtc-signer bootstrap coarse round failed",
+			payload.KeyGroupSource,
+		)
+	}
+
+	if logger != nil {
+		logger.Debugf(
+			"validated tbtc-signer key-group contract via RunDKG and bootstrap coarse round; using legacy fallback until signature cutover",
+		)
+	}
+
 	return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 		ctx,
 		logger,
 		request,
 		legacyPrivateKeyShare,
-		"tbtc-signer RunDKG is wired but coarse finalize flow is not wired",
+		"tbtc-signer bootstrap coarse round completed; using legacy fallback during migration",
 		payload.KeyGroupSource,
 	)
 }
@@ -242,6 +302,107 @@ func buildTaggedTBTCSignerDKGPlaceholderPublicKeyHex(identifier uint16) string {
 	// Transitional placeholder until canonical member public keys are available
 	// in the native signing request path.
 	return fmt.Sprintf("02%04x", identifier)
+}
+
+func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+	request *NativeExecutionFFISigningRequest,
+	keyGroup string,
+	nativeEngine NativeTBTCSignerEngine,
+) error {
+	if request == nil {
+		return fmt.Errorf("request is nil")
+	}
+
+	if request.Message == nil {
+		return fmt.Errorf("request message is nil")
+	}
+
+	if nativeEngine == nil {
+		return fmt.Errorf("native tbtc-signer engine is nil")
+	}
+
+	messageBytes := request.Message.Bytes()
+	if len(messageBytes) == 0 {
+		messageBytes = []byte{0}
+	}
+
+	roundState, err := nativeEngine.StartSignRound(
+		request.SessionID,
+		messageBytes,
+		keyGroup,
+	)
+	if err != nil {
+		return fmt.Errorf("start sign round failed: [%w]", err)
+	}
+
+	if roundState == nil {
+		return fmt.Errorf("start sign round returned nil state")
+	}
+
+	if roundState.RequiredContributions == 0 {
+		return fmt.Errorf("start sign round required contributions are zero")
+	}
+
+	_, includedMembersIndexes, err := includedMembersFromRequest(request)
+	if err != nil {
+		return fmt.Errorf("cannot determine included members: [%w]", err)
+	}
+
+	roundContributions := buildTaggedTBTCSignerSyntheticRoundContributions(
+		includedMembersIndexes,
+	)
+	if len(roundContributions) < int(roundState.RequiredContributions) {
+		return fmt.Errorf(
+			"insufficient synthetic round contributions: [%v] < [%v]",
+			len(roundContributions),
+			roundState.RequiredContributions,
+		)
+	}
+
+	signature, err := nativeEngine.FinalizeSignRound(
+		request.SessionID,
+		roundContributions,
+	)
+	if err != nil {
+		return fmt.Errorf("finalize sign round failed: [%w]", err)
+	}
+
+	if len(signature) == 0 {
+		return fmt.Errorf("finalize sign round returned empty signature")
+	}
+
+	return nil
+}
+
+func buildTaggedTBTCSignerSyntheticRoundContributions(
+	includedMembersIndexes []group.MemberIndex,
+) []NativeTBTCSignerRoundContribution {
+	contributions := make(
+		[]NativeTBTCSignerRoundContribution,
+		0,
+		len(includedMembersIndexes),
+	)
+
+	for _, memberIndex := range includedMembersIndexes {
+		if memberIndex == 0 {
+			continue
+		}
+
+		identifier := uint16(memberIndex)
+		contributions = append(
+			contributions,
+			NativeTBTCSignerRoundContribution{
+				Identifier: identifier,
+				Data: []byte{
+					byte(identifier >> 8),
+					byte(identifier),
+					0x01,
+				},
+			},
+		)
+	}
+
+	return contributions
 }
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithLegacyTECDSABridge(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -4,6 +4,7 @@ package signing
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -37,6 +38,7 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
 
 const buildTaggedTBTCSignerBootstrapVersionToken = "bootstrap"
+const buildTaggedTBTCSignerSyntheticContributionDomain = "tbtc-signer-bootstrap-contribution-v1"
 
 type nativeTBTCSignerVersionedEngine interface {
 	Version() (string, error)
@@ -381,9 +383,14 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		return fmt.Errorf("cannot determine included members: [%w]", err)
 	}
 
-	roundContributions := buildTaggedTBTCSignerSyntheticRoundContributions(
+	roundContributions, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+		roundState,
 		includedMembersIndexes,
 	)
+	if err != nil {
+		return fmt.Errorf("cannot build synthetic round contributions: [%w]", err)
+	}
+
 	if len(roundContributions) < int(roundState.RequiredContributions) {
 		return fmt.Errorf(
 			"insufficient synthetic round contributions: [%v] < [%v]",
@@ -408,8 +415,25 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 }
 
 func buildTaggedTBTCSignerSyntheticRoundContributions(
+	roundState *NativeTBTCSignerRoundState,
 	includedMembersIndexes []group.MemberIndex,
-) []NativeTBTCSignerRoundContribution {
+) ([]NativeTBTCSignerRoundContribution, error) {
+	if roundState == nil {
+		return nil, fmt.Errorf("round state is nil")
+	}
+
+	if roundState.SessionID == "" {
+		return nil, fmt.Errorf("round state session ID is empty")
+	}
+
+	if roundState.RoundID == "" {
+		return nil, fmt.Errorf("round state round ID is empty")
+	}
+
+	if roundState.MessageDigestHex == "" {
+		return nil, fmt.Errorf("round state message digest is empty")
+	}
+
 	contributions := make(
 		[]NativeTBTCSignerRoundContribution,
 		0,
@@ -418,24 +442,30 @@ func buildTaggedTBTCSignerSyntheticRoundContributions(
 
 	for _, memberIndex := range includedMembersIndexes {
 		if memberIndex == 0 {
-			continue
+			return nil, fmt.Errorf("included member index is zero")
 		}
 
 		identifier := uint16(memberIndex)
+		seed := fmt.Sprintf(
+			"%s:%s:%s:%s:%d",
+			buildTaggedTBTCSignerSyntheticContributionDomain,
+			roundState.SessionID,
+			roundState.RoundID,
+			roundState.MessageDigestHex,
+			identifier,
+		)
+		shareDigest := sha256.Sum256([]byte(seed))
+
 		contributions = append(
 			contributions,
 			NativeTBTCSignerRoundContribution{
 				Identifier: identifier,
-				Data: []byte{
-					byte(identifier >> 8),
-					byte(identifier),
-					0x01,
-				},
+				Data:       append([]byte{}, shareDigest[:]...),
 			},
 		)
 	}
 
-	return contributions
+	return contributions, nil
 }
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithLegacyTECDSABridge(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -40,9 +40,57 @@ type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
 const buildTaggedTBTCSignerVersionPrefix = "tbtc-signer/"
 const buildTaggedTBTCSignerBootstrapVersionPrerelease = "bootstrap"
 const buildTaggedTBTCSignerSyntheticContributionDomain = "tbtc-signer-bootstrap-contribution-v1"
+const buildTaggedTBTCSignerMessageTypePrefix = "frost_signing/native_tbtc_signer/"
 
 type nativeTBTCSignerVersionedEngine interface {
 	Version() (string, error)
+}
+
+type buildTaggedTBTCSignerRoundContributionMessage struct {
+	SenderIDValue          uint32 `json:"senderID"`
+	SessionIDValue         string `json:"sessionID"`
+	ContributionIdentifier uint16 `json:"contributionIdentifier"`
+	ContributionData       []byte `json:"contributionData"`
+}
+
+func (bttsrcm *buildTaggedTBTCSignerRoundContributionMessage) SenderID() group.MemberIndex {
+	return group.MemberIndex(bttsrcm.SenderIDValue)
+}
+
+func (bttsrcm *buildTaggedTBTCSignerRoundContributionMessage) SessionID() string {
+	return bttsrcm.SessionIDValue
+}
+
+func (bttsrcm *buildTaggedTBTCSignerRoundContributionMessage) Type() string {
+	return buildTaggedTBTCSignerMessageTypePrefix + "round_contribution"
+}
+
+func (bttsrcm *buildTaggedTBTCSignerRoundContributionMessage) Marshal() ([]byte, error) {
+	return json.Marshal(bttsrcm)
+}
+
+func (bttsrcm *buildTaggedTBTCSignerRoundContributionMessage) Unmarshal(data []byte) error {
+	if err := json.Unmarshal(data, bttsrcm); err != nil {
+		return err
+	}
+
+	if bttsrcm.SenderID() == 0 {
+		return fmt.Errorf("sender ID is zero")
+	}
+
+	if bttsrcm.SessionID() == "" {
+		return fmt.Errorf("session ID is empty")
+	}
+
+	if bttsrcm.ContributionIdentifier == 0 {
+		return fmt.Errorf("contribution identifier is zero")
+	}
+
+	if len(bttsrcm.ContributionData) == 0 {
+		return fmt.Errorf("contribution data is empty")
+	}
+
+	return nil
 }
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) Sign(
@@ -240,6 +288,7 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	}
 
 	if err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+		ctx,
 		request,
 		keyGroupForRound,
 		nativeEngine,
@@ -395,6 +444,7 @@ func isBuildTaggedTBTCSignerBootstrapVersion(version string) bool {
 }
 
 func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+	ctx context.Context,
 	request *NativeExecutionFFISigningRequest,
 	keyGroup string,
 	nativeEngine NativeTBTCSignerEngine,
@@ -409,6 +459,22 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 
 	if nativeEngine == nil {
 		return fmt.Errorf("native tbtc-signer engine is nil")
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	includedMembersSet, includedMembersIndexes, err := includedMembersFromRequest(request)
+	if err != nil {
+		return fmt.Errorf("cannot determine included members: [%w]", err)
+	}
+
+	if _, ok := includedMembersSet[request.MemberIndex]; !ok {
+		return fmt.Errorf(
+			"member [%v] not included in tbtc-signer signing attempt",
+			request.MemberIndex,
+		)
 	}
 
 	messageBytes := request.Message.Bytes()
@@ -433,22 +499,20 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		return fmt.Errorf("start sign round required contributions are zero")
 	}
 
-	_, includedMembersIndexes, err := includedMembersFromRequest(request)
-	if err != nil {
-		return fmt.Errorf("cannot determine included members: [%w]", err)
-	}
-
-	roundContributions, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+	roundContributions, err := buildTaggedTBTCSignerRoundContributions(
+		ctx,
+		request,
 		roundState,
+		includedMembersSet,
 		includedMembersIndexes,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot build synthetic round contributions: [%w]", err)
+		return fmt.Errorf("cannot collect round contributions: [%w]", err)
 	}
 
 	if len(roundContributions) < int(roundState.RequiredContributions) {
 		return fmt.Errorf(
-			"insufficient synthetic round contributions: [%v] < [%v]",
+			"insufficient round contributions: [%v] < [%v]",
 			len(roundContributions),
 			roundState.RequiredContributions,
 		)
@@ -467,6 +531,154 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	}
 
 	return nil
+}
+
+func buildTaggedTBTCSignerRoundContributions(
+	ctx context.Context,
+	request *NativeExecutionFFISigningRequest,
+	roundState *NativeTBTCSignerRoundState,
+	includedMembersSet map[group.MemberIndex]struct{},
+	includedMembersIndexes []group.MemberIndex,
+) ([]NativeTBTCSignerRoundContribution, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	if request.Channel == nil {
+		// Compatibility path for unit tests that do not attach a broadcast
+		// channel. Runtime signer flows provide a channel and use contribution
+		// exchange with peers.
+		return buildTaggedTBTCSignerSyntheticRoundContributions(
+			roundState,
+			includedMembersIndexes,
+		)
+	}
+
+	ownContributions, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+		roundState,
+		[]group.MemberIndex{request.MemberIndex},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build own round contribution: [%w]", err)
+	}
+
+	if len(ownContributions) != 1 {
+		return nil, fmt.Errorf("unexpected own contribution count: [%v]", len(ownContributions))
+	}
+
+	ownContribution := ownContributions[0]
+
+	roundContributionMessage := &buildTaggedTBTCSignerRoundContributionMessage{
+		SenderIDValue:          uint32(request.MemberIndex),
+		SessionIDValue:         request.SessionID,
+		ContributionIdentifier: ownContribution.Identifier,
+		ContributionData:       append([]byte{}, ownContribution.Data...),
+	}
+
+	if err := request.Channel.Send(
+		ctx,
+		roundContributionMessage,
+		net.BackoffRetransmissionStrategy,
+	); err != nil {
+		return nil, fmt.Errorf("cannot send round contribution message: [%w]", err)
+	}
+
+	peerMessages, err := collectBuildTaggedTBTCSignerRoundContributionMessages(
+		ctx,
+		request,
+		includedMembersSet,
+		includedMembersIndexes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	contributionsBySender := map[group.MemberIndex]NativeTBTCSignerRoundContribution{
+		request.MemberIndex: ownContribution,
+	}
+
+	for senderID, message := range peerMessages {
+		contributionsBySender[senderID] = NativeTBTCSignerRoundContribution{
+			Identifier: message.ContributionIdentifier,
+			Data:       append([]byte{}, message.ContributionData...),
+		}
+	}
+
+	orderedContributions := make(
+		[]NativeTBTCSignerRoundContribution,
+		0,
+		len(includedMembersIndexes),
+	)
+	for _, memberIndex := range includedMembersIndexes {
+		contribution, ok := contributionsBySender[memberIndex]
+		if !ok {
+			return nil, fmt.Errorf("missing contribution from member [%v]", memberIndex)
+		}
+
+		orderedContributions = append(orderedContributions, contribution)
+	}
+
+	return orderedContributions, nil
+}
+
+func collectBuildTaggedTBTCSignerRoundContributionMessages(
+	ctx context.Context,
+	request *NativeExecutionFFISigningRequest,
+	includedMembersSet map[group.MemberIndex]struct{},
+	includedMembersIndexes []group.MemberIndex,
+) (map[group.MemberIndex]*buildTaggedTBTCSignerRoundContributionMessage, error) {
+	expectedMessagesCount := len(includedMembersIndexes) - 1
+	if expectedMessagesCount <= 0 {
+		return map[group.MemberIndex]*buildTaggedTBTCSignerRoundContributionMessage{}, nil
+	}
+
+	recvCtx, cancelRecvCtx := context.WithCancel(ctx)
+	defer cancelRecvCtx()
+
+	messageChan := make(
+		chan *buildTaggedTBTCSignerRoundContributionMessage,
+		expectedMessagesCount*4+1,
+	)
+
+	request.Channel.Recv(recvCtx, func(message net.Message) {
+		payload, ok := message.Payload().(*buildTaggedTBTCSignerRoundContributionMessage)
+		if !ok {
+			return
+		}
+
+		if !shouldAcceptNativeFROSTMessage(
+			request,
+			includedMembersSet,
+			payload.SenderID(),
+			payload.SessionID(),
+			message.SenderPublicKey(),
+		) {
+			return
+		}
+
+		select {
+		case messageChan <- payload:
+		default:
+		}
+	})
+
+	receivedMessages := make(
+		map[group.MemberIndex]*buildTaggedTBTCSignerRoundContributionMessage,
+	)
+	for len(receivedMessages) < expectedMessagesCount {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf(
+				"tbtc-signer round contribution collection interrupted: [%w]",
+				ctx.Err(),
+			)
+
+		case message := <-messageChan:
+			receivedMessages[message.SenderID()] = message
+		}
+	}
+
+	return receivedMessages, nil
 }
 
 func buildTaggedTBTCSignerSyntheticRoundContributions(
@@ -617,8 +829,15 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) RegisterUnmarshallers(
 	channel net.BroadcastChannel,
 ) {
+	registerBuildTaggedTBTCSignerUnmarshallers(channel)
 	registerNativeFROSTSigningUnmarshallers(channel)
 	legacySigning.RegisterUnmarshallers(channel)
+}
+
+func registerBuildTaggedTBTCSignerUnmarshallers(channel net.BroadcastChannel) {
+	channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &buildTaggedTBTCSignerRoundContributionMessage{}
+	})
 }
 
 func decodeBuildTaggedLegacyPrivateKeyShare(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -172,7 +172,22 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	dkgParticipants, dkgThreshold, err := buildTaggedTBTCSignerRunDKGInputs(request)
+	includedMembersSet, includedMembersIndexes, err := includedMembersFromRequest(request)
+	if err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			fmt.Sprintf("cannot determine included members: [%v]", err),
+			payload.KeyGroupSource,
+		)
+	}
+
+	dkgParticipants, dkgThreshold, err := buildTaggedTBTCSignerRunDKGInputsForIncludedMembers(
+		request,
+		includedMembersIndexes,
+	)
 	if err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
@@ -292,6 +307,8 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		request,
 		keyGroupForRound,
 		nativeEngine,
+		includedMembersSet,
+		includedMembersIndexes,
 	); err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
@@ -325,6 +342,20 @@ func buildTaggedTBTCSignerRunDKGInputs(
 	_, includedMembersIndexes, err := includedMembersFromRequest(request)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	return buildTaggedTBTCSignerRunDKGInputsForIncludedMembers(
+		request,
+		includedMembersIndexes,
+	)
+}
+
+func buildTaggedTBTCSignerRunDKGInputsForIncludedMembers(
+	request *NativeExecutionFFISigningRequest,
+	includedMembersIndexes []group.MemberIndex,
+) ([]NativeTBTCSignerDKGParticipant, uint16, error) {
+	if request == nil {
+		return nil, 0, fmt.Errorf("request is nil")
 	}
 
 	if len(includedMembersIndexes) < 2 {
@@ -448,6 +479,8 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	request *NativeExecutionFFISigningRequest,
 	keyGroup string,
 	nativeEngine NativeTBTCSignerEngine,
+	includedMembersSet map[group.MemberIndex]struct{},
+	includedMembersIndexes []group.MemberIndex,
 ) error {
 	if request == nil {
 		return fmt.Errorf("request is nil")
@@ -465,9 +498,12 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		ctx = context.Background()
 	}
 
-	includedMembersSet, includedMembersIndexes, err := includedMembersFromRequest(request)
-	if err != nil {
-		return fmt.Errorf("cannot determine included members: [%w]", err)
+	if includedMembersSet == nil || len(includedMembersIndexes) == 0 {
+		var err error
+		includedMembersSet, includedMembersIndexes, err = includedMembersFromRequest(request)
+		if err != nil {
+			return fmt.Errorf("cannot determine included members: [%w]", err)
+		}
 	}
 
 	if _, ok := includedMembersSet[request.MemberIndex]; !ok {
@@ -512,7 +548,7 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		return fmt.Errorf("start sign round required contributions are zero")
 	}
 
-	if len(roundState.SigningParticipants) > 0 {
+	if len(signingParticipants) > 0 {
 		if len(roundState.SigningParticipants) != len(signingParticipants) {
 			return fmt.Errorf(
 				"start sign round returned unexpected signing participants count: [%v] != [%v]",

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -102,11 +102,82 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		return nil, err
 	}
 
-	// Do not start coarse native sessions until finalize flow is wired. Calling
-	// StartSignRound without finalize would orphan signer-engine state.
-	if currentNativeTBTCSignerEngine() != nil && logger != nil {
-		logger.Warnf(
-			"native tbtc-signer engine is registered but coarse finalize flow is not wired; using legacy fallback",
+	nativeEngine := currentNativeTBTCSignerEngine()
+	if nativeEngine == nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"native tbtc-signer engine is unavailable",
+			payload.KeyGroupSource,
+		)
+	}
+
+	dkgParticipants, dkgThreshold, err := buildTaggedTBTCSignerRunDKGInputs(request)
+	if err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			fmt.Sprintf("cannot prepare tbtc-signer RunDKG request: [%v]", err),
+			payload.KeyGroupSource,
+		)
+	}
+
+	dkgResult, err := nativeEngine.RunDKG(
+		request.SessionID,
+		dkgParticipants,
+		dkgThreshold,
+	)
+	if err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"tbtc-signer RunDKG failed",
+			payload.KeyGroupSource,
+		)
+	}
+
+	if dkgResult == nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"tbtc-signer RunDKG returned nil result",
+			payload.KeyGroupSource,
+		)
+	}
+
+	if dkgResult.KeyGroup == "" {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"tbtc-signer RunDKG returned empty key group",
+			payload.KeyGroupSource,
+		)
+	}
+
+	if payload.KeyGroup != dkgResult.KeyGroup {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"tbtc-signer key group does not match RunDKG result",
+			payload.KeyGroupSource,
+		)
+	}
+
+	if logger != nil {
+		logger.Debugf(
+			"validated tbtc-signer key-group contract via RunDKG; using legacy fallback until finalize flow is wired",
 		)
 	}
 
@@ -118,12 +189,59 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		logger,
 		request,
 		legacyPrivateKeyShare,
-		fmt.Sprintf(
-			"tbtc-signer coarse session flow is not wired (keyGroupSource=%s)",
-			payload.KeyGroupSource,
-		),
+		"tbtc-signer RunDKG is wired but coarse finalize flow is not wired",
 		payload.KeyGroupSource,
 	)
+}
+
+func buildTaggedTBTCSignerRunDKGInputs(
+	request *NativeExecutionFFISigningRequest,
+) ([]NativeTBTCSignerDKGParticipant, uint16, error) {
+	_, includedMembersIndexes, err := includedMembersFromRequest(request)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if len(includedMembersIndexes) < 2 {
+		return nil, 0, fmt.Errorf("insufficient included members for DKG")
+	}
+
+	threshold := request.DishonestThreshold + 1
+	if threshold < 2 {
+		return nil, 0, fmt.Errorf("derived threshold is below minimum: [%v]", threshold)
+	}
+
+	if threshold > len(includedMembersIndexes) {
+		return nil, 0, fmt.Errorf(
+			"derived threshold exceeds included members count: [%v] > [%v]",
+			threshold,
+			len(includedMembersIndexes),
+		)
+	}
+
+	participants := make([]NativeTBTCSignerDKGParticipant, 0, len(includedMembersIndexes))
+	for _, memberIndex := range includedMembersIndexes {
+		if memberIndex == 0 {
+			return nil, 0, fmt.Errorf("included member index is zero")
+		}
+
+		identifier := uint16(memberIndex)
+		participants = append(
+			participants,
+			NativeTBTCSignerDKGParticipant{
+				Identifier:   identifier,
+				PublicKeyHex: buildTaggedTBTCSignerDKGPlaceholderPublicKeyHex(identifier),
+			},
+		)
+	}
+
+	return participants, uint16(threshold), nil
+}
+
+func buildTaggedTBTCSignerDKGPlaceholderPublicKeyHex(identifier uint16) string {
+	// Transitional placeholder until canonical member public keys are available
+	// in the native signing request path.
+	return fmt.Sprintf("02%04x", identifier)
 }
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithLegacyTECDSABridge(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -4,6 +4,7 @@ package signing
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -90,37 +91,51 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	logger log.StandardLogger,
 	request *NativeExecutionFFISigningRequest,
 ) (*frost.Signature, error) {
-	keyGroup, err := decodeBuildTaggedTBTCSignerKeyGroup(request.SignerMaterial)
+	payload, err := decodeBuildTaggedTBTCSignerMaterialPayload(request.SignerMaterial)
+	if err != nil {
+		return nil, err
+	}
+
+	legacyPrivateKeyShare, err := decodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(payload)
 	if err != nil {
 		return nil, err
 	}
 
 	engine := currentNativeTBTCSignerEngine()
 	if engine == nil {
-		return nil, fmt.Errorf(
-			"%w: native tbtc-signer engine is unavailable",
-			ErrNativeCryptographyUnavailable,
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			"native tbtc-signer engine is unavailable",
 		)
 	}
 
 	_, err = engine.StartSignRound(
 		request.SessionID,
 		request.Message.Bytes(),
-		keyGroup,
+		payload.KeyGroup,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"%w: tbtc-signer StartSignRound failed: [%v]",
-			ErrNativeCryptographyUnavailable,
-			err,
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			fmt.Sprintf("tbtc-signer StartSignRound failed: [%v]", err),
 		)
 	}
 
 	// The coarse-session finalize flow is intentionally deferred until keep-core
-	// transport/orchestration is migrated from round-level message exchange.
-	return nil, fmt.Errorf(
-		"%w: tbtc-signer coarse session finalize flow is not wired",
-		ErrNativeCryptographyUnavailable,
+	// transport/orchestration is migrated from round-level message exchange. Use
+	// a Go-side legacy fallback while this migration is in progress.
+	return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+		ctx,
+		logger,
+		request,
+		legacyPrivateKeyShare,
+		"tbtc-signer coarse session finalize flow is not wired",
 	)
 }
 
@@ -134,6 +149,24 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	return btlcnnefsp.signWithLegacyPrivateKeyShare(
+		ctx,
+		logger,
+		request,
+		privateKeyShare,
+	)
+}
+
+func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithLegacyPrivateKeyShare(
+	ctx context.Context,
+	logger log.StandardLogger,
+	request *NativeExecutionFFISigningRequest,
+	privateKeyShare *tecdsa.PrivateKeyShare,
+) (*frost.Signature, error) {
+	if privateKeyShare == nil {
+		return nil, fmt.Errorf("legacy private key share is nil")
 	}
 
 	excludedMembersIndexes := []group.MemberIndex{}
@@ -159,6 +192,32 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	}
 
 	return FromTECDSASignature(legacyResult.Signature)
+}
+
+func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) fallbackTBTCSignerLegacySigning(
+	ctx context.Context,
+	logger log.StandardLogger,
+	request *NativeExecutionFFISigningRequest,
+	legacyPrivateKeyShare *tecdsa.PrivateKeyShare,
+	reason string,
+) (*frost.Signature, error) {
+	if legacyPrivateKeyShare == nil {
+		return nil, fmt.Errorf("%w: %s", ErrNativeCryptographyUnavailable, reason)
+	}
+
+	if logger != nil {
+		logger.Warnf(
+			"falling back to legacy tECDSA signer path for tbtc-signer payload: [%s]",
+			reason,
+		)
+	}
+
+	return btlcnnefsp.signWithLegacyPrivateKeyShare(
+		ctx,
+		logger,
+		request,
+		legacyPrivateKeyShare,
+	)
 }
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) RegisterUnmarshallers(
@@ -206,21 +265,22 @@ func decodeBuildTaggedLegacyPrivateKeyShare(
 }
 
 type buildTaggedTBTCSignerMaterialPayload struct {
-	KeyGroup string `json:"keyGroup"`
+	KeyGroup                 string `json:"keyGroup"`
+	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
 }
 
-func decodeBuildTaggedTBTCSignerKeyGroup(
+func decodeBuildTaggedTBTCSignerMaterialPayload(
 	signerMaterial *NativeSignerMaterial,
-) (string, error) {
+) (*buildTaggedTBTCSignerMaterialPayload, error) {
 	if signerMaterial == nil {
-		return "", fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: signer material is nil",
 			ErrNativeCryptographyUnavailable,
 		)
 	}
 
 	if signerMaterial.Format != NativeSignerMaterialFormatFrostTBTCSignerV1 {
-		return "", fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: unsupported signer material format: [%s]",
 			ErrNativeCryptographyUnavailable,
 			signerMaterial.Format,
@@ -228,7 +288,7 @@ func decodeBuildTaggedTBTCSignerKeyGroup(
 	}
 
 	if len(signerMaterial.Payload) == 0 {
-		return "", fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: signer material payload is empty",
 			ErrNativeCryptographyUnavailable,
 		)
@@ -236,7 +296,7 @@ func decodeBuildTaggedTBTCSignerKeyGroup(
 
 	var payload buildTaggedTBTCSignerMaterialPayload
 	if err := json.Unmarshal(signerMaterial.Payload, &payload); err != nil {
-		return "", fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: cannot unmarshal tbtc-signer payload: [%v]",
 			ErrNativeCryptographyUnavailable,
 			err,
@@ -244,11 +304,50 @@ func decodeBuildTaggedTBTCSignerKeyGroup(
 	}
 
 	if payload.KeyGroup == "" {
-		return "", fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: tbtc-signer key group is empty",
 			ErrNativeCryptographyUnavailable,
 		)
 	}
 
+	return &payload, nil
+}
+
+func decodeBuildTaggedTBTCSignerKeyGroup(
+	signerMaterial *NativeSignerMaterial,
+) (string, error) {
+	payload, err := decodeBuildTaggedTBTCSignerMaterialPayload(signerMaterial)
+	if err != nil {
+		return "", err
+	}
+
 	return payload.KeyGroup, nil
+}
+
+func decodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(
+	payload *buildTaggedTBTCSignerMaterialPayload,
+) (*tecdsa.PrivateKeyShare, error) {
+	if payload == nil || payload.LegacyPrivateKeyShareHex == "" {
+		return nil, nil
+	}
+
+	legacyPrivateKeySharePayload, err := hex.DecodeString(payload.LegacyPrivateKeyShareHex)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: cannot decode tbtc-signer legacy private key share: [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	privateKeyShare := &tecdsa.PrivateKeyShare{}
+	if err := privateKeyShare.Unmarshal(legacyPrivateKeySharePayload); err != nil {
+		return nil, fmt.Errorf(
+			"%w: cannot unmarshal tbtc-signer legacy private key share: [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	return privateKeyShare, nil
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -30,8 +30,9 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive is a
 // transitional primitive that executes native two-round FROST when
 // `frost-uniffi-v2` signer material is provided, and preserves legacy bridge
-// execution for `frost-uniffi-v1` payloads. `frost-tbtc-signer-v1` is reserved
-// for coarse session engine integration and currently returns a scaffold error.
+// execution for `frost-uniffi-v1` payloads. `frost-tbtc-signer-v1` currently
+// routes through a temporary legacy fallback until coarse session finalize flow
+// is wired end-to-end.
 type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) Sign(
@@ -101,41 +102,26 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		return nil, err
 	}
 
-	engine := currentNativeTBTCSignerEngine()
-	if engine == nil {
-		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
-			ctx,
-			logger,
-			request,
-			legacyPrivateKeyShare,
-			"native tbtc-signer engine is unavailable",
+	// Do not start coarse native sessions until finalize flow is wired. Calling
+	// StartSignRound without finalize would orphan signer-engine state.
+	if currentNativeTBTCSignerEngine() != nil && logger != nil {
+		logger.Warnf(
+			"native tbtc-signer engine is registered but coarse finalize flow is not wired; using legacy fallback",
 		)
 	}
 
-	_, err = engine.StartSignRound(
-		request.SessionID,
-		request.Message.Bytes(),
-		payload.KeyGroup,
-	)
-	if err != nil {
-		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
-			ctx,
-			logger,
-			request,
-			legacyPrivateKeyShare,
-			fmt.Sprintf("tbtc-signer StartSignRound failed: [%v]", err),
-		)
-	}
-
-	// The coarse-session finalize flow is intentionally deferred until keep-core
-	// transport/orchestration is migrated from round-level message exchange. Use
-	// a Go-side legacy fallback while this migration is in progress.
+	// The coarse-session flow is intentionally deferred until keep-core
+	// orchestration is migrated from round-level message exchange. Use a Go-side
+	// legacy fallback while this migration is in progress.
 	return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 		ctx,
 		logger,
 		request,
 		legacyPrivateKeyShare,
-		"tbtc-signer coarse session finalize flow is not wired",
+		fmt.Sprintf(
+			"tbtc-signer coarse session flow is not wired (keyGroupSource=%s)",
+			payload.KeyGroupSource,
+		),
 	)
 }
 
@@ -264,14 +250,9 @@ func decodeBuildTaggedLegacyPrivateKeyShare(
 	return privateKeyShare, nil
 }
 
-type buildTaggedTBTCSignerMaterialPayload struct {
-	KeyGroup                 string `json:"keyGroup"`
-	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
-}
-
 func decodeBuildTaggedTBTCSignerMaterialPayload(
 	signerMaterial *NativeSignerMaterial,
-) (*buildTaggedTBTCSignerMaterialPayload, error) {
+) (*NativeTBTCSignerMaterialPayload, error) {
 	if signerMaterial == nil {
 		return nil, fmt.Errorf(
 			"%w: signer material is nil",
@@ -294,7 +275,7 @@ func decodeBuildTaggedTBTCSignerMaterialPayload(
 		)
 	}
 
-	var payload buildTaggedTBTCSignerMaterialPayload
+	var payload NativeTBTCSignerMaterialPayload
 	if err := json.Unmarshal(signerMaterial.Payload, &payload); err != nil {
 		return nil, fmt.Errorf(
 			"%w: cannot unmarshal tbtc-signer payload: [%v]",
@@ -325,7 +306,7 @@ func decodeBuildTaggedTBTCSignerKeyGroup(
 }
 
 func decodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(
-	payload *buildTaggedTBTCSignerMaterialPayload,
+	payload *NativeTBTCSignerMaterialPayload,
 ) (*tecdsa.PrivateKeyShare, error) {
 	if payload == nil || payload.LegacyPrivateKeyShareHex == "" {
 		return nil, nil

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -482,8 +482,13 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		messageBytes = []byte{0}
 	}
 
+	if request.MemberIndex == 0 {
+		return fmt.Errorf("request member index is zero")
+	}
+
 	roundState, err := nativeEngine.StartSignRound(
 		request.SessionID,
+		uint16(request.MemberIndex),
 		messageBytes,
 		keyGroup,
 	)
@@ -554,19 +559,13 @@ func buildTaggedTBTCSignerRoundContributions(
 		)
 	}
 
-	ownContributions, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+	ownContribution, err := buildTaggedTBTCSignerOwnRoundContribution(
+		request,
 		roundState,
-		[]group.MemberIndex{request.MemberIndex},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build own round contribution: [%w]", err)
 	}
-
-	if len(ownContributions) != 1 {
-		return nil, fmt.Errorf("unexpected own contribution count: [%v]", len(ownContributions))
-	}
-
-	ownContribution := ownContributions[0]
 
 	roundContributionMessage := &buildTaggedTBTCSignerRoundContributionMessage{
 		SenderIDValue:          uint32(request.MemberIndex),
@@ -619,6 +618,64 @@ func buildTaggedTBTCSignerRoundContributions(
 	}
 
 	return orderedContributions, nil
+}
+
+func buildTaggedTBTCSignerOwnRoundContribution(
+	request *NativeExecutionFFISigningRequest,
+	roundState *NativeTBTCSignerRoundState,
+) (NativeTBTCSignerRoundContribution, error) {
+	if request == nil {
+		return NativeTBTCSignerRoundContribution{}, fmt.Errorf("request is nil")
+	}
+
+	if request.MemberIndex == 0 {
+		return NativeTBTCSignerRoundContribution{}, fmt.Errorf("request member index is zero")
+	}
+
+	if roundState != nil && roundState.OwnContribution != nil {
+		ownContribution := roundState.OwnContribution
+		if ownContribution.Identifier == 0 {
+			return NativeTBTCSignerRoundContribution{}, fmt.Errorf(
+				"round state own contribution identifier is zero",
+			)
+		}
+
+		if len(ownContribution.Data) == 0 {
+			return NativeTBTCSignerRoundContribution{}, fmt.Errorf(
+				"round state own contribution data is empty",
+			)
+		}
+
+		if ownContribution.Identifier != uint16(request.MemberIndex) {
+			return NativeTBTCSignerRoundContribution{}, fmt.Errorf(
+				"round state own contribution identifier [%v] does not match member index [%v]",
+				ownContribution.Identifier,
+				request.MemberIndex,
+			)
+		}
+
+		return NativeTBTCSignerRoundContribution{
+			Identifier: ownContribution.Identifier,
+			Data:       append([]byte{}, ownContribution.Data...),
+		}, nil
+	}
+
+	ownContributions, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+		roundState,
+		[]group.MemberIndex{request.MemberIndex},
+	)
+	if err != nil {
+		return NativeTBTCSignerRoundContribution{}, err
+	}
+
+	if len(ownContributions) != 1 {
+		return NativeTBTCSignerRoundContribution{}, fmt.Errorf(
+			"unexpected own contribution count: [%v]",
+			len(ownContributions),
+		)
+	}
+
+	return ownContributions[0], nil
 }
 
 func collectBuildTaggedTBTCSignerRoundContributionMessages(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -4,6 +4,7 @@ package signing
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/ipfs/go-log/v2"
@@ -28,7 +29,8 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive is a
 // transitional primitive that executes native two-round FROST when
 // `frost-uniffi-v2` signer material is provided, and preserves legacy bridge
-// execution for `frost-uniffi-v1` payloads.
+// execution for `frost-uniffi-v1` payloads. `frost-tbtc-signer-v1` is reserved
+// for coarse session engine integration and currently returns a scaffold error.
 type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) Sign(
@@ -71,6 +73,9 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	case NativeSignerMaterialFormatFrostUniFFIV1:
 		return btlcnnefsp.signWithLegacyTECDSABridge(ctx, logger, request)
 
+	case NativeSignerMaterialFormatFrostTBTCSignerV1:
+		return btlcnnefsp.signWithTBTCSignerCoarseEngine(ctx, logger, request)
+
 	default:
 		return nil, fmt.Errorf(
 			"%w: unsupported signer material format: [%s]",
@@ -78,6 +83,45 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			request.SignerMaterial.Format,
 		)
 	}
+}
+
+func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithTBTCSignerCoarseEngine(
+	ctx context.Context,
+	logger log.StandardLogger,
+	request *NativeExecutionFFISigningRequest,
+) (*frost.Signature, error) {
+	keyGroup, err := decodeBuildTaggedTBTCSignerKeyGroup(request.SignerMaterial)
+	if err != nil {
+		return nil, err
+	}
+
+	engine := currentNativeTBTCSignerEngine()
+	if engine == nil {
+		return nil, fmt.Errorf(
+			"%w: native tbtc-signer engine is unavailable",
+			ErrNativeCryptographyUnavailable,
+		)
+	}
+
+	_, err = engine.StartSignRound(
+		request.SessionID,
+		request.Message.Bytes(),
+		keyGroup,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: tbtc-signer StartSignRound failed: [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	// The coarse-session finalize flow is intentionally deferred until keep-core
+	// transport/orchestration is migrated from round-level message exchange.
+	return nil, fmt.Errorf(
+		"%w: tbtc-signer coarse session finalize flow is not wired",
+		ErrNativeCryptographyUnavailable,
+	)
 }
 
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithLegacyTECDSABridge(
@@ -159,4 +203,52 @@ func decodeBuildTaggedLegacyPrivateKeyShare(
 	}
 
 	return privateKeyShare, nil
+}
+
+type buildTaggedTBTCSignerMaterialPayload struct {
+	KeyGroup string `json:"keyGroup"`
+}
+
+func decodeBuildTaggedTBTCSignerKeyGroup(
+	signerMaterial *NativeSignerMaterial,
+) (string, error) {
+	if signerMaterial == nil {
+		return "", fmt.Errorf(
+			"%w: signer material is nil",
+			ErrNativeCryptographyUnavailable,
+		)
+	}
+
+	if signerMaterial.Format != NativeSignerMaterialFormatFrostTBTCSignerV1 {
+		return "", fmt.Errorf(
+			"%w: unsupported signer material format: [%s]",
+			ErrNativeCryptographyUnavailable,
+			signerMaterial.Format,
+		)
+	}
+
+	if len(signerMaterial.Payload) == 0 {
+		return "", fmt.Errorf(
+			"%w: signer material payload is empty",
+			ErrNativeCryptographyUnavailable,
+		)
+	}
+
+	var payload buildTaggedTBTCSignerMaterialPayload
+	if err := json.Unmarshal(signerMaterial.Payload, &payload); err != nil {
+		return "", fmt.Errorf(
+			"%w: cannot unmarshal tbtc-signer payload: [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if payload.KeyGroup == "" {
+		return "", fmt.Errorf(
+			"%w: tbtc-signer key group is empty",
+			ErrNativeCryptographyUnavailable,
+		)
+	}
+
+	return payload.KeyGroup, nil
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -486,11 +486,19 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		return fmt.Errorf("request member index is zero")
 	}
 
+	signingParticipants, err := buildTaggedTBTCSignerSigningParticipants(
+		includedMembersIndexes,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot derive signing participants: [%w]", err)
+	}
+
 	roundState, err := nativeEngine.StartSignRound(
 		request.SessionID,
 		uint16(request.MemberIndex),
 		messageBytes,
 		keyGroup,
+		signingParticipants,
 	)
 	if err != nil {
 		return fmt.Errorf("start sign round failed: [%w]", err)
@@ -502,6 +510,27 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 
 	if roundState.RequiredContributions == 0 {
 		return fmt.Errorf("start sign round required contributions are zero")
+	}
+
+	if len(roundState.SigningParticipants) > 0 {
+		if len(roundState.SigningParticipants) != len(signingParticipants) {
+			return fmt.Errorf(
+				"start sign round returned unexpected signing participants count: [%v] != [%v]",
+				len(roundState.SigningParticipants),
+				len(signingParticipants),
+			)
+		}
+
+		for i := range signingParticipants {
+			if roundState.SigningParticipants[i] != signingParticipants[i] {
+				return fmt.Errorf(
+					"start sign round returned unexpected signing participant at index [%d]: [%v] != [%v]",
+					i,
+					roundState.SigningParticipants[i],
+					signingParticipants[i],
+				)
+			}
+		}
 	}
 
 	roundContributions, err := buildTaggedTBTCSignerRoundContributions(
@@ -536,6 +565,33 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	}
 
 	return nil
+}
+
+func buildTaggedTBTCSignerSigningParticipants(
+	includedMembersIndexes []group.MemberIndex,
+) ([]uint16, error) {
+	if len(includedMembersIndexes) == 0 {
+		return nil, fmt.Errorf("included members are empty")
+	}
+
+	signingParticipants := make([]uint16, 0, len(includedMembersIndexes))
+	seenParticipants := make(map[uint16]struct{}, len(includedMembersIndexes))
+
+	for _, memberIndex := range includedMembersIndexes {
+		if memberIndex == 0 {
+			return nil, fmt.Errorf("included member index is zero")
+		}
+
+		participant := uint16(memberIndex)
+		if _, ok := seenParticipants[participant]; ok {
+			return nil, fmt.Errorf("duplicate included member index: [%v]", memberIndex)
+		}
+
+		seenParticipants[participant] = struct{}{}
+		signingParticipants = append(signingParticipants, participant)
+	}
+
+	return signingParticipants, nil
 }
 
 func buildTaggedTBTCSignerRoundContributions(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -171,13 +171,17 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	if payload.KeyGroup != dkgResult.KeyGroup {
+	keyGroupForRound, err := buildTaggedTBTCSignerRoundKeyGroup(
+		payload,
+		dkgResult,
+	)
+	if err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
 			logger,
 			request,
 			legacyPrivateKeyShare,
-			"tbtc-signer key group does not match RunDKG result",
+			err.Error(),
 			payload.KeyGroupSource,
 		)
 	}
@@ -225,7 +229,7 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 
 	if err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		request,
-		payload.KeyGroup,
+		keyGroupForRound,
 		nativeEngine,
 	); err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
@@ -302,6 +306,35 @@ func buildTaggedTBTCSignerDKGPlaceholderPublicKeyHex(identifier uint16) string {
 	// Transitional placeholder until canonical member public keys are available
 	// in the native signing request path.
 	return fmt.Sprintf("02%04x", identifier)
+}
+
+func buildTaggedTBTCSignerRoundKeyGroup(
+	payload *NativeTBTCSignerMaterialPayload,
+	dkgResult *NativeTBTCSignerDKGResult,
+) (string, error) {
+	if payload == nil {
+		return "", fmt.Errorf("tbtc-signer payload is nil")
+	}
+
+	if dkgResult == nil {
+		return "", fmt.Errorf("tbtc-signer RunDKG result is nil")
+	}
+
+	if dkgResult.KeyGroup == "" {
+		return "", fmt.Errorf("tbtc-signer RunDKG key group is empty")
+	}
+
+	if payload.KeyGroup == dkgResult.KeyGroup {
+		return payload.KeyGroup, nil
+	}
+
+	if payload.KeyGroupSource == NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey {
+		// Scaffold compatibility: legacy-wallet-pubkey key groups are
+		// placeholder-only and expected to diverge from coarse RunDKG output.
+		return dkgResult.KeyGroup, nil
+	}
+
+	return "", fmt.Errorf("tbtc-signer key group does not match RunDKG result")
 }
 
 func executeBuildTaggedTBTCSignerBootstrapCoarseRound(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -5,12 +5,45 @@ package signing
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
+
+type mockBuildTaggedTBTCSignerEngine struct {
+	startCalled bool
+	sessionID   string
+	message     []byte
+	keyGroup    string
+}
+
+func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
+	sessionID string,
+	message []byte,
+	keyGroup string,
+) (*NativeTBTCSignerRoundState, error) {
+	mbttse.startCalled = true
+	mbttse.sessionID = sessionID
+	mbttse.message = append([]byte{}, message...)
+	mbttse.keyGroup = keyGroup
+
+	return &NativeTBTCSignerRoundState{
+		SessionID:             sessionID,
+		RoundID:               "round-1",
+		RequiredContributions: 2,
+		MessageDigestHex:      "00",
+	}, nil
+}
+
+func (mbttse *mockBuildTaggedTBTCSignerEngine) FinalizeSignRound(
+	sessionID string,
+	roundContributions []NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	return nil, fmt.Errorf("not used")
+}
 
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_ValidatesRequest(
 	t *testing.T,
@@ -139,5 +172,136 @@ func TestDecodeBuildTaggedLegacyPrivateKeyShare_RejectsInvalidMaterial(
 				)
 			}
 		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerKeyGroup(t *testing.T) {
+	keyGroup, err := decodeBuildTaggedTBTCSignerKeyGroup(&NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+		Payload: []byte(`{"keyGroup":"group-1"}`),
+	})
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+
+	if keyGroup != "group-1" {
+		t.Fatalf(
+			"unexpected key group\nexpected: [%v]\nactual:   [%v]",
+			"group-1",
+			keyGroup,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerKeyGroup_RejectsInvalidMaterial(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name           string
+		signerMaterial *NativeSignerMaterial
+	}{
+		{
+			name:           "nil signer material",
+			signerMaterial: nil,
+		},
+		{
+			name: "unsupported format",
+			signerMaterial: &NativeSignerMaterial{
+				Format:  "other",
+				Payload: []byte(`{"keyGroup":"group-1"}`),
+			},
+		},
+		{
+			name: "empty payload",
+			signerMaterial: &NativeSignerMaterial{
+				Format: NativeSignerMaterialFormatFrostTBTCSignerV1,
+			},
+		},
+		{
+			name: "invalid payload",
+			signerMaterial: &NativeSignerMaterial{
+				Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+				Payload: []byte(`{"keyGroup":`),
+			},
+		},
+		{
+			name: "empty key group",
+			signerMaterial: &NativeSignerMaterial{
+				Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+				Payload: []byte(`{"keyGroup":""}`),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeBuildTaggedTBTCSignerKeyGroup(tc.signerMaterial)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+
+			if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+				t.Fatalf(
+					"unexpected error\nexpected: [%v]\nactual:   [%v]",
+					ErrNativeCryptographyUnavailable,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath(
+	t *testing.T,
+) {
+	engine := &mockBuildTaggedTBTCSignerEngine{}
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:   big.NewInt(123),
+		SessionID: "session-1",
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1"}`),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if !engine.startCalled {
+		t.Fatal("expected StartSignRound call")
+	}
+
+	if engine.sessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session ID\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			engine.sessionID,
+		)
+	}
+
+	if engine.keyGroup != "group-1" {
+		t.Fatalf(
+			"unexpected key group\nexpected: [%v]\nactual:   [%v]",
+			"group-1",
+			engine.keyGroup,
+		)
 	}
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -4,6 +4,7 @@ package signing
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -246,6 +247,111 @@ func TestDecodeBuildTaggedTBTCSignerKeyGroup_RejectsInvalidMaterial(
 					ErrNativeCryptographyUnavailable,
 					err,
 				)
+			}
+		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(t *testing.T) {
+	fixtures, err := tecdsatest.LoadPrivateKeyShareTestFixtures(5)
+	if err != nil {
+		t.Fatalf("failed loading key share fixtures: [%v]", err)
+	}
+
+	expectedPrivateKeyShare := tecdsa.NewPrivateKeyShare(fixtures[0])
+	expectedPayload, err := expectedPrivateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("failed marshaling private key share: [%v]", err)
+	}
+
+	decodedPrivateKeyShare, err := decodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(
+		&buildTaggedTBTCSignerMaterialPayload{
+			KeyGroup:                 "group-1",
+			LegacyPrivateKeyShareHex: hex.EncodeToString(expectedPayload),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+
+	if decodedPrivateKeyShare == nil {
+		t.Fatal("expected decoded private key share")
+	}
+
+	actualPayload, err := decodedPrivateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("failed marshaling decoded private key share: [%v]", err)
+	}
+
+	if !bytes.Equal(expectedPayload, actualPayload) {
+		t.Fatalf(
+			"unexpected decoded private key share\nexpected: [%x]\nactual:   [%x]",
+			expectedPayload,
+			actualPayload,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerLegacyPrivateKeyShare_RejectsInvalidPayload(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name        string
+		payload     *buildTaggedTBTCSignerMaterialPayload
+		expectError bool
+	}{
+		{
+			name:        "nil payload",
+			payload:     nil,
+			expectError: false,
+		},
+		{
+			name:        "empty legacy private key share",
+			payload:     &buildTaggedTBTCSignerMaterialPayload{},
+			expectError: false,
+		},
+		{
+			name: "invalid hex",
+			payload: &buildTaggedTBTCSignerMaterialPayload{
+				LegacyPrivateKeyShareHex: "zz",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid private key share payload",
+			payload: &buildTaggedTBTCSignerMaterialPayload{
+				LegacyPrivateKeyShareHex: hex.EncodeToString(big.NewInt(123).Bytes()),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded, err := decodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(tc.payload)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+
+				if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+					t.Fatalf(
+						"unexpected error\nexpected: [%v]\nactual:   [%v]",
+						ErrNativeCryptographyUnavailable,
+						err,
+					)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected nil error, got: [%v]", err)
+			}
+
+			if decoded != nil {
+				t.Fatalf("expected nil decoded private key share, got: [%v]", decoded)
 			}
 		})
 	}

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -401,16 +401,28 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	t *testing.T,
 ) {
 	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err := RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
 
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
 
-	_, err := primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
 		Message:   big.NewInt(123),
 		SessionID: "session-1",
 		SignerMaterial: &NativeSignerMaterial{
 			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
-			Payload: []byte(`{"keyGroup":"group-1"}`),
+			Payload: []byte(`{"keyGroup":"group-1","keyGroupSource":"legacy-wallet-pubkey"}`),
 		},
 	})
 	if err == nil {
@@ -423,5 +435,34 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			ErrNativeCryptographyUnavailable,
 			err,
 		)
+	}
+
+	if len(observedEvents) != 1 {
+		t.Fatalf(
+			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(observedEvents),
+		)
+	}
+
+	event := observedEvents[0]
+	if event.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected fallback session ID\nexpected: [%s]\nactual:   [%s]",
+			"session-1",
+			event.SessionID,
+		)
+	}
+
+	if event.KeyGroupSource != "legacy-wallet-pubkey" {
+		t.Fatalf(
+			"unexpected fallback key group source\nexpected: [%s]\nactual:   [%s]",
+			"legacy-wallet-pubkey",
+			event.KeyGroupSource,
+		)
+	}
+
+	if event.LegacyPrivateKeyShareExists {
+		t.Fatal("expected fallback event without legacy private key share")
 	}
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -36,6 +36,7 @@ type mockBuildTaggedTBTCSignerEngine struct {
 	versionErr        error
 	startCalled       bool
 	startSessionID    string
+	startMemberID     uint16
 	startMessage      []byte
 	startKeyGroup     string
 	startRoundState   *NativeTBTCSignerRoundState
@@ -91,11 +92,13 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) Version() (string, error) {
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	sessionID string,
+	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
 ) (*NativeTBTCSignerRoundState, error) {
 	mbttse.startCalled = true
 	mbttse.startSessionID = sessionID
+	mbttse.startMemberID = memberIdentifier
 	mbttse.startMessage = append([]byte{}, message...)
 	mbttse.startKeyGroup = keyGroup
 
@@ -160,10 +163,18 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) RunDKG(
 
 func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSignRound(
 	sessionID string,
+	memberIdentifier uint16,
 	_ []byte,
 	_ string,
 ) (*NativeTBTCSignerRoundState, error) {
 	if dbttsbre.roundState != nil {
+		if dbttsbre.roundState.OwnContribution == nil {
+			dbttsbre.roundState.OwnContribution = &NativeTBTCSignerRoundContribution{
+				Identifier: memberIdentifier,
+				Data:       []byte{byte(memberIdentifier), 0xab},
+			}
+		}
+
 		return dbttsbre.roundState, nil
 	}
 
@@ -172,6 +183,10 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 		RoundID:               "round-1",
 		RequiredContributions: 2,
 		MessageDigestHex:      "00",
+		OwnContribution: &NativeTBTCSignerRoundContribution{
+			Identifier: memberIdentifier,
+			Data:       []byte{byte(memberIdentifier), 0xab},
+		},
 	}, nil
 }
 
@@ -742,16 +757,31 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributions
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
 	primitive.RegisterUnmarshallers(channel)
 
-	roundState := &NativeTBTCSignerRoundState{
-		SessionID:             "session-1",
-		RoundID:               "round-1",
-		RequiredContributions: 2,
-		MessageDigestHex:      "0011",
-	}
-
 	engineByMember := map[group.MemberIndex]*deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{
-		1: &deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{roundState: roundState},
-		2: &deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{roundState: roundState},
+		1: &deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{
+			roundState: &NativeTBTCSignerRoundState{
+				SessionID:             "session-1",
+				RoundID:               "round-1",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: 1,
+					Data:       []byte{0x11, 0x01},
+				},
+			},
+		},
+		2: &deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{
+			roundState: &NativeTBTCSignerRoundState{
+				SessionID:             "session-1",
+				RoundID:               "round-1",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: 2,
+					Data:       []byte{0x22, 0x02},
+				},
+			},
+		},
 	}
 
 	requestByMember := map[group.MemberIndex]*NativeExecutionFFISigningRequest{
@@ -839,6 +869,24 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributions
 
 		if len(finalizeInputs[0].Data) == 0 || len(finalizeInputs[1].Data) == 0 {
 			t.Fatalf("expected non-empty finalize contribution data for member [%v]", memberIndex)
+		}
+
+		if !bytes.Equal(finalizeInputs[0].Data, []byte{0x11, 0x01}) {
+			t.Fatalf(
+				"unexpected contribution data for identifier 1, member [%v]\nexpected: [%x]\nactual:   [%x]",
+				memberIndex,
+				[]byte{0x11, 0x01},
+				finalizeInputs[0].Data,
+			)
+		}
+
+		if !bytes.Equal(finalizeInputs[1].Data, []byte{0x22, 0x02}) {
+			t.Fatalf(
+				"unexpected contribution data for identifier 2, member [%v]\nexpected: [%x]\nactual:   [%x]",
+				memberIndex,
+				[]byte{0x22, 0x02},
+				finalizeInputs[1].Data,
+			)
 		}
 	}
 }
@@ -1117,6 +1165,14 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			"unexpected StartSignRound session ID\nexpected: [%v]\nactual:   [%v]",
 			"session-1",
 			engine.startSessionID,
+		)
+	}
+
+	if engine.startMemberID != 1 {
+		t.Fatalf(
+			"unexpected StartSignRound member identifier\nexpected: [%v]\nactual:   [%v]",
+			1,
+			engine.startMemberID,
 		)
 	}
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"math/big"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
@@ -21,19 +23,24 @@ type mockBuildTaggedTBTCSignerEngine struct {
 	runDKGThreshold    uint16
 	runDKGResult       *NativeTBTCSignerDKGResult
 	runDKGErr          error
-	version            string
-	versionErr         error
-	startCalled        bool
-	startSessionID     string
-	startMessage       []byte
-	startKeyGroup      string
-	startRoundState    *NativeTBTCSignerRoundState
-	startErr           error
-	finalizeCalled     bool
-	finalizeSessionID  string
-	finalizeInputs     []NativeTBTCSignerRoundContribution
-	finalizeSignature  []byte
-	finalizeErr        error
+	runDKGFn           func(
+		sessionID string,
+		participants []NativeTBTCSignerDKGParticipant,
+		threshold uint16,
+	) (*NativeTBTCSignerDKGResult, error)
+	version           string
+	versionErr        error
+	startCalled       bool
+	startSessionID    string
+	startMessage      []byte
+	startKeyGroup     string
+	startRoundState   *NativeTBTCSignerRoundState
+	startErr          error
+	finalizeCalled    bool
+	finalizeSessionID string
+	finalizeInputs    []NativeTBTCSignerRoundContribution
+	finalizeSignature []byte
+	finalizeErr       error
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -51,6 +58,10 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
 
 	if mbttse.runDKGErr != nil {
 		return nil, mbttse.runDKGErr
+	}
+
+	if mbttse.runDKGFn != nil {
+		return mbttse.runDKGFn(sessionID, participants, threshold)
 	}
 
 	if mbttse.runDKGResult != nil {
@@ -660,6 +671,7 @@ func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 		payload     *NativeTBTCSignerMaterialPayload
 		dkgResult   *NativeTBTCSignerDKGResult
 		expected    string
+		substituted bool
 		expectError bool
 	}{
 		{
@@ -670,7 +682,8 @@ func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 			dkgResult: &NativeTBTCSignerDKGResult{
 				KeyGroup: "group-1",
 			},
-			expected: "group-1",
+			expected:    "group-1",
+			substituted: false,
 		},
 		{
 			name: "legacy source mismatch uses dkg key group",
@@ -681,7 +694,8 @@ func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 			dkgResult: &NativeTBTCSignerDKGResult{
 				KeyGroup: "dkg-group",
 			},
-			expected: "dkg-group",
+			expected:    "dkg-group",
+			substituted: true,
 		},
 		{
 			name: "non-legacy source mismatch rejects",
@@ -698,7 +712,7 @@ func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := buildTaggedTBTCSignerRoundKeyGroup(tc.payload, tc.dkgResult)
+			actual, substituted, err := buildTaggedTBTCSignerRoundKeyGroup(tc.payload, tc.dkgResult)
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("expected error")
@@ -714,6 +728,82 @@ func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 			if actual != tc.expected {
 				t.Fatalf(
 					"unexpected key group\nexpected: [%v]\nactual:   [%v]",
+					tc.expected,
+					actual,
+				)
+			}
+
+			if substituted != tc.substituted {
+				t.Fatalf(
+					"unexpected substitution flag\nexpected: [%v]\nactual:   [%v]",
+					tc.substituted,
+					substituted,
+				)
+			}
+		})
+	}
+}
+
+func TestIsBuildTaggedTBTCSignerBootstrapVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version  string
+		expected bool
+	}{
+		{
+			name:     "valid exact bootstrap",
+			version:  "tbtc-signer/0.1.0-bootstrap",
+			expected: true,
+		},
+		{
+			name:     "valid bootstrap dotted suffix",
+			version:  "tbtc-signer/0.1.0-bootstrap.1",
+			expected: true,
+		},
+		{
+			name:     "invalid non-bootstrap prerelease",
+			version:  "tbtc-signer/0.1.0-post-bootstrap",
+			expected: false,
+		},
+		{
+			name:     "invalid major version one",
+			version:  "tbtc-signer/1.0.0-bootstrap",
+			expected: false,
+		},
+		{
+			name:     "invalid missing prerelease",
+			version:  "tbtc-signer/0.1.0",
+			expected: false,
+		},
+		{
+			name:     "invalid malformed core semver",
+			version:  "tbtc-signer/0.1-bootstrap",
+			expected: false,
+		},
+		{
+			name:     "invalid prefix",
+			version:  "other/0.1.0-bootstrap",
+			expected: false,
+		},
+		{
+			name:     "invalid uppercase bootstrap token",
+			version:  "tbtc-signer/0.1.0-Bootstrap",
+			expected: false,
+		},
+		{
+			name:     "invalid substring trap",
+			version:  "tbtc-signer/0.1.0-post-bootstrap-cleanup",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isBuildTaggedTBTCSignerBootstrapVersion(tc.version)
+			if actual != tc.expected {
+				t.Fatalf(
+					"unexpected bootstrap version classification\nversion:  [%s]\nexpected: [%v]\nactual:   [%v]",
+					tc.version,
 					tc.expected,
 					actual,
 				)
@@ -1087,5 +1177,124 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 
 	if event.LegacyPrivateKeyShareExists {
 		t.Fatal("expected fallback event without legacy private key share")
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_AttemptVariationRunDKGConflictFallsBack(
+	t *testing.T,
+) {
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	var firstParticipants []NativeTBTCSignerDKGParticipant
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0",
+		runDKGFn: func(
+			sessionID string,
+			participants []NativeTBTCSignerDKGParticipant,
+			threshold uint16,
+		) (*NativeTBTCSignerDKGResult, error) {
+			if firstParticipants == nil {
+				firstParticipants = append(
+					[]NativeTBTCSignerDKGParticipant{},
+					participants...,
+				)
+
+				return &NativeTBTCSignerDKGResult{
+					SessionID:        sessionID,
+					KeyGroup:         "group-1",
+					ParticipantCount: uint16(len(participants)),
+					Threshold:        threshold,
+					CreatedAtUnix:    1,
+				}, nil
+			}
+
+			if !reflect.DeepEqual(participants, firstParticipants) {
+				return nil, errors.New("session_conflict")
+			}
+
+			return &NativeTBTCSignerDKGResult{
+				SessionID:        sessionID,
+				KeyGroup:         "group-1",
+				ParticipantCount: uint16(len(participants)),
+				Threshold:        threshold,
+				CreatedAtUnix:    1,
+			}, nil
+		},
+	}
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	baseRequest := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1","keyGroupSource":"legacy-wallet-pubkey"}`),
+		},
+	}
+
+	_, err = primitive.Sign(nil, nil, baseRequest)
+	if err == nil {
+		t.Fatal("expected first signing error due to legacy fallback without private key share")
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected first signing error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	secondRequest := *baseRequest
+	secondRequest.Attempt = &Attempt{
+		ExcludedMembersIndexes: []group.MemberIndex{3},
+	}
+
+	_, err = primitive.Sign(nil, nil, &secondRequest)
+	if err == nil {
+		t.Fatal("expected second signing error due to legacy fallback without private key share")
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected second signing error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if len(observedEvents) != 2 {
+		t.Fatalf(
+			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
+			2,
+			len(observedEvents),
+		)
+	}
+
+	if !strings.Contains(observedEvents[1].Reason, "session_conflict") {
+		t.Fatalf(
+			"expected second fallback reason to include session_conflict\nactual: [%s]",
+			observedEvents[1].Reason,
+		)
 	}
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -4,14 +4,18 @@ package signing
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"math/big"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
+	"github.com/keep-network/keep-core/pkg/net/local"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
@@ -131,6 +135,67 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) FinalizeSignRound(
 	}
 
 	return []byte{0xaa}, nil
+}
+
+type deterministicBuildTaggedTBTCSignerBootstrapRoundEngine struct {
+	roundState    *NativeTBTCSignerRoundState
+	finalizeMutex sync.Mutex
+	finalizeCalls int
+	finalizeInput []NativeTBTCSignerRoundContribution
+}
+
+func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) RunDKG(
+	sessionID string,
+	participants []NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) (*NativeTBTCSignerDKGResult, error) {
+	return &NativeTBTCSignerDKGResult{
+		SessionID:        sessionID,
+		KeyGroup:         "group-1",
+		ParticipantCount: uint16(len(participants)),
+		Threshold:        threshold,
+		CreatedAtUnix:    1,
+	}, nil
+}
+
+func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSignRound(
+	sessionID string,
+	_ []byte,
+	_ string,
+) (*NativeTBTCSignerRoundState, error) {
+	if dbttsbre.roundState != nil {
+		return dbttsbre.roundState, nil
+	}
+
+	return &NativeTBTCSignerRoundState{
+		SessionID:             sessionID,
+		RoundID:               "round-1",
+		RequiredContributions: 2,
+		MessageDigestHex:      "00",
+	}, nil
+}
+
+func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) FinalizeSignRound(
+	_ string,
+	roundContributions []NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	dbttsbre.finalizeMutex.Lock()
+	defer dbttsbre.finalizeMutex.Unlock()
+
+	dbttsbre.finalizeCalls++
+	dbttsbre.finalizeInput = append(
+		[]NativeTBTCSignerRoundContribution{},
+		roundContributions...,
+	)
+
+	return []byte{0xaa}, nil
+}
+
+func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) finalizeInputs() []NativeTBTCSignerRoundContribution {
+	dbttsbre.finalizeMutex.Lock()
+	defer dbttsbre.finalizeMutex.Unlock()
+
+	return append([]NativeTBTCSignerRoundContribution{}, dbttsbre.finalizeInput...)
 }
 
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_ValidatesRequest(
@@ -662,6 +727,119 @@ func TestBuildTaggedTBTCSignerSyntheticRoundContributions_RejectsInvalidInput(t 
 				t.Fatal("expected error")
 			}
 		})
+	}
+}
+
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributionsOverChannel(
+	t *testing.T,
+) {
+	provider := local.Connect()
+	channel, err := provider.BroadcastChannelFor("tbtc-signer-bootstrap-round-plumbing-test")
+	if err != nil {
+		t.Fatalf("failed creating broadcast channel: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+	primitive.RegisterUnmarshallers(channel)
+
+	roundState := &NativeTBTCSignerRoundState{
+		SessionID:             "session-1",
+		RoundID:               "round-1",
+		RequiredContributions: 2,
+		MessageDigestHex:      "0011",
+	}
+
+	engineByMember := map[group.MemberIndex]*deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{
+		1: &deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{roundState: roundState},
+		2: &deterministicBuildTaggedTBTCSignerBootstrapRoundEngine{roundState: roundState},
+	}
+
+	requestByMember := map[group.MemberIndex]*NativeExecutionFFISigningRequest{
+		1: {
+			Message:            big.NewInt(123),
+			SessionID:          "session-1",
+			MemberIndex:        1,
+			GroupSize:          2,
+			DishonestThreshold: 1,
+			Channel:            channel,
+			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
+				IncludedMembersIndexes: []group.MemberIndex{1, 2},
+			},
+		},
+		2: {
+			Message:            big.NewInt(123),
+			SessionID:          "session-1",
+			MemberIndex:        2,
+			GroupSize:          2,
+			DishonestThreshold: 1,
+			Channel:            channel,
+			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
+				IncludedMembersIndexes: []group.MemberIndex{1, 2},
+			},
+		},
+	}
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelCtx()
+
+	var wg sync.WaitGroup
+	signingErrors := make(chan error, len(requestByMember))
+
+	for memberIndex, request := range requestByMember {
+		engine := engineByMember[memberIndex]
+		wg.Add(1)
+
+		go func(
+			signingRequest *NativeExecutionFFISigningRequest,
+			signingEngine NativeTBTCSignerEngine,
+		) {
+			defer wg.Done()
+
+			signingErrors <- executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+				ctx,
+				signingRequest,
+				"group-1",
+				signingEngine,
+			)
+		}(request, engine)
+	}
+
+	wg.Wait()
+	close(signingErrors)
+
+	for signingErr := range signingErrors {
+		if signingErr != nil {
+			t.Fatalf("unexpected signing error: [%v]", signingErr)
+		}
+	}
+
+	for memberIndex, engine := range engineByMember {
+		finalizeInputs := engine.finalizeInputs()
+		if len(finalizeInputs) != 2 {
+			t.Fatalf(
+				"unexpected finalize input count for member [%v]\nexpected: [%v]\nactual:   [%v]",
+				memberIndex,
+				2,
+				len(finalizeInputs),
+			)
+		}
+
+		if finalizeInputs[0].Identifier != 1 || finalizeInputs[1].Identifier != 2 {
+			t.Fatalf(
+				"unexpected finalize identifiers for member [%v]\nexpected: [1 2]\nactual:   [%v %v]",
+				memberIndex,
+				finalizeInputs[0].Identifier,
+				finalizeInputs[1].Identifier,
+			)
+		}
+
+		if len(finalizeInputs[0].Data) == 0 || len(finalizeInputs[1].Data) == 0 {
+			t.Fatalf("expected non-empty finalize contribution data for member [%v]", memberIndex)
+		}
 	}
 }
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -265,7 +265,7 @@ func TestDecodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(t *testing.T) {
 	}
 
 	decodedPrivateKeyShare, err := decodeBuildTaggedTBTCSignerLegacyPrivateKeyShare(
-		&buildTaggedTBTCSignerMaterialPayload{
+		&NativeTBTCSignerMaterialPayload{
 			KeyGroup:                 "group-1",
 			LegacyPrivateKeyShareHex: hex.EncodeToString(expectedPayload),
 		},
@@ -297,7 +297,7 @@ func TestDecodeBuildTaggedTBTCSignerLegacyPrivateKeyShare_RejectsInvalidPayload(
 ) {
 	testCases := []struct {
 		name        string
-		payload     *buildTaggedTBTCSignerMaterialPayload
+		payload     *NativeTBTCSignerMaterialPayload
 		expectError bool
 	}{
 		{
@@ -307,19 +307,19 @@ func TestDecodeBuildTaggedTBTCSignerLegacyPrivateKeyShare_RejectsInvalidPayload(
 		},
 		{
 			name:        "empty legacy private key share",
-			payload:     &buildTaggedTBTCSignerMaterialPayload{},
+			payload:     &NativeTBTCSignerMaterialPayload{},
 			expectError: false,
 		},
 		{
 			name: "invalid hex",
-			payload: &buildTaggedTBTCSignerMaterialPayload{
+			payload: &NativeTBTCSignerMaterialPayload{
 				LegacyPrivateKeyShareHex: "zz",
 			},
 			expectError: true,
 		},
 		{
 			name: "invalid private key share payload",
-			payload: &buildTaggedTBTCSignerMaterialPayload{
+			payload: &NativeTBTCSignerMaterialPayload{
 				LegacyPrivateKeyShareHex: hex.EncodeToString(big.NewInt(123).Bytes()),
 			},
 			expectError: true,
@@ -391,23 +391,37 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		)
 	}
 
-	if !engine.startCalled {
-		t.Fatal("expected StartSignRound call")
+	if engine.startCalled {
+		t.Fatal("did not expect StartSignRound call while coarse finalize flow is unwired")
 	}
 
-	if engine.sessionID != "session-1" {
-		t.Fatalf(
-			"unexpected session ID\nexpected: [%v]\nactual:   [%v]",
-			"session-1",
-			engine.sessionID,
-		)
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_NoEngineNoLegacyShare(
+	t *testing.T,
+) {
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err := primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:   big.NewInt(123),
+		SessionID: "session-1",
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1"}`),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
 	}
 
-	if engine.keyGroup != "group-1" {
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
 		t.Fatalf(
-			"unexpected key group\nexpected: [%v]\nactual:   [%v]",
-			"group-1",
-			engine.keyGroup,
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
 		)
 	}
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -21,6 +21,14 @@ type mockBuildTaggedTBTCSignerEngine struct {
 	keyGroup    string
 }
 
+func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
+	sessionID string,
+	participants []NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) (*NativeTBTCSignerDKGResult, error) {
+	return nil, fmt.Errorf("not used")
+}
+
 func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	sessionID string,
 	message []byte,

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -518,6 +518,74 @@ func TestBuildTaggedTBTCSignerRunDKGInputs_RejectsInvalidRequest(t *testing.T) {
 	}
 }
 
+func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
+	testCases := []struct {
+		name        string
+		payload     *NativeTBTCSignerMaterialPayload
+		dkgResult   *NativeTBTCSignerDKGResult
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "exact match",
+			payload: &NativeTBTCSignerMaterialPayload{
+				KeyGroup: "group-1",
+			},
+			dkgResult: &NativeTBTCSignerDKGResult{
+				KeyGroup: "group-1",
+			},
+			expected: "group-1",
+		},
+		{
+			name: "legacy source mismatch uses dkg key group",
+			payload: &NativeTBTCSignerMaterialPayload{
+				KeyGroup:       "legacy-group",
+				KeyGroupSource: NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+			},
+			dkgResult: &NativeTBTCSignerDKGResult{
+				KeyGroup: "dkg-group",
+			},
+			expected: "dkg-group",
+		},
+		{
+			name: "non-legacy source mismatch rejects",
+			payload: &NativeTBTCSignerMaterialPayload{
+				KeyGroup:       "legacy-group",
+				KeyGroupSource: "dkg-persisted",
+			},
+			dkgResult: &NativeTBTCSignerDKGResult{
+				KeyGroup: "dkg-group",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := buildTaggedTBTCSignerRoundKeyGroup(tc.payload, tc.dkgResult)
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: [%v]", err)
+			}
+
+			if actual != tc.expected {
+				t.Fatalf(
+					"unexpected key group\nexpected: [%v]\nactual:   [%v]",
+					tc.expected,
+					actual,
+				)
+			}
+		})
+	}
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath(
 	t *testing.T,
 ) {
@@ -690,6 +758,129 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		if len(contribution.Data) == 0 {
 			t.Fatalf("expected non-empty contribution data at index [%d]", i)
 		}
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_LegacyKeyGroupSourceUsesRunDKGResult(
+	t *testing.T,
+) {
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0-bootstrap",
+		runDKGResult: &NativeTBTCSignerDKGResult{
+			SessionID:        "session-1",
+			KeyGroup:         "group-from-dkg",
+			ParticipantCount: 3,
+			Threshold:        2,
+			CreatedAtUnix:    1,
+		},
+		finalizeSignature: []byte{0xaa},
+	}
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format: NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(
+				`{"keyGroup":"legacy-wallet-derived","keyGroupSource":"legacy-wallet-pubkey"}`,
+			),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if !engine.startCalled {
+		t.Fatal("expected StartSignRound call in bootstrap path")
+	}
+
+	if engine.startKeyGroup != "group-from-dkg" {
+		t.Fatalf(
+			"unexpected StartSignRound key group\nexpected: [%v]\nactual:   [%v]",
+			"group-from-dkg",
+			engine.startKeyGroup,
+		)
+	}
+
+	if !engine.finalizeCalled {
+		t.Fatal("expected FinalizeSignRound call in bootstrap path")
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_KeyGroupMismatchNonLegacySourceSkipsCoarseRound(
+	t *testing.T,
+) {
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0-bootstrap",
+		runDKGResult: &NativeTBTCSignerDKGResult{
+			SessionID:        "session-1",
+			KeyGroup:         "group-from-dkg",
+			ParticipantCount: 3,
+			Threshold:        2,
+			CreatedAtUnix:    1,
+		},
+	}
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format: NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(
+				`{"keyGroup":"legacy-wallet-derived","keyGroupSource":"dkg-persisted"}`,
+			),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if engine.startCalled {
+		t.Fatal("did not expect StartSignRound call for non-legacy key-group mismatch")
+	}
+
+	if engine.finalizeCalled {
+		t.Fatal("did not expect FinalizeSignRound call for non-legacy key-group mismatch")
 	}
 }
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -32,20 +32,21 @@ type mockBuildTaggedTBTCSignerEngine struct {
 		participants []NativeTBTCSignerDKGParticipant,
 		threshold uint16,
 	) (*NativeTBTCSignerDKGResult, error)
-	version           string
-	versionErr        error
-	startCalled       bool
-	startSessionID    string
-	startMemberID     uint16
-	startMessage      []byte
-	startKeyGroup     string
-	startRoundState   *NativeTBTCSignerRoundState
-	startErr          error
-	finalizeCalled    bool
-	finalizeSessionID string
-	finalizeInputs    []NativeTBTCSignerRoundContribution
-	finalizeSignature []byte
-	finalizeErr       error
+	version                  string
+	versionErr               error
+	startCalled              bool
+	startSessionID           string
+	startMemberID            uint16
+	startMessage             []byte
+	startKeyGroup            string
+	startSigningParticipants []uint16
+	startRoundState          *NativeTBTCSignerRoundState
+	startErr                 error
+	finalizeCalled           bool
+	finalizeSessionID        string
+	finalizeInputs           []NativeTBTCSignerRoundContribution
+	finalizeSignature        []byte
+	finalizeErr              error
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -95,12 +96,14 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	mbttse.startCalled = true
 	mbttse.startSessionID = sessionID
 	mbttse.startMemberID = memberIdentifier
 	mbttse.startMessage = append([]byte{}, message...)
 	mbttse.startKeyGroup = keyGroup
+	mbttse.startSigningParticipants = append([]uint16{}, signingParticipants...)
 
 	if mbttse.startErr != nil {
 		return nil, mbttse.startErr
@@ -166,6 +169,7 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 	memberIdentifier uint16,
 	_ []byte,
 	_ string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	if dbttsbre.roundState != nil {
 		if dbttsbre.roundState.OwnContribution == nil {
@@ -178,11 +182,16 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 		return dbttsbre.roundState, nil
 	}
 
+	if len(signingParticipants) == 0 {
+		signingParticipants = []uint16{memberIdentifier}
+	}
+
 	return &NativeTBTCSignerRoundState{
 		SessionID:             sessionID,
 		RoundID:               "round-1",
 		RequiredContributions: 2,
 		MessageDigestHex:      "00",
+		SigningParticipants:   append([]uint16{}, signingParticipants...),
 		OwnContribution: &NativeTBTCSignerRoundContribution{
 			Identifier: memberIdentifier,
 			Data:       []byte{byte(memberIdentifier), 0xab},
@@ -1184,6 +1193,15 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		)
 	}
 
+	expectedSigningParticipants := []uint16{1, 2, 3}
+	if !reflect.DeepEqual(engine.startSigningParticipants, expectedSigningParticipants) {
+		t.Fatalf(
+			"unexpected StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedSigningParticipants,
+			engine.startSigningParticipants,
+		)
+	}
+
 	if !engine.finalizeCalled {
 		t.Fatal("expected FinalizeSignRound call in bootstrap tbtc-signer path")
 	}
@@ -1279,6 +1297,15 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			"unexpected StartSignRound key group\nexpected: [%v]\nactual:   [%v]",
 			"group-from-dkg",
 			engine.startKeyGroup,
+		)
+	}
+
+	expectedSigningParticipants := []uint16{1, 2, 3}
+	if !reflect.DeepEqual(engine.startSigningParticipants, expectedSigningParticipants) {
+		t.Fatalf(
+			"unexpected StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedSigningParticipants,
+			engine.startSigningParticipants,
 		)
 	}
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -40,13 +40,20 @@ type mockBuildTaggedTBTCSignerEngine struct {
 	startMessage             []byte
 	startKeyGroup            string
 	startSigningParticipants []uint16
-	startRoundState          *NativeTBTCSignerRoundState
-	startErr                 error
-	finalizeCalled           bool
-	finalizeSessionID        string
-	finalizeInputs           []NativeTBTCSignerRoundContribution
-	finalizeSignature        []byte
-	finalizeErr              error
+	startSignRoundFn         func(
+		sessionID string,
+		memberIdentifier uint16,
+		message []byte,
+		keyGroup string,
+		signingParticipants []uint16,
+	) (*NativeTBTCSignerRoundState, error)
+	startRoundState   *NativeTBTCSignerRoundState
+	startErr          error
+	finalizeCalled    bool
+	finalizeSessionID string
+	finalizeInputs    []NativeTBTCSignerRoundContribution
+	finalizeSignature []byte
+	finalizeErr       error
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -107,6 +114,16 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 
 	if mbttse.startErr != nil {
 		return nil, mbttse.startErr
+	}
+
+	if mbttse.startSignRoundFn != nil {
+		return mbttse.startSignRoundFn(
+			sessionID,
+			memberIdentifier,
+			message,
+			keyGroup,
+			signingParticipants,
+		)
 	}
 
 	if mbttse.startRoundState != nil {
@@ -1734,6 +1751,176 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
 			2,
 			len(observedEvents),
+		)
+	}
+
+	if !strings.Contains(observedEvents[1].Reason, "session_conflict") {
+		t.Fatalf(
+			"expected second fallback reason to include session_conflict\nactual: [%s]",
+			observedEvents[1].Reason,
+		)
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_AttemptVariationStartSignRoundConflictFallsBack(
+	t *testing.T,
+) {
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	var firstSigningParticipants []uint16
+	var observedSigningParticipants [][]uint16
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0-bootstrap",
+		runDKGFn: func(
+			sessionID string,
+			participants []NativeTBTCSignerDKGParticipant,
+			threshold uint16,
+		) (*NativeTBTCSignerDKGResult, error) {
+			return &NativeTBTCSignerDKGResult{
+				SessionID:        sessionID,
+				KeyGroup:         "group-1",
+				ParticipantCount: uint16(len(participants)),
+				Threshold:        threshold,
+				CreatedAtUnix:    1,
+			}, nil
+		},
+		startSignRoundFn: func(
+			sessionID string,
+			_ uint16,
+			_ []byte,
+			_ string,
+			signingParticipants []uint16,
+		) (*NativeTBTCSignerRoundState, error) {
+			observedSigningParticipants = append(
+				observedSigningParticipants,
+				append([]uint16{}, signingParticipants...),
+			)
+
+			if firstSigningParticipants == nil {
+				firstSigningParticipants = append(
+					[]uint16{},
+					signingParticipants...,
+				)
+			} else if !reflect.DeepEqual(signingParticipants, firstSigningParticipants) {
+				return nil, errors.New("session_conflict")
+			}
+
+			return &NativeTBTCSignerRoundState{
+				SessionID:             sessionID,
+				RoundID:               "round-1",
+				RequiredContributions: 2,
+				MessageDigestHex:      "00",
+				SigningParticipants: append(
+					[]uint16{},
+					signingParticipants...,
+				),
+			}, nil
+		},
+	}
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	baseRequest := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1","keyGroupSource":"legacy-wallet-pubkey"}`),
+		},
+	}
+
+	_, err = primitive.Sign(nil, nil, baseRequest)
+	if err == nil {
+		t.Fatal("expected first signing error due to legacy fallback without private key share")
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected first signing error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	secondRequest := *baseRequest
+	secondRequest.Attempt = &Attempt{
+		ExcludedMembersIndexes: []group.MemberIndex{2},
+	}
+
+	_, err = primitive.Sign(nil, nil, &secondRequest)
+	if err == nil {
+		t.Fatal("expected second signing error due to legacy fallback without private key share")
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected second signing error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if len(observedSigningParticipants) != 2 {
+		t.Fatalf(
+			"unexpected StartSignRound call count\nexpected: [%d]\nactual:   [%d]",
+			2,
+			len(observedSigningParticipants),
+		)
+	}
+
+	expectedFirstParticipants := []uint16{1, 2, 3}
+	if !reflect.DeepEqual(observedSigningParticipants[0], expectedFirstParticipants) {
+		t.Fatalf(
+			"unexpected first StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedFirstParticipants,
+			observedSigningParticipants[0],
+		)
+	}
+
+	expectedSecondParticipants := []uint16{1, 3}
+	if !reflect.DeepEqual(observedSigningParticipants[1], expectedSecondParticipants) {
+		t.Fatalf(
+			"unexpected second StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedSecondParticipants,
+			observedSigningParticipants[1],
+		)
+	}
+
+	if len(observedEvents) != 2 {
+		t.Fatalf(
+			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
+			2,
+			len(observedEvents),
+		)
+	}
+
+	if !strings.Contains(
+		observedEvents[0].Reason,
+		"tbtc-signer bootstrap coarse round completed",
+	) {
+		t.Fatalf(
+			"expected first fallback reason to include bootstrap completion\nactual: [%s]",
+			observedEvents[0].Reason,
 		)
 	}
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -11,14 +11,21 @@ import (
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
 
 type mockBuildTaggedTBTCSignerEngine struct {
-	startCalled bool
-	sessionID   string
-	message     []byte
-	keyGroup    string
+	runDKGCalled       bool
+	runDKGSessionID    string
+	runDKGParticipants []NativeTBTCSignerDKGParticipant
+	runDKGThreshold    uint16
+	runDKGResult       *NativeTBTCSignerDKGResult
+	runDKGErr          error
+	startCalled        bool
+	startSessionID     string
+	startMessage       []byte
+	startKeyGroup      string
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -26,7 +33,29 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
 	participants []NativeTBTCSignerDKGParticipant,
 	threshold uint16,
 ) (*NativeTBTCSignerDKGResult, error) {
-	return nil, fmt.Errorf("not used")
+	mbttse.runDKGCalled = true
+	mbttse.runDKGSessionID = sessionID
+	mbttse.runDKGParticipants = append(
+		[]NativeTBTCSignerDKGParticipant{},
+		participants...,
+	)
+	mbttse.runDKGThreshold = threshold
+
+	if mbttse.runDKGErr != nil {
+		return nil, mbttse.runDKGErr
+	}
+
+	if mbttse.runDKGResult != nil {
+		return mbttse.runDKGResult, nil
+	}
+
+	return &NativeTBTCSignerDKGResult{
+		SessionID:        sessionID,
+		KeyGroup:         "group-1",
+		ParticipantCount: uint16(len(participants)),
+		Threshold:        threshold,
+		CreatedAtUnix:    1,
+	}, nil
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
@@ -35,9 +64,9 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	keyGroup string,
 ) (*NativeTBTCSignerRoundState, error) {
 	mbttse.startCalled = true
-	mbttse.sessionID = sessionID
-	mbttse.message = append([]byte{}, message...)
-	mbttse.keyGroup = keyGroup
+	mbttse.startSessionID = sessionID
+	mbttse.startMessage = append([]byte{}, message...)
+	mbttse.startKeyGroup = keyGroup
 
 	return &NativeTBTCSignerRoundState{
 		SessionID:             sessionID,
@@ -365,6 +394,91 @@ func TestDecodeBuildTaggedTBTCSignerLegacyPrivateKeyShare_RejectsInvalidPayload(
 	}
 }
 
+func TestBuildTaggedTBTCSignerRunDKGInputs(t *testing.T) {
+	participants, threshold, err := buildTaggedTBTCSignerRunDKGInputs(
+		&NativeExecutionFFISigningRequest{
+			GroupSize:          5,
+			DishonestThreshold: 2,
+			Attempt: &Attempt{
+				IncludedMembersIndexes: []group.MemberIndex{1, 3, 5},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected RunDKG inputs error: [%v]", err)
+	}
+
+	if threshold != 3 {
+		t.Fatalf(
+			"unexpected threshold\nexpected: [%v]\nactual:   [%v]",
+			3,
+			threshold,
+		)
+	}
+
+	if len(participants) != 3 {
+		t.Fatalf(
+			"unexpected participants count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(participants),
+		)
+	}
+
+	expectedIdentifiers := []uint16{1, 3, 5}
+	expectedPublicKeys := []string{"020001", "020003", "020005"}
+
+	for i := range participants {
+		if participants[i].Identifier != expectedIdentifiers[i] {
+			t.Fatalf(
+				"unexpected participant identifier at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				expectedIdentifiers[i],
+				participants[i].Identifier,
+			)
+		}
+
+		if participants[i].PublicKeyHex != expectedPublicKeys[i] {
+			t.Fatalf(
+				"unexpected participant public key at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				expectedPublicKeys[i],
+				participants[i].PublicKeyHex,
+			)
+		}
+	}
+}
+
+func TestBuildTaggedTBTCSignerRunDKGInputs_RejectsInvalidRequest(t *testing.T) {
+	testCases := []struct {
+		name    string
+		request *NativeExecutionFFISigningRequest
+	}{
+		{
+			name: "zero group size",
+			request: &NativeExecutionFFISigningRequest{
+				GroupSize:          0,
+				DishonestThreshold: 1,
+			},
+		},
+		{
+			name: "derived threshold exceeds participants",
+			request: &NativeExecutionFFISigningRequest{
+				GroupSize:          2,
+				DishonestThreshold: 2,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := buildTaggedTBTCSignerRunDKGInputs(tc.request)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath(
 	t *testing.T,
 ) {
@@ -380,8 +494,11 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
 
 	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
-		Message:   big.NewInt(123),
-		SessionID: "session-1",
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
 		SignerMaterial: &NativeSignerMaterial{
 			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
 			Payload: []byte(`{"keyGroup":"group-1"}`),
@@ -399,10 +516,37 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		)
 	}
 
+	if !engine.runDKGCalled {
+		t.Fatal("expected RunDKG call in tbtc-signer path")
+	}
+
+	if engine.runDKGSessionID != "session-1" {
+		t.Fatalf(
+			"unexpected RunDKG session ID\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			engine.runDKGSessionID,
+		)
+	}
+
+	if engine.runDKGThreshold != 2 {
+		t.Fatalf(
+			"unexpected RunDKG threshold\nexpected: [%v]\nactual:   [%v]",
+			2,
+			engine.runDKGThreshold,
+		)
+	}
+
+	if len(engine.runDKGParticipants) != 3 {
+		t.Fatalf(
+			"unexpected RunDKG participants count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(engine.runDKGParticipants),
+		)
+	}
+
 	if engine.startCalled {
 		t.Fatal("did not expect StartSignRound call while coarse finalize flow is unwired")
 	}
-
 }
 
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_NoEngineNoLegacyShare(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -518,6 +518,142 @@ func TestBuildTaggedTBTCSignerRunDKGInputs_RejectsInvalidRequest(t *testing.T) {
 	}
 }
 
+func TestBuildTaggedTBTCSignerSyntheticRoundContributions(t *testing.T) {
+	roundState := &NativeTBTCSignerRoundState{
+		SessionID:        "session-1",
+		RoundID:          "round-1",
+		MessageDigestHex: "aabbccdd",
+	}
+
+	contributionsFirst, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+		roundState,
+		[]group.MemberIndex{1, 2, 3},
+	)
+	if err != nil {
+		t.Fatalf("unexpected synthetic contribution error: [%v]", err)
+	}
+
+	contributionsSecond, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+		roundState,
+		[]group.MemberIndex{1, 2, 3},
+	)
+	if err != nil {
+		t.Fatalf("unexpected synthetic contribution error: [%v]", err)
+	}
+
+	if len(contributionsFirst) != 3 {
+		t.Fatalf(
+			"unexpected contribution count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(contributionsFirst),
+		)
+	}
+
+	expectedIdentifiers := []uint16{1, 2, 3}
+	for i, contribution := range contributionsFirst {
+		if contribution.Identifier != expectedIdentifiers[i] {
+			t.Fatalf(
+				"unexpected contribution identifier at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				expectedIdentifiers[i],
+				contribution.Identifier,
+			)
+		}
+
+		if len(contribution.Data) != 32 {
+			t.Fatalf(
+				"unexpected contribution size at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				32,
+				len(contribution.Data),
+			)
+		}
+
+		if !bytes.Equal(contribution.Data, contributionsSecond[i].Data) {
+			t.Fatalf("expected deterministic contribution at index [%d]", i)
+		}
+	}
+
+	roundStateChanged := &NativeTBTCSignerRoundState{
+		SessionID:        "session-1",
+		RoundID:          "round-2",
+		MessageDigestHex: "aabbccdd",
+	}
+	contributionsChanged, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+		roundStateChanged,
+		[]group.MemberIndex{1, 2, 3},
+	)
+	if err != nil {
+		t.Fatalf("unexpected synthetic contribution error: [%v]", err)
+	}
+
+	if bytes.Equal(contributionsFirst[0].Data, contributionsChanged[0].Data) {
+		t.Fatal("expected contribution data to change when round metadata changes")
+	}
+}
+
+func TestBuildTaggedTBTCSignerSyntheticRoundContributions_RejectsInvalidInput(t *testing.T) {
+	testCases := []struct {
+		name       string
+		roundState *NativeTBTCSignerRoundState
+		members    []group.MemberIndex
+	}{
+		{
+			name:       "nil round state",
+			roundState: nil,
+			members:    []group.MemberIndex{1, 2},
+		},
+		{
+			name: "empty session id",
+			roundState: &NativeTBTCSignerRoundState{
+				SessionID:        "",
+				RoundID:          "round-1",
+				MessageDigestHex: "aa",
+			},
+			members: []group.MemberIndex{1, 2},
+		},
+		{
+			name: "empty round id",
+			roundState: &NativeTBTCSignerRoundState{
+				SessionID:        "session-1",
+				RoundID:          "",
+				MessageDigestHex: "aa",
+			},
+			members: []group.MemberIndex{1, 2},
+		},
+		{
+			name: "empty message digest",
+			roundState: &NativeTBTCSignerRoundState{
+				SessionID:        "session-1",
+				RoundID:          "round-1",
+				MessageDigestHex: "",
+			},
+			members: []group.MemberIndex{1, 2},
+		},
+		{
+			name: "zero member index",
+			roundState: &NativeTBTCSignerRoundState{
+				SessionID:        "session-1",
+				RoundID:          "round-1",
+				MessageDigestHex: "aa",
+			},
+			members: []group.MemberIndex{0, 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildTaggedTBTCSignerSyntheticRoundContributions(
+				tc.roundState,
+				tc.members,
+			)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -22,10 +21,19 @@ type mockBuildTaggedTBTCSignerEngine struct {
 	runDKGThreshold    uint16
 	runDKGResult       *NativeTBTCSignerDKGResult
 	runDKGErr          error
+	version            string
+	versionErr         error
 	startCalled        bool
 	startSessionID     string
 	startMessage       []byte
 	startKeyGroup      string
+	startRoundState    *NativeTBTCSignerRoundState
+	startErr           error
+	finalizeCalled     bool
+	finalizeSessionID  string
+	finalizeInputs     []NativeTBTCSignerRoundContribution
+	finalizeSignature  []byte
+	finalizeErr        error
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -58,6 +66,14 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
 	}, nil
 }
 
+func (mbttse *mockBuildTaggedTBTCSignerEngine) Version() (string, error) {
+	if mbttse.versionErr != nil {
+		return "", mbttse.versionErr
+	}
+
+	return mbttse.version, nil
+}
+
 func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	sessionID string,
 	message []byte,
@@ -67,6 +83,14 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	mbttse.startSessionID = sessionID
 	mbttse.startMessage = append([]byte{}, message...)
 	mbttse.startKeyGroup = keyGroup
+
+	if mbttse.startErr != nil {
+		return nil, mbttse.startErr
+	}
+
+	if mbttse.startRoundState != nil {
+		return mbttse.startRoundState, nil
+	}
 
 	return &NativeTBTCSignerRoundState{
 		SessionID:             sessionID,
@@ -80,7 +104,22 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) FinalizeSignRound(
 	sessionID string,
 	roundContributions []NativeTBTCSignerRoundContribution,
 ) ([]byte, error) {
-	return nil, fmt.Errorf("not used")
+	mbttse.finalizeCalled = true
+	mbttse.finalizeSessionID = sessionID
+	mbttse.finalizeInputs = append(
+		[]NativeTBTCSignerRoundContribution{},
+		roundContributions...,
+	)
+
+	if mbttse.finalizeErr != nil {
+		return nil, mbttse.finalizeErr
+	}
+
+	if len(mbttse.finalizeSignature) > 0 {
+		return append([]byte{}, mbttse.finalizeSignature...), nil
+	}
+
+	return []byte{0xaa}, nil
 }
 
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_ValidatesRequest(
@@ -545,7 +584,112 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	}
 
 	if engine.startCalled {
-		t.Fatal("did not expect StartSignRound call while coarse finalize flow is unwired")
+		t.Fatal("did not expect StartSignRound call for non-bootstrap tbtc-signer version")
+	}
+
+	if engine.finalizeCalled {
+		t.Fatal("did not expect FinalizeSignRound call for non-bootstrap tbtc-signer version")
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion(
+	t *testing.T,
+) {
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version:           "tbtc-signer/0.1.0-bootstrap",
+		finalizeSignature: []byte{0xaa},
+	}
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1"}`),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if !engine.runDKGCalled {
+		t.Fatal("expected RunDKG call in bootstrap tbtc-signer path")
+	}
+
+	if !engine.startCalled {
+		t.Fatal("expected StartSignRound call in bootstrap tbtc-signer path")
+	}
+
+	if engine.startSessionID != "session-1" {
+		t.Fatalf(
+			"unexpected StartSignRound session ID\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			engine.startSessionID,
+		)
+	}
+
+	if engine.startKeyGroup != "group-1" {
+		t.Fatalf(
+			"unexpected StartSignRound key group\nexpected: [%v]\nactual:   [%v]",
+			"group-1",
+			engine.startKeyGroup,
+		)
+	}
+
+	if !engine.finalizeCalled {
+		t.Fatal("expected FinalizeSignRound call in bootstrap tbtc-signer path")
+	}
+
+	if engine.finalizeSessionID != "session-1" {
+		t.Fatalf(
+			"unexpected FinalizeSignRound session ID\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			engine.finalizeSessionID,
+		)
+	}
+
+	if len(engine.finalizeInputs) != 3 {
+		t.Fatalf(
+			"unexpected FinalizeSignRound contributions count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(engine.finalizeInputs),
+		)
+	}
+
+	expectedIdentifiers := []uint16{1, 2, 3}
+	for i, contribution := range engine.finalizeInputs {
+		if contribution.Identifier != expectedIdentifiers[i] {
+			t.Fatalf(
+				"unexpected contribution identifier at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				expectedIdentifiers[i],
+				contribution.Identifier,
+			)
+		}
+
+		if len(contribution.Data) == 0 {
+			t.Fatalf("expected non-empty contribution data at index [%d]", i)
+		}
 	}
 }
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -127,6 +127,13 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	}
 
 	if mbttse.startRoundState != nil {
+		if len(mbttse.startRoundState.SigningParticipants) == 0 {
+			mbttse.startRoundState.SigningParticipants = append(
+				[]uint16{},
+				signingParticipants...,
+			)
+		}
+
 		return mbttse.startRoundState, nil
 	}
 
@@ -135,6 +142,7 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 		RoundID:               "round-1",
 		RequiredContributions: 2,
 		MessageDigestHex:      "00",
+		SigningParticipants:   append([]uint16{}, signingParticipants...),
 	}, nil
 }
 
@@ -194,6 +202,13 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 				Identifier: memberIdentifier,
 				Data:       []byte{byte(memberIdentifier), 0xab},
 			}
+		}
+
+		if len(dbttsbre.roundState.SigningParticipants) == 0 {
+			dbttsbre.roundState.SigningParticipants = append(
+				[]uint16{},
+				signingParticipants...,
+			)
 		}
 
 		return dbttsbre.roundState, nil
@@ -860,6 +875,8 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributions
 				signingRequest,
 				"group-1",
 				signingEngine,
+				nil,
+				nil,
 			)
 		}(request, engine)
 	}
@@ -1008,6 +1025,8 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_UsesThresholdCohortOve
 				signingRequest,
 				"group-1",
 				signingEngine,
+				nil,
+				nil,
 			)
 		}(request, engine)
 	}
@@ -1087,12 +1106,73 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_FailsWhenRoundStateSig
 		request,
 		"group-1",
 		engine,
+		nil,
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 
 	expectedErrFragment := "start sign round returned unexpected signing participant"
+	if !strings.Contains(err.Error(), expectedErrFragment) {
+		t.Fatalf(
+			"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",
+			expectedErrFragment,
+			err,
+		)
+	}
+}
+
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_FailsWhenRoundStateSigningParticipantsMissing(
+	t *testing.T,
+) {
+	request := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          2,
+		DishonestThreshold: 1,
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+		},
+	}
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		startSignRoundFn: func(
+			sessionID string,
+			memberIdentifier uint16,
+			message []byte,
+			keyGroup string,
+			signingParticipants []uint16,
+		) (*NativeTBTCSignerRoundState, error) {
+			return &NativeTBTCSignerRoundState{
+				SessionID:             sessionID,
+				RoundID:               "round-1",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: memberIdentifier,
+					Data:       []byte{0x11, 0x01},
+				},
+			}, nil
+		},
+	}
+
+	err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+		context.Background(),
+		request,
+		"group-1",
+		engine,
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	expectedErrFragment := "start sign round returned unexpected signing participants count"
 	if !strings.Contains(err.Error(), expectedErrFragment) {
 		t.Fatalf(
 			"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -900,6 +900,191 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributions
 	}
 }
 
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_UsesThresholdCohortOverFullGroup(
+	t *testing.T,
+) {
+	provider := local.Connect()
+	channel, err := provider.BroadcastChannelFor("tbtc-signer-bootstrap-round-threshold-cohort-test")
+	if err != nil {
+		t.Fatalf("failed creating broadcast channel: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+	primitive.RegisterUnmarshallers(channel)
+
+	engineByMember := map[group.MemberIndex]*mockBuildTaggedTBTCSignerEngine{
+		1: {
+			startRoundState: &NativeTBTCSignerRoundState{
+				SessionID:             "session-threshold",
+				RoundID:               "round-threshold",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				SigningParticipants:   []uint16{1, 3},
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: 1,
+					Data:       []byte{0x11, 0x01},
+				},
+			},
+		},
+		3: {
+			startRoundState: &NativeTBTCSignerRoundState{
+				SessionID:             "session-threshold",
+				RoundID:               "round-threshold",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				SigningParticipants:   []uint16{1, 3},
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: 3,
+					Data:       []byte{0x33, 0x03},
+				},
+			},
+		},
+	}
+
+	requestByMember := map[group.MemberIndex]*NativeExecutionFFISigningRequest{
+		1: {
+			Message:            big.NewInt(123),
+			SessionID:          "session-threshold",
+			MemberIndex:        1,
+			GroupSize:          3,
+			DishonestThreshold: 1,
+			Channel:            channel,
+			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
+				IncludedMembersIndexes: []group.MemberIndex{1, 3},
+			},
+		},
+		3: {
+			Message:            big.NewInt(123),
+			SessionID:          "session-threshold",
+			MemberIndex:        3,
+			GroupSize:          3,
+			DishonestThreshold: 1,
+			Channel:            channel,
+			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
+				IncludedMembersIndexes: []group.MemberIndex{1, 3},
+			},
+		},
+	}
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelCtx()
+
+	var wg sync.WaitGroup
+	signingErrors := make(chan error, len(requestByMember))
+
+	for memberIndex, request := range requestByMember {
+		engine := engineByMember[memberIndex]
+		wg.Add(1)
+
+		go func(
+			signingRequest *NativeExecutionFFISigningRequest,
+			signingEngine NativeTBTCSignerEngine,
+		) {
+			defer wg.Done()
+
+			signingErrors <- executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+				ctx,
+				signingRequest,
+				"group-1",
+				signingEngine,
+			)
+		}(request, engine)
+	}
+
+	wg.Wait()
+	close(signingErrors)
+
+	for signingErr := range signingErrors {
+		if signingErr != nil {
+			t.Fatalf("unexpected signing error: [%v]", signingErr)
+		}
+	}
+
+	expectedSigningParticipants := []uint16{1, 3}
+	for memberIndex, engine := range engineByMember {
+		if !reflect.DeepEqual(engine.startSigningParticipants, expectedSigningParticipants) {
+			t.Fatalf(
+				"unexpected StartSignRound signing participants for member [%v]\nexpected: [%v]\nactual:   [%v]",
+				memberIndex,
+				expectedSigningParticipants,
+				engine.startSigningParticipants,
+			)
+		}
+
+		if len(engine.finalizeInputs) != 2 {
+			t.Fatalf(
+				"unexpected finalize input count for member [%v]\nexpected: [%v]\nactual:   [%v]",
+				memberIndex,
+				2,
+				len(engine.finalizeInputs),
+			)
+		}
+
+		if engine.finalizeInputs[0].Identifier != 1 || engine.finalizeInputs[1].Identifier != 3 {
+			t.Fatalf(
+				"unexpected finalize identifiers for member [%v]\nexpected: [1 3]\nactual:   [%v %v]",
+				memberIndex,
+				engine.finalizeInputs[0].Identifier,
+				engine.finalizeInputs[1].Identifier,
+			)
+		}
+	}
+}
+
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_FailsWhenRoundStateSigningParticipantsMismatch(
+	t *testing.T,
+) {
+	request := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          2,
+		DishonestThreshold: 1,
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+		},
+	}
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		startRoundState: &NativeTBTCSignerRoundState{
+			SessionID:             "session-1",
+			RoundID:               "round-1",
+			RequiredContributions: 2,
+			MessageDigestHex:      "0011",
+			SigningParticipants:   []uint16{1, 3},
+			OwnContribution: &NativeTBTCSignerRoundContribution{
+				Identifier: 1,
+				Data:       []byte{0x11, 0x01},
+			},
+		},
+	}
+
+	err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+		context.Background(),
+		request,
+		"group-1",
+		engine,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	expectedErrFragment := "start sign round returned unexpected signing participant"
+	if !strings.Contains(err.Error(), expectedErrFragment) {
+		t.Fatalf(
+			"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",
+			expectedErrFragment,
+			err,
+		)
+	}
+}
+
 func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -4,55 +4,25 @@ package signing
 
 import "fmt"
 
-type buildTaggedTBTCSignerNativeFROSTBridge struct{}
+type buildTaggedTBTCSignerEngine struct{}
 
 func registerBuildTaggedNativeFROSTSigningEngine() error {
-	engine, err := newUniFFINativeFROSTSigningEngine(
-		&buildTaggedTBTCSignerNativeFROSTBridge{},
-	)
-	if err != nil {
-		return err
-	}
-
-	return RegisterNativeFROSTSigningEngine(engine)
+	return RegisterNativeTBTCSignerEngine(&buildTaggedTBTCSignerEngine{})
 }
 
-func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) GenerateNoncesAndCommitments(
-	keyPackageIdentifier string,
-	keyPackageData []byte,
-) (
-	noncesData []byte,
-	commitmentIdentifier string,
-	commitmentData []byte,
-	err error,
-) {
-	return nil, "", nil, buildTaggedTBTCSignerBridgeNotImplementedError(
-		"GenerateNoncesAndCommitments",
-	)
-}
-
-func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) NewSigningPackage(
+func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
+	sessionID string,
 	message []byte,
-	commitments []uniFFINativeFROSTCommitment,
-) (signingPackageData []byte, err error) {
-	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("NewSigningPackage")
+	keyGroup string,
+) (*NativeTBTCSignerRoundState, error) {
+	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("StartSignRound")
 }
 
-func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) Sign(
-	signingPackageData []byte,
-	noncesData []byte,
-	keyPackageIdentifier string,
-	keyPackageData []byte,
-) (signatureShareIdentifier string, signatureShareData []byte, err error) {
-	return "", nil, buildTaggedTBTCSignerBridgeNotImplementedError("Sign")
-}
-
-func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) Aggregate(
-	signingPackageData []byte,
-	signatureShares []uniFFINativeFROSTSignatureShare,
-	publicKeyPackage *NativeFROSTPublicKeyPackage,
-) (signature []byte, err error) {
-	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("Aggregate")
+func (bttse *buildTaggedTBTCSignerEngine) FinalizeSignRound(
+	sessionID string,
+	roundContributions []NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("FinalizeSignRound")
 }
 
 func buildTaggedTBTCSignerBridgeNotImplementedError(operation string) error {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -137,16 +137,18 @@ type buildTaggedTBTCSignerRunDKGResponse struct {
 }
 
 type buildTaggedTBTCSignerStartSignRoundRequest struct {
-	SessionID  string `json:"session_id"`
-	MessageHex string `json:"message_hex"`
-	KeyGroup   string `json:"key_group"`
+	SessionID        string `json:"session_id"`
+	MemberIdentifier uint16 `json:"member_identifier"`
+	MessageHex       string `json:"message_hex"`
+	KeyGroup         string `json:"key_group"`
 }
 
 type buildTaggedTBTCSignerStartSignRoundResponse struct {
-	SessionID             string `json:"session_id"`
-	RoundID               string `json:"round_id"`
-	RequiredContributions uint16 `json:"required_contributions"`
-	MessageDigestHex      string `json:"message_digest_hex"`
+	SessionID             string                                          `json:"session_id"`
+	RoundID               string                                          `json:"round_id"`
+	RequiredContributions uint16                                          `json:"required_contributions"`
+	MessageDigestHex      string                                          `json:"message_digest_hex"`
+	OwnContribution       *buildTaggedTBTCSignerFinalizeRoundContribution `json:"own_contribution"`
 }
 
 type buildTaggedTBTCSignerFinalizeSignRoundRequest struct {
@@ -212,11 +214,13 @@ func (bttse *buildTaggedTBTCSignerEngine) RunDKG(
 
 func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
 	sessionID string,
+	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
 ) (*NativeTBTCSignerRoundState, error) {
 	requestPayload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		sessionID,
+		memberIdentifier,
 		message,
 		keyGroup,
 	)
@@ -395,6 +399,7 @@ func decodeBuildTaggedTBTCSignerRunDKGResponse(
 
 func buildTaggedTBTCSignerStartSignRoundRequestPayload(
 	sessionID string,
+	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
 ) ([]byte, error) {
@@ -412,10 +417,18 @@ func buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		)
 	}
 
+	if memberIdentifier == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			"member identifier is zero",
+		)
+	}
+
 	request := buildTaggedTBTCSignerStartSignRoundRequest{
-		SessionID:  sessionID,
-		MessageHex: hex.EncodeToString(message),
-		KeyGroup:   keyGroup,
+		SessionID:        sessionID,
+		MemberIdentifier: memberIdentifier,
+		MessageHex:       hex.EncodeToString(message),
+		KeyGroup:         keyGroup,
 	}
 
 	payload, err := json.Marshal(request)
@@ -461,11 +474,47 @@ func decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		)
 	}
 
+	var ownContribution *NativeTBTCSignerRoundContribution
+	if response.OwnContribution != nil {
+		if response.OwnContribution.Identifier == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				"response own contribution identifier is zero",
+			)
+		}
+
+		if response.OwnContribution.SignatureShareHex == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				"response own contribution signature share is empty",
+			)
+		}
+
+		ownContributionData, err := hex.DecodeString(
+			response.OwnContribution.SignatureShareHex,
+		)
+		if err != nil {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf(
+					"response own contribution signature share is invalid hex: %v",
+					err,
+				),
+			)
+		}
+
+		ownContribution = &NativeTBTCSignerRoundContribution{
+			Identifier: response.OwnContribution.Identifier,
+			Data:       ownContributionData,
+		}
+	}
+
 	return &NativeTBTCSignerRoundState{
 		SessionID:             response.SessionID,
 		RoundID:               response.RoundID,
 		RequiredContributions: response.RequiredContributions,
 		MessageDigestHex:      response.MessageDigestHex,
+		OwnContribution:       ownContribution,
 	}, nil
 }
 

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -21,6 +21,10 @@ typedef struct {
   TbtcBuffer buffer;
 } TbtcSignerResult;
 
+typedef TbtcSignerResult (*tbtc_run_dkg_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef TbtcSignerResult (*tbtc_start_sign_round_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -37,6 +41,18 @@ static TbtcSignerResult unavailable_tbtc_signer_result(void) {
   result.buffer.ptr = NULL;
   result.buffer.len = 0;
   return result;
+}
+
+static TbtcSignerResult tbtc_signer_run_dkg(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_run_dkg_fn run_dkg = (tbtc_run_dkg_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_run_dkg"
+  );
+  if (run_dkg == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return run_dkg(request_ptr, request_len);
 }
 
 static TbtcSignerResult tbtc_signer_start_sign_round(const uint8_t* request_ptr, size_t request_len) {
@@ -88,6 +104,25 @@ type buildTaggedTBTCSignerErrorResponse struct {
 	Message string `json:"message"`
 }
 
+type buildTaggedTBTCSignerRunDKGRequest struct {
+	SessionID    string                                `json:"session_id"`
+	Participants []buildTaggedTBTCSignerDKGParticipant `json:"participants"`
+	Threshold    uint16                                `json:"threshold"`
+}
+
+type buildTaggedTBTCSignerDKGParticipant struct {
+	Identifier   uint16 `json:"identifier"`
+	PublicKeyHex string `json:"public_key_hex"`
+}
+
+type buildTaggedTBTCSignerRunDKGResponse struct {
+	SessionID        string `json:"session_id"`
+	KeyGroup         string `json:"key_group"`
+	ParticipantCount uint16 `json:"participant_count"`
+	Threshold        uint16 `json:"threshold"`
+	CreatedAtUnix    uint64 `json:"created_at_unix"`
+}
+
 type buildTaggedTBTCSignerStartSignRoundRequest struct {
 	SessionID  string `json:"session_id"`
 	MessageHex string `json:"message_hex"`
@@ -121,6 +156,28 @@ const buildTaggedTBTCSignerUnavailableStatusCode = -1
 
 func registerBuildTaggedNativeFROSTSigningEngine() error {
 	return RegisterNativeTBTCSignerEngine(&buildTaggedTBTCSignerEngine{})
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) RunDKG(
+	sessionID string,
+	participants []NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) (*NativeTBTCSignerDKGResult, error) {
+	requestPayload, err := buildTaggedTBTCSignerRunDKGRequestPayload(
+		sessionID,
+		participants,
+		threshold,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerRunDKG(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerRunDKGResponse(responsePayload)
 }
 
 func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
@@ -183,6 +240,127 @@ func buildTaggedTBTCSignerOperationError(
 		operation,
 		message,
 	)
+}
+
+func buildTaggedTBTCSignerRunDKGRequestPayload(
+	sessionID string,
+	participants []NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"session ID is empty",
+		)
+	}
+
+	if len(participants) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"participants are empty",
+		)
+	}
+
+	if threshold == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"threshold is zero",
+		)
+	}
+
+	requestParticipants := make(
+		[]buildTaggedTBTCSignerDKGParticipant,
+		0,
+		len(participants),
+	)
+
+	for i, participant := range participants {
+		if participant.Identifier == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"RunDKG",
+				fmt.Sprintf("participant [%d] identifier is zero", i),
+			)
+		}
+
+		if participant.PublicKeyHex == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"RunDKG",
+				fmt.Sprintf("participant [%d] public key hex is empty", i),
+			)
+		}
+
+		requestParticipants = append(
+			requestParticipants,
+			buildTaggedTBTCSignerDKGParticipant{
+				Identifier:   participant.Identifier,
+				PublicKeyHex: participant.PublicKeyHex,
+			},
+		)
+	}
+
+	request := buildTaggedTBTCSignerRunDKGRequest{
+		SessionID:    sessionID,
+		Participants: requestParticipants,
+		Threshold:    threshold,
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			fmt.Sprintf("cannot marshal request: %v", err),
+		)
+	}
+
+	return payload, nil
+}
+
+func decodeBuildTaggedTBTCSignerRunDKGResponse(
+	responsePayload []byte,
+) (*NativeTBTCSignerDKGResult, error) {
+	var response buildTaggedTBTCSignerRunDKGResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	if response.SessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"response session ID is empty",
+		)
+	}
+
+	if response.KeyGroup == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"response key group is empty",
+		)
+	}
+
+	if response.ParticipantCount == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"response participant count is zero",
+		)
+	}
+
+	if response.Threshold == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"RunDKG",
+			"response threshold is zero",
+		)
+	}
+
+	return &NativeTBTCSignerDKGResult{
+		SessionID:        response.SessionID,
+		KeyGroup:         response.KeyGroup,
+		ParticipantCount: response.ParticipantCount,
+		Threshold:        response.Threshold,
+		CreatedAtUnix:    response.CreatedAtUnix,
+	}, nil
 }
 
 func buildTaggedTBTCSignerStartSignRoundRequestPayload(
@@ -345,6 +523,18 @@ func decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
 	}
 
 	return signature, nil
+}
+
+func callBuildTaggedTBTCSignerRunDKG(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"RunDKG",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_run_dkg(requestPtr, requestLen)
+		},
+	)
 }
 
 func callBuildTaggedTBTCSignerStartSignRound(

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -137,10 +137,11 @@ type buildTaggedTBTCSignerRunDKGResponse struct {
 }
 
 type buildTaggedTBTCSignerStartSignRoundRequest struct {
-	SessionID        string `json:"session_id"`
-	MemberIdentifier uint16 `json:"member_identifier"`
-	MessageHex       string `json:"message_hex"`
-	KeyGroup         string `json:"key_group"`
+	SessionID           string   `json:"session_id"`
+	MemberIdentifier    uint16   `json:"member_identifier"`
+	MessageHex          string   `json:"message_hex"`
+	KeyGroup            string   `json:"key_group"`
+	SigningParticipants []uint16 `json:"signing_participants,omitempty"`
 }
 
 type buildTaggedTBTCSignerStartSignRoundResponse struct {
@@ -148,6 +149,7 @@ type buildTaggedTBTCSignerStartSignRoundResponse struct {
 	RoundID               string                                          `json:"round_id"`
 	RequiredContributions uint16                                          `json:"required_contributions"`
 	MessageDigestHex      string                                          `json:"message_digest_hex"`
+	SigningParticipants   []uint16                                        `json:"signing_participants,omitempty"`
 	OwnContribution       *buildTaggedTBTCSignerFinalizeRoundContribution `json:"own_contribution"`
 }
 
@@ -217,12 +219,14 @@ func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	requestPayload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		sessionID,
 		memberIdentifier,
 		message,
 		keyGroup,
+		signingParticipants,
 	)
 	if err != nil {
 		return nil, err
@@ -402,6 +406,7 @@ func buildTaggedTBTCSignerStartSignRoundRequestPayload(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) ([]byte, error) {
 	if sessionID == "" {
 		return nil, buildTaggedTBTCSignerOperationError(
@@ -424,11 +429,29 @@ func buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		)
 	}
 
+	seenParticipants := make(map[uint16]struct{}, len(signingParticipants))
+	for i, participant := range signingParticipants {
+		if participant == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf("signing participant [%d] is zero", i),
+			)
+		}
+		if _, ok := seenParticipants[participant]; ok {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf("signing participant [%d] is duplicated", participant),
+			)
+		}
+		seenParticipants[participant] = struct{}{}
+	}
+
 	request := buildTaggedTBTCSignerStartSignRoundRequest{
-		SessionID:        sessionID,
-		MemberIdentifier: memberIdentifier,
-		MessageHex:       hex.EncodeToString(message),
-		KeyGroup:         keyGroup,
+		SessionID:           sessionID,
+		MemberIdentifier:    memberIdentifier,
+		MessageHex:          hex.EncodeToString(message),
+		KeyGroup:            keyGroup,
+		SigningParticipants: append([]uint16{}, signingParticipants...),
 	}
 
 	payload, err := json.Marshal(request)
@@ -474,6 +497,25 @@ func decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		)
 	}
 
+	seenSigningParticipants := make(map[uint16]struct{}, len(response.SigningParticipants))
+	for _, participant := range response.SigningParticipants {
+		if participant == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				"response signing participant is zero",
+			)
+		}
+
+		if _, ok := seenSigningParticipants[participant]; ok {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf("response signing participant [%d] is duplicated", participant),
+			)
+		}
+
+		seenSigningParticipants[participant] = struct{}{}
+	}
+
 	var ownContribution *NativeTBTCSignerRoundContribution
 	if response.OwnContribution != nil {
 		if response.OwnContribution.Identifier == 0 {
@@ -514,6 +556,7 @@ func decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		RoundID:               response.RoundID,
 		RequiredContributions: response.RequiredContributions,
 		MessageDigestHex:      response.MessageDigestHex,
+		SigningParticipants:   append([]uint16{}, response.SigningParticipants...),
 		OwnContribution:       ownContribution,
 	}, nil
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -1,0 +1,63 @@
+//go:build frost_native && frost_tbtc_signer && cgo && !frost_uniffi_sdk
+
+package signing
+
+import "fmt"
+
+type buildTaggedTBTCSignerNativeFROSTBridge struct{}
+
+func registerBuildTaggedNativeFROSTSigningEngine() error {
+	engine, err := newUniFFINativeFROSTSigningEngine(
+		&buildTaggedTBTCSignerNativeFROSTBridge{},
+	)
+	if err != nil {
+		return err
+	}
+
+	return RegisterNativeFROSTSigningEngine(engine)
+}
+
+func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) GenerateNoncesAndCommitments(
+	keyPackageIdentifier string,
+	keyPackageData []byte,
+) (
+	noncesData []byte,
+	commitmentIdentifier string,
+	commitmentData []byte,
+	err error,
+) {
+	return nil, "", nil, buildTaggedTBTCSignerBridgeNotImplementedError(
+		"GenerateNoncesAndCommitments",
+	)
+}
+
+func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) NewSigningPackage(
+	message []byte,
+	commitments []uniFFINativeFROSTCommitment,
+) (signingPackageData []byte, err error) {
+	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("NewSigningPackage")
+}
+
+func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) Sign(
+	signingPackageData []byte,
+	noncesData []byte,
+	keyPackageIdentifier string,
+	keyPackageData []byte,
+) (signatureShareIdentifier string, signatureShareData []byte, err error) {
+	return "", nil, buildTaggedTBTCSignerBridgeNotImplementedError("Sign")
+}
+
+func (bttsnfb *buildTaggedTBTCSignerNativeFROSTBridge) Aggregate(
+	signingPackageData []byte,
+	signatureShares []uniFFINativeFROSTSignatureShare,
+	publicKeyPackage *NativeFROSTPublicKeyPackage,
+) (signature []byte, err error) {
+	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("Aggregate")
+}
+
+func buildTaggedTBTCSignerBridgeNotImplementedError(operation string) error {
+	return fmt.Errorf(
+		"tbtc-signer bridge operation [%v] is not implemented",
+		operation,
+	)
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -2,9 +2,122 @@
 
 package signing
 
-import "fmt"
+/*
+#cgo CFLAGS: -std=c11
+#cgo linux LDFLAGS: -ldl
+#cgo freebsd LDFLAGS: -ldl
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+typedef struct {
+  uint8_t* ptr;
+  size_t len;
+} TbtcBuffer;
+
+typedef struct {
+  int32_t status_code;
+  TbtcBuffer buffer;
+} TbtcSignerResult;
+
+typedef TbtcSignerResult (*tbtc_start_sign_round_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
+typedef TbtcSignerResult (*tbtc_finalize_sign_round_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
+typedef void (*tbtc_free_buffer_fn)(uint8_t* ptr, size_t len);
+
+static TbtcSignerResult unavailable_tbtc_signer_result(void) {
+  TbtcSignerResult result;
+  result.status_code = -1;
+  result.buffer.ptr = NULL;
+  result.buffer.len = 0;
+  return result;
+}
+
+static TbtcSignerResult tbtc_signer_start_sign_round(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_start_sign_round_fn start_sign_round = (tbtc_start_sign_round_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_start_sign_round"
+  );
+  if (start_sign_round == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return start_sign_round(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_finalize_sign_round(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_finalize_sign_round_fn finalize_sign_round = (tbtc_finalize_sign_round_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_finalize_sign_round"
+  );
+  if (finalize_sign_round == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return finalize_sign_round(request_ptr, request_len);
+}
+
+static void tbtc_signer_free_buffer(uint8_t* ptr, size_t len) {
+  tbtc_free_buffer_fn free_buffer = (tbtc_free_buffer_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_free_buffer"
+  );
+  if (free_buffer != NULL) {
+    free_buffer(ptr, len);
+  }
+}
+*/
+import "C"
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"unsafe"
+)
 
 type buildTaggedTBTCSignerEngine struct{}
+type buildTaggedTBTCSignerErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type buildTaggedTBTCSignerStartSignRoundRequest struct {
+	SessionID  string `json:"session_id"`
+	MessageHex string `json:"message_hex"`
+	KeyGroup   string `json:"key_group"`
+}
+
+type buildTaggedTBTCSignerStartSignRoundResponse struct {
+	SessionID             string `json:"session_id"`
+	RoundID               string `json:"round_id"`
+	RequiredContributions uint16 `json:"required_contributions"`
+	MessageDigestHex      string `json:"message_digest_hex"`
+}
+
+type buildTaggedTBTCSignerFinalizeSignRoundRequest struct {
+	SessionID          string                                           `json:"session_id"`
+	RoundContributions []buildTaggedTBTCSignerFinalizeRoundContribution `json:"round_contributions"`
+}
+
+type buildTaggedTBTCSignerFinalizeRoundContribution struct {
+	Identifier        uint16 `json:"identifier"`
+	SignatureShareHex string `json:"signature_share_hex"`
+}
+
+type buildTaggedTBTCSignerFinalizeSignRoundResponse struct {
+	SessionID    string `json:"session_id"`
+	RoundID      string `json:"round_id"`
+	SignatureHex string `json:"signature_hex"`
+}
+
+const buildTaggedTBTCSignerUnavailableStatusCode = -1
 
 func registerBuildTaggedNativeFROSTSigningEngine() error {
 	return RegisterNativeTBTCSignerEngine(&buildTaggedTBTCSignerEngine{})
@@ -15,19 +128,318 @@ func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
 	message []byte,
 	keyGroup string,
 ) (*NativeTBTCSignerRoundState, error) {
-	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("StartSignRound")
+	requestPayload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
+		sessionID,
+		message,
+		keyGroup,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerStartSignRound(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerStartSignRoundResponse(responsePayload)
 }
 
 func (bttse *buildTaggedTBTCSignerEngine) FinalizeSignRound(
 	sessionID string,
 	roundContributions []NativeTBTCSignerRoundContribution,
 ) ([]byte, error) {
-	return nil, buildTaggedTBTCSignerBridgeNotImplementedError("FinalizeSignRound")
+	requestPayload, err := buildTaggedTBTCSignerFinalizeSignRoundRequestPayload(
+		sessionID,
+		roundContributions,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerFinalizeSignRound(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(responsePayload)
 }
 
-func buildTaggedTBTCSignerBridgeNotImplementedError(operation string) error {
+func buildTaggedTBTCSignerUnavailableError(operation string) error {
 	return fmt.Errorf(
-		"tbtc-signer bridge operation [%v] is not implemented",
+		"%w: tbtc-signer bridge operation [%v] is unavailable; link libfrost_tbtc",
+		ErrNativeCryptographyUnavailable,
 		operation,
 	)
+}
+
+func buildTaggedTBTCSignerOperationError(
+	operation string,
+	message string,
+) error {
+	return fmt.Errorf(
+		"%w: tbtc-signer bridge operation [%v] failed: [%s]",
+		ErrNativeCryptographyUnavailable,
+		operation,
+		message,
+	)
+}
+
+func buildTaggedTBTCSignerStartSignRoundRequestPayload(
+	sessionID string,
+	message []byte,
+	keyGroup string,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			"session ID is empty",
+		)
+	}
+
+	if keyGroup == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			"key group is empty",
+		)
+	}
+
+	request := buildTaggedTBTCSignerStartSignRoundRequest{
+		SessionID:  sessionID,
+		MessageHex: hex.EncodeToString(message),
+		KeyGroup:   keyGroup,
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			fmt.Sprintf("cannot marshal request: %v", err),
+		)
+	}
+
+	return payload, nil
+}
+
+func decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+	responsePayload []byte,
+) (*NativeTBTCSignerRoundState, error) {
+	var response buildTaggedTBTCSignerStartSignRoundResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	if response.SessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			"response session ID is empty",
+		)
+	}
+
+	if response.RoundID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			"response round ID is empty",
+		)
+	}
+
+	if response.MessageDigestHex == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"StartSignRound",
+			"response message digest is empty",
+		)
+	}
+
+	return &NativeTBTCSignerRoundState{
+		SessionID:             response.SessionID,
+		RoundID:               response.RoundID,
+		RequiredContributions: response.RequiredContributions,
+		MessageDigestHex:      response.MessageDigestHex,
+	}, nil
+}
+
+func buildTaggedTBTCSignerFinalizeSignRoundRequestPayload(
+	sessionID string,
+	roundContributions []NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"FinalizeSignRound",
+			"session ID is empty",
+		)
+	}
+
+	if len(roundContributions) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"FinalizeSignRound",
+			"round contributions are empty",
+		)
+	}
+
+	payloadContributions := make(
+		[]buildTaggedTBTCSignerFinalizeRoundContribution,
+		0,
+		len(roundContributions),
+	)
+
+	for i, contribution := range roundContributions {
+		if len(contribution.Data) == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"FinalizeSignRound",
+				fmt.Sprintf("round contribution [%d] data is empty", i),
+			)
+		}
+
+		payloadContributions = append(
+			payloadContributions,
+			buildTaggedTBTCSignerFinalizeRoundContribution{
+				Identifier:        contribution.Identifier,
+				SignatureShareHex: hex.EncodeToString(contribution.Data),
+			},
+		)
+	}
+
+	request := buildTaggedTBTCSignerFinalizeSignRoundRequest{
+		SessionID:          sessionID,
+		RoundContributions: payloadContributions,
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"FinalizeSignRound",
+			fmt.Sprintf("cannot marshal request: %v", err),
+		)
+	}
+
+	return payload, nil
+}
+
+func decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
+	responsePayload []byte,
+) ([]byte, error) {
+	var response buildTaggedTBTCSignerFinalizeSignRoundResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"FinalizeSignRound",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	if response.SignatureHex == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"FinalizeSignRound",
+			"response signature is empty",
+		)
+	}
+
+	signature, err := hex.DecodeString(response.SignatureHex)
+	if err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"FinalizeSignRound",
+			fmt.Sprintf("response signature is invalid hex: %v", err),
+		)
+	}
+
+	return signature, nil
+}
+
+func callBuildTaggedTBTCSignerStartSignRound(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"StartSignRound",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_start_sign_round(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerFinalizeSignRound(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"FinalizeSignRound",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_finalize_sign_round(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerOperation(
+	operation string,
+	requestPayload []byte,
+	call func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult,
+) ([]byte, error) {
+	if len(requestPayload) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			operation,
+			"request payload is empty",
+		)
+	}
+
+	requestPtr := C.CBytes(requestPayload)
+	defer C.free(requestPtr)
+
+	result := call((*C.uint8_t)(requestPtr), C.size_t(len(requestPayload)))
+	return parseBuildTaggedTBTCSignerResult(operation, result)
+}
+
+func parseBuildTaggedTBTCSignerResult(
+	operation string,
+	result C.TbtcSignerResult,
+) ([]byte, error) {
+	defer C.tbtc_signer_free_buffer(result.buffer.ptr, result.buffer.len)
+
+	statusCode := int32(result.status_code)
+	if statusCode == buildTaggedTBTCSignerUnavailableStatusCode {
+		return nil, buildTaggedTBTCSignerUnavailableError(operation)
+	}
+
+	var payload []byte
+	if result.buffer.ptr != nil && result.buffer.len > 0 {
+		payload = C.GoBytes(unsafe.Pointer(result.buffer.ptr), C.int(result.buffer.len))
+	}
+
+	if statusCode != 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			operation,
+			buildTaggedTBTCSignerErrorMessage(payload),
+		)
+	}
+
+	if len(payload) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			operation,
+			"response payload is empty",
+		)
+	}
+
+	return payload, nil
+}
+
+func buildTaggedTBTCSignerErrorMessage(payload []byte) string {
+	var errorResponse buildTaggedTBTCSignerErrorResponse
+	if err := json.Unmarshal(payload, &errorResponse); err != nil {
+		return fmt.Sprintf(
+			"cannot decode error payload [%x]: %v",
+			payload,
+			err,
+		)
+	}
+
+	if errorResponse.Code == "" && errorResponse.Message == "" {
+		return fmt.Sprintf("empty error payload: [%s]", string(payload))
+	}
+
+	if errorResponse.Code != "" {
+		return fmt.Sprintf("%s: %s", errorResponse.Code, errorResponse.Message)
+	}
+
+	return errorResponse.Message
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -21,6 +21,7 @@ typedef struct {
   TbtcBuffer buffer;
 } TbtcSignerResult;
 
+typedef TbtcSignerResult (*tbtc_version_fn)(void);
 typedef TbtcSignerResult (*tbtc_run_dkg_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -41,6 +42,18 @@ static TbtcSignerResult unavailable_tbtc_signer_result(void) {
   result.buffer.ptr = NULL;
   result.buffer.len = 0;
   return result;
+}
+
+static TbtcSignerResult tbtc_signer_version(void) {
+  tbtc_version_fn version = (tbtc_version_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_version"
+  );
+  if (version == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return version();
 }
 
 static TbtcSignerResult tbtc_signer_run_dkg(const uint8_t* request_ptr, size_t request_len) {
@@ -156,6 +169,23 @@ const buildTaggedTBTCSignerUnavailableStatusCode = -1
 
 func registerBuildTaggedNativeFROSTSigningEngine() error {
 	return RegisterNativeTBTCSignerEngine(&buildTaggedTBTCSignerEngine{})
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) Version() (string, error) {
+	responsePayload, err := callBuildTaggedTBTCSignerVersion()
+	if err != nil {
+		return "", err
+	}
+
+	version := string(responsePayload)
+	if version == "" {
+		return "", buildTaggedTBTCSignerOperationError(
+			"Version",
+			"response version is empty",
+		)
+	}
+
+	return version, nil
 }
 
 func (bttse *buildTaggedTBTCSignerEngine) RunDKG(
@@ -523,6 +553,11 @@ func decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
 	}
 
 	return signature, nil
+}
+
+func callBuildTaggedTBTCSignerVersion() ([]byte, error) {
+	result := C.tbtc_signer_version()
+	return parseBuildTaggedTBTCSignerResult("Version", result)
 }
 
 func callBuildTaggedTBTCSignerRunDKG(

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-func TestRegisterBuildTaggedTBTCSignerNativeFROSTSigningEngine(t *testing.T) {
-	UnregisterNativeFROSTSigningEngine()
+func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
+	UnregisterNativeTBTCSignerEngine()
 	t.Cleanup(func() {
-		UnregisterNativeFROSTSigningEngine()
+		UnregisterNativeTBTCSignerEngine()
 	})
 
 	err := registerBuildTaggedNativeFROSTSigningEngine()
@@ -18,15 +18,16 @@ func TestRegisterBuildTaggedTBTCSignerNativeFROSTSigningEngine(t *testing.T) {
 		t.Fatalf("unexpected registration error: [%v]", err)
 	}
 
-	engine := currentNativeFROSTSigningEngine()
+	engine := currentNativeTBTCSignerEngine()
 	if engine == nil {
-		t.Fatal("expected native FROST signing engine registration")
+		t.Fatal("expected native tbtc-signer engine registration")
 	}
 
-	_, _, err = engine.GenerateNoncesAndCommitments(&NativeFROSTKeyPackage{
-		Identifier: "participant-1",
-		Data:       []byte{1, 2, 3},
-	})
+	_, err = engine.StartSignRound(
+		"session-1",
+		[]byte("message"),
+		"key-group",
+	)
 	if err == nil {
 		t.Fatal("expected not-implemented tbtc-signer bridge error")
 	}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -491,6 +491,69 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 	}
 }
 
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsZeroSigningParticipant(
+	t *testing.T,
+) {
+	_, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,0,3],"own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
+		),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsDuplicateSigningParticipant(
+	t *testing.T,
+) {
+	_, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,2,2],"own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
+		),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsZeroOwnContributionIdentifier(
+	t *testing.T,
+) {
+	_, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,2,3],"own_contribution":{"identifier":0,"signature_share_hex":"deadbeef"}}`,
+		),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
 func TestDecodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(t *testing.T) {
 	signature, err := decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
 		[]byte(`{"session_id":"session-1","round_id":"round-1","signature_hex":"deadbeef"}`),

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1,0 +1,37 @@
+//go:build frost_native && frost_tbtc_signer && cgo && !frost_uniffi_sdk
+
+package signing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegisterBuildTaggedTBTCSignerNativeFROSTSigningEngine(t *testing.T) {
+	UnregisterNativeFROSTSigningEngine()
+	t.Cleanup(func() {
+		UnregisterNativeFROSTSigningEngine()
+	})
+
+	err := registerBuildTaggedNativeFROSTSigningEngine()
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	engine := currentNativeFROSTSigningEngine()
+	if engine == nil {
+		t.Fatal("expected native FROST signing engine registration")
+	}
+
+	_, _, err = engine.GenerateNoncesAndCommitments(&NativeFROSTKeyPackage{
+		Identifier: "participant-1",
+		Data:       []byte{1, 2, 3},
+	})
+	if err == nil {
+		t.Fatal("expected not-implemented tbtc-signer bridge error")
+	}
+
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("unexpected bridge error: [%v]", err)
+	}
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -45,6 +45,26 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 	if !strings.Contains(err.Error(), "unavailable") {
 		t.Fatalf("unexpected bridge error: [%v]", err)
 	}
+
+	versionedEngine, ok := engine.(interface {
+		Version() (string, error)
+	})
+	if !ok {
+		t.Fatal("expected versioned native tbtc-signer engine")
+	}
+
+	_, err = versionedEngine.Version()
+	if err == nil {
+		t.Fatal("expected unavailable tbtc-signer version bridge error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"expected native cryptography unavailable error: [%v], got [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
 }
 
 func TestBuildTaggedTBTCSignerRunDKGRequestPayload(t *testing.T) {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -30,6 +30,7 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 		1,
 		[]byte("message"),
 		"key-group",
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected unavailable tbtc-signer bridge error")
@@ -257,6 +258,7 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 		3,
 		[]byte{0xab, 0xcd},
 		"key-group-1",
+		[]uint16{1, 2, 3},
 	)
 	if err != nil {
 		t.Fatalf("unexpected payload build error: [%v]", err)
@@ -298,6 +300,26 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 			request.MemberIdentifier,
 		)
 	}
+
+	if len(request.SigningParticipants) != 3 {
+		t.Fatalf(
+			"unexpected signing participants count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(request.SigningParticipants),
+		)
+	}
+
+	expectedSigningParticipants := []uint16{1, 2, 3}
+	for i := range expectedSigningParticipants {
+		if request.SigningParticipants[i] != expectedSigningParticipants[i] {
+			t.Fatalf(
+				"unexpected signing participant at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				expectedSigningParticipants[i],
+				request.SigningParticipants[i],
+			)
+		}
+	}
 }
 
 func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *testing.T) {
@@ -306,6 +328,7 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *tes
 		1,
 		[]byte{0xab},
 		"key-group-1",
+		nil,
 	)
 	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
 		t.Fatalf(
@@ -322,6 +345,7 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_ZeroMemberID(t *testi
 		0,
 		[]byte{0xab},
 		"key-group-1",
+		nil,
 	)
 	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
 		t.Fatalf(
@@ -387,7 +411,7 @@ func TestBuildTaggedTBTCSignerFinalizeSignRoundRequestPayload(t *testing.T) {
 func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 	roundState, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		[]byte(
-			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,2,3],"own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
 		),
 	)
 	if err != nil {
@@ -423,6 +447,14 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 			"unexpected message digest hex\nexpected: [%v]\nactual:   [%v]",
 			"abcd",
 			roundState.MessageDigestHex,
+		)
+	}
+
+	if len(roundState.SigningParticipants) != 3 {
+		t.Fatalf(
+			"unexpected signing participants count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(roundState.SigningParticipants),
 		)
 	}
 

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -3,6 +3,7 @@
 package signing
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -29,10 +30,18 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 		"key-group",
 	)
 	if err == nil {
-		t.Fatal("expected not-implemented tbtc-signer bridge error")
+		t.Fatal("expected unavailable tbtc-signer bridge error")
 	}
 
-	if !strings.Contains(err.Error(), "not implemented") {
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"expected native cryptography unavailable error: [%v], got [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if !strings.Contains(err.Error(), "unavailable") {
 		t.Fatalf("unexpected bridge error: [%v]", err)
 	}
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -47,6 +47,189 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 	}
 }
 
+func TestBuildTaggedTBTCSignerRunDKGRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerRunDKGRequestPayload(
+		"session-1",
+		[]NativeTBTCSignerDKGParticipant{
+			{
+				Identifier:   1,
+				PublicKeyHex: "02aa",
+			},
+			{
+				Identifier:   2,
+				PublicKeyHex: "02bb",
+			},
+		},
+		2,
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerRunDKGRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			request.SessionID,
+		)
+	}
+
+	if request.Threshold != 2 {
+		t.Fatalf(
+			"unexpected threshold\nexpected: [%v]\nactual:   [%v]",
+			2,
+			request.Threshold,
+		)
+	}
+
+	if len(request.Participants) != 2 {
+		t.Fatalf(
+			"unexpected participants count\nexpected: [%v]\nactual:   [%v]",
+			2,
+			len(request.Participants),
+		)
+	}
+
+	if request.Participants[0].Identifier != 1 {
+		t.Fatalf(
+			"unexpected participant identifier\nexpected: [%v]\nactual:   [%v]",
+			1,
+			request.Participants[0].Identifier,
+		)
+	}
+
+	if request.Participants[0].PublicKeyHex != "02aa" {
+		t.Fatalf(
+			"unexpected participant public key hex\nexpected: [%v]\nactual:   [%v]",
+			"02aa",
+			request.Participants[0].PublicKeyHex,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerRunDKGRequestPayload_RejectsInvalidInput(t *testing.T) {
+	testCases := []struct {
+		name         string
+		sessionID    string
+		participants []NativeTBTCSignerDKGParticipant
+		threshold    uint16
+	}{
+		{
+			name:         "empty session id",
+			sessionID:    "",
+			participants: []NativeTBTCSignerDKGParticipant{{Identifier: 1, PublicKeyHex: "02aa"}},
+			threshold:    2,
+		},
+		{
+			name:         "empty participants",
+			sessionID:    "session-1",
+			participants: nil,
+			threshold:    2,
+		},
+		{
+			name:      "zero threshold",
+			sessionID: "session-1",
+			participants: []NativeTBTCSignerDKGParticipant{
+				{Identifier: 1, PublicKeyHex: "02aa"},
+			},
+			threshold: 0,
+		},
+		{
+			name:      "participant zero identifier",
+			sessionID: "session-1",
+			participants: []NativeTBTCSignerDKGParticipant{
+				{Identifier: 0, PublicKeyHex: "02aa"},
+			},
+			threshold: 1,
+		},
+		{
+			name:      "participant empty public key hex",
+			sessionID: "session-1",
+			participants: []NativeTBTCSignerDKGParticipant{
+				{Identifier: 1, PublicKeyHex: ""},
+			},
+			threshold: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildTaggedTBTCSignerRunDKGRequestPayload(
+				tc.sessionID,
+				tc.participants,
+				tc.threshold,
+			)
+			if err == nil {
+				t.Fatal("expected payload build error")
+			}
+
+			if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+				t.Fatalf(
+					"expected native cryptography unavailable error: [%v], got [%v]",
+					ErrNativeCryptographyUnavailable,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerRunDKGResponse(t *testing.T) {
+	result, err := decodeBuildTaggedTBTCSignerRunDKGResponse(
+		[]byte(
+			`{"session_id":"session-1","key_group":"group-1","participant_count":3,"threshold":2,"created_at_unix":123456789}`,
+		),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+
+	if result.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			result.SessionID,
+		)
+	}
+
+	if result.KeyGroup != "group-1" {
+		t.Fatalf(
+			"unexpected key group\nexpected: [%v]\nactual:   [%v]",
+			"group-1",
+			result.KeyGroup,
+		)
+	}
+
+	if result.ParticipantCount != 3 {
+		t.Fatalf(
+			"unexpected participant count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			result.ParticipantCount,
+		)
+	}
+
+	if result.Threshold != 2 {
+		t.Fatalf(
+			"unexpected threshold\nexpected: [%v]\nactual:   [%v]",
+			2,
+			result.Threshold,
+		)
+	}
+
+	if result.CreatedAtUnix != 123456789 {
+		t.Fatalf(
+			"unexpected created-at unix\nexpected: [%v]\nactual:   [%v]",
+			123456789,
+			result.CreatedAtUnix,
+		)
+	}
+}
+
 func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 	payload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		"session-1",

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -27,6 +27,7 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 
 	_, err = engine.StartSignRound(
 		"session-1",
+		1,
 		[]byte("message"),
 		"key-group",
 	)
@@ -253,6 +254,7 @@ func TestDecodeBuildTaggedTBTCSignerRunDKGResponse(t *testing.T) {
 func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 	payload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		"session-1",
+		3,
 		[]byte{0xab, 0xcd},
 		"key-group-1",
 	)
@@ -288,11 +290,36 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 			request.KeyGroup,
 		)
 	}
+
+	if request.MemberIdentifier != 3 {
+		t.Fatalf(
+			"unexpected member identifier\nexpected: [%v]\nactual:   [%v]",
+			3,
+			request.MemberIdentifier,
+		)
+	}
 }
 
 func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *testing.T) {
 	_, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		"",
+		1,
+		[]byte{0xab},
+		"key-group-1",
+	)
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"expected native cryptography unavailable error: [%v], got [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_ZeroMemberID(t *testing.T) {
+	_, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
+		"session-1",
+		0,
 		[]byte{0xab},
 		"key-group-1",
 	)
@@ -360,7 +387,7 @@ func TestBuildTaggedTBTCSignerFinalizeSignRoundRequestPayload(t *testing.T) {
 func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 	roundState, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		[]byte(
-			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd"}`,
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
 		),
 	)
 	if err != nil {
@@ -397,6 +424,38 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 			"abcd",
 			roundState.MessageDigestHex,
 		)
+	}
+
+	if roundState.OwnContribution == nil {
+		t.Fatal("expected own contribution in round state response")
+	}
+
+	if roundState.OwnContribution.Identifier != 3 {
+		t.Fatalf(
+			"unexpected own contribution identifier\nexpected: [%v]\nactual:   [%v]",
+			3,
+			roundState.OwnContribution.Identifier,
+		)
+	}
+
+	expectedOwnContributionData := []byte{0xde, 0xad, 0xbe, 0xef}
+	if len(roundState.OwnContribution.Data) != len(expectedOwnContributionData) {
+		t.Fatalf(
+			"unexpected own contribution data length\nexpected: [%v]\nactual:   [%v]",
+			len(expectedOwnContributionData),
+			len(roundState.OwnContribution.Data),
+		)
+	}
+
+	for i := range roundState.OwnContribution.Data {
+		if roundState.OwnContribution.Data[i] != expectedOwnContributionData[i] {
+			t.Fatalf(
+				"unexpected own contribution byte at index [%d]\nexpected: [%x]\nactual:   [%x]",
+				i,
+				expectedOwnContributionData[i],
+				roundState.OwnContribution.Data[i],
+			)
+		}
 	}
 }
 

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -3,6 +3,7 @@
 package signing
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -43,5 +44,184 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "unavailable") {
 		t.Fatalf("unexpected bridge error: [%v]", err)
+	}
+}
+
+func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
+		"session-1",
+		[]byte{0xab, 0xcd},
+		"key-group-1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerStartSignRoundRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			request.SessionID,
+		)
+	}
+
+	if request.MessageHex != "abcd" {
+		t.Fatalf(
+			"unexpected message hex\nexpected: [%v]\nactual:   [%v]",
+			"abcd",
+			request.MessageHex,
+		)
+	}
+
+	if request.KeyGroup != "key-group-1" {
+		t.Fatalf(
+			"unexpected key group\nexpected: [%v]\nactual:   [%v]",
+			"key-group-1",
+			request.KeyGroup,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *testing.T) {
+	_, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
+		"",
+		[]byte{0xab},
+		"key-group-1",
+	)
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"expected native cryptography unavailable error: [%v], got [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerFinalizeSignRoundRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerFinalizeSignRoundRequestPayload(
+		"session-1",
+		[]NativeTBTCSignerRoundContribution{
+			{
+				Identifier: 7,
+				Data:       []byte{0xde, 0xad},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerFinalizeSignRoundRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			request.SessionID,
+		)
+	}
+
+	if len(request.RoundContributions) != 1 {
+		t.Fatalf(
+			"unexpected contribution count\nexpected: [%v]\nactual:   [%v]",
+			1,
+			len(request.RoundContributions),
+		)
+	}
+
+	if request.RoundContributions[0].Identifier != 7 {
+		t.Fatalf(
+			"unexpected contribution identifier\nexpected: [%v]\nactual:   [%v]",
+			7,
+			request.RoundContributions[0].Identifier,
+		)
+	}
+
+	if request.RoundContributions[0].SignatureShareHex != "dead" {
+		t.Fatalf(
+			"unexpected contribution signature share\nexpected: [%v]\nactual:   [%v]",
+			"dead",
+			request.RoundContributions[0].SignatureShareHex,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
+	roundState, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd"}`,
+		),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+
+	if roundState.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			roundState.SessionID,
+		)
+	}
+
+	if roundState.RoundID != "round-1" {
+		t.Fatalf(
+			"unexpected round id\nexpected: [%v]\nactual:   [%v]",
+			"round-1",
+			roundState.RoundID,
+		)
+	}
+
+	if roundState.RequiredContributions != 2 {
+		t.Fatalf(
+			"unexpected required contributions\nexpected: [%v]\nactual:   [%v]",
+			2,
+			roundState.RequiredContributions,
+		)
+	}
+
+	if roundState.MessageDigestHex != "abcd" {
+		t.Fatalf(
+			"unexpected message digest hex\nexpected: [%v]\nactual:   [%v]",
+			"abcd",
+			roundState.MessageDigestHex,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(t *testing.T) {
+	signature, err := decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
+		[]byte(`{"session_id":"session-1","round_id":"round-1","signature_hex":"deadbeef"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+
+	expectedSignature := []byte{0xde, 0xad, 0xbe, 0xef}
+	if len(signature) != len(expectedSignature) {
+		t.Fatalf(
+			"unexpected signature length\nexpected: [%v]\nactual:   [%v]",
+			len(expectedSignature),
+			len(signature),
+		)
+	}
+
+	for i := range signature {
+		if signature[i] != expectedSignature[i] {
+			t.Fatalf(
+				"unexpected signature byte at index [%d]\nexpected: [%x]\nactual:   [%x]",
+				i,
+				expectedSignature[i],
+				signature[i],
+			)
+		}
 	}
 }

--- a/pkg/frost/signing/native_frost_engine_uniffi_registration_frost_native_default.go
+++ b/pkg/frost/signing/native_frost_engine_uniffi_registration_frost_native_default.go
@@ -1,4 +1,4 @@
-//go:build frost_native && !(frost_uniffi_sdk && cgo)
+//go:build frost_native && !(frost_uniffi_sdk && cgo) && !(frost_tbtc_signer && cgo)
 
 package signing
 

--- a/pkg/frost/signing/native_frost_protocol_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -149,6 +150,93 @@ func (dnfse *deterministicNativeFROSTSigningEngine) Aggregate(
 	return signatureDigest[:], nil
 }
 
+type recordingNativeFROSTSigningEngine struct {
+	deterministicNativeFROSTSigningEngine
+	mutex                     sync.Mutex
+	commitmentIDSnapshots     [][]string
+	signatureShareIDSnapshots [][]string
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) NewSigningPackage(
+	message []byte,
+	commitments []*NativeFROSTCommitment,
+) (*NativeFROSTSigningPackage, error) {
+	commitmentIDs := make([]string, 0, len(commitments))
+	for _, commitment := range commitments {
+		if commitment == nil {
+			commitmentIDs = append(commitmentIDs, "<nil>")
+			continue
+		}
+
+		commitmentIDs = append(commitmentIDs, commitment.Identifier)
+	}
+
+	rnfse.mutex.Lock()
+	rnfse.commitmentIDSnapshots = append(
+		rnfse.commitmentIDSnapshots,
+		append([]string{}, commitmentIDs...),
+	)
+	rnfse.mutex.Unlock()
+
+	return rnfse.deterministicNativeFROSTSigningEngine.NewSigningPackage(
+		message,
+		commitments,
+	)
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) Aggregate(
+	signingPackage *NativeFROSTSigningPackage,
+	signatureShares []*NativeFROSTSignatureShare,
+	publicKeyPackage *NativeFROSTPublicKeyPackage,
+) ([]byte, error) {
+	signatureShareIDs := make([]string, 0, len(signatureShares))
+	for _, signatureShare := range signatureShares {
+		if signatureShare == nil {
+			signatureShareIDs = append(signatureShareIDs, "<nil>")
+			continue
+		}
+
+		signatureShareIDs = append(signatureShareIDs, signatureShare.Identifier)
+	}
+
+	rnfse.mutex.Lock()
+	rnfse.signatureShareIDSnapshots = append(
+		rnfse.signatureShareIDSnapshots,
+		append([]string{}, signatureShareIDs...),
+	)
+	rnfse.mutex.Unlock()
+
+	return rnfse.deterministicNativeFROSTSigningEngine.Aggregate(
+		signingPackage,
+		signatureShares,
+		publicKeyPackage,
+	)
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) commitmentIDs() [][]string {
+	rnfse.mutex.Lock()
+	defer rnfse.mutex.Unlock()
+
+	snapshots := make([][]string, 0, len(rnfse.commitmentIDSnapshots))
+	for _, snapshot := range rnfse.commitmentIDSnapshots {
+		snapshots = append(snapshots, append([]string{}, snapshot...))
+	}
+
+	return snapshots
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) signatureShareIDs() [][]string {
+	rnfse.mutex.Lock()
+	defer rnfse.mutex.Unlock()
+
+	snapshots := make([][]string, 0, len(rnfse.signatureShareIDSnapshots))
+	for _, snapshot := range rnfse.signatureShareIDSnapshots {
+		snapshots = append(snapshots, append([]string{}, snapshot...))
+	}
+
+	return snapshots
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_NativeFROSTPath(
 	t *testing.T,
 ) {
@@ -231,6 +319,190 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_Nati
 	}
 }
 
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_NativeFROSTPath_AttemptVariationUsesCohortSelections(
+	t *testing.T,
+) {
+	engine := &recordingNativeFROSTSigningEngine{}
+	RegisterNativeFROSTSigningEngine(engine)
+	t.Cleanup(UnregisterNativeFROSTSigningEngine)
+
+	provider := local.Connect()
+	channel, err := provider.BroadcastChannelFor("native-frost-signing-protocol-attempt-variation-test")
+	if err != nil {
+		t.Fatalf("failed creating broadcast channel: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+	primitive.RegisterUnmarshallers(channel)
+
+	runRound := func(
+		sessionID string,
+		includedMembers []group.MemberIndex,
+		groupSize int,
+	) []*frost.Signature {
+		requests := make([]*NativeExecutionFFISigningRequest, len(includedMembers))
+		for i := 0; i < len(includedMembers); i++ {
+			memberIndex := includedMembers[i]
+
+			request, roundErr := newNativeFROSTSigningRequestWithSessionForTest(
+				memberIndex,
+				includedMembers,
+				channel,
+				groupSize,
+				sessionID,
+			)
+			if roundErr != nil {
+				t.Fatalf(
+					"failed preparing request for member [%v] in session [%s]: [%v]",
+					memberIndex,
+					sessionID,
+					roundErr,
+				)
+			}
+
+			requests[i] = request
+		}
+
+		ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancelCtx()
+
+		results := make([]*frostSignatureResultForTest, len(includedMembers))
+		var wg sync.WaitGroup
+		wg.Add(len(includedMembers))
+
+		for i := 0; i < len(includedMembers); i++ {
+			go func(index int) {
+				defer wg.Done()
+
+				signature, signErr := primitive.Sign(ctx, nil, requests[index])
+				results[index] = &frostSignatureResultForTest{
+					signature: signature,
+					err:       signErr,
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		signatures := make([]*frost.Signature, len(includedMembers))
+		for i := 0; i < len(includedMembers); i++ {
+			if results[i] == nil {
+				t.Fatalf(
+					"missing signing result for member [%v] in session [%s]",
+					includedMembers[i],
+					sessionID,
+				)
+			}
+
+			if results[i].err != nil {
+				t.Fatalf(
+					"unexpected signing error for member [%v] in session [%s]: [%v]",
+					includedMembers[i],
+					sessionID,
+					results[i].err,
+				)
+			}
+
+			if results[i].signature == nil {
+				t.Fatalf(
+					"nil signature for member [%v] in session [%s]",
+					includedMembers[i],
+					sessionID,
+				)
+			}
+
+			signatures[i] = results[i].signature
+		}
+
+		return signatures
+	}
+
+	assertSignaturesMatch := func(
+		sessionID string,
+		signatures []*frost.Signature,
+	) {
+		if len(signatures) == 0 {
+			t.Fatalf("no signatures for session [%s]", sessionID)
+		}
+
+		for i := 1; i < len(signatures); i++ {
+			if !signatures[0].Equals(signatures[i]) {
+				t.Fatalf(
+					"signature mismatch in session [%s]\nfirst:  [%v]\nsecond: [%v]",
+					sessionID,
+					signatures[0],
+					signatures[i],
+				)
+			}
+		}
+	}
+
+	roundOneSignatures := runRound(
+		"native-frost-signing-session-attempt-1",
+		[]group.MemberIndex{1, 2, 3},
+		3,
+	)
+	assertSignaturesMatch("native-frost-signing-session-attempt-1", roundOneSignatures)
+
+	roundTwoSignatures := runRound(
+		"native-frost-signing-session-attempt-2",
+		[]group.MemberIndex{1, 3},
+		3,
+	)
+	assertSignaturesMatch("native-frost-signing-session-attempt-2", roundTwoSignatures)
+
+	snapshotHistogram := func(snapshots [][]string) map[string]int {
+		histogram := make(map[string]int)
+		for _, snapshot := range snapshots {
+			histogram[strings.Join(snapshot, ",")]++
+		}
+
+		return histogram
+	}
+
+	expectedHistogram := map[string]int{
+		"member-1,member-2,member-3": 3,
+		"member-1,member-3":          2,
+	}
+
+	assertHistogram := func(name string, actual map[string]int) {
+		if len(actual) != len(expectedHistogram) {
+			t.Fatalf(
+				"unexpected %s histogram size\nexpected: [%v]\nactual:   [%v]",
+				name,
+				len(expectedHistogram),
+				len(actual),
+			)
+		}
+
+		for key, expectedCount := range expectedHistogram {
+			actualCount, ok := actual[key]
+			if !ok {
+				t.Fatalf("missing %s histogram key: [%s]", name, key)
+			}
+
+			if actualCount != expectedCount {
+				t.Fatalf(
+					"unexpected %s count for key [%s]\nexpected: [%v]\nactual:   [%v]",
+					name,
+					key,
+					expectedCount,
+					actualCount,
+				)
+			}
+		}
+	}
+
+	assertHistogram(
+		"commitment IDs",
+		snapshotHistogram(engine.commitmentIDs()),
+	)
+	assertHistogram(
+		"signature share IDs",
+		snapshotHistogram(engine.signatureShareIDs()),
+	)
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_NativeFROSTPathWithoutEngine(
 	t *testing.T,
 ) {
@@ -281,6 +553,22 @@ func newNativeFROSTSigningRequestForTest(
 	channel net.BroadcastChannel,
 	groupSize int,
 ) (*NativeExecutionFFISigningRequest, error) {
+	return newNativeFROSTSigningRequestWithSessionForTest(
+		memberIndex,
+		includedMembers,
+		channel,
+		groupSize,
+		"native-frost-signing-session",
+	)
+}
+
+func newNativeFROSTSigningRequestWithSessionForTest(
+	memberIndex group.MemberIndex,
+	includedMembers []group.MemberIndex,
+	channel net.BroadcastChannel,
+	groupSize int,
+	sessionID string,
+) (*NativeExecutionFFISigningRequest, error) {
 	keyPackage := &NativeFROSTKeyPackage{
 		Identifier: fmt.Sprintf("member-%v", memberIndex),
 		Data: []byte{
@@ -307,7 +595,7 @@ func newNativeFROSTSigningRequestForTest(
 
 	return &NativeExecutionFFISigningRequest{
 		Message:            bigOneForTest(),
-		SessionID:          "native-frost-signing-session",
+		SessionID:          sessionID,
 		MemberIndex:        memberIndex,
 		GroupSize:          groupSize,
 		DishonestThreshold: 1,

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -1,0 +1,74 @@
+//go:build frost_native
+
+package signing
+
+import "fmt"
+
+const (
+	// NativeSignerMaterialFormatFrostTBTCSignerV1 carries signer material for
+	// tbtc-signer coarse session APIs.
+	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
+)
+
+// NativeTBTCSignerRoundContribution is a participant contribution consumed by
+// tbtc-signer during signature finalization.
+type NativeTBTCSignerRoundContribution struct {
+	Identifier string `json:"identifier"`
+	Data       []byte `json:"data"`
+}
+
+// NativeTBTCSignerRoundState captures coarse session round metadata returned by
+// StartSignRound.
+type NativeTBTCSignerRoundState struct {
+	SessionID             string `json:"sessionID"`
+	RoundID               string `json:"roundID"`
+	RequiredContributions uint16 `json:"requiredContributions"`
+	MessageDigestHex      string `json:"messageDigestHex"`
+}
+
+// NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer
+// operations.
+type NativeTBTCSignerEngine interface {
+	StartSignRound(
+		sessionID string,
+		message []byte,
+		keyGroup string,
+	) (*NativeTBTCSignerRoundState, error)
+	FinalizeSignRound(
+		sessionID string,
+		roundContributions []NativeTBTCSignerRoundContribution,
+	) ([]byte, error)
+}
+
+var nativeTBTCSignerEngine NativeTBTCSignerEngine
+
+// RegisterNativeTBTCSignerEngine registers the coarse tbtc-signer engine used
+// by frost_tbtc_signer builds.
+func RegisterNativeTBTCSignerEngine(engine NativeTBTCSignerEngine) error {
+	if engine == nil {
+		return fmt.Errorf("native tbtc-signer engine is nil")
+	}
+
+	executionBackendMutex.Lock()
+	defer executionBackendMutex.Unlock()
+
+	nativeTBTCSignerEngine = engine
+
+	return nil
+}
+
+// UnregisterNativeTBTCSignerEngine clears coarse tbtc-signer engine
+// registration.
+func UnregisterNativeTBTCSignerEngine() {
+	executionBackendMutex.Lock()
+	defer executionBackendMutex.Unlock()
+
+	nativeTBTCSignerEngine = nil
+}
+
+func currentNativeTBTCSignerEngine() NativeTBTCSignerEngine {
+	executionBackendMutex.RLock()
+	defer executionBackendMutex.RUnlock()
+
+	return nativeTBTCSignerEngine
+}

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -18,6 +18,22 @@ type NativeTBTCSignerMaterialPayload struct {
 	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
 }
 
+// NativeTBTCSignerDKGParticipant identifies a DKG participant for coarse
+// tbtc-signer RunDKG operation.
+type NativeTBTCSignerDKGParticipant struct {
+	Identifier   uint16 `json:"identifier"`
+	PublicKeyHex string `json:"publicKeyHex"`
+}
+
+// NativeTBTCSignerDKGResult captures DKG result metadata returned by RunDKG.
+type NativeTBTCSignerDKGResult struct {
+	SessionID        string `json:"sessionID"`
+	KeyGroup         string `json:"keyGroup"`
+	ParticipantCount uint16 `json:"participantCount"`
+	Threshold        uint16 `json:"threshold"`
+	CreatedAtUnix    uint64 `json:"createdAtUnix"`
+}
+
 // NativeTBTCSignerRoundContribution is a participant contribution consumed by
 // tbtc-signer during signature finalization.
 type NativeTBTCSignerRoundContribution struct {
@@ -37,6 +53,11 @@ type NativeTBTCSignerRoundState struct {
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer
 // operations.
 type NativeTBTCSignerEngine interface {
+	RunDKG(
+		sessionID string,
+		participants []NativeTBTCSignerDKGParticipant,
+		threshold uint16,
+	) (*NativeTBTCSignerDKGResult, error)
 	StartSignRound(
 		sessionID string,
 		message []byte,

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -8,6 +8,9 @@ const (
 	// NativeSignerMaterialFormatFrostTBTCSignerV1 carries signer material for
 	// tbtc-signer coarse session APIs.
 	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
+	// NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey marks scaffold-era
+	// key-group derivation from the legacy wallet public key.
+	NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey = "legacy-wallet-pubkey"
 )
 
 // NativeTBTCSignerMaterialPayload is the signer-material payload schema for

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -30,12 +30,12 @@ type NativeTBTCSignerRoundContribution struct {
 // NativeTBTCSignerRoundState captures coarse session round metadata returned by
 // StartSignRound.
 type NativeTBTCSignerRoundState struct {
-	SessionID             string `json:"sessionID"`
-	RoundID               string `json:"roundID"`
-	RequiredContributions uint16 `json:"requiredContributions"`
-	MessageDigestHex      string `json:"messageDigestHex"`
-	SigningParticipants   []uint16
-	OwnContribution       *NativeTBTCSignerRoundContribution
+	SessionID             string                             `json:"sessionID"`
+	RoundID               string                             `json:"roundID"`
+	RequiredContributions uint16                             `json:"requiredContributions"`
+	MessageDigestHex      string                             `json:"messageDigestHex"`
+	SigningParticipants   []uint16                           `json:"signingParticipants"`
+	OwnContribution       *NativeTBTCSignerRoundContribution `json:"ownContribution"`
 }
 
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -51,6 +51,7 @@ type NativeTBTCSignerRoundState struct {
 	RoundID               string `json:"roundID"`
 	RequiredContributions uint16 `json:"requiredContributions"`
 	MessageDigestHex      string `json:"messageDigestHex"`
+	SigningParticipants   []uint16
 	OwnContribution       *NativeTBTCSignerRoundContribution
 }
 
@@ -67,6 +68,7 @@ type NativeTBTCSignerEngine interface {
 		memberIdentifier uint16,
 		message []byte,
 		keyGroup string,
+		signingParticipants []uint16,
 	) (*NativeTBTCSignerRoundState, error)
 	FinalizeSignRound(
 		sessionID string,

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -4,23 +4,6 @@ package signing
 
 import "fmt"
 
-const (
-	// NativeSignerMaterialFormatFrostTBTCSignerV1 carries signer material for
-	// tbtc-signer coarse session APIs.
-	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
-	// NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey marks scaffold-era
-	// key-group derivation from the legacy wallet public key.
-	NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey = "legacy-wallet-pubkey"
-)
-
-// NativeTBTCSignerMaterialPayload is the signer-material payload schema for
-// `frost-tbtc-signer-v1`.
-type NativeTBTCSignerMaterialPayload struct {
-	KeyGroup                 string `json:"keyGroup"`
-	KeyGroupSource           string `json:"keyGroupSource,omitempty"`
-	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
-}
-
 // NativeTBTCSignerDKGParticipant identifies a DKG participant for coarse
 // tbtc-signer RunDKG operation.
 type NativeTBTCSignerDKGParticipant struct {

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -10,10 +10,18 @@ const (
 	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
 )
 
+// NativeTBTCSignerMaterialPayload is the signer-material payload schema for
+// `frost-tbtc-signer-v1`.
+type NativeTBTCSignerMaterialPayload struct {
+	KeyGroup                 string `json:"keyGroup"`
+	KeyGroupSource           string `json:"keyGroupSource,omitempty"`
+	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
+}
+
 // NativeTBTCSignerRoundContribution is a participant contribution consumed by
 // tbtc-signer during signature finalization.
 type NativeTBTCSignerRoundContribution struct {
-	Identifier string `json:"identifier"`
+	Identifier uint16 `json:"identifier"`
 	Data       []byte `json:"data"`
 }
 

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -51,6 +51,7 @@ type NativeTBTCSignerRoundState struct {
 	RoundID               string `json:"roundID"`
 	RequiredContributions uint16 `json:"requiredContributions"`
 	MessageDigestHex      string `json:"messageDigestHex"`
+	OwnContribution       *NativeTBTCSignerRoundContribution
 }
 
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer
@@ -63,6 +64,7 @@ type NativeTBTCSignerEngine interface {
 	) (*NativeTBTCSignerDKGResult, error)
 	StartSignRound(
 		sessionID string,
+		memberIdentifier uint16,
 		message []byte,
 		keyGroup string,
 	) (*NativeTBTCSignerRoundState, error)

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -19,9 +19,11 @@ func (mntse *mockNativeTBTCSignerEngine) RunDKG(
 
 func (mntse *mockNativeTBTCSignerEngine) StartSignRound(
 	sessionID string,
+	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
 ) (*NativeTBTCSignerRoundState, error) {
+	_ = memberIdentifier
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -22,8 +22,10 @@ func (mntse *mockNativeTBTCSignerEngine) StartSignRound(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	_ = memberIdentifier
+	_ = signingParticipants
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -9,6 +9,14 @@ import (
 
 type mockNativeTBTCSignerEngine struct{}
 
+func (mntse *mockNativeTBTCSignerEngine) RunDKG(
+	sessionID string,
+	participants []NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) (*NativeTBTCSignerDKGResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (mntse *mockNativeTBTCSignerEngine) StartSignRound(
 	sessionID string,
 	message []byte,

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -1,0 +1,66 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"fmt"
+	"testing"
+)
+
+type mockNativeTBTCSignerEngine struct{}
+
+func (mntse *mockNativeTBTCSignerEngine) StartSignRound(
+	sessionID string,
+	message []byte,
+	keyGroup string,
+) (*NativeTBTCSignerRoundState, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (mntse *mockNativeTBTCSignerEngine) FinalizeSignRound(
+	sessionID string,
+	roundContributions []NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestRegisterNativeTBTCSignerEngineRejectsNil(t *testing.T) {
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	err := RegisterNativeTBTCSignerEngine(nil)
+	if err == nil {
+		t.Fatal("expected registration error")
+	}
+}
+
+func TestRegisterNativeTBTCSignerEngine(t *testing.T) {
+	UnregisterNativeTBTCSignerEngine()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+
+	engine := &mockNativeTBTCSignerEngine{}
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	if currentNativeTBTCSignerEngine() != engine {
+		t.Fatal("expected current native tbtc-signer engine to match registered engine")
+	}
+}
+
+func TestUnregisterNativeTBTCSignerEngine(t *testing.T) {
+	UnregisterNativeTBTCSignerEngine()
+
+	err := RegisterNativeTBTCSignerEngine(&mockNativeTBTCSignerEngine{})
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	UnregisterNativeTBTCSignerEngine()
+
+	if currentNativeTBTCSignerEngine() != nil {
+		t.Fatal("expected native tbtc-signer engine to be nil after unregister")
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_fallback_telemetry.go
+++ b/pkg/frost/signing/native_tbtc_signer_fallback_telemetry.go
@@ -1,0 +1,61 @@
+package signing
+
+import (
+	"fmt"
+	"sync"
+)
+
+// NativeTBTCSignerFallbackEvent describes a single fallback from the
+// tbtc-signer coarse path to the legacy signing path.
+type NativeTBTCSignerFallbackEvent struct {
+	SessionID                   string
+	Reason                      string
+	KeyGroupSource              string
+	LegacyPrivateKeyShareExists bool
+}
+
+// NativeTBTCSignerFallbackObserver consumes fallback telemetry events.
+type NativeTBTCSignerFallbackObserver func(event NativeTBTCSignerFallbackEvent)
+
+var (
+	nativeTBTCSignerFallbackObserverMutex sync.RWMutex
+	nativeTBTCSignerFallbackObserver      NativeTBTCSignerFallbackObserver
+)
+
+// RegisterNativeTBTCSignerFallbackObserver registers a process-wide observer
+// used to report tbtc-signer fallback events.
+func RegisterNativeTBTCSignerFallbackObserver(
+	observer NativeTBTCSignerFallbackObserver,
+) error {
+	if observer == nil {
+		return fmt.Errorf("native tbtc-signer fallback observer is nil")
+	}
+
+	nativeTBTCSignerFallbackObserverMutex.Lock()
+	defer nativeTBTCSignerFallbackObserverMutex.Unlock()
+
+	nativeTBTCSignerFallbackObserver = observer
+
+	return nil
+}
+
+// UnregisterNativeTBTCSignerFallbackObserver clears fallback-observer
+// registration.
+func UnregisterNativeTBTCSignerFallbackObserver() {
+	nativeTBTCSignerFallbackObserverMutex.Lock()
+	defer nativeTBTCSignerFallbackObserverMutex.Unlock()
+
+	nativeTBTCSignerFallbackObserver = nil
+}
+
+func emitNativeTBTCSignerFallbackEvent(event NativeTBTCSignerFallbackEvent) {
+	nativeTBTCSignerFallbackObserverMutex.RLock()
+	observer := nativeTBTCSignerFallbackObserver
+	nativeTBTCSignerFallbackObserverMutex.RUnlock()
+
+	if observer == nil {
+		return
+	}
+
+	observer(event)
+}

--- a/pkg/frost/signing/native_tbtc_signer_fallback_telemetry_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_fallback_telemetry_test.go
@@ -1,0 +1,56 @@
+package signing
+
+import (
+	"testing"
+)
+
+func TestRegisterNativeTBTCSignerFallbackObserverRejectsNil(t *testing.T) {
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	err := RegisterNativeTBTCSignerFallbackObserver(nil)
+	if err == nil {
+		t.Fatal("expected registration error")
+	}
+}
+
+func TestEmitNativeTBTCSignerFallbackEvent(t *testing.T) {
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	var (
+		received bool
+		actual   NativeTBTCSignerFallbackEvent
+	)
+
+	err := RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			received = true
+			actual = event
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	expected := NativeTBTCSignerFallbackEvent{
+		SessionID:                   "session-1",
+		Reason:                      "fallback reason",
+		KeyGroupSource:              "legacy-wallet-pubkey",
+		LegacyPrivateKeyShareExists: true,
+	}
+
+	emitNativeTBTCSignerFallbackEvent(expected)
+
+	if !received {
+		t.Fatal("expected fallback event to be delivered")
+	}
+
+	if actual != expected {
+		t.Fatalf(
+			"unexpected fallback event\nexpected: [%+v]\nactual:   [%+v]",
+			expected,
+			actual,
+		)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_material.go
+++ b/pkg/frost/signing/native_tbtc_signer_material.go
@@ -1,0 +1,18 @@
+package signing
+
+const (
+	// NativeSignerMaterialFormatFrostTBTCSignerV1 carries signer material for
+	// tbtc-signer coarse session APIs.
+	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
+	// NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey marks scaffold-era
+	// key-group derivation from the legacy wallet public key.
+	NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey = "legacy-wallet-pubkey"
+)
+
+// NativeTBTCSignerMaterialPayload is the signer-material payload schema for
+// `frost-tbtc-signer-v1`.
+type NativeTBTCSignerMaterialPayload struct {
+	KeyGroup                 string `json:"keyGroup"`
+	KeyGroupSource           string `json:"keyGroupSource,omitempty"`
+	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
+}

--- a/pkg/frost/signing/request.go
+++ b/pkg/frost/signing/request.go
@@ -11,9 +11,9 @@ import (
 
 // Request carries execution input for a FROST signing backend.
 type Request struct {
-	Message             *big.Int
-	SessionID           string
-	MemberIndex         group.MemberIndex
+	Message     *big.Int
+	SessionID   string
+	MemberIndex group.MemberIndex
 	// SignerMaterial carries backend-specific signer material.
 	// Legacy backend expects *tecdsa.PrivateKeyShare.
 	SignerMaterial any

--- a/pkg/tbtc/marshaling_test.go
+++ b/pkg/tbtc/marshaling_test.go
@@ -26,9 +26,7 @@ func TestSignerMarshalling(t *testing.T) {
 	if err := pbutils.RoundTrip(marshaled, unmarshaled); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(marshaled, unmarshaled) {
-		t.Fatal("unexpected content of unmarshaled signer")
-	}
+	assertSignerEquivalent(t, "unmarshaled signer", marshaled, unmarshaled)
 }
 
 func TestSignerMarshalling_NonTECDSAKey(t *testing.T) {

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -216,6 +216,26 @@ func (n *node) setPerformanceMetrics(metrics interface {
 	RecordDuration(name string, duration time.Duration)
 }) {
 	n.performanceMetrics = metrics
+
+	if metrics == nil {
+		signing.UnregisterNativeTBTCSignerFallbackObserver()
+	} else {
+		err := signing.RegisterNativeTBTCSignerFallbackObserver(
+			func(event signing.NativeTBTCSignerFallbackEvent) {
+				metrics.IncrementCounter(
+					clientinfo.MetricSigningNativeTBTCSignerFallbackTotal,
+					1,
+				)
+			},
+		)
+		if err != nil {
+			logger.Warnf(
+				"cannot register native tbtc-signer fallback observer: [%v]",
+				err,
+			)
+		}
+	}
+
 	if n.walletDispatcher != nil {
 		n.walletDispatcher.setMetricsRecorder(metrics)
 	}

--- a/pkg/tbtc/node_test.go
+++ b/pkg/tbtc/node_test.go
@@ -100,9 +100,7 @@ func TestNode_GetSigningExecutor(t *testing.T) {
 		len(executor.signers),
 	)
 
-	if !reflect.DeepEqual(signer, executor.signers[0]) {
-		t.Errorf("executor holds an unexpected signer")
-	}
+	assertSignerEquivalent(t, "executor signer", signer, executor.signers[0])
 
 	expectedChannel := fmt.Sprintf(
 		"%s-%s",

--- a/pkg/tbtc/registry_test.go
+++ b/pkg/tbtc/registry_test.go
@@ -283,9 +283,12 @@ func TestWalletRegistry_PrePopulateWalletCache(t *testing.T) {
 		len(walletRegistry.walletCache[walletStorageKey].signers),
 	)
 
-	if !reflect.DeepEqual(signer, walletRegistry.walletCache[walletStorageKey].signers[0]) {
-		t.Errorf("loaded wallet signer differs from the original one")
-	}
+	assertSignerEquivalent(
+		t,
+		"pre-populated wallet signer",
+		signer,
+		walletRegistry.walletCache[walletStorageKey].signers[0],
+	)
 }
 
 func TestWalletRegistry_GetWalletsPublicKeys(t *testing.T) {
@@ -459,9 +462,12 @@ func TestWalletStorage_LoadSigners(t *testing.T) {
 		len(signersByWallet[walletStorageKey]),
 	)
 
-	if !reflect.DeepEqual(signer, signersByWallet[walletStorageKey][0]) {
-		t.Errorf("loaded wallet signer differs from the original one")
-	}
+	assertSignerEquivalent(
+		t,
+		"loaded wallet signer",
+		signer,
+		signersByWallet[walletStorageKey][0],
+	)
 }
 
 func TestWalletStorage_ArchiveWallet(t *testing.T) {

--- a/pkg/tbtc/signer_equivalence_test.go
+++ b/pkg/tbtc/signer_equivalence_test.go
@@ -1,0 +1,82 @@
+package tbtc
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func assertSignerEquivalent(
+	t *testing.T,
+	name string,
+	expected *signer,
+	actual *signer,
+) {
+	t.Helper()
+
+	if expected == nil {
+		if actual != nil {
+			t.Fatalf("%s should be nil", name)
+		}
+		return
+	}
+
+	if actual == nil {
+		t.Fatalf("%s is nil", name)
+	}
+
+	if !expected.wallet.publicKey.Equal(actual.wallet.publicKey) {
+		t.Fatalf("%s has unexpected wallet public key", name)
+	}
+
+	if !reflect.DeepEqual(
+		expected.wallet.signingGroupOperators,
+		actual.wallet.signingGroupOperators,
+	) {
+		t.Fatalf(
+			"%s has unexpected signing group operators\nexpected: [%v]\nactual:   [%v]",
+			name,
+			expected.wallet.signingGroupOperators,
+			actual.wallet.signingGroupOperators,
+		)
+	}
+
+	if expected.signingGroupMemberIndex != actual.signingGroupMemberIndex {
+		t.Fatalf(
+			"%s has unexpected member index\nexpected: [%v]\nactual:   [%v]",
+			name,
+			expected.signingGroupMemberIndex,
+			actual.signingGroupMemberIndex,
+		)
+	}
+
+	if expected.privateKeyShare == nil {
+		if actual.privateKeyShare != nil {
+			t.Fatalf("%s should have nil private key share", name)
+		}
+		return
+	}
+
+	if actual.privateKeyShare == nil {
+		t.Fatalf("%s has nil private key share", name)
+	}
+
+	expectedPrivateKeyShare, err := expected.privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal expected private key share for %s: [%v]", name, err)
+	}
+
+	actualPrivateKeyShare, err := actual.privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal actual private key share for %s: [%v]", name, err)
+	}
+
+	if !bytes.Equal(expectedPrivateKeyShare, actualPrivateKeyShare) {
+		t.Fatalf(
+			"%s has unexpected private key share\nexpected: [%x]\nactual:   [%x]",
+			name,
+			expectedPrivateKeyShare,
+			actualPrivateKeyShare,
+		)
+	}
+}

--- a/pkg/tbtc/signer_material_encoding.go
+++ b/pkg/tbtc/signer_material_encoding.go
@@ -244,7 +244,7 @@ func legacyPrivateKeyShareFromNativeSignerMaterial(
 		return privateKeyShare
 
 	case frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1:
-		var payload tbtcSignerMaterialPayload
+		var payload frostsigning.NativeTBTCSignerMaterialPayload
 		if err := json.Unmarshal(nativeSignerMaterial.Payload, &payload); err != nil {
 			return nil
 		}

--- a/pkg/tbtc/signer_material_encoding.go
+++ b/pkg/tbtc/signer_material_encoding.go
@@ -3,6 +3,8 @@ package tbtc
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
@@ -232,14 +234,38 @@ func legacyPrivateKeyShareFromNativeSignerMaterial(
 		return nil
 	}
 
-	if nativeSignerMaterial.Format != frostsigning.NativeSignerMaterialFormatFrostUniFFIV1 {
+	switch nativeSignerMaterial.Format {
+	case frostsigning.NativeSignerMaterialFormatFrostUniFFIV1:
+		privateKeyShare := &tecdsa.PrivateKeyShare{}
+		if err := privateKeyShare.Unmarshal(nativeSignerMaterial.Payload); err != nil {
+			return nil
+		}
+
+		return privateKeyShare
+
+	case frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1:
+		var payload tbtcSignerMaterialPayload
+		if err := json.Unmarshal(nativeSignerMaterial.Payload, &payload); err != nil {
+			return nil
+		}
+
+		if payload.LegacyPrivateKeyShareHex == "" {
+			return nil
+		}
+
+		legacyPayload, err := hex.DecodeString(payload.LegacyPrivateKeyShareHex)
+		if err != nil {
+			return nil
+		}
+
+		privateKeyShare := &tecdsa.PrivateKeyShare{}
+		if err := privateKeyShare.Unmarshal(legacyPayload); err != nil {
+			return nil
+		}
+
+		return privateKeyShare
+
+	default:
 		return nil
 	}
-
-	privateKeyShare := &tecdsa.PrivateKeyShare{}
-	if err := privateKeyShare.Unmarshal(nativeSignerMaterial.Payload); err != nil {
-		return nil
-	}
-
-	return privateKeyShare
 }

--- a/pkg/tbtc/signer_material_encoding_frost_native_test.go
+++ b/pkg/tbtc/signer_material_encoding_frost_native_test.go
@@ -4,6 +4,8 @@ package tbtc
 
 import (
 	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"testing"
 
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
@@ -50,22 +52,49 @@ func TestUnmarshalSignerMaterialFromPersistence_LegacyEncodingResolvesNativeMate
 		)
 	}
 
-	if nativeSignerMaterial.Format != frostsigning.NativeSignerMaterialFormatFrostUniFFIV1 {
+	var actualPayload []byte
+	switch nativeSignerMaterial.Format {
+	case frostsigning.NativeSignerMaterialFormatFrostUniFFIV1:
+		decodedPrivateKeyShare := &tecdsa.PrivateKeyShare{}
+		if err := decodedPrivateKeyShare.Unmarshal(nativeSignerMaterial.Payload); err != nil {
+			t.Fatalf("failed unmarshalling native signer material payload: [%v]", err)
+		}
+
+		actualPayload, err = decodedPrivateKeyShare.Marshal()
+		if err != nil {
+			t.Fatalf("failed marshaling decoded private key share: [%v]", err)
+		}
+
+	case frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1:
+		var payload tbtcSignerMaterialPayload
+		if err := json.Unmarshal(nativeSignerMaterial.Payload, &payload); err != nil {
+			t.Fatalf("failed unmarshalling tbtc signer material payload: [%v]", err)
+		}
+
+		if payload.KeyGroup == "" {
+			t.Fatal("expected non-empty tbtc-signer key group")
+		}
+
+		legacyPrivateKeySharePayload, err := hex.DecodeString(payload.LegacyPrivateKeyShareHex)
+		if err != nil {
+			t.Fatalf("failed decoding legacy private key share payload: [%v]", err)
+		}
+
+		decodedPrivateKeyShare := &tecdsa.PrivateKeyShare{}
+		if err := decodedPrivateKeyShare.Unmarshal(legacyPrivateKeySharePayload); err != nil {
+			t.Fatalf("failed unmarshalling decoded private key share: [%v]", err)
+		}
+
+		actualPayload, err = decodedPrivateKeyShare.Marshal()
+		if err != nil {
+			t.Fatalf("failed marshaling decoded private key share: [%v]", err)
+		}
+
+	default:
 		t.Fatalf(
-			"unexpected signer material format\nexpected: [%v]\nactual:   [%v]",
-			frostsigning.NativeSignerMaterialFormatFrostUniFFIV1,
+			"unexpected signer material format\nactual: [%v]",
 			nativeSignerMaterial.Format,
 		)
-	}
-
-	decodedPrivateKeyShare := &tecdsa.PrivateKeyShare{}
-	if err := decodedPrivateKeyShare.Unmarshal(nativeSignerMaterial.Payload); err != nil {
-		t.Fatalf("failed unmarshalling native signer material payload: [%v]", err)
-	}
-
-	actualPayload, err := decodedPrivateKeyShare.Marshal()
-	if err != nil {
-		t.Fatalf("failed marshaling decoded private key share: [%v]", err)
 	}
 
 	if !bytes.Equal(actualPayload, legacyEncoded) {

--- a/pkg/tbtc/signer_material_encoding_frost_native_test.go
+++ b/pkg/tbtc/signer_material_encoding_frost_native_test.go
@@ -66,13 +66,17 @@ func TestUnmarshalSignerMaterialFromPersistence_LegacyEncodingResolvesNativeMate
 		}
 
 	case frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1:
-		var payload tbtcSignerMaterialPayload
+		var payload frostsigning.NativeTBTCSignerMaterialPayload
 		if err := json.Unmarshal(nativeSignerMaterial.Payload, &payload); err != nil {
 			t.Fatalf("failed unmarshalling tbtc signer material payload: [%v]", err)
 		}
 
 		if payload.KeyGroup == "" {
 			t.Fatal("expected non-empty tbtc-signer key group")
+		}
+
+		if payload.KeyGroupSource == "" {
+			t.Fatal("expected non-empty tbtc-signer key group source")
 		}
 
 		legacyPrivateKeySharePayload, err := hex.DecodeString(payload.LegacyPrivateKeyShareHex)

--- a/pkg/tbtc/signer_material_payload.go
+++ b/pkg/tbtc/signer_material_payload.go
@@ -1,0 +1,8 @@
+package tbtc
+
+// tbtcSignerMaterialPayload is the persisted signer-material payload for
+// `frost-tbtc-signer-v1`.
+type tbtcSignerMaterialPayload struct {
+	KeyGroup                 string `json:"keyGroup"`
+	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
+}

--- a/pkg/tbtc/signer_material_payload.go
+++ b/pkg/tbtc/signer_material_payload.go
@@ -1,8 +1,0 @@
-package tbtc
-
-// tbtcSignerMaterialPayload is the persisted signer-material payload for
-// `frost-tbtc-signer-v1`.
-type tbtcSignerMaterialPayload struct {
-	KeyGroup                 string `json:"keyGroup"`
-	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
-}

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer.go
@@ -1,8 +1,11 @@
-//go:build frost_native && !(frost_tbtc_signer && cgo)
+//go:build frost_native && frost_tbtc_signer && cgo
 
 package tbtc
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
@@ -31,9 +34,9 @@ func defaultSignerMaterialResolverProviderForBuild() (SignerMaterialResolver, er
 	return &buildTaggedNativeSignerMaterialResolver{}, nil
 }
 
-// buildTaggedNativeSignerMaterialResolver derives transitional native signer
-// material from a legacy private key share for frost_native builds not using
-// the `frost_tbtc_signer` tag.
+// buildTaggedNativeSignerMaterialResolver derives transitional signer material
+// for frost_tbtc_signer builds. It carries a deterministic key-group handle and
+// embeds legacy private-key-share bytes to preserve temporary Go-side fallback.
 type buildTaggedNativeSignerMaterialResolver struct{}
 
 func (btnsmr *buildTaggedNativeSignerMaterialResolver) ResolveSignerMaterial(
@@ -43,13 +46,28 @@ func (btnsmr *buildTaggedNativeSignerMaterialResolver) ResolveSignerMaterial(
 		return nil, fmt.Errorf("private key share is nil")
 	}
 
-	payload, err := privateKeyShare.Marshal()
+	legacyPrivateKeySharePayload, err := privateKeyShare.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal private key share: [%w]", err)
 	}
 
+	walletPublicKeyBytes, err := marshalPublicKey(privateKeyShare.PublicKey())
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal wallet public key: [%w]", err)
+	}
+
+	keyGroupDigest := sha256.Sum256(walletPublicKeyBytes)
+
+	payload, err := json.Marshal(tbtcSignerMaterialPayload{
+		KeyGroup:                 hex.EncodeToString(keyGroupDigest[:]),
+		LegacyPrivateKeyShareHex: hex.EncodeToString(legacyPrivateKeySharePayload),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal tbtc signer material payload: [%w]", err)
+	}
+
 	return &frostsigning.NativeSignerMaterial{
-		Format:  frostsigning.NativeSignerMaterialFormatFrostUniFFIV1,
+		Format:  frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
 		Payload: payload,
 	}, nil
 }

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer.go
@@ -58,8 +58,11 @@ func (btnsmr *buildTaggedNativeSignerMaterialResolver) ResolveSignerMaterial(
 
 	keyGroupDigest := sha256.Sum256(walletPublicKeyBytes)
 
-	payload, err := json.Marshal(tbtcSignerMaterialPayload{
+	// TODO: Replace this placeholder key-group derivation with Rust DKG output.
+	// The current value identifies scaffold-era material only.
+	payload, err := json.Marshal(frostsigning.NativeTBTCSignerMaterialPayload{
 		KeyGroup:                 hex.EncodeToString(keyGroupDigest[:]),
+		KeyGroupSource:           "legacy-wallet-pubkey",
 		LegacyPrivateKeyShareHex: hex.EncodeToString(legacyPrivateKeySharePayload),
 	})
 	if err != nil {

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer.go
@@ -62,7 +62,7 @@ func (btnsmr *buildTaggedNativeSignerMaterialResolver) ResolveSignerMaterial(
 	// The current value identifies scaffold-era material only.
 	payload, err := json.Marshal(frostsigning.NativeTBTCSignerMaterialPayload{
 		KeyGroup:                 hex.EncodeToString(keyGroupDigest[:]),
-		KeyGroupSource:           "legacy-wallet-pubkey",
+		KeyGroupSource:           frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
 		LegacyPrivateKeyShareHex: hex.EncodeToString(legacyPrivateKeySharePayload),
 	})
 	if err != nil {

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_test.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_test.go
@@ -61,13 +61,17 @@ func TestRegisterSignerMaterialResolverForBuild_UsesDefaultProvider(
 		}
 
 	case frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1:
-		var payload tbtcSignerMaterialPayload
+		var payload frostsigning.NativeTBTCSignerMaterialPayload
 		if err := json.Unmarshal(nativeSignerMaterial.Payload, &payload); err != nil {
 			t.Fatalf("failed unmarshalling tbtc signer material payload: [%v]", err)
 		}
 
 		if payload.KeyGroup == "" {
 			t.Fatal("expected non-empty tbtc-signer key group")
+		}
+
+		if payload.KeyGroupSource == "" {
+			t.Fatal("expected non-empty tbtc-signer key group source")
 		}
 
 		legacyPrivateKeySharePayload, err := hex.DecodeString(payload.LegacyPrivateKeyShareHex)

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_test.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_test.go
@@ -4,6 +4,8 @@ package tbtc
 
 import (
 	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -40,27 +42,54 @@ func TestRegisterSignerMaterialResolverForBuild_UsesDefaultProvider(
 		)
 	}
 
-	if nativeSignerMaterial.Format != frostsigning.NativeSignerMaterialFormatFrostUniFFIV1 {
-		t.Fatalf(
-			"unexpected native signer material format\nexpected: [%s]\nactual:   [%s]",
-			frostsigning.NativeSignerMaterialFormatFrostUniFFIV1,
-			nativeSignerMaterial.Format,
-		)
-	}
-
-	decodedPrivateKeyShare := &tecdsa.PrivateKeyShare{}
-	if err := decodedPrivateKeyShare.Unmarshal(nativeSignerMaterial.Payload); err != nil {
-		t.Fatalf("failed unmarshalling resolved signer payload: [%v]", err)
-	}
-
 	expectedPayload, err := privateKeyShare.Marshal()
 	if err != nil {
 		t.Fatalf("failed marshaling expected private key share: [%v]", err)
 	}
 
-	actualPayload, err := decodedPrivateKeyShare.Marshal()
-	if err != nil {
-		t.Fatalf("failed marshaling decoded private key share: [%v]", err)
+	var actualPayload []byte
+	switch nativeSignerMaterial.Format {
+	case frostsigning.NativeSignerMaterialFormatFrostUniFFIV1:
+		decodedPrivateKeyShare := &tecdsa.PrivateKeyShare{}
+		if err := decodedPrivateKeyShare.Unmarshal(nativeSignerMaterial.Payload); err != nil {
+			t.Fatalf("failed unmarshalling resolved signer payload: [%v]", err)
+		}
+
+		actualPayload, err = decodedPrivateKeyShare.Marshal()
+		if err != nil {
+			t.Fatalf("failed marshaling decoded private key share: [%v]", err)
+		}
+
+	case frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1:
+		var payload tbtcSignerMaterialPayload
+		if err := json.Unmarshal(nativeSignerMaterial.Payload, &payload); err != nil {
+			t.Fatalf("failed unmarshalling tbtc signer material payload: [%v]", err)
+		}
+
+		if payload.KeyGroup == "" {
+			t.Fatal("expected non-empty tbtc-signer key group")
+		}
+
+		legacyPrivateKeySharePayload, err := hex.DecodeString(payload.LegacyPrivateKeyShareHex)
+		if err != nil {
+			t.Fatalf("failed decoding legacy private key share payload: [%v]", err)
+		}
+
+		decodedPrivateKeyShare := &tecdsa.PrivateKeyShare{}
+		if err := decodedPrivateKeyShare.Unmarshal(legacyPrivateKeySharePayload); err != nil {
+			t.Fatalf("failed unmarshalling decoded private key share: [%v]", err)
+		}
+
+		actualPayload, err = decodedPrivateKeyShare.Marshal()
+		if err != nil {
+			t.Fatalf("failed marshaling decoded private key share: [%v]", err)
+		}
+
+	default:
+		t.Fatalf(
+			"unexpected native signer material format: [%s]",
+			nativeSignerMaterial.Format,
+		)
 	}
 
 	if !bytes.Equal(expectedPayload, actualPayload) {

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -10,7 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/frost"
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
 	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 type countingNativeExecutionFFISigningPrimitive struct {
@@ -26,6 +30,17 @@ type countingNativeExecutionFFISigningPrimitive struct {
 
 type deterministicNativeExecutionFFISigningPrimitiveForTBTC struct {
 	signCalls atomic.Int64
+}
+
+type attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC struct {
+	signCalls atomic.Int64
+	mutex     sync.Mutex
+	records   []attemptTrackingRecordForTBTC
+}
+
+type attemptTrackingRecordForTBTC struct {
+	attemptNumber       uint
+	includedMemberIndex []group.MemberIndex
 }
 
 var deterministicNativeFROSTSignatureForTBTC = [frost.SignatureSize]byte{
@@ -87,6 +102,87 @@ func (dnefspf *deterministicNativeExecutionFFISigningPrimitiveForTBTC) Sign(
 func (dnefspf *deterministicNativeExecutionFFISigningPrimitiveForTBTC) RegisterUnmarshallers(
 	channel net.BroadcastChannel,
 ) {
+}
+
+func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) Sign(
+	ctx context.Context,
+	logger log.StandardLogger,
+	request *frostsigning.NativeExecutionFFISigningRequest,
+) (*frost.Signature, error) {
+	atnefspf.signCalls.Add(1)
+
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	if request.Attempt == nil {
+		return nil, fmt.Errorf("request attempt is nil")
+	}
+
+	atnefspf.mutex.Lock()
+	atnefspf.records = append(
+		atnefspf.records,
+		attemptTrackingRecordForTBTC{
+			attemptNumber: request.Attempt.Number,
+			includedMemberIndex: append(
+				[]group.MemberIndex{},
+				request.Attempt.IncludedMembersIndexes...,
+			),
+		},
+	)
+	atnefspf.mutex.Unlock()
+
+	// Force retry-loop progression so the next attempt is exercised.
+	if request.Attempt.Number == 1 {
+		return nil, fmt.Errorf("forced attempt failure")
+	}
+
+	signature := &frost.Signature{}
+	if err := signature.Unmarshal(deterministicNativeFROSTSignatureForTBTC[:]); err != nil {
+		return nil, err
+	}
+
+	return signature, nil
+}
+
+func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) RegisterUnmarshallers(
+	channel net.BroadcastChannel,
+) {
+}
+
+func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) uniqueCohortsByAttempt() map[uint][][]group.MemberIndex {
+	atnefspf.mutex.Lock()
+	defer atnefspf.mutex.Unlock()
+
+	result := make(map[uint][][]group.MemberIndex)
+	seen := make(map[uint]map[string]struct{})
+
+	for _, record := range atnefspf.records {
+		if seen[record.attemptNumber] == nil {
+			seen[record.attemptNumber] = make(map[string]struct{})
+		}
+
+		keyParts := make([]string, 0, len(record.includedMemberIndex))
+		for _, memberIndex := range record.includedMemberIndex {
+			keyParts = append(
+				keyParts,
+				strconv.FormatUint(uint64(memberIndex), 10),
+			)
+		}
+		cohortKey := strings.Join(keyParts, ",")
+
+		if _, ok := seen[record.attemptNumber][cohortKey]; ok {
+			continue
+		}
+
+		seen[record.attemptNumber][cohortKey] = struct{}{}
+		result[record.attemptNumber] = append(
+			result[record.attemptNumber],
+			append([]group.MemberIndex{}, record.includedMemberIndex...),
+		)
+	}
+
+	return result
 }
 
 func TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter(t *testing.T) {
@@ -342,6 +438,118 @@ func TestSigningExecutor_Sign_NativeBackend_FallsBackWhenOnlyLegacySignerMateria
 		new(big.Int).SetBytes(signature.S[:]),
 	) {
 		t.Fatalf("invalid signature: [%+v]", signature)
+	}
+
+	if endBlock <= startBlock {
+		t.Fatal("wrong end block")
+	}
+}
+
+func TestSigningExecutor_Sign_FFIStrictBackend_AttemptVariationChangesCohortSelection(
+	t *testing.T,
+) {
+	executor := setupSigningExecutor(t)
+	configureSignersWithNativeFROSTUniFFIV2Material(t, executor)
+
+	primitive := &attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC{}
+
+	frostsigning.ResetExecutionBackend()
+	frostsigning.UnregisterNativeExecutionAdapter()
+	frostsigning.UnregisterNativeExecutionBridge()
+	frostsigning.UnregisterNativeExecutionFFIExecutor()
+	frostsigning.RegisterNativeExecutionAdapterForBuild()
+	err := frostsigning.RegisterNativeExecutionFFISigningPrimitive(primitive)
+	if err != nil {
+		t.Fatalf("unexpected native FFI primitive registration error: [%v]", err)
+	}
+	t.Cleanup(frostsigning.ResetExecutionBackend)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionAdapter)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionBridge)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionFFIExecutor)
+
+	err = configureFrostSigningBackend(Config{FrostSigningBackend: "ffi"})
+	if err != nil {
+		t.Fatalf("unexpected strict ffi backend config error: [%v]", err)
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	message := big.NewInt(100)
+	startBlock := uint64(0)
+
+	signature, _, endBlock, err := executor.sign(ctx, message, startBlock)
+	if err != nil {
+		t.Fatalf("unexpected strict ffi signing error: [%v]", err)
+	}
+
+	signatureBytes, err := signature.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal signature: [%v]", err)
+	}
+
+	if !bytes.Equal(signatureBytes, deterministicNativeFROSTSignatureForTBTC[:]) {
+		t.Fatalf(
+			"unexpected native FROST signature\nexpected: [%x]\nactual:   [%x]",
+			deterministicNativeFROSTSignatureForTBTC[:],
+			signatureBytes,
+		)
+	}
+
+	if primitive.signCalls.Load() == 0 {
+		t.Fatal("expected native FFI primitive sign call")
+	}
+
+	cohortsByAttempt := primitive.uniqueCohortsByAttempt()
+	attemptOneCohorts, ok := cohortsByAttempt[1]
+	if !ok {
+		t.Fatal("expected observed cohort for attempt 1")
+	}
+	if len(attemptOneCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptOneCohorts),
+		)
+	}
+
+	attemptTwoCohorts, ok := cohortsByAttempt[2]
+	if !ok {
+		t.Fatal("expected observed cohort for attempt 2")
+	}
+	if len(attemptTwoCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptTwoCohorts),
+		)
+	}
+
+	attemptOneCohort := attemptOneCohorts[0]
+	attemptTwoCohort := attemptTwoCohorts[0]
+
+	expectedCohortSize := executor.groupParameters.HonestThreshold
+	if len(attemptOneCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptOneCohort),
+		)
+	}
+	if len(attemptTwoCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptTwoCohort),
+		)
+	}
+
+	if reflect.DeepEqual(attemptOneCohort, attemptTwoCohort) {
+		t.Fatalf(
+			"expected cohort variation across attempts\nattempt 1: [%v]\nattempt 2: [%v]",
+			attemptOneCohort,
+			attemptTwoCohort,
+		)
 	}
 
 	if endBlock <= startBlock {

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +42,11 @@ type attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC struct {
 type attemptTrackingRecordForTBTC struct {
 	attemptNumber       uint
 	includedMemberIndex []group.MemberIndex
+}
+
+type attemptTrackingNativeTBTCSignerEngineForTBTC struct {
+	mutex                 sync.Mutex
+	startCohortsByAttempt map[uint][][]uint16
 }
 
 var deterministicNativeFROSTSignatureForTBTC = [frost.SignatureSize]byte{
@@ -183,6 +189,137 @@ func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) unique
 	}
 
 	return result
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) Version() (string, error) {
+	return "tbtc-signer/0.1.0-bootstrap", nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) RunDKG(
+	sessionID string,
+	participants []frostsigning.NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) (*frostsigning.NativeTBTCSignerDKGResult, error) {
+	return &frostsigning.NativeTBTCSignerDKGResult{
+		SessionID:        sessionID,
+		KeyGroup:         "group-1",
+		ParticipantCount: uint16(len(participants)),
+		Threshold:        threshold,
+		CreatedAtUnix:    1,
+	}, nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) StartSignRound(
+	sessionID string,
+	memberIdentifier uint16,
+	message []byte,
+	keyGroup string,
+	signingParticipants []uint16,
+) (*frostsigning.NativeTBTCSignerRoundState, error) {
+	attemptNumber, err := attemptNumberFromSessionIDForTBTC(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if keyGroup == "" {
+		return nil, fmt.Errorf("key group is empty")
+	}
+
+	if memberIdentifier == 0 {
+		return nil, fmt.Errorf("member identifier is zero")
+	}
+
+	if len(message) == 0 {
+		return nil, fmt.Errorf("message is empty")
+	}
+
+	if len(signingParticipants) == 0 {
+		return nil, fmt.Errorf("signing participants are empty")
+	}
+
+	atntsfe.mutex.Lock()
+	if atntsfe.startCohortsByAttempt == nil {
+		atntsfe.startCohortsByAttempt = make(map[uint][][]uint16)
+	}
+
+	cohort := append([]uint16{}, signingParticipants...)
+	atntsfe.startCohortsByAttempt[attemptNumber] = append(
+		atntsfe.startCohortsByAttempt[attemptNumber],
+		cohort,
+	)
+	atntsfe.mutex.Unlock()
+
+	return &frostsigning.NativeTBTCSignerRoundState{
+		SessionID:             sessionID,
+		RoundID:               fmt.Sprintf("round-%v", attemptNumber),
+		RequiredContributions: uint16(len(signingParticipants)),
+		MessageDigestHex:      "00",
+		SigningParticipants:   append([]uint16{}, signingParticipants...),
+		OwnContribution: &frostsigning.NativeTBTCSignerRoundContribution{
+			Identifier: memberIdentifier,
+			Data:       []byte{byte(memberIdentifier), byte(attemptNumber)},
+		},
+	}, nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) FinalizeSignRound(
+	sessionID string,
+	roundContributions []frostsigning.NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	if _, err := attemptNumberFromSessionIDForTBTC(sessionID); err != nil {
+		return nil, err
+	}
+
+	if len(roundContributions) == 0 {
+		return nil, fmt.Errorf("round contributions are empty")
+	}
+
+	return []byte{0xaa}, nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) uniqueStartCohortsByAttempt() map[uint][][]uint16 {
+	atntsfe.mutex.Lock()
+	defer atntsfe.mutex.Unlock()
+
+	result := make(map[uint][][]uint16)
+	seen := make(map[uint]map[string]struct{})
+
+	for attemptNumber, cohorts := range atntsfe.startCohortsByAttempt {
+		if seen[attemptNumber] == nil {
+			seen[attemptNumber] = make(map[string]struct{})
+		}
+
+		for _, cohort := range cohorts {
+			parts := make([]string, 0, len(cohort))
+			for _, participant := range cohort {
+				parts = append(parts, strconv.FormatUint(uint64(participant), 10))
+			}
+			key := strings.Join(parts, ",")
+
+			if _, ok := seen[attemptNumber][key]; ok {
+				continue
+			}
+
+			seen[attemptNumber][key] = struct{}{}
+			result[attemptNumber] = append(result[attemptNumber], append([]uint16{}, cohort...))
+		}
+	}
+
+	return result
+}
+
+func attemptNumberFromSessionIDForTBTC(sessionID string) (uint, error) {
+	separatorIndex := strings.LastIndex(sessionID, "-")
+	if separatorIndex < 0 || separatorIndex == len(sessionID)-1 {
+		return 0, fmt.Errorf("invalid session id format: [%s]", sessionID)
+	}
+
+	attemptNumber, err := strconv.ParseUint(sessionID[separatorIndex+1:], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse attempt number from session id [%s]: [%w]", sessionID, err)
+	}
+
+	return uint(attemptNumber), nil
 }
 
 func TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter(t *testing.T) {
@@ -557,6 +694,152 @@ func TestSigningExecutor_Sign_FFIStrictBackend_AttemptVariationChangesCohortSele
 	}
 }
 
+func TestSigningExecutor_Sign_FFIStrictBackend_TBTCSignerPath_AttemptVariationChangesCohortSelection(
+	t *testing.T,
+) {
+	executor := setupSigningExecutor(t)
+	configureSignersWithTBTCSignerMaterial(t, executor, 3)
+
+	nativeTBTCSignerEngine := &attemptTrackingNativeTBTCSignerEngineForTBTC{}
+
+	frostsigning.UnregisterNativeTBTCSignerEngine()
+	frostsigning.UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerFallbackObserver)
+
+	err := frostsigning.RegisterNativeTBTCSignerEngine(nativeTBTCSignerEngine)
+	if err != nil {
+		t.Fatalf("unexpected native tbtc-signer engine registration error: [%v]", err)
+	}
+
+	var fallbackEvents []frostsigning.NativeTBTCSignerFallbackEvent
+	err = frostsigning.RegisterNativeTBTCSignerFallbackObserver(
+		func(event frostsigning.NativeTBTCSignerFallbackEvent) {
+			fallbackEvents = append(fallbackEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected fallback observer registration error: [%v]", err)
+	}
+
+	frostsigning.ResetExecutionBackend()
+	frostsigning.UnregisterNativeExecutionAdapter()
+	frostsigning.UnregisterNativeExecutionBridge()
+	frostsigning.UnregisterNativeExecutionFFIExecutor()
+	frostsigning.RegisterNativeExecutionAdapterForBuild()
+	t.Cleanup(frostsigning.ResetExecutionBackend)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionAdapter)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionBridge)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionFFIExecutor)
+
+	err = configureFrostSigningBackend(Config{FrostSigningBackend: "ffi"})
+	if err != nil {
+		t.Fatalf("unexpected strict ffi backend config error: [%v]", err)
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	message := big.NewInt(100)
+	startBlock := uint64(0)
+
+	signature, _, endBlock, err := executor.sign(ctx, message, startBlock)
+	if err != nil {
+		t.Fatalf("unexpected strict ffi tbtc-signer-path signing error: [%v]", err)
+	}
+
+	walletPublicKey := executor.wallet().publicKey
+	if !ecdsa.Verify(
+		walletPublicKey,
+		message.Bytes(),
+		new(big.Int).SetBytes(signature.R[:]),
+		new(big.Int).SetBytes(signature.S[:]),
+	) {
+		t.Fatalf("invalid signature: [%+v]", signature)
+	}
+
+	cohortsByAttempt := nativeTBTCSignerEngine.uniqueStartCohortsByAttempt()
+	attemptOneCohorts, ok := cohortsByAttempt[1]
+	if !ok {
+		t.Fatal("expected observed StartSignRound cohort for attempt 1")
+	}
+	if len(attemptOneCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptOneCohorts),
+		)
+	}
+
+	attemptTwoCohorts, ok := cohortsByAttempt[2]
+	if !ok {
+		t.Fatal("expected observed StartSignRound cohort for attempt 2")
+	}
+	if len(attemptTwoCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptTwoCohorts),
+		)
+	}
+
+	attemptOneCohort := attemptOneCohorts[0]
+	attemptTwoCohort := attemptTwoCohorts[0]
+
+	expectedCohortSize := executor.groupParameters.HonestThreshold
+	if len(attemptOneCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptOneCohort),
+		)
+	}
+	if len(attemptTwoCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptTwoCohort),
+		)
+	}
+
+	if !containsParticipantForTBTC(attemptOneCohort, 3) {
+		t.Fatalf(
+			"expected attempt 1 cohort to include broken signer member 3\nactual: [%v]",
+			attemptOneCohort,
+		)
+	}
+
+	if containsParticipantForTBTC(attemptTwoCohort, 3) {
+		t.Fatalf(
+			"expected attempt 2 cohort to exclude broken signer member 3\nactual: [%v]",
+			attemptTwoCohort,
+		)
+	}
+
+	if reflect.DeepEqual(attemptOneCohort, attemptTwoCohort) {
+		t.Fatalf(
+			"expected cohort variation across attempts\nattempt 1: [%v]\nattempt 2: [%v]",
+			attemptOneCohort,
+			attemptTwoCohort,
+		)
+	}
+
+	missingLegacyFallbackObserved := false
+	for _, event := range fallbackEvents {
+		if !event.LegacyPrivateKeyShareExists {
+			missingLegacyFallbackObserved = true
+			break
+		}
+	}
+	if !missingLegacyFallbackObserved {
+		t.Fatal("expected at least one fallback event without legacy private key share")
+	}
+
+	if endBlock <= startBlock {
+		t.Fatal("wrong end block")
+	}
+}
+
 func configureSignersWithNativeFROSTUniFFIV2Material(
 	t *testing.T,
 	executor *signingExecutor,
@@ -592,4 +875,48 @@ func configureSignersWithNativeFROSTUniFFIV2Material(
 			Payload: payload,
 		}
 	}
+}
+
+func configureSignersWithTBTCSignerMaterial(
+	t *testing.T,
+	executor *signingExecutor,
+	brokenMemberIndex group.MemberIndex,
+) {
+	t.Helper()
+
+	for _, signer := range executor.signers {
+		legacyPrivateKeyShareHex := ""
+		if signer.signingGroupMemberIndex != brokenMemberIndex {
+			legacyPrivateKeySharePayload, err := signer.privateKeyShare.Marshal()
+			if err != nil {
+				t.Fatalf("cannot marshal private key share: [%v]", err)
+			}
+
+			legacyPrivateKeyShareHex = hex.EncodeToString(legacyPrivateKeySharePayload)
+		}
+
+		payload, err := json.Marshal(frostsigning.NativeTBTCSignerMaterialPayload{
+			KeyGroup:                 "group-1",
+			KeyGroupSource:           frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+			LegacyPrivateKeyShareHex: legacyPrivateKeyShareHex,
+		})
+		if err != nil {
+			t.Fatalf("cannot marshal tbtc-signer material payload: [%v]", err)
+		}
+
+		signer.signerMaterial = &frostsigning.NativeSignerMaterial{
+			Format:  frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: payload,
+		}
+	}
+}
+
+func containsParticipantForTBTC(cohort []uint16, memberIndex uint16) bool {
+	for _, participant := range cohort {
+		if participant == memberIndex {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -707,13 +707,8 @@ func TestSigningExecutor_Sign_FFIStrictBackend_TBTCSignerPath_AttemptVariationCh
 	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerFallbackObserver)
 
-	err := frostsigning.RegisterNativeTBTCSignerEngine(nativeTBTCSignerEngine)
-	if err != nil {
-		t.Fatalf("unexpected native tbtc-signer engine registration error: [%v]", err)
-	}
-
 	var fallbackEvents []frostsigning.NativeTBTCSignerFallbackEvent
-	err = frostsigning.RegisterNativeTBTCSignerFallbackObserver(
+	err := frostsigning.RegisterNativeTBTCSignerFallbackObserver(
 		func(event frostsigning.NativeTBTCSignerFallbackEvent) {
 			fallbackEvents = append(fallbackEvents, event)
 		},
@@ -727,6 +722,10 @@ func TestSigningExecutor_Sign_FFIStrictBackend_TBTCSignerPath_AttemptVariationCh
 	frostsigning.UnregisterNativeExecutionBridge()
 	frostsigning.UnregisterNativeExecutionFFIExecutor()
 	frostsigning.RegisterNativeExecutionAdapterForBuild()
+	err = frostsigning.RegisterNativeTBTCSignerEngine(nativeTBTCSignerEngine)
+	if err != nil {
+		t.Fatalf("unexpected native tbtc-signer engine registration error: [%v]", err)
+	}
 	t.Cleanup(frostsigning.ResetExecutionBackend)
 	t.Cleanup(frostsigning.UnregisterNativeExecutionAdapter)
 	t.Cleanup(frostsigning.UnregisterNativeExecutionBridge)

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -1047,6 +1047,25 @@ func (lc *LocalChain) GetWallet(walletPublicKeyHash [20]byte) (
 	return data, nil
 }
 
+func (lc *LocalChain) WalletPublicKeyHashForWalletID(
+	walletID [32]byte,
+) ([20]byte, error) {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	for walletPublicKeyHash, walletData := range lc.walletChainData {
+		if walletData == nil {
+			continue
+		}
+
+		if walletData.WalletID == walletID || walletData.EcdsaWalletID == walletID {
+			return walletPublicKeyHash, nil
+		}
+	}
+
+	return [20]byte{}, fmt.Errorf("wallet public key hash for wallet ID not found")
+}
+
 func (lc *LocalChain) SetWallet(
 	walletPublicKeyHash [20]byte,
 	data *tbtc.WalletChainData,


### PR DESCRIPTION
## Summary
- add a build-tagged native FROST engine registration path for `frost_tbtc_signer && cgo`
- preserve existing behavior for current builds by excluding `frost_tbtc_signer` from the default fallback registration file
- register a dedicated `buildTaggedTBTCSignerNativeFROSTBridge` under the new tag combination
- add focused registration coverage for the new build-tag path

## Why this shape
This PR intentionally introduces a **scaffold-only** bridge path so we can stack tbtc-signer integration work on top of the existing `feat/frost-schnorr-migration-scaffold` branch without destabilizing active UniFFI/default flows.

The bridge methods currently return explicit `not implemented` errors. This keeps compile-time/runtime routing explicit while follow-on work wires either:
1. round-operation exports from `tbtc-signer`, or
2. coarse session-oriented execution path changes in keep-core.

## Validation
- `GOCACHE=/tmp/keep-core-gocache go test ./pkg/frost/signing -tags frost_native`
- `GOCACHE=/tmp/keep-core-gocache go test ./pkg/frost/signing -tags 'frost_native frost_tbtc_signer'`
- `GOCACHE=/tmp/keep-core-gocache go test ./pkg/tbtc -run 'TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend' -tags frost_native`
- `GOCACHE=/tmp/keep-core-gocache go test ./pkg/tbtc -run 'TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend' -tags 'frost_native frost_tbtc_signer'`

## Follow-ups
- wire functional tbtc-signer bridge operations
- decide final adapter contract (round-level bridge vs coarse session bridge)
- add end-to-end signing parity tests under `frost_tbtc_signer`
