### PR TITLE
frost/signing: fail closed on invalid coarse attempt policy

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -174,6 +175,14 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 
 	includedMembersSet, includedMembersIndexes, err := includedMembersFromRequest(request)
 	if err != nil {
+		if errors.Is(err, ErrInvalidSigningAttemptPolicy) {
+			return nil, fmt.Errorf(
+				"%w: invalid tbtc-signer signing attempt policy: [%v]",
+				ErrNativeBridgeOperationFailed,
+				err,
+			)
+		}
+
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
 			logger,

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"reflect"
@@ -2352,6 +2353,103 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 			"unexpected coarse signature event count\nexpected: [%d]\nactual:   [%d]",
 			1,
 			len(observedCoarseSignatureEvents),
+		)
+	}
+}
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_InvalidAttemptPolicy_DoesNotFallback(
+	t *testing.T,
+) {
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0-bootstrap",
+	}
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	err := RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	fixtures, err := tecdsatest.LoadPrivateKeyShareTestFixtures(3)
+	if err != nil {
+		t.Fatalf("failed loading key share fixtures: [%v]", err)
+	}
+
+	privateKeyShare := tecdsa.NewPrivateKeyShare(fixtures[0])
+	privateKeySharePayload, err := privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("failed marshaling private key share: [%v]", err)
+	}
+
+	signerMaterialPayload, err := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup:                 "group-1",
+		KeyGroupSource:           NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+		LegacyPrivateKeyShareHex: hex.EncodeToString(privateKeySharePayload),
+	})
+	if err != nil {
+		t.Fatalf("cannot marshal signer material payload: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: signerMaterialPayload,
+		},
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 2,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+			ExcludedMembersIndexes: []group.MemberIndex{2},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected not to include: [%v]\nactual:                 [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if engine.runDKGCalled {
+		t.Fatal("did not expect RunDKG call for invalid attempt policy")
+	}
+
+	if len(observedEvents) != 0 {
+		t.Fatalf(
+			"did not expect fallback events\nactual: [%v]",
+			observedEvents,
 		)
 	}
 }

--- a/pkg/frost/signing/native_frost_protocol_frost_native.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native.go
@@ -5,6 +5,7 @@ package signing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -15,6 +16,12 @@ import (
 )
 
 const nativeFROSTMessageTypePrefix = "frost_signing/native_frost/"
+
+var (
+	// ErrInvalidSigningAttemptPolicy indicates the provided attempt metadata
+	// violates coordinator/cohort policy invariants.
+	ErrInvalidSigningAttemptPolicy = errors.New("invalid signing attempt policy")
+)
 
 type nativeFROSTUniFFIV2SignerMaterial struct {
 	KeyPackage       *NativeFROSTKeyPackage       `json:"keyPackage"`
@@ -435,11 +442,17 @@ func includedMembersFromRequest(
 	attempt := request.Attempt
 	if attempt != nil {
 		if attempt.Number == 0 {
-			return nil, nil, fmt.Errorf("attempt number is zero")
+			return nil, nil, fmt.Errorf(
+				"%w: attempt number is zero",
+				ErrInvalidSigningAttemptPolicy,
+			)
 		}
 
 		if attempt.CoordinatorMemberIndex == 0 {
-			return nil, nil, fmt.Errorf("attempt coordinator member index is zero")
+			return nil, nil, fmt.Errorf(
+				"%w: attempt coordinator member index is zero",
+				ErrInvalidSigningAttemptPolicy,
+			)
 		}
 	}
 
@@ -459,12 +472,16 @@ func includedMembersFromRequest(
 	if attempt != nil && len(attempt.IncludedMembersIndexes) > 0 {
 		for _, memberIndex := range attempt.IncludedMembersIndexes {
 			if memberIndex == 0 {
-				return nil, nil, fmt.Errorf("included member index is zero")
+				return nil, nil, fmt.Errorf(
+					"%w: included member index is zero",
+					ErrInvalidSigningAttemptPolicy,
+				)
 			}
 
 			if _, excluded := excludedMembersSet[memberIndex]; excluded {
 				return nil, nil, fmt.Errorf(
-					"member [%v] is both included and excluded in attempt",
+					"%w: member [%v] is both included and excluded in attempt",
+					ErrInvalidSigningAttemptPolicy,
 					memberIndex,
 				)
 			}
@@ -481,13 +498,21 @@ func includedMembersFromRequest(
 	}
 
 	if len(includedMembersSet) == 0 {
+		if attempt != nil {
+			return nil, nil, fmt.Errorf(
+				"%w: included members set is empty",
+				ErrInvalidSigningAttemptPolicy,
+			)
+		}
+
 		return nil, nil, fmt.Errorf("included members set is empty")
 	}
 
 	if attempt != nil {
 		if _, included := includedMembersSet[attempt.CoordinatorMemberIndex]; !included {
 			return nil, nil, fmt.Errorf(
-				"attempt coordinator [%v] is not included",
+				"%w: attempt coordinator [%v] is not included",
+				ErrInvalidSigningAttemptPolicy,
 				attempt.CoordinatorMemberIndex,
 			)
 		}


### PR DESCRIPTION
## Summary
- classify coordinator/cohort attempt-policy violations with a dedicated sentinel error in included-member derivation
- stop tbtc-signer coarse path from falling back to legacy signing when attempt-policy validation fails
- add regression coverage proving invalid attempt policy does not trigger legacy fallback even when legacy private key share is present

## Testing
- GOCACHE=/tmp/keep-core-gocache go test -count=1 -tags frost_native ./pkg/frost/signing
- GOCACHE=/tmp/keep-core-gocache go test -count=1 -tags frost_native ./pkg/tbtc -run "TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend|TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter|TestConfigureFrostSigningBackend_FFIStrictUnavailable_NoBridge|TestSigningExecutor_Sign_NativeBackend|TestSigningExecutor_Sign_FFIStrictBackend_WithNativeSignerMaterial|TestSigningExecutor_Sign_NativeBackend_FallsBackWhenOnlyLegacySignerMaterial|TestRegisterSignerMaterialResolverForBuild"