### PR TITLE
feat(tbtc): add covenant signer job substrate

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
 	chainEthereum "github.com/keep-network/keep-core/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 	"github.com/keep-network/keep-core/pkg/maintainer/spv"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/tbtc"
@@ -46,6 +47,8 @@ func initFlags(
 			initStorageFlags(cmd, cfg)
 		case config.ClientInfo:
 			initClientInfoFlags(cmd, cfg)
+		case config.CovenantSigner:
+			initCovenantSignerFlags(cmd, cfg)
 		case config.Tbtc:
 			initTbtcFlags(cmd, cfg)
 		case config.Maintainer:
@@ -307,6 +310,15 @@ func initTbtcFlags(cmd *cobra.Command, cfg *config.Config) {
 		"tbtc.keyGenerationConcurrency",
 		tbtc.DefaultKeyGenerationConcurrency,
 		"tECDSA key generation concurrency.",
+	)
+}
+
+func initCovenantSignerFlags(cmd *cobra.Command, cfg *config.Config) {
+	cmd.Flags().IntVar(
+		&cfg.CovenantSigner.Port,
+		"covenantSigner.port",
+		covenantsigner.Config{}.Port,
+		"Covenant signer provider HTTP server listening port. Zero disables the service.",
 	)
 }
 

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -190,6 +190,13 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: 76 * time.Second,
 		defaultValue:          10 * time.Minute,
 	},
+	"covenantSigner.port": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.CovenantSigner.Port },
+		flagName:              "--covenantSigner.port",
+		flagValue:             "9711",
+		expectedValueFromFlag: 9711,
+		defaultValue:          0,
+	},
 	"tbtc.preParamsPoolSize": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsPoolSize },
 		flagName:              "--tbtc.preParamsPoolSize",

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,6 +20,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/generator"
 	"github.com/keep-network/keep-core/pkg/net"
@@ -173,6 +174,15 @@ func start(cmd *cobra.Command) error {
 		)
 		if err != nil {
 			return fmt.Errorf("error initializing TBTC: [%v]", err)
+		}
+
+		_, _, err = covenantsigner.Initialize(
+			ctx,
+			clientConfig.CovenantSigner,
+			tbtcDataPersistence,
+		)
+		if err != nil {
+			return fmt.Errorf("error initializing covenant signer: [%v]", err)
 		}
 	}
 

--- a/config/category.go
+++ b/config/category.go
@@ -9,6 +9,7 @@ const (
 	Network
 	Storage
 	ClientInfo
+	CovenantSigner
 	Tbtc
 	Maintainer
 	Developer
@@ -22,6 +23,7 @@ var StartCmdCategories = []Category{
 	Network,
 	Storage,
 	ClientInfo,
+	CovenantSigner,
 	Tbtc,
 	Developer,
 }
@@ -41,6 +43,7 @@ var AllCategories = []Category{
 	Network,
 	Storage,
 	ClientInfo,
+	CovenantSigner,
 	Tbtc,
 	Maintainer,
 	Developer,

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ import (
 	commonEthereum "github.com/keep-network/keep-common/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 	"github.com/keep-network/keep-core/pkg/maintainer"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/storage"
@@ -45,13 +46,14 @@ const (
 
 // Config is the top level config structure.
 type Config struct {
-	Ethereum   commonEthereum.Config
-	Bitcoin    BitcoinConfig
-	LibP2P     libp2p.Config `mapstructure:"network"`
-	Storage    storage.Config
-	ClientInfo clientinfo.Config
-	Maintainer maintainer.Config
-	Tbtc       tbtc.Config
+	Ethereum       commonEthereum.Config
+	Bitcoin        BitcoinConfig
+	LibP2P         libp2p.Config `mapstructure:"network"`
+	Storage        storage.Config
+	ClientInfo     clientinfo.Config
+	CovenantSigner covenantsigner.Config
+	Maintainer     maintainer.Config
+	Tbtc           tbtc.Config
 }
 
 // BitcoinConfig defines the configuration for Bitcoin.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -199,6 +199,10 @@ func TestReadConfigFromFile(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.ClientInfo.EthereumMetricsTick },
 			expectedValue: 87 * time.Second,
 		},
+		"CovenantSigner.Port": {
+			readValueFunc: func(c *Config) interface{} { return c.CovenantSigner.Port },
+			expectedValue: 9702,
+		},
 		"Maintainer.BitcoinDifficulty.Enabled": {
 			readValueFunc: func(c *Config) interface{} { return c.Maintainer.BitcoinDifficulty.Enabled },
 			expectedValue: true,

--- a/pkg/covenantsigner/config.go
+++ b/pkg/covenantsigner/config.go
@@ -1,0 +1,7 @@
+package covenantsigner
+
+// Config configures the covenant signer HTTP service.
+type Config struct {
+	// Port enables the covenant signer provider HTTP surface when non-zero.
+	Port int
+}

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
 )
@@ -223,6 +225,70 @@ func TestServicePollCanTransitionToReady(t *testing.T) {
 	}
 }
 
+func TestServiceTimestampsAdvanceAcrossTransitions(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+		poll: func(*Job) (*Transition, error) {
+			return &Transition{
+				State:          JobStateArtifactReady,
+				Detail:         "artifact ready",
+				PSBTHash:       "0x090a",
+				TransactionHex: "0x0b0c",
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitResult, err := service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_timestamps",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submittedJob, ok, err := service.store.GetByRequestID(submitResult.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected submitted job")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	_, err = service.Poll(context.Background(), TemplateSelfV1, SignerPollInput{
+		RouteRequestID: "ors_timestamps",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	polledJob, ok, err := service.store.GetByRequestID(submitResult.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected polled job")
+	}
+
+	if submittedJob.CreatedAt == polledJob.UpdatedAt {
+		t.Fatalf("expected updated timestamp to advance, got created=%s updated=%s", submittedJob.CreatedAt, polledJob.UpdatedAt)
+	}
+	if polledJob.CompletedAt == "" {
+		t.Fatal("expected completed timestamp to be populated")
+	}
+}
+
 func TestServicePollMapsJobNotFoundToFailed(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -354,5 +420,74 @@ func TestServerHandlesSubmitAndPathPoll(t *testing.T) {
 	if pollResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(pollResponse.Body)
 		t.Fatalf("unexpected poll status: %d %s", pollResponse.StatusCode, string(body))
+	}
+}
+
+func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service))
+	defer server.Close()
+
+	payload := bytes.NewBufferString(`{
+		"routeRequestId":"ors_http_unknown",
+		"stage":"SIGNER_COORDINATION",
+		"request":{
+			"facadeRequestId":"rf_123",
+			"idempotencyKey":"idem_123",
+			"route":"self_v1",
+			"strategy":"0x1234",
+			"reserve":"0xabcd",
+			"epoch":12,
+			"maturityHeight":912345,
+			"activeOutpoint":{"txid":"0x0102","vout":1,"scriptHash":"0x0304"},
+			"destinationCommitmentHash":"0x0506",
+			"artifactSignatures":["0x0708"],
+			"artifacts":{},
+			"scriptTemplate":{"template":"self_v1","depositorPublicKey":"0x021111","signerPublicKey":"0x022222","delta2":4320},
+			"signing":{"signerRequired":true,"custodianRequired":false},
+			"futureField":"ignored"
+		},
+		"futureTopLevel":"ignored"
+	}`)
+
+	response, err := http.Post(server.URL+"/v1/self_v1/signer/requests", "application/json", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("unexpected submit status: %d %s", response.StatusCode, string(body))
+	}
+}
+
+func TestInitializeRejectsInvalidOrUnavailablePort(t *testing.T) {
+	handle := newMemoryHandle()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, enabled, err := Initialize(ctx, Config{Port: -1}, handle); err == nil || enabled {
+		t.Fatalf("expected invalid negative port to fail, got enabled=%v err=%v", enabled, err)
+	}
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	if _, enabled, err := Initialize(ctx, Config{Port: port}, handle); err == nil || enabled {
+		t.Fatalf("expected occupied port to fail, got enabled=%v err=%v", enabled, err)
 	}
 }

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -1,0 +1,358 @@
+package covenantsigner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/keep-network/keep-common/pkg/persistence"
+)
+
+type memoryDescriptor struct {
+	name      string
+	directory string
+	content   []byte
+}
+
+func (md *memoryDescriptor) Name() string      { return md.name }
+func (md *memoryDescriptor) Directory() string { return md.directory }
+func (md *memoryDescriptor) Content() ([]byte, error) {
+	return md.content, nil
+}
+
+type memoryHandle struct {
+	items map[string]*memoryDescriptor
+}
+
+func newMemoryHandle() *memoryHandle {
+	return &memoryHandle{items: make(map[string]*memoryDescriptor)}
+}
+
+func (mh *memoryHandle) key(directory, name string) string {
+	return directory + "/" + name
+}
+
+func (mh *memoryHandle) Save(data []byte, directory string, name string) error {
+	mh.items[mh.key(directory, name)] = &memoryDescriptor{
+		name:      name,
+		directory: directory,
+		content:   append([]byte{}, data...),
+	}
+	return nil
+}
+
+func (mh *memoryHandle) Delete(directory string, name string) error {
+	delete(mh.items, mh.key(directory, name))
+	return nil
+}
+
+func (mh *memoryHandle) ReadAll() (<-chan persistence.DataDescriptor, <-chan error) {
+	dataChan := make(chan persistence.DataDescriptor, len(mh.items))
+	errorChan := make(chan error)
+	for _, item := range mh.items {
+		dataChan <- item
+	}
+	close(dataChan)
+	close(errorChan)
+	return dataChan, errorChan
+}
+
+type scriptedEngine struct {
+	submit func(*Job) (*Transition, error)
+	poll   func(*Job) (*Transition, error)
+}
+
+func (se *scriptedEngine) OnSubmit(_ context.Context, job *Job) (*Transition, error) {
+	if se.submit == nil {
+		return nil, nil
+	}
+	return se.submit(job)
+}
+
+func (se *scriptedEngine) OnPoll(_ context.Context, job *Job) (*Transition, error) {
+	if se.poll == nil {
+		return nil, nil
+	}
+	return se.poll(job)
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func validSelfTemplate() json.RawMessage {
+	return mustTemplate(SelfV1Template{
+		Template:           TemplateSelfV1,
+		DepositorPublicKey: "0x021111",
+		SignerPublicKey:    "0x022222",
+		Delta2:             4320,
+	})
+}
+
+func validQcTemplate() json.RawMessage {
+	return mustTemplate(QcV1Template{
+		Template:           TemplateQcV1,
+		DepositorPublicKey: "0x021111",
+		CustodianPublicKey: "0x023333",
+		SignerPublicKey:    "0x022222",
+		Beta:               144,
+		Delta2:             4320,
+	})
+}
+
+func mustTemplate(value any) json.RawMessage {
+	data, _ := json.Marshal(value)
+	return data
+}
+
+func baseRequest(route TemplateID) RouteSubmitRequest {
+	request := RouteSubmitRequest{
+		FacadeRequestID:           "rf_123",
+		IdempotencyKey:            "idem_123",
+		Route:                     route,
+		Strategy:                  "0x1234",
+		Reserve:                   "0xabcd",
+		Epoch:                     12,
+		MaturityHeight:            912345,
+		ActiveOutpoint:            CovenantOutpoint{TxID: "0x0102", Vout: 1, ScriptHash: "0x0304"},
+		DestinationCommitmentHash: "0x0506",
+		ArtifactSignatures:        []string{"0x0708"},
+		Artifacts:                 map[RecoveryPathID]ArtifactRecord{},
+	}
+
+	switch route {
+	case TemplateSelfV1:
+		request.ScriptTemplate = validSelfTemplate()
+		request.Signing = SigningRequirements{SignerRequired: true, CustodianRequired: false}
+	case TemplateQcV1:
+		request.ScriptTemplate = validQcTemplate()
+		request.Signing = SigningRequirements{SignerRequired: true, CustodianRequired: true}
+	}
+
+	return request
+}
+
+func TestServiceSubmitDeduplicatesByRouteRequestID(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := SignerSubmitInput{
+		RouteRequestID: "ors_123",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	}
+
+	first, err := service.Submit(context.Background(), TemplateSelfV1, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := service.Submit(context.Background(), TemplateSelfV1, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first.RequestID == "" {
+		t.Fatal("expected durable request id")
+	}
+	if first.RequestID != second.RequestID {
+		t.Fatalf("expected dedupe on routeRequestId, got %s vs %s", first.RequestID, second.RequestID)
+	}
+}
+
+func TestServicePollCanTransitionToReady(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+		poll: func(*Job) (*Transition, error) {
+			return &Transition{
+				State:          JobStateArtifactReady,
+				Detail:         "artifact ready",
+				PSBTHash:       "0x090a",
+				TransactionHex: "0x0b0c",
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitResult, err := service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_ready",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollResult, err := service.Poll(context.Background(), TemplateSelfV1, SignerPollInput{
+		RouteRequestID: "ors_ready",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pollResult.Status != StepStatusReady {
+		t.Fatalf("expected READY, got %s", pollResult.Status)
+	}
+	if pollResult.PSBTHash != "0x090a" || pollResult.TransactionHex != "0x0b0c" {
+		t.Fatalf("unexpected ready payload: %#v", pollResult)
+	}
+}
+
+func TestServicePollMapsJobNotFoundToFailed(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+		poll: func(*Job) (*Transition, error) {
+			return nil, errJobNotFound
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitResult, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_missing",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollResult, err := service.Poll(context.Background(), TemplateQcV1, SignerPollInput{
+		RouteRequestID: "orq_missing",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pollResult.Status != StepStatusFailed || pollResult.Reason != ReasonJobNotFound {
+		t.Fatalf("unexpected failed result: %#v", pollResult)
+	}
+}
+
+func TestStoreReloadPreservesJobs(t *testing.T) {
+	handle := newMemoryHandle()
+	store, err := NewStore(handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job := &Job{
+		RequestID:       "kcs_self_1234",
+		RouteRequestID:  "ors_reload",
+		Route:           TemplateSelfV1,
+		IdempotencyKey:  "idem_reload",
+		FacadeRequestID: "rf_reload",
+		RequestDigest:   "0xdeadbeef",
+		State:           JobStatePending,
+		Detail:          "queued",
+		CreatedAt:       "2026-03-09T00:00:00Z",
+		UpdatedAt:       "2026-03-09T00:00:00Z",
+		Request:         baseRequest(TemplateSelfV1),
+	}
+
+	if err := store.Put(job); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := NewStore(handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadedJob, ok, err := reloaded.GetByRouteRequest(TemplateSelfV1, "ors_reload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected persisted job")
+	}
+	if !reflect.DeepEqual(job.Request, loadedJob.Request) {
+		t.Fatalf("unexpected reloaded request: %#v", loadedJob.Request)
+	}
+}
+
+func TestServerHandlesSubmitAndPathPoll(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service))
+	defer server.Close()
+
+	submitPayload := mustJSON(t, SignerSubmitInput{
+		RouteRequestID: "ors_http",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+
+	response, err := http.Post(server.URL+"/v1/self_v1/signer/requests", "application/json", bytes.NewReader(submitPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("unexpected submit status: %d %s", response.StatusCode, string(body))
+	}
+
+	submitResult := StepResult{}
+	if err := json.NewDecoder(response.Body).Decode(&submitResult); err != nil {
+		t.Fatal(err)
+	}
+
+	pollPayload := mustJSON(t, SignerPollInput{
+		RouteRequestID: "ors_http",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+
+	pollResponse, err := http.Post(server.URL+"/v1/self_v1/signer/requests/"+submitResult.RequestID+":poll", "application/json", bytes.NewReader(pollPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pollResponse.Body.Close()
+
+	if pollResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(pollResponse.Body)
+		t.Fatalf("unexpected poll status: %d %s", pollResponse.StatusCode, string(body))
+	}
+}

--- a/pkg/covenantsigner/doc.go
+++ b/pkg/covenantsigner/doc.go
@@ -1,0 +1,4 @@
+// Package covenantsigner implements the first keep-core covenant signer
+// extension slice: durable submit/poll semantics, request validation, and a
+// compatible HTTP surface for covenant recovery/presign signer jobs.
+package covenantsigner

--- a/pkg/covenantsigner/engine.go
+++ b/pkg/covenantsigner/engine.go
@@ -1,0 +1,39 @@
+package covenantsigner
+
+import (
+	"context"
+	"errors"
+)
+
+var errJobNotFound = errors.New("covenant signer job not found")
+
+type Transition struct {
+	State          JobState
+	Detail         string
+	Reason         FailureReason
+	PSBTHash       string
+	TransactionHex string
+	Handoff        map[string]any
+}
+
+type Engine interface {
+	OnSubmit(ctx context.Context, job *Job) (*Transition, error)
+	OnPoll(ctx context.Context, job *Job) (*Transition, error)
+}
+
+type passiveEngine struct{}
+
+func NewPassiveEngine() Engine {
+	return &passiveEngine{}
+}
+
+func (pe *passiveEngine) OnSubmit(context.Context, *Job) (*Transition, error) {
+	return &Transition{
+		State:  JobStatePending,
+		Detail: "accepted for covenant signing",
+	}, nil
+}
+
+func (pe *passiveEngine) OnPoll(context.Context, *Job) (*Transition, error) {
+	return nil, nil
+}

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -23,6 +24,9 @@ func Initialize(ctx context.Context, config Config, handle persistence.BasicHand
 	if config.Port == 0 {
 		return nil, false, nil
 	}
+	if config.Port < 0 || config.Port > 65535 {
+		return nil, false, fmt.Errorf("invalid covenant signer port [%d]", config.Port)
+	}
 
 	service, err := NewService(handle, NewPassiveEngine())
 	if err != nil {
@@ -37,13 +41,18 @@ func Initialize(ctx context.Context, config Config, handle persistence.BasicHand
 		},
 	}
 
+	listener, err := net.Listen("tcp", server.httpServer.Addr)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to bind covenant signer port [%d]: %w", config.Port, err)
+	}
+
 	go func() {
 		<-ctx.Done()
 		_ = server.httpServer.Shutdown(context.Background())
 	}()
 
 	go func() {
-		if err := server.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Errorf("covenant signer server failed: [%v]", err)
 		}
 	}()
@@ -76,7 +85,6 @@ func decodeJSON[T any](w http.ResponseWriter, r *http.Request, target *T) bool {
 	defer r.Body.Close()
 
 	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return false
@@ -102,7 +110,8 @@ func handleError(w http.ResponseWriter, err error) {
 		return
 	}
 
-	http.Error(w, err.Error(), http.StatusInternalServerError)
+	logger.Errorf("covenant signer request failed: [%v]", err)
+	http.Error(w, "internal server error", http.StatusInternalServerError)
 }
 
 func submitHandler(service *Service, route TemplateID) http.HandlerFunc {

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -1,0 +1,179 @@
+package covenantsigner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-common/pkg/persistence"
+)
+
+var logger = log.Logger("keep-covenant-signer")
+
+type Server struct {
+	service    *Service
+	httpServer *http.Server
+}
+
+func Initialize(ctx context.Context, config Config, handle persistence.BasicHandle) (*Server, bool, error) {
+	if config.Port == 0 {
+		return nil, false, nil
+	}
+
+	service, err := NewService(handle, NewPassiveEngine())
+	if err != nil {
+		return nil, false, err
+	}
+
+	server := &Server{
+		service: service,
+		httpServer: &http.Server{
+			Addr:    fmt.Sprintf(":%d", config.Port),
+			Handler: newHandler(service),
+		},
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = server.httpServer.Shutdown(context.Background())
+	}()
+
+	go func() {
+		if err := server.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Errorf("covenant signer server failed: [%v]", err)
+		}
+	}()
+
+	logger.Infof("enabled covenant signer provider endpoint on port [%v]", config.Port)
+
+	return server, true, nil
+}
+
+func newHandler(service *Service) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	mux.HandleFunc("POST /v1/self_v1/signer/requests", submitHandler(service, TemplateSelfV1))
+	mux.HandleFunc("POST /v1/qc_v1/signer/requests", submitHandler(service, TemplateQcV1))
+	mux.HandleFunc("POST /v1/self_v1/signer/requests:poll", pollBodyHandler(service, TemplateSelfV1))
+	mux.HandleFunc("POST /v1/qc_v1/signer/requests:poll", pollBodyHandler(service, TemplateQcV1))
+	mux.HandleFunc("/v1/self_v1/signer/requests/", pollPathHandler(service, TemplateSelfV1))
+	mux.HandleFunc("/v1/qc_v1/signer/requests/", pollPathHandler(service, TemplateQcV1))
+
+	return mux
+}
+
+func decodeJSON[T any](w http.ResponseWriter, r *http.Request, target *T) bool {
+	defer r.Body.Close()
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	var inputErr *inputError
+	if errors.As(err, &inputErr) {
+		http.Error(w, inputErr.Error(), http.StatusBadRequest)
+		return
+	}
+	if errors.Is(err, errJobNotFound) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+func submitHandler(service *Service, route TemplateID) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		input := SignerSubmitInput{}
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		result, err := service.Submit(r.Context(), route, input)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func pollBodyHandler(service *Service, route TemplateID) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		input := SignerPollInput{}
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		result, err := service.Poll(r.Context(), route, input)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func pollPathHandler(service *Service, route TemplateID) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+
+		prefix := "/v1/" + string(route) + "/signer/requests/"
+		if !strings.HasPrefix(r.URL.Path, prefix) || !strings.HasSuffix(r.URL.Path, ":poll") {
+			http.NotFound(w, r)
+			return
+		}
+
+		pathRequestID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, prefix), ":poll")
+		if pathRequestID == "" || strings.Contains(pathRequestID, "/") {
+			http.NotFound(w, r)
+			return
+		}
+
+		input := SignerPollInput{}
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+		if input.RequestID != "" && input.RequestID != pathRequestID {
+			http.Error(w, "requestId in body does not match path", http.StatusBadRequest)
+			return
+		}
+		input.RequestID = pathRequestID
+
+		result, err := service.Poll(r.Context(), route, input)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -1,0 +1,219 @@
+package covenantsigner
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/keep-network/keep-common/pkg/persistence"
+)
+
+type Service struct {
+	store  *Store
+	engine Engine
+	now    func() time.Time
+}
+
+func NewService(handle persistence.BasicHandle, engine Engine) (*Service, error) {
+	if engine == nil {
+		engine = NewPassiveEngine()
+	}
+
+	store, err := NewStore(handle)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{
+		store:  store,
+		engine: engine,
+		now:    time.Now().UTC,
+	}, nil
+}
+
+func newRequestID(prefix string) (string, error) {
+	randomBytes := make([]byte, 8)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s_%s", prefix, hex.EncodeToString(randomBytes)), nil
+}
+
+func applyTransition(job *Job, transition *Transition, now time.Time) {
+	if transition == nil {
+		return
+	}
+
+	job.State = transition.State
+	job.Detail = transition.Detail
+	job.Reason = transition.Reason
+	job.PSBTHash = transition.PSBTHash
+	job.TransactionHex = transition.TransactionHex
+	job.Handoff = transition.Handoff
+	job.UpdatedAt = now.Format(time.RFC3339Nano)
+
+	switch transition.State {
+	case JobStateArtifactReady, JobStateHandoffReady:
+		job.CompletedAt = job.UpdatedAt
+		job.FailedAt = ""
+	case JobStateFailed:
+		job.FailedAt = job.UpdatedAt
+	}
+}
+
+func mapJobResult(job *Job) StepResult {
+	switch job.State {
+	case JobStateArtifactReady:
+		return StepResult{
+			Status:         StepStatusReady,
+			RequestID:      job.RequestID,
+			Detail:         job.Detail,
+			PSBTHash:       job.PSBTHash,
+			TransactionHex: job.TransactionHex,
+		}
+	case JobStateHandoffReady:
+		return StepResult{
+			Status:    StepStatusReady,
+			RequestID: job.RequestID,
+			Detail:    job.Detail,
+			Handoff:   job.Handoff,
+		}
+	case JobStateFailed:
+		return StepResult{
+			Status:    StepStatusFailed,
+			RequestID: job.RequestID,
+			Detail:    job.Detail,
+			Reason:    job.Reason,
+		}
+	default:
+		return StepResult{
+			Status:    StepStatusPending,
+			RequestID: job.RequestID,
+			Detail:    job.Detail,
+		}
+	}
+}
+
+func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubmitInput) (StepResult, error) {
+	if err := validateSubmitInput(route, input); err != nil {
+		return StepResult{}, err
+	}
+
+	if existing, ok, err := s.store.GetByRouteRequest(route, input.RouteRequestID); err != nil {
+		return StepResult{}, err
+	} else if ok {
+		return mapJobResult(existing), nil
+	}
+
+	requestIDPrefix := "kcs"
+	if route == TemplateQcV1 {
+		requestIDPrefix = "kcs_qc"
+	} else if route == TemplateSelfV1 {
+		requestIDPrefix = "kcs_self"
+	}
+
+	requestID, err := newRequestID(requestIDPrefix)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	now := s.now()
+	requestDigest, err := requestDigest(input.Request)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	job := &Job{
+		RequestID:       requestID,
+		RouteRequestID:  input.RouteRequestID,
+		Route:           route,
+		IdempotencyKey:  input.Request.IdempotencyKey,
+		FacadeRequestID: input.Request.FacadeRequestID,
+		RequestDigest:   requestDigest,
+		State:           JobStateSubmitted,
+		Detail:          "accepted for covenant signing",
+		CreatedAt:       now.Format(time.RFC3339Nano),
+		UpdatedAt:       now.Format(time.RFC3339Nano),
+		Request:         input.Request,
+	}
+
+	if err := s.store.Put(job); err != nil {
+		return StepResult{}, err
+	}
+
+	transition, err := s.engine.OnSubmit(ctx, job)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	if transition == nil {
+		transition = &Transition{
+			State:  JobStatePending,
+			Detail: "accepted for covenant signing",
+		}
+	}
+
+	applyTransition(job, transition, s.now())
+	if err := s.store.Put(job); err != nil {
+		return StepResult{}, err
+	}
+
+	return mapJobResult(job), nil
+}
+
+func (s *Service) Poll(ctx context.Context, route TemplateID, input SignerPollInput) (StepResult, error) {
+	if err := validatePollInput(route, input); err != nil {
+		return StepResult{}, err
+	}
+
+	job, ok, err := s.store.GetByRequestID(input.RequestID)
+	if err != nil {
+		return StepResult{}, err
+	}
+	if !ok || job.Route != route {
+		return StepResult{}, errJobNotFound
+	}
+	if job.RouteRequestID != input.RouteRequestID {
+		return StepResult{}, &inputError{"routeRequestId does not match stored job"}
+	}
+
+	digest, err := requestDigest(input.Request)
+	if err != nil {
+		return StepResult{}, err
+	}
+	if digest != job.RequestDigest {
+		return StepResult{}, &inputError{"request does not match stored job payload"}
+	}
+
+	if job.State == JobStateArtifactReady || job.State == JobStateHandoffReady || job.State == JobStateFailed {
+		return mapJobResult(job), nil
+	}
+
+	transition, err := s.engine.OnPoll(ctx, job)
+	if err != nil {
+		if err == errJobNotFound {
+			applyTransition(job, &Transition{
+				State:  JobStateFailed,
+				Reason: ReasonJobNotFound,
+				Detail: "signer job no longer exists",
+			}, s.now())
+			if storeErr := s.store.Put(job); storeErr != nil {
+				return StepResult{}, storeErr
+			}
+			return mapJobResult(job), nil
+		}
+		return StepResult{}, err
+	}
+
+	if transition != nil {
+		applyTransition(job, transition, s.now())
+		if err := s.store.Put(job); err != nil {
+			return StepResult{}, err
+		}
+	}
+
+	return mapJobResult(job), nil
+}

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
@@ -14,6 +15,7 @@ type Service struct {
 	store  *Store
 	engine Engine
 	now    func() time.Time
+	mutex  sync.Mutex
 }
 
 func NewService(handle persistence.BasicHandle, engine Engine) (*Service, error) {
@@ -29,7 +31,7 @@ func NewService(handle persistence.BasicHandle, engine Engine) (*Service, error)
 	return &Service{
 		store:  store,
 		engine: engine,
-		now:    time.Now().UTC,
+		now:    func() time.Time { return time.Now().UTC() },
 	}, nil
 }
 
@@ -98,6 +100,9 @@ func mapJobResult(job *Job) StepResult {
 }
 
 func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubmitInput) (StepResult, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	if err := validateSubmitInput(route, input); err != nil {
 		return StepResult{}, err
 	}

--- a/pkg/covenantsigner/store.go
+++ b/pkg/covenantsigner/store.go
@@ -1,0 +1,173 @@
+package covenantsigner
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/keep-network/keep-common/pkg/persistence"
+)
+
+const jobsDirectory = "covenant-signer/jobs"
+
+type Store struct {
+	handle      persistence.BasicHandle
+	mutex       sync.Mutex
+	byRequestID map[string]*Job
+	byRouteKey  map[string]string
+}
+
+func NewStore(handle persistence.BasicHandle) (*Store, error) {
+	store := &Store{
+		handle:      handle,
+		byRequestID: make(map[string]*Job),
+		byRouteKey:  make(map[string]string),
+	}
+
+	if err := store.load(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+func routeKey(route TemplateID, routeRequestID string) string {
+	return fmt.Sprintf("%s:%s", route, routeRequestID)
+}
+
+func cloneJob(job *Job) (*Job, error) {
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return nil, err
+	}
+
+	cloned := &Job{}
+	if err := json.Unmarshal(payload, cloned); err != nil {
+		return nil, err
+	}
+
+	return cloned, nil
+}
+
+func (s *Store) load() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	dataChan, errorChan := s.handle.ReadAll()
+
+	for dataChan != nil || errorChan != nil {
+		select {
+		case descriptor, ok := <-dataChan:
+			if !ok {
+				dataChan = nil
+				continue
+			}
+
+			if descriptor.Directory() != jobsDirectory {
+				continue
+			}
+
+			content, err := descriptor.Content()
+			if err != nil {
+				return err
+			}
+
+			job := &Job{}
+			if err := json.Unmarshal(content, job); err != nil {
+				return err
+			}
+
+			existingID, ok := s.byRouteKey[routeKey(job.Route, job.RouteRequestID)]
+			if ok {
+				existing := s.byRequestID[existingID]
+				if existing != nil && existing.UpdatedAt >= job.UpdatedAt {
+					continue
+				}
+			}
+
+			s.byRequestID[job.RequestID] = job
+			s.byRouteKey[routeKey(job.Route, job.RouteRequestID)] = job.RequestID
+		case err, ok := <-errorChan:
+			if !ok {
+				errorChan = nil
+				continue
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *Store) GetByRequestID(requestID string) (*Job, bool, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	job, ok := s.byRequestID[requestID]
+	if !ok {
+		return nil, false, nil
+	}
+
+	cloned, err := cloneJob(job)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return cloned, true, nil
+}
+
+func (s *Store) GetByRouteRequest(route TemplateID, routeRequestID string) (*Job, bool, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	requestID, ok := s.byRouteKey[routeKey(route, routeRequestID)]
+	if !ok {
+		return nil, false, nil
+	}
+
+	job := s.byRequestID[requestID]
+	if job == nil {
+		return nil, false, nil
+	}
+
+	cloned, err := cloneJob(job)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return cloned, true, nil
+}
+
+func (s *Store) Put(job *Job) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+
+	key := routeKey(job.Route, job.RouteRequestID)
+	if existingRequestID, ok := s.byRouteKey[key]; ok && existingRequestID != job.RequestID {
+		if err := s.handle.Delete(jobsDirectory, existingRequestID+".json"); err != nil {
+			return err
+		}
+		delete(s.byRequestID, existingRequestID)
+	}
+
+	if err := s.handle.Save(payload, jobsDirectory, job.RequestID+".json"); err != nil {
+		return err
+	}
+
+	cloned, err := cloneJob(job)
+	if err != nil {
+		return err
+	}
+
+	s.byRequestID[job.RequestID] = cloned
+	s.byRouteKey[key] = job.RequestID
+
+	return nil
+}

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -1,0 +1,151 @@
+package covenantsigner
+
+import "encoding/json"
+
+type TemplateID string
+
+const (
+	TemplateQcV1   TemplateID = "qc_v1"
+	TemplateSelfV1 TemplateID = "self_v1"
+)
+
+type RecoveryPathID string
+
+const (
+	PathCooperative RecoveryPathID = "COOPERATIVE"
+	PathMigration   RecoveryPathID = "MIGRATION"
+	PathEarlyExit   RecoveryPathID = "EARLY_EXIT"
+	PathLastResort  RecoveryPathID = "LAST_RESORT"
+)
+
+type RecoveryStage string
+
+const (
+	StageSignerCoordination RecoveryStage = "SIGNER_COORDINATION"
+)
+
+type FailureReason string
+
+const (
+	ReasonAuthFailed          FailureReason = "AUTH_FAILED"
+	ReasonPolicyRejected      FailureReason = "POLICY_REJECTED"
+	ReasonInvalidInput        FailureReason = "INVALID_INPUT"
+	ReasonProviderUnavailable FailureReason = "PROVIDER_UNAVAILABLE"
+	ReasonJobNotFound         FailureReason = "JOB_NOT_FOUND"
+	ReasonJobPending          FailureReason = "JOB_PENDING"
+	ReasonProviderFailed      FailureReason = "PROVIDER_FAILED"
+	ReasonMalformedArtifact   FailureReason = "MALFORMED_ARTIFACT"
+)
+
+type StepStatus string
+
+const (
+	StepStatusPending StepStatus = "PENDING"
+	StepStatusReady   StepStatus = "READY"
+	StepStatusFailed  StepStatus = "FAILED"
+)
+
+type JobState string
+
+const (
+	JobStateSubmitted     JobState = "SUBMITTED"
+	JobStateValidating    JobState = "VALIDATING"
+	JobStateSigning       JobState = "SIGNING"
+	JobStatePending       JobState = "PENDING"
+	JobStateArtifactReady JobState = "ARTIFACT_READY"
+	JobStateHandoffReady  JobState = "HANDOFF_READY"
+	JobStateFailed        JobState = "FAILED"
+)
+
+type CovenantOutpoint struct {
+	TxID       string `json:"txid"`
+	Vout       uint32 `json:"vout"`
+	ScriptHash string `json:"scriptHash,omitempty"`
+}
+
+type ArtifactRecord struct {
+	PSBTHash                  string `json:"psbtHash"`
+	DestinationCommitmentHash string `json:"destinationCommitmentHash"`
+	TransactionHex            string `json:"transactionHex,omitempty"`
+	TransactionID             string `json:"transactionId,omitempty"`
+}
+
+type SigningRequirements struct {
+	SignerRequired    bool `json:"signerRequired"`
+	CustodianRequired bool `json:"custodianRequired"`
+}
+
+type RouteSubmitRequest struct {
+	FacadeRequestID           string                            `json:"facadeRequestId"`
+	IdempotencyKey            string                            `json:"idempotencyKey"`
+	Route                     TemplateID                        `json:"route"`
+	Strategy                  string                            `json:"strategy"`
+	Reserve                   string                            `json:"reserve"`
+	Epoch                     uint64                            `json:"epoch"`
+	MaturityHeight            uint64                            `json:"maturityHeight"`
+	ActiveOutpoint            CovenantOutpoint                  `json:"activeOutpoint"`
+	DestinationCommitmentHash string                            `json:"destinationCommitmentHash"`
+	ArtifactSignatures        []string                          `json:"artifactSignatures"`
+	Artifacts                 map[RecoveryPathID]ArtifactRecord `json:"artifacts"`
+	ScriptTemplate            json.RawMessage                   `json:"scriptTemplate"`
+	Signing                   SigningRequirements               `json:"signing"`
+}
+
+type SignerSubmitInput struct {
+	RouteRequestID string             `json:"routeRequestId"`
+	Request        RouteSubmitRequest `json:"request"`
+	Stage          RecoveryStage      `json:"stage"`
+}
+
+type SignerPollInput struct {
+	RouteRequestID string             `json:"routeRequestId"`
+	RequestID      string             `json:"requestId"`
+	Request        RouteSubmitRequest `json:"request"`
+	Stage          RecoveryStage      `json:"stage"`
+}
+
+type StepResult struct {
+	Status         StepStatus     `json:"status"`
+	RequestID      string         `json:"requestId,omitempty"`
+	Detail         string         `json:"detail,omitempty"`
+	Reason         FailureReason  `json:"reason,omitempty"`
+	PSBTHash       string         `json:"psbtHash,omitempty"`
+	TransactionHex string         `json:"transactionHex,omitempty"`
+	Handoff        map[string]any `json:"handoff,omitempty"`
+}
+
+type Job struct {
+	RequestID       string             `json:"requestId"`
+	RouteRequestID  string             `json:"routeRequestId"`
+	Route           TemplateID         `json:"route"`
+	IdempotencyKey  string             `json:"idempotencyKey"`
+	FacadeRequestID string             `json:"facadeRequestId"`
+	RequestDigest   string             `json:"requestDigest"`
+	State           JobState           `json:"state"`
+	Detail          string             `json:"detail,omitempty"`
+	Reason          FailureReason      `json:"reason,omitempty"`
+	CreatedAt       string             `json:"createdAt"`
+	UpdatedAt       string             `json:"updatedAt"`
+	CompletedAt     string             `json:"completedAt,omitempty"`
+	FailedAt        string             `json:"failedAt,omitempty"`
+	Request         RouteSubmitRequest `json:"request"`
+	PSBTHash        string             `json:"psbtHash,omitempty"`
+	TransactionHex  string             `json:"transactionHex,omitempty"`
+	Handoff         map[string]any     `json:"handoff,omitempty"`
+}
+
+type SelfV1Template struct {
+	Template           TemplateID `json:"template"`
+	DepositorPublicKey string     `json:"depositorPublicKey"`
+	SignerPublicKey    string     `json:"signerPublicKey"`
+	Delta2             uint64     `json:"delta2"`
+}
+
+type QcV1Template struct {
+	Template           TemplateID `json:"template"`
+	DepositorPublicKey string     `json:"depositorPublicKey"`
+	CustodianPublicKey string     `json:"custodianPublicKey"`
+	SignerPublicKey    string     `json:"signerPublicKey"`
+	Beta               uint64     `json:"beta"`
+	Delta2             uint64     `json:"delta2"`
+}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -1,0 +1,151 @@
+package covenantsigner
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type inputError struct {
+	message string
+}
+
+func (ie *inputError) Error() string {
+	return ie.message
+}
+
+func strictUnmarshal(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(target)
+}
+
+func requestDigest(request RouteSubmitRequest) (string, error) {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(payload)
+	return "0x" + hex.EncodeToString(sum[:]), nil
+}
+
+func validateHexString(name string, value string) error {
+	if !strings.HasPrefix(value, "0x") || len(value) <= 2 || len(value)%2 != 0 {
+		return &inputError{fmt.Sprintf("%s must be a 0x-prefixed even-length hex string", name)}
+	}
+
+	if _, err := hex.DecodeString(strings.TrimPrefix(value, "0x")); err != nil {
+		return &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	return nil
+}
+
+func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
+	if request.FacadeRequestID == "" {
+		return &inputError{"request.facadeRequestId is required"}
+	}
+	if request.IdempotencyKey == "" {
+		return &inputError{"request.idempotencyKey is required"}
+	}
+	if request.Route != route {
+		return &inputError{"request.route does not match endpoint route"}
+	}
+	if err := validateHexString("request.strategy", request.Strategy); err != nil {
+		return err
+	}
+	if err := validateHexString("request.reserve", request.Reserve); err != nil {
+		return err
+	}
+	if err := validateHexString("request.activeOutpoint.txid", request.ActiveOutpoint.TxID); err != nil {
+		return err
+	}
+	if request.ActiveOutpoint.ScriptHash != "" {
+		if err := validateHexString("request.activeOutpoint.scriptHash", request.ActiveOutpoint.ScriptHash); err != nil {
+			return err
+		}
+	}
+	if err := validateHexString("request.destinationCommitmentHash", request.DestinationCommitmentHash); err != nil {
+		return err
+	}
+	if len(request.ArtifactSignatures) == 0 {
+		return &inputError{"request.artifactSignatures must not be empty"}
+	}
+	for i, signature := range request.ArtifactSignatures {
+		if err := validateHexString(fmt.Sprintf("request.artifactSignatures[%d]", i), signature); err != nil {
+			return err
+		}
+	}
+
+	switch route {
+	case TemplateSelfV1:
+		if !request.Signing.SignerRequired || request.Signing.CustodianRequired {
+			return &inputError{"request.signing must set signerRequired=true and custodianRequired=false for self_v1"}
+		}
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(request.ScriptTemplate, template); err != nil {
+			return &inputError{fmt.Sprintf("request.scriptTemplate is invalid for self_v1: %v", err)}
+		}
+		if template.Template != TemplateSelfV1 {
+			return &inputError{"request.scriptTemplate.template must be self_v1"}
+		}
+		if err := validateHexString("request.scriptTemplate.depositorPublicKey", template.DepositorPublicKey); err != nil {
+			return err
+		}
+		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
+			return err
+		}
+	case TemplateQcV1:
+		if !request.Signing.SignerRequired || !request.Signing.CustodianRequired {
+			return &inputError{"request.signing must set signerRequired=true and custodianRequired=true for qc_v1"}
+		}
+		template := &QcV1Template{}
+		if err := strictUnmarshal(request.ScriptTemplate, template); err != nil {
+			return &inputError{fmt.Sprintf("request.scriptTemplate is invalid for qc_v1: %v", err)}
+		}
+		if template.Template != TemplateQcV1 {
+			return &inputError{"request.scriptTemplate.template must be qc_v1"}
+		}
+		if err := validateHexString("request.scriptTemplate.depositorPublicKey", template.DepositorPublicKey); err != nil {
+			return err
+		}
+		if err := validateHexString("request.scriptTemplate.custodianPublicKey", template.CustodianPublicKey); err != nil {
+			return err
+		}
+		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
+			return err
+		}
+	default:
+		return &inputError{"unsupported request.route"}
+	}
+
+	return nil
+}
+
+func validateSubmitInput(route TemplateID, input SignerSubmitInput) error {
+	if input.RouteRequestID == "" {
+		return &inputError{"routeRequestId is required"}
+	}
+	if input.Stage != StageSignerCoordination {
+		return &inputError{"stage must be SIGNER_COORDINATION"}
+	}
+	return validateCommonRequest(route, input.Request)
+}
+
+func validatePollInput(route TemplateID, input SignerPollInput) error {
+	if input.RequestID == "" {
+		return &inputError{"requestId is required"}
+	}
+	if err := validateSubmitInput(route, SignerSubmitInput{
+		RouteRequestID: input.RouteRequestID,
+		Request:        input.Request,
+		Stage:          input.Stage,
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/config.json
+++ b/test/config.json
@@ -39,6 +39,9 @@
         "NetworkMetricsTick": "43s",
         "EthereumMetricsTick": "1m27s"
     },
+    "CovenantSigner": {
+        "Port": 9702
+    },
     "Maintainer": {
         "BitcoinDifficulty": {
             "Enabled": true,

--- a/test/config.toml
+++ b/test/config.toml
@@ -35,6 +35,9 @@ Port = 3498
 NetworkMetricsTick = "43s"
 EthereumMetricsTick = "1m27s"
 
+[covenantsigner]
+Port = 9702
+
 [maintainer.BitcoinDifficulty]
 Enabled = true
 DisableProxy = true

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -30,6 +30,8 @@ ClientInfo:
   Port: 3498
   NetworkMetricsTick: "43s"
   EthereumMetricsTick: "1m27s"
+CovenantSigner:
+  Port: 9702
 Maintainer:
   BitcoinDifficulty:
     Enabled: true


### PR DESCRIPTION
## Summary
- add a new `pkg/covenantsigner` substrate package with durable submit/poll semantics for covenant signer jobs
- wire an optional `covenantSigner.port` HTTP server into `keep start` backed by work persistence
- add route-aware request validation, job dedup by `routeRequestId`, health endpoint, and targeted tests

## Scope
This is the first keep-core covenant signer extension slice only:
- common covenant job domain
- persistent store
- HTTP+JSON signer-provider surface
- request validation and idempotency

It does **not** yet implement the real signer cryptography / artifact generation path. The default engine accepts jobs and leaves them pending until the signing internals are plugged in by follow-up work.

## Verification
- `go test ./pkg/covenantsigner`
- `go test ./config ./cmd`