### PR TITLE
feat(tbtc): implement self_v1 signer completion

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -159,7 +159,7 @@ func start(cmd *cobra.Command) error {
 			btcChain,
 		)
 
-		err = tbtc.Initialize(
+		covenantSignerEngine, err := tbtc.Initialize(
 			ctx,
 			tbtcChain,
 			btcChain,
@@ -180,6 +180,7 @@ func start(cmd *cobra.Command) error {
 			ctx,
 			clientConfig.CovenantSigner,
 			tbtcDataPersistence,
+			covenantSignerEngine,
 		)
 		if err != nil {
 			return fmt.Errorf("error initializing covenant signer: [%v]", err)

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -156,6 +156,41 @@ func (tb *TransactionBuilder) AddOutput(output *TransactionOutput) {
 	tb.internal.AddTxOut(wire.NewTxOut(output.Value, output.PublicKeyScript))
 }
 
+// SetInputSequence overrides the sequence number for the input at the given
+// index.
+func (tb *TransactionBuilder) SetInputSequence(index int, sequence uint32) error {
+	if index < 0 || index >= len(tb.internal.TxIn) {
+		return fmt.Errorf("wrong input index")
+	}
+
+	tb.internal.TxIn[index].Sequence = sequence
+
+	return nil
+}
+
+// SetInputWitness overrides the witness stack for the input at the given
+// index.
+func (tb *TransactionBuilder) SetInputWitness(index int, witness [][]byte) error {
+	if index < 0 || index >= len(tb.internal.TxIn) {
+		return fmt.Errorf("wrong input index")
+	}
+
+	tb.internal.TxIn[index].Witness = witness
+	tb.internal.TxIn[index].SignatureScript = nil
+
+	return nil
+}
+
+// SetLocktime overrides the transaction locktime.
+func (tb *TransactionBuilder) SetLocktime(locktime uint32) {
+	tb.internal.LockTime = locktime
+}
+
+// Build returns the transaction in its current state.
+func (tb *TransactionBuilder) Build() *Transaction {
+	return tb.internal.toTransaction()
+}
+
 // ComputeSignatureHashes computes the signature hashes for all transaction
 // inputs and stores them into the builder's state. Elements of the returned
 // slice are ordered in the same way as the transaction inputs they correspond

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -215,6 +215,49 @@ func TestTransactionBuilder_AddOutput(t *testing.T) {
 	assertInternalOutput(t, builder, 0, output)
 }
 
+func TestTransactionBuilder_SetInputSequenceWitnessAndLocktime(t *testing.T) {
+	localChain := newLocalChain()
+	builder := NewTransactionBuilder(localChain)
+
+	inputTransaction := transactionFrom(t, "01000000000101a0367a0790e3dfc199df34ca9ce5c35591510b6525d2d5869166728a5ed554be0100000000ffffffff02e02e00000000000022002086a303cdd2e2eab1d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962cff100000000000160014e257eccafbc07c381642ce6e7e55120fb077fbed02473044022050759dde2c84bccf3c1502b0e33a6acb570117fd27a982c0c2991c9f9737508e02201fcba5d6f6c0ab780042138a9110418b3f589d8d09a900f20ee28cfcdb14d2970121039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000")
+	if err := localChain.addTransaction(inputTransaction); err != nil {
+		t.Fatal(err)
+	}
+
+	utxo := &UnspentTransactionOutput{
+		Outpoint: &TransactionOutpoint{
+			TransactionHash: inputTransaction.Hash(),
+			OutputIndex:     0,
+		},
+		Value: 12000,
+	}
+	redeemScript := hexToSlice(t, "14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac68")
+
+	if err := builder.AddScriptHashInput(utxo, redeemScript); err != nil {
+		t.Fatal(err)
+	}
+	if err := builder.SetInputSequence(0, 0xfffffffd); err != nil {
+		t.Fatal(err)
+	}
+	if err := builder.SetInputWitness(0, [][]byte{{0x01}, {0x02}, redeemScript}); err != nil {
+		t.Fatal(err)
+	}
+	builder.SetLocktime(12345)
+
+	assertInternalInput(t, builder, 0, &TransactionInput{
+		Outpoint:        utxo.Outpoint,
+		SignatureScript: nil,
+		Witness:         [][]byte{{0x01}, {0x02}, redeemScript},
+		Sequence:        0xfffffffd,
+	})
+
+	transaction := builder.Build()
+	testutils.AssertIntsEqual(t, "locktime", 12345, int(transaction.Locktime))
+	if !reflect.DeepEqual(transaction.Inputs[0].Witness, [][]byte{{0x01}, {0x02}, redeemScript}) {
+		t.Fatal("unexpected built transaction witness")
+	}
+}
+
 // The goal of this test is making sure that the TransactionBuilder can
 // produce proper signature hashes and apply signatures for all input types,
 // i.e. P2PKH, P2WPKH, P2SH, and P2WSH. This test uses transactions that

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -745,7 +745,7 @@ func TestInitializeRejectsInvalidOrUnavailablePort(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if _, enabled, err := Initialize(ctx, Config{Port: -1}, handle); err == nil || enabled {
+	if _, enabled, err := Initialize(ctx, Config{Port: -1}, handle, nil); err == nil || enabled {
 		t.Fatalf("expected invalid negative port to fail, got enabled=%v err=%v", enabled, err)
 	}
 
@@ -756,7 +756,7 @@ func TestInitializeRejectsInvalidOrUnavailablePort(t *testing.T) {
 	defer listener.Close()
 
 	port := listener.Addr().(*net.TCPAddr).Port
-	if _, enabled, err := Initialize(ctx, Config{Port: port}, handle); err == nil || enabled {
+	if _, enabled, err := Initialize(ctx, Config{Port: port}, handle, nil); err == nil || enabled {
 		t.Fatalf("expected occupied port to fail, got enabled=%v err=%v", enabled, err)
 	}
 }

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -20,7 +20,12 @@ type Server struct {
 	httpServer *http.Server
 }
 
-func Initialize(ctx context.Context, config Config, handle persistence.BasicHandle) (*Server, bool, error) {
+func Initialize(
+	ctx context.Context,
+	config Config,
+	handle persistence.BasicHandle,
+	engine Engine,
+) (*Server, bool, error) {
 	if config.Port == 0 {
 		return nil, false, nil
 	}
@@ -28,7 +33,7 @@ func Initialize(ctx context.Context, config Config, handle persistence.BasicHand
 		return nil, false, fmt.Errorf("invalid covenant signer port [%d]", config.Port)
 	}
 
-	service, err := NewService(handle, NewPassiveEngine())
+	service, err := NewService(handle, engine)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -1,0 +1,397 @@
+package tbtc
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
+	"github.com/keep-network/keep-core/pkg/tecdsa"
+)
+
+type covenantSignerEngine struct {
+	node *node
+}
+
+func newCovenantSignerEngine(node *node) covenantsigner.Engine {
+	return &covenantSignerEngine{node: node}
+}
+
+func (cse *covenantSignerEngine) OnSubmit(
+	ctx context.Context,
+	job *covenantsigner.Job,
+) (*covenantsigner.Transition, error) {
+	switch job.Route {
+	case covenantsigner.TemplateSelfV1:
+		return cse.submitSelfV1(ctx, job), nil
+	case covenantsigner.TemplateQcV1:
+		return &covenantsigner.Transition{
+			State:  covenantsigner.JobStatePending,
+			Detail: "accepted for qc_v1 signer coordination",
+		}, nil
+	default:
+		return &covenantsigner.Transition{
+			State:  covenantsigner.JobStateFailed,
+			Reason: covenantsigner.ReasonInvalidInput,
+			Detail: "unsupported covenant route",
+		}, nil
+	}
+}
+
+func (cse *covenantSignerEngine) OnPoll(
+	context.Context,
+	*covenantsigner.Job,
+) (*covenantsigner.Transition, error) {
+	return nil, nil
+}
+
+func (cse *covenantSignerEngine) submitSelfV1(
+	ctx context.Context,
+	job *covenantsigner.Job,
+) *covenantsigner.Transition {
+	template, err := decodeSelfV1Template(job.Request.ScriptTemplate)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+
+	walletPublicKey, err := parseCompressedPublicKey(template.SignerPublicKey)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, "invalid self_v1 signer public key")
+	}
+
+	signingExecutor, ok, err := cse.node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonProviderFailed, fmt.Sprintf("cannot resolve signing executor: %v", err))
+	}
+	if !ok {
+		return failedTransition(covenantsigner.ReasonPolicyRejected, "wallet is not controlled by this node")
+	}
+
+	witnessScript, err := buildSelfV1WitnessScript(template, job.Request.MaturityHeight)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+
+	activeUtxo, err := cse.resolveSelfV1ActiveUtxo(job.Request, witnessScript)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+
+	transaction, err := cse.buildAndSignSelfV1Transaction(
+		ctx,
+		signingExecutor,
+		job.Request,
+		activeUtxo,
+		witnessScript,
+	)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonProviderFailed, err.Error())
+	}
+
+	transactionHex := "0x" + hex.EncodeToString(transaction.Serialize(bitcoin.Witness))
+
+	// Until the wider stack standardizes a PSBT-native artifact hash,
+	// return a deterministic 32-byte artifact identifier derived from the
+	// final witness transaction serialization.
+	psbtHash := "0x" + transaction.WitnessHash().Hex(bitcoin.InternalByteOrder)
+
+	return &covenantsigner.Transition{
+		State:          covenantsigner.JobStateArtifactReady,
+		Detail:         "self_v1 artifact ready",
+		PSBTHash:       psbtHash,
+		TransactionHex: transactionHex,
+	}
+}
+
+func decodeSelfV1Template(raw json.RawMessage) (*covenantsigner.SelfV1Template, error) {
+	template := &covenantsigner.SelfV1Template{}
+	if err := json.Unmarshal(raw, template); err != nil {
+		return nil, fmt.Errorf("cannot decode self_v1 template: %v", err)
+	}
+	if template.Template != covenantsigner.TemplateSelfV1 {
+		return nil, fmt.Errorf("request template must be self_v1")
+	}
+	return template, nil
+}
+
+func parseCompressedPublicKey(encoded string) (*ecdsa.PublicKey, error) {
+	bytes, err := canonicalCompressedPublicKeyBytes(encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := btcec.ParsePubKey(bytes, btcec.S256())
+	if err != nil {
+		return nil, err
+	}
+
+	return &ecdsa.PublicKey{
+		Curve: tecdsa.Curve,
+		X:     parsed.X,
+		Y:     parsed.Y,
+	}, nil
+}
+
+func buildSelfV1WitnessScript(
+	template *covenantsigner.SelfV1Template,
+	maturityHeight uint64,
+) (bitcoin.Script, error) {
+	if maturityHeight > math.MaxUint32 {
+		return nil, fmt.Errorf("maturity height exceeds bitcoin locktime range")
+	}
+	if template.Delta2 > math.MaxUint32 || maturityHeight > math.MaxUint32-template.Delta2 {
+		return nil, fmt.Errorf("self_v1 delta2 overflows bitcoin locktime range")
+	}
+
+	depositorPublicKey, err := canonicalCompressedPublicKeyBytes(template.DepositorPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid self_v1 depositor public key")
+	}
+	signerPublicKey, err := canonicalCompressedPublicKeyBytes(template.SignerPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid self_v1 signer public key")
+	}
+
+	maturityScriptNumber, err := encodeScriptNumber(uint32(maturityHeight))
+	if err != nil {
+		return nil, err
+	}
+	lastResortScriptNumber, err := encodeScriptNumber(uint32(maturityHeight + template.Delta2))
+	if err != nil {
+		return nil, err
+	}
+
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_IF).
+		AddOp(txscript.OP_2).
+		AddData(depositorPublicKey).
+		AddData(signerPublicKey).
+		AddOp(txscript.OP_2).
+		AddOp(txscript.OP_CHECKMULTISIG).
+		AddOp(txscript.OP_ELSE).
+		AddOp(txscript.OP_IF).
+		AddData(maturityScriptNumber).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddData(signerPublicKey).
+		AddOp(txscript.OP_CHECKSIG).
+		AddOp(txscript.OP_ELSE).
+		AddData(lastResortScriptNumber).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddData(depositorPublicKey).
+		AddOp(txscript.OP_CHECKSIG).
+		AddOp(txscript.OP_ENDIF).
+		AddOp(txscript.OP_ENDIF).
+		Script()
+}
+
+func (cse *covenantSignerEngine) resolveSelfV1ActiveUtxo(
+	request covenantsigner.RouteSubmitRequest,
+	witnessScript bitcoin.Script,
+) (*bitcoin.UnspentTransactionOutput, error) {
+	activeTxHash, err := bitcoin.NewHashFromString(
+		strings.TrimPrefix(request.ActiveOutpoint.TxID, "0x"),
+		bitcoin.ReversedByteOrder,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("active outpoint txid is invalid")
+	}
+
+	transaction, err := cse.node.btcChain.GetTransaction(activeTxHash)
+	if err != nil {
+		return nil, fmt.Errorf("active outpoint transaction not found")
+	}
+	if int(request.ActiveOutpoint.Vout) >= len(transaction.Outputs) {
+		return nil, fmt.Errorf("active outpoint output index is out of range")
+	}
+
+	expectedWitnessScriptHash := bitcoin.WitnessScriptHash(witnessScript)
+	expectedScriptPubKey, err := bitcoin.PayToWitnessScriptHash(expectedWitnessScriptHash)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build expected self_v1 locking script: %v", err)
+	}
+
+	actualOutput := transaction.Outputs[request.ActiveOutpoint.Vout]
+	if !bytes.Equal(actualOutput.PublicKeyScript, expectedScriptPubKey) {
+		return nil, fmt.Errorf("active outpoint script does not match self_v1 template")
+	}
+	if actualOutput.Value <= 0 {
+		return nil, fmt.Errorf("active outpoint value must be greater than zero")
+	}
+	if uint64(actualOutput.Value) != request.MigrationTransactionPlan.InputValueSats {
+		return nil, fmt.Errorf("active outpoint value does not match migration transaction plan")
+	}
+
+	if request.ActiveOutpoint.ScriptHash != "" {
+		scriptHash := sha256.Sum256(expectedScriptPubKey)
+		expectedScriptHash := "0x" + hex.EncodeToString(scriptHash[:])
+		if strings.ToLower(request.ActiveOutpoint.ScriptHash) != expectedScriptHash {
+			return nil, fmt.Errorf("active outpoint script hash does not match self_v1 template")
+		}
+	}
+
+	return &bitcoin.UnspentTransactionOutput{
+		Outpoint: &bitcoin.TransactionOutpoint{
+			TransactionHash: activeTxHash,
+			OutputIndex:     request.ActiveOutpoint.Vout,
+		},
+		Value: actualOutput.Value,
+	}, nil
+}
+
+func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
+	ctx context.Context,
+	signingExecutor *signingExecutor,
+	request covenantsigner.RouteSubmitRequest,
+	activeUtxo *bitcoin.UnspentTransactionOutput,
+	witnessScript bitcoin.Script,
+) (*bitcoin.Transaction, error) {
+	destinationScript, err := decodePrefixedHex(request.MigrationDestination.DepositScript)
+	if err != nil {
+		return nil, fmt.Errorf("migration destination deposit script is invalid")
+	}
+
+	builder := bitcoin.NewTransactionBuilder(cse.node.btcChain)
+	if err := builder.AddScriptHashInput(activeUtxo, witnessScript); err != nil {
+		return nil, fmt.Errorf("cannot add covenant input: %v", err)
+	}
+	if err := builder.SetInputSequence(0, request.MigrationTransactionPlan.InputSequence); err != nil {
+		return nil, fmt.Errorf("cannot set covenant input sequence: %v", err)
+	}
+	builder.SetLocktime(uint32(request.MigrationTransactionPlan.LockTime))
+	builder.AddOutput(&bitcoin.TransactionOutput{
+		Value:           int64(request.MigrationTransactionPlan.DestinationValueSats),
+		PublicKeyScript: destinationScript,
+	})
+
+	anchorScript, err := canonicalAnchorScriptPubKey()
+	if err != nil {
+		return nil, err
+	}
+	builder.AddOutput(&bitcoin.TransactionOutput{
+		Value:           int64(request.MigrationTransactionPlan.AnchorValueSats),
+		PublicKeyScript: anchorScript,
+	})
+
+	sigHashes, err := builder.ComputeSignatureHashes()
+	if err != nil {
+		return nil, fmt.Errorf("cannot compute covenant sighash: %v", err)
+	}
+	if len(sigHashes) != 1 {
+		return nil, fmt.Errorf("unexpected covenant sighash count")
+	}
+
+	startBlock, err := signingExecutor.getCurrentBlockFn()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine signing start block: %v", err)
+	}
+
+	signatures, err := signingExecutor.signBatch(ctx, sigHashes, startBlock)
+	if err != nil {
+		return nil, fmt.Errorf("cannot sign covenant transaction: %v", err)
+	}
+	if len(signatures) != 1 {
+		return nil, fmt.Errorf("unexpected covenant signature count")
+	}
+
+	witness, err := buildSelfV1MigrationWitness(signatures[0], witnessScript)
+	if err != nil {
+		return nil, err
+	}
+	if err := builder.SetInputWitness(0, witness); err != nil {
+		return nil, fmt.Errorf("cannot set covenant witness: %v", err)
+	}
+
+	transaction := builder.Build()
+	if len(transaction.Inputs) != 1 {
+		return nil, fmt.Errorf("unexpected covenant input count")
+	}
+	if !bytes.Equal(transaction.Inputs[0].Witness[len(transaction.Inputs[0].Witness)-1], witnessScript) {
+		// This can never happen with the current builder path, but keeping the
+		// explicit comparison helps catch future witness-shape regressions.
+		return nil, fmt.Errorf("unexpected covenant witness stack")
+	}
+
+	return transaction, nil
+}
+
+func buildSelfV1MigrationWitness(
+	signature *tecdsa.Signature,
+	witnessScript bitcoin.Script,
+) ([][]byte, error) {
+	if signature == nil || signature.R == nil || signature.S == nil {
+		return nil, fmt.Errorf("missing covenant signature")
+	}
+
+	signatureBytes := append(
+		(&btcec.Signature{R: signature.R, S: signature.S}).Serialize(),
+		byte(txscript.SigHashAll),
+	)
+
+	return [][]byte{
+		signatureBytes,
+		{0x01},
+		{},
+		witnessScript,
+	}, nil
+}
+
+func canonicalAnchorScriptPubKey() (bitcoin.Script, error) {
+	witnessScriptHash := bitcoin.WitnessScriptHash(bitcoin.Script{txscript.OP_TRUE})
+	return bitcoin.PayToWitnessScriptHash(witnessScriptHash)
+}
+
+func decodePrefixedHex(value string) ([]byte, error) {
+	return hex.DecodeString(strings.TrimPrefix(value, "0x"))
+}
+
+func canonicalCompressedPublicKeyBytes(encoded string) ([]byte, error) {
+	bytes, err := decodePrefixedHex(encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := btcec.ParsePubKey(bytes, btcec.S256())
+	if err != nil {
+		return nil, err
+	}
+
+	return parsed.SerializeCompressed(), nil
+}
+
+func encodeScriptNumber(value uint32) ([]byte, error) {
+	if value == 0 {
+		return []byte{}, nil
+	}
+
+	result := make([]byte, 0, 5)
+	absolute := value
+	for absolute > 0 {
+		result = append(result, byte(absolute&0xff))
+		absolute >>= 8
+	}
+
+	if result[len(result)-1]&0x80 != 0 {
+		result = append(result, 0x00)
+	}
+
+	return result, nil
+}
+
+func failedTransition(reason covenantsigner.FailureReason, detail string) *covenantsigner.Transition {
+	return &covenantsigner.Transition{
+		State:  covenantsigner.JobStateFailed,
+		Reason: reason,
+		Detail: detail,
+	}
+}

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -85,6 +85,9 @@ func (cse *covenantSignerEngine) submitSelfV1(
 	if err != nil {
 		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
 	}
+	if err := validateSelfV1OutputValues(job.Request); err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
 
 	transaction, err := cse.buildAndSignSelfV1Transaction(
 		ctx,
@@ -145,6 +148,9 @@ func buildSelfV1WitnessScript(
 	template *covenantsigner.SelfV1Template,
 	maturityHeight uint64,
 ) (bitcoin.Script, error) {
+	if maturityHeight == 0 {
+		return nil, fmt.Errorf("maturity height must be greater than zero")
+	}
 	if maturityHeight > math.MaxUint32 {
 		return nil, fmt.Errorf("maturity height exceeds bitcoin locktime range")
 	}
@@ -233,6 +239,8 @@ func (cse *covenantSignerEngine) resolveSelfV1ActiveUtxo(
 	}
 
 	if request.ActiveOutpoint.ScriptHash != "" {
+		// The optional scriptHash convention follows the tBTC-side request
+		// contract: sha256(scriptPubKey) for the active covenant output.
 		scriptHash := sha256.Sum256(expectedScriptPubKey)
 		expectedScriptHash := "0x" + hex.EncodeToString(scriptHash[:])
 		if strings.ToLower(request.ActiveOutpoint.ScriptHash) != expectedScriptHash {
@@ -249,6 +257,22 @@ func (cse *covenantSignerEngine) resolveSelfV1ActiveUtxo(
 	}, nil
 }
 
+func validateSelfV1OutputValues(request covenantsigner.RouteSubmitRequest) error {
+	_, err := toBitcoinOutputValue(
+		request.MigrationTransactionPlan.DestinationValueSats,
+		"migration destination value",
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = toBitcoinOutputValue(
+		request.MigrationTransactionPlan.AnchorValueSats,
+		"migration anchor value",
+	)
+	return err
+}
+
 func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
 	ctx context.Context,
 	signingExecutor *signingExecutor,
@@ -260,6 +284,20 @@ func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
 	if err != nil {
 		return nil, fmt.Errorf("migration destination deposit script is invalid")
 	}
+	destinationValue, err := toBitcoinOutputValue(
+		request.MigrationTransactionPlan.DestinationValueSats,
+		"migration destination value",
+	)
+	if err != nil {
+		return nil, err
+	}
+	anchorValue, err := toBitcoinOutputValue(
+		request.MigrationTransactionPlan.AnchorValueSats,
+		"migration anchor value",
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	builder := bitcoin.NewTransactionBuilder(cse.node.btcChain)
 	if err := builder.AddScriptHashInput(activeUtxo, witnessScript); err != nil {
@@ -270,7 +308,7 @@ func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
 	}
 	builder.SetLocktime(uint32(request.MigrationTransactionPlan.LockTime))
 	builder.AddOutput(&bitcoin.TransactionOutput{
-		Value:           int64(request.MigrationTransactionPlan.DestinationValueSats),
+		Value:           destinationValue,
 		PublicKeyScript: destinationScript,
 	})
 
@@ -279,7 +317,7 @@ func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
 		return nil, err
 	}
 	builder.AddOutput(&bitcoin.TransactionOutput{
-		Value:           int64(request.MigrationTransactionPlan.AnchorValueSats),
+		Value:           anchorValue,
 		PublicKeyScript: anchorScript,
 	})
 
@@ -367,6 +405,14 @@ func canonicalCompressedPublicKeyBytes(encoded string) ([]byte, error) {
 	}
 
 	return parsed.SerializeCompressed(), nil
+}
+
+func toBitcoinOutputValue(value uint64, field string) (int64, error) {
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("%s exceeds bitcoin output value range", field)
+	}
+
+	return int64(value), nil
 }
 
 func encodeScriptNumber(value uint32) ([]byte, error) {

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -296,6 +297,123 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 	}
 	if !ecdsa.Verify(walletPublicKey, sighashBytes, parsedSignature.R, parsedSignature.S) {
 		t.Fatal("invalid covenant signature")
+	}
+}
+
+func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	service, err := covenantsigner.NewService(
+		newCovenantSignerMemoryHandle(),
+		newCovenantSignerEngine(node),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x42}, 32))
+	depositorPublicKey := depositorPrivateKey.PubKey().SerializeCompressed()
+	signerPublicKey := (*btcec.PublicKey)(walletPublicKey).SerializeCompressed()
+
+	template := &covenantsigner.SelfV1Template{
+		Template:           covenantsigner.TemplateSelfV1,
+		DepositorPublicKey: "0x" + hex.EncodeToString(depositorPublicKey),
+		SignerPublicKey:    "0x" + hex.EncodeToString(signerPublicKey),
+		Delta2:             4320,
+	}
+	templateJSON, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destinationScript, err := bitcoin.PayToWitnessPublicKeyHash([20]byte{
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	revealer := "0x2222222222222222222222222222222222222222"
+	reserve := "0x1111111111111111111111111111111111111111"
+	vault := "0x3333333333333333333333333333333333333333"
+	request := covenantsigner.RouteSubmitRequest{
+		FacadeRequestID: "rf_self_zero",
+		IdempotencyKey:  "idem_self_zero",
+		Route:           covenantsigner.TemplateSelfV1,
+		Strategy:        "0x1234",
+		Reserve:         reserve,
+		Epoch:           12,
+		MaturityHeight:  0,
+		ActiveOutpoint: covenantsigner.CovenantOutpoint{
+			TxID: "0x" + strings.Repeat("11", 32),
+		},
+		MigrationDestination: &covenantsigner.MigrationDestinationReservation{
+			ReservationID:             "cmdr_self_zero",
+			Reserve:                   reserve,
+			Epoch:                     12,
+			Route:                     covenantsigner.ReservationRouteMigration,
+			Revealer:                  revealer,
+			Vault:                     vault,
+			Network:                   "regtest",
+			Status:                    covenantsigner.ReservationStatusReserved,
+			DepositScript:             "0x" + hex.EncodeToString(destinationScript),
+		},
+		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
+			InputValueSats:       1_000_000,
+			DestinationValueSats: 998_000,
+			AnchorValueSats:      330,
+			FeeSats:              1_670,
+			InputSequence:        0xfffffffd,
+			LockTime:             0,
+		},
+		ArtifactSignatures: []string{"0x0708"},
+		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
+		ScriptTemplate:     templateJSON,
+		Signing: covenantsigner.SigningRequirements{
+			SignerRequired:    true,
+			CustodianRequired: false,
+		},
+	}
+	request.MigrationDestination.DepositScriptHash = testDepositScriptHash(t, destinationScript)
+	request.MigrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
+	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
+	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
+
+	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
+		RouteRequestID: "ors_self_zero",
+		Stage:          covenantsigner.StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Status != covenantsigner.StepStatusFailed {
+		t.Fatalf("expected FAILED, got %s", result.Status)
+	}
+	if result.Reason != covenantsigner.ReasonInvalidInput {
+		t.Fatalf("unexpected failure reason: %s", result.Reason)
+	}
+	if !strings.Contains(result.Detail, "maturity height must be greater than zero") {
+		t.Fatalf("unexpected failure detail: %s", result.Detail)
+	}
+}
+
+func TestValidateSelfV1OutputValues_RejectsValuesExceedingInt64(t *testing.T) {
+	err := validateSelfV1OutputValues(covenantsigner.RouteSubmitRequest{
+		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
+			DestinationValueSats: uint64(math.MaxInt64) + 1,
+			AnchorValueSats:      330,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected output value validation error")
+	}
+	if !strings.Contains(err.Error(), "migration destination value exceeds bitcoin output value range") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -1,0 +1,435 @@
+package tbtc
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/keep-network/keep-common/pkg/persistence"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/generator"
+	"github.com/keep-network/keep-core/pkg/internal/tecdsatest"
+	"github.com/keep-network/keep-core/pkg/net/local"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+	"github.com/keep-network/keep-core/pkg/tecdsa"
+)
+
+type covenantSignerMemoryDescriptor struct {
+	name      string
+	directory string
+	content   []byte
+}
+
+func (md *covenantSignerMemoryDescriptor) Name() string      { return md.name }
+func (md *covenantSignerMemoryDescriptor) Directory() string { return md.directory }
+func (md *covenantSignerMemoryDescriptor) Content() ([]byte, error) {
+	return md.content, nil
+}
+
+type covenantSignerMemoryHandle struct {
+	items map[string]*covenantSignerMemoryDescriptor
+}
+
+func newCovenantSignerMemoryHandle() *covenantSignerMemoryHandle {
+	return &covenantSignerMemoryHandle{items: make(map[string]*covenantSignerMemoryDescriptor)}
+}
+
+func (h *covenantSignerMemoryHandle) key(directory, name string) string {
+	return directory + "/" + name
+}
+
+func (h *covenantSignerMemoryHandle) Save(data []byte, directory, name string) error {
+	h.items[h.key(directory, name)] = &covenantSignerMemoryDescriptor{
+		name:      name,
+		directory: directory,
+		content:   append([]byte{}, data...),
+	}
+	return nil
+}
+
+func (h *covenantSignerMemoryHandle) Delete(directory, name string) error {
+	delete(h.items, h.key(directory, name))
+	return nil
+}
+
+func (h *covenantSignerMemoryHandle) ReadAll() (<-chan persistence.DataDescriptor, <-chan error) {
+	dataChan := make(chan persistence.DataDescriptor, len(h.items))
+	errChan := make(chan error)
+	for _, item := range h.items {
+		dataChan <- item
+	}
+	close(dataChan)
+	close(errChan)
+	return dataChan, errChan
+}
+
+func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
+	node, bitcoinChain, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	service, err := covenantsigner.NewService(
+		newCovenantSignerMemoryHandle(),
+		newCovenantSignerEngine(node),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x42}, 32))
+	depositorPublicKey := depositorPrivateKey.PubKey().SerializeCompressed()
+	signerPublicKey := (*btcec.PublicKey)(walletPublicKey).SerializeCompressed()
+
+	template := &covenantsigner.SelfV1Template{
+		Template:           covenantsigner.TemplateSelfV1,
+		DepositorPublicKey: "0x" + hex.EncodeToString(depositorPublicKey),
+		SignerPublicKey:    "0x" + hex.EncodeToString(signerPublicKey),
+		Delta2:             4320,
+	}
+	templateJSON, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maturityHeight := uint64(912345)
+	witnessScript, err := buildSelfV1WitnessScript(template, maturityHeight)
+	if err != nil {
+		t.Fatal(err)
+	}
+	witnessScriptHash := bitcoin.WitnessScriptHash(witnessScript)
+	activeScriptPubKey, err := bitcoin.PayToWitnessScriptHash(witnessScriptHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destinationScript, err := bitcoin.PayToWitnessPublicKeyHash([20]byte{
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		inputValueSats       = uint64(1_000_000)
+		destinationValueSats = uint64(998_000)
+		anchorValueSats      = uint64(330)
+		feeSats              = uint64(1_670)
+	)
+
+	prevTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           int64(inputValueSats),
+				PublicKeyScript: activeScriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+	bitcoinChain.transactions = append(bitcoinChain.transactions, prevTransaction)
+
+	activeScriptHash := sha256.Sum256(activeScriptPubKey)
+	revealer := "0x2222222222222222222222222222222222222222"
+	reserve := "0x1111111111111111111111111111111111111111"
+	vault := "0x3333333333333333333333333333333333333333"
+
+	migrationDestination := &covenantsigner.MigrationDestinationReservation{
+		ReservationID: "cmdr_self_1",
+		Reserve:       reserve,
+		Epoch:         12,
+		Route:         covenantsigner.ReservationRouteMigration,
+		Revealer:      revealer,
+		Vault:         vault,
+		Network:       "regtest",
+		Status:        covenantsigner.ReservationStatusReserved,
+		DepositScript: "0x" + hex.EncodeToString(destinationScript),
+	}
+	migrationDestination.DepositScriptHash = testDepositScriptHash(t, destinationScript)
+	migrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
+	migrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, migrationDestination)
+
+	request := covenantsigner.RouteSubmitRequest{
+		FacadeRequestID:           "rf_self_1",
+		IdempotencyKey:            "idem_self_1",
+		Route:                     covenantsigner.TemplateSelfV1,
+		Strategy:                  "0x1234",
+		Reserve:                   reserve,
+		Epoch:                     12,
+		MaturityHeight:            maturityHeight,
+		ActiveOutpoint:            covenantsigner.CovenantOutpoint{TxID: "0x" + prevTransaction.Hash().Hex(bitcoin.ReversedByteOrder), Vout: 0, ScriptHash: "0x" + hex.EncodeToString(activeScriptHash[:])},
+		DestinationCommitmentHash: migrationDestination.DestinationCommitmentHash,
+		MigrationDestination:      migrationDestination,
+		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
+			InputValueSats:       inputValueSats,
+			DestinationValueSats: destinationValueSats,
+			AnchorValueSats:      anchorValueSats,
+			FeeSats:              feeSats,
+			InputSequence:        0xfffffffd,
+			LockTime:             maturityHeight,
+		},
+		ArtifactSignatures: []string{"0x0708"},
+		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
+		ScriptTemplate:     templateJSON,
+		Signing: covenantsigner.SigningRequirements{
+			SignerRequired:    true,
+			CustodianRequired: false,
+		},
+	}
+
+	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
+		RouteRequestID: "ors_self_ready",
+		Stage:          covenantsigner.StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Status != covenantsigner.StepStatusReady {
+		t.Fatalf("expected READY, got %s", result.Status)
+	}
+	if result.PSBTHash == "" || result.TransactionHex == "" {
+		t.Fatalf("expected final artifact payload, got %#v", result)
+	}
+
+	transactionBytes, err := hex.DecodeString(strings.TrimPrefix(result.TransactionHex, "0x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transaction := &bitcoin.Transaction{}
+	if err := transaction.Deserialize(transactionBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	if transaction.Locktime != uint32(maturityHeight) {
+		t.Fatalf("unexpected locktime: %d", transaction.Locktime)
+	}
+	if len(transaction.Inputs) != 1 {
+		t.Fatalf("unexpected input count: %d", len(transaction.Inputs))
+	}
+	if transaction.Inputs[0].Sequence != 0xfffffffd {
+		t.Fatalf("unexpected input sequence: %x", transaction.Inputs[0].Sequence)
+	}
+	if len(transaction.Outputs) != 2 {
+		t.Fatalf("unexpected output count: %d", len(transaction.Outputs))
+	}
+	if transaction.Outputs[0].Value != int64(destinationValueSats) {
+		t.Fatalf("unexpected destination value: %d", transaction.Outputs[0].Value)
+	}
+	if !bytes.Equal(transaction.Outputs[0].PublicKeyScript, destinationScript) {
+		t.Fatal("unexpected destination output script")
+	}
+
+	expectedAnchorScript, err := canonicalAnchorScriptPubKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transaction.Outputs[1].Value != int64(anchorValueSats) {
+		t.Fatalf("unexpected anchor value: %d", transaction.Outputs[1].Value)
+	}
+	if !bytes.Equal(transaction.Outputs[1].PublicKeyScript, expectedAnchorScript) {
+		t.Fatal("unexpected anchor output script")
+	}
+
+	if len(transaction.Inputs[0].Witness) != 4 {
+		t.Fatalf("unexpected witness item count: %d", len(transaction.Inputs[0].Witness))
+	}
+	if !bytes.Equal(transaction.Inputs[0].Witness[1], []byte{0x01}) {
+		t.Fatal("missing migration selector witness item")
+	}
+	if len(transaction.Inputs[0].Witness[2]) != 0 {
+		t.Fatal("expected empty second selector witness item")
+	}
+	if !bytes.Equal(transaction.Inputs[0].Witness[3], witnessScript) {
+		t.Fatal("unexpected witness script")
+	}
+
+	if result.PSBTHash != "0x"+transaction.WitnessHash().Hex(bitcoin.InternalByteOrder) {
+		t.Fatalf("unexpected psbtHash: %s", result.PSBTHash)
+	}
+
+	signatureWithHashType := transaction.Inputs[0].Witness[0]
+	if len(signatureWithHashType) == 0 || signatureWithHashType[len(signatureWithHashType)-1] != byte(txscript.SigHashAll) {
+		t.Fatal("unexpected sighash type in witness signature")
+	}
+
+	wireTransaction := wire.NewMsgTx(wire.TxVersion)
+	if err := wireTransaction.Deserialize(bytes.NewReader(transaction.Serialize(bitcoin.Witness))); err != nil {
+		t.Fatal(err)
+	}
+
+	sighashBytes, err := txscript.CalcWitnessSigHash(
+		witnessScript,
+		txscript.NewTxSigHashes(wireTransaction),
+		txscript.SigHashAll,
+		wireTransaction,
+		0,
+		int64(inputValueSats),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsedSignature, err := btcec.ParseDERSignature(signatureWithHashType[:len(signatureWithHashType)-1], btcec.S256())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ecdsa.Verify(walletPublicKey, sighashBytes, parsedSignature.R, parsedSignature.S) {
+		t.Fatal("invalid covenant signature")
+	}
+}
+
+func setupCovenantSignerTestNode(
+	t *testing.T,
+) (*node, *localBitcoinChain, *ecdsa.PublicKey) {
+	t.Helper()
+
+	groupParameters := &GroupParameters{
+		GroupSize:       5,
+		GroupQuorum:     4,
+		HonestThreshold: 3,
+	}
+
+	operatorPrivateKey, operatorPublicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain := ConnectWithKey(operatorPrivateKey)
+	localProvider := local.ConnectWithKey(operatorPublicKey)
+	bitcoinChain := newLocalBitcoinChain()
+
+	operatorAddress, err := localChain.Signing().PublicKeyToAddress(operatorPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var operators []chain.Address
+	for i := 0; i < groupParameters.GroupSize; i++ {
+		operators = append(operators, operatorAddress)
+	}
+
+	testData, err := tecdsatest.LoadPrivateKeyShareTestFixtures(groupParameters.GroupSize)
+	if err != nil {
+		t.Fatalf("failed to load test data: [%v]", err)
+	}
+
+	signers := make([]*signer, len(testData))
+	for i := range testData {
+		privateKeyShare := tecdsa.NewPrivateKeyShare(testData[i])
+		signers[i] = &signer{
+			wallet: wallet{
+				publicKey:             privateKeyShare.PublicKey(),
+				signingGroupOperators: operators,
+			},
+			signingGroupMemberIndex: group.MemberIndex(i + 1),
+			privateKeyShare:         privateKeyShare,
+		}
+	}
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signers[0].wallet.publicKey)
+	walletID, err := localChain.CalculateWalletID(signers[0].wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain.setWallet(
+		walletPublicKeyHash,
+		&WalletChainData{
+			EcdsaWalletID: walletID,
+			State:         StateLive,
+		},
+	)
+
+	node, err := newNode(
+		groupParameters,
+		localChain,
+		bitcoinChain,
+		localProvider,
+		createMockKeyStorePersistence(t, signers...),
+		&mockPersistenceHandle{},
+		generator.StartScheduler(),
+		&mockCoordinationProposalGenerator{},
+		Config{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	executor, ok, err := node.getSigningExecutor(signers[0].wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("node is supposed to control wallet signers")
+	}
+	executor.signingAttemptsLimit *= 8
+
+	return node, bitcoinChain, signers[0].wallet.publicKey
+}
+
+func testMigrationExtraData(revealer string) string {
+	return "0x" + hex.EncodeToString([]byte("AC_MIGRATEV1")) + strings.TrimPrefix(strings.ToLower(revealer), "0x")
+}
+
+func testDepositScriptHash(t *testing.T, depositScript bitcoin.Script) string {
+	t.Helper()
+
+	sum := sha256.Sum256(depositScript)
+	return "0x" + hex.EncodeToString(sum[:])
+}
+
+type testDestinationCommitmentPayload struct {
+	Reserve            string `json:"reserve"`
+	Epoch              uint64 `json:"epoch"`
+	Route              string `json:"route"`
+	Revealer           string `json:"revealer"`
+	Vault              string `json:"vault"`
+	Network            string `json:"network"`
+	DepositScriptHash  string `json:"depositScriptHash"`
+	MigrationExtraData string `json:"migrationExtraData"`
+}
+
+func testDestinationCommitmentHash(
+	t *testing.T,
+	reservation *covenantsigner.MigrationDestinationReservation,
+) string {
+	t.Helper()
+
+	payload, err := json.Marshal(testDestinationCommitmentPayload{
+		Reserve:            strings.ToLower(reservation.Reserve),
+		Epoch:              reservation.Epoch,
+		Route:              string(reservation.Route),
+		Revealer:           strings.ToLower(reservation.Revealer),
+		Vault:              strings.ToLower(reservation.Vault),
+		Network:            strings.TrimSpace(reservation.Network),
+		DepositScriptHash:  strings.ToLower(reservation.DepositScriptHash),
+		MigrationExtraData: strings.ToLower(reservation.MigrationExtraData),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(payload)
+	return "0x" + hex.EncodeToString(sum[:])
+}

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 
 	"github.com/ipfs/go-log"
 
@@ -69,7 +70,8 @@ type Config struct {
 
 // Initialize kicks off the TBTC by initializing internal state, ensuring
 // preconditions like staking are met, and then kicking off the internal TBTC
-// implementation. Returns an error if this failed.
+// implementation. Returns the covenant signer engine bound to the initialized
+// node together with an error if initialization failed.
 func Initialize(
 	ctx context.Context,
 	chain Chain,
@@ -82,7 +84,7 @@ func Initialize(
 	config Config,
 	clientInfo *clientinfo.Registry,
 	perfMetrics *clientinfo.PerformanceMetrics,
-) error {
+) (covenantsigner.Engine, error) {
 	groupParameters := &GroupParameters{
 		GroupSize:       100,
 		GroupQuorum:     90,
@@ -101,12 +103,12 @@ func Initialize(
 		config,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot set up TBTC node: [%v]", err)
+		return nil, fmt.Errorf("cannot set up TBTC node: [%v]", err)
 	}
 
 	err = node.runCoordinationLayer(ctx)
 	if err != nil {
-		return fmt.Errorf("cannot run coordination layer: [%w]", err)
+		return nil, fmt.Errorf("cannot run coordination layer: [%w]", err)
 	}
 
 	deduplicator := newDeduplicator()
@@ -161,7 +163,7 @@ func Initialize(
 		),
 	)
 	if err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"could not set up sortition pool monitoring: [%v]",
 			err,
 		)
@@ -323,7 +325,7 @@ func Initialize(
 		}()
 	})
 
-	return nil
+	return newCovenantSignerEngine(node), nil
 }
 
 // enoughPreParamsInPoolPolicy is a policy that enforces the sufficient size


### PR DESCRIPTION
## Summary
- wire the covenant signer server to a real engine from tbtc instead of the passive stub
- add the first real self_v1 signer path that fetches the active outpoint, verifies the reserved migration destination and transaction plan, signs the canonical maturity spend, and returns READY with transactionHex + deterministic artifact hash
- extend the bitcoin transaction builder with explicit locktime/sequence/witness controls and add end-to-end signer coverage

## Testing
- go test ./pkg/bitcoin ./pkg/covenantsigner
- go test ./pkg/tbtc -run TestCovenantSignerEngine_SubmitSelfV1Ready -v
- go test ./config ./cmd