### PR TITLE
feat(tbtc): validate migration destination reservation artifacts

### DIFF
--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -384,6 +384,94 @@ func TestServiceRejectsMismatchedMigrationDestinationArtifact(t *testing.T) {
 	}
 }
 
+func TestServiceRejectsInvalidMigrationDestinationVariants(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name      string
+		mutate    func(request *RouteSubmitRequest)
+		expectErr string
+	}{
+		{
+			name: "missing reservation artifact",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination = nil
+			},
+			expectErr: "request.migrationDestination is required",
+		},
+		{
+			name: "wrong reservation route",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination.Route = "COOPERATIVE"
+			},
+			expectErr: "request.migrationDestination.route must be MIGRATION",
+		},
+		{
+			name: "retired reservation status",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination.Status = ReservationStatusRetired
+			},
+			expectErr: "request.migrationDestination.status must be RESERVED or COMMITTED_TO_EPOCH",
+		},
+		{
+			name: "epoch mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination.Epoch = 13
+			},
+			expectErr: "request.migrationDestination.epoch does not match request.epoch",
+		},
+		{
+			name: "reserve mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination.Reserve = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+			expectErr: "request.migrationDestination.reserve does not match request.reserve",
+		},
+		{
+			name: "request commitment mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.DestinationCommitmentHash = "0xdeadbeef"
+			},
+			expectErr: "request.migrationDestination.destinationCommitmentHash does not match request.destinationCommitmentHash",
+		},
+		{
+			name: "migration extraData mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination.MigrationExtraData = "0xdeadbeef"
+			},
+			expectErr: "request.migrationDestination.migrationExtraData does not match migration revealer encoding",
+		},
+		{
+			name: "canonical commitment mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationDestination.DestinationCommitmentHash = "0xdeadbeef"
+				request.DestinationCommitmentHash = "0xdeadbeef"
+			},
+			expectErr: "request.migrationDestination.destinationCommitmentHash does not match canonical reservation artifact",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := baseRequest(TemplateSelfV1)
+			testCase.mutate(&request)
+
+			_, err := service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+				RouteRequestID: "ors_invalid_variant_" + strings.ReplaceAll(testCase.name, " ", "_"),
+				Stage:          StageSignerCoordination,
+				Request:        request,
+			})
+			if err == nil || !strings.Contains(err.Error(), testCase.expectErr) {
+				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
+			}
+		})
+	}
+}
+
 func TestStoreReloadPreservesJobs(t *testing.T) {
 	handle := newMemoryHandle()
 	store, err := NewStore(handle)

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,16 +119,18 @@ func mustTemplate(value any) json.RawMessage {
 }
 
 func baseRequest(route TemplateID) RouteSubmitRequest {
+	migrationDestination := validMigrationDestination()
 	request := RouteSubmitRequest{
 		FacadeRequestID:           "rf_123",
 		IdempotencyKey:            "idem_123",
 		Route:                     route,
 		Strategy:                  "0x1234",
-		Reserve:                   "0xabcd",
+		Reserve:                   migrationDestination.Reserve,
 		Epoch:                     12,
 		MaturityHeight:            912345,
 		ActiveOutpoint:            CovenantOutpoint{TxID: "0x0102", Vout: 1, ScriptHash: "0x0304"},
-		DestinationCommitmentHash: "0x0506",
+		DestinationCommitmentHash: migrationDestination.DestinationCommitmentHash,
+		MigrationDestination:      migrationDestination,
 		ArtifactSignatures:        []string{"0x0708"},
 		Artifacts:                 map[RecoveryPathID]ArtifactRecord{},
 	}
@@ -142,6 +145,26 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 	}
 
 	return request
+}
+
+func validMigrationDestination() *MigrationDestinationReservation {
+	reservation := &MigrationDestinationReservation{
+		ReservationID: "cmdr_12345678",
+		Reserve:       "0x1111111111111111111111111111111111111111",
+		Epoch:         12,
+		Route:         ReservationRouteMigration,
+		Revealer:      "0x2222222222222222222222222222222222222222",
+		Vault:         "0x3333333333333333333333333333333333333333",
+		Network:       "regtest",
+		Status:        ReservationStatusReserved,
+		DepositScript: "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	reservation.DepositScriptHash, _ = computeDepositScriptHash(reservation.DepositScript)
+	reservation.MigrationExtraData = computeMigrationExtraData(reservation.Revealer)
+	reservation.DestinationCommitmentHash, _ = computeDestinationCommitmentHash(reservation)
+
+	return reservation
 }
 
 func TestServiceSubmitDeduplicatesByRouteRequestID(t *testing.T) {
@@ -327,6 +350,40 @@ func TestServicePollMapsJobNotFoundToFailed(t *testing.T) {
 	}
 }
 
+func TestMigrationDestinationMatchesKnownVector(t *testing.T) {
+	reservation := validMigrationDestination()
+
+	if reservation.DepositScriptHash != "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3" {
+		t.Fatalf("unexpected depositScriptHash: %s", reservation.DepositScriptHash)
+	}
+	if reservation.MigrationExtraData != "0x41435f4d49475241544556312222222222222222222222222222222222222222" {
+		t.Fatalf("unexpected migrationExtraData: %s", reservation.MigrationExtraData)
+	}
+	if reservation.DestinationCommitmentHash != "0x3efc50372759413e0f1900a2340fbb947648c524e5ec3cb4cf8887ea2d7df474" {
+		t.Fatalf("unexpected destinationCommitmentHash: %s", reservation.DestinationCommitmentHash)
+	}
+}
+
+func TestServiceRejectsMismatchedMigrationDestinationArtifact(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateSelfV1)
+	request.MigrationDestination.DepositScriptHash = "0xdeadbeef"
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_bad_reservation",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(err.Error(), "depositScriptHash does not match depositScript") {
+		t.Fatalf("expected depositScriptHash mismatch, got %v", err)
+	}
+}
+
 func TestStoreReloadPreservesJobs(t *testing.T) {
 	handle := newMemoryHandle()
 	store, err := NewStore(handle)
@@ -445,11 +502,25 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 			"idempotencyKey":"idem_123",
 			"route":"self_v1",
 			"strategy":"0x1234",
-			"reserve":"0xabcd",
+			"reserve":"0x1111111111111111111111111111111111111111",
 			"epoch":12,
 			"maturityHeight":912345,
 			"activeOutpoint":{"txid":"0x0102","vout":1,"scriptHash":"0x0304"},
-			"destinationCommitmentHash":"0x0506",
+			"destinationCommitmentHash":"0x3efc50372759413e0f1900a2340fbb947648c524e5ec3cb4cf8887ea2d7df474",
+			"migrationDestination":{
+				"reservationId":"cmdr_12345678",
+				"reserve":"0x1111111111111111111111111111111111111111",
+				"epoch":12,
+				"route":"MIGRATION",
+				"revealer":"0x2222222222222222222222222222222222222222",
+				"vault":"0x3333333333333333333333333333333333333333",
+				"network":"regtest",
+				"status":"RESERVED",
+				"depositScript":"0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"depositScriptHash":"0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+				"migrationExtraData":"0x41435f4d49475241544556312222222222222222222222222222222222222222",
+				"destinationCommitmentHash":"0x3efc50372759413e0f1900a2340fbb947648c524e5ec3cb4cf8887ea2d7df474"
+			},
 			"artifactSignatures":["0x0708"],
 			"artifacts":{},
 			"scriptTemplate":{"template":"self_v1","depositorPublicKey":"0x021111","signerPublicKey":"0x022222","delta2":4320},

--- a/pkg/covenantsigner/doc.go
+++ b/pkg/covenantsigner/doc.go
@@ -1,4 +1,6 @@
-// Package covenantsigner implements the first keep-core covenant signer
-// extension slice: durable submit/poll semantics, request validation, and a
-// compatible HTTP surface for covenant recovery/presign signer jobs.
+// Package covenantsigner implements keep-core covenant signer substrate slices:
+// durable submit/poll semantics, strict request validation, and a compatible
+// HTTP surface for covenant recovery/presign signer jobs. The current branch
+// also validates the concrete migration destination reservation artifact that
+// later real signing flows will consume.
 package covenantsigner

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -37,6 +37,22 @@ const (
 	ReasonMalformedArtifact   FailureReason = "MALFORMED_ARTIFACT"
 )
 
+type ReservationRoute string
+
+const (
+	ReservationRouteMigration ReservationRoute = "MIGRATION"
+)
+
+type ReservationStatus string
+
+const (
+	ReservationStatusReserved         ReservationStatus = "RESERVED"
+	ReservationStatusCommittedToEpoch ReservationStatus = "COMMITTED_TO_EPOCH"
+	ReservationStatusRevealed         ReservationStatus = "REVEALED"
+	ReservationStatusRetired          ReservationStatus = "RETIRED"
+	ReservationStatusExpired          ReservationStatus = "EXPIRED"
+)
+
 type StepStatus string
 
 const (
@@ -70,6 +86,21 @@ type ArtifactRecord struct {
 	TransactionID             string `json:"transactionId,omitempty"`
 }
 
+type MigrationDestinationReservation struct {
+	ReservationID             string            `json:"reservationId,omitempty"`
+	Reserve                   string            `json:"reserve"`
+	Epoch                     uint64            `json:"epoch"`
+	Route                     ReservationRoute  `json:"route"`
+	Revealer                  string            `json:"revealer"`
+	Vault                     string            `json:"vault"`
+	Network                   string            `json:"network"`
+	Status                    ReservationStatus `json:"status"`
+	DepositScript             string            `json:"depositScript"`
+	DepositScriptHash         string            `json:"depositScriptHash"`
+	MigrationExtraData        string            `json:"migrationExtraData"`
+	DestinationCommitmentHash string            `json:"destinationCommitmentHash"`
+}
+
 type SigningRequirements struct {
 	SignerRequired    bool `json:"signerRequired"`
 	CustodianRequired bool `json:"custodianRequired"`
@@ -85,6 +116,7 @@ type RouteSubmitRequest struct {
 	MaturityHeight            uint64                            `json:"maturityHeight"`
 	ActiveOutpoint            CovenantOutpoint                  `json:"activeOutpoint"`
 	DestinationCommitmentHash string                            `json:"destinationCommitmentHash"`
+	MigrationDestination      *MigrationDestinationReservation  `json:"migrationDestination,omitempty"`
 	ArtifactSignatures        []string                          `json:"artifactSignatures"`
 	Artifacts                 map[RecoveryPathID]ArtifactRecord `json:"artifacts"`
 	ScriptTemplate            json.RawMessage                   `json:"scriptTemplate"`

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -45,6 +45,140 @@ func validateHexString(name string, value string) error {
 	return nil
 }
 
+func validateAddressString(name string, value string) error {
+	if err := validateHexString(name, value); err != nil {
+		return err
+	}
+
+	if len(value) != 42 {
+		return &inputError{fmt.Sprintf("%s must be a 20-byte 0x-prefixed hex address", name)}
+	}
+
+	return nil
+}
+
+func normalizeLowerHex(value string) string {
+	return strings.ToLower(value)
+}
+
+func computeMigrationExtraData(revealer string) string {
+	return "0x" + hex.EncodeToString([]byte("AC_MIGRATEV1")) + strings.TrimPrefix(normalizeLowerHex(revealer), "0x")
+}
+
+func computeDepositScriptHash(depositScript string) (string, error) {
+	rawScript, err := hex.DecodeString(strings.TrimPrefix(depositScript, "0x"))
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(rawScript)
+	return "0x" + hex.EncodeToString(sum[:]), nil
+}
+
+type destinationCommitmentPayload struct {
+	Reserve            string `json:"reserve"`
+	Epoch              uint64 `json:"epoch"`
+	Route              string `json:"route"`
+	Revealer           string `json:"revealer"`
+	Vault              string `json:"vault"`
+	Network            string `json:"network"`
+	DepositScriptHash  string `json:"depositScriptHash"`
+	MigrationExtraData string `json:"migrationExtraData"`
+}
+
+func computeDestinationCommitmentHash(
+	reservation *MigrationDestinationReservation,
+) (string, error) {
+	payload, err := json.Marshal(destinationCommitmentPayload{
+		Reserve:            normalizeLowerHex(reservation.Reserve),
+		Epoch:              reservation.Epoch,
+		Route:              string(reservation.Route),
+		Revealer:           normalizeLowerHex(reservation.Revealer),
+		Vault:              normalizeLowerHex(reservation.Vault),
+		Network:            strings.TrimSpace(reservation.Network),
+		DepositScriptHash:  normalizeLowerHex(reservation.DepositScriptHash),
+		MigrationExtraData: normalizeLowerHex(reservation.MigrationExtraData),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(payload)
+	return "0x" + hex.EncodeToString(sum[:]), nil
+}
+
+func validateMigrationDestination(
+	request RouteSubmitRequest,
+	reservation *MigrationDestinationReservation,
+) error {
+	if reservation == nil {
+		return &inputError{"request.migrationDestination is required"}
+	}
+	if reservation.Route != ReservationRouteMigration {
+		return &inputError{"request.migrationDestination.route must be MIGRATION"}
+	}
+	if reservation.Status != ReservationStatusReserved &&
+		reservation.Status != ReservationStatusCommittedToEpoch {
+		return &inputError{"request.migrationDestination.status must be RESERVED or COMMITTED_TO_EPOCH"}
+	}
+	if err := validateAddressString("request.migrationDestination.reserve", reservation.Reserve); err != nil {
+		return err
+	}
+	if err := validateAddressString("request.migrationDestination.revealer", reservation.Revealer); err != nil {
+		return err
+	}
+	if err := validateAddressString("request.migrationDestination.vault", reservation.Vault); err != nil {
+		return err
+	}
+	if strings.TrimSpace(reservation.Network) == "" {
+		return &inputError{"request.migrationDestination.network is required"}
+	}
+	if err := validateHexString("request.migrationDestination.depositScript", reservation.DepositScript); err != nil {
+		return err
+	}
+	if err := validateHexString("request.migrationDestination.depositScriptHash", reservation.DepositScriptHash); err != nil {
+		return err
+	}
+	if err := validateHexString("request.migrationDestination.migrationExtraData", reservation.MigrationExtraData); err != nil {
+		return err
+	}
+	if err := validateHexString("request.migrationDestination.destinationCommitmentHash", reservation.DestinationCommitmentHash); err != nil {
+		return err
+	}
+	if request.Epoch != reservation.Epoch {
+		return &inputError{"request.migrationDestination.epoch does not match request.epoch"}
+	}
+	if normalizeLowerHex(request.Reserve) != normalizeLowerHex(reservation.Reserve) {
+		return &inputError{"request.migrationDestination.reserve does not match request.reserve"}
+	}
+	if normalizeLowerHex(request.DestinationCommitmentHash) != normalizeLowerHex(reservation.DestinationCommitmentHash) {
+		return &inputError{"request.migrationDestination.destinationCommitmentHash does not match request.destinationCommitmentHash"}
+	}
+
+	expectedExtraData := computeMigrationExtraData(reservation.Revealer)
+	if normalizeLowerHex(reservation.MigrationExtraData) != expectedExtraData {
+		return &inputError{"request.migrationDestination.migrationExtraData does not match migration revealer encoding"}
+	}
+
+	depositScriptHash, err := computeDepositScriptHash(reservation.DepositScript)
+	if err != nil {
+		return &inputError{"request.migrationDestination.depositScript is not valid hex"}
+	}
+	if normalizeLowerHex(reservation.DepositScriptHash) != depositScriptHash {
+		return &inputError{"request.migrationDestination.depositScriptHash does not match depositScript"}
+	}
+
+	commitmentHash, err := computeDestinationCommitmentHash(reservation)
+	if err != nil {
+		return err
+	}
+	if normalizeLowerHex(reservation.DestinationCommitmentHash) != commitmentHash {
+		return &inputError{"request.migrationDestination.destinationCommitmentHash does not match canonical reservation artifact"}
+	}
+
+	return nil
+}
+
 func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if request.FacadeRequestID == "" {
 		return &inputError{"request.facadeRequestId is required"}
@@ -70,6 +204,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 		}
 	}
 	if err := validateHexString("request.destinationCommitmentHash", request.DestinationCommitmentHash); err != nil {
+		return err
+	}
+	if err := validateMigrationDestination(request, request.MigrationDestination); err != nil {
 		return err
 	}
 	if len(request.ArtifactSignatures) == 0 {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -76,6 +76,8 @@ func computeDepositScriptHash(depositScript string) (string, error) {
 }
 
 type destinationCommitmentPayload struct {
+	// Field order is hash-significant and must stay aligned with the TypeScript
+	// reservation-service object literal used to compute the same commitment.
 	Reserve            string `json:"reserve"`
 	Epoch              uint64 `json:"epoch"`
 	Route              string `json:"route"`
@@ -206,6 +208,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if err := validateHexString("request.destinationCommitmentHash", request.DestinationCommitmentHash); err != nil {
 		return err
 	}
+	// This intentionally creates a deployment ordering constraint: the
+	// orchestrator must supply the concrete migration destination artifact
+	// before this signer version can accept requests.
 	if err := validateMigrationDestination(request, request.MigrationDestination); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- extend the covenant signer request contract with a concrete migration destination reservation artifact
- validate reservation script hash, migration extraData encoding, and canonical destination commitment hash inside keep-core
- add fixed-vector and mismatch coverage so later real signing can rely on a verified destination artifact instead of only an opaque hash

## Why now
The new tBTC covenant migration destination reservation service is merged on the covenant project branch. The keep-core signer substrate now needs to consume that concrete artifact so later self_v1/qc_v1 signing slices can fail closed on destination mismatch before implementing real tx construction.

## Verification
- `go test ./pkg/covenantsigner`
- `go test ./config`
- `go test ./cmd`
