### PR TITLE
Cut over bootstrap tbtc-signer path to coarse signature output

### DIFF
--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -2,6 +2,7 @@ package bitcoin
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -307,6 +308,71 @@ func (tb *TransactionBuilder) TotalInputsValue() int64 {
 	}
 
 	return totalInputsValue
+}
+
+// UnsignedTransactionInput carries canonical unsigned input metadata extracted
+// from the builder state.
+type UnsignedTransactionInput struct {
+	TxIDHex   string
+	Vout      uint32
+	ValueSats uint64
+}
+
+// UnsignedTransactionOutput carries canonical unsigned output metadata
+// extracted from the builder state.
+type UnsignedTransactionOutput struct {
+	ScriptPubKeyHex string
+	ValueSats       uint64
+}
+
+// UnsignedTransactionIO returns canonical unsigned transaction input/output
+// metadata from the builder state.
+func (tb *TransactionBuilder) UnsignedTransactionIO() (
+	[]UnsignedTransactionInput,
+	[]UnsignedTransactionOutput,
+	error,
+) {
+	if len(tb.internal.TxIn) != len(tb.sigHashArgs) {
+		return nil, nil, fmt.Errorf(
+			"input metadata mismatch: [%d] tx inputs, [%d] sighash args",
+			len(tb.internal.TxIn),
+			len(tb.sigHashArgs),
+		)
+	}
+
+	inputs := make([]UnsignedTransactionInput, 0, len(tb.internal.TxIn))
+	for i, input := range tb.internal.TxIn {
+		value := tb.sigHashArgs[i].value
+		if value < 0 {
+			return nil, nil, fmt.Errorf("input [%d] value is negative", i)
+		}
+
+		inputs = append(
+			inputs,
+			UnsignedTransactionInput{
+				TxIDHex:   input.PreviousOutPoint.Hash.String(),
+				Vout:      input.PreviousOutPoint.Index,
+				ValueSats: uint64(value),
+			},
+		)
+	}
+
+	outputs := make([]UnsignedTransactionOutput, 0, len(tb.internal.TxOut))
+	for i, output := range tb.internal.TxOut {
+		if output.Value < 0 {
+			return nil, nil, fmt.Errorf("output [%d] value is negative", i)
+		}
+
+		outputs = append(
+			outputs,
+			UnsignedTransactionOutput{
+				ScriptPubKeyHex: hex.EncodeToString(output.PkScript),
+				ValueSats:       uint64(output.Value),
+			},
+		)
+	}
+
+	return inputs, outputs, nil
 }
 
 // inputSigHashArgs is a helper structure holding some arguments required to

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -333,15 +333,25 @@ func (tb *TransactionBuilder) ReplaceUnsignedTransaction(
 	replacedInternal.fromTransaction(transaction)
 
 	for i := range replacedInternal.TxIn {
-		if i >= len(previousInputs) {
-			break
-		}
-
 		previousInput := previousInputs[i]
 		replacedInput := replacedInternal.TxIn[i]
 
 		if previousInput == nil || replacedInput == nil {
 			continue
+		}
+
+		if len(replacedInput.SignatureScript) > 0 {
+			return fmt.Errorf(
+				"replacement transaction input [%d] has unexpected non-empty signature script",
+				i,
+			)
+		}
+
+		if len(replacedInput.Witness) > 0 {
+			return fmt.Errorf(
+				"replacement transaction input [%d] has unexpected non-empty witness",
+				i,
+			)
 		}
 
 		if tb.sigHashArgs[i].witness {

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -365,6 +365,11 @@ func (tb *TransactionBuilder) ReplaceUnsignedTransaction(
 	return nil
 }
 
+// UnsignedTransaction returns the current unsigned transaction builder state.
+func (tb *TransactionBuilder) UnsignedTransaction() *Transaction {
+	return tb.internal.toTransaction()
+}
+
 // UnsignedTransactionInput carries canonical unsigned input metadata extracted
 // from the builder state.
 type UnsignedTransactionInput struct {

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -310,6 +310,61 @@ func (tb *TransactionBuilder) TotalInputsValue() int64 {
 	return totalInputsValue
 }
 
+// ReplaceUnsignedTransaction replaces the internal unsigned transaction while
+// preserving per-input sighash metadata collected during builder input setup.
+func (tb *TransactionBuilder) ReplaceUnsignedTransaction(
+	transaction *Transaction,
+) error {
+	if transaction == nil {
+		return fmt.Errorf("transaction is nil")
+	}
+
+	if len(transaction.Inputs) != len(tb.sigHashArgs) {
+		return fmt.Errorf(
+			"input metadata mismatch: [%d] tx inputs, [%d] sighash args",
+			len(transaction.Inputs),
+			len(tb.sigHashArgs),
+		)
+	}
+
+	previousInputs := tb.internal.TxIn
+
+	replacedInternal := newInternalTransaction()
+	replacedInternal.fromTransaction(transaction)
+
+	for i := range replacedInternal.TxIn {
+		if i >= len(previousInputs) {
+			break
+		}
+
+		previousInput := previousInputs[i]
+		replacedInput := replacedInternal.TxIn[i]
+
+		if previousInput == nil || replacedInput == nil {
+			continue
+		}
+
+		if tb.sigHashArgs[i].witness {
+			if len(replacedInput.Witness) == 0 && len(previousInput.Witness) == 1 {
+				redeemScript := append([]byte{}, previousInput.Witness[0]...)
+				replacedInput.Witness = wire.TxWitness{redeemScript}
+			}
+		} else {
+			if len(replacedInput.SignatureScript) == 0 && len(previousInput.SignatureScript) > 0 {
+				replacedInput.SignatureScript = append(
+					[]byte{},
+					previousInput.SignatureScript...,
+				)
+			}
+		}
+	}
+
+	tb.internal = replacedInternal
+	tb.sigHashes = nil
+
+	return nil
+}
+
 // UnsignedTransactionInput carries canonical unsigned input metadata extracted
 // from the builder state.
 type UnsignedTransactionInput struct {

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -350,6 +350,8 @@ func (tb *TransactionBuilder) UnsignedTransactionIO() (
 		inputs = append(
 			inputs,
 			UnsignedTransactionInput{
+				// chainhash.Hash.String renders txid in standard Bitcoin display
+				// (RPC/explorer) byte order, i.e. reversed vs internal bytes.
 				TxIDHex:   input.PreviousOutPoint.Hash.String(),
 				Vout:      input.PreviousOutPoint.Index,
 				ValueSats: uint64(value),

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -222,8 +222,9 @@ func TestTransactionBuilder_UnsignedTransactionIO(t *testing.T) {
 
 	var txHash chainhash.Hash
 	for i := range txHash {
-		txHash[i] = 0x11
+		txHash[i] = byte(i + 1)
 	}
+	const expectedTxIDHex = "201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"
 
 	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 7), nil, nil))
 	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{value: 1234})
@@ -241,10 +242,10 @@ func TestTransactionBuilder_UnsignedTransactionIO(t *testing.T) {
 		t.Fatalf("unexpected input count: [%d]", len(inputs))
 	}
 
-	if inputs[0].TxIDHex != txHash.String() {
+	if inputs[0].TxIDHex != expectedTxIDHex {
 		t.Fatalf(
 			"unexpected input txid\nexpected: [%v]\nactual:   [%v]",
-			txHash.String(),
+			expectedTxIDHex,
 			inputs[0].TxIDHex,
 		)
 	}

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/keep-network/keep-core/internal/testutils"
 )
 
@@ -213,6 +215,101 @@ func TestTransactionBuilder_AddOutput(t *testing.T) {
 	builder.AddOutput(output)
 
 	assertInternalOutput(t, builder, 0, output)
+}
+
+func TestTransactionBuilder_UnsignedTransactionIO(t *testing.T) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	for i := range txHash {
+		txHash[i] = 0x11
+	}
+
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 7), nil, nil))
+	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{value: 1234})
+	builder.AddOutput(&TransactionOutput{
+		Value:           1000,
+		PublicKeyScript: hexToSlice(t, "0014deadbeef"),
+	})
+
+	inputs, outputs, err := builder.UnsignedTransactionIO()
+	if err != nil {
+		t.Fatalf("unexpected extraction error: [%v]", err)
+	}
+
+	if len(inputs) != 1 {
+		t.Fatalf("unexpected input count: [%d]", len(inputs))
+	}
+
+	if inputs[0].TxIDHex != txHash.String() {
+		t.Fatalf(
+			"unexpected input txid\nexpected: [%v]\nactual:   [%v]",
+			txHash.String(),
+			inputs[0].TxIDHex,
+		)
+	}
+
+	if inputs[0].Vout != 7 {
+		t.Fatalf("unexpected input vout: [%d]", inputs[0].Vout)
+	}
+
+	if inputs[0].ValueSats != 1234 {
+		t.Fatalf("unexpected input value: [%d]", inputs[0].ValueSats)
+	}
+
+	if len(outputs) != 1 {
+		t.Fatalf("unexpected output count: [%d]", len(outputs))
+	}
+
+	if outputs[0].ScriptPubKeyHex != "0014deadbeef" {
+		t.Fatalf(
+			"unexpected output script\nexpected: [%v]\nactual:   [%v]",
+			"0014deadbeef",
+			outputs[0].ScriptPubKeyHex,
+		)
+	}
+
+	if outputs[0].ValueSats != 1000 {
+		t.Fatalf("unexpected output value: [%d]", outputs[0].ValueSats)
+	}
+}
+
+func TestTransactionBuilder_UnsignedTransactionIO_RejectsNegativeInputValue(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{value: -1})
+	builder.AddOutput(&TransactionOutput{
+		Value:           1,
+		PublicKeyScript: hexToSlice(t, "0014aa"),
+	})
+
+	_, _, err := builder.UnsignedTransactionIO()
+	if err == nil {
+		t.Fatal("expected extraction error")
+	}
+}
+
+func TestTransactionBuilder_UnsignedTransactionIO_RejectsNegativeOutputValue(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{value: 1})
+	builder.AddOutput(&TransactionOutput{
+		Value:           -1,
+		PublicKeyScript: hexToSlice(t, "0014aa"),
+	})
+
+	_, _, err := builder.UnsignedTransactionIO()
+	if err == nil {
+		t.Fatal("expected extraction error")
+	}
 }
 
 // The goal of this test is making sure that the TransactionBuilder can

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -217,6 +217,163 @@ func TestTransactionBuilder_AddOutput(t *testing.T) {
 	assertInternalOutput(t, builder, 0, output)
 }
 
+func TestTransactionBuilder_ReplaceUnsignedTransaction(t *testing.T) {
+	builder := NewTransactionBuilder(nil)
+
+	var initialInputHash1 chainhash.Hash
+	var initialInputHash2 chainhash.Hash
+	initialInputHash1[0] = 0x11
+	initialInputHash2[0] = 0x22
+
+	builder.internal.AddTxIn(
+		wire.NewTxIn(
+			wire.NewOutPoint(&initialInputHash1, 1),
+			[]byte{0xde, 0xad},
+			nil,
+		),
+	)
+	builder.internal.AddTxIn(
+		wire.NewTxIn(
+			wire.NewOutPoint(&initialInputHash2, 2),
+			nil,
+			[][]byte{{0xbe, 0xef}},
+		),
+	)
+	builder.sigHashArgs = append(
+		builder.sigHashArgs,
+		&inputSigHashArgs{value: 111, scriptCode: []byte{0x51}, witness: false},
+		&inputSigHashArgs{value: 222, scriptCode: []byte{0x52}, witness: true},
+	)
+	builder.sigHashes = []*big.Int{big.NewInt(1), big.NewInt(2)}
+
+	var replacementInputHash1 chainhash.Hash
+	var replacementInputHash2 chainhash.Hash
+	replacementInputHash1[0] = 0x33
+	replacementInputHash2[0] = 0x44
+
+	err := builder.ReplaceUnsignedTransaction(
+		&Transaction{
+			Version: 2,
+			Inputs: []*TransactionInput{
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(replacementInputHash1),
+						OutputIndex:     7,
+					},
+					Sequence: 0xffffffff,
+				},
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(replacementInputHash2),
+						OutputIndex:     8,
+					},
+					Sequence: 0xffffffff,
+				},
+			},
+			Outputs: []*TransactionOutput{
+				{
+					Value:           1000,
+					PublicKeyScript: hexToSlice(t, "0014deadbeef"),
+				},
+			},
+			Locktime: 0,
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected replacement error: [%v]", err)
+	}
+
+	if len(builder.sigHashes) != 0 {
+		t.Fatalf("expected sighashes reset after replacement: [%d]", len(builder.sigHashes))
+	}
+
+	// Preserve P2SH/P2WSH placeholder scripts needed for final signature
+	// application while replacing tx skeleton.
+	if !reflect.DeepEqual([]byte{0xde, 0xad}, builder.internal.TxIn[0].SignatureScript) {
+		t.Fatalf(
+			"unexpected preserved signature script\nexpected: [%x]\nactual:   [%x]",
+			[]byte{0xde, 0xad},
+			builder.internal.TxIn[0].SignatureScript,
+		)
+	}
+
+	if len(builder.internal.TxIn[1].Witness) != 1 {
+		t.Fatalf("unexpected preserved witness length: [%d]", len(builder.internal.TxIn[1].Witness))
+	}
+
+	if !reflect.DeepEqual([]byte{0xbe, 0xef}, builder.internal.TxIn[1].Witness[0]) {
+		t.Fatalf(
+			"unexpected preserved witness script\nexpected: [%x]\nactual:   [%x]",
+			[]byte{0xbe, 0xef},
+			builder.internal.TxIn[1].Witness[0],
+		)
+	}
+
+	inputs, outputs, err := builder.UnsignedTransactionIO()
+	if err != nil {
+		t.Fatalf("unexpected extraction error after replacement: [%v]", err)
+	}
+
+	if len(inputs) != 2 {
+		t.Fatalf("unexpected input count after replacement: [%d]", len(inputs))
+	}
+
+	if inputs[0].TxIDHex != replacementInputHash1.String() || inputs[0].Vout != 7 {
+		t.Fatalf("unexpected first input after replacement: [%+v]", inputs[0])
+	}
+
+	if inputs[1].TxIDHex != replacementInputHash2.String() || inputs[1].Vout != 8 {
+		t.Fatalf("unexpected second input after replacement: [%+v]", inputs[1])
+	}
+
+	if len(outputs) != 1 {
+		t.Fatalf("unexpected output count after replacement: [%d]", len(outputs))
+	}
+}
+
+func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsInputMetadataMismatch(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{value: 1})
+
+	err := builder.ReplaceUnsignedTransaction(
+		&Transaction{
+			Inputs: []*TransactionInput{
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(txHash),
+						OutputIndex:     0,
+					},
+				},
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(txHash),
+						OutputIndex:     1,
+					},
+				},
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected input metadata mismatch error")
+	}
+
+	if !reflect.DeepEqual(
+		fmt.Sprintf(
+			"input metadata mismatch: [%d] tx inputs, [%d] sighash args",
+			2,
+			1,
+		),
+		err.Error(),
+	) {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
 func TestTransactionBuilder_UnsignedTransactionIO(t *testing.T) {
 	builder := NewTransactionBuilder(nil)
 

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -369,6 +370,82 @@ func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsInputMetadataMisma
 			1,
 		),
 		err.Error(),
+	) {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsNonEmptyReplacementSignatureScript(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(
+		builder.sigHashArgs,
+		&inputSigHashArgs{value: 1, scriptCode: []byte{0x51}, witness: false},
+	)
+
+	err := builder.ReplaceUnsignedTransaction(
+		&Transaction{
+			Inputs: []*TransactionInput{
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(txHash),
+						OutputIndex:     0,
+					},
+					SignatureScript: []byte{0xaa},
+					Sequence:        0xffffffff,
+				},
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected replacement signature script error")
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"replacement transaction input [0] has unexpected non-empty signature script",
+	) {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsNonEmptyReplacementWitness(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(
+		builder.sigHashArgs,
+		&inputSigHashArgs{value: 1, scriptCode: []byte{0x51}, witness: true},
+	)
+
+	err := builder.ReplaceUnsignedTransaction(
+		&Transaction{
+			Inputs: []*TransactionInput{
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(txHash),
+						OutputIndex:     0,
+					},
+					Witness:  wire.TxWitness{[]byte{0xbb}},
+					Sequence: 0xffffffff,
+				},
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected replacement witness error")
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"replacement transaction input [0] has unexpected non-empty witness",
 	) {
 		t.Fatalf("unexpected error: [%v]", err)
 	}

--- a/pkg/frost/signing/native_bridge.go
+++ b/pkg/frost/signing/native_bridge.go
@@ -17,6 +17,12 @@ var (
 	ErrNativeCryptographyUnavailable = errors.New(
 		"native FROST cryptographic execution is unavailable",
 	)
+	// ErrNativeBridgeOperationFailed indicates that native cryptographic
+	// execution is available but a bridge operation returned a non-success
+	// status. This error should not trigger availability fallback.
+	ErrNativeBridgeOperationFailed = errors.New(
+		"native FROST bridge operation failed",
+	)
 )
 
 // NativeExecutionBridge defines a native cryptographic execution entrypoint

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -32,9 +32,9 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive is a
 // transitional primitive that executes native two-round FROST when
 // `frost-uniffi-v2` signer material is provided, and preserves legacy bridge
-// execution for `frost-uniffi-v1` payloads. `frost-tbtc-signer-v1` currently
-// routes through a temporary legacy fallback until coarse session finalize flow
-// is wired end-to-end.
+// execution for `frost-uniffi-v1` payloads. `frost-tbtc-signer-v1` uses the
+// coarse signing flow for bootstrap engine versions and falls back to legacy
+// signing for unsupported or failed coarse-path executions.
 type buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive struct{}
 
 const buildTaggedTBTCSignerVersionPrefix = "tbtc-signer/"
@@ -338,6 +338,14 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 			"validated tbtc-signer key-group contract via RunDKG and bootstrap coarse round; returning coarse signature",
 		)
 	}
+
+	emitNativeTBTCSignerCoarseSignatureEvent(
+		NativeTBTCSignerCoarseSignatureEvent{
+			SessionID:      request.SessionID,
+			KeyGroupSource: payload.KeyGroupSource,
+			EngineVersion:  engineVersion,
+		},
+	)
 
 	return coarseSignature, nil
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -634,6 +634,9 @@ func decodeBuildTaggedTBTCSignerSignature(signature []byte) (*frost.Signature, e
 		return nil, fmt.Errorf("signature is empty")
 	}
 
+	// Unmarshal validates signature wire format (length + split into R/S) only.
+	// Cryptographic validity is enforced by downstream Schnorr verification at
+	// submission time.
 	result := &frost.Signature{}
 	if err := result.Unmarshal(signature); err != nil {
 		return nil, fmt.Errorf("invalid frost signature bytes: [%w]", err)

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -302,14 +302,15 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	if err := executeBuildTaggedTBTCSignerBootstrapCoarseRound(
+	coarseSignatureBytes, err := executeBuildTaggedTBTCSignerBootstrapCoarseRoundWithSignature(
 		ctx,
 		request,
 		keyGroupForRound,
 		nativeEngine,
 		includedMembersSet,
 		includedMembersIndexes,
-	); err != nil {
+	)
+	if err != nil {
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
 			logger,
@@ -320,20 +321,25 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		)
 	}
 
-	if logger != nil {
-		logger.Debugf(
-			"validated tbtc-signer key-group contract via RunDKG and bootstrap coarse round; using legacy fallback until signature cutover",
+	coarseSignature, err := decodeBuildTaggedTBTCSignerSignature(coarseSignatureBytes)
+	if err != nil {
+		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
+			ctx,
+			logger,
+			request,
+			legacyPrivateKeyShare,
+			fmt.Sprintf("cannot decode tbtc-signer coarse signature: [%v]", err),
+			payload.KeyGroupSource,
 		)
 	}
 
-	return btlcnnefsp.fallbackTBTCSignerLegacySigning(
-		ctx,
-		logger,
-		request,
-		legacyPrivateKeyShare,
-		"tbtc-signer bootstrap coarse round completed; using legacy fallback during migration",
-		payload.KeyGroupSource,
-	)
+	if logger != nil {
+		logger.Debugf(
+			"validated tbtc-signer key-group contract via RunDKG and bootstrap coarse round; returning coarse signature",
+		)
+	}
+
+	return coarseSignature, nil
 }
 
 func buildTaggedTBTCSignerRunDKGInputs(
@@ -482,16 +488,36 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	includedMembersSet map[group.MemberIndex]struct{},
 	includedMembersIndexes []group.MemberIndex,
 ) error {
+	_, err := executeBuildTaggedTBTCSignerBootstrapCoarseRoundWithSignature(
+		ctx,
+		request,
+		keyGroup,
+		nativeEngine,
+		includedMembersSet,
+		includedMembersIndexes,
+	)
+
+	return err
+}
+
+func executeBuildTaggedTBTCSignerBootstrapCoarseRoundWithSignature(
+	ctx context.Context,
+	request *NativeExecutionFFISigningRequest,
+	keyGroup string,
+	nativeEngine NativeTBTCSignerEngine,
+	includedMembersSet map[group.MemberIndex]struct{},
+	includedMembersIndexes []group.MemberIndex,
+) ([]byte, error) {
 	if request == nil {
-		return fmt.Errorf("request is nil")
+		return nil, fmt.Errorf("request is nil")
 	}
 
 	if request.Message == nil {
-		return fmt.Errorf("request message is nil")
+		return nil, fmt.Errorf("request message is nil")
 	}
 
 	if nativeEngine == nil {
-		return fmt.Errorf("native tbtc-signer engine is nil")
+		return nil, fmt.Errorf("native tbtc-signer engine is nil")
 	}
 
 	if ctx == nil {
@@ -502,12 +528,12 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		var err error
 		includedMembersSet, includedMembersIndexes, err = includedMembersFromRequest(request)
 		if err != nil {
-			return fmt.Errorf("cannot determine included members: [%w]", err)
+			return nil, fmt.Errorf("cannot determine included members: [%w]", err)
 		}
 	}
 
 	if _, ok := includedMembersSet[request.MemberIndex]; !ok {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"member [%v] not included in tbtc-signer signing attempt",
 			request.MemberIndex,
 		)
@@ -519,14 +545,14 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 	}
 
 	if request.MemberIndex == 0 {
-		return fmt.Errorf("request member index is zero")
+		return nil, fmt.Errorf("request member index is zero")
 	}
 
 	signingParticipants, err := buildTaggedTBTCSignerSigningParticipants(
 		includedMembersIndexes,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot derive signing participants: [%w]", err)
+		return nil, fmt.Errorf("cannot derive signing participants: [%w]", err)
 	}
 
 	roundState, err := nativeEngine.StartSignRound(
@@ -537,20 +563,20 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		signingParticipants,
 	)
 	if err != nil {
-		return fmt.Errorf("start sign round failed: [%w]", err)
+		return nil, fmt.Errorf("start sign round failed: [%w]", err)
 	}
 
 	if roundState == nil {
-		return fmt.Errorf("start sign round returned nil state")
+		return nil, fmt.Errorf("start sign round returned nil state")
 	}
 
 	if roundState.RequiredContributions == 0 {
-		return fmt.Errorf("start sign round required contributions are zero")
+		return nil, fmt.Errorf("start sign round required contributions are zero")
 	}
 
 	if len(signingParticipants) > 0 {
 		if len(roundState.SigningParticipants) != len(signingParticipants) {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"start sign round returned unexpected signing participants count: [%v] != [%v]",
 				len(roundState.SigningParticipants),
 				len(signingParticipants),
@@ -559,7 +585,7 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 
 		for i := range signingParticipants {
 			if roundState.SigningParticipants[i] != signingParticipants[i] {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"start sign round returned unexpected signing participant at index [%d]: [%v] != [%v]",
 					i,
 					roundState.SigningParticipants[i],
@@ -577,11 +603,11 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		includedMembersIndexes,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot collect round contributions: [%w]", err)
+		return nil, fmt.Errorf("cannot collect round contributions: [%w]", err)
 	}
 
 	if len(roundContributions) < int(roundState.RequiredContributions) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"insufficient round contributions: [%v] < [%v]",
 			len(roundContributions),
 			roundState.RequiredContributions,
@@ -593,14 +619,27 @@ func executeBuildTaggedTBTCSignerBootstrapCoarseRound(
 		roundContributions,
 	)
 	if err != nil {
-		return fmt.Errorf("finalize sign round failed: [%w]", err)
+		return nil, fmt.Errorf("finalize sign round failed: [%w]", err)
 	}
 
 	if len(signature) == 0 {
-		return fmt.Errorf("finalize sign round returned empty signature")
+		return nil, fmt.Errorf("finalize sign round returned empty signature")
 	}
 
-	return nil
+	return signature, nil
+}
+
+func decodeBuildTaggedTBTCSignerSignature(signature []byte) (*frost.Signature, error) {
+	if len(signature) == 0 {
+		return nil, fmt.Errorf("signature is empty")
+	}
+
+	result := &frost.Signature{}
+	if err := result.Unmarshal(signature); err != nil {
+		return nil, fmt.Errorf("invalid frost signature bytes: [%w]", err)
+	}
+
+	return result, nil
 }
 
 func buildTaggedTBTCSignerSigningParticipants(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -254,6 +254,15 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) finalize
 	return append([]NativeTBTCSignerRoundContribution{}, dbttsbre.finalizeInput...)
 }
 
+func buildTaggedTBTCSignerValidTestSignature(seed byte) []byte {
+	signature := make([]byte, 64)
+	for i := range signature {
+		signature[i] = seed + byte(i)
+	}
+
+	return signature
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_ValidatesRequest(
 	t *testing.T,
 ) {
@@ -1408,19 +1417,31 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 ) {
 	engine := &mockBuildTaggedTBTCSignerEngine{
 		version:           "tbtc-signer/0.1.0-bootstrap",
-		finalizeSignature: []byte{0xaa},
+		finalizeSignature: buildTaggedTBTCSignerValidTestSignature(0x11),
 	}
 	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
 
 	err := RegisterNativeTBTCSignerEngine(engine)
 	if err != nil {
 		t.Fatalf("unexpected registration error: [%v]", err)
 	}
 
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
 
-	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+	signature, err := primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
 		Message:            big.NewInt(123),
 		SessionID:          "session-1",
 		MemberIndex:        1,
@@ -1431,15 +1452,25 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			Payload: []byte(`{"keyGroup":"group-1"}`),
 		},
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
 	}
 
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if signature == nil {
+		t.Fatal("expected signature")
+	}
+
+	marshaledSignature, err := signature.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal signature: [%v]", err)
+	}
+
+	expectedSignature := buildTaggedTBTCSignerValidTestSignature(0x11)
+	if !bytes.Equal(marshaledSignature, expectedSignature) {
 		t.Fatalf(
-			"unexpected error\nexpected: [%v]\nactual:   [%v]",
-			ErrNativeCryptographyUnavailable,
-			err,
+			"unexpected signature bytes\nexpected: [%x]\nactual:   [%x]",
+			expectedSignature,
+			marshaledSignature,
 		)
 	}
 
@@ -1488,6 +1519,13 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		t.Fatal("expected FinalizeSignRound call in bootstrap tbtc-signer path")
 	}
 
+	if len(observedEvents) != 0 {
+		t.Fatalf(
+			"did not expect fallback events\nactual: [%v]",
+			observedEvents,
+		)
+	}
+
 	if engine.finalizeSessionID != "session-1" {
 		t.Fatalf(
 			"unexpected FinalizeSignRound session ID\nexpected: [%v]\nactual:   [%v]",
@@ -1533,7 +1571,7 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			Threshold:        2,
 			CreatedAtUnix:    1,
 		},
-		finalizeSignature: []byte{0xaa},
+		finalizeSignature: buildTaggedTBTCSignerValidTestSignature(0x22),
 	}
 	UnregisterNativeTBTCSignerEngine()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
@@ -1545,7 +1583,7 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
 
-	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+	signature, err := primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
 		Message:            big.NewInt(123),
 		SessionID:          "session-1",
 		MemberIndex:        1,
@@ -1558,15 +1596,25 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			),
 		},
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
 	}
 
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if signature == nil {
+		t.Fatal("expected signature")
+	}
+
+	marshaledSignature, err := signature.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal signature: [%v]", err)
+	}
+
+	expectedSignature := buildTaggedTBTCSignerValidTestSignature(0x22)
+	if !bytes.Equal(marshaledSignature, expectedSignature) {
 		t.Fatalf(
-			"unexpected error\nexpected: [%v]\nactual:   [%v]",
-			ErrNativeCryptographyUnavailable,
-			err,
+			"unexpected signature bytes\nexpected: [%x]\nactual:   [%x]",
+			expectedSignature,
+			marshaledSignature,
 		)
 	}
 
@@ -1854,7 +1902,8 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	var observedSigningParticipants [][]uint16
 
 	engine := &mockBuildTaggedTBTCSignerEngine{
-		version: "tbtc-signer/0.1.0-bootstrap",
+		version:           "tbtc-signer/0.1.0-bootstrap",
+		finalizeSignature: buildTaggedTBTCSignerValidTestSignature(0x44),
 		runDKGFn: func(
 			sessionID string,
 			participants []NativeTBTCSignerDKGParticipant,
@@ -1931,16 +1980,12 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		},
 	}
 
-	_, err = primitive.Sign(nil, nil, baseRequest)
-	if err == nil {
-		t.Fatal("expected first signing error due to legacy fallback without private key share")
+	firstSignature, err := primitive.Sign(nil, nil, baseRequest)
+	if err != nil {
+		t.Fatalf("unexpected first signing error: [%v]", err)
 	}
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
-		t.Fatalf(
-			"unexpected first signing error\nexpected: [%v]\nactual:   [%v]",
-			ErrNativeCryptographyUnavailable,
-			err,
-		)
+	if firstSignature == nil {
+		t.Fatal("expected first signature")
 	}
 
 	secondRequest := *baseRequest
@@ -1986,28 +2031,18 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		)
 	}
 
-	if len(observedEvents) != 2 {
+	if len(observedEvents) != 1 {
 		t.Fatalf(
 			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
-			2,
+			1,
 			len(observedEvents),
 		)
 	}
 
-	if !strings.Contains(
-		observedEvents[0].Reason,
-		"tbtc-signer bootstrap coarse round completed",
-	) {
+	if !strings.Contains(observedEvents[0].Reason, "session_conflict") {
 		t.Fatalf(
-			"expected first fallback reason to include bootstrap completion\nactual: [%s]",
+			"expected fallback reason to include session_conflict\nactual: [%s]",
 			observedEvents[0].Reason,
-		)
-	}
-
-	if !strings.Contains(observedEvents[1].Reason, "session_conflict") {
-		t.Fatalf(
-			"expected second fallback reason to include session_conflict\nactual: [%s]",
-			observedEvents[1].Reason,
 		)
 	}
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -1421,8 +1421,10 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	}
 	UnregisterNativeTBTCSignerEngine()
 	UnregisterNativeTBTCSignerFallbackObserver()
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
 
 	err := RegisterNativeTBTCSignerEngine(engine)
 	if err != nil {
@@ -1437,6 +1439,19 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	)
 	if err != nil {
 		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	var observedCoarseSignatureEvents []NativeTBTCSignerCoarseSignatureEvent
+	err = RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(event NativeTBTCSignerCoarseSignatureEvent) {
+			observedCoarseSignatureEvents = append(
+				observedCoarseSignatureEvents,
+				event,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected coarse observer registration error: [%v]", err)
 	}
 
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
@@ -1526,6 +1541,30 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		)
 	}
 
+	if len(observedCoarseSignatureEvents) != 1 {
+		t.Fatalf(
+			"unexpected coarse signature event count\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(observedCoarseSignatureEvents),
+		)
+	}
+
+	if observedCoarseSignatureEvents[0].SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected coarse signature session ID\nexpected: [%s]\nactual:   [%s]",
+			"session-1",
+			observedCoarseSignatureEvents[0].SessionID,
+		)
+	}
+
+	if observedCoarseSignatureEvents[0].EngineVersion != "tbtc-signer/0.1.0-bootstrap" {
+		t.Fatalf(
+			"unexpected coarse signature engine version\nexpected: [%s]\nactual:   [%s]",
+			"tbtc-signer/0.1.0-bootstrap",
+			observedCoarseSignatureEvents[0].EngineVersion,
+		)
+	}
+
 	if engine.finalizeSessionID != "session-1" {
 		t.Fatalf(
 			"unexpected FinalizeSignRound session ID\nexpected: [%v]\nactual:   [%v]",
@@ -1568,8 +1607,10 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	}
 	UnregisterNativeTBTCSignerEngine()
 	UnregisterNativeTBTCSignerFallbackObserver()
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
 
 	err := RegisterNativeTBTCSignerEngine(engine)
 	if err != nil {
@@ -1584,6 +1625,19 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	)
 	if err != nil {
 		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	var observedCoarseSignatureEvents []NativeTBTCSignerCoarseSignatureEvent
+	err = RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(event NativeTBTCSignerCoarseSignatureEvent) {
+			observedCoarseSignatureEvents = append(
+				observedCoarseSignatureEvents,
+				event,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected coarse observer registration error: [%v]", err)
 	}
 
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
@@ -1640,6 +1694,13 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			observedEvents[0].Reason,
 		)
 	}
+
+	if len(observedCoarseSignatureEvents) != 0 {
+		t.Fatalf(
+			"did not expect coarse signature events\nactual: [%v]",
+			observedCoarseSignatureEvents,
+		)
+	}
 }
 
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_LegacyKeyGroupSourceUsesRunDKGResult(
@@ -1657,11 +1718,26 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		finalizeSignature: buildTaggedTBTCSignerValidTestSignature(0x22),
 	}
 	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
 
 	err := RegisterNativeTBTCSignerEngine(engine)
 	if err != nil {
 		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedCoarseSignatureEvents []NativeTBTCSignerCoarseSignatureEvent
+	err = RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(event NativeTBTCSignerCoarseSignatureEvent) {
+			observedCoarseSignatureEvents = append(
+				observedCoarseSignatureEvents,
+				event,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected coarse observer registration error: [%v]", err)
 	}
 
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
@@ -1724,6 +1800,30 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 
 	if !engine.finalizeCalled {
 		t.Fatal("expected FinalizeSignRound call in bootstrap path")
+	}
+
+	if len(observedCoarseSignatureEvents) != 1 {
+		t.Fatalf(
+			"unexpected coarse signature event count\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(observedCoarseSignatureEvents),
+		)
+	}
+
+	if observedCoarseSignatureEvents[0].KeyGroupSource != "legacy-wallet-pubkey" {
+		t.Fatalf(
+			"unexpected coarse signature key group source\nexpected: [%s]\nactual:   [%s]",
+			"legacy-wallet-pubkey",
+			observedCoarseSignatureEvents[0].KeyGroupSource,
+		)
+	}
+
+	if observedCoarseSignatureEvents[0].EngineVersion != "tbtc-signer/0.1.0-bootstrap" {
+		t.Fatalf(
+			"unexpected coarse signature engine version\nexpected: [%s]\nactual:   [%s]",
+			"tbtc-signer/0.1.0-bootstrap",
+			observedCoarseSignatureEvents[0].EngineVersion,
+		)
 	}
 }
 
@@ -1789,8 +1889,10 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 ) {
 	UnregisterNativeTBTCSignerEngine()
 	UnregisterNativeTBTCSignerFallbackObserver()
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
 
 	var observedEvents []NativeTBTCSignerFallbackEvent
 	err := RegisterNativeTBTCSignerFallbackObserver(
@@ -1859,8 +1961,10 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 ) {
 	UnregisterNativeTBTCSignerEngine()
 	UnregisterNativeTBTCSignerFallbackObserver()
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
 
 	var firstParticipants []NativeTBTCSignerDKGParticipant
 	engine := &mockBuildTaggedTBTCSignerEngine{
@@ -1978,8 +2082,10 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 ) {
 	UnregisterNativeTBTCSignerEngine()
 	UnregisterNativeTBTCSignerFallbackObserver()
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)
 	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
 
 	var firstSigningParticipants []uint16
 	var observedSigningParticipants [][]uint16
@@ -2047,6 +2153,19 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	)
 	if err != nil {
 		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	var observedCoarseSignatureEvents []NativeTBTCSignerCoarseSignatureEvent
+	err = RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(event NativeTBTCSignerCoarseSignatureEvent) {
+			observedCoarseSignatureEvents = append(
+				observedCoarseSignatureEvents,
+				event,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected coarse observer registration error: [%v]", err)
 	}
 
 	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
@@ -2126,6 +2245,14 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		t.Fatalf(
 			"expected fallback reason to include session_conflict\nactual: [%s]",
 			observedEvents[0].Reason,
+		)
+	}
+
+	if len(observedCoarseSignatureEvents) != 1 {
+		t.Fatalf(
+			"unexpected coarse signature event count\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(observedCoarseSignatureEvents),
 		)
 	}
 }

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -1559,6 +1559,89 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 	}
 }
 
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_InvalidCoarseSignatureFallsBack(
+	t *testing.T,
+) {
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version:           "tbtc-signer/0.1.0-bootstrap",
+		finalizeSignature: []byte{0xaa},
+	}
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: []byte(`{"keyGroup":"group-1","keyGroupSource":"legacy-wallet-pubkey"}`),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if !engine.runDKGCalled {
+		t.Fatal("expected RunDKG call in bootstrap path")
+	}
+
+	if !engine.startCalled {
+		t.Fatal("expected StartSignRound call in bootstrap path")
+	}
+
+	if !engine.finalizeCalled {
+		t.Fatal("expected FinalizeSignRound call in bootstrap path")
+	}
+
+	if len(observedEvents) != 1 {
+		t.Fatalf(
+			"unexpected fallback event count\nexpected: [%d]\nactual:   [%d]",
+			1,
+			len(observedEvents),
+		)
+	}
+
+	if !strings.Contains(
+		observedEvents[0].Reason,
+		"cannot decode tbtc-signer coarse signature",
+	) {
+		t.Fatalf(
+			"expected fallback reason to include decode failure\nactual: [%s]",
+			observedEvents[0].Reason,
+		)
+	}
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_BootstrapVersion_LegacyKeyGroupSourceUsesRunDKGResult(
 	t *testing.T,
 ) {

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -168,6 +168,15 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) FinalizeSignRound(
 	return []byte{0xaa}, nil
 }
 
+func (mbttse *mockBuildTaggedTBTCSignerEngine) BuildTaprootTx(
+	sessionID string,
+	inputs []NativeTBTCSignerTxInput,
+	outputs []NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) (*NativeTBTCSignerTxResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 type deterministicBuildTaggedTBTCSignerBootstrapRoundEngine struct {
 	roundState    *NativeTBTCSignerRoundState
 	finalizeMutex sync.Mutex
@@ -245,6 +254,15 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) Finalize
 	)
 
 	return []byte{0xaa}, nil
+}
+
+func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) BuildTaprootTx(
+	sessionID string,
+	inputs []NativeTBTCSignerTxInput,
+	outputs []NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) (*NativeTBTCSignerTxResult, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) finalizeInputs() []NativeTBTCSignerRoundContribution {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -34,6 +34,10 @@ typedef TbtcSignerResult (*tbtc_finalize_sign_round_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_build_taproot_tx_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef void (*tbtc_free_buffer_fn)(uint8_t* ptr, size_t len);
 
 static TbtcSignerResult unavailable_tbtc_signer_result(void) {
@@ -90,6 +94,18 @@ static TbtcSignerResult tbtc_signer_finalize_sign_round(const uint8_t* request_p
   }
 
   return finalize_sign_round(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_build_taproot_tx(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_build_taproot_tx_fn build_taproot_tx = (tbtc_build_taproot_tx_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_build_taproot_tx"
+  );
+  if (build_taproot_tx == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return build_taproot_tx(request_ptr, request_len);
 }
 
 static void tbtc_signer_free_buffer(uint8_t* ptr, size_t len) {
@@ -167,6 +183,29 @@ type buildTaggedTBTCSignerFinalizeSignRoundResponse struct {
 	SessionID    string `json:"session_id"`
 	RoundID      string `json:"round_id"`
 	SignatureHex string `json:"signature_hex"`
+}
+
+type buildTaggedTBTCSignerBuildTaprootTxRequest struct {
+	SessionID     string                                      `json:"session_id"`
+	Inputs        []buildTaggedTBTCSignerBuildTaprootTxInput  `json:"inputs"`
+	Outputs       []buildTaggedTBTCSignerBuildTaprootTxOutput `json:"outputs"`
+	ScriptTreeHex *string                                     `json:"script_tree_hex,omitempty"`
+}
+
+type buildTaggedTBTCSignerBuildTaprootTxInput struct {
+	TxIDHex   string `json:"txid_hex"`
+	Vout      uint32 `json:"vout"`
+	ValueSats uint64 `json:"value_sats"`
+}
+
+type buildTaggedTBTCSignerBuildTaprootTxOutput struct {
+	ScriptPubKeyHex string `json:"script_pubkey_hex"`
+	ValueSats       uint64 `json:"value_sats"`
+}
+
+type buildTaggedTBTCSignerBuildTaprootTxResponse struct {
+	SessionID string `json:"session_id"`
+	TxHex     string `json:"tx_hex"`
 }
 
 const buildTaggedTBTCSignerUnavailableStatusCode = -1
@@ -258,6 +297,30 @@ func (bttse *buildTaggedTBTCSignerEngine) FinalizeSignRound(
 	}
 
 	return decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(responsePayload)
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) BuildTaprootTx(
+	sessionID string,
+	inputs []NativeTBTCSignerTxInput,
+	outputs []NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) (*NativeTBTCSignerTxResult, error) {
+	requestPayload, err := buildTaggedTBTCSignerBuildTaprootTxRequestPayload(
+		sessionID,
+		inputs,
+		outputs,
+		scriptTreeHex,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerBuildTaprootTx(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerBuildTaprootTxResponse(responsePayload)
 }
 
 func buildTaggedTBTCSignerUnavailableError(operation string) error {
@@ -647,6 +710,147 @@ func decodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(
 	return signature, nil
 }
 
+func buildTaggedTBTCSignerBuildTaprootTxRequestPayload(
+	sessionID string,
+	inputs []NativeTBTCSignerTxInput,
+	outputs []NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			"session ID is empty",
+		)
+	}
+
+	if len(inputs) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			"inputs are empty",
+		)
+	}
+
+	if len(outputs) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			"outputs are empty",
+		)
+	}
+
+	requestInputs := make(
+		[]buildTaggedTBTCSignerBuildTaprootTxInput,
+		0,
+		len(inputs),
+	)
+	for i, input := range inputs {
+		if input.TxIDHex == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"BuildTaprootTx",
+				fmt.Sprintf("input [%d] txid hex is empty", i),
+			)
+		}
+
+		requestInputs = append(
+			requestInputs,
+			buildTaggedTBTCSignerBuildTaprootTxInput{
+				TxIDHex:   input.TxIDHex,
+				Vout:      input.Vout,
+				ValueSats: input.ValueSats,
+			},
+		)
+	}
+
+	requestOutputs := make(
+		[]buildTaggedTBTCSignerBuildTaprootTxOutput,
+		0,
+		len(outputs),
+	)
+	for i, output := range outputs {
+		if output.ScriptPubKeyHex == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"BuildTaprootTx",
+				fmt.Sprintf("output [%d] script pubkey hex is empty", i),
+			)
+		}
+
+		requestOutputs = append(
+			requestOutputs,
+			buildTaggedTBTCSignerBuildTaprootTxOutput{
+				ScriptPubKeyHex: output.ScriptPubKeyHex,
+				ValueSats:       output.ValueSats,
+			},
+		)
+	}
+
+	var requestScriptTreeHex *string
+	if scriptTreeHex != nil {
+		if *scriptTreeHex == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"BuildTaprootTx",
+				"script tree hex is empty",
+			)
+		}
+
+		copied := *scriptTreeHex
+		requestScriptTreeHex = &copied
+	}
+
+	request := buildTaggedTBTCSignerBuildTaprootTxRequest{
+		SessionID:     sessionID,
+		Inputs:        requestInputs,
+		Outputs:       requestOutputs,
+		ScriptTreeHex: requestScriptTreeHex,
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			fmt.Sprintf("cannot marshal request: %v", err),
+		)
+	}
+
+	return payload, nil
+}
+
+func decodeBuildTaggedTBTCSignerBuildTaprootTxResponse(
+	responsePayload []byte,
+) (*NativeTBTCSignerTxResult, error) {
+	var response buildTaggedTBTCSignerBuildTaprootTxResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	if response.SessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			"response session ID is empty",
+		)
+	}
+
+	if response.TxHex == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			"response tx hex is empty",
+		)
+	}
+
+	if _, err := hex.DecodeString(response.TxHex); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			fmt.Sprintf("response tx hex is invalid: %v", err),
+		)
+	}
+
+	return &NativeTBTCSignerTxResult{
+		SessionID: response.SessionID,
+		TxHex:     response.TxHex,
+	}, nil
+}
+
 func callBuildTaggedTBTCSignerVersion() ([]byte, error) {
 	result := C.tbtc_signer_version()
 	return parseBuildTaggedTBTCSignerResult("Version", result)
@@ -684,6 +888,18 @@ func callBuildTaggedTBTCSignerFinalizeSignRound(
 		requestPayload,
 		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
 			return C.tbtc_signer_finalize_sign_round(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerBuildTaprootTx(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"BuildTaprootTx",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_build_taproot_tx(requestPtr, requestLen)
 		},
 	)
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -343,6 +343,18 @@ func buildTaggedTBTCSignerOperationError(
 	)
 }
 
+func buildTaggedTBTCSignerBridgeOperationError(
+	operation string,
+	message string,
+) error {
+	return fmt.Errorf(
+		"%w: tbtc-signer bridge operation [%v] failed: [%s]",
+		ErrNativeBridgeOperationFailed,
+		operation,
+		message,
+	)
+}
+
 func buildTaggedTBTCSignerRunDKGRequestPayload(
 	sessionID string,
 	participants []NativeTBTCSignerDKGParticipant,
@@ -930,20 +942,15 @@ func parseBuildTaggedTBTCSignerResult(
 	defer C.tbtc_signer_free_buffer(result.buffer.ptr, result.buffer.len)
 
 	statusCode := int32(result.status_code)
-	if statusCode == buildTaggedTBTCSignerUnavailableStatusCode {
-		return nil, buildTaggedTBTCSignerUnavailableError(operation)
-	}
 
 	var payload []byte
 	if result.buffer.ptr != nil && result.buffer.len > 0 {
 		payload = C.GoBytes(unsafe.Pointer(result.buffer.ptr), C.int(result.buffer.len))
 	}
 
-	if statusCode != 0 {
-		return nil, buildTaggedTBTCSignerOperationError(
-			operation,
-			buildTaggedTBTCSignerErrorMessage(payload),
-		)
+	statusErr := buildTaggedTBTCSignerResultStatusError(operation, statusCode, payload)
+	if statusErr != nil {
+		return nil, statusErr
 	}
 
 	if len(payload) == 0 {
@@ -954,6 +961,25 @@ func parseBuildTaggedTBTCSignerResult(
 	}
 
 	return payload, nil
+}
+
+func buildTaggedTBTCSignerResultStatusError(
+	operation string,
+	statusCode int32,
+	payload []byte,
+) error {
+	if statusCode == buildTaggedTBTCSignerUnavailableStatusCode {
+		return buildTaggedTBTCSignerUnavailableError(operation)
+	}
+
+	if statusCode != 0 {
+		return buildTaggedTBTCSignerBridgeOperationError(
+			operation,
+			buildTaggedTBTCSignerErrorMessage(payload),
+		)
+	}
+
+	return nil
 }
 
 func buildTaggedTBTCSignerErrorMessage(payload []byte) string {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -48,6 +48,28 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 		t.Fatalf("unexpected bridge error: [%v]", err)
 	}
 
+	_, err = engine.BuildTaprootTx(
+		"session-1",
+		[]NativeTBTCSignerTxInput{
+			{TxIDHex: "11", Vout: 0, ValueSats: 1},
+		},
+		[]NativeTBTCSignerTxOutput{
+			{ScriptPubKeyHex: "0014", ValueSats: 1},
+		},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected unavailable tbtc-signer build-tx bridge error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"expected native cryptography unavailable error: [%v], got [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
 	versionedEngine, ok := engine.(interface {
 		Version() (string, error)
 	})
@@ -580,5 +602,198 @@ func TestDecodeBuildTaggedTBTCSignerFinalizeSignRoundResponse(t *testing.T) {
 				signature[i],
 			)
 		}
+	}
+}
+
+func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload(t *testing.T) {
+	scriptTreeHex := "deadbeef"
+
+	payload, err := buildTaggedTBTCSignerBuildTaprootTxRequestPayload(
+		"session-buildtx-1",
+		[]NativeTBTCSignerTxInput{
+			{
+				TxIDHex:   strings.Repeat("11", 32),
+				Vout:      3,
+				ValueSats: 1000,
+			},
+		},
+		[]NativeTBTCSignerTxOutput{
+			{
+				ScriptPubKeyHex: "0014deadbeef",
+				ValueSats:       900,
+			},
+		},
+		&scriptTreeHex,
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerBuildTaprootTxRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.SessionID != "session-buildtx-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-buildtx-1",
+			request.SessionID,
+		)
+	}
+
+	if len(request.Inputs) != 1 {
+		t.Fatalf(
+			"unexpected input count\nexpected: [%v]\nactual:   [%v]",
+			1,
+			len(request.Inputs),
+		)
+	}
+
+	if request.Inputs[0].TxIDHex != strings.Repeat("11", 32) {
+		t.Fatalf(
+			"unexpected input txid\nexpected: [%v]\nactual:   [%v]",
+			strings.Repeat("11", 32),
+			request.Inputs[0].TxIDHex,
+		)
+	}
+
+	if len(request.Outputs) != 1 {
+		t.Fatalf(
+			"unexpected output count\nexpected: [%v]\nactual:   [%v]",
+			1,
+			len(request.Outputs),
+		)
+	}
+
+	if request.Outputs[0].ScriptPubKeyHex != "0014deadbeef" {
+		t.Fatalf(
+			"unexpected output script pubkey\nexpected: [%v]\nactual:   [%v]",
+			"0014deadbeef",
+			request.Outputs[0].ScriptPubKeyHex,
+		)
+	}
+
+	if request.ScriptTreeHex == nil || *request.ScriptTreeHex != scriptTreeHex {
+		t.Fatal("expected script tree hex to be present and preserved")
+	}
+}
+
+func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
+	t *testing.T,
+) {
+	scriptTreeHex := ""
+
+	testCases := []struct {
+		name          string
+		sessionID     string
+		inputs        []NativeTBTCSignerTxInput
+		outputs       []NativeTBTCSignerTxOutput
+		scriptTreeHex *string
+	}{
+		{
+			name:      "empty session id",
+			sessionID: "",
+			inputs: []NativeTBTCSignerTxInput{
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+			},
+			outputs: []NativeTBTCSignerTxOutput{
+				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
+			},
+		},
+		{
+			name:      "empty inputs",
+			sessionID: "session-1",
+			inputs:    nil,
+			outputs: []NativeTBTCSignerTxOutput{
+				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
+			},
+		},
+		{
+			name:      "empty outputs",
+			sessionID: "session-1",
+			inputs: []NativeTBTCSignerTxInput{
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+			},
+			outputs: nil,
+		},
+		{
+			name:      "input txid empty",
+			sessionID: "session-1",
+			inputs: []NativeTBTCSignerTxInput{
+				{TxIDHex: "", Vout: 0, ValueSats: 1},
+			},
+			outputs: []NativeTBTCSignerTxOutput{
+				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
+			},
+		},
+		{
+			name:      "output script empty",
+			sessionID: "session-1",
+			inputs: []NativeTBTCSignerTxInput{
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+			},
+			outputs: []NativeTBTCSignerTxOutput{
+				{ScriptPubKeyHex: "", ValueSats: 1},
+			},
+		},
+		{
+			name:      "script tree empty string",
+			sessionID: "session-1",
+			inputs: []NativeTBTCSignerTxInput{
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+			},
+			outputs: []NativeTBTCSignerTxOutput{
+				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
+			},
+			scriptTreeHex: &scriptTreeHex,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildTaggedTBTCSignerBuildTaprootTxRequestPayload(
+				tc.sessionID,
+				tc.inputs,
+				tc.outputs,
+				tc.scriptTreeHex,
+			)
+			if err == nil {
+				t.Fatal("expected payload build error")
+			}
+
+			if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+				t.Fatalf(
+					"expected native cryptography unavailable error: [%v], got [%v]",
+					ErrNativeCryptographyUnavailable,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerBuildTaprootTxResponse(t *testing.T) {
+	result, err := decodeBuildTaggedTBTCSignerBuildTaprootTxResponse(
+		[]byte(`{"session_id":"session-buildtx-1","tx_hex":"deadbeef"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+
+	if result.SessionID != "session-buildtx-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-buildtx-1",
+			result.SessionID,
+		)
+	}
+
+	if result.TxHex != "deadbeef" {
+		t.Fatalf(
+			"unexpected tx hex\nexpected: [%v]\nactual:   [%v]",
+			"deadbeef",
+			result.TxHex,
+		)
 	}
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -91,6 +91,62 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 	}
 }
 
+func TestBuildTaggedTBTCSignerResultStatusError_Unavailable(t *testing.T) {
+	err := buildTaggedTBTCSignerResultStatusError(
+		"BuildTaprootTx",
+		buildTaggedTBTCSignerUnavailableStatusCode,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected unavailable error")
+	}
+
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"expected native cryptography unavailable error: [%v], got [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf(
+			"did not expect native bridge operation failed error: [%v]",
+			err,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerResultStatusError_BridgeOperationFailure(t *testing.T) {
+	err := buildTaggedTBTCSignerResultStatusError(
+		"BuildTaprootTx",
+		2,
+		[]byte(`{"code":"validation","message":"invalid input"}`),
+	)
+	if err == nil {
+		t.Fatal("expected bridge operation failure error")
+	}
+
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf(
+			"expected native bridge operation failed error: [%v], got [%v]",
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"did not expect native cryptography unavailable error: [%v]",
+			err,
+		)
+	}
+
+	if !strings.Contains(err.Error(), "validation: invalid input") {
+		t.Fatalf("unexpected bridge operation error: [%v]", err)
+	}
+}
+
 func TestBuildTaggedTBTCSignerRunDKGRequestPayload(t *testing.T) {
 	payload, err := buildTaggedTBTCSignerRunDKGRequestPayload(
 		"session-1",

--- a/pkg/frost/signing/native_tbtc_signer_build_taproot_tx_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_build_taproot_tx_frost_native.go
@@ -1,0 +1,36 @@
+//go:build frost_native
+
+package signing
+
+import "fmt"
+
+// BuildNativeTBTCSignerTaprootTx routes a BuildTaprootTx request through the
+// currently-registered coarse tbtc-signer engine.
+func BuildNativeTBTCSignerTaprootTx(
+	sessionID string,
+	inputs []NativeTBTCSignerTxInput,
+	outputs []NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) (*NativeTBTCSignerTxResult, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("session ID is empty")
+	}
+
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("inputs are empty")
+	}
+
+	if len(outputs) == 0 {
+		return nil, fmt.Errorf("outputs are empty")
+	}
+
+	nativeEngine := currentNativeTBTCSignerEngine()
+	if nativeEngine == nil {
+		return nil, fmt.Errorf(
+			"%w: native tbtc-signer engine is unavailable",
+			ErrNativeCryptographyUnavailable,
+		)
+	}
+
+	return nativeEngine.BuildTaprootTx(sessionID, inputs, outputs, scriptTreeHex)
+}

--- a/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry.go
+++ b/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry.go
@@ -26,8 +26,7 @@ var (
 
 // RegisterNativeTBTCSignerCoarseSignatureObserver registers a process-wide
 // observer used to report tbtc-signer coarse-signature success events.
-// Only a single observer is supported; a subsequent registration replaces the
-// existing observer.
+// Only a single observer is supported.
 func RegisterNativeTBTCSignerCoarseSignatureObserver(
 	observer NativeTBTCSignerCoarseSignatureObserver,
 ) error {
@@ -37,6 +36,12 @@ func RegisterNativeTBTCSignerCoarseSignatureObserver(
 
 	nativeTBTCSignerCoarseSignatureObserverMutex.Lock()
 	defer nativeTBTCSignerCoarseSignatureObserverMutex.Unlock()
+
+	if nativeTBTCSignerCoarseSignatureObserver != nil {
+		return fmt.Errorf(
+			"native tbtc-signer coarse signature observer is already registered",
+		)
+	}
 
 	nativeTBTCSignerCoarseSignatureObserver = observer
 

--- a/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry.go
+++ b/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry.go
@@ -1,0 +1,65 @@
+package signing
+
+import (
+	"fmt"
+	"sync"
+)
+
+// NativeTBTCSignerCoarseSignatureEvent describes successful coarse-path
+// signature production for tbtc-signer payloads.
+type NativeTBTCSignerCoarseSignatureEvent struct {
+	SessionID      string
+	KeyGroupSource string
+	EngineVersion  string
+}
+
+// NativeTBTCSignerCoarseSignatureObserver consumes coarse-signature telemetry
+// events.
+type NativeTBTCSignerCoarseSignatureObserver func(
+	event NativeTBTCSignerCoarseSignatureEvent,
+)
+
+var (
+	nativeTBTCSignerCoarseSignatureObserverMutex sync.RWMutex
+	nativeTBTCSignerCoarseSignatureObserver      NativeTBTCSignerCoarseSignatureObserver
+)
+
+// RegisterNativeTBTCSignerCoarseSignatureObserver registers a process-wide
+// observer used to report tbtc-signer coarse-signature success events.
+func RegisterNativeTBTCSignerCoarseSignatureObserver(
+	observer NativeTBTCSignerCoarseSignatureObserver,
+) error {
+	if observer == nil {
+		return fmt.Errorf("native tbtc-signer coarse signature observer is nil")
+	}
+
+	nativeTBTCSignerCoarseSignatureObserverMutex.Lock()
+	defer nativeTBTCSignerCoarseSignatureObserverMutex.Unlock()
+
+	nativeTBTCSignerCoarseSignatureObserver = observer
+
+	return nil
+}
+
+// UnregisterNativeTBTCSignerCoarseSignatureObserver clears coarse-signature
+// observer registration.
+func UnregisterNativeTBTCSignerCoarseSignatureObserver() {
+	nativeTBTCSignerCoarseSignatureObserverMutex.Lock()
+	defer nativeTBTCSignerCoarseSignatureObserverMutex.Unlock()
+
+	nativeTBTCSignerCoarseSignatureObserver = nil
+}
+
+func emitNativeTBTCSignerCoarseSignatureEvent(
+	event NativeTBTCSignerCoarseSignatureEvent,
+) {
+	nativeTBTCSignerCoarseSignatureObserverMutex.RLock()
+	observer := nativeTBTCSignerCoarseSignatureObserver
+	nativeTBTCSignerCoarseSignatureObserverMutex.RUnlock()
+
+	if observer == nil {
+		return
+	}
+
+	observer(event)
+}

--- a/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry.go
+++ b/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry.go
@@ -26,6 +26,8 @@ var (
 
 // RegisterNativeTBTCSignerCoarseSignatureObserver registers a process-wide
 // observer used to report tbtc-signer coarse-signature success events.
+// Only a single observer is supported; a subsequent registration replaces the
+// existing observer.
 func RegisterNativeTBTCSignerCoarseSignatureObserver(
 	observer NativeTBTCSignerCoarseSignatureObserver,
 ) error {

--- a/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry_test.go
@@ -1,0 +1,53 @@
+package signing
+
+import "testing"
+
+func TestRegisterNativeTBTCSignerCoarseSignatureObserverRejectsNil(t *testing.T) {
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
+
+	err := RegisterNativeTBTCSignerCoarseSignatureObserver(nil)
+	if err == nil {
+		t.Fatal("expected registration error")
+	}
+}
+
+func TestEmitNativeTBTCSignerCoarseSignatureEvent(t *testing.T) {
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
+
+	var (
+		received bool
+		actual   NativeTBTCSignerCoarseSignatureEvent
+	)
+
+	err := RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(event NativeTBTCSignerCoarseSignatureEvent) {
+			received = true
+			actual = event
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	expected := NativeTBTCSignerCoarseSignatureEvent{
+		SessionID:      "session-1",
+		KeyGroupSource: "legacy-wallet-pubkey",
+		EngineVersion:  "tbtc-signer/0.1.0-bootstrap",
+	}
+
+	emitNativeTBTCSignerCoarseSignatureEvent(expected)
+
+	if !received {
+		t.Fatal("expected coarse signature event to be delivered")
+	}
+
+	if actual != expected {
+		t.Fatalf(
+			"unexpected coarse signature event\nexpected: [%+v]\nactual:   [%+v]",
+			expected,
+			actual,
+		)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry_test.go
@@ -12,6 +12,25 @@ func TestRegisterNativeTBTCSignerCoarseSignatureObserverRejectsNil(t *testing.T)
 	}
 }
 
+func TestRegisterNativeTBTCSignerCoarseSignatureObserverRejectsDuplicate(t *testing.T) {
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
+
+	firstErr := RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(NativeTBTCSignerCoarseSignatureEvent) {},
+	)
+	if firstErr != nil {
+		t.Fatalf("unexpected first registration error: [%v]", firstErr)
+	}
+
+	secondErr := RegisterNativeTBTCSignerCoarseSignatureObserver(
+		func(NativeTBTCSignerCoarseSignatureEvent) {},
+	)
+	if secondErr == nil {
+		t.Fatal("expected duplicate registration error")
+	}
+}
+
 func TestEmitNativeTBTCSignerCoarseSignatureEvent(t *testing.T) {
 	UnregisterNativeTBTCSignerCoarseSignatureObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)

--- a/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_coarse_signature_telemetry_test.go
@@ -51,3 +51,16 @@ func TestEmitNativeTBTCSignerCoarseSignatureEvent(t *testing.T) {
 		)
 	}
 }
+
+func TestEmitNativeTBTCSignerCoarseSignatureEventWithoutObserver(t *testing.T) {
+	UnregisterNativeTBTCSignerCoarseSignatureObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerCoarseSignatureObserver)
+
+	emitNativeTBTCSignerCoarseSignatureEvent(
+		NativeTBTCSignerCoarseSignatureEvent{
+			SessionID:      "session-1",
+			KeyGroupSource: "legacy-wallet-pubkey",
+			EngineVersion:  "tbtc-signer/0.1.0-bootstrap",
+		},
+	)
+}

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -27,6 +27,28 @@ type NativeTBTCSignerRoundContribution struct {
 	Data       []byte `json:"data"`
 }
 
+// NativeTBTCSignerTxInput describes an unsigned transaction input consumed by
+// BuildTaprootTx.
+type NativeTBTCSignerTxInput struct {
+	TxIDHex   string `json:"txIDHex"`
+	Vout      uint32 `json:"vout"`
+	ValueSats uint64 `json:"valueSats"`
+}
+
+// NativeTBTCSignerTxOutput describes an unsigned transaction output consumed
+// by BuildTaprootTx.
+type NativeTBTCSignerTxOutput struct {
+	ScriptPubKeyHex string `json:"scriptPubKeyHex"`
+	ValueSats       uint64 `json:"valueSats"`
+}
+
+// NativeTBTCSignerTxResult captures unsigned transaction metadata returned by
+// BuildTaprootTx.
+type NativeTBTCSignerTxResult struct {
+	SessionID string `json:"sessionID"`
+	TxHex     string `json:"txHex"`
+}
+
 // NativeTBTCSignerRoundState captures coarse session round metadata returned by
 // StartSignRound.
 type NativeTBTCSignerRoundState struct {
@@ -57,6 +79,12 @@ type NativeTBTCSignerEngine interface {
 		sessionID string,
 		roundContributions []NativeTBTCSignerRoundContribution,
 	) ([]byte, error)
+	BuildTaprootTx(
+		sessionID string,
+		inputs []NativeTBTCSignerTxInput,
+		outputs []NativeTBTCSignerTxOutput,
+		scriptTreeHex *string,
+	) (*NativeTBTCSignerTxResult, error)
 }
 
 var nativeTBTCSignerEngine NativeTBTCSignerEngine

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -36,6 +36,15 @@ func (mntse *mockNativeTBTCSignerEngine) FinalizeSignRound(
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (mntse *mockNativeTBTCSignerEngine) BuildTaprootTx(
+	sessionID string,
+	inputs []NativeTBTCSignerTxInput,
+	outputs []NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) (*NativeTBTCSignerTxResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func TestRegisterNativeTBTCSignerEngineRejectsNil(t *testing.T) {
 	UnregisterNativeTBTCSignerEngine()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)

--- a/pkg/frost/signing/native_tbtc_signer_fallback_telemetry.go
+++ b/pkg/frost/signing/native_tbtc_signer_fallback_telemetry.go
@@ -24,6 +24,7 @@ var (
 
 // RegisterNativeTBTCSignerFallbackObserver registers a process-wide observer
 // used to report tbtc-signer fallback events.
+// Only a single observer is supported.
 func RegisterNativeTBTCSignerFallbackObserver(
 	observer NativeTBTCSignerFallbackObserver,
 ) error {
@@ -33,6 +34,10 @@ func RegisterNativeTBTCSignerFallbackObserver(
 
 	nativeTBTCSignerFallbackObserverMutex.Lock()
 	defer nativeTBTCSignerFallbackObserverMutex.Unlock()
+
+	if nativeTBTCSignerFallbackObserver != nil {
+		return fmt.Errorf("native tbtc-signer fallback observer is already registered")
+	}
 
 	nativeTBTCSignerFallbackObserver = observer
 

--- a/pkg/frost/signing/native_tbtc_signer_fallback_telemetry_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_fallback_telemetry_test.go
@@ -14,6 +14,25 @@ func TestRegisterNativeTBTCSignerFallbackObserverRejectsNil(t *testing.T) {
 	}
 }
 
+func TestRegisterNativeTBTCSignerFallbackObserverRejectsDuplicate(t *testing.T) {
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	firstErr := RegisterNativeTBTCSignerFallbackObserver(
+		func(NativeTBTCSignerFallbackEvent) {},
+	)
+	if firstErr != nil {
+		t.Fatalf("unexpected first registration error: [%v]", firstErr)
+	}
+
+	secondErr := RegisterNativeTBTCSignerFallbackObserver(
+		func(NativeTBTCSignerFallbackEvent) {},
+	)
+	if secondErr == nil {
+		t.Fatal("expected duplicate registration error")
+	}
+}
+
 func TestEmitNativeTBTCSignerFallbackEvent(t *testing.T) {
 	UnregisterNativeTBTCSignerFallbackObserver()
 	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_default.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_default.go
@@ -1,0 +1,13 @@
+//go:build !(frost_native && frost_tbtc_signer && cgo)
+
+package tbtc
+
+import "github.com/keep-network/keep-core/pkg/bitcoin"
+
+// buildTaprootTxViaNativeSigner is a no-op on builds that do not link the
+// native tbtc-signer bridge.
+func buildTaprootTxViaNativeSigner(
+	unsignedTx *bitcoin.TransactionBuilder,
+) (string, error) {
+	return "", nil
+}

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
@@ -1,0 +1,104 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package tbtc
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
+)
+
+func buildTaprootTxViaNativeSigner(
+	unsignedTx *bitcoin.TransactionBuilder,
+) (string, error) {
+	if unsignedTx == nil {
+		return "", fmt.Errorf("unsigned transaction builder is nil")
+	}
+
+	inputs, outputs, err := unsignedTx.UnsignedTransactionIO()
+	if err != nil {
+		return "", fmt.Errorf("cannot extract unsigned transaction I/O: [%w]", err)
+	}
+
+	nativeInputs := make([]frostsigning.NativeTBTCSignerTxInput, 0, len(inputs))
+	for _, input := range inputs {
+		nativeInputs = append(
+			nativeInputs,
+			frostsigning.NativeTBTCSignerTxInput{
+				TxIDHex:   input.TxIDHex,
+				Vout:      input.Vout,
+				ValueSats: input.ValueSats,
+			},
+		)
+	}
+
+	nativeOutputs := make([]frostsigning.NativeTBTCSignerTxOutput, 0, len(outputs))
+	for _, output := range outputs {
+		nativeOutputs = append(
+			nativeOutputs,
+			frostsigning.NativeTBTCSignerTxOutput{
+				ScriptPubKeyHex: output.ScriptPubKeyHex,
+				ValueSats:       output.ValueSats,
+			},
+		)
+	}
+
+	sessionID := buildTaprootTxSessionID(inputs, outputs)
+
+	result, err := frostsigning.BuildNativeTBTCSignerTaprootTx(
+		sessionID,
+		nativeInputs,
+		nativeOutputs,
+		nil,
+	)
+	if err != nil {
+		// Keep legacy fallback behavior when native tbtc-signer bridge is not
+		// linked/available for the running build.
+		if errors.Is(err, frostsigning.ErrNativeCryptographyUnavailable) {
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	if result == nil {
+		return "", fmt.Errorf("native tbtc-signer returned nil BuildTaprootTx result")
+	}
+
+	if result.SessionID != sessionID {
+		return "", fmt.Errorf(
+			"native tbtc-signer BuildTaprootTx returned unexpected session ID: [%v] != [%v]",
+			result.SessionID,
+			sessionID,
+		)
+	}
+
+	if result.TxHex == "" {
+		return "", fmt.Errorf("native tbtc-signer BuildTaprootTx returned empty tx hex")
+	}
+
+	return result.TxHex, nil
+}
+
+func buildTaprootTxSessionID(
+	inputs []bitcoin.UnsignedTransactionInput,
+	outputs []bitcoin.UnsignedTransactionOutput,
+) string {
+	sessionPayload, err := json.Marshal(struct {
+		Inputs  []bitcoin.UnsignedTransactionInput  `json:"inputs"`
+		Outputs []bitcoin.UnsignedTransactionOutput `json:"outputs"`
+	}{
+		Inputs:  inputs,
+		Outputs: outputs,
+	})
+	if err != nil {
+		return fmt.Sprintf("buildtx-fallback-%d-%d", len(inputs), len(outputs))
+	}
+
+	digest := sha256.Sum256(sessionPayload)
+	return fmt.Sprintf("buildtx-%x", digest[:])
+}

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
@@ -92,6 +92,8 @@ func buildTaprootTxSessionID(
 ) string {
 	// Session ID is deterministically derived from Go-side transaction I/O using
 	// encoding/json. Rust currently treats this session_id as opaque.
+	// If input/output schema changes in a future migration phase, update this
+	// derivation intentionally to avoid silent cross-version session ID drift.
 	sessionPayload, err := json.Marshal(struct {
 		Inputs  []bitcoin.UnsignedTransactionInput  `json:"inputs"`
 		Outputs []bitcoin.UnsignedTransactionOutput `json:"outputs"`

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
@@ -56,8 +56,10 @@ func buildTaprootTxViaNativeSigner(
 		nil,
 	)
 	if err != nil {
-		// Keep legacy fallback behavior when native tbtc-signer bridge is not
-		// linked/available for the running build.
+		// Keep legacy fallback behavior for the observational BuildTaprootTx
+		// phase when native bridge support is unavailable.
+		// Note that current bridge error mapping can also classify operational
+		// failures as unavailable; tighten this split before signing-substitution.
 		if errors.Is(err, frostsigning.ErrNativeCryptographyUnavailable) {
 			return "", nil
 		}
@@ -88,6 +90,8 @@ func buildTaprootTxSessionID(
 	inputs []bitcoin.UnsignedTransactionInput,
 	outputs []bitcoin.UnsignedTransactionOutput,
 ) string {
+	// Session ID is deterministically derived from Go-side transaction I/O using
+	// encoding/json. Rust currently treats this session_id as opaque.
 	sessionPayload, err := json.Marshal(struct {
 		Inputs  []bitcoin.UnsignedTransactionInput  `json:"inputs"`
 		Outputs []bitcoin.UnsignedTransactionOutput `json:"outputs"`

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -277,6 +277,15 @@ func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) FinalizeSignRound(
 	return []byte{0xaa}, nil
 }
 
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) BuildTaprootTx(
+	sessionID string,
+	inputs []frostsigning.NativeTBTCSignerTxInput,
+	outputs []frostsigning.NativeTBTCSignerTxOutput,
+	scriptTreeHex *string,
+) (*frostsigning.NativeTBTCSignerTxResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) uniqueStartCohortsByAttempt() map[uint][][]uint16 {
 	atntsfe.mutex.Lock()
 	defer atntsfe.mutex.Unlock()

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -512,23 +512,6 @@ func decodeNativeUnsignedTransactionHex(
 	return nativeUnsignedTx, nil
 }
 
-func nativeUnsignedTransactionIODiverges(
-	nativeUnsignedTxHex string,
-	expectedInputs []bitcoin.UnsignedTransactionInput,
-	expectedOutputs []bitcoin.UnsignedTransactionOutput,
-) (bool, error) {
-	nativeUnsignedTx, err := decodeNativeUnsignedTransactionHex(nativeUnsignedTxHex)
-	if err != nil {
-		return false, err
-	}
-
-	return nativeUnsignedTransactionIODivergesFromTransaction(
-		nativeUnsignedTx,
-		expectedInputs,
-		expectedOutputs,
-	)
-}
-
 func nativeUnsignedTransactionDivergesFromTransaction(
 	nativeUnsignedTx *bitcoin.Transaction,
 	expectedTransaction *bitcoin.Transaction,
@@ -556,31 +539,6 @@ func nativeUnsignedTransactionDivergesFromTransaction(
 			!unsignedTransactionOutputsEqual(
 				actualShape.Outputs,
 				expectedShape.Outputs,
-			),
-		nil
-}
-
-func nativeUnsignedTransactionIODivergesFromTransaction(
-	nativeUnsignedTx *bitcoin.Transaction,
-	expectedInputs []bitcoin.UnsignedTransactionInput,
-	expectedOutputs []bitcoin.UnsignedTransactionOutput,
-) (bool, error) {
-	actualInputReferences, actualOutputs, err := extractUnsignedTransactionIOFromTransaction(
-		nativeUnsignedTx,
-	)
-	if err != nil {
-		return false, err
-	}
-
-	expectedInputReferences := unsignedTransactionInputReferences(expectedInputs)
-
-	return !unsignedTransactionInputReferencesEqual(
-			expectedInputReferences,
-			actualInputReferences,
-		) ||
-			!unsignedTransactionOutputsEqual(
-				expectedOutputs,
-				actualOutputs,
 			),
 		nil
 }
@@ -651,21 +609,6 @@ func extractUnsignedTransactionShapeFromTransaction(
 		InputSequences:  inputSequences,
 		Outputs:         outputs,
 	}, nil
-}
-
-func extractUnsignedTransactionIOFromTransaction(
-	transaction *bitcoin.Transaction,
-) (
-	[]unsignedTransactionInputReference,
-	[]bitcoin.UnsignedTransactionOutput,
-	error,
-) {
-	shape, err := extractUnsignedTransactionShapeFromTransaction(transaction)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return shape.InputReferences, shape.Outputs, nil
 }
 
 func unsignedTransactionInputReferences(

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -302,6 +304,9 @@ type walletTransactionExecutor struct {
 }
 
 var buildTaprootTxViaNativeSignerFn = buildTaprootTxViaNativeSigner
+var nativeBuildTaprootTxSigningSubstitutionEnabledFn = nativeBuildTaprootTxSigningSubstitutionEnabled
+
+const nativeBuildTaprootTxSigningSubstitutionEnvVar = "KEEP_CORE_NATIVE_BUILDTX_SIGNING_SUBSTITUTION"
 
 func newWalletTransactionExecutor(
 	btcChain bitcoin.Chain,
@@ -326,6 +331,8 @@ func (wte *walletTransactionExecutor) signTransaction(
 	signingStartBlock uint64,
 	signingTimeoutBlock uint64,
 ) (*bitcoin.Transaction, error) {
+	substitutionEnabled := nativeBuildTaprootTxSigningSubstitutionEnabledFn()
+
 	nativeUnsignedTxHex, err := buildTaprootTxViaNativeSignerFn(unsignedTx)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -342,17 +349,44 @@ func (wte *walletTransactionExecutor) signTransaction(
 
 		expectedInputs, expectedOutputs, err := unsignedTx.UnsignedTransactionIO()
 		if err != nil {
+			if substitutionEnabled {
+				return nil, fmt.Errorf(
+					"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+					err,
+				)
+			}
+
 			signTxLogger.Warnf(
 				"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
 				err,
 			)
 		} else {
-			warnOnNativeUnsignedTransactionIODivergence(
+			nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
 				signTxLogger,
 				nativeUnsignedTxHex,
 				expectedInputs,
 				expectedOutputs,
+				substitutionEnabled,
 			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"cannot process native BuildTaprootTx unsigned transaction for signing: [%v]",
+					err,
+				)
+			}
+
+			if nativeUnsignedTx != nil {
+				if err := unsignedTx.ReplaceUnsignedTransaction(nativeUnsignedTx); err != nil {
+					return nil, fmt.Errorf(
+						"cannot substitute Go unsigned transaction with native BuildTaprootTx output: [%v]",
+						err,
+					)
+				}
+
+				signTxLogger.Infof(
+					"substituted Go unsigned transaction with native tbtc-signer BuildTaprootTx output",
+				)
+			}
 		}
 	}
 
@@ -411,30 +445,89 @@ func (wte *walletTransactionExecutor) signTransaction(
 	return tx, nil
 }
 
-func warnOnNativeUnsignedTransactionIODivergence(
+func nativeBuildTaprootTxSigningSubstitutionEnabled() bool {
+	switch strings.ToLower(
+		strings.TrimSpace(
+			os.Getenv(nativeBuildTaprootTxSigningSubstitutionEnvVar),
+		),
+	) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func evaluateNativeUnsignedTransactionForSigning(
 	signTxLogger log.StandardLogger,
 	nativeUnsignedTxHex string,
 	expectedInputs []bitcoin.UnsignedTransactionInput,
 	expectedOutputs []bitcoin.UnsignedTransactionOutput,
-) {
-	diverges, err := nativeUnsignedTransactionIODiverges(
-		nativeUnsignedTxHex,
-		expectedInputs,
-		expectedOutputs,
-	)
+	substitutionEnabled bool,
+) (*bitcoin.Transaction, error) {
+	nativeUnsignedTx, err := decodeNativeUnsignedTransactionHex(nativeUnsignedTxHex)
 	if err != nil {
+		if substitutionEnabled {
+			return nil, err
+		}
+
 		signTxLogger.Warnf(
 			"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
 			err,
 		)
-		return
+		return nil, nil
+	}
+
+	diverges, err := nativeUnsignedTransactionIODivergesFromTransaction(
+		nativeUnsignedTx,
+		expectedInputs,
+		expectedOutputs,
+	)
+	if err != nil {
+		if substitutionEnabled {
+			return nil, err
+		}
+
+		signTxLogger.Warnf(
+			"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+			err,
+		)
+		return nil, nil
 	}
 
 	if diverges {
+		if substitutionEnabled {
+			return nil, fmt.Errorf(
+				"native BuildTaprootTx unsigned transaction I/O diverges from Go builder state",
+			)
+		}
+
 		signTxLogger.Warnf(
 			"native BuildTaprootTx unsigned transaction I/O diverges from Go builder state",
 		)
 	}
+
+	if substitutionEnabled {
+		return nativeUnsignedTx, nil
+	}
+
+	return nil, nil
+}
+
+func decodeNativeUnsignedTransactionHex(
+	nativeUnsignedTxHex string,
+) (*bitcoin.Transaction, error) {
+	nativeUnsignedTxBytes, err := hex.DecodeString(nativeUnsignedTxHex)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode native tx hex: [%w]", err)
+	}
+
+	nativeUnsignedTx := &bitcoin.Transaction{}
+	if err := nativeUnsignedTx.Deserialize(nativeUnsignedTxBytes); err != nil {
+		return nil, fmt.Errorf("cannot deserialize native tx bytes: [%w]", err)
+	}
+
+	return nativeUnsignedTx, nil
 }
 
 func nativeUnsignedTransactionIODiverges(
@@ -442,16 +535,23 @@ func nativeUnsignedTransactionIODiverges(
 	expectedInputs []bitcoin.UnsignedTransactionInput,
 	expectedOutputs []bitcoin.UnsignedTransactionOutput,
 ) (bool, error) {
-	nativeUnsignedTxBytes, err := hex.DecodeString(nativeUnsignedTxHex)
+	nativeUnsignedTx, err := decodeNativeUnsignedTransactionHex(nativeUnsignedTxHex)
 	if err != nil {
-		return false, fmt.Errorf("cannot decode native tx hex: [%w]", err)
+		return false, err
 	}
 
-	nativeUnsignedTx := &bitcoin.Transaction{}
-	if err := nativeUnsignedTx.Deserialize(nativeUnsignedTxBytes); err != nil {
-		return false, fmt.Errorf("cannot deserialize native tx bytes: [%w]", err)
-	}
+	return nativeUnsignedTransactionIODivergesFromTransaction(
+		nativeUnsignedTx,
+		expectedInputs,
+		expectedOutputs,
+	)
+}
 
+func nativeUnsignedTransactionIODivergesFromTransaction(
+	nativeUnsignedTx *bitcoin.Transaction,
+	expectedInputs []bitcoin.UnsignedTransactionInput,
+	expectedOutputs []bitcoin.UnsignedTransactionOutput,
+) (bool, error) {
 	actualInputReferences, actualOutputs, err := extractUnsignedTransactionIOFromTransaction(
 		nativeUnsignedTx,
 	)

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -611,23 +611,6 @@ func extractUnsignedTransactionShapeFromTransaction(
 	}, nil
 }
 
-func unsignedTransactionInputReferences(
-	inputs []bitcoin.UnsignedTransactionInput,
-) []unsignedTransactionInputReference {
-	result := make([]unsignedTransactionInputReference, 0, len(inputs))
-	for _, input := range inputs {
-		result = append(
-			result,
-			unsignedTransactionInputReference{
-				TxIDHex: input.TxIDHex,
-				Vout:    input.Vout,
-			},
-		)
-	}
-
-	return result
-}
-
 func unsignedTransactionInputReferencesEqual(
 	first []unsignedTransactionInputReference,
 	second []unsignedTransactionInputReference,

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -347,46 +347,30 @@ func (wte *walletTransactionExecutor) signTransaction(
 			len(nativeUnsignedTxHex),
 		)
 
-		expectedInputs, expectedOutputs, err := unsignedTx.UnsignedTransactionIO()
+		nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
+			signTxLogger,
+			nativeUnsignedTxHex,
+			unsignedTx.UnsignedTransaction(),
+			substitutionEnabled,
+		)
 		if err != nil {
-			if substitutionEnabled {
-				return nil, fmt.Errorf(
-					"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
-					err,
-				)
-			}
-
-			signTxLogger.Warnf(
-				"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+			return nil, fmt.Errorf(
+				"cannot process native BuildTaprootTx unsigned transaction for signing: [%v]",
 				err,
 			)
-		} else {
-			nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
-				signTxLogger,
-				nativeUnsignedTxHex,
-				expectedInputs,
-				expectedOutputs,
-				substitutionEnabled,
-			)
-			if err != nil {
+		}
+
+		if nativeUnsignedTx != nil {
+			if err := unsignedTx.ReplaceUnsignedTransaction(nativeUnsignedTx); err != nil {
 				return nil, fmt.Errorf(
-					"cannot process native BuildTaprootTx unsigned transaction for signing: [%v]",
+					"cannot substitute Go unsigned transaction with native BuildTaprootTx output: [%v]",
 					err,
 				)
 			}
 
-			if nativeUnsignedTx != nil {
-				if err := unsignedTx.ReplaceUnsignedTransaction(nativeUnsignedTx); err != nil {
-					return nil, fmt.Errorf(
-						"cannot substitute Go unsigned transaction with native BuildTaprootTx output: [%v]",
-						err,
-					)
-				}
-
-				signTxLogger.Infof(
-					"substituted Go unsigned transaction with native tbtc-signer BuildTaprootTx output",
-				)
-			}
+			signTxLogger.Infof(
+				"substituted Go unsigned transaction with native tbtc-signer BuildTaprootTx output",
+			)
 		}
 	}
 
@@ -461,8 +445,7 @@ func nativeBuildTaprootTxSigningSubstitutionEnabled() bool {
 func evaluateNativeUnsignedTransactionForSigning(
 	signTxLogger log.StandardLogger,
 	nativeUnsignedTxHex string,
-	expectedInputs []bitcoin.UnsignedTransactionInput,
-	expectedOutputs []bitcoin.UnsignedTransactionOutput,
+	expectedTransaction *bitcoin.Transaction,
 	substitutionEnabled bool,
 ) (*bitcoin.Transaction, error) {
 	nativeUnsignedTx, err := decodeNativeUnsignedTransactionHex(nativeUnsignedTxHex)
@@ -472,16 +455,15 @@ func evaluateNativeUnsignedTransactionForSigning(
 		}
 
 		signTxLogger.Warnf(
-			"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+			"cannot compare native BuildTaprootTx unsigned transaction with Go builder state: [%v]",
 			err,
 		)
 		return nil, nil
 	}
 
-	diverges, err := nativeUnsignedTransactionIODivergesFromTransaction(
+	diverges, err := nativeUnsignedTransactionDivergesFromTransaction(
 		nativeUnsignedTx,
-		expectedInputs,
-		expectedOutputs,
+		expectedTransaction,
 	)
 	if err != nil {
 		if substitutionEnabled {
@@ -489,7 +471,7 @@ func evaluateNativeUnsignedTransactionForSigning(
 		}
 
 		signTxLogger.Warnf(
-			"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+			"cannot compare native BuildTaprootTx unsigned transaction with Go builder state: [%v]",
 			err,
 		)
 		return nil, nil
@@ -498,12 +480,12 @@ func evaluateNativeUnsignedTransactionForSigning(
 	if diverges {
 		if substitutionEnabled {
 			return nil, fmt.Errorf(
-				"native BuildTaprootTx unsigned transaction I/O diverges from Go builder state",
+				"native BuildTaprootTx unsigned transaction diverges from Go builder state",
 			)
 		}
 
 		signTxLogger.Warnf(
-			"native BuildTaprootTx unsigned transaction I/O diverges from Go builder state",
+			"native BuildTaprootTx unsigned transaction diverges from Go builder state",
 		)
 	}
 
@@ -547,6 +529,37 @@ func nativeUnsignedTransactionIODiverges(
 	)
 }
 
+func nativeUnsignedTransactionDivergesFromTransaction(
+	nativeUnsignedTx *bitcoin.Transaction,
+	expectedTransaction *bitcoin.Transaction,
+) (bool, error) {
+	actualShape, err := extractUnsignedTransactionShapeFromTransaction(nativeUnsignedTx)
+	if err != nil {
+		return false, err
+	}
+
+	expectedShape, err := extractUnsignedTransactionShapeFromTransaction(expectedTransaction)
+	if err != nil {
+		return false, err
+	}
+
+	return actualShape.Version != expectedShape.Version ||
+			actualShape.Locktime != expectedShape.Locktime ||
+			!unsignedTransactionInputReferencesEqual(
+				actualShape.InputReferences,
+				expectedShape.InputReferences,
+			) ||
+			!unsignedTransactionInputSequencesEqual(
+				actualShape.InputSequences,
+				expectedShape.InputSequences,
+			) ||
+			!unsignedTransactionOutputsEqual(
+				actualShape.Outputs,
+				expectedShape.Outputs,
+			),
+		nil
+}
+
 func nativeUnsignedTransactionIODivergesFromTransaction(
 	nativeUnsignedTx *bitcoin.Transaction,
 	expectedInputs []bitcoin.UnsignedTransactionInput,
@@ -572,25 +585,34 @@ func nativeUnsignedTransactionIODivergesFromTransaction(
 		nil
 }
 
-func extractUnsignedTransactionIOFromTransaction(
+type unsignedTransactionShape struct {
+	Version         int32
+	Locktime        uint32
+	InputReferences []unsignedTransactionInputReference
+	InputSequences  []uint32
+	Outputs         []bitcoin.UnsignedTransactionOutput
+}
+
+func extractUnsignedTransactionShapeFromTransaction(
 	transaction *bitcoin.Transaction,
-) (
-	[]unsignedTransactionInputReference,
-	[]bitcoin.UnsignedTransactionOutput,
-	error,
-) {
+) (*unsignedTransactionShape, error) {
+	if transaction == nil {
+		return nil, fmt.Errorf("transaction is nil")
+	}
+
 	inputReferences := make(
 		[]unsignedTransactionInputReference,
 		0,
 		len(transaction.Inputs),
 	)
+	inputSequences := make([]uint32, 0, len(transaction.Inputs))
 	for i, input := range transaction.Inputs {
 		if input == nil {
-			return nil, nil, fmt.Errorf("transaction input [%d] is nil", i)
+			return nil, fmt.Errorf("transaction input [%d] is nil", i)
 		}
 
 		if input.Outpoint == nil {
-			return nil, nil, fmt.Errorf("transaction input [%d] outpoint is nil", i)
+			return nil, fmt.Errorf("transaction input [%d] outpoint is nil", i)
 		}
 
 		inputReferences = append(
@@ -600,16 +622,17 @@ func extractUnsignedTransactionIOFromTransaction(
 				Vout:    input.Outpoint.OutputIndex,
 			},
 		)
+		inputSequences = append(inputSequences, input.Sequence)
 	}
 
 	outputs := make([]bitcoin.UnsignedTransactionOutput, 0, len(transaction.Outputs))
 	for i, output := range transaction.Outputs {
 		if output == nil {
-			return nil, nil, fmt.Errorf("transaction output [%d] is nil", i)
+			return nil, fmt.Errorf("transaction output [%d] is nil", i)
 		}
 
 		if output.Value < 0 {
-			return nil, nil, fmt.Errorf("transaction output [%d] value is negative", i)
+			return nil, fmt.Errorf("transaction output [%d] value is negative", i)
 		}
 
 		outputs = append(
@@ -621,7 +644,28 @@ func extractUnsignedTransactionIOFromTransaction(
 		)
 	}
 
-	return inputReferences, outputs, nil
+	return &unsignedTransactionShape{
+		Version:         transaction.Version,
+		Locktime:        transaction.Locktime,
+		InputReferences: inputReferences,
+		InputSequences:  inputSequences,
+		Outputs:         outputs,
+	}, nil
+}
+
+func extractUnsignedTransactionIOFromTransaction(
+	transaction *bitcoin.Transaction,
+) (
+	[]unsignedTransactionInputReference,
+	[]bitcoin.UnsignedTransactionOutput,
+	error,
+) {
+	shape, err := extractUnsignedTransactionShapeFromTransaction(transaction)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return shape.InputReferences, shape.Outputs, nil
 }
 
 func unsignedTransactionInputReferences(
@@ -661,6 +705,23 @@ func unsignedTransactionInputReferencesEqual(
 func unsignedTransactionOutputsEqual(
 	first []bitcoin.UnsignedTransactionOutput,
 	second []bitcoin.UnsignedTransactionOutput,
+) bool {
+	if len(first) != len(second) {
+		return false
+	}
+
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func unsignedTransactionInputSequencesEqual(
+	first []uint32,
+	second []uint32,
 ) bool {
 	if len(first) != len(second) {
 		return false

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -461,7 +461,7 @@ func evaluateNativeUnsignedTransactionForSigning(
 		return nil, nil
 	}
 
-	diverges, err := nativeUnsignedTransactionDivergesFromTransaction(
+	diverges, divergenceReason, err := nativeUnsignedTransactionDivergesFromTransaction(
 		nativeUnsignedTx,
 		expectedTransaction,
 	)
@@ -478,15 +478,20 @@ func evaluateNativeUnsignedTransactionForSigning(
 	}
 
 	if diverges {
-		if substitutionEnabled {
-			return nil, fmt.Errorf(
-				"native BuildTaprootTx unsigned transaction diverges from Go builder state",
+		divergenceMessage := "native BuildTaprootTx unsigned transaction diverges from Go builder state"
+		if divergenceReason != "" {
+			divergenceMessage = fmt.Sprintf(
+				"%s: %s",
+				divergenceMessage,
+				divergenceReason,
 			)
 		}
 
-		signTxLogger.Warnf(
-			"native BuildTaprootTx unsigned transaction diverges from Go builder state",
-		)
+		if substitutionEnabled {
+			return nil, fmt.Errorf("%s", divergenceMessage)
+		}
+
+		signTxLogger.Warnf(divergenceMessage)
 	}
 
 	if substitutionEnabled {
@@ -515,32 +520,83 @@ func decodeNativeUnsignedTransactionHex(
 func nativeUnsignedTransactionDivergesFromTransaction(
 	nativeUnsignedTx *bitcoin.Transaction,
 	expectedTransaction *bitcoin.Transaction,
-) (bool, error) {
+) (bool, string, error) {
 	actualShape, err := extractUnsignedTransactionShapeFromTransaction(nativeUnsignedTx)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	expectedShape, err := extractUnsignedTransactionShapeFromTransaction(expectedTransaction)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
-	return actualShape.Version != expectedShape.Version ||
-			actualShape.Locktime != expectedShape.Locktime ||
-			!unsignedTransactionInputReferencesEqual(
-				actualShape.InputReferences,
-				expectedShape.InputReferences,
-			) ||
-			!unsignedTransactionInputSequencesEqual(
-				actualShape.InputSequences,
-				expectedShape.InputSequences,
-			) ||
-			!unsignedTransactionOutputsEqual(
-				actualShape.Outputs,
-				expectedShape.Outputs,
-			),
-		nil
+	if actualShape.Version != expectedShape.Version {
+		return true, fmt.Sprintf(
+			"version mismatch: expected [%d], got [%d]",
+			expectedShape.Version,
+			actualShape.Version,
+		), nil
+	}
+
+	if actualShape.Locktime != expectedShape.Locktime {
+		return true, fmt.Sprintf(
+			"locktime mismatch: expected [%d], got [%d]",
+			expectedShape.Locktime,
+			actualShape.Locktime,
+		), nil
+	}
+
+	if reason, diverges := unsignedTransactionInputReferencesDivergenceReason(
+		actualShape.InputReferences,
+		expectedShape.InputReferences,
+	); diverges {
+		return true, reason, nil
+	}
+
+	if reason, diverges := unsignedTransactionInputSequencesDivergenceReason(
+		actualShape.InputSequences,
+		expectedShape.InputSequences,
+	); diverges {
+		return true, reason, nil
+	}
+
+	if reason, diverges := unsignedTransactionOutputsDivergenceReason(
+		actualShape.Outputs,
+		expectedShape.Outputs,
+	); diverges {
+		return true, reason, nil
+	}
+
+	return false, "", nil
+}
+
+func unsignedTransactionInputReferencesDivergenceReason(
+	actual []unsignedTransactionInputReference,
+	expected []unsignedTransactionInputReference,
+) (string, bool) {
+	if len(actual) != len(expected) {
+		return fmt.Sprintf(
+			"input reference count mismatch: expected [%d], got [%d]",
+			len(expected),
+			len(actual),
+		), true
+	}
+
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return fmt.Sprintf(
+				"input reference mismatch at index [%d]: expected [%s:%d], got [%s:%d]",
+				i,
+				expected[i].TxIDHex,
+				expected[i].Vout,
+				actual[i].TxIDHex,
+				actual[i].Vout,
+			), true
+		}
+	}
+
+	return "", false
 }
 
 type unsignedTransactionShape struct {
@@ -611,55 +667,65 @@ func extractUnsignedTransactionShapeFromTransaction(
 	}, nil
 }
 
-func unsignedTransactionInputReferencesEqual(
-	first []unsignedTransactionInputReference,
-	second []unsignedTransactionInputReference,
-) bool {
-	if len(first) != len(second) {
-		return false
+func unsignedTransactionOutputsDivergenceReason(
+	actual []bitcoin.UnsignedTransactionOutput,
+	expected []bitcoin.UnsignedTransactionOutput,
+) (string, bool) {
+	if len(actual) != len(expected) {
+		return fmt.Sprintf(
+			"output count mismatch: expected [%d], got [%d]",
+			len(expected),
+			len(actual),
+		), true
 	}
 
-	for i := range first {
-		if first[i] != second[i] {
-			return false
+	for i := range actual {
+		if actual[i].ValueSats != expected[i].ValueSats {
+			return fmt.Sprintf(
+				"output value mismatch at index [%d]: expected [%d], got [%d]",
+				i,
+				expected[i].ValueSats,
+				actual[i].ValueSats,
+			), true
+		}
+
+		if actual[i].ScriptPubKeyHex != expected[i].ScriptPubKeyHex {
+			return fmt.Sprintf(
+				"output script mismatch at index [%d]: expected [%s], got [%s]",
+				i,
+				expected[i].ScriptPubKeyHex,
+				actual[i].ScriptPubKeyHex,
+			), true
 		}
 	}
 
-	return true
+	return "", false
 }
 
-func unsignedTransactionOutputsEqual(
-	first []bitcoin.UnsignedTransactionOutput,
-	second []bitcoin.UnsignedTransactionOutput,
-) bool {
-	if len(first) != len(second) {
-		return false
+func unsignedTransactionInputSequencesDivergenceReason(
+	actual []uint32,
+	expected []uint32,
+) (string, bool) {
+	if len(actual) != len(expected) {
+		return fmt.Sprintf(
+			"input sequence count mismatch: expected [%d], got [%d]",
+			len(expected),
+			len(actual),
+		), true
 	}
 
-	for i := range first {
-		if first[i] != second[i] {
-			return false
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return fmt.Sprintf(
+				"input sequence mismatch at index [%d]: expected [%d], got [%d]",
+				i,
+				expected[i],
+				actual[i],
+			), true
 		}
 	}
 
-	return true
-}
-
-func unsignedTransactionInputSequencesEqual(
-	first []uint32,
-	second []uint32,
-) bool {
-	if len(first) != len(second) {
-		return false
-	}
-
-	for i := range first {
-		if first[i] != second[i] {
-			return false
-		}
-	}
-
-	return true
+	return "", false
 }
 
 // broadcastTransaction broadcasts a signed Bitcoin transaction until

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -296,6 +296,8 @@ type walletTransactionExecutor struct {
 	waitForBlockFn waitForBlockFn
 }
 
+var buildTaprootTxViaNativeSignerFn = buildTaprootTxViaNativeSigner
+
 func newWalletTransactionExecutor(
 	btcChain bitcoin.Chain,
 	executingWallet wallet,
@@ -319,6 +321,21 @@ func (wte *walletTransactionExecutor) signTransaction(
 	signingStartBlock uint64,
 	signingTimeoutBlock uint64,
 ) (*bitcoin.Transaction, error) {
+	nativeUnsignedTxHex, err := buildTaprootTxViaNativeSignerFn(unsignedTx)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error while building unsigned transaction with native tbtc-signer: [%v]",
+			err,
+		)
+	}
+
+	if nativeUnsignedTxHex != "" {
+		signTxLogger.Debugf(
+			"received unsigned transaction from native tbtc-signer BuildTaprootTx [txHexLen:%d]",
+			len(nativeUnsignedTxHex),
+		)
+	}
+
 	signTxLogger.Infof("computing transaction's sig hashes")
 
 	sigHashes, err := unsignedTx.ComputeSignatureHashes()

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -23,6 +23,11 @@ import (
 	"go.uber.org/zap"
 )
 
+type unsignedTransactionInputReference struct {
+	TxIDHex string
+	Vout    uint32
+}
+
 // WalletActionType represents actions types that can be performed by a wallet.
 type WalletActionType uint8
 
@@ -334,6 +339,21 @@ func (wte *walletTransactionExecutor) signTransaction(
 			"received unsigned transaction from native tbtc-signer BuildTaprootTx [txHexLen:%d]",
 			len(nativeUnsignedTxHex),
 		)
+
+		expectedInputs, expectedOutputs, err := unsignedTx.UnsignedTransactionIO()
+		if err != nil {
+			signTxLogger.Warnf(
+				"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+				err,
+			)
+		} else {
+			warnOnNativeUnsignedTransactionIODivergence(
+				signTxLogger,
+				nativeUnsignedTxHex,
+				expectedInputs,
+				expectedOutputs,
+			)
+		}
 	}
 
 	signTxLogger.Infof("computing transaction's sig hashes")
@@ -389,6 +409,170 @@ func (wte *walletTransactionExecutor) signTransaction(
 	signTxLogger.Infof("transaction created successfully")
 
 	return tx, nil
+}
+
+func warnOnNativeUnsignedTransactionIODivergence(
+	signTxLogger log.StandardLogger,
+	nativeUnsignedTxHex string,
+	expectedInputs []bitcoin.UnsignedTransactionInput,
+	expectedOutputs []bitcoin.UnsignedTransactionOutput,
+) {
+	diverges, err := nativeUnsignedTransactionIODiverges(
+		nativeUnsignedTxHex,
+		expectedInputs,
+		expectedOutputs,
+	)
+	if err != nil {
+		signTxLogger.Warnf(
+			"cannot compare native BuildTaprootTx unsigned transaction I/O with Go builder state: [%v]",
+			err,
+		)
+		return
+	}
+
+	if diverges {
+		signTxLogger.Warnf(
+			"native BuildTaprootTx unsigned transaction I/O diverges from Go builder state",
+		)
+	}
+}
+
+func nativeUnsignedTransactionIODiverges(
+	nativeUnsignedTxHex string,
+	expectedInputs []bitcoin.UnsignedTransactionInput,
+	expectedOutputs []bitcoin.UnsignedTransactionOutput,
+) (bool, error) {
+	nativeUnsignedTxBytes, err := hex.DecodeString(nativeUnsignedTxHex)
+	if err != nil {
+		return false, fmt.Errorf("cannot decode native tx hex: [%w]", err)
+	}
+
+	nativeUnsignedTx := &bitcoin.Transaction{}
+	if err := nativeUnsignedTx.Deserialize(nativeUnsignedTxBytes); err != nil {
+		return false, fmt.Errorf("cannot deserialize native tx bytes: [%w]", err)
+	}
+
+	actualInputReferences, actualOutputs, err := extractUnsignedTransactionIOFromTransaction(
+		nativeUnsignedTx,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	expectedInputReferences := unsignedTransactionInputReferences(expectedInputs)
+
+	return !unsignedTransactionInputReferencesEqual(
+			expectedInputReferences,
+			actualInputReferences,
+		) ||
+			!unsignedTransactionOutputsEqual(
+				expectedOutputs,
+				actualOutputs,
+			),
+		nil
+}
+
+func extractUnsignedTransactionIOFromTransaction(
+	transaction *bitcoin.Transaction,
+) (
+	[]unsignedTransactionInputReference,
+	[]bitcoin.UnsignedTransactionOutput,
+	error,
+) {
+	inputReferences := make(
+		[]unsignedTransactionInputReference,
+		0,
+		len(transaction.Inputs),
+	)
+	for i, input := range transaction.Inputs {
+		if input == nil {
+			return nil, nil, fmt.Errorf("transaction input [%d] is nil", i)
+		}
+
+		if input.Outpoint == nil {
+			return nil, nil, fmt.Errorf("transaction input [%d] outpoint is nil", i)
+		}
+
+		inputReferences = append(
+			inputReferences,
+			unsignedTransactionInputReference{
+				TxIDHex: input.Outpoint.TransactionHash.Hex(bitcoin.ReversedByteOrder),
+				Vout:    input.Outpoint.OutputIndex,
+			},
+		)
+	}
+
+	outputs := make([]bitcoin.UnsignedTransactionOutput, 0, len(transaction.Outputs))
+	for i, output := range transaction.Outputs {
+		if output == nil {
+			return nil, nil, fmt.Errorf("transaction output [%d] is nil", i)
+		}
+
+		if output.Value < 0 {
+			return nil, nil, fmt.Errorf("transaction output [%d] value is negative", i)
+		}
+
+		outputs = append(
+			outputs,
+			bitcoin.UnsignedTransactionOutput{
+				ScriptPubKeyHex: hex.EncodeToString(output.PublicKeyScript),
+				ValueSats:       uint64(output.Value),
+			},
+		)
+	}
+
+	return inputReferences, outputs, nil
+}
+
+func unsignedTransactionInputReferences(
+	inputs []bitcoin.UnsignedTransactionInput,
+) []unsignedTransactionInputReference {
+	result := make([]unsignedTransactionInputReference, 0, len(inputs))
+	for _, input := range inputs {
+		result = append(
+			result,
+			unsignedTransactionInputReference{
+				TxIDHex: input.TxIDHex,
+				Vout:    input.Vout,
+			},
+		)
+	}
+
+	return result
+}
+
+func unsignedTransactionInputReferencesEqual(
+	first []unsignedTransactionInputReference,
+	second []unsignedTransactionInputReference,
+) bool {
+	if len(first) != len(second) {
+		return false
+	}
+
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func unsignedTransactionOutputsEqual(
+	first []bitcoin.UnsignedTransactionOutput,
+	second []bitcoin.UnsignedTransactionOutput,
+) bool {
+	if len(first) != len(second) {
+		return false
+	}
+
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // broadcastTransaction broadcasts a signed Bitcoin transaction until

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -208,18 +208,24 @@ func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarnin
 	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
 		logger,
 		nativeTxHex,
-		[]bitcoin.UnsignedTransactionInput{
-			{
-				TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
-				Vout:      7,
-				ValueSats: 1234,
+		&bitcoin.Transaction{
+			Version: 2,
+			Inputs: []*bitcoin.TransactionInput{
+				{
+					Outpoint: &bitcoin.TransactionOutpoint{
+						TransactionHash: txHash,
+						OutputIndex:     7,
+					},
+					Sequence: 0xffffffff,
+				},
 			},
-		},
-		[]bitcoin.UnsignedTransactionOutput{
-			{
-				ScriptPubKeyHex: "0014deadbeef",
-				ValueSats:       999,
+			Outputs: []*bitcoin.TransactionOutput{
+				{
+					Value:           999,
+					PublicKeyScript: scriptPubKey,
+				},
 			},
+			Locktime: 0,
 		},
 		false,
 	)
@@ -285,18 +291,24 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsDive
 	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
 		logger,
 		nativeTxHex,
-		[]bitcoin.UnsignedTransactionInput{
-			{
-				TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
-				Vout:      7,
-				ValueSats: 1234,
+		&bitcoin.Transaction{
+			Version: 2,
+			Inputs: []*bitcoin.TransactionInput{
+				{
+					Outpoint: &bitcoin.TransactionOutpoint{
+						TransactionHash: txHash,
+						OutputIndex:     7,
+					},
+					Sequence: 0xffffffff,
+				},
 			},
-		},
-		[]bitcoin.UnsignedTransactionOutput{
-			{
-				ScriptPubKeyHex: "0014deadbeef",
-				ValueSats:       999,
+			Outputs: []*bitcoin.TransactionOutput{
+				{
+					Value:           999,
+					PublicKeyScript: scriptPubKey,
+				},
 			},
+			Locktime: 0,
 		},
 		true,
 	)
@@ -358,19 +370,7 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeAcceptsMatc
 	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
 		logger,
 		nativeTxHex,
-		[]bitcoin.UnsignedTransactionInput{
-			{
-				TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
-				Vout:      7,
-				ValueSats: 1234,
-			},
-		},
-		[]bitcoin.UnsignedTransactionOutput{
-			{
-				ScriptPubKeyHex: "0014deadbeef",
-				ValueSats:       1000,
-			},
-		},
+		nativeTransaction,
 		true,
 	)
 	if err != nil {
@@ -379,6 +379,87 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeAcceptsMatc
 
 	if nativeUnsignedTx == nil {
 		t.Fatal("expected native transaction substitution candidate")
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warnings in substitution mode: [%v]", logger.warningMessages)
+	}
+}
+
+func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsStructuralDivergence(
+	t *testing.T,
+) {
+	logger := &warningCaptureLogger{}
+
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	expectedTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
+		logger,
+		nativeTxHex,
+		expectedTransaction,
+		true,
+	)
+	if err == nil {
+		t.Fatal("expected substitution-mode structural divergence error")
+	}
+
+	if !strings.Contains(err.Error(), "diverges") {
+		t.Fatalf("unexpected substitution-mode error: [%v]", err)
+	}
+
+	if nativeUnsignedTx != nil {
+		t.Fatal("did not expect native transaction on divergence")
 	}
 
 	if len(logger.warningMessages) != 0 {
@@ -540,12 +621,19 @@ func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeUnsignedTran
 	if len(logger.warningMessages) != 0 {
 		t.Fatalf("unexpected warning logs: [%v]", logger.warningMessages)
 	}
+
+	if !containsLoggedMessage(
+		logger.infoMessages,
+		"substituted Go unsigned transaction with native tbtc-signer BuildTaprootTx output",
+	) {
+		t.Fatalf("expected substitution info log, got: [%v]", logger.infoMessages)
+	}
 }
 
 func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisabled(
 	t *testing.T,
 ) {
-	privateKey, unsignedTx, nativeUnsignedTxHex, nativeUnsignedTx := buildTaprootTxSubstitutionFixture(t)
+	privateKey, unsignedTx, nativeUnsignedTxHex, _ := buildTaprootTxSubstitutionFixture(t)
 
 	originalBuildTaprootTxViaNativeSignerFn := buildTaprootTxViaNativeSignerFn
 	originalSigningSubstitutionEnabledFn := nativeBuildTaprootTxSigningSubstitutionEnabledFn
@@ -589,23 +677,9 @@ func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisa
 		)
 	}
 
-	if tx.Version == nativeUnsignedTx.Version {
-		t.Fatalf(
-			"did not expect transaction version substitution when gate disabled: [%v]",
-			tx.Version,
-		)
-	}
-
 	if tx.Locktime != 0 {
 		t.Fatalf(
 			"unexpected non-substituted transaction locktime\nexpected: [0]\nactual:   [%v]",
-			tx.Locktime,
-		)
-	}
-
-	if tx.Locktime == nativeUnsignedTx.Locktime {
-		t.Fatalf(
-			"did not expect transaction locktime substitution when gate disabled: [%v]",
 			tx.Locktime,
 		)
 	}
@@ -617,15 +691,15 @@ func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisa
 		)
 	}
 
-	if tx.Inputs[0].Sequence == nativeUnsignedTx.Inputs[0].Sequence {
-		t.Fatalf(
-			"did not expect input sequence substitution when gate disabled: [%v]",
-			tx.Inputs[0].Sequence,
-		)
-	}
-
 	if len(logger.warningMessages) != 0 {
 		t.Fatalf("unexpected warning logs: [%v]", logger.warningMessages)
+	}
+
+	if containsLoggedMessage(
+		logger.infoMessages,
+		"substituted Go unsigned transaction with native tbtc-signer BuildTaprootTx output",
+	) {
+		t.Fatalf("did not expect substitution info log when gate disabled: [%v]", logger.infoMessages)
 	}
 }
 
@@ -690,6 +764,80 @@ func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransact
 
 	if tx != nil {
 		t.Fatal("expected no signed transaction on substitution divergence")
+	}
+
+	if !strings.Contains(err.Error(), "diverges") {
+		t.Fatalf("unexpected signTransaction divergence error: [%v]", err)
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warning logs in substitution mode: [%v]", logger.warningMessages)
+	}
+}
+
+func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransactionStructuralDivergenceWhenGateEnabled(
+	t *testing.T,
+) {
+	privateKey, unsignedTx, _, nativeUnsignedTx := buildTaprootTxSubstitutionFixture(t)
+
+	divergingNativeUnsignedTx := *nativeUnsignedTx
+	divergingInputs := make(
+		[]*bitcoin.TransactionInput,
+		len(nativeUnsignedTx.Inputs),
+	)
+	for i, input := range nativeUnsignedTx.Inputs {
+		if input == nil {
+			t.Fatalf("native fixture input [%d] is nil", i)
+		}
+
+		clonedInput := *input
+		divergingInputs[i] = &clonedInput
+	}
+	divergingNativeUnsignedTx.Inputs = divergingInputs
+	divergingNativeUnsignedTx.Version = nativeUnsignedTx.Version + 1
+	divergingNativeUnsignedTx.Locktime = nativeUnsignedTx.Locktime + 1
+	divergingNativeUnsignedTx.Inputs[0].Sequence = nativeUnsignedTx.Inputs[0].Sequence - 1
+	divergingNativeUnsignedTxHex := hex.EncodeToString(
+		divergingNativeUnsignedTx.Serialize(bitcoin.Standard),
+	)
+
+	originalBuildTaprootTxViaNativeSignerFn := buildTaprootTxViaNativeSignerFn
+	originalSigningSubstitutionEnabledFn := nativeBuildTaprootTxSigningSubstitutionEnabledFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = originalBuildTaprootTxViaNativeSignerFn
+		nativeBuildTaprootTxSigningSubstitutionEnabledFn = originalSigningSubstitutionEnabledFn
+	})
+
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		return divergingNativeUnsignedTxHex, nil
+	}
+	nativeBuildTaprootTxSigningSubstitutionEnabledFn = func() bool {
+		return true
+	}
+
+	wte := &walletTransactionExecutor{
+		executingWallet: wallet{
+			publicKey: &privateKey.PublicKey,
+		},
+		signingExecutor: &deterministicECDSASigningExecutorForBuildTaprootTxSubstitution{
+			privateKey: privateKey,
+		},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+
+	logger := &warningCaptureLogger{}
+
+	tx, err := wte.signTransaction(logger, unsignedTx, 0, 0)
+	if err == nil {
+		t.Fatal("expected signTransaction structural divergence error")
+	}
+
+	if tx != nil {
+		t.Fatal("expected no signed transaction on substitution structural divergence")
 	}
 
 	if !strings.Contains(err.Error(), "diverges") {
@@ -769,15 +917,15 @@ func buildTaprootTxSubstitutionFixture(
 	)
 
 	nativeUnsignedTx := &bitcoin.Transaction{
-		Version:  3,
-		Locktime: 123,
+		Version:  1,
+		Locktime: 0,
 		Inputs: []*bitcoin.TransactionInput{
 			{
 				Outpoint: &bitcoin.TransactionOutpoint{
 					TransactionHash: fundingTransaction.Hash(),
 					OutputIndex:     0,
 				},
-				Sequence: 0xfffffffd,
+				Sequence: 0xffffffff,
 			},
 		},
 		Outputs: []*bitcoin.TransactionOutput{
@@ -805,6 +953,7 @@ func mustDecodeHex(t *testing.T, value string) []byte {
 
 type warningCaptureLogger struct {
 	warningMessages []string
+	infoMessages    []string
 }
 
 func (wcl *warningCaptureLogger) Debug(args ...interface{}) {}
@@ -819,9 +968,13 @@ func (wcl *warningCaptureLogger) Fatal(args ...interface{}) {}
 
 func (wcl *warningCaptureLogger) Fatalf(format string, args ...interface{}) {}
 
-func (wcl *warningCaptureLogger) Info(args ...interface{}) {}
+func (wcl *warningCaptureLogger) Info(args ...interface{}) {
+	wcl.infoMessages = append(wcl.infoMessages, fmt.Sprint(args...))
+}
 
-func (wcl *warningCaptureLogger) Infof(format string, args ...interface{}) {}
+func (wcl *warningCaptureLogger) Infof(format string, args ...interface{}) {
+	wcl.infoMessages = append(wcl.infoMessages, fmt.Sprintf(format, args...))
+}
 
 func (wcl *warningCaptureLogger) Panic(args ...interface{}) {}
 
@@ -834,6 +987,16 @@ func (wcl *warningCaptureLogger) Warnf(format string, args ...interface{}) {
 		wcl.warningMessages,
 		fmt.Sprintf(format, args...),
 	)
+}
+
+func containsLoggedMessage(messages []string, substring string) bool {
+	for _, message := range messages {
+		if strings.Contains(message, substring) {
+			return true
+		}
+	}
+
+	return false
 }
 
 type deterministicECDSASigningExecutorForBuildTaprootTxSubstitution struct {

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -43,130 +43,6 @@ func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
 	}
 }
 
-func TestNativeUnsignedTransactionIODiverges_MatchingIO(t *testing.T) {
-	txHashBytes := make([]byte, bitcoin.HashByteLength)
-	for i := range txHashBytes {
-		txHashBytes[i] = byte(i + 1)
-	}
-
-	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
-	if err != nil {
-		t.Fatalf("cannot build tx hash: [%v]", err)
-	}
-
-	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
-	nativeTransaction := &bitcoin.Transaction{
-		Version: 2,
-		Inputs: []*bitcoin.TransactionInput{
-			{
-				Outpoint: &bitcoin.TransactionOutpoint{
-					TransactionHash: txHash,
-					OutputIndex:     7,
-				},
-				Sequence: 0xffffffff,
-			},
-		},
-		Outputs: []*bitcoin.TransactionOutput{
-			{
-				Value:           1000,
-				PublicKeyScript: scriptPubKey,
-			},
-		},
-		Locktime: 0,
-	}
-
-	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
-
-	expectedInputs := []bitcoin.UnsignedTransactionInput{
-		{
-			TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
-			Vout:      7,
-			ValueSats: 1234,
-		},
-	}
-	expectedOutputs := []bitcoin.UnsignedTransactionOutput{
-		{
-			ScriptPubKeyHex: "0014deadbeef",
-			ValueSats:       1000,
-		},
-	}
-
-	diverges, err := nativeUnsignedTransactionIODiverges(
-		nativeTxHex,
-		expectedInputs,
-		expectedOutputs,
-	)
-	if err != nil {
-		t.Fatalf("unexpected comparison error: [%v]", err)
-	}
-
-	if diverges {
-		t.Fatal("expected matching unsigned transaction I/O")
-	}
-}
-
-func TestNativeUnsignedTransactionIODiverges_MismatchedIO(t *testing.T) {
-	txHashBytes := make([]byte, bitcoin.HashByteLength)
-	for i := range txHashBytes {
-		txHashBytes[i] = byte(i + 1)
-	}
-
-	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
-	if err != nil {
-		t.Fatalf("cannot build tx hash: [%v]", err)
-	}
-
-	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
-	nativeTransaction := &bitcoin.Transaction{
-		Version: 2,
-		Inputs: []*bitcoin.TransactionInput{
-			{
-				Outpoint: &bitcoin.TransactionOutpoint{
-					TransactionHash: txHash,
-					OutputIndex:     7,
-				},
-				Sequence: 0xffffffff,
-			},
-		},
-		Outputs: []*bitcoin.TransactionOutput{
-			{
-				Value:           1000,
-				PublicKeyScript: scriptPubKey,
-			},
-		},
-		Locktime: 0,
-	}
-
-	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
-
-	expectedInputs := []bitcoin.UnsignedTransactionInput{
-		{
-			TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
-			Vout:      7,
-			ValueSats: 1234,
-		},
-	}
-	expectedOutputs := []bitcoin.UnsignedTransactionOutput{
-		{
-			ScriptPubKeyHex: "0014deadbeef",
-			ValueSats:       999,
-		},
-	}
-
-	diverges, err := nativeUnsignedTransactionIODiverges(
-		nativeTxHex,
-		expectedInputs,
-		expectedOutputs,
-	)
-	if err != nil {
-		t.Fatalf("unexpected comparison error: [%v]", err)
-	}
-
-	if !diverges {
-		t.Fatal("expected unsigned transaction I/O divergence")
-	}
-}
-
 func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarning(
 	t *testing.T,
 ) {
@@ -222,6 +98,89 @@ func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarnin
 			Outputs: []*bitcoin.TransactionOutput{
 				{
 					Value:           999,
+					PublicKeyScript: scriptPubKey,
+				},
+			},
+			Locktime: 0,
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected evaluation error: [%v]", err)
+	}
+
+	if nativeUnsignedTx != nil {
+		t.Fatal("did not expect native transaction substitution in observational mode")
+	}
+
+	if len(logger.warningMessages) != 1 {
+		t.Fatalf(
+			"unexpected warning message count\nexpected: [%v]\nactual:   [%v]",
+			1,
+			len(logger.warningMessages),
+		)
+	}
+
+	if !strings.Contains(logger.warningMessages[0], "diverges") {
+		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
+	}
+}
+
+func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarningOnStructuralDivergence(
+	t *testing.T,
+) {
+	logger := &warningCaptureLogger{}
+
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
+		logger,
+		nativeTxHex,
+		&bitcoin.Transaction{
+			Version: 1,
+			Inputs: []*bitcoin.TransactionInput{
+				{
+					Outpoint: &bitcoin.TransactionOutpoint{
+						TransactionHash: txHash,
+						OutputIndex:     7,
+					},
+					Sequence: 0xffffffff,
+				},
+			},
+			Outputs: []*bitcoin.TransactionOutput{
+				{
+					Value:           1000,
 					PublicKeyScript: scriptPubKey,
 				},
 			},

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -582,6 +582,13 @@ func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisa
 		t.Fatalf("unexpected signTransaction error: [%v]", err)
 	}
 
+	if tx.Version != 1 {
+		t.Fatalf(
+			"unexpected non-substituted transaction version\nexpected: [1]\nactual:   [%v]",
+			tx.Version,
+		)
+	}
+
 	if tx.Version == nativeUnsignedTx.Version {
 		t.Fatalf(
 			"did not expect transaction version substitution when gate disabled: [%v]",
@@ -589,10 +596,24 @@ func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisa
 		)
 	}
 
+	if tx.Locktime != 0 {
+		t.Fatalf(
+			"unexpected non-substituted transaction locktime\nexpected: [0]\nactual:   [%v]",
+			tx.Locktime,
+		)
+	}
+
 	if tx.Locktime == nativeUnsignedTx.Locktime {
 		t.Fatalf(
 			"did not expect transaction locktime substitution when gate disabled: [%v]",
 			tx.Locktime,
+		)
+	}
+
+	if tx.Inputs[0].Sequence != 0xffffffff {
+		t.Fatalf(
+			"unexpected non-substituted input sequence\nexpected: [4294967295]\nactual:   [%v]",
+			tx.Inputs[0].Sequence,
 		)
 	}
 
@@ -605,6 +626,78 @@ func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisa
 
 	if len(logger.warningMessages) != 0 {
 		t.Fatalf("unexpected warning logs: [%v]", logger.warningMessages)
+	}
+}
+
+func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransactionDivergenceWhenGateEnabled(
+	t *testing.T,
+) {
+	privateKey, unsignedTx, _, nativeUnsignedTx := buildTaprootTxSubstitutionFixture(t)
+
+	divergingNativeUnsignedTx := *nativeUnsignedTx
+	divergingOutputs := make(
+		[]*bitcoin.TransactionOutput,
+		len(nativeUnsignedTx.Outputs),
+	)
+	for i, output := range nativeUnsignedTx.Outputs {
+		if output == nil {
+			t.Fatalf("native fixture output [%d] is nil", i)
+		}
+
+		clonedOutput := *output
+		divergingOutputs[i] = &clonedOutput
+	}
+	divergingNativeUnsignedTx.Outputs = divergingOutputs
+	divergingNativeUnsignedTx.Outputs[0].Value = nativeUnsignedTx.Outputs[0].Value - 1
+	divergingNativeUnsignedTxHex := hex.EncodeToString(
+		divergingNativeUnsignedTx.Serialize(bitcoin.Standard),
+	)
+
+	originalBuildTaprootTxViaNativeSignerFn := buildTaprootTxViaNativeSignerFn
+	originalSigningSubstitutionEnabledFn := nativeBuildTaprootTxSigningSubstitutionEnabledFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = originalBuildTaprootTxViaNativeSignerFn
+		nativeBuildTaprootTxSigningSubstitutionEnabledFn = originalSigningSubstitutionEnabledFn
+	})
+
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		return divergingNativeUnsignedTxHex, nil
+	}
+	nativeBuildTaprootTxSigningSubstitutionEnabledFn = func() bool {
+		return true
+	}
+
+	wte := &walletTransactionExecutor{
+		executingWallet: wallet{
+			publicKey: &privateKey.PublicKey,
+		},
+		signingExecutor: &deterministicECDSASigningExecutorForBuildTaprootTxSubstitution{
+			privateKey: privateKey,
+		},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+
+	logger := &warningCaptureLogger{}
+
+	tx, err := wte.signTransaction(logger, unsignedTx, 0, 0)
+	if err == nil {
+		t.Fatal("expected signTransaction divergence error")
+	}
+
+	if tx != nil {
+		t.Fatal("expected no signed transaction on substitution divergence")
+	}
+
+	if !strings.Contains(err.Error(), "diverges") {
+		t.Fatalf("unexpected signTransaction divergence error: [%v]", err)
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warning logs in substitution mode: [%v]", logger.warningMessages)
 	}
 }
 

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -1,7 +1,9 @@
 package tbtc
 
 import (
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -32,4 +34,237 @@ func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
 	if !strings.Contains(err.Error(), "native tbtc-signer") {
 		t.Fatalf("unexpected error: [%v]", err)
 	}
+}
+
+func TestNativeUnsignedTransactionIODiverges_MatchingIO(t *testing.T) {
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	expectedInputs := []bitcoin.UnsignedTransactionInput{
+		{
+			TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
+			Vout:      7,
+			ValueSats: 1234,
+		},
+	}
+	expectedOutputs := []bitcoin.UnsignedTransactionOutput{
+		{
+			ScriptPubKeyHex: "0014deadbeef",
+			ValueSats:       1000,
+		},
+	}
+
+	diverges, err := nativeUnsignedTransactionIODiverges(
+		nativeTxHex,
+		expectedInputs,
+		expectedOutputs,
+	)
+	if err != nil {
+		t.Fatalf("unexpected comparison error: [%v]", err)
+	}
+
+	if diverges {
+		t.Fatal("expected matching unsigned transaction I/O")
+	}
+}
+
+func TestNativeUnsignedTransactionIODiverges_MismatchedIO(t *testing.T) {
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	expectedInputs := []bitcoin.UnsignedTransactionInput{
+		{
+			TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
+			Vout:      7,
+			ValueSats: 1234,
+		},
+	}
+	expectedOutputs := []bitcoin.UnsignedTransactionOutput{
+		{
+			ScriptPubKeyHex: "0014deadbeef",
+			ValueSats:       999,
+		},
+	}
+
+	diverges, err := nativeUnsignedTransactionIODiverges(
+		nativeTxHex,
+		expectedInputs,
+		expectedOutputs,
+	)
+	if err != nil {
+		t.Fatalf("unexpected comparison error: [%v]", err)
+	}
+
+	if !diverges {
+		t.Fatal("expected unsigned transaction I/O divergence")
+	}
+}
+
+func TestWarnOnNativeUnsignedTransactionIODivergence_LogsWarning(t *testing.T) {
+	logger := &warningCaptureLogger{}
+
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	warnOnNativeUnsignedTransactionIODivergence(
+		logger,
+		nativeTxHex,
+		[]bitcoin.UnsignedTransactionInput{
+			{
+				TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
+				Vout:      7,
+				ValueSats: 1234,
+			},
+		},
+		[]bitcoin.UnsignedTransactionOutput{
+			{
+				ScriptPubKeyHex: "0014deadbeef",
+				ValueSats:       999,
+			},
+		},
+	)
+
+	if len(logger.warningMessages) != 1 {
+		t.Fatalf(
+			"unexpected warning message count\nexpected: [%v]\nactual:   [%v]",
+			1,
+			len(logger.warningMessages),
+		)
+	}
+
+	if !strings.Contains(logger.warningMessages[0], "diverges") {
+		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
+	}
+}
+
+func mustDecodeHex(t *testing.T, value string) []byte {
+	result, err := hex.DecodeString(value)
+	if err != nil {
+		t.Fatalf("cannot decode hex: [%v]", err)
+	}
+
+	return result
+}
+
+type warningCaptureLogger struct {
+	warningMessages []string
+}
+
+func (wcl *warningCaptureLogger) Debug(args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Debugf(format string, args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Error(args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Errorf(format string, args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Fatal(args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Fatalf(format string, args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Info(args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Infof(format string, args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Panic(args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Panicf(format string, args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Warn(args ...interface{}) {}
+
+func (wcl *warningCaptureLogger) Warnf(format string, args ...interface{}) {
+	wcl.warningMessages = append(
+		wcl.warningMessages,
+		fmt.Sprintf(format, args...),
+	)
 }

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -124,6 +124,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarnin
 	if !strings.Contains(logger.warningMessages[0], "diverges") {
 		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
 	}
+
+	if !strings.Contains(logger.warningMessages[0], "output value mismatch") {
+		t.Fatalf("missing divergence detail in warning: [%v]", logger.warningMessages[0])
+	}
 }
 
 func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarningOnStructuralDivergence(
@@ -207,6 +211,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarnin
 	if !strings.Contains(logger.warningMessages[0], "diverges") {
 		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
 	}
+
+	if !strings.Contains(logger.warningMessages[0], "version mismatch") {
+		t.Fatalf("missing divergence detail in warning: [%v]", logger.warningMessages[0])
+	}
 }
 
 func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsDivergence(
@@ -277,6 +285,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsDive
 
 	if !strings.Contains(err.Error(), "diverges") {
 		t.Fatalf("unexpected substitution-mode error: [%v]", err)
+	}
+
+	if !strings.Contains(err.Error(), "output value mismatch") {
+		t.Fatalf("missing divergence detail in substitution error: [%v]", err)
 	}
 
 	if nativeUnsignedTx != nil {
@@ -415,6 +427,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsStru
 
 	if !strings.Contains(err.Error(), "diverges") {
 		t.Fatalf("unexpected substitution-mode error: [%v]", err)
+	}
+
+	if !strings.Contains(err.Error(), "version mismatch") {
+		t.Fatalf("missing divergence detail in substitution error: [%v]", err)
 	}
 
 	if nativeUnsignedTx != nil {
@@ -729,6 +745,10 @@ func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransact
 		t.Fatalf("unexpected signTransaction divergence error: [%v]", err)
 	}
 
+	if !strings.Contains(err.Error(), "output value mismatch") {
+		t.Fatalf("missing divergence detail in signTransaction error: [%v]", err)
+	}
+
 	if len(logger.warningMessages) != 0 {
 		t.Fatalf("unexpected warning logs in substitution mode: [%v]", logger.warningMessages)
 	}
@@ -801,6 +821,10 @@ func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransact
 
 	if !strings.Contains(err.Error(), "diverges") {
 		t.Fatalf("unexpected signTransaction divergence error: [%v]", err)
+	}
+
+	if !strings.Contains(err.Error(), "version mismatch") {
+		t.Fatalf("missing divergence detail in signTransaction error: [%v]", err)
 	}
 
 	if len(logger.warningMessages) != 0 {

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -160,7 +160,9 @@ func TestNativeUnsignedTransactionIODiverges_MismatchedIO(t *testing.T) {
 	}
 }
 
-func TestWarnOnNativeUnsignedTransactionIODivergence_LogsWarning(t *testing.T) {
+func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarning(
+	t *testing.T,
+) {
 	logger := &warningCaptureLogger{}
 
 	txHashBytes := make([]byte, bitcoin.HashByteLength)
@@ -196,7 +198,7 @@ func TestWarnOnNativeUnsignedTransactionIODivergence_LogsWarning(t *testing.T) {
 
 	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
 
-	warnOnNativeUnsignedTransactionIODivergence(
+	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
 		logger,
 		nativeTxHex,
 		[]bitcoin.UnsignedTransactionInput{
@@ -212,7 +214,15 @@ func TestWarnOnNativeUnsignedTransactionIODivergence_LogsWarning(t *testing.T) {
 				ValueSats:       999,
 			},
 		},
+		false,
 	)
+	if err != nil {
+		t.Fatalf("unexpected evaluation error: [%v]", err)
+	}
+
+	if nativeUnsignedTx != nil {
+		t.Fatal("did not expect native transaction substitution in observational mode")
+	}
 
 	if len(logger.warningMessages) != 1 {
 		t.Fatalf(
@@ -224,6 +234,180 @@ func TestWarnOnNativeUnsignedTransactionIODivergence_LogsWarning(t *testing.T) {
 
 	if !strings.Contains(logger.warningMessages[0], "diverges") {
 		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
+	}
+}
+
+func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsDivergence(
+	t *testing.T,
+) {
+	logger := &warningCaptureLogger{}
+
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
+		logger,
+		nativeTxHex,
+		[]bitcoin.UnsignedTransactionInput{
+			{
+				TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
+				Vout:      7,
+				ValueSats: 1234,
+			},
+		},
+		[]bitcoin.UnsignedTransactionOutput{
+			{
+				ScriptPubKeyHex: "0014deadbeef",
+				ValueSats:       999,
+			},
+		},
+		true,
+	)
+	if err == nil {
+		t.Fatal("expected substitution-mode divergence error")
+	}
+
+	if !strings.Contains(err.Error(), "diverges") {
+		t.Fatalf("unexpected substitution-mode error: [%v]", err)
+	}
+
+	if nativeUnsignedTx != nil {
+		t.Fatal("did not expect native transaction on divergence")
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warnings in substitution mode: [%v]", logger.warningMessages)
+	}
+}
+
+func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeAcceptsMatchingIO(
+	t *testing.T,
+) {
+	logger := &warningCaptureLogger{}
+
+	txHashBytes := make([]byte, bitcoin.HashByteLength)
+	for i := range txHashBytes {
+		txHashBytes[i] = byte(i + 1)
+	}
+
+	txHash, err := bitcoin.NewHash(txHashBytes, bitcoin.InternalByteOrder)
+	if err != nil {
+		t.Fatalf("cannot build tx hash: [%v]", err)
+	}
+
+	scriptPubKey := mustDecodeHex(t, "0014deadbeef")
+	nativeTransaction := &bitcoin.Transaction{
+		Version: 2,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: txHash,
+					OutputIndex:     7,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000,
+				PublicKeyScript: scriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+
+	nativeTxHex := hex.EncodeToString(nativeTransaction.Serialize(bitcoin.Standard))
+
+	nativeUnsignedTx, err := evaluateNativeUnsignedTransactionForSigning(
+		logger,
+		nativeTxHex,
+		[]bitcoin.UnsignedTransactionInput{
+			{
+				TxIDHex:   txHash.Hex(bitcoin.ReversedByteOrder),
+				Vout:      7,
+				ValueSats: 1234,
+			},
+		},
+		[]bitcoin.UnsignedTransactionOutput{
+			{
+				ScriptPubKeyHex: "0014deadbeef",
+				ValueSats:       1000,
+			},
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected substitution-mode evaluation error: [%v]", err)
+	}
+
+	if nativeUnsignedTx == nil {
+		t.Fatal("expected native transaction substitution candidate")
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warnings in substitution mode: [%v]", logger.warningMessages)
+	}
+}
+
+func TestNativeBuildTaprootTxSigningSubstitutionEnabled(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{name: "unset", envValue: "", expected: false},
+		{name: "true", envValue: "true", expected: true},
+		{name: "TRUE", envValue: "TRUE", expected: true},
+		{name: "one", envValue: "1", expected: true},
+		{name: "yes", envValue: "yes", expected: true},
+		{name: "on", envValue: "on", expected: true},
+		{name: "false", envValue: "false", expected: false},
+		{name: "zero", envValue: "0", expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(nativeBuildTaprootTxSigningSubstitutionEnvVar, tc.envValue)
+
+			actual := nativeBuildTaprootTxSigningSubstitutionEnabled()
+			if actual != tc.expected {
+				t.Fatalf(
+					"unexpected flag state\nexpected: [%v]\nactual:   [%v]",
+					tc.expected,
+					actual,
+				)
+			}
+		})
 	}
 }
 

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -1,0 +1,35 @@
+package tbtc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
+
+func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
+	t *testing.T,
+) {
+	original := buildTaprootTxViaNativeSignerFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = original
+	})
+
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		return "", errors.New("build tx failed")
+	}
+
+	wte := &walletTransactionExecutor{}
+
+	_, err := wte.signTransaction(nil, nil, 0, 0)
+	if err == nil {
+		t.Fatal("expected signTransaction error")
+	}
+
+	if !strings.Contains(err.Error(), "native tbtc-signer") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -1,13 +1,20 @@
 package tbtc
 
 import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/frost"
+	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
 
 func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
@@ -411,6 +418,289 @@ func TestNativeBuildTaprootTxSigningSubstitutionEnabled(t *testing.T) {
 	}
 }
 
+func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeUnsignedTransactionWhenGateEnabled(
+	t *testing.T,
+) {
+	privateKey, unsignedTx, nativeUnsignedTxHex, nativeUnsignedTx := buildTaprootTxSubstitutionFixture(t)
+
+	originalBuildTaprootTxViaNativeSignerFn := buildTaprootTxViaNativeSignerFn
+	originalSigningSubstitutionEnabledFn := nativeBuildTaprootTxSigningSubstitutionEnabledFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = originalBuildTaprootTxViaNativeSignerFn
+		nativeBuildTaprootTxSigningSubstitutionEnabledFn = originalSigningSubstitutionEnabledFn
+	})
+
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		return nativeUnsignedTxHex, nil
+	}
+	nativeBuildTaprootTxSigningSubstitutionEnabledFn = func() bool {
+		return true
+	}
+
+	wte := &walletTransactionExecutor{
+		executingWallet: wallet{
+			publicKey: &privateKey.PublicKey,
+		},
+		signingExecutor: &deterministicECDSASigningExecutorForBuildTaprootTxSubstitution{
+			privateKey: privateKey,
+		},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+
+	logger := &warningCaptureLogger{}
+
+	tx, err := wte.signTransaction(logger, unsignedTx, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected signTransaction error: [%v]", err)
+	}
+
+	if tx.Version != nativeUnsignedTx.Version {
+		t.Fatalf(
+			"unexpected substituted transaction version\nexpected: [%v]\nactual:   [%v]",
+			nativeUnsignedTx.Version,
+			tx.Version,
+		)
+	}
+
+	if tx.Locktime != nativeUnsignedTx.Locktime {
+		t.Fatalf(
+			"unexpected substituted transaction locktime\nexpected: [%v]\nactual:   [%v]",
+			nativeUnsignedTx.Locktime,
+			tx.Locktime,
+		)
+	}
+
+	if len(tx.Inputs) != len(nativeUnsignedTx.Inputs) {
+		t.Fatalf(
+			"unexpected substituted input count\nexpected: [%v]\nactual:   [%v]",
+			len(nativeUnsignedTx.Inputs),
+			len(tx.Inputs),
+		)
+	}
+
+	if tx.Inputs[0].Outpoint.TransactionHash != nativeUnsignedTx.Inputs[0].Outpoint.TransactionHash {
+		t.Fatalf(
+			"unexpected substituted input txid\nexpected: [%v]\nactual:   [%v]",
+			nativeUnsignedTx.Inputs[0].Outpoint.TransactionHash,
+			tx.Inputs[0].Outpoint.TransactionHash,
+		)
+	}
+
+	if tx.Inputs[0].Outpoint.OutputIndex != nativeUnsignedTx.Inputs[0].Outpoint.OutputIndex {
+		t.Fatalf(
+			"unexpected substituted input vout\nexpected: [%v]\nactual:   [%v]",
+			nativeUnsignedTx.Inputs[0].Outpoint.OutputIndex,
+			tx.Inputs[0].Outpoint.OutputIndex,
+		)
+	}
+
+	if tx.Inputs[0].Sequence != nativeUnsignedTx.Inputs[0].Sequence {
+		t.Fatalf(
+			"unexpected substituted input sequence\nexpected: [%v]\nactual:   [%v]",
+			nativeUnsignedTx.Inputs[0].Sequence,
+			tx.Inputs[0].Sequence,
+		)
+	}
+
+	if len(tx.Inputs[0].SignatureScript) == 0 {
+		t.Fatal("expected signature script to be populated after signing")
+	}
+
+	if len(tx.Outputs) != len(nativeUnsignedTx.Outputs) {
+		t.Fatalf(
+			"unexpected substituted output count\nexpected: [%v]\nactual:   [%v]",
+			len(nativeUnsignedTx.Outputs),
+			len(tx.Outputs),
+		)
+	}
+
+	if tx.Outputs[0].Value != nativeUnsignedTx.Outputs[0].Value {
+		t.Fatalf(
+			"unexpected substituted output value\nexpected: [%v]\nactual:   [%v]",
+			nativeUnsignedTx.Outputs[0].Value,
+			tx.Outputs[0].Value,
+		)
+	}
+
+	if !bytes.Equal(
+		tx.Outputs[0].PublicKeyScript,
+		nativeUnsignedTx.Outputs[0].PublicKeyScript,
+	) {
+		t.Fatalf(
+			"unexpected substituted output script\nexpected: [%x]\nactual:   [%x]",
+			nativeUnsignedTx.Outputs[0].PublicKeyScript,
+			tx.Outputs[0].PublicKeyScript,
+		)
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warning logs: [%v]", logger.warningMessages)
+	}
+}
+
+func TestWalletTransactionExecutor_SignTransaction_DoesNotSubstituteWhenGateDisabled(
+	t *testing.T,
+) {
+	privateKey, unsignedTx, nativeUnsignedTxHex, nativeUnsignedTx := buildTaprootTxSubstitutionFixture(t)
+
+	originalBuildTaprootTxViaNativeSignerFn := buildTaprootTxViaNativeSignerFn
+	originalSigningSubstitutionEnabledFn := nativeBuildTaprootTxSigningSubstitutionEnabledFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = originalBuildTaprootTxViaNativeSignerFn
+		nativeBuildTaprootTxSigningSubstitutionEnabledFn = originalSigningSubstitutionEnabledFn
+	})
+
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		return nativeUnsignedTxHex, nil
+	}
+	nativeBuildTaprootTxSigningSubstitutionEnabledFn = func() bool {
+		return false
+	}
+
+	wte := &walletTransactionExecutor{
+		executingWallet: wallet{
+			publicKey: &privateKey.PublicKey,
+		},
+		signingExecutor: &deterministicECDSASigningExecutorForBuildTaprootTxSubstitution{
+			privateKey: privateKey,
+		},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+
+	logger := &warningCaptureLogger{}
+
+	tx, err := wte.signTransaction(logger, unsignedTx, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected signTransaction error: [%v]", err)
+	}
+
+	if tx.Version == nativeUnsignedTx.Version {
+		t.Fatalf(
+			"did not expect transaction version substitution when gate disabled: [%v]",
+			tx.Version,
+		)
+	}
+
+	if tx.Locktime == nativeUnsignedTx.Locktime {
+		t.Fatalf(
+			"did not expect transaction locktime substitution when gate disabled: [%v]",
+			tx.Locktime,
+		)
+	}
+
+	if tx.Inputs[0].Sequence == nativeUnsignedTx.Inputs[0].Sequence {
+		t.Fatalf(
+			"did not expect input sequence substitution when gate disabled: [%v]",
+			tx.Inputs[0].Sequence,
+		)
+	}
+
+	if len(logger.warningMessages) != 0 {
+		t.Fatalf("unexpected warning logs: [%v]", logger.warningMessages)
+	}
+}
+
+func buildTaprootTxSubstitutionFixture(
+	t *testing.T,
+) (
+	*ecdsa.PrivateKey,
+	*bitcoin.TransactionBuilder,
+	string,
+	*bitcoin.Transaction,
+) {
+	privateKey := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: tecdsa.Curve,
+		},
+		D: big.NewInt(111),
+	}
+	privateKey.PublicKey.X, privateKey.PublicKey.Y = tecdsa.Curve.ScalarBaseMult(
+		privateKey.D.Bytes(),
+	)
+
+	pubKeyHash := [20]byte{}
+	for i := range pubKeyHash {
+		pubKeyHash[i] = byte(i + 1)
+	}
+
+	lockingScript, err := bitcoin.PayToPublicKeyHash(pubKeyHash)
+	if err != nil {
+		t.Fatalf("cannot create locking script: [%v]", err)
+	}
+
+	localBitcoinChain := newLocalBitcoinChain()
+
+	fundingTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs:  []*bitcoin.TransactionInput{},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           10000,
+				PublicKeyScript: lockingScript,
+			},
+		},
+		Locktime: 0,
+	}
+
+	if err := localBitcoinChain.BroadcastTransaction(fundingTransaction); err != nil {
+		t.Fatalf("cannot broadcast funding transaction: [%v]", err)
+	}
+
+	unsignedTx := bitcoin.NewTransactionBuilder(localBitcoinChain)
+	if err := unsignedTx.AddPublicKeyHashInput(
+		&bitcoin.UnspentTransactionOutput{
+			Outpoint: &bitcoin.TransactionOutpoint{
+				TransactionHash: fundingTransaction.Hash(),
+				OutputIndex:     0,
+			},
+			Value: 10000,
+		},
+	); err != nil {
+		t.Fatalf("cannot add unsigned input: [%v]", err)
+	}
+
+	replacementOutputScript := mustDecodeHex(t, "0014deadbeef")
+	unsignedTx.AddOutput(
+		&bitcoin.TransactionOutput{
+			Value:           9000,
+			PublicKeyScript: replacementOutputScript,
+		},
+	)
+
+	nativeUnsignedTx := &bitcoin.Transaction{
+		Version:  3,
+		Locktime: 123,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: fundingTransaction.Hash(),
+					OutputIndex:     0,
+				},
+				Sequence: 0xfffffffd,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           9000,
+				PublicKeyScript: replacementOutputScript,
+			},
+		},
+	}
+
+	return privateKey,
+		unsignedTx,
+		hex.EncodeToString(nativeUnsignedTx.Serialize(bitcoin.Standard)),
+		nativeUnsignedTx
+}
+
 func mustDecodeHex(t *testing.T, value string) []byte {
 	result, err := hex.DecodeString(value)
 	if err != nil {
@@ -451,4 +741,37 @@ func (wcl *warningCaptureLogger) Warnf(format string, args ...interface{}) {
 		wcl.warningMessages,
 		fmt.Sprintf(format, args...),
 	)
+}
+
+type deterministicECDSASigningExecutorForBuildTaprootTxSubstitution struct {
+	privateKey *ecdsa.PrivateKey
+}
+
+func (desefbts *deterministicECDSASigningExecutorForBuildTaprootTxSubstitution) signBatch(
+	ctx context.Context,
+	messages []*big.Int,
+	startBlock uint64,
+) ([]*frost.Signature, error) {
+	signatures := make([]*frost.Signature, 0, len(messages))
+
+	for _, message := range messages {
+		r, s, err := ecdsa.Sign(
+			rand.Reader,
+			desefbts.privateKey,
+			message.Bytes(),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		signature := &frost.Signature{}
+		rBytes := r.Bytes()
+		copy(signature.R[len(signature.R)-len(rBytes):], rBytes)
+		sBytes := s.Bytes()
+		copy(signature.S[len(signature.S)-len(sBytes):], sBytes)
+
+		signatures = append(signatures, signature)
+	}
+
+	return signatures, nil
 }


### PR DESCRIPTION
## Summary
- cut over the `frost_tbtc_signer` bootstrap path to return coarse tbtc-signer signature output on successful `RunDKG -> StartSignRound -> FinalizeSignRound`
- keep legacy signing fallback only for verified coarse-path failures (bridge errors, decode failures, or structural divergence)
- wire `BuildTaprootTx` through the transitional native tbtc-signer orchestration path
- gate `BuildTaprootTx` signing substitution on strict native-vs-legacy transaction input/output equivalence checks
- add coarse success/fallback telemetry and observer-registration guards
- expand unit and integration coverage for coarse cutover, retry/attempt-variation behavior, and `BuildTaprootTx` substitution safety

## Stack Context
- base branch: `feat/frost-schnorr-migration-scaffold` (`#3866`)
- recommended review order:
  1. review `#3866` for scaffold/runtime seams
  2. review this PR as the cutover + hardening delta

## Review Guide (hot paths)
- coarse cutover + fallback semantics:
  - `pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go`
  - `pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go`
- `BuildTaprootTx` wiring and substitution gating:
  - `pkg/tbtc/wallet.go`
  - `pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go`
  - `pkg/bitcoin/transaction_builder.go`
- coverage for tx assembly/substitution and bridge safety:
  - `pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go`
  - `pkg/bitcoin/transaction_builder_test.go`
  - `pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go`

## Scope Boundaries
- in scope: bootstrap/coarse-path cutover hardening and safe `BuildTaprootTx` integration
- out of scope: full production signer-runtime replacement and later migration phase gates
