### PR TITLE
feat(tbtc): validate covenant migration transaction plan

### DIFF
--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -131,8 +131,16 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 		ActiveOutpoint:            CovenantOutpoint{TxID: "0x0102", Vout: 1, ScriptHash: "0x0304"},
 		DestinationCommitmentHash: migrationDestination.DestinationCommitmentHash,
 		MigrationDestination:      migrationDestination,
-		ArtifactSignatures:        []string{"0x0708"},
-		Artifacts:                 map[RecoveryPathID]ArtifactRecord{},
+		MigrationTransactionPlan: &MigrationTransactionPlan{
+			InputValueSats:       1000000,
+			DestinationValueSats: 998000,
+			AnchorValueSats:      canonicalAnchorValueSats,
+			FeeSats:              1670,
+			InputSequence:        canonicalCovenantInputSequence,
+			LockTime:             912345,
+		},
+		ArtifactSignatures: []string{"0x0708"},
+		Artifacts:          map[RecoveryPathID]ArtifactRecord{},
 	}
 
 	switch route {
@@ -472,6 +480,100 @@ func TestServiceRejectsInvalidMigrationDestinationVariants(t *testing.T) {
 	}
 }
 
+func TestServiceRejectsInvalidMigrationTransactionPlanVariants(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name      string
+		mutate    func(request *RouteSubmitRequest)
+		expectErr string
+	}{
+		{
+			name: "missing transaction plan",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan = nil
+			},
+			expectErr: "request.migrationTransactionPlan is required",
+		},
+		{
+			name: "zero input value",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.InputValueSats = 0
+			},
+			expectErr: "request.migrationTransactionPlan.inputValueSats must be greater than zero",
+		},
+		{
+			name: "zero destination value",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.DestinationValueSats = 0
+			},
+			expectErr: "request.migrationTransactionPlan.destinationValueSats must be greater than zero",
+		},
+		{
+			name: "wrong anchor value",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.AnchorValueSats = 331
+			},
+			expectErr: "request.migrationTransactionPlan.anchorValueSats must equal the canonical 330 sat anchor",
+		},
+		{
+			name: "wrong input sequence",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.InputSequence = 0xFFFFFFFF
+			},
+			expectErr: "request.migrationTransactionPlan.inputSequence must equal 0xFFFFFFFD",
+		},
+		{
+			name: "locktime mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.LockTime = request.MaturityHeight + 1
+			},
+			expectErr: "request.migrationTransactionPlan.lockTime must match request.maturityHeight",
+		},
+		{
+			name: "insufficient input for destination",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.InputValueSats = request.MigrationTransactionPlan.DestinationValueSats - 1
+			},
+			expectErr: "request.migrationTransactionPlan.inputValueSats must cover destinationValueSats",
+		},
+		{
+			name: "insufficient input for anchor",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.InputValueSats = request.MigrationTransactionPlan.DestinationValueSats + canonicalAnchorValueSats - 1
+			},
+			expectErr: "request.migrationTransactionPlan.inputValueSats must cover anchorValueSats",
+		},
+		{
+			name: "accounting mismatch",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.FeeSats++
+			},
+			expectErr: "request.migrationTransactionPlan values must satisfy inputValueSats = destinationValueSats + anchorValueSats + feeSats",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := baseRequest(TemplateSelfV1)
+			testCase.mutate(&request)
+
+			_, err := service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+				RouteRequestID: "ors_invalid_plan_" + strings.ReplaceAll(testCase.name, " ", "_"),
+				Stage:          StageSignerCoordination,
+				Request:        request,
+			})
+			if err == nil || !strings.Contains(err.Error(), testCase.expectErr) {
+				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
+			}
+		})
+	}
+}
+
 func TestStoreReloadPreservesJobs(t *testing.T) {
 	handle := newMemoryHandle()
 	store, err := NewStore(handle)
@@ -608,6 +710,14 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 				"depositScriptHash":"0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
 				"migrationExtraData":"0x41435f4d49475241544556312222222222222222222222222222222222222222",
 				"destinationCommitmentHash":"0x3efc50372759413e0f1900a2340fbb947648c524e5ec3cb4cf8887ea2d7df474"
+			},
+			"migrationTransactionPlan":{
+				"inputValueSats":1000000,
+				"destinationValueSats":998000,
+				"anchorValueSats":330,
+				"feeSats":1670,
+				"inputSequence":4294967293,
+				"lockTime":912345
 			},
 			"artifactSignatures":["0x0708"],
 			"artifacts":{},

--- a/pkg/covenantsigner/doc.go
+++ b/pkg/covenantsigner/doc.go
@@ -2,5 +2,6 @@
 // durable submit/poll semantics, strict request validation, and a compatible
 // HTTP surface for covenant recovery/presign signer jobs. The current branch
 // also validates the concrete migration destination reservation artifact that
-// later real signing flows will consume.
+// later real signing flows will consume, together with the canonical
+// pre-signed migration transaction plan fields needed before tx construction.
 package covenantsigner

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -101,6 +101,15 @@ type MigrationDestinationReservation struct {
 	DestinationCommitmentHash string            `json:"destinationCommitmentHash"`
 }
 
+type MigrationTransactionPlan struct {
+	InputValueSats       uint64 `json:"inputValueSats"`
+	DestinationValueSats uint64 `json:"destinationValueSats"`
+	AnchorValueSats      uint64 `json:"anchorValueSats"`
+	FeeSats              uint64 `json:"feeSats"`
+	InputSequence        uint32 `json:"inputSequence"`
+	LockTime             uint64 `json:"lockTime"`
+}
+
 type SigningRequirements struct {
 	SignerRequired    bool `json:"signerRequired"`
 	CustodianRequired bool `json:"custodianRequired"`
@@ -117,6 +126,7 @@ type RouteSubmitRequest struct {
 	ActiveOutpoint            CovenantOutpoint                  `json:"activeOutpoint"`
 	DestinationCommitmentHash string                            `json:"destinationCommitmentHash"`
 	MigrationDestination      *MigrationDestinationReservation  `json:"migrationDestination,omitempty"`
+	MigrationTransactionPlan  *MigrationTransactionPlan         `json:"migrationTransactionPlan,omitempty"`
 	ArtifactSignatures        []string                          `json:"artifactSignatures"`
 	Artifacts                 map[RecoveryPathID]ArtifactRecord `json:"artifacts"`
 	ScriptTemplate            json.RawMessage                   `json:"scriptTemplate"`

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -256,6 +256,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if err := validateMigrationDestination(request, request.MigrationDestination); err != nil {
 		return err
 	}
+	// This intentionally creates the next deployment ordering constraint: the
+	// orchestrator must supply the canonical migration transaction plan before
+	// this signer version can accept requests.
 	if err := validateMigrationTransactionPlan(request, request.MigrationTransactionPlan); err != nil {
 		return err
 	}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 )
 
+const (
+	canonicalCovenantInputSequence uint32 = 0xFFFFFFFD
+	canonicalAnchorValueSats       uint64 = 330
+)
+
 type inputError struct {
 	message string
 }
@@ -181,6 +186,43 @@ func validateMigrationDestination(
 	return nil
 }
 
+func validateMigrationTransactionPlan(
+	request RouteSubmitRequest,
+	plan *MigrationTransactionPlan,
+) error {
+	if plan == nil {
+		return &inputError{"request.migrationTransactionPlan is required"}
+	}
+	if plan.InputValueSats == 0 {
+		return &inputError{"request.migrationTransactionPlan.inputValueSats must be greater than zero"}
+	}
+	if plan.DestinationValueSats == 0 {
+		return &inputError{"request.migrationTransactionPlan.destinationValueSats must be greater than zero"}
+	}
+	if plan.AnchorValueSats != canonicalAnchorValueSats {
+		return &inputError{"request.migrationTransactionPlan.anchorValueSats must equal the canonical 330 sat anchor"}
+	}
+	if plan.InputSequence != canonicalCovenantInputSequence {
+		return &inputError{"request.migrationTransactionPlan.inputSequence must equal 0xFFFFFFFD"}
+	}
+	if plan.LockTime != request.MaturityHeight {
+		return &inputError{"request.migrationTransactionPlan.lockTime must match request.maturityHeight"}
+	}
+	if plan.InputValueSats < plan.DestinationValueSats {
+		return &inputError{"request.migrationTransactionPlan.inputValueSats must cover destinationValueSats"}
+	}
+	remainingAfterDestination := plan.InputValueSats - plan.DestinationValueSats
+	if remainingAfterDestination < plan.AnchorValueSats {
+		return &inputError{"request.migrationTransactionPlan.inputValueSats must cover anchorValueSats"}
+	}
+	remainingAfterAnchor := remainingAfterDestination - plan.AnchorValueSats
+	if remainingAfterAnchor != plan.FeeSats {
+		return &inputError{"request.migrationTransactionPlan values must satisfy inputValueSats = destinationValueSats + anchorValueSats + feeSats"}
+	}
+
+	return nil
+}
+
 func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if request.FacadeRequestID == "" {
 		return &inputError{"request.facadeRequestId is required"}
@@ -212,6 +254,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	// orchestrator must supply the concrete migration destination artifact
 	// before this signer version can accept requests.
 	if err := validateMigrationDestination(request, request.MigrationDestination); err != nil {
+		return err
+	}
+	if err := validateMigrationTransactionPlan(request, request.MigrationTransactionPlan); err != nil {
 		return err
 	}
 	if len(request.ArtifactSignatures) == 0 {


### PR DESCRIPTION
## Summary
- require a concrete migration transaction plan alongside the reservation artifact
- validate canonical Leaf-1 pre-signed policy fields in keep-core before real signing work
- add focused negative coverage for bad plan inputs and HTTP submit payloads

## Testing
- go test ./pkg/covenantsigner ./config ./cmd