### PR TITLE
feat(tbtc): add qc_v1 signer handoff

### DIFF
--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -456,6 +456,8 @@ func (cse *covenantSignerEngine) resolveQcV1ActiveUtxo(
 	}
 
 	if request.ActiveOutpoint.ScriptHash != "" {
+		// The optional scriptHash convention follows the tBTC-side request
+		// contract: sha256(scriptPubKey) for the active covenant output.
 		scriptHash := sha256.Sum256(expectedScriptPubKey)
 		expectedScriptHash := "0x" + hex.EncodeToString(scriptHash[:])
 		if strings.ToLower(request.ActiveOutpoint.ScriptHash) != expectedScriptHash {
@@ -717,6 +719,9 @@ func buildWitnessSignatureBytes(signature *tecdsa.Signature) ([]byte, error) {
 }
 
 func computeQcV1SignerHandoffPayloadHash(payload map[string]any) (string, error) {
+	// The handoff bundle ID is content-addressed using Go's stable JSON map-key
+	// ordering. Future non-Go custodian consumers that want to recompute this
+	// hash must preserve the same canonical field set and serialization rules.
 	rawPayload, err := json.Marshal(payload)
 	if err != nil {
 		return "", err

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -22,6 +22,22 @@ type covenantSignerEngine struct {
 	node *node
 }
 
+const qcV1SignerHandoffKind = "qc_v1_signer_handoff_v1"
+
+type qcV1SignerHandoff struct {
+	Kind                      string
+	SignerRequestID           string
+	BundleID                  string
+	DestinationCommitmentHash string
+	PayloadHash               string
+	UnsignedTransactionHex    string
+	WitnessScript             string
+	SignerSignature           string
+	SelectorWitnessItems      []string
+	RequiresDummy             bool
+	SighashType               uint32
+}
+
 func newCovenantSignerEngine(node *node) covenantsigner.Engine {
 	return &covenantSignerEngine{node: node}
 }
@@ -34,10 +50,7 @@ func (cse *covenantSignerEngine) OnSubmit(
 	case covenantsigner.TemplateSelfV1:
 		return cse.submitSelfV1(ctx, job), nil
 	case covenantsigner.TemplateQcV1:
-		return &covenantsigner.Transition{
-			State:  covenantsigner.JobStatePending,
-			Detail: "accepted for qc_v1 signer coordination",
-		}, nil
+		return cse.submitQcV1(ctx, job), nil
 	default:
 		return &covenantsigner.Transition{
 			State:  covenantsigner.JobStateFailed,
@@ -85,7 +98,7 @@ func (cse *covenantSignerEngine) submitSelfV1(
 	if err != nil {
 		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
 	}
-	if err := validateSelfV1OutputValues(job.Request); err != nil {
+	if err := validateMigrationOutputValues(job.Request); err != nil {
 		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
 	}
 
@@ -115,6 +128,60 @@ func (cse *covenantSignerEngine) submitSelfV1(
 	}
 }
 
+func (cse *covenantSignerEngine) submitQcV1(
+	ctx context.Context,
+	job *covenantsigner.Job,
+) *covenantsigner.Transition {
+	template, err := decodeQcV1Template(job.Request.ScriptTemplate)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+
+	walletPublicKey, err := parseCompressedPublicKey(template.SignerPublicKey)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, "invalid qc_v1 signer public key")
+	}
+
+	signingExecutor, ok, err := cse.node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonProviderFailed, fmt.Sprintf("cannot resolve signing executor: %v", err))
+	}
+	if !ok {
+		return failedTransition(covenantsigner.ReasonPolicyRejected, "wallet is not controlled by this node")
+	}
+
+	witnessScript, err := buildQcV1WitnessScript(template, job.Request.MaturityHeight)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+
+	activeUtxo, err := cse.resolveQcV1ActiveUtxo(job.Request, witnessScript)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+	if err := validateMigrationOutputValues(job.Request); err != nil {
+		return failedTransition(covenantsigner.ReasonInvalidInput, err.Error())
+	}
+
+	handoff, err := cse.buildQcV1SignerHandoff(
+		ctx,
+		job.RequestID,
+		signingExecutor,
+		job.Request,
+		activeUtxo,
+		witnessScript,
+	)
+	if err != nil {
+		return failedTransition(covenantsigner.ReasonProviderFailed, err.Error())
+	}
+
+	return &covenantsigner.Transition{
+		State:   covenantsigner.JobStateHandoffReady,
+		Detail:  "qc_v1 signer handoff ready for custodian coordination",
+		Handoff: handoff.toMap(),
+	}
+}
+
 func decodeSelfV1Template(raw json.RawMessage) (*covenantsigner.SelfV1Template, error) {
 	template := &covenantsigner.SelfV1Template{}
 	if err := json.Unmarshal(raw, template); err != nil {
@@ -122,6 +189,17 @@ func decodeSelfV1Template(raw json.RawMessage) (*covenantsigner.SelfV1Template, 
 	}
 	if template.Template != covenantsigner.TemplateSelfV1 {
 		return nil, fmt.Errorf("request template must be self_v1")
+	}
+	return template, nil
+}
+
+func decodeQcV1Template(raw json.RawMessage) (*covenantsigner.QcV1Template, error) {
+	template := &covenantsigner.QcV1Template{}
+	if err := json.Unmarshal(raw, template); err != nil {
+		return nil, fmt.Errorf("cannot decode qc_v1 template: %v", err)
+	}
+	if template.Template != covenantsigner.TemplateQcV1 {
+		return nil, fmt.Errorf("request template must be qc_v1")
 	}
 	return template, nil
 }
@@ -201,6 +279,89 @@ func buildSelfV1WitnessScript(
 		Script()
 }
 
+func buildQcV1WitnessScript(
+	template *covenantsigner.QcV1Template,
+	maturityHeight uint64,
+) (bitcoin.Script, error) {
+	if maturityHeight == 0 {
+		return nil, fmt.Errorf("maturity height must be greater than zero")
+	}
+	if maturityHeight > math.MaxUint32 {
+		return nil, fmt.Errorf("maturity height exceeds bitcoin locktime range")
+	}
+	if template.Beta > math.MaxUint32 || template.Beta >= maturityHeight {
+		return nil, fmt.Errorf("qc_v1 beta must be below maturity height")
+	}
+	if template.Delta2 > math.MaxUint32 || maturityHeight > math.MaxUint32-template.Delta2 {
+		return nil, fmt.Errorf("qc_v1 delta2 overflows bitcoin locktime range")
+	}
+
+	depositorPublicKey, err := canonicalCompressedPublicKeyBytes(template.DepositorPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid qc_v1 depositor public key")
+	}
+	custodianPublicKey, err := canonicalCompressedPublicKeyBytes(template.CustodianPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid qc_v1 custodian public key")
+	}
+	signerPublicKey, err := canonicalCompressedPublicKeyBytes(template.SignerPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid qc_v1 signer public key")
+	}
+
+	maturityScriptNumber, err := encodeScriptNumber(uint32(maturityHeight))
+	if err != nil {
+		return nil, err
+	}
+	earlyExitScriptNumber, err := encodeScriptNumber(uint32(maturityHeight - template.Beta))
+	if err != nil {
+		return nil, err
+	}
+	lastResortScriptNumber, err := encodeScriptNumber(uint32(maturityHeight + template.Delta2))
+	if err != nil {
+		return nil, err
+	}
+
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_IF).
+		AddOp(txscript.OP_3).
+		AddData(depositorPublicKey).
+		AddData(custodianPublicKey).
+		AddData(signerPublicKey).
+		AddOp(txscript.OP_3).
+		AddOp(txscript.OP_CHECKMULTISIG).
+		AddOp(txscript.OP_ELSE).
+		AddOp(txscript.OP_IF).
+		AddData(maturityScriptNumber).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddOp(txscript.OP_2).
+		AddData(signerPublicKey).
+		AddData(custodianPublicKey).
+		AddOp(txscript.OP_2).
+		AddOp(txscript.OP_CHECKMULTISIG).
+		AddOp(txscript.OP_ELSE).
+		AddOp(txscript.OP_IF).
+		AddData(earlyExitScriptNumber).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddOp(txscript.OP_2).
+		AddData(depositorPublicKey).
+		AddData(custodianPublicKey).
+		AddOp(txscript.OP_2).
+		AddOp(txscript.OP_CHECKMULTISIG).
+		AddOp(txscript.OP_ELSE).
+		AddData(lastResortScriptNumber).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddData(depositorPublicKey).
+		AddOp(txscript.OP_CHECKSIG).
+		AddOp(txscript.OP_ENDIF).
+		AddOp(txscript.OP_ENDIF).
+		AddOp(txscript.OP_ENDIF).
+		Script()
+}
+
 func (cse *covenantSignerEngine) resolveSelfV1ActiveUtxo(
 	request covenantsigner.RouteSubmitRequest,
 	witnessScript bitcoin.Script,
@@ -257,7 +418,61 @@ func (cse *covenantSignerEngine) resolveSelfV1ActiveUtxo(
 	}, nil
 }
 
-func validateSelfV1OutputValues(request covenantsigner.RouteSubmitRequest) error {
+func (cse *covenantSignerEngine) resolveQcV1ActiveUtxo(
+	request covenantsigner.RouteSubmitRequest,
+	witnessScript bitcoin.Script,
+) (*bitcoin.UnspentTransactionOutput, error) {
+	activeTxHash, err := bitcoin.NewHashFromString(
+		strings.TrimPrefix(request.ActiveOutpoint.TxID, "0x"),
+		bitcoin.ReversedByteOrder,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("active outpoint txid is invalid")
+	}
+
+	transaction, err := cse.node.btcChain.GetTransaction(activeTxHash)
+	if err != nil {
+		return nil, fmt.Errorf("active outpoint transaction not found")
+	}
+	if int(request.ActiveOutpoint.Vout) >= len(transaction.Outputs) {
+		return nil, fmt.Errorf("active outpoint output index is out of range")
+	}
+
+	expectedWitnessScriptHash := bitcoin.WitnessScriptHash(witnessScript)
+	expectedScriptPubKey, err := bitcoin.PayToWitnessScriptHash(expectedWitnessScriptHash)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build expected qc_v1 locking script: %v", err)
+	}
+
+	actualOutput := transaction.Outputs[request.ActiveOutpoint.Vout]
+	if !bytes.Equal(actualOutput.PublicKeyScript, expectedScriptPubKey) {
+		return nil, fmt.Errorf("active outpoint script does not match qc_v1 template")
+	}
+	if actualOutput.Value <= 0 {
+		return nil, fmt.Errorf("active outpoint value must be greater than zero")
+	}
+	if uint64(actualOutput.Value) != request.MigrationTransactionPlan.InputValueSats {
+		return nil, fmt.Errorf("active outpoint value does not match migration transaction plan")
+	}
+
+	if request.ActiveOutpoint.ScriptHash != "" {
+		scriptHash := sha256.Sum256(expectedScriptPubKey)
+		expectedScriptHash := "0x" + hex.EncodeToString(scriptHash[:])
+		if strings.ToLower(request.ActiveOutpoint.ScriptHash) != expectedScriptHash {
+			return nil, fmt.Errorf("active outpoint script hash does not match qc_v1 template")
+		}
+	}
+
+	return &bitcoin.UnspentTransactionOutput{
+		Outpoint: &bitcoin.TransactionOutpoint{
+			TransactionHash: activeTxHash,
+			OutputIndex:     request.ActiveOutpoint.Vout,
+		},
+		Value: actualOutput.Value,
+	}, nil
+}
+
+func validateMigrationOutputValues(request covenantsigner.RouteSubmitRequest) error {
 	_, err := toBitcoinOutputValue(
 		request.MigrationTransactionPlan.DestinationValueSats,
 		"migration destination value",
@@ -363,18 +578,124 @@ func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
 	return transaction, nil
 }
 
+func (cse *covenantSignerEngine) buildQcV1SignerHandoff(
+	ctx context.Context,
+	requestID string,
+	signingExecutor *signingExecutor,
+	request covenantsigner.RouteSubmitRequest,
+	activeUtxo *bitcoin.UnspentTransactionOutput,
+	witnessScript bitcoin.Script,
+) (*qcV1SignerHandoff, error) {
+	destinationScript, err := decodePrefixedHex(request.MigrationDestination.DepositScript)
+	if err != nil {
+		return nil, fmt.Errorf("migration destination deposit script is invalid")
+	}
+	destinationValue, err := toBitcoinOutputValue(
+		request.MigrationTransactionPlan.DestinationValueSats,
+		"migration destination value",
+	)
+	if err != nil {
+		return nil, err
+	}
+	anchorValue, err := toBitcoinOutputValue(
+		request.MigrationTransactionPlan.AnchorValueSats,
+		"migration anchor value",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	builder := bitcoin.NewTransactionBuilder(cse.node.btcChain)
+	if err := builder.AddScriptHashInput(activeUtxo, witnessScript); err != nil {
+		return nil, fmt.Errorf("cannot add covenant input: %v", err)
+	}
+	if err := builder.SetInputSequence(0, request.MigrationTransactionPlan.InputSequence); err != nil {
+		return nil, fmt.Errorf("cannot set covenant input sequence: %v", err)
+	}
+	builder.SetLocktime(uint32(request.MigrationTransactionPlan.LockTime))
+	builder.AddOutput(&bitcoin.TransactionOutput{
+		Value:           destinationValue,
+		PublicKeyScript: destinationScript,
+	})
+
+	anchorScript, err := canonicalAnchorScriptPubKey()
+	if err != nil {
+		return nil, err
+	}
+	builder.AddOutput(&bitcoin.TransactionOutput{
+		Value:           anchorValue,
+		PublicKeyScript: anchorScript,
+	})
+
+	sigHashes, err := builder.ComputeSignatureHashes()
+	if err != nil {
+		return nil, fmt.Errorf("cannot compute covenant sighash: %v", err)
+	}
+	if len(sigHashes) != 1 {
+		return nil, fmt.Errorf("unexpected covenant sighash count")
+	}
+
+	startBlock, err := signingExecutor.getCurrentBlockFn()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine signing start block: %v", err)
+	}
+
+	signatures, err := signingExecutor.signBatch(ctx, sigHashes, startBlock)
+	if err != nil {
+		return nil, fmt.Errorf("cannot sign covenant transaction: %v", err)
+	}
+	if len(signatures) != 1 {
+		return nil, fmt.Errorf("unexpected covenant signature count")
+	}
+
+	signatureBytes, err := buildWitnessSignatureBytes(signatures[0])
+	if err != nil {
+		return nil, err
+	}
+
+	unsignedTransaction := builder.Build()
+	unsignedTransactionHex := "0x" + hex.EncodeToString(unsignedTransaction.Serialize(bitcoin.Standard))
+	witnessScriptHex := "0x" + hex.EncodeToString(witnessScript)
+	signatureHex := "0x" + hex.EncodeToString(signatureBytes)
+	selectorWitnessItems := []string{"0x01", "0x"}
+
+	payloadHash, err := computeQcV1SignerHandoffPayloadHash(map[string]any{
+		"kind":                     qcV1SignerHandoffKind,
+		"unsignedTransactionHex":   unsignedTransactionHex,
+		"witnessScript":            witnessScriptHex,
+		"signerSignature":          signatureHex,
+		"selectorWitnessItems":     selectorWitnessItems,
+		"requiresDummy":            true,
+		"sighashType":              uint32(txscript.SigHashAll),
+		"destinationCommitmentHash": request.DestinationCommitmentHash,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &qcV1SignerHandoff{
+		Kind:                      qcV1SignerHandoffKind,
+		SignerRequestID:           requestID,
+		BundleID:                  payloadHash,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		PayloadHash:               payloadHash,
+		UnsignedTransactionHex:    unsignedTransactionHex,
+		WitnessScript:             witnessScriptHex,
+		SignerSignature:           signatureHex,
+		SelectorWitnessItems:      selectorWitnessItems,
+		RequiresDummy:             true,
+		SighashType:               uint32(txscript.SigHashAll),
+	}, nil
+}
+
 func buildSelfV1MigrationWitness(
 	signature *tecdsa.Signature,
 	witnessScript bitcoin.Script,
 ) ([][]byte, error) {
-	if signature == nil || signature.R == nil || signature.S == nil {
-		return nil, fmt.Errorf("missing covenant signature")
+	signatureBytes, err := buildWitnessSignatureBytes(signature)
+	if err != nil {
+		return nil, err
 	}
-
-	signatureBytes := append(
-		(&btcec.Signature{R: signature.R, S: signature.S}).Serialize(),
-		byte(txscript.SigHashAll),
-	)
 
 	return [][]byte{
 		signatureBytes,
@@ -382,6 +703,43 @@ func buildSelfV1MigrationWitness(
 		{},
 		witnessScript,
 	}, nil
+}
+
+func buildWitnessSignatureBytes(signature *tecdsa.Signature) ([]byte, error) {
+	if signature == nil || signature.R == nil || signature.S == nil {
+		return nil, fmt.Errorf("missing covenant signature")
+	}
+
+	return append(
+		(&btcec.Signature{R: signature.R, S: signature.S}).Serialize(),
+		byte(txscript.SigHashAll),
+	), nil
+}
+
+func computeQcV1SignerHandoffPayloadHash(payload map[string]any) (string, error) {
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(rawPayload)
+	return "0x" + hex.EncodeToString(sum[:]), nil
+}
+
+func (handoff *qcV1SignerHandoff) toMap() map[string]any {
+	return map[string]any{
+		"kind":                      handoff.Kind,
+		"signerRequestId":           handoff.SignerRequestID,
+		"bundleId":                  handoff.BundleID,
+		"destinationCommitmentHash": handoff.DestinationCommitmentHash,
+		"payloadHash":               handoff.PayloadHash,
+		"unsignedTransactionHex":    handoff.UnsignedTransactionHex,
+		"witnessScript":             handoff.WitnessScript,
+		"signerSignature":           handoff.SignerSignature,
+		"selectorWitnessItems":      handoff.SelectorWitnessItems,
+		"requiresDummy":             handoff.RequiresDummy,
+		"sighashType":               handoff.SighashType,
+	}
 }
 
 func canonicalAnchorScriptPubKey() (bitcoin.Script, error) {

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -576,6 +576,247 @@ func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
 	}
 }
 
+func TestCovenantSignerEngine_SubmitQcV1RejectsInvalidBeta(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	service, err := covenantsigner.NewService(
+		newCovenantSignerMemoryHandle(),
+		newCovenantSignerEngine(node),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x42}, 32))
+	depositorPublicKey := depositorPrivateKey.PubKey().SerializeCompressed()
+	custodianPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x24}, 32))
+	custodianPublicKey := custodianPrivateKey.PubKey().SerializeCompressed()
+	signerPublicKey := (*btcec.PublicKey)(walletPublicKey).SerializeCompressed()
+
+	template := &covenantsigner.QcV1Template{
+		Template:           covenantsigner.TemplateQcV1,
+		DepositorPublicKey: "0x" + hex.EncodeToString(depositorPublicKey),
+		CustodianPublicKey: "0x" + hex.EncodeToString(custodianPublicKey),
+		SignerPublicKey:    "0x" + hex.EncodeToString(signerPublicKey),
+		Beta:               500,
+		Delta2:             4320,
+	}
+	templateJSON, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destinationScript, err := bitcoin.PayToWitnessPublicKeyHash([20]byte{
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	revealer := "0x4444444444444444444444444444444444444444"
+	reserve := "0x1111111111111111111111111111111111111111"
+	vault := "0x3333333333333333333333333333333333333333"
+	request := covenantsigner.RouteSubmitRequest{
+		FacadeRequestID: "rf_qc_bad_beta",
+		IdempotencyKey:  "idem_qc_bad_beta",
+		Route:           covenantsigner.TemplateQcV1,
+		Strategy:        "0x1234",
+		Reserve:         reserve,
+		Epoch:           21,
+		MaturityHeight:  500,
+		ActiveOutpoint: covenantsigner.CovenantOutpoint{
+			TxID: "0x" + strings.Repeat("11", 32),
+		},
+		MigrationDestination: &covenantsigner.MigrationDestinationReservation{
+			ReservationID: "cmdr_qc_bad_beta",
+			Reserve:       reserve,
+			Epoch:         21,
+			Route:         covenantsigner.ReservationRouteMigration,
+			Revealer:      revealer,
+			Vault:         vault,
+			Network:       "regtest",
+			Status:        covenantsigner.ReservationStatusReserved,
+			DepositScript: "0x" + hex.EncodeToString(destinationScript),
+		},
+		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
+			InputValueSats:       2_000_000,
+			DestinationValueSats: 1_997_500,
+			AnchorValueSats:      330,
+			FeeSats:              2_170,
+			InputSequence:        0xfffffffd,
+			LockTime:             500,
+		},
+		ArtifactSignatures: []string{"0x090a"},
+		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
+		ScriptTemplate:     templateJSON,
+		Signing: covenantsigner.SigningRequirements{
+			SignerRequired:    true,
+			CustodianRequired: true,
+		},
+	}
+	request.MigrationDestination.DepositScriptHash = testDepositScriptHash(t, destinationScript)
+	request.MigrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
+	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
+	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
+
+	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
+		RouteRequestID: "ors_qc_bad_beta",
+		Stage:          covenantsigner.StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Status != covenantsigner.StepStatusFailed {
+		t.Fatalf("expected FAILED, got %s", result.Status)
+	}
+	if result.Reason != covenantsigner.ReasonInvalidInput {
+		t.Fatalf("unexpected failure reason: %s", result.Reason)
+	}
+	if !strings.Contains(result.Detail, "qc_v1 beta must be below maturity height") {
+		t.Fatalf("unexpected failure detail: %s", result.Detail)
+	}
+}
+
+func TestCovenantSignerEngine_SubmitQcV1RejectsScriptHashMismatch(t *testing.T) {
+	node, bitcoinChain, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	service, err := covenantsigner.NewService(
+		newCovenantSignerMemoryHandle(),
+		newCovenantSignerEngine(node),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x42}, 32))
+	depositorPublicKey := depositorPrivateKey.PubKey().SerializeCompressed()
+	custodianPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x24}, 32))
+	custodianPublicKey := custodianPrivateKey.PubKey().SerializeCompressed()
+	signerPublicKey := (*btcec.PublicKey)(walletPublicKey).SerializeCompressed()
+
+	template := &covenantsigner.QcV1Template{
+		Template:           covenantsigner.TemplateQcV1,
+		DepositorPublicKey: "0x" + hex.EncodeToString(depositorPublicKey),
+		CustodianPublicKey: "0x" + hex.EncodeToString(custodianPublicKey),
+		SignerPublicKey:    "0x" + hex.EncodeToString(signerPublicKey),
+		Beta:               144,
+		Delta2:             4320,
+	}
+	templateJSON, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maturityHeight := uint64(912345)
+	witnessScript, err := buildQcV1WitnessScript(template, maturityHeight)
+	if err != nil {
+		t.Fatal(err)
+	}
+	witnessScriptHash := bitcoin.WitnessScriptHash(witnessScript)
+	activeScriptPubKey, err := bitcoin.PayToWitnessScriptHash(witnessScriptHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destinationScript, err := bitcoin.PayToWitnessPublicKeyHash([20]byte{
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           2_000_000,
+				PublicKeyScript: activeScriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+	bitcoinChain.transactions = append(bitcoinChain.transactions, prevTransaction)
+
+	revealer := "0x4444444444444444444444444444444444444444"
+	reserve := "0x1111111111111111111111111111111111111111"
+	vault := "0x3333333333333333333333333333333333333333"
+	migrationDestination := &covenantsigner.MigrationDestinationReservation{
+		ReservationID: "cmdr_qc_bad_script_hash",
+		Reserve:       reserve,
+		Epoch:         21,
+		Route:         covenantsigner.ReservationRouteMigration,
+		Revealer:      revealer,
+		Vault:         vault,
+		Network:       "regtest",
+		Status:        covenantsigner.ReservationStatusCommittedToEpoch,
+		DepositScript: "0x" + hex.EncodeToString(destinationScript),
+	}
+	migrationDestination.DepositScriptHash = testDepositScriptHash(t, destinationScript)
+	migrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
+	migrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, migrationDestination)
+
+	request := covenantsigner.RouteSubmitRequest{
+		FacadeRequestID:           "rf_qc_bad_script_hash",
+		IdempotencyKey:            "idem_qc_bad_script_hash",
+		Route:                     covenantsigner.TemplateQcV1,
+		Strategy:                  "0x1234",
+		Reserve:                   reserve,
+		Epoch:                     21,
+		MaturityHeight:            maturityHeight,
+		ActiveOutpoint:            covenantsigner.CovenantOutpoint{TxID: "0x" + prevTransaction.Hash().Hex(bitcoin.ReversedByteOrder), Vout: 0, ScriptHash: "0x" + strings.Repeat("aa", 32)},
+		DestinationCommitmentHash: migrationDestination.DestinationCommitmentHash,
+		MigrationDestination:      migrationDestination,
+		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
+			InputValueSats:       2_000_000,
+			DestinationValueSats: 1_997_500,
+			AnchorValueSats:      330,
+			FeeSats:              2_170,
+			InputSequence:        0xfffffffd,
+			LockTime:             maturityHeight,
+		},
+		ArtifactSignatures: []string{"0x090a"},
+		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
+		ScriptTemplate:     templateJSON,
+		Signing: covenantsigner.SigningRequirements{
+			SignerRequired:    true,
+			CustodianRequired: true,
+		},
+	}
+
+	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
+		RouteRequestID: "ors_qc_bad_script_hash",
+		Stage:          covenantsigner.StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Status != covenantsigner.StepStatusFailed {
+		t.Fatalf("expected FAILED, got %s", result.Status)
+	}
+	if result.Reason != covenantsigner.ReasonInvalidInput {
+		t.Fatalf("unexpected failure reason: %s", result.Reason)
+	}
+	if !strings.Contains(result.Detail, "active outpoint script hash does not match qc_v1 template") {
+		t.Fatalf("unexpected failure detail: %s", result.Detail)
+	}
+}
+
 func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T) {
 	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
 

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -300,6 +300,282 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 	}
 }
 
+func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
+	node, bitcoinChain, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	service, err := covenantsigner.NewService(
+		newCovenantSignerMemoryHandle(),
+		newCovenantSignerEngine(node),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x42}, 32))
+	depositorPublicKey := depositorPrivateKey.PubKey().SerializeCompressed()
+	custodianPrivateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{0x24}, 32))
+	custodianPublicKey := custodianPrivateKey.PubKey().SerializeCompressed()
+	signerPublicKey := (*btcec.PublicKey)(walletPublicKey).SerializeCompressed()
+
+	template := &covenantsigner.QcV1Template{
+		Template:           covenantsigner.TemplateQcV1,
+		DepositorPublicKey: "0x" + hex.EncodeToString(depositorPublicKey),
+		CustodianPublicKey: "0x" + hex.EncodeToString(custodianPublicKey),
+		SignerPublicKey:    "0x" + hex.EncodeToString(signerPublicKey),
+		Beta:               144,
+		Delta2:             4320,
+	}
+	templateJSON, err := json.Marshal(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maturityHeight := uint64(912345)
+	witnessScript, err := buildQcV1WitnessScript(template, maturityHeight)
+	if err != nil {
+		t.Fatal(err)
+	}
+	witnessScriptHash := bitcoin.WitnessScriptHash(witnessScript)
+	activeScriptPubKey, err := bitcoin.PayToWitnessScriptHash(witnessScriptHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destinationScript, err := bitcoin.PayToWitnessPublicKeyHash([20]byte{
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		inputValueSats       = uint64(2_000_000)
+		destinationValueSats = uint64(1_997_500)
+		anchorValueSats      = uint64(330)
+		feeSats              = uint64(2_170)
+	)
+
+	prevTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           int64(inputValueSats),
+				PublicKeyScript: activeScriptPubKey,
+			},
+		},
+		Locktime: 0,
+	}
+	bitcoinChain.transactions = append(bitcoinChain.transactions, prevTransaction)
+
+	activeScriptHash := sha256.Sum256(activeScriptPubKey)
+	revealer := "0x4444444444444444444444444444444444444444"
+	reserve := "0x1111111111111111111111111111111111111111"
+	vault := "0x3333333333333333333333333333333333333333"
+
+	migrationDestination := &covenantsigner.MigrationDestinationReservation{
+		ReservationID: "cmdr_qc_1",
+		Reserve:       reserve,
+		Epoch:         21,
+		Route:         covenantsigner.ReservationRouteMigration,
+		Revealer:      revealer,
+		Vault:         vault,
+		Network:       "regtest",
+		Status:        covenantsigner.ReservationStatusCommittedToEpoch,
+		DepositScript: "0x" + hex.EncodeToString(destinationScript),
+	}
+	migrationDestination.DepositScriptHash = testDepositScriptHash(t, destinationScript)
+	migrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
+	migrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, migrationDestination)
+
+	request := covenantsigner.RouteSubmitRequest{
+		FacadeRequestID:           "rf_qc_1",
+		IdempotencyKey:            "idem_qc_1",
+		Route:                     covenantsigner.TemplateQcV1,
+		Strategy:                  "0x1234",
+		Reserve:                   reserve,
+		Epoch:                     21,
+		MaturityHeight:            maturityHeight,
+		ActiveOutpoint:            covenantsigner.CovenantOutpoint{TxID: "0x" + prevTransaction.Hash().Hex(bitcoin.ReversedByteOrder), Vout: 0, ScriptHash: "0x" + hex.EncodeToString(activeScriptHash[:])},
+		DestinationCommitmentHash: migrationDestination.DestinationCommitmentHash,
+		MigrationDestination:      migrationDestination,
+		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
+			InputValueSats:       inputValueSats,
+			DestinationValueSats: destinationValueSats,
+			AnchorValueSats:      anchorValueSats,
+			FeeSats:              feeSats,
+			InputSequence:        0xfffffffd,
+			LockTime:             maturityHeight,
+		},
+		ArtifactSignatures: []string{"0x090a"},
+		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
+		ScriptTemplate:     templateJSON,
+		Signing: covenantsigner.SigningRequirements{
+			SignerRequired:    true,
+			CustodianRequired: true,
+		},
+	}
+
+	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
+		RouteRequestID: "ors_qc_ready",
+		Stage:          covenantsigner.StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Status != covenantsigner.StepStatusReady {
+		t.Fatalf("expected READY, got %s", result.Status)
+	}
+	if result.Handoff == nil {
+		t.Fatal("expected handoff payload")
+	}
+	if result.TransactionHex != "" || result.PSBTHash != "" {
+		t.Fatalf("expected handoff-only result, got %#v", result)
+	}
+
+	handoffKind, ok := result.Handoff["kind"].(string)
+	if !ok || handoffKind != qcV1SignerHandoffKind {
+		t.Fatalf("unexpected handoff kind: %#v", result.Handoff["kind"])
+	}
+	if signerRequestID, ok := result.Handoff["signerRequestId"].(string); !ok || signerRequestID != result.RequestID {
+		t.Fatalf("unexpected signerRequestId: %#v", result.Handoff["signerRequestId"])
+	}
+	if requiresDummy, ok := result.Handoff["requiresDummy"].(bool); !ok || !requiresDummy {
+		t.Fatalf("unexpected requiresDummy: %#v", result.Handoff["requiresDummy"])
+	}
+	if sighashType, ok := result.Handoff["sighashType"].(uint32); !ok || sighashType != uint32(txscript.SigHashAll) {
+		t.Fatalf("unexpected sighashType: %#v", result.Handoff["sighashType"])
+	}
+
+	selectorWitnessItems, ok := result.Handoff["selectorWitnessItems"].([]string)
+	if !ok {
+		t.Fatalf("unexpected selector witness items type: %#v", result.Handoff["selectorWitnessItems"])
+	}
+	if len(selectorWitnessItems) != 2 || selectorWitnessItems[0] != "0x01" || selectorWitnessItems[1] != "0x" {
+		t.Fatalf("unexpected selector witness items: %#v", selectorWitnessItems)
+	}
+
+	unsignedTransactionHex, ok := result.Handoff["unsignedTransactionHex"].(string)
+	if !ok || unsignedTransactionHex == "" {
+		t.Fatalf("unexpected unsignedTransactionHex: %#v", result.Handoff["unsignedTransactionHex"])
+	}
+	unsignedTransactionBytes, err := hex.DecodeString(strings.TrimPrefix(unsignedTransactionHex, "0x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsignedTransaction := &bitcoin.Transaction{}
+	if err := unsignedTransaction.Deserialize(unsignedTransactionBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	if unsignedTransaction.Locktime != uint32(maturityHeight) {
+		t.Fatalf("unexpected locktime: %d", unsignedTransaction.Locktime)
+	}
+	if len(unsignedTransaction.Inputs) != 1 {
+		t.Fatalf("unexpected input count: %d", len(unsignedTransaction.Inputs))
+	}
+	if unsignedTransaction.Inputs[0].Sequence != 0xfffffffd {
+		t.Fatalf("unexpected input sequence: %x", unsignedTransaction.Inputs[0].Sequence)
+	}
+	if len(unsignedTransaction.Outputs) != 2 {
+		t.Fatalf("unexpected output count: %d", len(unsignedTransaction.Outputs))
+	}
+	if unsignedTransaction.Outputs[0].Value != int64(destinationValueSats) {
+		t.Fatalf("unexpected destination value: %d", unsignedTransaction.Outputs[0].Value)
+	}
+	if !bytes.Equal(unsignedTransaction.Outputs[0].PublicKeyScript, destinationScript) {
+		t.Fatal("unexpected destination output script")
+	}
+
+	expectedAnchorScript, err := canonicalAnchorScriptPubKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unsignedTransaction.Outputs[1].Value != int64(anchorValueSats) {
+		t.Fatalf("unexpected anchor value: %d", unsignedTransaction.Outputs[1].Value)
+	}
+	if !bytes.Equal(unsignedTransaction.Outputs[1].PublicKeyScript, expectedAnchorScript) {
+		t.Fatal("unexpected anchor output script")
+	}
+
+	witnessScriptHex, ok := result.Handoff["witnessScript"].(string)
+	if !ok || witnessScriptHex == "" {
+		t.Fatalf("unexpected witnessScript: %#v", result.Handoff["witnessScript"])
+	}
+	if witnessScriptHex != "0x"+hex.EncodeToString(witnessScript) {
+		t.Fatalf("unexpected witness script hex: %s", witnessScriptHex)
+	}
+
+	signatureHex, ok := result.Handoff["signerSignature"].(string)
+	if !ok || signatureHex == "" {
+		t.Fatalf("unexpected signerSignature: %#v", result.Handoff["signerSignature"])
+	}
+	signatureBytes, err := hex.DecodeString(strings.TrimPrefix(signatureHex, "0x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(signatureBytes) == 0 || signatureBytes[len(signatureBytes)-1] != byte(txscript.SigHashAll) {
+		t.Fatal("unexpected sighash type in handoff signature")
+	}
+
+	wireTransaction := wire.NewMsgTx(wire.TxVersion)
+	if err := wireTransaction.Deserialize(bytes.NewReader(unsignedTransaction.Serialize(bitcoin.Standard))); err != nil {
+		t.Fatal(err)
+	}
+	sighashBytes, err := txscript.CalcWitnessSigHash(
+		witnessScript,
+		txscript.NewTxSigHashes(wireTransaction),
+		txscript.SigHashAll,
+		wireTransaction,
+		0,
+		int64(inputValueSats),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedSignature, err := btcec.ParseDERSignature(signatureBytes[:len(signatureBytes)-1], btcec.S256())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ecdsa.Verify(walletPublicKey, sighashBytes, parsedSignature.R, parsedSignature.S) {
+		t.Fatal("invalid qc_v1 signer handoff signature")
+	}
+
+	expectedPayloadHash, err := computeQcV1SignerHandoffPayloadHash(map[string]any{
+		"kind":                      qcV1SignerHandoffKind,
+		"unsignedTransactionHex":    unsignedTransactionHex,
+		"witnessScript":             witnessScriptHex,
+		"signerSignature":           signatureHex,
+		"selectorWitnessItems":      selectorWitnessItems,
+		"requiresDummy":             true,
+		"sighashType":               uint32(txscript.SigHashAll),
+		"destinationCommitmentHash": request.DestinationCommitmentHash,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if payloadHash, ok := result.Handoff["payloadHash"].(string); !ok || payloadHash != expectedPayloadHash {
+		t.Fatalf("unexpected payloadHash: %#v", result.Handoff["payloadHash"])
+	}
+	if bundleID, ok := result.Handoff["bundleId"].(string); !ok || bundleID != expectedPayloadHash {
+		t.Fatalf("unexpected bundleId: %#v", result.Handoff["bundleId"])
+	}
+	if destinationCommitmentHash, ok := result.Handoff["destinationCommitmentHash"].(string); !ok || destinationCommitmentHash != request.DestinationCommitmentHash {
+		t.Fatalf("unexpected destinationCommitmentHash: %#v", result.Handoff["destinationCommitmentHash"])
+	}
+}
+
 func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T) {
 	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
 
@@ -402,8 +678,8 @@ func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T
 	}
 }
 
-func TestValidateSelfV1OutputValues_RejectsValuesExceedingInt64(t *testing.T) {
-	err := validateSelfV1OutputValues(covenantsigner.RouteSubmitRequest{
+func TestValidateMigrationOutputValues_RejectsValuesExceedingInt64(t *testing.T) {
+	err := validateMigrationOutputValues(covenantsigner.RouteSubmitRequest{
 		MigrationTransactionPlan: &covenantsigner.MigrationTransactionPlan{
 			DestinationValueSats: uint64(math.MaxInt64) + 1,
 			AnchorValueSats:      330,


### PR DESCRIPTION
## Summary
- add a real qc_v1 signer path in keep-core that produces signer handoff bundles
- build and sign the canonical unsigned migration spend, then return a typed handoff instead of a final artifact
- cover the new handoff path with direct pkg/tbtc tests

## Testing
- go test ./pkg/tbtc -run focused covenant signer tests
- go test ./pkg/bitcoin ./pkg/covenantsigner ./config ./cmd