### PR TITLE
frost/signing: enforce attempt coordinator inclusion policy

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -598,6 +598,8 @@ func TestBuildTaggedTBTCSignerRunDKGInputs(t *testing.T) {
 			GroupSize:          5,
 			DishonestThreshold: 2,
 			Attempt: &Attempt{
+				Number:                 1,
+				CoordinatorMemberIndex: 1,
 				IncludedMembersIndexes: []group.MemberIndex{1, 3, 5},
 			},
 		},
@@ -672,6 +674,81 @@ func TestBuildTaggedTBTCSignerRunDKGInputs_RejectsInvalidRequest(t *testing.T) {
 			_, _, err := buildTaggedTBTCSignerRunDKGInputs(tc.request)
 			if err == nil {
 				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestIncludedMembersFromRequest_RejectsInvalidAttemptPolicy(t *testing.T) {
+	testCases := []struct {
+		name        string
+		request     *NativeExecutionFFISigningRequest
+		errFragment string
+	}{
+		{
+			name: "zero attempt number",
+			request: &NativeExecutionFFISigningRequest{
+				GroupSize: 3,
+				Attempt: &Attempt{
+					Number:                 0,
+					CoordinatorMemberIndex: 1,
+					IncludedMembersIndexes: []group.MemberIndex{1, 2},
+				},
+			},
+			errFragment: "attempt number is zero",
+		},
+		{
+			name: "zero coordinator",
+			request: &NativeExecutionFFISigningRequest{
+				GroupSize: 3,
+				Attempt: &Attempt{
+					Number:                 1,
+					CoordinatorMemberIndex: 0,
+					IncludedMembersIndexes: []group.MemberIndex{1, 2},
+				},
+			},
+			errFragment: "attempt coordinator member index is zero",
+		},
+		{
+			name: "coordinator not included",
+			request: &NativeExecutionFFISigningRequest{
+				GroupSize: 3,
+				Attempt: &Attempt{
+					Number:                 1,
+					CoordinatorMemberIndex: 3,
+					IncludedMembersIndexes: []group.MemberIndex{1, 2},
+				},
+			},
+			errFragment: "attempt coordinator [3] is not included",
+		},
+		{
+			name: "member both included and excluded",
+			request: &NativeExecutionFFISigningRequest{
+				GroupSize: 3,
+				Attempt: &Attempt{
+					Number:                 1,
+					CoordinatorMemberIndex: 1,
+					IncludedMembersIndexes: []group.MemberIndex{1, 2},
+					ExcludedMembersIndexes: []group.MemberIndex{2},
+				},
+			},
+			errFragment: "member [2] is both included and excluded in attempt",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := includedMembersFromRequest(tc.request)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+
+			if !strings.Contains(err.Error(), tc.errFragment) {
+				t.Fatalf(
+					"unexpected error\nexpected to contain: [%v]\nactual:              [%v]",
+					tc.errFragment,
+					err,
+				)
 			}
 		})
 	}
@@ -2064,6 +2141,8 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 
 	secondRequest := *baseRequest
 	secondRequest.Attempt = &Attempt{
+		Number:                 2,
+		CoordinatorMemberIndex: 1,
 		ExcludedMembersIndexes: []group.MemberIndex{3},
 	}
 
@@ -2210,6 +2289,8 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 
 	secondRequest := *baseRequest
 	secondRequest.Attempt = &Attempt{
+		Number:                 2,
+		CoordinatorMemberIndex: 1,
 		ExcludedMembersIndexes: []group.MemberIndex{2},
 	}
 

--- a/pkg/frost/signing/native_frost_protocol_frost_native.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native.go
@@ -432,28 +432,46 @@ func includedMembersFromRequest(
 		return nil, nil, fmt.Errorf("group size must be positive")
 	}
 
-	includedMembersSet := make(map[group.MemberIndex]struct{})
+	attempt := request.Attempt
+	if attempt != nil {
+		if attempt.Number == 0 {
+			return nil, nil, fmt.Errorf("attempt number is zero")
+		}
 
-	if request.Attempt != nil && len(request.Attempt.IncludedMembersIndexes) > 0 {
-		for _, memberIndex := range request.Attempt.IncludedMembersIndexes {
+		if attempt.CoordinatorMemberIndex == 0 {
+			return nil, nil, fmt.Errorf("attempt coordinator member index is zero")
+		}
+	}
+
+	includedMembersSet := make(map[group.MemberIndex]struct{})
+	excludedMembersSet := make(map[group.MemberIndex]struct{})
+
+	if attempt != nil {
+		for _, memberIndex := range attempt.ExcludedMembersIndexes {
+			if memberIndex == 0 {
+				continue
+			}
+
+			excludedMembersSet[memberIndex] = struct{}{}
+		}
+	}
+
+	if attempt != nil && len(attempt.IncludedMembersIndexes) > 0 {
+		for _, memberIndex := range attempt.IncludedMembersIndexes {
 			if memberIndex == 0 {
 				return nil, nil, fmt.Errorf("included member index is zero")
+			}
+
+			if _, excluded := excludedMembersSet[memberIndex]; excluded {
+				return nil, nil, fmt.Errorf(
+					"member [%v] is both included and excluded in attempt",
+					memberIndex,
+				)
 			}
 
 			includedMembersSet[memberIndex] = struct{}{}
 		}
 	} else {
-		excludedMembersSet := make(map[group.MemberIndex]struct{})
-		if request.Attempt != nil {
-			for _, memberIndex := range request.Attempt.ExcludedMembersIndexes {
-				if memberIndex == 0 {
-					continue
-				}
-
-				excludedMembersSet[memberIndex] = struct{}{}
-			}
-		}
-
 		for i := 1; i <= request.GroupSize; i++ {
 			memberIndex := group.MemberIndex(i)
 			if _, excluded := excludedMembersSet[memberIndex]; !excluded {
@@ -464,6 +482,15 @@ func includedMembersFromRequest(
 
 	if len(includedMembersSet) == 0 {
 		return nil, nil, fmt.Errorf("included members set is empty")
+	}
+
+	if attempt != nil {
+		if _, included := includedMembersSet[attempt.CoordinatorMemberIndex]; !included {
+			return nil, nil, fmt.Errorf(
+				"attempt coordinator [%v] is not included",
+				attempt.CoordinatorMemberIndex,
+			)
+		}
 	}
 
 	includedMembersIndexes := make([]group.MemberIndex, 0, len(includedMembersSet))


### PR DESCRIPTION
## Summary
- enforce native attempt policy in shared included-member derivation used by native FROST and tbtc-signer coarse paths
- reject zero attempt number, zero coordinator, coordinator not in included cohort, and included/excluded overlap
- update attempt-variation tests to provide explicit attempt metadata and add policy rejection coverage

## Testing
- GOCACHE=/tmp/keep-core-gocache go test -count=1 -tags frost_native ./pkg/frost/signing
- GOCACHE=/tmp/keep-core-gocache go test -count=1 -tags frost_native ./pkg/tbtc -run "TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend|TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter|TestConfigureFrostSigningBackend_FFIStrictUnavailable_NoBridge|TestSigningExecutor_Sign_NativeBackend|TestSigningExecutor_Sign_FFIStrictBackend_WithNativeSignerMaterial|TestSigningExecutor_Sign_NativeBackend_FallsBackWhenOnlyLegacySignerMaterial|TestRegisterSignerMaterialResolverForBuild"