### PR TITLE
Harden ReplaceUnsignedTransaction against pre-populated signing data

### DIFF
--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -333,15 +333,25 @@ func (tb *TransactionBuilder) ReplaceUnsignedTransaction(
 	replacedInternal.fromTransaction(transaction)
 
 	for i := range replacedInternal.TxIn {
-		if i >= len(previousInputs) {
-			break
-		}
-
 		previousInput := previousInputs[i]
 		replacedInput := replacedInternal.TxIn[i]
 
 		if previousInput == nil || replacedInput == nil {
 			continue
+		}
+
+		if len(replacedInput.SignatureScript) > 0 {
+			return fmt.Errorf(
+				"replacement transaction input [%d] has unexpected non-empty signature script",
+				i,
+			)
+		}
+
+		if len(replacedInput.Witness) > 0 {
+			return fmt.Errorf(
+				"replacement transaction input [%d] has unexpected non-empty witness",
+				i,
+			)
 		}
 
 		if tb.sigHashArgs[i].witness {

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -369,6 +370,82 @@ func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsInputMetadataMisma
 			1,
 		),
 		err.Error(),
+	) {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsNonEmptyReplacementSignatureScript(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(
+		builder.sigHashArgs,
+		&inputSigHashArgs{value: 1, scriptCode: []byte{0x51}, witness: false},
+	)
+
+	err := builder.ReplaceUnsignedTransaction(
+		&Transaction{
+			Inputs: []*TransactionInput{
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(txHash),
+						OutputIndex:     0,
+					},
+					SignatureScript: []byte{0xaa},
+					Sequence:        0xffffffff,
+				},
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected replacement signature script error")
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"replacement transaction input [0] has unexpected non-empty signature script",
+	) {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestTransactionBuilder_ReplaceUnsignedTransaction_RejectsNonEmptyReplacementWitness(
+	t *testing.T,
+) {
+	builder := NewTransactionBuilder(nil)
+
+	var txHash chainhash.Hash
+	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 0), nil, nil))
+	builder.sigHashArgs = append(
+		builder.sigHashArgs,
+		&inputSigHashArgs{value: 1, scriptCode: []byte{0x51}, witness: true},
+	)
+
+	err := builder.ReplaceUnsignedTransaction(
+		&Transaction{
+			Inputs: []*TransactionInput{
+				{
+					Outpoint: &TransactionOutpoint{
+						TransactionHash: Hash(txHash),
+						OutputIndex:     0,
+					},
+					Witness:  wire.TxWitness{[]byte{0xbb}},
+					Sequence: 0xffffffff,
+				},
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected replacement witness error")
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"replacement transaction input [0] has unexpected non-empty witness",
 	) {
 		t.Fatalf("unexpected error: [%v]", err)
 	}

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
@@ -92,6 +92,8 @@ func buildTaprootTxSessionID(
 ) string {
 	// Session ID is deterministically derived from Go-side transaction I/O using
 	// encoding/json. Rust currently treats this session_id as opaque.
+	// If input/output schema changes in a future migration phase, update this
+	// derivation intentionally to avoid silent cross-version session ID drift.
 	sessionPayload, err := json.Marshal(struct {
 		Inputs  []bitcoin.UnsignedTransactionInput  `json:"inputs"`
 		Outputs []bitcoin.UnsignedTransactionOutput `json:"outputs"`

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -461,7 +461,7 @@ func evaluateNativeUnsignedTransactionForSigning(
 		return nil, nil
 	}
 
-	diverges, err := nativeUnsignedTransactionDivergesFromTransaction(
+	diverges, divergenceReason, err := nativeUnsignedTransactionDivergesFromTransaction(
 		nativeUnsignedTx,
 		expectedTransaction,
 	)
@@ -478,15 +478,20 @@ func evaluateNativeUnsignedTransactionForSigning(
 	}
 
 	if diverges {
-		if substitutionEnabled {
-			return nil, fmt.Errorf(
-				"native BuildTaprootTx unsigned transaction diverges from Go builder state",
+		divergenceMessage := "native BuildTaprootTx unsigned transaction diverges from Go builder state"
+		if divergenceReason != "" {
+			divergenceMessage = fmt.Sprintf(
+				"%s: %s",
+				divergenceMessage,
+				divergenceReason,
 			)
 		}
 
-		signTxLogger.Warnf(
-			"native BuildTaprootTx unsigned transaction diverges from Go builder state",
-		)
+		if substitutionEnabled {
+			return nil, fmt.Errorf("%s", divergenceMessage)
+		}
+
+		signTxLogger.Warnf(divergenceMessage)
 	}
 
 	if substitutionEnabled {
@@ -515,32 +520,83 @@ func decodeNativeUnsignedTransactionHex(
 func nativeUnsignedTransactionDivergesFromTransaction(
 	nativeUnsignedTx *bitcoin.Transaction,
 	expectedTransaction *bitcoin.Transaction,
-) (bool, error) {
+) (bool, string, error) {
 	actualShape, err := extractUnsignedTransactionShapeFromTransaction(nativeUnsignedTx)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	expectedShape, err := extractUnsignedTransactionShapeFromTransaction(expectedTransaction)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
-	return actualShape.Version != expectedShape.Version ||
-			actualShape.Locktime != expectedShape.Locktime ||
-			!unsignedTransactionInputReferencesEqual(
-				actualShape.InputReferences,
-				expectedShape.InputReferences,
-			) ||
-			!unsignedTransactionInputSequencesEqual(
-				actualShape.InputSequences,
-				expectedShape.InputSequences,
-			) ||
-			!unsignedTransactionOutputsEqual(
-				actualShape.Outputs,
-				expectedShape.Outputs,
-			),
-		nil
+	if actualShape.Version != expectedShape.Version {
+		return true, fmt.Sprintf(
+			"version mismatch: expected [%d], got [%d]",
+			expectedShape.Version,
+			actualShape.Version,
+		), nil
+	}
+
+	if actualShape.Locktime != expectedShape.Locktime {
+		return true, fmt.Sprintf(
+			"locktime mismatch: expected [%d], got [%d]",
+			expectedShape.Locktime,
+			actualShape.Locktime,
+		), nil
+	}
+
+	if reason, diverges := unsignedTransactionInputReferencesDivergenceReason(
+		actualShape.InputReferences,
+		expectedShape.InputReferences,
+	); diverges {
+		return true, reason, nil
+	}
+
+	if reason, diverges := unsignedTransactionInputSequencesDivergenceReason(
+		actualShape.InputSequences,
+		expectedShape.InputSequences,
+	); diverges {
+		return true, reason, nil
+	}
+
+	if reason, diverges := unsignedTransactionOutputsDivergenceReason(
+		actualShape.Outputs,
+		expectedShape.Outputs,
+	); diverges {
+		return true, reason, nil
+	}
+
+	return false, "", nil
+}
+
+func unsignedTransactionInputReferencesDivergenceReason(
+	actual []unsignedTransactionInputReference,
+	expected []unsignedTransactionInputReference,
+) (string, bool) {
+	if len(actual) != len(expected) {
+		return fmt.Sprintf(
+			"input reference count mismatch: expected [%d], got [%d]",
+			len(expected),
+			len(actual),
+		), true
+	}
+
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return fmt.Sprintf(
+				"input reference mismatch at index [%d]: expected [%s:%d], got [%s:%d]",
+				i,
+				expected[i].TxIDHex,
+				expected[i].Vout,
+				actual[i].TxIDHex,
+				actual[i].Vout,
+			), true
+		}
+	}
+
+	return "", false
 }
 
 type unsignedTransactionShape struct {
@@ -611,55 +667,65 @@ func extractUnsignedTransactionShapeFromTransaction(
 	}, nil
 }
 
-func unsignedTransactionInputReferencesEqual(
-	first []unsignedTransactionInputReference,
-	second []unsignedTransactionInputReference,
-) bool {
-	if len(first) != len(second) {
-		return false
+func unsignedTransactionOutputsDivergenceReason(
+	actual []bitcoin.UnsignedTransactionOutput,
+	expected []bitcoin.UnsignedTransactionOutput,
+) (string, bool) {
+	if len(actual) != len(expected) {
+		return fmt.Sprintf(
+			"output count mismatch: expected [%d], got [%d]",
+			len(expected),
+			len(actual),
+		), true
 	}
 
-	for i := range first {
-		if first[i] != second[i] {
-			return false
+	for i := range actual {
+		if actual[i].ValueSats != expected[i].ValueSats {
+			return fmt.Sprintf(
+				"output value mismatch at index [%d]: expected [%d], got [%d]",
+				i,
+				expected[i].ValueSats,
+				actual[i].ValueSats,
+			), true
+		}
+
+		if actual[i].ScriptPubKeyHex != expected[i].ScriptPubKeyHex {
+			return fmt.Sprintf(
+				"output script mismatch at index [%d]: expected [%s], got [%s]",
+				i,
+				expected[i].ScriptPubKeyHex,
+				actual[i].ScriptPubKeyHex,
+			), true
 		}
 	}
 
-	return true
+	return "", false
 }
 
-func unsignedTransactionOutputsEqual(
-	first []bitcoin.UnsignedTransactionOutput,
-	second []bitcoin.UnsignedTransactionOutput,
-) bool {
-	if len(first) != len(second) {
-		return false
+func unsignedTransactionInputSequencesDivergenceReason(
+	actual []uint32,
+	expected []uint32,
+) (string, bool) {
+	if len(actual) != len(expected) {
+		return fmt.Sprintf(
+			"input sequence count mismatch: expected [%d], got [%d]",
+			len(expected),
+			len(actual),
+		), true
 	}
 
-	for i := range first {
-		if first[i] != second[i] {
-			return false
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return fmt.Sprintf(
+				"input sequence mismatch at index [%d]: expected [%d], got [%d]",
+				i,
+				expected[i],
+				actual[i],
+			), true
 		}
 	}
 
-	return true
-}
-
-func unsignedTransactionInputSequencesEqual(
-	first []uint32,
-	second []uint32,
-) bool {
-	if len(first) != len(second) {
-		return false
-	}
-
-	for i := range first {
-		if first[i] != second[i] {
-			return false
-		}
-	}
-
-	return true
+	return "", false
 }
 
 // broadcastTransaction broadcasts a signed Bitcoin transaction until

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -124,6 +124,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarnin
 	if !strings.Contains(logger.warningMessages[0], "diverges") {
 		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
 	}
+
+	if !strings.Contains(logger.warningMessages[0], "output value mismatch") {
+		t.Fatalf("missing divergence detail in warning: [%v]", logger.warningMessages[0])
+	}
 }
 
 func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarningOnStructuralDivergence(
@@ -207,6 +211,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_ObservationalModeLogsWarnin
 	if !strings.Contains(logger.warningMessages[0], "diverges") {
 		t.Fatalf("unexpected warning message: [%v]", logger.warningMessages[0])
 	}
+
+	if !strings.Contains(logger.warningMessages[0], "version mismatch") {
+		t.Fatalf("missing divergence detail in warning: [%v]", logger.warningMessages[0])
+	}
 }
 
 func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsDivergence(
@@ -277,6 +285,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsDive
 
 	if !strings.Contains(err.Error(), "diverges") {
 		t.Fatalf("unexpected substitution-mode error: [%v]", err)
+	}
+
+	if !strings.Contains(err.Error(), "output value mismatch") {
+		t.Fatalf("missing divergence detail in substitution error: [%v]", err)
 	}
 
 	if nativeUnsignedTx != nil {
@@ -415,6 +427,10 @@ func TestEvaluateNativeUnsignedTransactionForSigning_SubstitutionModeRejectsStru
 
 	if !strings.Contains(err.Error(), "diverges") {
 		t.Fatalf("unexpected substitution-mode error: [%v]", err)
+	}
+
+	if !strings.Contains(err.Error(), "version mismatch") {
+		t.Fatalf("missing divergence detail in substitution error: [%v]", err)
 	}
 
 	if nativeUnsignedTx != nil {
@@ -729,6 +745,10 @@ func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransact
 		t.Fatalf("unexpected signTransaction divergence error: [%v]", err)
 	}
 
+	if !strings.Contains(err.Error(), "output value mismatch") {
+		t.Fatalf("missing divergence detail in signTransaction error: [%v]", err)
+	}
+
 	if len(logger.warningMessages) != 0 {
 		t.Fatalf("unexpected warning logs in substitution mode: [%v]", logger.warningMessages)
 	}
@@ -801,6 +821,10 @@ func TestWalletTransactionExecutor_SignTransaction_RejectsNativeUnsignedTransact
 
 	if !strings.Contains(err.Error(), "diverges") {
 		t.Fatalf("unexpected signTransaction divergence error: [%v]", err)
+	}
+
+	if !strings.Contains(err.Error(), "version mismatch") {
+		t.Fatalf("missing divergence detail in signTransaction error: [%v]", err)
 	}
 
 	if len(logger.warningMessages) != 0 {


### PR DESCRIPTION
## Summary
- reject replacement inputs that already contain non-empty signature script data
- reject replacement inputs that already contain non-empty witness data
- remove unreachable loop bounds guard in replacement path
- add targeted unit coverage for both replacement rejection paths
- add field-level divergence diagnostics for native `BuildTaprootTx` unsigned transaction comparison (version/locktime/input refs/sequences/outputs)
- include divergence detail in both substitution errors and observational warnings to speed root-cause triage
- add test assertions for detailed divergence reasons in `evaluateNativeUnsignedTransactionForSigning` and wallet transaction signing paths
- document session-id derivation stability expectations for native `BuildTaprootTx`

## Why
- replacement API expects an unsigned transaction skeleton
- pre-populated signing data can silently alter placeholder preservation behavior
- generic "diverges" messages slow down cross-language mismatch debugging during rollout

## Validation
- `go test ./pkg/bitcoin -run TestTransactionBuilder_ReplaceUnsignedTransaction`
- `go test ./pkg/tbtc -run 'TestWalletTransactionExecutor_SignTransaction_|TestEvaluateNativeUnsignedTransactionForSigning_|TestNativeBuildTaprootTxSigningSubstitutionEnabled'`
