### PR TITLE
Harden tbtc-signer bridge error classification

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -343,18 +343,6 @@ func buildTaggedTBTCSignerOperationError(
 	)
 }
 
-func buildTaggedTBTCSignerBridgeOperationError(
-	operation string,
-	message string,
-) error {
-	return fmt.Errorf(
-		"%w: tbtc-signer bridge operation [%v] failed: [%s]",
-		ErrNativeBridgeOperationFailed,
-		operation,
-		message,
-	)
-}
-
 func buildTaggedTBTCSignerRunDKGRequestPayload(
 	sessionID string,
 	participants []NativeTBTCSignerDKGParticipant,
@@ -973,7 +961,7 @@ func buildTaggedTBTCSignerResultStatusError(
 	}
 
 	if statusCode != 0 {
-		return buildTaggedTBTCSignerBridgeOperationError(
+		return buildTaggedTBTCSignerOperationError(
 			operation,
 			buildTaggedTBTCSignerErrorMessage(payload),
 		)

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -337,7 +337,7 @@ func buildTaggedTBTCSignerOperationError(
 ) error {
 	return fmt.Errorf(
 		"%w: tbtc-signer bridge operation [%v] failed: [%s]",
-		ErrNativeCryptographyUnavailable,
+		ErrNativeBridgeOperationFailed,
 		operation,
 		message,
 	)

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -268,10 +268,17 @@ func TestBuildTaggedTBTCSignerRunDKGRequestPayload_RejectsInvalidInput(t *testin
 				t.Fatal("expected payload build error")
 			}
 
-			if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+			if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 				t.Fatalf(
-					"expected native cryptography unavailable error: [%v], got [%v]",
-					ErrNativeCryptographyUnavailable,
+					"expected native bridge operation failed error: [%v], got [%v]",
+					ErrNativeBridgeOperationFailed,
+					err,
+				)
+			}
+
+			if errors.Is(err, ErrNativeCryptographyUnavailable) {
+				t.Fatalf(
+					"did not expect native cryptography unavailable error: [%v]",
 					err,
 				)
 			}
@@ -408,10 +415,17 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_EmptySessionID(t *tes
 		"key-group-1",
 		nil,
 	)
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 		t.Fatalf(
-			"expected native cryptography unavailable error: [%v], got [%v]",
-			ErrNativeCryptographyUnavailable,
+			"expected native bridge operation failed error: [%v], got [%v]",
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"did not expect native cryptography unavailable error: [%v]",
 			err,
 		)
 	}
@@ -425,10 +439,17 @@ func TestBuildTaggedTBTCSignerStartSignRoundRequestPayload_ZeroMemberID(t *testi
 		"key-group-1",
 		nil,
 	)
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 		t.Fatalf(
-			"expected native cryptography unavailable error: [%v], got [%v]",
-			ErrNativeCryptographyUnavailable,
+			"expected native bridge operation failed error: [%v], got [%v]",
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"did not expect native cryptography unavailable error: [%v]",
 			err,
 		)
 	}
@@ -581,10 +602,17 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsZeroSigningPar
 		t.Fatal("expected error")
 	}
 
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 		t.Fatalf(
 			"unexpected error\nexpected: [%v]\nactual:   [%v]",
-			ErrNativeCryptographyUnavailable,
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"did not expect native cryptography unavailable error: [%v]",
 			err,
 		)
 	}
@@ -602,10 +630,17 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsDuplicateSigni
 		t.Fatal("expected error")
 	}
 
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 		t.Fatalf(
 			"unexpected error\nexpected: [%v]\nactual:   [%v]",
-			ErrNativeCryptographyUnavailable,
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"did not expect native cryptography unavailable error: [%v]",
 			err,
 		)
 	}
@@ -623,10 +658,17 @@ func TestDecodeBuildTaggedTBTCSignerStartSignRoundResponse_RejectsZeroOwnContrib
 		t.Fatal("expected error")
 	}
 
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 		t.Fatalf(
 			"unexpected error\nexpected: [%v]\nactual:   [%v]",
-			ErrNativeCryptographyUnavailable,
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"did not expect native cryptography unavailable error: [%v]",
 			err,
 		)
 	}
@@ -818,10 +860,17 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 				t.Fatal("expected payload build error")
 			}
 
-			if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+			if !errors.Is(err, ErrNativeBridgeOperationFailed) {
 				t.Fatalf(
-					"expected native cryptography unavailable error: [%v], got [%v]",
-					ErrNativeCryptographyUnavailable,
+					"expected native bridge operation failed error: [%v], got [%v]",
+					ErrNativeBridgeOperationFailed,
+					err,
+				)
+			}
+
+			if errors.Is(err, ErrNativeCryptographyUnavailable) {
+				t.Fatalf(
+					"did not expect native cryptography unavailable error: [%v]",
 					err,
 				)
 			}

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
@@ -58,8 +58,6 @@ func buildTaprootTxViaNativeSigner(
 	if err != nil {
 		// Keep legacy fallback behavior for the observational BuildTaprootTx
 		// phase when native bridge support is unavailable.
-		// Note that current bridge error mapping can also classify operational
-		// failures as unavailable; tighten this split before signing-substitution.
 		if errors.Is(err, frostsigning.ErrNativeCryptographyUnavailable) {
 			return "", nil
 		}

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -336,7 +336,7 @@ func (wte *walletTransactionExecutor) signTransaction(
 	nativeUnsignedTxHex, err := buildTaprootTxViaNativeSignerFn(unsignedTx)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error while building unsigned transaction with native tbtc-signer: [%v]",
+			"error while building unsigned transaction with native tbtc-signer: [%w]",
 			err,
 		)
 	}

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -21,6 +21,8 @@ import (
 func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
 	t *testing.T,
 ) {
+	privateKey, unsignedTx, _, _ := buildTaprootTxSubstitutionFixture(t)
+
 	original := buildTaprootTxViaNativeSignerFn
 	t.Cleanup(func() {
 		buildTaprootTxViaNativeSignerFn = original
@@ -32,9 +34,18 @@ func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
 		return "", errors.New("build tx failed")
 	}
 
-	wte := &walletTransactionExecutor{}
+	wte := &walletTransactionExecutor{
+		executingWallet: wallet{
+			publicKey: &privateKey.PublicKey,
+		},
+		signingExecutor: &unexpectedSigningExecutorForBuildTaprootTxError{},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+	logger := &warningCaptureLogger{}
 
-	_, err := wte.signTransaction(nil, nil, 0, 0)
+	_, err := wte.signTransaction(logger, unsignedTx, 0, 0)
 	if err == nil {
 		t.Fatal("expected signTransaction error")
 	}
@@ -47,6 +58,8 @@ func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
 func TestWalletTransactionExecutor_SignTransaction_PropagatesBuildTaprootTxBridgeOperationError(
 	t *testing.T,
 ) {
+	privateKey, unsignedTx, _, _ := buildTaprootTxSubstitutionFixture(t)
+
 	original := buildTaprootTxViaNativeSignerFn
 	t.Cleanup(func() {
 		buildTaprootTxViaNativeSignerFn = original
@@ -61,9 +74,18 @@ func TestWalletTransactionExecutor_SignTransaction_PropagatesBuildTaprootTxBridg
 		)
 	}
 
-	wte := &walletTransactionExecutor{}
+	wte := &walletTransactionExecutor{
+		executingWallet: wallet{
+			publicKey: &privateKey.PublicKey,
+		},
+		signingExecutor: &unexpectedSigningExecutorForBuildTaprootTxError{},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+	logger := &warningCaptureLogger{}
 
-	_, err := wte.signTransaction(nil, nil, 0, 0)
+	_, err := wte.signTransaction(logger, unsignedTx, 0, 0)
 	if err == nil {
 		t.Fatal("expected signTransaction error")
 	}
@@ -1051,4 +1073,14 @@ func (desefbts *deterministicECDSASigningExecutorForBuildTaprootTxSubstitution) 
 	}
 
 	return signatures, nil
+}
+
+type unexpectedSigningExecutorForBuildTaprootTxError struct{}
+
+func (usefbte *unexpectedSigningExecutorForBuildTaprootTxError) signBatch(
+	ctx context.Context,
+	messages []*big.Int,
+	startBlock uint64,
+) ([]*frost.Signature, error) {
+	return nil, errors.New("unexpected signBatch invocation")
 }

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/frost"
+	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
 
@@ -36,6 +37,43 @@ func TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError(
 	_, err := wte.signTransaction(nil, nil, 0, 0)
 	if err == nil {
 		t.Fatal("expected signTransaction error")
+	}
+
+	if !strings.Contains(err.Error(), "native tbtc-signer") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func TestWalletTransactionExecutor_SignTransaction_PropagatesBuildTaprootTxBridgeOperationError(
+	t *testing.T,
+) {
+	original := buildTaprootTxViaNativeSignerFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = original
+	})
+
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		return "", fmt.Errorf(
+			"%w: operation failed",
+			frostsigning.ErrNativeBridgeOperationFailed,
+		)
+	}
+
+	wte := &walletTransactionExecutor{}
+
+	_, err := wte.signTransaction(nil, nil, 0, 0)
+	if err == nil {
+		t.Fatal("expected signTransaction error")
+	}
+
+	if !errors.Is(err, frostsigning.ErrNativeBridgeOperationFailed) {
+		t.Fatalf(
+			"expected bridge operation failure error: [%v], got [%v]",
+			frostsigning.ErrNativeBridgeOperationFailed,
+			err,
+		)
 	}
 
 	if !strings.Contains(err.Error(), "native tbtc-signer") {


### PR DESCRIPTION
## Summary
- classify `buildTaggedTBTCSignerOperationError` as `ErrNativeBridgeOperationFailed` instead of `ErrNativeCryptographyUnavailable`
- keep `ErrNativeCryptographyUnavailable` reserved for true bridge unavailability (`status_code == -1`)
- update tbtc-signer registration/build payload/response validation tests to assert operational failures are not treated as availability failures
- collapse duplicate bridge-operation error constructor usage to a single helper path
- add an explicit wallet boundary test that `ErrNativeBridgeOperationFailed` propagates through `signTransaction` (not swallowed by unavailability fallback)
- preserve wrapped error identity in the BuildTaprootTx signing path (`%w`) so taxonomy can be asserted at caller boundaries
- remove the stale BuildTaprootTx fallback comment now that bridge error classification is explicit

## Why
- observational BuildTaprootTx fallback should trigger only when native cryptography is genuinely unavailable
- local/bridge operation failures should remain surfaced as actionable errors and must not be misclassified as unavailable
- integration-boundary tests should lock the taxonomy guarantee before signing substitution

## Validation
- `go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/signing`
- `go test -tags 'frost_native frost_tbtc_signer' ./pkg/tbtc -run 'TestWalletTransactionExecutor_SignTransaction_ReturnsBuildTaprootTxError|TestWalletTransactionExecutor_SignTransaction_PropagatesBuildTaprootTxBridgeOperationError|TestEvaluateNativeUnsignedTransactionForSigning_|TestWalletTransactionExecutor_SignTransaction_'`
