### PR TITLE
Pass explicit signing participants to tbtc-signer StartSignRound

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1467,21 +1467,46 @@ func pastNewWalletRegisteredV2Events(
 	walletPublicKeyHash [][20]byte,
 	bridge any,
 ) ([]*tbtc.NewWalletRegisteredEvent, error) {
+	if bridge == nil {
+		return nil, nil
+	}
+
 	bridgeValue := reflect.ValueOf(bridge)
 	pastV2Events := bridgeValue.MethodByName("PastNewWalletRegisteredV2Events")
 	if !pastV2Events.IsValid() {
 		return nil, nil
 	}
 
-	results := pastV2Events.Call(
-		[]reflect.Value{
-			reflect.ValueOf(startBlock),
-			reflect.ValueOf(endBlock),
-			reflect.ValueOf(walletID),
-			reflect.ValueOf(ecdsaWalletID),
-			reflect.ValueOf(walletPublicKeyHash),
-		},
+	var (
+		results []reflect.Value
+		callErr error
 	)
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				callErr = fmt.Errorf(
+					"panic calling PastNewWalletRegisteredV2Events: [%v]",
+					recovered,
+				)
+			}
+		}()
+
+		results = pastV2Events.Call(
+			[]reflect.Value{
+				reflect.ValueOf(startBlock),
+				reflect.ValueOf(endBlock),
+				reflect.ValueOf(walletID),
+				reflect.ValueOf(ecdsaWalletID),
+				reflect.ValueOf(walletPublicKeyHash),
+			},
+		)
+	}()
+
+	if callErr != nil {
+		return nil, callErr
+	}
+
 	if len(results) != 2 {
 		return nil, fmt.Errorf(
 			"unexpected PastNewWalletRegisteredV2Events result count: [%v]",
@@ -1534,6 +1559,13 @@ func pastNewWalletRegisteredV2Events(
 			walletPubKeyHashField = eventValue.FieldByName("WalletPublicKeyHash")
 		}
 		rawField := eventValue.FieldByName("Raw")
+		if !rawField.IsValid() {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 raw event payload at index [%v]",
+				i,
+			)
+		}
+
 		if rawField.Kind() == reflect.Pointer {
 			if rawField.IsNil() {
 				return nil, fmt.Errorf("unexpected nil raw event payload")
@@ -1541,6 +1573,15 @@ func pastNewWalletRegisteredV2Events(
 
 			rawField = rawField.Elem()
 		}
+
+		if rawField.Kind() != reflect.Struct {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 raw event payload kind at index [%v]: [%v]",
+				i,
+				rawField.Kind(),
+			)
+		}
+
 		blockNumberField := rawField.FieldByName("BlockNumber")
 
 		if !walletIDField.IsValid() ||
@@ -1686,13 +1727,10 @@ func resolveWalletPublicKeyHashForWalletID(
 	bridge any,
 ) ([20]byte, error) {
 	resolveCanonical, ok := bridge.(walletPublicKeyHashForWalletIDFn)
-	if !ok {
-		resolveCanonical = nil
-	}
 
 	var walletPublicKeyHash [20]byte
 	var err error
-	if resolveCanonical != nil {
+	if ok {
 		walletPublicKeyHash, err = resolveCanonical.WalletPubKeyHashForWalletID(walletID)
 	} else {
 		err = fmt.Errorf("wallet public key hash accessor unavailable")
@@ -1706,6 +1744,14 @@ func resolveWalletPublicKeyHashForWalletID(
 
 	legacyWalletPublicKeyHash, ok := tbtc.WalletPublicKeyHashFromLegacyWalletID(walletID)
 	if ok {
+		if err != nil {
+			logger.Infof(
+				"canonical wallet public key hash resolution failed for wallet ID [0x%x]; using legacy derivation: [%v]",
+				walletID,
+				err,
+			)
+		}
+
 		return legacyWalletPublicKeyHash, nil
 	}
 

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1392,18 +1392,10 @@ func (tc *TbtcChain) PastNewWalletRegisteredEvents(
 		walletID,
 		ecdsaWalletID,
 		walletPublicKeyHash,
-		tc.bridge.PastNewWalletRegisteredV2Events,
+		tc.bridge,
 		tc.bridge.PastNewWalletRegisteredEvents,
 	)
 }
-
-type pastNewWalletRegisteredV2EventsFn func(
-	startBlock uint64,
-	endBlock *uint64,
-	walletID [][32]byte,
-	ecdsaWalletID [][32]byte,
-	walletPubKeyHash [][20]byte,
-) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error)
 
 type pastNewWalletRegisteredEventsFn func(
 	startBlock uint64,
@@ -1418,30 +1410,19 @@ func pastNewWalletRegisteredEvents(
 	walletID [][32]byte,
 	ecdsaWalletID [][32]byte,
 	walletPublicKeyHash [][20]byte,
-	pastV2Events pastNewWalletRegisteredV2EventsFn,
+	bridge any,
 	pastLegacyEvents pastNewWalletRegisteredEventsFn,
 ) ([]*tbtc.NewWalletRegisteredEvent, error) {
-	v2Events, err := pastV2Events(
+	convertedEvents, err := pastNewWalletRegisteredV2Events(
 		startBlock,
 		endBlock,
 		walletID,
 		ecdsaWalletID,
 		walletPublicKeyHash,
+		bridge,
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	convertedEvents := make([]*tbtc.NewWalletRegisteredEvent, 0, len(v2Events))
-	for _, event := range v2Events {
-		convertedEvent := &tbtc.NewWalletRegisteredEvent{
-			WalletID:            event.WalletID,
-			EcdsaWalletID:       event.EcdsaWalletID,
-			WalletPublicKeyHash: event.WalletPubKeyHash,
-			BlockNumber:         event.Raw.BlockNumber,
-		}
-
-		convertedEvents = append(convertedEvents, convertedEvent)
 	}
 
 	// Fallback for legacy deployments that do not emit NewWalletRegisteredV2.
@@ -1474,6 +1455,118 @@ func pastNewWalletRegisteredEvents(
 			return convertedEvents[i].BlockNumber < convertedEvents[j].BlockNumber
 		},
 	)
+
+	return convertedEvents, nil
+}
+
+func pastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+	bridge any,
+) ([]*tbtc.NewWalletRegisteredEvent, error) {
+	bridgeValue := reflect.ValueOf(bridge)
+	pastV2Events := bridgeValue.MethodByName("PastNewWalletRegisteredV2Events")
+	if !pastV2Events.IsValid() {
+		return nil, nil
+	}
+
+	results := pastV2Events.Call(
+		[]reflect.Value{
+			reflect.ValueOf(startBlock),
+			reflect.ValueOf(endBlock),
+			reflect.ValueOf(walletID),
+			reflect.ValueOf(ecdsaWalletID),
+			reflect.ValueOf(walletPublicKeyHash),
+		},
+	)
+	if len(results) != 2 {
+		return nil, fmt.Errorf(
+			"unexpected PastNewWalletRegisteredV2Events result count: [%v]",
+			len(results),
+		)
+	}
+
+	if !results[1].IsNil() {
+		err, ok := results[1].Interface().(error)
+		if !ok {
+			return nil, fmt.Errorf(
+				"unexpected PastNewWalletRegisteredV2Events error type: [%T]",
+				results[1].Interface(),
+			)
+		}
+
+		return nil, err
+	}
+
+	eventsValue := results[0]
+	if eventsValue.Kind() != reflect.Slice {
+		return nil, fmt.Errorf(
+			"unexpected PastNewWalletRegisteredV2Events events type: [%v]",
+			eventsValue.Kind(),
+		)
+	}
+
+	convertedEvents := make([]*tbtc.NewWalletRegisteredEvent, 0, eventsValue.Len())
+	for i := 0; i < eventsValue.Len(); i++ {
+		eventValue := eventsValue.Index(i)
+		if eventValue.Kind() == reflect.Pointer {
+			if eventValue.IsNil() {
+				continue
+			}
+
+			eventValue = eventValue.Elem()
+		}
+
+		if eventValue.Kind() != reflect.Struct {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 event kind: [%v]",
+				eventValue.Kind(),
+			)
+		}
+
+		walletIDField := eventValue.FieldByName("WalletID")
+		ecdsaWalletIDField := eventValue.FieldByName("EcdsaWalletID")
+		walletPubKeyHashField := eventValue.FieldByName("WalletPubKeyHash")
+		if !walletPubKeyHashField.IsValid() {
+			walletPubKeyHashField = eventValue.FieldByName("WalletPublicKeyHash")
+		}
+		rawField := eventValue.FieldByName("Raw")
+		if rawField.Kind() == reflect.Pointer {
+			if rawField.IsNil() {
+				return nil, fmt.Errorf("unexpected nil raw event payload")
+			}
+
+			rawField = rawField.Elem()
+		}
+		blockNumberField := rawField.FieldByName("BlockNumber")
+
+		if !walletIDField.IsValid() ||
+			walletIDField.Type() != reflect.TypeOf([32]byte{}) ||
+			!ecdsaWalletIDField.IsValid() ||
+			ecdsaWalletIDField.Type() != reflect.TypeOf([32]byte{}) ||
+			!walletPubKeyHashField.IsValid() ||
+			walletPubKeyHashField.Type() != reflect.TypeOf([20]byte{}) ||
+			!blockNumberField.IsValid() ||
+			blockNumberField.Kind() != reflect.Uint64 {
+			return nil, fmt.Errorf(
+				"unexpected NewWalletRegisteredV2 event shape at index [%v]",
+				i,
+			)
+		}
+
+		convertedEvents = append(
+			convertedEvents,
+			&tbtc.NewWalletRegisteredEvent{
+				WalletID:            walletIDField.Interface().([32]byte),
+				EcdsaWalletID:       ecdsaWalletIDField.Interface().([32]byte),
+				WalletPublicKeyHash: walletPubKeyHashField.Interface().([20]byte),
+				BlockNumber:         blockNumberField.Uint(),
+			},
+		)
+	}
 
 	return convertedEvents, nil
 }
@@ -1536,7 +1629,10 @@ func (tc *TbtcChain) GetWallet(
 		return nil, fmt.Errorf("cannot parse wallet state: [%v]", err)
 	}
 
-	walletID, err := tc.bridge.WalletID(walletPublicKeyHash)
+	walletID, err := walletIDForWalletPublicKeyHash(
+		tc.bridge,
+		walletPublicKeyHash,
+	)
 	if err != nil {
 		// Fallback for legacy deployments where walletID accessor may not exist.
 		walletID = tbtc.DeriveLegacyWalletID(walletPublicKeyHash)
@@ -1561,19 +1657,47 @@ func (tc *TbtcChain) WalletPublicKeyHashForWalletID(
 ) ([20]byte, error) {
 	return resolveWalletPublicKeyHashForWalletID(
 		walletID,
-		tc.bridge.WalletPubKeyHashForWalletID,
+		tc.bridge,
 	)
 }
 
-type walletPublicKeyHashForWalletIDFn func(
-	walletID [32]byte,
-) ([20]byte, error)
+type walletIDForWalletPublicKeyHashFn interface {
+	WalletID(walletPublicKeyHash [20]byte) ([32]byte, error)
+}
+
+func walletIDForWalletPublicKeyHash(
+	bridge any,
+	walletPublicKeyHash [20]byte,
+) ([32]byte, error) {
+	resolver, ok := bridge.(walletIDForWalletPublicKeyHashFn)
+	if !ok {
+		return [32]byte{}, fmt.Errorf("wallet ID accessor unavailable")
+	}
+
+	return resolver.WalletID(walletPublicKeyHash)
+}
+
+type walletPublicKeyHashForWalletIDFn interface {
+	WalletPubKeyHashForWalletID(walletID [32]byte) ([20]byte, error)
+}
 
 func resolveWalletPublicKeyHashForWalletID(
 	walletID [32]byte,
-	resolveCanonical walletPublicKeyHashForWalletIDFn,
+	bridge any,
 ) ([20]byte, error) {
-	walletPublicKeyHash, err := resolveCanonical(walletID)
+	resolveCanonical, ok := bridge.(walletPublicKeyHashForWalletIDFn)
+	if !ok {
+		resolveCanonical = nil
+	}
+
+	var walletPublicKeyHash [20]byte
+	var err error
+	if resolveCanonical != nil {
+		walletPublicKeyHash, err = resolveCanonical.WalletPubKeyHashForWalletID(walletID)
+	} else {
+		err = fmt.Errorf("wallet public key hash accessor unavailable")
+	}
+
 	if err == nil {
 		if walletPublicKeyHash != [20]byte{} {
 			return walletPublicKeyHash, nil

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -328,6 +328,105 @@ func TestCalculateWalletID(t *testing.T) {
 	testutils.AssertBytesEqual(t, expectedWalletID[:], actualWalletID[:])
 }
 
+type pastNewWalletRegisteredV2EventsBridgeMock struct {
+	pastEvents func(
+		startBlock uint64,
+		endBlock *uint64,
+		walletID [][32]byte,
+		ecdsaWalletID [][32]byte,
+		walletPublicKeyHash [][20]byte,
+	) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error)
+}
+
+func (m *pastNewWalletRegisteredV2EventsBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+	return m.pastEvents(
+		startBlock,
+		endBlock,
+		walletID,
+		ecdsaWalletID,
+		walletPublicKeyHash,
+	)
+}
+
+type pastNewWalletRegisteredV2EventsAltFieldBridgeMock struct {
+	pastEvents func(
+		startBlock uint64,
+		endBlock *uint64,
+		walletID [][32]byte,
+		ecdsaWalletID [][32]byte,
+		walletPublicKeyHash [][20]byte,
+	) ([]*pastNewWalletRegisteredV2EventsAltFieldEvent, error)
+}
+
+type pastNewWalletRegisteredV2EventsAltFieldEvent struct {
+	WalletID            [32]byte
+	EcdsaWalletID       [32]byte
+	WalletPublicKeyHash [20]byte
+	Raw                 types.Log
+}
+
+func (m *pastNewWalletRegisteredV2EventsAltFieldBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+) ([]*pastNewWalletRegisteredV2EventsAltFieldEvent, error) {
+	return m.pastEvents(
+		startBlock,
+		endBlock,
+		walletID,
+		ecdsaWalletID,
+		walletPublicKeyHash,
+	)
+}
+
+type pastNewWalletRegisteredV2EventsMissingRawBridgeMock struct {
+	pastEvents func(
+		startBlock uint64,
+		endBlock *uint64,
+		walletID [][32]byte,
+		ecdsaWalletID [][32]byte,
+		walletPublicKeyHash [][20]byte,
+	) ([]*pastNewWalletRegisteredV2EventsMissingRawEvent, error)
+}
+
+type pastNewWalletRegisteredV2EventsMissingRawEvent struct {
+	WalletID         [32]byte
+	EcdsaWalletID    [32]byte
+	WalletPubKeyHash [20]byte
+}
+
+func (m *pastNewWalletRegisteredV2EventsMissingRawBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+	endBlock *uint64,
+	walletID [][32]byte,
+	ecdsaWalletID [][32]byte,
+	walletPublicKeyHash [][20]byte,
+) ([]*pastNewWalletRegisteredV2EventsMissingRawEvent, error) {
+	return m.pastEvents(
+		startBlock,
+		endBlock,
+		walletID,
+		ecdsaWalletID,
+		walletPublicKeyHash,
+	)
+}
+
+type pastNewWalletRegisteredV2EventsWrongSignatureBridgeMock struct{}
+
+func (m *pastNewWalletRegisteredV2EventsWrongSignatureBridgeMock) PastNewWalletRegisteredV2Events(
+	startBlock uint64,
+) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+	return nil, nil
+}
+
 func TestPastNewWalletRegisteredEvents_UsesV2EventsWhenAvailable(t *testing.T) {
 	startBlock := uint64(500)
 	endBlock := uint64(700)
@@ -349,36 +448,38 @@ func TestPastNewWalletRegisteredEvents_UsesV2EventsWhenAvailable(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		func(
-			actualStartBlock uint64,
-			actualEndBlock *uint64,
-			_ [][32]byte,
-			_ [][32]byte,
-			_ [][20]byte,
-		) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
-			if actualStartBlock != startBlock {
-				t.Fatalf("unexpected start block: [%v]", actualStartBlock)
-			}
+		&pastNewWalletRegisteredV2EventsBridgeMock{
+			pastEvents: func(
+				actualStartBlock uint64,
+				actualEndBlock *uint64,
+				_ [][32]byte,
+				_ [][32]byte,
+				_ [][20]byte,
+			) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+				if actualStartBlock != startBlock {
+					t.Fatalf("unexpected start block: [%v]", actualStartBlock)
+				}
 
-			if actualEndBlock == nil || *actualEndBlock != endBlock {
-				t.Fatalf("unexpected end block: [%v]", actualEndBlock)
-			}
+				if actualEndBlock == nil || *actualEndBlock != endBlock {
+					t.Fatalf("unexpected end block: [%v]", actualEndBlock)
+				}
 
-			// Provide events out of order to verify post-conversion sort.
-			return []*tbtcabi.BridgeNewWalletRegisteredV2{
-				{
-					WalletID:         expectedWalletIDB,
-					EcdsaWalletID:    expectedECDSAWalletIDB,
-					WalletPubKeyHash: expectedWalletPublicKeyHashB,
-					Raw:              types.Log{BlockNumber: 650},
-				},
-				{
-					WalletID:         expectedWalletIDA,
-					EcdsaWalletID:    expectedECDSAWalletIDA,
-					WalletPubKeyHash: expectedWalletPublicKeyHashA,
-					Raw:              types.Log{BlockNumber: 600},
-				},
-			}, nil
+				// Provide events out of order to verify post-conversion sort.
+				return []*tbtcabi.BridgeNewWalletRegisteredV2{
+					{
+						WalletID:         expectedWalletIDB,
+						EcdsaWalletID:    expectedECDSAWalletIDB,
+						WalletPubKeyHash: expectedWalletPublicKeyHashB,
+						Raw:              types.Log{BlockNumber: 650},
+					},
+					{
+						WalletID:         expectedWalletIDA,
+						EcdsaWalletID:    expectedECDSAWalletIDA,
+						WalletPubKeyHash: expectedWalletPublicKeyHashA,
+						Raw:              types.Log{BlockNumber: 600},
+					},
+				}, nil
+			},
 		},
 		func(uint64, *uint64, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegistered, error) {
 			legacyFallbackCalled = true
@@ -424,8 +525,16 @@ func TestPastNewWalletRegisteredEvents_FallsBackToLegacyWhenV2Empty(t *testing.T
 		nil, // no canonical wallet-ID filter -> fallback path enabled
 		nil,
 		nil,
-		func(uint64, *uint64, [][32]byte, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
-			return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+		&pastNewWalletRegisteredV2EventsBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+				return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+			},
 		},
 		func(uint64, *uint64, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegistered, error) {
 			legacyFallbackCalled = true
@@ -473,8 +582,16 @@ func TestPastNewWalletRegisteredEvents_DoesNotFallbackWithWalletIDFilter(t *test
 		walletIDFilter,
 		nil,
 		nil,
-		func(uint64, *uint64, [][32]byte, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
-			return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+		&pastNewWalletRegisteredV2EventsBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*tbtcabi.BridgeNewWalletRegisteredV2, error) {
+				return []*tbtcabi.BridgeNewWalletRegisteredV2{}, nil
+			},
 		},
 		func(uint64, *uint64, [][32]byte, [][20]byte) ([]*tbtcabi.BridgeNewWalletRegistered, error) {
 			legacyFallbackCalled = true
@@ -494,6 +611,133 @@ func TestPastNewWalletRegisteredEvents_DoesNotFallbackWithWalletIDFilter(t *test
 	}
 }
 
+func TestPastNewWalletRegisteredV2Events_ReturnsEmptyWhenMethodUnavailable(t *testing.T) {
+	actualEvents, err := pastNewWalletRegisteredV2Events(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		struct{}{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+
+	if len(actualEvents) != 0 {
+		t.Fatalf("unexpected events count: [%v]", len(actualEvents))
+	}
+}
+
+func TestPastNewWalletRegisteredV2Events_UsesWalletPublicKeyHashFallbackField(t *testing.T) {
+	expectedWalletID := [32]byte{0x01}
+	expectedECDSAWalletID := [32]byte{0x02}
+	expectedWalletPublicKeyHash := [20]byte{0x03}
+
+	actualEvents, err := pastNewWalletRegisteredV2Events(
+		11,
+		nil,
+		nil,
+		nil,
+		nil,
+		&pastNewWalletRegisteredV2EventsAltFieldBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*pastNewWalletRegisteredV2EventsAltFieldEvent, error) {
+				return []*pastNewWalletRegisteredV2EventsAltFieldEvent{
+					{
+						WalletID:            expectedWalletID,
+						EcdsaWalletID:       expectedECDSAWalletID,
+						WalletPublicKeyHash: expectedWalletPublicKeyHash,
+						Raw:                 types.Log{BlockNumber: 121},
+					},
+				}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+
+	if len(actualEvents) != 1 {
+		t.Fatalf("unexpected events count: [%v]", len(actualEvents))
+	}
+
+	if actualEvents[0].WalletPublicKeyHash != expectedWalletPublicKeyHash {
+		t.Fatalf(
+			"unexpected wallet public key hash\nexpected: [%x]\nactual:   [%x]",
+			expectedWalletPublicKeyHash,
+			actualEvents[0].WalletPublicKeyHash,
+		)
+	}
+}
+
+func TestPastNewWalletRegisteredV2Events_ReturnsErrorOnCallPanic(t *testing.T) {
+	_, err := pastNewWalletRegisteredV2Events(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		&pastNewWalletRegisteredV2EventsWrongSignatureBridgeMock{},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "panic calling PastNewWalletRegisteredV2Events") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestPastNewWalletRegisteredV2Events_ReturnsErrorWhenRawMissing(t *testing.T) {
+	_, err := pastNewWalletRegisteredV2Events(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		&pastNewWalletRegisteredV2EventsMissingRawBridgeMock{
+			pastEvents: func(
+				uint64,
+				*uint64,
+				[][32]byte,
+				[][32]byte,
+				[][20]byte,
+			) ([]*pastNewWalletRegisteredV2EventsMissingRawEvent, error) {
+				return []*pastNewWalletRegisteredV2EventsMissingRawEvent{
+					{
+						WalletID:         [32]byte{0x05},
+						EcdsaWalletID:    [32]byte{0x06},
+						WalletPubKeyHash: [20]byte{0x07},
+					},
+				}, nil
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "raw event payload") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+type walletPublicKeyHashForWalletIDBridgeMock struct {
+	resolve func(walletID [32]byte) ([20]byte, error)
+}
+
+func (m *walletPublicKeyHashForWalletIDBridgeMock) WalletPubKeyHashForWalletID(
+	walletID [32]byte,
+) ([20]byte, error) {
+	return m.resolve(walletID)
+}
+
 func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 	t.Run("returns canonical mapping when non-zero", func(t *testing.T) {
 		walletID := [32]byte{0x01}
@@ -501,12 +745,14 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		actualWalletPublicKeyHash, err := resolveWalletPublicKeyHashForWalletID(
 			walletID,
-			func(actualWalletID [32]byte) ([20]byte, error) {
-				if actualWalletID != walletID {
-					t.Fatalf("unexpected wallet ID: [%x]", actualWalletID)
-				}
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func(actualWalletID [32]byte) ([20]byte, error) {
+					if actualWalletID != walletID {
+						t.Fatalf("unexpected wallet ID: [%x]", actualWalletID)
+					}
 
-				return expectedWalletPublicKeyHash, nil
+					return expectedWalletPublicKeyHash, nil
+				},
 			},
 		)
 		if err != nil {
@@ -528,8 +774,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		actualWalletPublicKeyHash, err := resolveWalletPublicKeyHashForWalletID(
 			legacyWalletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, errors.New("canonical lookup unavailable")
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, errors.New("canonical lookup unavailable")
+				},
 			},
 		)
 		if err != nil {
@@ -551,8 +799,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		actualWalletPublicKeyHash, err := resolveWalletPublicKeyHashForWalletID(
 			legacyWalletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, nil
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, nil
+				},
 			},
 		)
 		if err != nil {
@@ -574,8 +824,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		_, err := resolveWalletPublicKeyHashForWalletID(
 			walletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, canonicalErr
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, canonicalErr
+				},
 			},
 		)
 		if err == nil {
@@ -595,8 +847,10 @@ func TestResolveWalletPublicKeyHashForWalletID(t *testing.T) {
 
 		_, err := resolveWalletPublicKeyHashForWalletID(
 			walletID,
-			func([32]byte) ([20]byte, error) {
-				return [20]byte{}, nil
+			&walletPublicKeyHashForWalletIDBridgeMock{
+				resolve: func([32]byte) ([20]byte, error) {
+					return [20]byte{}, nil
+				},
 			},
 		)
 		if err == nil {

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -172,7 +172,22 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	dkgParticipants, dkgThreshold, err := buildTaggedTBTCSignerRunDKGInputs(request)
+	includedMembersSet, includedMembersIndexes, err := includedMembersFromRequest(request)
+	if err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			fmt.Sprintf("cannot determine included members: [%v]", err),
+			payload.KeyGroupSource,
+		)
+	}
+
+	dkgParticipants, dkgThreshold, err := buildTaggedTBTCSignerRunDKGInputsForIncludedMembers(
+		request,
+		includedMembersIndexes,
+	)
 	if err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
@@ -292,6 +307,8 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		request,
 		keyGroupForRound,
 		nativeEngine,
+		includedMembersSet,
+		includedMembersIndexes,
 	); err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
@@ -325,6 +342,20 @@ func buildTaggedTBTCSignerRunDKGInputs(
 	_, includedMembersIndexes, err := includedMembersFromRequest(request)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	return buildTaggedTBTCSignerRunDKGInputsForIncludedMembers(
+		request,
+		includedMembersIndexes,
+	)
+}
+
+func buildTaggedTBTCSignerRunDKGInputsForIncludedMembers(
+	request *NativeExecutionFFISigningRequest,
+	includedMembersIndexes []group.MemberIndex,
+) ([]NativeTBTCSignerDKGParticipant, uint16, error) {
+	if request == nil {
+		return nil, 0, fmt.Errorf("request is nil")
 	}
 
 	if len(includedMembersIndexes) < 2 {
@@ -448,6 +479,8 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	request *NativeExecutionFFISigningRequest,
 	keyGroup string,
 	nativeEngine NativeTBTCSignerEngine,
+	includedMembersSet map[group.MemberIndex]struct{},
+	includedMembersIndexes []group.MemberIndex,
 ) error {
 	if request == nil {
 		return fmt.Errorf("request is nil")
@@ -465,9 +498,12 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		ctx = context.Background()
 	}
 
-	includedMembersSet, includedMembersIndexes, err := includedMembersFromRequest(request)
-	if err != nil {
-		return fmt.Errorf("cannot determine included members: [%w]", err)
+	if includedMembersSet == nil || len(includedMembersIndexes) == 0 {
+		var err error
+		includedMembersSet, includedMembersIndexes, err = includedMembersFromRequest(request)
+		if err != nil {
+			return fmt.Errorf("cannot determine included members: [%w]", err)
+		}
 	}
 
 	if _, ok := includedMembersSet[request.MemberIndex]; !ok {
@@ -512,7 +548,7 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		return fmt.Errorf("start sign round required contributions are zero")
 	}
 
-	if len(roundState.SigningParticipants) > 0 {
+	if len(signingParticipants) > 0 {
 		if len(roundState.SigningParticipants) != len(signingParticipants) {
 			return fmt.Errorf(
 				"start sign round returned unexpected signing participants count: [%v] != [%v]",

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -486,11 +486,19 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		return fmt.Errorf("request member index is zero")
 	}
 
+	signingParticipants, err := buildTaggedTBTCSignerSigningParticipants(
+		includedMembersIndexes,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot derive signing participants: [%w]", err)
+	}
+
 	roundState, err := nativeEngine.StartSignRound(
 		request.SessionID,
 		uint16(request.MemberIndex),
 		messageBytes,
 		keyGroup,
+		signingParticipants,
 	)
 	if err != nil {
 		return fmt.Errorf("start sign round failed: [%w]", err)
@@ -502,6 +510,27 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 
 	if roundState.RequiredContributions == 0 {
 		return fmt.Errorf("start sign round required contributions are zero")
+	}
+
+	if len(roundState.SigningParticipants) > 0 {
+		if len(roundState.SigningParticipants) != len(signingParticipants) {
+			return fmt.Errorf(
+				"start sign round returned unexpected signing participants count: [%v] != [%v]",
+				len(roundState.SigningParticipants),
+				len(signingParticipants),
+			)
+		}
+
+		for i := range signingParticipants {
+			if roundState.SigningParticipants[i] != signingParticipants[i] {
+				return fmt.Errorf(
+					"start sign round returned unexpected signing participant at index [%d]: [%v] != [%v]",
+					i,
+					roundState.SigningParticipants[i],
+					signingParticipants[i],
+				)
+			}
+		}
 	}
 
 	roundContributions, err := buildTaggedTBTCSignerRoundContributions(
@@ -536,6 +565,33 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	}
 
 	return nil
+}
+
+func buildTaggedTBTCSignerSigningParticipants(
+	includedMembersIndexes []group.MemberIndex,
+) ([]uint16, error) {
+	if len(includedMembersIndexes) == 0 {
+		return nil, fmt.Errorf("included members are empty")
+	}
+
+	signingParticipants := make([]uint16, 0, len(includedMembersIndexes))
+	seenParticipants := make(map[uint16]struct{}, len(includedMembersIndexes))
+
+	for _, memberIndex := range includedMembersIndexes {
+		if memberIndex == 0 {
+			return nil, fmt.Errorf("included member index is zero")
+		}
+
+		participant := uint16(memberIndex)
+		if _, ok := seenParticipants[participant]; ok {
+			return nil, fmt.Errorf("duplicate included member index: [%v]", memberIndex)
+		}
+
+		seenParticipants[participant] = struct{}{}
+		signingParticipants = append(signingParticipants, participant)
+	}
+
+	return signingParticipants, nil
 }
 
 func buildTaggedTBTCSignerRoundContributions(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -32,20 +32,21 @@ type mockBuildTaggedTBTCSignerEngine struct {
 		participants []NativeTBTCSignerDKGParticipant,
 		threshold uint16,
 	) (*NativeTBTCSignerDKGResult, error)
-	version           string
-	versionErr        error
-	startCalled       bool
-	startSessionID    string
-	startMemberID     uint16
-	startMessage      []byte
-	startKeyGroup     string
-	startRoundState   *NativeTBTCSignerRoundState
-	startErr          error
-	finalizeCalled    bool
-	finalizeSessionID string
-	finalizeInputs    []NativeTBTCSignerRoundContribution
-	finalizeSignature []byte
-	finalizeErr       error
+	version                  string
+	versionErr               error
+	startCalled              bool
+	startSessionID           string
+	startMemberID            uint16
+	startMessage             []byte
+	startKeyGroup            string
+	startSigningParticipants []uint16
+	startRoundState          *NativeTBTCSignerRoundState
+	startErr                 error
+	finalizeCalled           bool
+	finalizeSessionID        string
+	finalizeInputs           []NativeTBTCSignerRoundContribution
+	finalizeSignature        []byte
+	finalizeErr              error
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -95,12 +96,14 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	mbttse.startCalled = true
 	mbttse.startSessionID = sessionID
 	mbttse.startMemberID = memberIdentifier
 	mbttse.startMessage = append([]byte{}, message...)
 	mbttse.startKeyGroup = keyGroup
+	mbttse.startSigningParticipants = append([]uint16{}, signingParticipants...)
 
 	if mbttse.startErr != nil {
 		return nil, mbttse.startErr
@@ -166,6 +169,7 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 	memberIdentifier uint16,
 	_ []byte,
 	_ string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	if dbttsbre.roundState != nil {
 		if dbttsbre.roundState.OwnContribution == nil {
@@ -178,11 +182,16 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 		return dbttsbre.roundState, nil
 	}
 
+	if len(signingParticipants) == 0 {
+		signingParticipants = []uint16{memberIdentifier}
+	}
+
 	return &NativeTBTCSignerRoundState{
 		SessionID:             sessionID,
 		RoundID:               "round-1",
 		RequiredContributions: 2,
 		MessageDigestHex:      "00",
+		SigningParticipants:   append([]uint16{}, signingParticipants...),
 		OwnContribution: &NativeTBTCSignerRoundContribution{
 			Identifier: memberIdentifier,
 			Data:       []byte{byte(memberIdentifier), 0xab},
@@ -1184,6 +1193,15 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		)
 	}
 
+	expectedSigningParticipants := []uint16{1, 2, 3}
+	if !reflect.DeepEqual(engine.startSigningParticipants, expectedSigningParticipants) {
+		t.Fatalf(
+			"unexpected StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedSigningParticipants,
+			engine.startSigningParticipants,
+		)
+	}
+
 	if !engine.finalizeCalled {
 		t.Fatal("expected FinalizeSignRound call in bootstrap tbtc-signer path")
 	}
@@ -1279,6 +1297,15 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			"unexpected StartSignRound key group\nexpected: [%v]\nactual:   [%v]",
 			"group-from-dkg",
 			engine.startKeyGroup,
+		)
+	}
+
+	expectedSigningParticipants := []uint16{1, 2, 3}
+	if !reflect.DeepEqual(engine.startSigningParticipants, expectedSigningParticipants) {
+		t.Fatalf(
+			"unexpected StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedSigningParticipants,
+			engine.startSigningParticipants,
 		)
 	}
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -40,13 +40,20 @@ type mockBuildTaggedTBTCSignerEngine struct {
 	startMessage             []byte
 	startKeyGroup            string
 	startSigningParticipants []uint16
-	startRoundState          *NativeTBTCSignerRoundState
-	startErr                 error
-	finalizeCalled           bool
-	finalizeSessionID        string
-	finalizeInputs           []NativeTBTCSignerRoundContribution
-	finalizeSignature        []byte
-	finalizeErr              error
+	startSignRoundFn         func(
+		sessionID string,
+		memberIdentifier uint16,
+		message []byte,
+		keyGroup string,
+		signingParticipants []uint16,
+	) (*NativeTBTCSignerRoundState, error)
+	startRoundState   *NativeTBTCSignerRoundState
+	startErr          error
+	finalizeCalled    bool
+	finalizeSessionID string
+	finalizeInputs    []NativeTBTCSignerRoundContribution
+	finalizeSignature []byte
+	finalizeErr       error
 }
 
 func (mbttse *mockBuildTaggedTBTCSignerEngine) RunDKG(
@@ -107,6 +114,16 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 
 	if mbttse.startErr != nil {
 		return nil, mbttse.startErr
+	}
+
+	if mbttse.startSignRoundFn != nil {
+		return mbttse.startSignRoundFn(
+			sessionID,
+			memberIdentifier,
+			message,
+			keyGroup,
+			signingParticipants,
+		)
 	}
 
 	if mbttse.startRoundState != nil {
@@ -1734,6 +1751,176 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
 			2,
 			len(observedEvents),
+		)
+	}
+
+	if !strings.Contains(observedEvents[1].Reason, "session_conflict") {
+		t.Fatalf(
+			"expected second fallback reason to include session_conflict\nactual: [%s]",
+			observedEvents[1].Reason,
+		)
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_AttemptVariationStartSignRoundConflictFallsBack(
+	t *testing.T,
+) {
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	var firstSigningParticipants []uint16
+	var observedSigningParticipants [][]uint16
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0-bootstrap",
+		runDKGFn: func(
+			sessionID string,
+			participants []NativeTBTCSignerDKGParticipant,
+			threshold uint16,
+		) (*NativeTBTCSignerDKGResult, error) {
+			return &NativeTBTCSignerDKGResult{
+				SessionID:        sessionID,
+				KeyGroup:         "group-1",
+				ParticipantCount: uint16(len(participants)),
+				Threshold:        threshold,
+				CreatedAtUnix:    1,
+			}, nil
+		},
+		startSignRoundFn: func(
+			sessionID string,
+			_ uint16,
+			_ []byte,
+			_ string,
+			signingParticipants []uint16,
+		) (*NativeTBTCSignerRoundState, error) {
+			observedSigningParticipants = append(
+				observedSigningParticipants,
+				append([]uint16{}, signingParticipants...),
+			)
+
+			if firstSigningParticipants == nil {
+				firstSigningParticipants = append(
+					[]uint16{},
+					signingParticipants...,
+				)
+			} else if !reflect.DeepEqual(signingParticipants, firstSigningParticipants) {
+				return nil, errors.New("session_conflict")
+			}
+
+			return &NativeTBTCSignerRoundState{
+				SessionID:             sessionID,
+				RoundID:               "round-1",
+				RequiredContributions: 2,
+				MessageDigestHex:      "00",
+				SigningParticipants: append(
+					[]uint16{},
+					signingParticipants...,
+				),
+			}, nil
+		},
+	}
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	baseRequest := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1","keyGroupSource":"legacy-wallet-pubkey"}`),
+		},
+	}
+
+	_, err = primitive.Sign(nil, nil, baseRequest)
+	if err == nil {
+		t.Fatal("expected first signing error due to legacy fallback without private key share")
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected first signing error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	secondRequest := *baseRequest
+	secondRequest.Attempt = &Attempt{
+		ExcludedMembersIndexes: []group.MemberIndex{2},
+	}
+
+	_, err = primitive.Sign(nil, nil, &secondRequest)
+	if err == nil {
+		t.Fatal("expected second signing error due to legacy fallback without private key share")
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected second signing error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if len(observedSigningParticipants) != 2 {
+		t.Fatalf(
+			"unexpected StartSignRound call count\nexpected: [%d]\nactual:   [%d]",
+			2,
+			len(observedSigningParticipants),
+		)
+	}
+
+	expectedFirstParticipants := []uint16{1, 2, 3}
+	if !reflect.DeepEqual(observedSigningParticipants[0], expectedFirstParticipants) {
+		t.Fatalf(
+			"unexpected first StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedFirstParticipants,
+			observedSigningParticipants[0],
+		)
+	}
+
+	expectedSecondParticipants := []uint16{1, 3}
+	if !reflect.DeepEqual(observedSigningParticipants[1], expectedSecondParticipants) {
+		t.Fatalf(
+			"unexpected second StartSignRound signing participants\nexpected: [%v]\nactual:   [%v]",
+			expectedSecondParticipants,
+			observedSigningParticipants[1],
+		)
+	}
+
+	if len(observedEvents) != 2 {
+		t.Fatalf(
+			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
+			2,
+			len(observedEvents),
+		)
+	}
+
+	if !strings.Contains(
+		observedEvents[0].Reason,
+		"tbtc-signer bootstrap coarse round completed",
+	) {
+		t.Fatalf(
+			"expected first fallback reason to include bootstrap completion\nactual: [%s]",
+			observedEvents[0].Reason,
 		)
 	}
 

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -127,6 +127,13 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 	}
 
 	if mbttse.startRoundState != nil {
+		if len(mbttse.startRoundState.SigningParticipants) == 0 {
+			mbttse.startRoundState.SigningParticipants = append(
+				[]uint16{},
+				signingParticipants...,
+			)
+		}
+
 		return mbttse.startRoundState, nil
 	}
 
@@ -135,6 +142,7 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) StartSignRound(
 		RoundID:               "round-1",
 		RequiredContributions: 2,
 		MessageDigestHex:      "00",
+		SigningParticipants:   append([]uint16{}, signingParticipants...),
 	}, nil
 }
 
@@ -194,6 +202,13 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) StartSig
 				Identifier: memberIdentifier,
 				Data:       []byte{byte(memberIdentifier), 0xab},
 			}
+		}
+
+		if len(dbttsbre.roundState.SigningParticipants) == 0 {
+			dbttsbre.roundState.SigningParticipants = append(
+				[]uint16{},
+				signingParticipants...,
+			)
 		}
 
 		return dbttsbre.roundState, nil
@@ -860,6 +875,8 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributions
 				signingRequest,
 				"group-1",
 				signingEngine,
+				nil,
+				nil,
 			)
 		}(request, engine)
 	}
@@ -1008,6 +1025,8 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_UsesThresholdCohortOve
 				signingRequest,
 				"group-1",
 				signingEngine,
+				nil,
+				nil,
 			)
 		}(request, engine)
 	}
@@ -1087,12 +1106,73 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_FailsWhenRoundStateSig
 		request,
 		"group-1",
 		engine,
+		nil,
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 
 	expectedErrFragment := "start sign round returned unexpected signing participant"
+	if !strings.Contains(err.Error(), expectedErrFragment) {
+		t.Fatalf(
+			"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",
+			expectedErrFragment,
+			err,
+		)
+	}
+}
+
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_FailsWhenRoundStateSigningParticipantsMissing(
+	t *testing.T,
+) {
+	request := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          2,
+		DishonestThreshold: 1,
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+		},
+	}
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		startSignRoundFn: func(
+			sessionID string,
+			memberIdentifier uint16,
+			message []byte,
+			keyGroup string,
+			signingParticipants []uint16,
+		) (*NativeTBTCSignerRoundState, error) {
+			return &NativeTBTCSignerRoundState{
+				SessionID:             sessionID,
+				RoundID:               "round-1",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: memberIdentifier,
+					Data:       []byte{0x11, 0x01},
+				},
+			}, nil
+		},
+	}
+
+	err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+		context.Background(),
+		request,
+		"group-1",
+		engine,
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	expectedErrFragment := "start sign round returned unexpected signing participants count"
 	if !strings.Contains(err.Error(), expectedErrFragment) {
 		t.Fatalf(
 			"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -900,6 +900,191 @@ func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributions
 	}
 }
 
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_UsesThresholdCohortOverFullGroup(
+	t *testing.T,
+) {
+	provider := local.Connect()
+	channel, err := provider.BroadcastChannelFor("tbtc-signer-bootstrap-round-threshold-cohort-test")
+	if err != nil {
+		t.Fatalf("failed creating broadcast channel: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+	primitive.RegisterUnmarshallers(channel)
+
+	engineByMember := map[group.MemberIndex]*mockBuildTaggedTBTCSignerEngine{
+		1: {
+			startRoundState: &NativeTBTCSignerRoundState{
+				SessionID:             "session-threshold",
+				RoundID:               "round-threshold",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				SigningParticipants:   []uint16{1, 3},
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: 1,
+					Data:       []byte{0x11, 0x01},
+				},
+			},
+		},
+		3: {
+			startRoundState: &NativeTBTCSignerRoundState{
+				SessionID:             "session-threshold",
+				RoundID:               "round-threshold",
+				RequiredContributions: 2,
+				MessageDigestHex:      "0011",
+				SigningParticipants:   []uint16{1, 3},
+				OwnContribution: &NativeTBTCSignerRoundContribution{
+					Identifier: 3,
+					Data:       []byte{0x33, 0x03},
+				},
+			},
+		},
+	}
+
+	requestByMember := map[group.MemberIndex]*NativeExecutionFFISigningRequest{
+		1: {
+			Message:            big.NewInt(123),
+			SessionID:          "session-threshold",
+			MemberIndex:        1,
+			GroupSize:          3,
+			DishonestThreshold: 1,
+			Channel:            channel,
+			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
+				IncludedMembersIndexes: []group.MemberIndex{1, 3},
+			},
+		},
+		3: {
+			Message:            big.NewInt(123),
+			SessionID:          "session-threshold",
+			MemberIndex:        3,
+			GroupSize:          3,
+			DishonestThreshold: 1,
+			Channel:            channel,
+			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
+				IncludedMembersIndexes: []group.MemberIndex{1, 3},
+			},
+		},
+	}
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelCtx()
+
+	var wg sync.WaitGroup
+	signingErrors := make(chan error, len(requestByMember))
+
+	for memberIndex, request := range requestByMember {
+		engine := engineByMember[memberIndex]
+		wg.Add(1)
+
+		go func(
+			signingRequest *NativeExecutionFFISigningRequest,
+			signingEngine NativeTBTCSignerEngine,
+		) {
+			defer wg.Done()
+
+			signingErrors <- executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+				ctx,
+				signingRequest,
+				"group-1",
+				signingEngine,
+			)
+		}(request, engine)
+	}
+
+	wg.Wait()
+	close(signingErrors)
+
+	for signingErr := range signingErrors {
+		if signingErr != nil {
+			t.Fatalf("unexpected signing error: [%v]", signingErr)
+		}
+	}
+
+	expectedSigningParticipants := []uint16{1, 3}
+	for memberIndex, engine := range engineByMember {
+		if !reflect.DeepEqual(engine.startSigningParticipants, expectedSigningParticipants) {
+			t.Fatalf(
+				"unexpected StartSignRound signing participants for member [%v]\nexpected: [%v]\nactual:   [%v]",
+				memberIndex,
+				expectedSigningParticipants,
+				engine.startSigningParticipants,
+			)
+		}
+
+		if len(engine.finalizeInputs) != 2 {
+			t.Fatalf(
+				"unexpected finalize input count for member [%v]\nexpected: [%v]\nactual:   [%v]",
+				memberIndex,
+				2,
+				len(engine.finalizeInputs),
+			)
+		}
+
+		if engine.finalizeInputs[0].Identifier != 1 || engine.finalizeInputs[1].Identifier != 3 {
+			t.Fatalf(
+				"unexpected finalize identifiers for member [%v]\nexpected: [1 3]\nactual:   [%v %v]",
+				memberIndex,
+				engine.finalizeInputs[0].Identifier,
+				engine.finalizeInputs[1].Identifier,
+			)
+		}
+	}
+}
+
+func TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_FailsWhenRoundStateSigningParticipantsMismatch(
+	t *testing.T,
+) {
+	request := &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          2,
+		DishonestThreshold: 1,
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+		},
+	}
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		startRoundState: &NativeTBTCSignerRoundState{
+			SessionID:             "session-1",
+			RoundID:               "round-1",
+			RequiredContributions: 2,
+			MessageDigestHex:      "0011",
+			SigningParticipants:   []uint16{1, 3},
+			OwnContribution: &NativeTBTCSignerRoundContribution{
+				Identifier: 1,
+				Data:       []byte{0x11, 0x01},
+			},
+		},
+	}
+
+	err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+		context.Background(),
+		request,
+		"group-1",
+		engine,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	expectedErrFragment := "start sign round returned unexpected signing participant"
+	if !strings.Contains(err.Error(), expectedErrFragment) {
+		t.Fatalf(
+			"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",
+			expectedErrFragment,
+			err,
+		)
+	}
+}
+
 func TestBuildTaggedTBTCSignerRoundKeyGroup(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -137,10 +137,11 @@ type buildTaggedTBTCSignerRunDKGResponse struct {
 }
 
 type buildTaggedTBTCSignerStartSignRoundRequest struct {
-	SessionID        string `json:"session_id"`
-	MemberIdentifier uint16 `json:"member_identifier"`
-	MessageHex       string `json:"message_hex"`
-	KeyGroup         string `json:"key_group"`
+	SessionID           string   `json:"session_id"`
+	MemberIdentifier    uint16   `json:"member_identifier"`
+	MessageHex          string   `json:"message_hex"`
+	KeyGroup            string   `json:"key_group"`
+	SigningParticipants []uint16 `json:"signing_participants,omitempty"`
 }
 
 type buildTaggedTBTCSignerStartSignRoundResponse struct {
@@ -148,6 +149,7 @@ type buildTaggedTBTCSignerStartSignRoundResponse struct {
 	RoundID               string                                          `json:"round_id"`
 	RequiredContributions uint16                                          `json:"required_contributions"`
 	MessageDigestHex      string                                          `json:"message_digest_hex"`
+	SigningParticipants   []uint16                                        `json:"signing_participants,omitempty"`
 	OwnContribution       *buildTaggedTBTCSignerFinalizeRoundContribution `json:"own_contribution"`
 }
 
@@ -217,12 +219,14 @@ func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	requestPayload, err := buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		sessionID,
 		memberIdentifier,
 		message,
 		keyGroup,
+		signingParticipants,
 	)
 	if err != nil {
 		return nil, err
@@ -402,6 +406,7 @@ func buildTaggedTBTCSignerStartSignRoundRequestPayload(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) ([]byte, error) {
 	if sessionID == "" {
 		return nil, buildTaggedTBTCSignerOperationError(
@@ -424,11 +429,29 @@ func buildTaggedTBTCSignerStartSignRoundRequestPayload(
 		)
 	}
 
+	seenParticipants := make(map[uint16]struct{}, len(signingParticipants))
+	for i, participant := range signingParticipants {
+		if participant == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf("signing participant [%d] is zero", i),
+			)
+		}
+		if _, ok := seenParticipants[participant]; ok {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf("signing participant [%d] is duplicated", participant),
+			)
+		}
+		seenParticipants[participant] = struct{}{}
+	}
+
 	request := buildTaggedTBTCSignerStartSignRoundRequest{
-		SessionID:        sessionID,
-		MemberIdentifier: memberIdentifier,
-		MessageHex:       hex.EncodeToString(message),
-		KeyGroup:         keyGroup,
+		SessionID:           sessionID,
+		MemberIdentifier:    memberIdentifier,
+		MessageHex:          hex.EncodeToString(message),
+		KeyGroup:            keyGroup,
+		SigningParticipants: append([]uint16{}, signingParticipants...),
 	}
 
 	payload, err := json.Marshal(request)
@@ -474,6 +497,25 @@ func decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		)
 	}
 
+	seenSigningParticipants := make(map[uint16]struct{}, len(response.SigningParticipants))
+	for _, participant := range response.SigningParticipants {
+		if participant == 0 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				"response signing participant is zero",
+			)
+		}
+
+		if _, ok := seenSigningParticipants[participant]; ok {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"StartSignRound",
+				fmt.Sprintf("response signing participant [%d] is duplicated", participant),
+			)
+		}
+
+		seenSigningParticipants[participant] = struct{}{}
+	}
+
 	var ownContribution *NativeTBTCSignerRoundContribution
 	if response.OwnContribution != nil {
 		if response.OwnContribution.Identifier == 0 {
@@ -514,6 +556,7 @@ func decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		RoundID:               response.RoundID,
 		RequiredContributions: response.RequiredContributions,
 		MessageDigestHex:      response.MessageDigestHex,
+		SigningParticipants:   append([]uint16{}, response.SigningParticipants...),
 		OwnContribution:       ownContribution,
 	}, nil
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -491,6 +491,69 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 	}
 }
 
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsZeroSigningParticipant(
+	t *testing.T,
+) {
+	_, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,0,3],"own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
+		),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsDuplicateSigningParticipant(
+	t *testing.T,
+) {
+	_, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,2,2],"own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
+		),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsZeroOwnContributionIdentifier(
+	t *testing.T,
+) {
+	_, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
+		[]byte(
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,2,3],"own_contribution":{"identifier":0,"signature_share_hex":"deadbeef"}}`,
+		),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+}
+
 func TestDecodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(t *testing.T) {
 	signature, err := decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
 		[]byte(`{"session_id":"session-1","round_id":"round-1","signature_hex":"deadbeef"}`),

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -30,6 +30,7 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 		1,
 		[]byte("message"),
 		"key-group",
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected unavailable tbtc-signer bridge error")
@@ -257,6 +258,7 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 		3,
 		[]byte{0xab, 0xcd},
 		"key-group-1",
+		[]uint16{1, 2, 3},
 	)
 	if err != nil {
 		t.Fatalf("unexpected payload build error: [%v]", err)
@@ -298,6 +300,26 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload(t *testing.T) {
 			request.MemberIdentifier,
 		)
 	}
+
+	if len(request.SigningParticipants) != 3 {
+		t.Fatalf(
+			"unexpected signing participants count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(request.SigningParticipants),
+		)
+	}
+
+	expectedSigningParticipants := []uint16{1, 2, 3}
+	for i := range expectedSigningParticipants {
+		if request.SigningParticipants[i] != expectedSigningParticipants[i] {
+			t.Fatalf(
+				"unexpected signing participant at index [%d]\nexpected: [%v]\nactual:   [%v]",
+				i,
+				expectedSigningParticipants[i],
+				request.SigningParticipants[i],
+			)
+		}
+	}
 }
 
 func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *testing.T) {
@@ -306,6 +328,7 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *tes
 		1,
 		[]byte{0xab},
 		"key-group-1",
+		nil,
 	)
 	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
 		t.Fatalf(
@@ -322,6 +345,7 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_ZeroMemberID(t *testi
 		0,
 		[]byte{0xab},
 		"key-group-1",
+		nil,
 	)
 	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
 		t.Fatalf(
@@ -387,7 +411,7 @@ func TestBuildTaggedTBTCSignerFinalizeSignRoundRequestPayload(t *testing.T) {
 func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 	roundState, err := decodeBuildTaggedTBTCSignerStartSignRoundResponse(
 		[]byte(
-			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
+			`{"session_id":"session-1","round_id":"round-1","required_contributions":2,"message_digest_hex":"abcd","signing_participants":[1,2,3],"own_contribution":{"identifier":3,"signature_share_hex":"deadbeef"}}`,
 		),
 	)
 	if err != nil {
@@ -423,6 +447,14 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse(t *testing.T) {
 			"unexpected message digest hex\nexpected: [%v]\nactual:   [%v]",
 			"abcd",
 			roundState.MessageDigestHex,
+		)
+	}
+
+	if len(roundState.SigningParticipants) != 3 {
+		t.Fatalf(
+			"unexpected signing participants count\nexpected: [%v]\nactual:   [%v]",
+			3,
+			len(roundState.SigningParticipants),
 		)
 	}
 

--- a/pkg/frost/signing/native_frost_protocol_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -149,6 +150,93 @@ func (dnfse *deterministicNativeFROSTSigningEngine) Aggregate(
 	return signatureDigest[:], nil
 }
 
+type recordingNativeFROSTSigningEngine struct {
+	deterministicNativeFROSTSigningEngine
+	mutex                     sync.Mutex
+	commitmentIDSnapshots     [][]string
+	signatureShareIDSnapshots [][]string
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) NewSigningPackage(
+	message []byte,
+	commitments []*NativeFROSTCommitment,
+) (*NativeFROSTSigningPackage, error) {
+	commitmentIDs := make([]string, 0, len(commitments))
+	for _, commitment := range commitments {
+		if commitment == nil {
+			commitmentIDs = append(commitmentIDs, "<nil>")
+			continue
+		}
+
+		commitmentIDs = append(commitmentIDs, commitment.Identifier)
+	}
+
+	rnfse.mutex.Lock()
+	rnfse.commitmentIDSnapshots = append(
+		rnfse.commitmentIDSnapshots,
+		append([]string{}, commitmentIDs...),
+	)
+	rnfse.mutex.Unlock()
+
+	return rnfse.deterministicNativeFROSTSigningEngine.NewSigningPackage(
+		message,
+		commitments,
+	)
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) Aggregate(
+	signingPackage *NativeFROSTSigningPackage,
+	signatureShares []*NativeFROSTSignatureShare,
+	publicKeyPackage *NativeFROSTPublicKeyPackage,
+) ([]byte, error) {
+	signatureShareIDs := make([]string, 0, len(signatureShares))
+	for _, signatureShare := range signatureShares {
+		if signatureShare == nil {
+			signatureShareIDs = append(signatureShareIDs, "<nil>")
+			continue
+		}
+
+		signatureShareIDs = append(signatureShareIDs, signatureShare.Identifier)
+	}
+
+	rnfse.mutex.Lock()
+	rnfse.signatureShareIDSnapshots = append(
+		rnfse.signatureShareIDSnapshots,
+		append([]string{}, signatureShareIDs...),
+	)
+	rnfse.mutex.Unlock()
+
+	return rnfse.deterministicNativeFROSTSigningEngine.Aggregate(
+		signingPackage,
+		signatureShares,
+		publicKeyPackage,
+	)
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) commitmentIDs() [][]string {
+	rnfse.mutex.Lock()
+	defer rnfse.mutex.Unlock()
+
+	snapshots := make([][]string, 0, len(rnfse.commitmentIDSnapshots))
+	for _, snapshot := range rnfse.commitmentIDSnapshots {
+		snapshots = append(snapshots, append([]string{}, snapshot...))
+	}
+
+	return snapshots
+}
+
+func (rnfse *recordingNativeFROSTSigningEngine) signatureShareIDs() [][]string {
+	rnfse.mutex.Lock()
+	defer rnfse.mutex.Unlock()
+
+	snapshots := make([][]string, 0, len(rnfse.signatureShareIDSnapshots))
+	for _, snapshot := range rnfse.signatureShareIDSnapshots {
+		snapshots = append(snapshots, append([]string{}, snapshot...))
+	}
+
+	return snapshots
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_NativeFROSTPath(
 	t *testing.T,
 ) {
@@ -231,6 +319,190 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_Nati
 	}
 }
 
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_NativeFROSTPath_AttemptVariationUsesCohortSelections(
+	t *testing.T,
+) {
+	engine := &recordingNativeFROSTSigningEngine{}
+	RegisterNativeFROSTSigningEngine(engine)
+	t.Cleanup(UnregisterNativeFROSTSigningEngine)
+
+	provider := local.Connect()
+	channel, err := provider.BroadcastChannelFor("native-frost-signing-protocol-attempt-variation-test")
+	if err != nil {
+		t.Fatalf("failed creating broadcast channel: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+	primitive.RegisterUnmarshallers(channel)
+
+	runRound := func(
+		sessionID string,
+		includedMembers []group.MemberIndex,
+		groupSize int,
+	) []*frost.Signature {
+		requests := make([]*NativeExecutionFFISigningRequest, len(includedMembers))
+		for i := 0; i < len(includedMembers); i++ {
+			memberIndex := includedMembers[i]
+
+			request, roundErr := newNativeFROSTSigningRequestWithSessionForTest(
+				memberIndex,
+				includedMembers,
+				channel,
+				groupSize,
+				sessionID,
+			)
+			if roundErr != nil {
+				t.Fatalf(
+					"failed preparing request for member [%v] in session [%s]: [%v]",
+					memberIndex,
+					sessionID,
+					roundErr,
+				)
+			}
+
+			requests[i] = request
+		}
+
+		ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancelCtx()
+
+		results := make([]*frostSignatureResultForTest, len(includedMembers))
+		var wg sync.WaitGroup
+		wg.Add(len(includedMembers))
+
+		for i := 0; i < len(includedMembers); i++ {
+			go func(index int) {
+				defer wg.Done()
+
+				signature, signErr := primitive.Sign(ctx, nil, requests[index])
+				results[index] = &frostSignatureResultForTest{
+					signature: signature,
+					err:       signErr,
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		signatures := make([]*frost.Signature, len(includedMembers))
+		for i := 0; i < len(includedMembers); i++ {
+			if results[i] == nil {
+				t.Fatalf(
+					"missing signing result for member [%v] in session [%s]",
+					includedMembers[i],
+					sessionID,
+				)
+			}
+
+			if results[i].err != nil {
+				t.Fatalf(
+					"unexpected signing error for member [%v] in session [%s]: [%v]",
+					includedMembers[i],
+					sessionID,
+					results[i].err,
+				)
+			}
+
+			if results[i].signature == nil {
+				t.Fatalf(
+					"nil signature for member [%v] in session [%s]",
+					includedMembers[i],
+					sessionID,
+				)
+			}
+
+			signatures[i] = results[i].signature
+		}
+
+		return signatures
+	}
+
+	assertSignaturesMatch := func(
+		sessionID string,
+		signatures []*frost.Signature,
+	) {
+		if len(signatures) == 0 {
+			t.Fatalf("no signatures for session [%s]", sessionID)
+		}
+
+		for i := 1; i < len(signatures); i++ {
+			if !signatures[0].Equals(signatures[i]) {
+				t.Fatalf(
+					"signature mismatch in session [%s]\nfirst:  [%v]\nsecond: [%v]",
+					sessionID,
+					signatures[0],
+					signatures[i],
+				)
+			}
+		}
+	}
+
+	roundOneSignatures := runRound(
+		"native-frost-signing-session-attempt-1",
+		[]group.MemberIndex{1, 2, 3},
+		3,
+	)
+	assertSignaturesMatch("native-frost-signing-session-attempt-1", roundOneSignatures)
+
+	roundTwoSignatures := runRound(
+		"native-frost-signing-session-attempt-2",
+		[]group.MemberIndex{1, 3},
+		3,
+	)
+	assertSignaturesMatch("native-frost-signing-session-attempt-2", roundTwoSignatures)
+
+	snapshotHistogram := func(snapshots [][]string) map[string]int {
+		histogram := make(map[string]int)
+		for _, snapshot := range snapshots {
+			histogram[strings.Join(snapshot, ",")]++
+		}
+
+		return histogram
+	}
+
+	expectedHistogram := map[string]int{
+		"member-1,member-2,member-3": 3,
+		"member-1,member-3":          2,
+	}
+
+	assertHistogram := func(name string, actual map[string]int) {
+		if len(actual) != len(expectedHistogram) {
+			t.Fatalf(
+				"unexpected %s histogram size\nexpected: [%v]\nactual:   [%v]",
+				name,
+				len(expectedHistogram),
+				len(actual),
+			)
+		}
+
+		for key, expectedCount := range expectedHistogram {
+			actualCount, ok := actual[key]
+			if !ok {
+				t.Fatalf("missing %s histogram key: [%s]", name, key)
+			}
+
+			if actualCount != expectedCount {
+				t.Fatalf(
+					"unexpected %s count for key [%s]\nexpected: [%v]\nactual:   [%v]",
+					name,
+					key,
+					expectedCount,
+					actualCount,
+				)
+			}
+		}
+	}
+
+	assertHistogram(
+		"commitment IDs",
+		snapshotHistogram(engine.commitmentIDs()),
+	)
+	assertHistogram(
+		"signature share IDs",
+		snapshotHistogram(engine.signatureShareIDs()),
+	)
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_NativeFROSTPathWithoutEngine(
 	t *testing.T,
 ) {
@@ -281,6 +553,22 @@ func newNativeFROSTSigningRequestForTest(
 	channel net.BroadcastChannel,
 	groupSize int,
 ) (*NativeExecutionFFISigningRequest, error) {
+	return newNativeFROSTSigningRequestWithSessionForTest(
+		memberIndex,
+		includedMembers,
+		channel,
+		groupSize,
+		"native-frost-signing-session",
+	)
+}
+
+func newNativeFROSTSigningRequestWithSessionForTest(
+	memberIndex group.MemberIndex,
+	includedMembers []group.MemberIndex,
+	channel net.BroadcastChannel,
+	groupSize int,
+	sessionID string,
+) (*NativeExecutionFFISigningRequest, error) {
 	keyPackage := &NativeFROSTKeyPackage{
 		Identifier: fmt.Sprintf("member-%v", memberIndex),
 		Data: []byte{
@@ -307,7 +595,7 @@ func newNativeFROSTSigningRequestForTest(
 
 	return &NativeExecutionFFISigningRequest{
 		Message:            bigOneForTest(),
-		SessionID:          "native-frost-signing-session",
+		SessionID:          sessionID,
 		MemberIndex:        memberIndex,
 		GroupSize:          groupSize,
 		DishonestThreshold: 1,

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -30,12 +30,12 @@ type NativeTBTCSignerRoundContribution struct {
 // NativeTBTCSignerRoundState captures coarse session round metadata returned by
 // StartSignRound.
 type NativeTBTCSignerRoundState struct {
-	SessionID             string `json:"sessionID"`
-	RoundID               string `json:"roundID"`
-	RequiredContributions uint16 `json:"requiredContributions"`
-	MessageDigestHex      string `json:"messageDigestHex"`
-	SigningParticipants   []uint16
-	OwnContribution       *NativeTBTCSignerRoundContribution
+	SessionID             string                             `json:"sessionID"`
+	RoundID               string                             `json:"roundID"`
+	RequiredContributions uint16                             `json:"requiredContributions"`
+	MessageDigestHex      string                             `json:"messageDigestHex"`
+	SigningParticipants   []uint16                           `json:"signingParticipants"`
+	OwnContribution       *NativeTBTCSignerRoundContribution `json:"ownContribution"`
 }
 
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -51,6 +51,7 @@ type NativeTBTCSignerRoundState struct {
 	RoundID               string `json:"roundID"`
 	RequiredContributions uint16 `json:"requiredContributions"`
 	MessageDigestHex      string `json:"messageDigestHex"`
+	SigningParticipants   []uint16
 	OwnContribution       *NativeTBTCSignerRoundContribution
 }
 
@@ -67,6 +68,7 @@ type NativeTBTCSignerEngine interface {
 		memberIdentifier uint16,
 		message []byte,
 		keyGroup string,
+		signingParticipants []uint16,
 	) (*NativeTBTCSignerRoundState, error)
 	FinalizeSignRound(
 		sessionID string,

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -4,23 +4,6 @@ package signing
 
 import "fmt"
 
-const (
-	// NativeSignerMaterialFormatFrostTBTCSignerV1 carries signer material for
-	// tbtc-signer coarse session APIs.
-	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
-	// NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey marks scaffold-era
-	// key-group derivation from the legacy wallet public key.
-	NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey = "legacy-wallet-pubkey"
-)
-
-// NativeTBTCSignerMaterialPayload is the signer-material payload schema for
-// `frost-tbtc-signer-v1`.
-type NativeTBTCSignerMaterialPayload struct {
-	KeyGroup                 string `json:"keyGroup"`
-	KeyGroupSource           string `json:"keyGroupSource,omitempty"`
-	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
-}
-
 // NativeTBTCSignerDKGParticipant identifies a DKG participant for coarse
 // tbtc-signer RunDKG operation.
 type NativeTBTCSignerDKGParticipant struct {

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -22,8 +22,10 @@ func (mntse *mockNativeTBTCSignerEngine) StartSignRound(
 	memberIdentifier uint16,
 	message []byte,
 	keyGroup string,
+	signingParticipants []uint16,
 ) (*NativeTBTCSignerRoundState, error) {
 	_ = memberIdentifier
+	_ = signingParticipants
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/frost/signing/native_tbtc_signer_material.go
+++ b/pkg/frost/signing/native_tbtc_signer_material.go
@@ -1,0 +1,18 @@
+package signing
+
+const (
+	// NativeSignerMaterialFormatFrostTBTCSignerV1 carries signer material for
+	// tbtc-signer coarse session APIs.
+	NativeSignerMaterialFormatFrostTBTCSignerV1 = "frost-tbtc-signer-v1"
+	// NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey marks scaffold-era
+	// key-group derivation from the legacy wallet public key.
+	NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey = "legacy-wallet-pubkey"
+)
+
+// NativeTBTCSignerMaterialPayload is the signer-material payload schema for
+// `frost-tbtc-signer-v1`.
+type NativeTBTCSignerMaterialPayload struct {
+	KeyGroup                 string `json:"keyGroup"`
+	KeyGroupSource           string `json:"keyGroupSource,omitempty"`
+	LegacyPrivateKeyShareHex string `json:"legacyPrivateKeyShareHex,omitempty"`
+}

--- a/pkg/frost/signing/request.go
+++ b/pkg/frost/signing/request.go
@@ -11,9 +11,9 @@ import (
 
 // Request carries execution input for a FROST signing backend.
 type Request struct {
-	Message             *big.Int
-	SessionID           string
-	MemberIndex         group.MemberIndex
+	Message     *big.Int
+	SessionID   string
+	MemberIndex group.MemberIndex
 	// SignerMaterial carries backend-specific signer material.
 	// Legacy backend expects *tecdsa.PrivateKeyShare.
 	SignerMaterial any

--- a/pkg/tbtc/marshaling_test.go
+++ b/pkg/tbtc/marshaling_test.go
@@ -26,9 +26,7 @@ func TestSignerMarshalling(t *testing.T) {
 	if err := pbutils.RoundTrip(marshaled, unmarshaled); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(marshaled, unmarshaled) {
-		t.Fatal("unexpected content of unmarshaled signer")
-	}
+	assertSignerEquivalent(t, "unmarshaled signer", marshaled, unmarshaled)
 }
 
 func TestSignerMarshalling_NonTECDSAKey(t *testing.T) {

--- a/pkg/tbtc/node_test.go
+++ b/pkg/tbtc/node_test.go
@@ -100,9 +100,7 @@ func TestNode_GetSigningExecutor(t *testing.T) {
 		len(executor.signers),
 	)
 
-	if !reflect.DeepEqual(signer, executor.signers[0]) {
-		t.Errorf("executor holds an unexpected signer")
-	}
+	assertSignerEquivalent(t, "executor signer", signer, executor.signers[0])
 
 	expectedChannel := fmt.Sprintf(
 		"%s-%s",

--- a/pkg/tbtc/registry_test.go
+++ b/pkg/tbtc/registry_test.go
@@ -283,9 +283,12 @@ func TestWalletRegistry_PrePopulateWalletCache(t *testing.T) {
 		len(walletRegistry.walletCache[walletStorageKey].signers),
 	)
 
-	if !reflect.DeepEqual(signer, walletRegistry.walletCache[walletStorageKey].signers[0]) {
-		t.Errorf("loaded wallet signer differs from the original one")
-	}
+	assertSignerEquivalent(
+		t,
+		"pre-populated wallet signer",
+		signer,
+		walletRegistry.walletCache[walletStorageKey].signers[0],
+	)
 }
 
 func TestWalletRegistry_GetWalletsPublicKeys(t *testing.T) {
@@ -459,9 +462,12 @@ func TestWalletStorage_LoadSigners(t *testing.T) {
 		len(signersByWallet[walletStorageKey]),
 	)
 
-	if !reflect.DeepEqual(signer, signersByWallet[walletStorageKey][0]) {
-		t.Errorf("loaded wallet signer differs from the original one")
-	}
+	assertSignerEquivalent(
+		t,
+		"loaded wallet signer",
+		signer,
+		signersByWallet[walletStorageKey][0],
+	)
 }
 
 func TestWalletStorage_ArchiveWallet(t *testing.T) {

--- a/pkg/tbtc/signer_equivalence_test.go
+++ b/pkg/tbtc/signer_equivalence_test.go
@@ -1,0 +1,82 @@
+package tbtc
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func assertSignerEquivalent(
+	t *testing.T,
+	name string,
+	expected *signer,
+	actual *signer,
+) {
+	t.Helper()
+
+	if expected == nil {
+		if actual != nil {
+			t.Fatalf("%s should be nil", name)
+		}
+		return
+	}
+
+	if actual == nil {
+		t.Fatalf("%s is nil", name)
+	}
+
+	if !expected.wallet.publicKey.Equal(actual.wallet.publicKey) {
+		t.Fatalf("%s has unexpected wallet public key", name)
+	}
+
+	if !reflect.DeepEqual(
+		expected.wallet.signingGroupOperators,
+		actual.wallet.signingGroupOperators,
+	) {
+		t.Fatalf(
+			"%s has unexpected signing group operators\nexpected: [%v]\nactual:   [%v]",
+			name,
+			expected.wallet.signingGroupOperators,
+			actual.wallet.signingGroupOperators,
+		)
+	}
+
+	if expected.signingGroupMemberIndex != actual.signingGroupMemberIndex {
+		t.Fatalf(
+			"%s has unexpected member index\nexpected: [%v]\nactual:   [%v]",
+			name,
+			expected.signingGroupMemberIndex,
+			actual.signingGroupMemberIndex,
+		)
+	}
+
+	if expected.privateKeyShare == nil {
+		if actual.privateKeyShare != nil {
+			t.Fatalf("%s should have nil private key share", name)
+		}
+		return
+	}
+
+	if actual.privateKeyShare == nil {
+		t.Fatalf("%s has nil private key share", name)
+	}
+
+	expectedPrivateKeyShare, err := expected.privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal expected private key share for %s: [%v]", name, err)
+	}
+
+	actualPrivateKeyShare, err := actual.privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal actual private key share for %s: [%v]", name, err)
+	}
+
+	if !bytes.Equal(expectedPrivateKeyShare, actualPrivateKeyShare) {
+		t.Fatalf(
+			"%s has unexpected private key share\nexpected: [%x]\nactual:   [%x]",
+			name,
+			expectedPrivateKeyShare,
+			actualPrivateKeyShare,
+		)
+	}
+}

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -10,7 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/frost"
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
 	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 type countingNativeExecutionFFISigningPrimitive struct {
@@ -26,6 +30,17 @@ type countingNativeExecutionFFISigningPrimitive struct {
 
 type deterministicNativeExecutionFFISigningPrimitiveForTBTC struct {
 	signCalls atomic.Int64
+}
+
+type attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC struct {
+	signCalls atomic.Int64
+	mutex     sync.Mutex
+	records   []attemptTrackingRecordForTBTC
+}
+
+type attemptTrackingRecordForTBTC struct {
+	attemptNumber       uint
+	includedMemberIndex []group.MemberIndex
 }
 
 var deterministicNativeFROSTSignatureForTBTC = [frost.SignatureSize]byte{
@@ -87,6 +102,87 @@ func (dnefspf *deterministicNativeExecutionFFISigningPrimitiveForTBTC) Sign(
 func (dnefspf *deterministicNativeExecutionFFISigningPrimitiveForTBTC) RegisterUnmarshallers(
 	channel net.BroadcastChannel,
 ) {
+}
+
+func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) Sign(
+	ctx context.Context,
+	logger log.StandardLogger,
+	request *frostsigning.NativeExecutionFFISigningRequest,
+) (*frost.Signature, error) {
+	atnefspf.signCalls.Add(1)
+
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	if request.Attempt == nil {
+		return nil, fmt.Errorf("request attempt is nil")
+	}
+
+	atnefspf.mutex.Lock()
+	atnefspf.records = append(
+		atnefspf.records,
+		attemptTrackingRecordForTBTC{
+			attemptNumber: request.Attempt.Number,
+			includedMemberIndex: append(
+				[]group.MemberIndex{},
+				request.Attempt.IncludedMembersIndexes...,
+			),
+		},
+	)
+	atnefspf.mutex.Unlock()
+
+	// Force retry-loop progression so the next attempt is exercised.
+	if request.Attempt.Number == 1 {
+		return nil, fmt.Errorf("forced attempt failure")
+	}
+
+	signature := &frost.Signature{}
+	if err := signature.Unmarshal(deterministicNativeFROSTSignatureForTBTC[:]); err != nil {
+		return nil, err
+	}
+
+	return signature, nil
+}
+
+func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) RegisterUnmarshallers(
+	channel net.BroadcastChannel,
+) {
+}
+
+func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) uniqueCohortsByAttempt() map[uint][][]group.MemberIndex {
+	atnefspf.mutex.Lock()
+	defer atnefspf.mutex.Unlock()
+
+	result := make(map[uint][][]group.MemberIndex)
+	seen := make(map[uint]map[string]struct{})
+
+	for _, record := range atnefspf.records {
+		if seen[record.attemptNumber] == nil {
+			seen[record.attemptNumber] = make(map[string]struct{})
+		}
+
+		keyParts := make([]string, 0, len(record.includedMemberIndex))
+		for _, memberIndex := range record.includedMemberIndex {
+			keyParts = append(
+				keyParts,
+				strconv.FormatUint(uint64(memberIndex), 10),
+			)
+		}
+		cohortKey := strings.Join(keyParts, ",")
+
+		if _, ok := seen[record.attemptNumber][cohortKey]; ok {
+			continue
+		}
+
+		seen[record.attemptNumber][cohortKey] = struct{}{}
+		result[record.attemptNumber] = append(
+			result[record.attemptNumber],
+			append([]group.MemberIndex{}, record.includedMemberIndex...),
+		)
+	}
+
+	return result
 }
 
 func TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter(t *testing.T) {
@@ -342,6 +438,118 @@ func TestSigningExecutor_Sign_NativeBackend_FallsBackWhenOnlyLegacySignerMateria
 		new(big.Int).SetBytes(signature.S[:]),
 	) {
 		t.Fatalf("invalid signature: [%+v]", signature)
+	}
+
+	if endBlock <= startBlock {
+		t.Fatal("wrong end block")
+	}
+}
+
+func TestSigningExecutor_Sign_FFIStrictBackend_AttemptVariationChangesCohortSelection(
+	t *testing.T,
+) {
+	executor := setupSigningExecutor(t)
+	configureSignersWithNativeFROSTUniFFIV2Material(t, executor)
+
+	primitive := &attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC{}
+
+	frostsigning.ResetExecutionBackend()
+	frostsigning.UnregisterNativeExecutionAdapter()
+	frostsigning.UnregisterNativeExecutionBridge()
+	frostsigning.UnregisterNativeExecutionFFIExecutor()
+	frostsigning.RegisterNativeExecutionAdapterForBuild()
+	err := frostsigning.RegisterNativeExecutionFFISigningPrimitive(primitive)
+	if err != nil {
+		t.Fatalf("unexpected native FFI primitive registration error: [%v]", err)
+	}
+	t.Cleanup(frostsigning.ResetExecutionBackend)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionAdapter)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionBridge)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionFFIExecutor)
+
+	err = configureFrostSigningBackend(Config{FrostSigningBackend: "ffi"})
+	if err != nil {
+		t.Fatalf("unexpected strict ffi backend config error: [%v]", err)
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	message := big.NewInt(100)
+	startBlock := uint64(0)
+
+	signature, _, endBlock, err := executor.sign(ctx, message, startBlock)
+	if err != nil {
+		t.Fatalf("unexpected strict ffi signing error: [%v]", err)
+	}
+
+	signatureBytes, err := signature.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal signature: [%v]", err)
+	}
+
+	if !bytes.Equal(signatureBytes, deterministicNativeFROSTSignatureForTBTC[:]) {
+		t.Fatalf(
+			"unexpected native FROST signature\nexpected: [%x]\nactual:   [%x]",
+			deterministicNativeFROSTSignatureForTBTC[:],
+			signatureBytes,
+		)
+	}
+
+	if primitive.signCalls.Load() == 0 {
+		t.Fatal("expected native FFI primitive sign call")
+	}
+
+	cohortsByAttempt := primitive.uniqueCohortsByAttempt()
+	attemptOneCohorts, ok := cohortsByAttempt[1]
+	if !ok {
+		t.Fatal("expected observed cohort for attempt 1")
+	}
+	if len(attemptOneCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptOneCohorts),
+		)
+	}
+
+	attemptTwoCohorts, ok := cohortsByAttempt[2]
+	if !ok {
+		t.Fatal("expected observed cohort for attempt 2")
+	}
+	if len(attemptTwoCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptTwoCohorts),
+		)
+	}
+
+	attemptOneCohort := attemptOneCohorts[0]
+	attemptTwoCohort := attemptTwoCohorts[0]
+
+	expectedCohortSize := executor.groupParameters.HonestThreshold
+	if len(attemptOneCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptOneCohort),
+		)
+	}
+	if len(attemptTwoCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptTwoCohort),
+		)
+	}
+
+	if reflect.DeepEqual(attemptOneCohort, attemptTwoCohort) {
+		t.Fatalf(
+			"expected cohort variation across attempts\nattempt 1: [%v]\nattempt 2: [%v]",
+			attemptOneCohort,
+			attemptTwoCohort,
+		)
 	}
 
 	if endBlock <= startBlock {

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +42,11 @@ type attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC struct {
 type attemptTrackingRecordForTBTC struct {
 	attemptNumber       uint
 	includedMemberIndex []group.MemberIndex
+}
+
+type attemptTrackingNativeTBTCSignerEngineForTBTC struct {
+	mutex                 sync.Mutex
+	startCohortsByAttempt map[uint][][]uint16
 }
 
 var deterministicNativeFROSTSignatureForTBTC = [frost.SignatureSize]byte{
@@ -183,6 +189,137 @@ func (atnefspf *attemptTrackingNativeExecutionFFISigningPrimitiveForTBTC) unique
 	}
 
 	return result
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) Version() (string, error) {
+	return "tbtc-signer/0.1.0-bootstrap", nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) RunDKG(
+	sessionID string,
+	participants []frostsigning.NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+) (*frostsigning.NativeTBTCSignerDKGResult, error) {
+	return &frostsigning.NativeTBTCSignerDKGResult{
+		SessionID:        sessionID,
+		KeyGroup:         "group-1",
+		ParticipantCount: uint16(len(participants)),
+		Threshold:        threshold,
+		CreatedAtUnix:    1,
+	}, nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) StartSignRound(
+	sessionID string,
+	memberIdentifier uint16,
+	message []byte,
+	keyGroup string,
+	signingParticipants []uint16,
+) (*frostsigning.NativeTBTCSignerRoundState, error) {
+	attemptNumber, err := attemptNumberFromSessionIDForTBTC(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if keyGroup == "" {
+		return nil, fmt.Errorf("key group is empty")
+	}
+
+	if memberIdentifier == 0 {
+		return nil, fmt.Errorf("member identifier is zero")
+	}
+
+	if len(message) == 0 {
+		return nil, fmt.Errorf("message is empty")
+	}
+
+	if len(signingParticipants) == 0 {
+		return nil, fmt.Errorf("signing participants are empty")
+	}
+
+	atntsfe.mutex.Lock()
+	if atntsfe.startCohortsByAttempt == nil {
+		atntsfe.startCohortsByAttempt = make(map[uint][][]uint16)
+	}
+
+	cohort := append([]uint16{}, signingParticipants...)
+	atntsfe.startCohortsByAttempt[attemptNumber] = append(
+		atntsfe.startCohortsByAttempt[attemptNumber],
+		cohort,
+	)
+	atntsfe.mutex.Unlock()
+
+	return &frostsigning.NativeTBTCSignerRoundState{
+		SessionID:             sessionID,
+		RoundID:               fmt.Sprintf("round-%v", attemptNumber),
+		RequiredContributions: uint16(len(signingParticipants)),
+		MessageDigestHex:      "00",
+		SigningParticipants:   append([]uint16{}, signingParticipants...),
+		OwnContribution: &frostsigning.NativeTBTCSignerRoundContribution{
+			Identifier: memberIdentifier,
+			Data:       []byte{byte(memberIdentifier), byte(attemptNumber)},
+		},
+	}, nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) FinalizeSignRound(
+	sessionID string,
+	roundContributions []frostsigning.NativeTBTCSignerRoundContribution,
+) ([]byte, error) {
+	if _, err := attemptNumberFromSessionIDForTBTC(sessionID); err != nil {
+		return nil, err
+	}
+
+	if len(roundContributions) == 0 {
+		return nil, fmt.Errorf("round contributions are empty")
+	}
+
+	return []byte{0xaa}, nil
+}
+
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) uniqueStartCohortsByAttempt() map[uint][][]uint16 {
+	atntsfe.mutex.Lock()
+	defer atntsfe.mutex.Unlock()
+
+	result := make(map[uint][][]uint16)
+	seen := make(map[uint]map[string]struct{})
+
+	for attemptNumber, cohorts := range atntsfe.startCohortsByAttempt {
+		if seen[attemptNumber] == nil {
+			seen[attemptNumber] = make(map[string]struct{})
+		}
+
+		for _, cohort := range cohorts {
+			parts := make([]string, 0, len(cohort))
+			for _, participant := range cohort {
+				parts = append(parts, strconv.FormatUint(uint64(participant), 10))
+			}
+			key := strings.Join(parts, ",")
+
+			if _, ok := seen[attemptNumber][key]; ok {
+				continue
+			}
+
+			seen[attemptNumber][key] = struct{}{}
+			result[attemptNumber] = append(result[attemptNumber], append([]uint16{}, cohort...))
+		}
+	}
+
+	return result
+}
+
+func attemptNumberFromSessionIDForTBTC(sessionID string) (uint, error) {
+	separatorIndex := strings.LastIndex(sessionID, "-")
+	if separatorIndex < 0 || separatorIndex == len(sessionID)-1 {
+		return 0, fmt.Errorf("invalid session id format: [%s]", sessionID)
+	}
+
+	attemptNumber, err := strconv.ParseUint(sessionID[separatorIndex+1:], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse attempt number from session id [%s]: [%w]", sessionID, err)
+	}
+
+	return uint(attemptNumber), nil
 }
 
 func TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter(t *testing.T) {
@@ -557,6 +694,152 @@ func TestSigningExecutor_Sign_FFIStrictBackend_AttemptVariationChangesCohortSele
 	}
 }
 
+func TestSigningExecutor_Sign_FFIStrictBackend_TBTCSignerPath_AttemptVariationChangesCohortSelection(
+	t *testing.T,
+) {
+	executor := setupSigningExecutor(t)
+	configureSignersWithTBTCSignerMaterial(t, executor, 3)
+
+	nativeTBTCSignerEngine := &attemptTrackingNativeTBTCSignerEngineForTBTC{}
+
+	frostsigning.UnregisterNativeTBTCSignerEngine()
+	frostsigning.UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerFallbackObserver)
+
+	err := frostsigning.RegisterNativeTBTCSignerEngine(nativeTBTCSignerEngine)
+	if err != nil {
+		t.Fatalf("unexpected native tbtc-signer engine registration error: [%v]", err)
+	}
+
+	var fallbackEvents []frostsigning.NativeTBTCSignerFallbackEvent
+	err = frostsigning.RegisterNativeTBTCSignerFallbackObserver(
+		func(event frostsigning.NativeTBTCSignerFallbackEvent) {
+			fallbackEvents = append(fallbackEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected fallback observer registration error: [%v]", err)
+	}
+
+	frostsigning.ResetExecutionBackend()
+	frostsigning.UnregisterNativeExecutionAdapter()
+	frostsigning.UnregisterNativeExecutionBridge()
+	frostsigning.UnregisterNativeExecutionFFIExecutor()
+	frostsigning.RegisterNativeExecutionAdapterForBuild()
+	t.Cleanup(frostsigning.ResetExecutionBackend)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionAdapter)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionBridge)
+	t.Cleanup(frostsigning.UnregisterNativeExecutionFFIExecutor)
+
+	err = configureFrostSigningBackend(Config{FrostSigningBackend: "ffi"})
+	if err != nil {
+		t.Fatalf("unexpected strict ffi backend config error: [%v]", err)
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	message := big.NewInt(100)
+	startBlock := uint64(0)
+
+	signature, _, endBlock, err := executor.sign(ctx, message, startBlock)
+	if err != nil {
+		t.Fatalf("unexpected strict ffi tbtc-signer-path signing error: [%v]", err)
+	}
+
+	walletPublicKey := executor.wallet().publicKey
+	if !ecdsa.Verify(
+		walletPublicKey,
+		message.Bytes(),
+		new(big.Int).SetBytes(signature.R[:]),
+		new(big.Int).SetBytes(signature.S[:]),
+	) {
+		t.Fatalf("invalid signature: [%+v]", signature)
+	}
+
+	cohortsByAttempt := nativeTBTCSignerEngine.uniqueStartCohortsByAttempt()
+	attemptOneCohorts, ok := cohortsByAttempt[1]
+	if !ok {
+		t.Fatal("expected observed StartSignRound cohort for attempt 1")
+	}
+	if len(attemptOneCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptOneCohorts),
+		)
+	}
+
+	attemptTwoCohorts, ok := cohortsByAttempt[2]
+	if !ok {
+		t.Fatal("expected observed StartSignRound cohort for attempt 2")
+	}
+	if len(attemptTwoCohorts) != 1 {
+		t.Fatalf(
+			"unexpected unique cohort count for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(attemptTwoCohorts),
+		)
+	}
+
+	attemptOneCohort := attemptOneCohorts[0]
+	attemptTwoCohort := attemptTwoCohorts[0]
+
+	expectedCohortSize := executor.groupParameters.HonestThreshold
+	if len(attemptOneCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 1\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptOneCohort),
+		)
+	}
+	if len(attemptTwoCohort) != expectedCohortSize {
+		t.Fatalf(
+			"unexpected cohort size for attempt 2\nexpected: [%d]\nactual:   [%d]",
+			expectedCohortSize,
+			len(attemptTwoCohort),
+		)
+	}
+
+	if !containsParticipantForTBTC(attemptOneCohort, 3) {
+		t.Fatalf(
+			"expected attempt 1 cohort to include broken signer member 3\nactual: [%v]",
+			attemptOneCohort,
+		)
+	}
+
+	if containsParticipantForTBTC(attemptTwoCohort, 3) {
+		t.Fatalf(
+			"expected attempt 2 cohort to exclude broken signer member 3\nactual: [%v]",
+			attemptTwoCohort,
+		)
+	}
+
+	if reflect.DeepEqual(attemptOneCohort, attemptTwoCohort) {
+		t.Fatalf(
+			"expected cohort variation across attempts\nattempt 1: [%v]\nattempt 2: [%v]",
+			attemptOneCohort,
+			attemptTwoCohort,
+		)
+	}
+
+	missingLegacyFallbackObserved := false
+	for _, event := range fallbackEvents {
+		if !event.LegacyPrivateKeyShareExists {
+			missingLegacyFallbackObserved = true
+			break
+		}
+	}
+	if !missingLegacyFallbackObserved {
+		t.Fatal("expected at least one fallback event without legacy private key share")
+	}
+
+	if endBlock <= startBlock {
+		t.Fatal("wrong end block")
+	}
+}
+
 func configureSignersWithNativeFROSTUniFFIV2Material(
 	t *testing.T,
 	executor *signingExecutor,
@@ -592,4 +875,48 @@ func configureSignersWithNativeFROSTUniFFIV2Material(
 			Payload: payload,
 		}
 	}
+}
+
+func configureSignersWithTBTCSignerMaterial(
+	t *testing.T,
+	executor *signingExecutor,
+	brokenMemberIndex group.MemberIndex,
+) {
+	t.Helper()
+
+	for _, signer := range executor.signers {
+		legacyPrivateKeyShareHex := ""
+		if signer.signingGroupMemberIndex != brokenMemberIndex {
+			legacyPrivateKeySharePayload, err := signer.privateKeyShare.Marshal()
+			if err != nil {
+				t.Fatalf("cannot marshal private key share: [%v]", err)
+			}
+
+			legacyPrivateKeyShareHex = hex.EncodeToString(legacyPrivateKeySharePayload)
+		}
+
+		payload, err := json.Marshal(frostsigning.NativeTBTCSignerMaterialPayload{
+			KeyGroup:                 "group-1",
+			KeyGroupSource:           frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+			LegacyPrivateKeyShareHex: legacyPrivateKeyShareHex,
+		})
+		if err != nil {
+			t.Fatalf("cannot marshal tbtc-signer material payload: [%v]", err)
+		}
+
+		signer.signerMaterial = &frostsigning.NativeSignerMaterial{
+			Format:  frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: payload,
+		}
+	}
+}
+
+func containsParticipantForTBTC(cohort []uint16, memberIndex uint16) bool {
+	for _, participant := range cohort {
+		if participant == memberIndex {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -707,13 +707,8 @@ func TestSigningExecutor_Sign_FFIStrictBackend_TBTCSignerPath_AttemptVariationCh
 	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(frostsigning.UnregisterNativeTBTCSignerFallbackObserver)
 
-	err := frostsigning.RegisterNativeTBTCSignerEngine(nativeTBTCSignerEngine)
-	if err != nil {
-		t.Fatalf("unexpected native tbtc-signer engine registration error: [%v]", err)
-	}
-
 	var fallbackEvents []frostsigning.NativeTBTCSignerFallbackEvent
-	err = frostsigning.RegisterNativeTBTCSignerFallbackObserver(
+	err := frostsigning.RegisterNativeTBTCSignerFallbackObserver(
 		func(event frostsigning.NativeTBTCSignerFallbackEvent) {
 			fallbackEvents = append(fallbackEvents, event)
 		},
@@ -727,6 +722,10 @@ func TestSigningExecutor_Sign_FFIStrictBackend_TBTCSignerPath_AttemptVariationCh
 	frostsigning.UnregisterNativeExecutionBridge()
 	frostsigning.UnregisterNativeExecutionFFIExecutor()
 	frostsigning.RegisterNativeExecutionAdapterForBuild()
+	err = frostsigning.RegisterNativeTBTCSignerEngine(nativeTBTCSignerEngine)
+	if err != nil {
+		t.Fatalf("unexpected native tbtc-signer engine registration error: [%v]", err)
+	}
 	t.Cleanup(frostsigning.ResetExecutionBackend)
 	t.Cleanup(frostsigning.UnregisterNativeExecutionAdapter)
 	t.Cleanup(frostsigning.UnregisterNativeExecutionBridge)

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -1047,6 +1047,25 @@ func (lc *LocalChain) GetWallet(walletPublicKeyHash [20]byte) (
 	return data, nil
 }
 
+func (lc *LocalChain) WalletPublicKeyHashForWalletID(
+	walletID [32]byte,
+) ([20]byte, error) {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	for walletPublicKeyHash, walletData := range lc.walletChainData {
+		if walletData == nil {
+			continue
+		}
+
+		if walletData.WalletID == walletID || walletData.EcdsaWalletID == walletID {
+			return walletPublicKeyHash, nil
+		}
+	}
+
+	return [20]byte{}, fmt.Errorf("wallet public key hash for wallet ID not found")
+}
+
 func (lc *LocalChain) SetWallet(
 	walletPublicKeyHash [20]byte,
 	data *tbtc.WalletChainData,


### PR DESCRIPTION
## Summary
- extend the coarse native tbtc-signer engine contract to carry explicit `signingParticipants` into `StartSignRound`
- include `signing_participants` in bridge request/response payloads with validation for zero/duplicate identifiers
- derive signing participants from included members in the transitional bootstrap path and assert round-state consistency
- update signing tests to cover payload encoding/decoding and bootstrap cohort propagation

## Testing
- `GOCACHE=/tmp/keep-core-gocache go test -tags "frost_native frost_tbtc_signer" ./pkg/frost/signing -run "TestBuildTaggedTBTCSignerStartSignRoundRequestPayload|TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse|TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion|TestExecuteBuildTaggedTBTCSignerBootstrapCoarseRound_ExchangesContributionsOverChannel"`
- `GOCACHE=/tmp/keep-core-gocache go test -tags "frost_native frost_tbtc_signer" ./pkg/frost/signing`
- `GOCACHE=/tmp/keep-core-gocache go test -tags frost_native ./pkg/tbtc -run "TestSigningExecutor_Sign_NativeBackend|TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend"`