### PR TITLE
frost-signing: fail-close consumed attempt replay errors

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -42,6 +42,7 @@ const buildTaggedTBTCSignerVersionPrefix = "tbtc-signer/"
 const buildTaggedTBTCSignerBootstrapVersionPrerelease = "bootstrap"
 const buildTaggedTBTCSignerSyntheticContributionDomain = "tbtc-signer-bootstrap-contribution-v1"
 const buildTaggedTBTCSignerMessageTypePrefix = "frost_signing/native_tbtc_signer/"
+const buildTaggedTBTCSignerConsumedAttemptReplayErrorFragment = "already consumed for sign attempt"
 
 type nativeTBTCSignerVersionedEngine interface {
 	Version() (string, error)
@@ -320,6 +321,15 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 		includedMembersIndexes,
 	)
 	if err != nil {
+		if isBuildTaggedTBTCSignerConsumedAttemptReplayError(err) {
+			return nil, fmt.Errorf(
+				"%w: consumed tbtc-signer attempt replay: %w: %v",
+				ErrNativeBridgeOperationFailed,
+				ErrConsumedSigningAttemptReplay,
+				err,
+			)
+		}
+
 		return btlcnnefsp.fallbackTBTCSignerLegacySigning(
 			ctx,
 			logger,
@@ -357,6 +367,16 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	)
 
 	return coarseSignature, nil
+}
+
+func isBuildTaggedTBTCSignerConsumedAttemptReplayError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "attempt_id") &&
+		strings.Contains(message, buildTaggedTBTCSignerConsumedAttemptReplayErrorFragment)
 }
 
 func buildTaggedTBTCSignerRunDKGInputs(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -2507,3 +2507,117 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 		})
 	}
 }
+
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_ConsumedAttemptReplay_DoesNotFallback(
+	t *testing.T,
+) {
+	fixtures, err := tecdsatest.LoadPrivateKeyShareTestFixtures(3)
+	if err != nil {
+		t.Fatalf("failed loading key share fixtures: [%v]", err)
+	}
+
+	privateKeyShare := tecdsa.NewPrivateKeyShare(fixtures[0])
+	privateKeySharePayload, err := privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("failed marshaling private key share: [%v]", err)
+	}
+
+	signerMaterialPayload, err := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup:                 "group-1",
+		KeyGroupSource:           NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+		LegacyPrivateKeyShareHex: hex.EncodeToString(privateKeySharePayload),
+	})
+	if err != nil {
+		t.Fatalf("cannot marshal signer material payload: [%v]", err)
+	}
+
+	engine := &mockBuildTaggedTBTCSignerEngine{
+		version: "tbtc-signer/0.1.0-bootstrap",
+		startErr: errors.New(
+			"validation: attempt_id [11] already consumed for sign attempt in session [session-1]",
+		),
+	}
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+
+	err = RegisterNativeTBTCSignerEngine(engine)
+	if err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	err = RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+
+	_, err = primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: signerMaterialPayload,
+		},
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrNativeBridgeOperationFailed,
+			err,
+		)
+	}
+
+	if !errors.Is(err, ErrConsumedSigningAttemptReplay) {
+		t.Fatalf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			ErrConsumedSigningAttemptReplay,
+			err,
+		)
+	}
+
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf(
+			"unexpected error\nexpected not to include: [%v]\nactual:                 [%v]",
+			ErrNativeCryptographyUnavailable,
+			err,
+		)
+	}
+
+	if !engine.runDKGCalled {
+		t.Fatal("expected RunDKG call before consumed-attempt replay rejection")
+	}
+
+	if len(observedEvents) != 0 {
+		t.Fatalf(
+			"did not expect fallback events\nactual: [%v]",
+			observedEvents,
+		)
+	}
+
+	if !strings.Contains(err.Error(), "already consumed for sign attempt") {
+		t.Fatalf(
+			"expected replay fragment in error message\nactual: [%v]",
+			err,
+		)
+	}
+}

--- a/pkg/frost/signing/native_frost_protocol_frost_native.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native.go
@@ -21,6 +21,9 @@ var (
 	// ErrInvalidSigningAttemptPolicy indicates the provided attempt metadata
 	// violates coordinator/cohort policy invariants.
 	ErrInvalidSigningAttemptPolicy = errors.New("invalid signing attempt policy")
+	// ErrConsumedSigningAttemptReplay indicates signer-side replay protection
+	// rejected a previously consumed signing attempt payload.
+	ErrConsumedSigningAttemptReplay = errors.New("consumed signing attempt replay")
 )
 
 type nativeFROSTUniFFIV2SignerMaterial struct {


### PR DESCRIPTION
## Summary
- classify signer `attempt_id already consumed for sign attempt` failures as non-fallback bridge errors on the coarse tbtc-signer path
- add `ErrConsumedSigningAttemptReplay` sentinel for explicit retry-policy classification
- add regression coverage proving consumed-attempt replay does not trigger legacy fallback

## Testing
- GOCACHE=/tmp/keep-core-gocache go test -count=1 -tags frost_native ./pkg/frost/signing -run "ConsumedAttemptReplay|InvalidAttemptPolicy|BuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath"
- GOCACHE=/tmp/keep-core-gocache go test -count=1 -tags frost_native ./pkg/tbtc -run "TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend|TestConfigureFrostSigningBackend_FFIStrictConfigured_BuildAdapter|TestConfigureFrostSigningBackend_FFIStrictUnavailable_NoBridge|TestSigningExecutor_Sign_NativeBackend|TestSigningExecutor_Sign_FFIStrictBackend_WithNativeSignerMaterial|TestSigningExecutor_Sign_NativeBackend_FallsBackWhenOnlyLegacySignerMaterial|TestRegisterSignerMaterialResolverForBuild"
