### PR TITLE
[PSBT Covenant] Harden covenant signer service exposure

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -332,6 +332,12 @@ func initCovenantSignerFlags(cmd *cobra.Command, cfg *config.Config) {
 		covenantsigner.Config{}.AuthToken,
 		"Covenant signer provider static Bearer auth token. Required for non-loopback binds; prefer config file or env var over CLI in production.",
 	)
+	cmd.Flags().BoolVar(
+		&cfg.CovenantSigner.EnableSelfV1,
+		"covenantSigner.enableSelfV1",
+		false,
+		"Expose self_v1 covenant signer HTTP routes. Keep disabled for a qc_v1-first launch unless self_v1 is explicitly approved.",
+	)
 }
 
 // Initialize flags for Maintainer configuration.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -320,6 +320,18 @@ func initCovenantSignerFlags(cmd *cobra.Command, cfg *config.Config) {
 		covenantsigner.Config{}.Port,
 		"Covenant signer provider HTTP server listening port. Zero disables the service.",
 	)
+	cmd.Flags().StringVar(
+		&cfg.CovenantSigner.ListenAddress,
+		"covenantSigner.listenAddress",
+		covenantsigner.DefaultListenAddress,
+		"Covenant signer provider HTTP listen address. Defaults to loopback-only.",
+	)
+	cmd.Flags().StringVar(
+		&cfg.CovenantSigner.AuthToken,
+		"covenantSigner.authToken",
+		covenantsigner.Config{}.AuthToken,
+		"Covenant signer provider static Bearer auth token. Required for non-loopback binds; prefer config file or env var over CLI in production.",
+	)
 }
 
 // Initialize flags for Maintainer configuration.

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -212,6 +212,13 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: "secret-token",
 		defaultValue:          "",
 	},
+	"covenantSigner.enableSelfV1": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.CovenantSigner.EnableSelfV1 },
+		flagName:              "--covenantSigner.enableSelfV1",
+		flagValue:             "",
+		expectedValueFromFlag: true,
+		defaultValue:          false,
+	},
 	"tbtc.preParamsPoolSize": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsPoolSize },
 		flagName:              "--tbtc.preParamsPoolSize",

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -22,6 +22,7 @@ import (
 	ethereumEcdsa "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen"
 	ethereumTbtc "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen"
 	ethereumThreshold "github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 )
 
 var cmdFlagsTests = map[string]struct {
@@ -196,6 +197,20 @@ var cmdFlagsTests = map[string]struct {
 		flagValue:             "9711",
 		expectedValueFromFlag: 9711,
 		defaultValue:          0,
+	},
+	"covenantSigner.listenAddress": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.CovenantSigner.ListenAddress },
+		flagName:              "--covenantSigner.listenAddress",
+		flagValue:             "0.0.0.0",
+		expectedValueFromFlag: "0.0.0.0",
+		defaultValue:          covenantsigner.DefaultListenAddress,
+	},
+	"covenantSigner.authToken": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.CovenantSigner.AuthToken },
+		flagName:              "--covenantSigner.authToken",
+		flagValue:             "secret-token",
+		expectedValueFromFlag: "secret-token",
+		defaultValue:          "",
 	},
 	"tbtc.preParamsPoolSize": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.PreParamsPoolSize },

--- a/pkg/covenantsigner/config.go
+++ b/pkg/covenantsigner/config.go
@@ -12,4 +12,7 @@ type Config struct {
 	// AuthToken enables static Bearer authentication for signer endpoints.
 	// Non-loopback binds must set this.
 	AuthToken string
+	// EnableSelfV1 exposes the self_v1 signer HTTP routes. Keep this disabled
+	// for a qc_v1-first launch unless self_v1 has cleared its own go-live gate.
+	EnableSelfV1 bool
 }

--- a/pkg/covenantsigner/config.go
+++ b/pkg/covenantsigner/config.go
@@ -1,7 +1,15 @@
 package covenantsigner
 
+const DefaultListenAddress = "127.0.0.1"
+
 // Config configures the covenant signer HTTP service.
 type Config struct {
 	// Port enables the covenant signer provider HTTP surface when non-zero.
 	Port int
+	// ListenAddress controls which interface the covenant signer HTTP service
+	// binds to. Empty defaults to loopback-only.
+	ListenAddress string
+	// AuthToken enables static Bearer authentication for signer endpoints.
+	// Non-loopback binds must set this.
+	AuthToken string
 }

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -210,6 +210,87 @@ func TestServiceSubmitDeduplicatesByRouteRequestID(t *testing.T) {
 	}
 }
 
+func TestServiceSubmitReturnsExistingJobWhileInitialEngineCallIsInFlight(t *testing.T) {
+	handle := newMemoryHandle()
+	engineStarted := make(chan struct{})
+	releaseEngine := make(chan struct{})
+
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			select {
+			case <-engineStarted:
+			default:
+				close(engineStarted)
+			}
+
+			<-releaseEngine
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := SignerSubmitInput{
+		RouteRequestID: "ors_inflight",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	}
+
+	firstResultChan := make(chan StepResult, 1)
+	firstErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Submit(context.Background(), TemplateSelfV1, input)
+		if err != nil {
+			firstErrChan <- err
+			return
+		}
+
+		firstResultChan <- result
+	}()
+
+	<-engineStarted
+
+	secondResultChan := make(chan StepResult, 1)
+	secondErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Submit(context.Background(), TemplateSelfV1, input)
+		if err != nil {
+			secondErrChan <- err
+			return
+		}
+
+		secondResultChan <- result
+	}()
+
+	var secondResult StepResult
+	select {
+	case err := <-secondErrChan:
+		t.Fatal(err)
+	case secondResult = <-secondResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected deduplicated submit to return while initial engine call is in flight")
+	}
+
+	close(releaseEngine)
+
+	var firstResult StepResult
+	select {
+	case err := <-firstErrChan:
+		t.Fatal(err)
+	case firstResult = <-firstResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected initial submit to finish after engine release")
+	}
+
+	if firstResult.RequestID == "" {
+		t.Fatal("expected durable request id on initial submit")
+	}
+	if firstResult.RequestID != secondResult.RequestID {
+		t.Fatalf("expected in-flight dedupe to reuse request id, got %s vs %s", firstResult.RequestID, secondResult.RequestID)
+	}
+}
+
 func TestServicePollCanTransitionToReady(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -627,7 +708,7 @@ func TestServerHandlesSubmitAndPathPoll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service))
+	server := httptest.NewServer(newHandler(service, ""))
 	defer server.Close()
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
@@ -681,7 +762,7 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service))
+	server := httptest.NewServer(newHandler(service, ""))
 	defer server.Close()
 
 	payload := bytes.NewBufferString(`{
@@ -748,15 +829,101 @@ func TestInitializeRejectsInvalidOrUnavailablePort(t *testing.T) {
 	if _, enabled, err := Initialize(ctx, Config{Port: -1}, handle, nil); err == nil || enabled {
 		t.Fatalf("expected invalid negative port to fail, got enabled=%v err=%v", enabled, err)
 	}
+	if _, enabled, err := Initialize(
+		ctx,
+		Config{Port: 9711, ListenAddress: "0.0.0.0"},
+		handle,
+		nil,
+	); err == nil || enabled {
+		t.Fatalf("expected non-loopback bind without auth token to fail, got enabled=%v err=%v", enabled, err)
+	}
 
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", net.JoinHostPort(DefaultListenAddress, "0"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer listener.Close()
 
 	port := listener.Addr().(*net.TCPAddr).Port
-	if _, enabled, err := Initialize(ctx, Config{Port: port}, handle, nil); err == nil || enabled {
+	if _, enabled, err := Initialize(
+		ctx,
+		Config{Port: port, ListenAddress: DefaultListenAddress},
+		handle,
+		nil,
+	); err == nil || enabled {
 		t.Fatalf("expected occupied port to fail, got enabled=%v err=%v", enabled, err)
+	}
+}
+
+func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, "test-token"))
+	defer server.Close()
+
+	submitPayload := mustJSON(t, SignerSubmitInput{
+		RouteRequestID: "ors_http_auth",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+
+	response, err := http.Get(server.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected healthz status: %d", response.StatusCode)
+	}
+
+	request, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/self_v1/signer/requests",
+		bytes.NewReader(submitPayload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected unauthorized submit without bearer token, got %d %s", response.StatusCode, string(body))
+	}
+
+	authorizedRequest, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/self_v1/signer/requests",
+		bytes.NewReader(submitPayload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizedRequest.Header.Set("Content-Type", "application/json")
+	authorizedRequest.Header.Set("Authorization", "Bearer test-token")
+
+	authorizedResponse, err := http.DefaultClient.Do(authorizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer authorizedResponse.Body.Close()
+
+	if authorizedResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(authorizedResponse.Body)
+		t.Fatalf("unexpected authorized submit status: %d %s", authorizedResponse.StatusCode, string(body))
 	}
 }

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -299,6 +299,245 @@ func TestServiceSubmitReturnsExistingJobWhileInitialEngineCallIsInFlight(t *test
 	}
 }
 
+func TestServicePollReturnsNewerPersistedStateWhenItsTransitionBecomesStale(t *testing.T) {
+	handle := newMemoryHandle()
+	submitStarted := make(chan struct{})
+	releaseSubmit := make(chan struct{})
+	pollStarted := make(chan struct{})
+	releasePoll := make(chan struct{})
+
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			select {
+			case <-submitStarted:
+			default:
+				close(submitStarted)
+			}
+
+			<-releaseSubmit
+			return &Transition{
+				State:          JobStateArtifactReady,
+				Detail:         "artifact ready",
+				PSBTHash:       "0x090a",
+				TransactionHex: "0x0b0c",
+			}, nil
+		},
+		poll: func(*Job) (*Transition, error) {
+			select {
+			case <-pollStarted:
+			default:
+				close(pollStarted)
+			}
+
+			<-releasePoll
+			return &Transition{State: JobStatePending, Detail: "stale pending"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := SignerSubmitInput{
+		RouteRequestID: "ors_poll_stale_pending",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	}
+
+	submitResultChan := make(chan StepResult, 1)
+	submitErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Submit(context.Background(), TemplateSelfV1, input)
+		if err != nil {
+			submitErrChan <- err
+			return
+		}
+
+		submitResultChan <- result
+	}()
+
+	<-submitStarted
+
+	storedJob, ok, err := service.store.GetByRouteRequest(TemplateSelfV1, input.RouteRequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected submitted job to exist while submit engine is in flight")
+	}
+
+	pollResultChan := make(chan StepResult, 1)
+	pollErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Poll(context.Background(), TemplateSelfV1, SignerPollInput{
+			RouteRequestID: input.RouteRequestID,
+			RequestID:      storedJob.RequestID,
+			Stage:          StageSignerCoordination,
+			Request:        input.Request,
+		})
+		if err != nil {
+			pollErrChan <- err
+			return
+		}
+
+		pollResultChan <- result
+	}()
+
+	<-pollStarted
+	close(releaseSubmit)
+
+	var submitResult StepResult
+	select {
+	case err := <-submitErrChan:
+		t.Fatal(err)
+	case submitResult = <-submitResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected submit to finish after engine release")
+	}
+
+	close(releasePoll)
+
+	var pollResult StepResult
+	select {
+	case err := <-pollErrChan:
+		t.Fatal(err)
+	case pollResult = <-pollResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected poll to finish after release")
+	}
+
+	if pollResult.Status != StepStatusReady {
+		t.Fatalf("expected stale poll to return latest READY state, got %#v", pollResult)
+	}
+	if pollResult.PSBTHash != submitResult.PSBTHash || pollResult.TransactionHex != submitResult.TransactionHex {
+		t.Fatalf("expected poll to return persisted READY payload, got submit=%#v poll=%#v", submitResult, pollResult)
+	}
+
+	persistedJob, ok, err := service.store.GetByRequestID(storedJob.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected persisted job after stale poll")
+	}
+	if persistedJob.State != JobStateArtifactReady {
+		t.Fatalf("expected persisted READY state, got %s", persistedJob.State)
+	}
+}
+
+func TestServicePollDoesNotOverwriteNewerPersistedStateWithJobNotFound(t *testing.T) {
+	handle := newMemoryHandle()
+	submitStarted := make(chan struct{})
+	releaseSubmit := make(chan struct{})
+	pollStarted := make(chan struct{})
+	releasePoll := make(chan struct{})
+
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			select {
+			case <-submitStarted:
+			default:
+				close(submitStarted)
+			}
+
+			<-releaseSubmit
+			return &Transition{
+				State:          JobStateArtifactReady,
+				Detail:         "artifact ready",
+				PSBTHash:       "0x0d0e",
+				TransactionHex: "0x0f10",
+			}, nil
+		},
+		poll: func(*Job) (*Transition, error) {
+			select {
+			case <-pollStarted:
+			default:
+				close(pollStarted)
+			}
+
+			<-releasePoll
+			return nil, errJobNotFound
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := SignerSubmitInput{
+		RouteRequestID: "ors_poll_stale_missing",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	}
+
+	submitResultChan := make(chan StepResult, 1)
+	submitErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Submit(context.Background(), TemplateSelfV1, input)
+		if err != nil {
+			submitErrChan <- err
+			return
+		}
+
+		submitResultChan <- result
+	}()
+
+	<-submitStarted
+
+	storedJob, ok, err := service.store.GetByRouteRequest(TemplateSelfV1, input.RouteRequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected submitted job to exist while submit engine is in flight")
+	}
+
+	pollResultChan := make(chan StepResult, 1)
+	pollErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Poll(context.Background(), TemplateSelfV1, SignerPollInput{
+			RouteRequestID: input.RouteRequestID,
+			RequestID:      storedJob.RequestID,
+			Stage:          StageSignerCoordination,
+			Request:        input.Request,
+		})
+		if err != nil {
+			pollErrChan <- err
+			return
+		}
+
+		pollResultChan <- result
+	}()
+
+	<-pollStarted
+	close(releaseSubmit)
+
+	var submitResult StepResult
+	select {
+	case err := <-submitErrChan:
+		t.Fatal(err)
+	case submitResult = <-submitResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected submit to finish after engine release")
+	}
+
+	close(releasePoll)
+
+	var pollResult StepResult
+	select {
+	case err := <-pollErrChan:
+		t.Fatal(err)
+	case pollResult = <-pollResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected poll to finish after release")
+	}
+
+	if pollResult.Status != StepStatusReady {
+		t.Fatalf("expected stale job-not-found poll to return latest READY state, got %#v", pollResult)
+	}
+	if pollResult.PSBTHash != submitResult.PSBTHash || pollResult.TransactionHex != submitResult.TransactionHex {
+		t.Fatalf("expected poll to return persisted READY payload, got submit=%#v poll=%#v", submitResult, pollResult)
+	}
+}
+
 func TestServicePollCanTransitionToReady(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -633,9 +872,16 @@ func TestServiceRejectsInvalidMigrationTransactionPlanVariants(t *testing.T) {
 		{
 			name: "locktime mismatch",
 			mutate: func(request *RouteSubmitRequest) {
-				request.MigrationTransactionPlan.LockTime = request.MaturityHeight + 1
+				request.MigrationTransactionPlan.LockTime = uint32(request.MaturityHeight + 1)
 			},
 			expectErr: "request.migrationTransactionPlan.lockTime must match request.maturityHeight",
+		},
+		{
+			name: "maturity height exceeds uint32",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MaturityHeight = 0x1_0000_0000
+			},
+			expectErr: "request.maturityHeight must fit in uint32",
 		},
 		{
 			name: "insufficient input for destination",
@@ -714,32 +960,86 @@ func TestServiceRejectsMigrationTransactionPlanBoundToDifferentDestinationCommit
 	}
 }
 
-func TestMigrationTransactionPlanCommitmentHashMatchesCanonicalVector(t *testing.T) {
-	request := RouteSubmitRequest{
-		Reserve:                   "0x2000000000000000000000000000000000000002",
-		Epoch:                     12,
-		ActiveOutpoint:            CovenantOutpoint{TxID: "0x1111111111111111111111111111111111111111111111111111111111111111", Vout: 1},
-		DestinationCommitmentHash: "0xf1b1739d99ea890ea6d419d6db28f4d5fe0871c32619a0984c1bfdbe4025f768",
-	}
-	plan := &MigrationTransactionPlan{
-		PlanVersion:          migrationTransactionPlanVersion,
-		PlanCommitmentHash:   "0x0000000000000000000000000000000000000000000000000000000000000000",
-		InputValueSats:       1_000_000,
-		DestinationValueSats: 998_000,
-		AnchorValueSats:      canonicalAnchorValueSats,
-		FeeSats:              1_670,
-		InputSequence:        canonicalCovenantInputSequence,
-		LockTime:             950000,
+func TestMigrationTransactionPlanCommitmentHashMatchesCanonicalVectors(t *testing.T) {
+	testCases := []struct {
+		name     string
+		request  RouteSubmitRequest
+		plan     *MigrationTransactionPlan
+		expected string
+	}{
+		{
+			name: "canonical cross-stack vector",
+			request: RouteSubmitRequest{
+				Reserve:                   "0x2000000000000000000000000000000000000002",
+				Epoch:                     12,
+				ActiveOutpoint:            CovenantOutpoint{TxID: "0x1111111111111111111111111111111111111111111111111111111111111111", Vout: 1},
+				DestinationCommitmentHash: "0xf1b1739d99ea890ea6d419d6db28f4d5fe0871c32619a0984c1bfdbe4025f768",
+			},
+			plan: &MigrationTransactionPlan{
+				PlanVersion:          migrationTransactionPlanVersion,
+				PlanCommitmentHash:   "0x0000000000000000000000000000000000000000000000000000000000000000",
+				InputValueSats:       1_000_000,
+				DestinationValueSats: 998_000,
+				AnchorValueSats:      canonicalAnchorValueSats,
+				FeeSats:              1_670,
+				InputSequence:        canonicalCovenantInputSequence,
+				LockTime:             950000,
+			},
+			expected: "0x8dcafe57b888040d644e80dfd1b8b089dfd5016205d78316549ef71d032070f2",
+		},
+		{
+			name: "mixed-case hex inputs normalize before hashing",
+			request: RouteSubmitRequest{
+				Reserve:                   "0xAbCd00000000000000000000000000000000Ef01",
+				Epoch:                     0,
+				ActiveOutpoint:            CovenantOutpoint{TxID: "0xAaBbCcDdAaBbCcDdAaBbCcDdAaBbCcDdAaBbCcDdAaBbCcDdAaBbCcDdAaBbCcDd", Vout: 0},
+				DestinationCommitmentHash: "0xFfEeDdCcBbAa00998877665544332211FfEeDdCcBbAa00998877665544332211",
+			},
+			plan: &MigrationTransactionPlan{
+				PlanVersion:          migrationTransactionPlanVersion,
+				PlanCommitmentHash:   "0x0000000000000000000000000000000000000000000000000000000000000000",
+				InputValueSats:       100_000,
+				DestinationValueSats: 99_300,
+				AnchorValueSats:      canonicalAnchorValueSats,
+				FeeSats:              370,
+				InputSequence:        canonicalCovenantInputSequence,
+				LockTime:             1,
+			},
+			expected: "0x626ce76714e04a41a5ec06a96082cac2ebd4d8f687fdc77766ffd9c0d11dac14",
+		},
+		{
+			name: "max uint32 fields and large safe integer amounts remain stable",
+			request: RouteSubmitRequest{
+				Reserve:                   "0x9999999999999999999999999999999999999999",
+				Epoch:                     4294967295,
+				ActiveOutpoint:            CovenantOutpoint{TxID: "0x0000000000000000000000000000000000000000000000000000000000000001", Vout: 4294967295},
+				DestinationCommitmentHash: "0x00000000000000000000000000000000000000000000000000000000000000aa",
+			},
+			plan: &MigrationTransactionPlan{
+				PlanVersion:          migrationTransactionPlanVersion,
+				PlanCommitmentHash:   "0x0000000000000000000000000000000000000000000000000000000000000000",
+				InputValueSats:       9_007_199_254_740_000,
+				DestinationValueSats: 9_007_199_254_737_000,
+				AnchorValueSats:      canonicalAnchorValueSats,
+				FeeSats:              2670,
+				InputSequence:        canonicalCovenantInputSequence,
+				LockTime:             0xffffffff,
+			},
+			expected: "0x42983bef3abb9680093ca0254c780c6ed4e6178405649bf1846ebb381ca89e02",
+		},
 	}
 
-	actual, err := computeMigrationTransactionPlanCommitmentHash(request, plan)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := computeMigrationTransactionPlanCommitmentHash(testCase.request, testCase.plan)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	expected := "0x8dcafe57b888040d644e80dfd1b8b089dfd5016205d78316549ef71d032070f2"
-	if actual != expected {
-		t.Fatalf("unexpected plan commitment hash: %s", actual)
+			if actual != testCase.expected {
+				t.Fatalf("unexpected plan commitment hash: %s", actual)
+			}
+		})
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -132,6 +133,7 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 		DestinationCommitmentHash: migrationDestination.DestinationCommitmentHash,
 		MigrationDestination:      migrationDestination,
 		MigrationTransactionPlan: &MigrationTransactionPlan{
+			PlanVersion:          migrationTransactionPlanVersion,
 			InputValueSats:       1000000,
 			DestinationValueSats: 998000,
 			AnchorValueSats:      canonicalAnchorValueSats,
@@ -151,6 +153,12 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 		request.ScriptTemplate = validQcTemplate()
 		request.Signing = SigningRequirements{SignerRequired: true, CustodianRequired: true}
 	}
+
+	request.MigrationTransactionPlan.PlanCommitmentHash, _ =
+		computeMigrationTransactionPlanCommitmentHash(
+			request,
+			request.MigrationTransactionPlan,
+		)
 
 	return request
 }
@@ -581,6 +589,20 @@ func TestServiceRejectsInvalidMigrationTransactionPlanVariants(t *testing.T) {
 			expectErr: "request.migrationTransactionPlan is required",
 		},
 		{
+			name: "missing plan version",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.PlanVersion = 0
+			},
+			expectErr: "request.migrationTransactionPlan.planVersion must equal 1",
+		},
+		{
+			name: "wrong commitment hash",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.PlanCommitmentHash = ""
+			},
+			expectErr: "request.migrationTransactionPlan.planCommitmentHash must be a 0x-prefixed even-length hex string",
+		},
+		{
 			name: "zero input value",
 			mutate: func(request *RouteSubmitRequest) {
 				request.MigrationTransactionPlan.InputValueSats = 0
@@ -630,6 +652,13 @@ func TestServiceRejectsInvalidMigrationTransactionPlanVariants(t *testing.T) {
 			expectErr: "request.migrationTransactionPlan.inputValueSats must cover anchorValueSats",
 		},
 		{
+			name: "tampered commitment hash",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.PlanCommitmentHash = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+			},
+			expectErr: "request.migrationTransactionPlan.planCommitmentHash does not match canonical migration transaction plan",
+		},
+		{
 			name: "accounting mismatch",
 			mutate: func(request *RouteSubmitRequest) {
 				request.MigrationTransactionPlan.FeeSats++
@@ -652,6 +681,65 @@ func TestServiceRejectsInvalidMigrationTransactionPlanVariants(t *testing.T) {
 				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
 			}
 		})
+	}
+}
+
+func TestServiceRejectsMigrationTransactionPlanBoundToDifferentDestinationCommitment(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateSelfV1)
+
+	mutatedDestination := validMigrationDestination()
+	mutatedDestination.Revealer = "0x4444444444444444444444444444444444444444"
+	mutatedDestination.MigrationExtraData = computeMigrationExtraData(mutatedDestination.Revealer)
+	mutatedDestination.DestinationCommitmentHash, err = computeDestinationCommitmentHash(mutatedDestination)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request.DestinationCommitmentHash = mutatedDestination.DestinationCommitmentHash
+	request.MigrationDestination = mutatedDestination
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_invalid_plan_destination_binding",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(err.Error(), "request.migrationTransactionPlan.planCommitmentHash does not match canonical migration transaction plan") {
+		t.Fatalf("expected plan binding error, got %v", err)
+	}
+}
+
+func TestMigrationTransactionPlanCommitmentHashMatchesCanonicalVector(t *testing.T) {
+	request := RouteSubmitRequest{
+		Reserve:                   "0x2000000000000000000000000000000000000002",
+		Epoch:                     12,
+		ActiveOutpoint:            CovenantOutpoint{TxID: "0x1111111111111111111111111111111111111111111111111111111111111111", Vout: 1},
+		DestinationCommitmentHash: "0xf1b1739d99ea890ea6d419d6db28f4d5fe0871c32619a0984c1bfdbe4025f768",
+	}
+	plan := &MigrationTransactionPlan{
+		PlanVersion:          migrationTransactionPlanVersion,
+		PlanCommitmentHash:   "0x0000000000000000000000000000000000000000000000000000000000000000",
+		InputValueSats:       1_000_000,
+		DestinationValueSats: 998_000,
+		AnchorValueSats:      canonicalAnchorValueSats,
+		FeeSats:              1_670,
+		InputSequence:        canonicalCovenantInputSequence,
+		LockTime:             950000,
+	}
+
+	actual, err := computeMigrationTransactionPlanCommitmentHash(request, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "0x8dcafe57b888040d644e80dfd1b8b089dfd5016205d78316549ef71d032070f2"
+	if actual != expected {
+		t.Fatalf("unexpected plan commitment hash: %s", actual)
 	}
 }
 
@@ -765,7 +853,8 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 	server := httptest.NewServer(newHandler(service, ""))
 	defer server.Close()
 
-	payload := bytes.NewBufferString(`{
+	base := baseRequest(TemplateSelfV1)
+	payload := bytes.NewBufferString(fmt.Sprintf(`{
 		"routeRequestId":"ors_http_unknown",
 		"stage":"SIGNER_COORDINATION",
 		"request":{
@@ -777,7 +866,7 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 			"epoch":12,
 			"maturityHeight":912345,
 			"activeOutpoint":{"txid":"0x0102","vout":1,"scriptHash":"0x0304"},
-			"destinationCommitmentHash":"0x3efc50372759413e0f1900a2340fbb947648c524e5ec3cb4cf8887ea2d7df474",
+			"destinationCommitmentHash":"%s",
 			"migrationDestination":{
 				"reservationId":"cmdr_12345678",
 				"reserve":"0x1111111111111111111111111111111111111111",
@@ -790,9 +879,11 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 				"depositScript":"0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"depositScriptHash":"0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
 				"migrationExtraData":"0x41435f4d49475241544556312222222222222222222222222222222222222222",
-				"destinationCommitmentHash":"0x3efc50372759413e0f1900a2340fbb947648c524e5ec3cb4cf8887ea2d7df474"
+				"destinationCommitmentHash":"%s"
 			},
 			"migrationTransactionPlan":{
+				"planVersion":1,
+				"planCommitmentHash":"%s",
 				"inputValueSats":1000000,
 				"destinationValueSats":998000,
 				"anchorValueSats":330,
@@ -807,7 +898,7 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 			"futureField":"ignored"
 		},
 		"futureTopLevel":"ignored"
-	}`)
+	}`, base.DestinationCommitmentHash, base.DestinationCommitmentHash, base.MigrationTransactionPlan.PlanCommitmentHash))
 
 	response, err := http.Post(server.URL+"/v1/self_v1/signer/requests", "application/json", payload)
 	if err != nil {

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -424,6 +424,131 @@ func TestServicePollReturnsNewerPersistedStateWhenItsTransitionBecomesStale(t *t
 	}
 }
 
+func TestServiceSubmitReturnsNewerPersistedStateWhenItsTransitionBecomesStale(t *testing.T) {
+	handle := newMemoryHandle()
+	submitStarted := make(chan struct{})
+	releaseSubmit := make(chan struct{})
+	pollStarted := make(chan struct{})
+	releasePoll := make(chan struct{})
+
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			select {
+			case <-submitStarted:
+			default:
+				close(submitStarted)
+			}
+
+			<-releaseSubmit
+			return &Transition{State: JobStatePending, Detail: "stale pending"}, nil
+		},
+		poll: func(*Job) (*Transition, error) {
+			select {
+			case <-pollStarted:
+			default:
+				close(pollStarted)
+			}
+
+			<-releasePoll
+			return &Transition{
+				State:          JobStateArtifactReady,
+				Detail:         "artifact ready",
+				PSBTHash:       "0x090a",
+				TransactionHex: "0x0b0c",
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := SignerSubmitInput{
+		RouteRequestID: "ors_submit_stale_pending",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	}
+
+	submitResultChan := make(chan StepResult, 1)
+	submitErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Submit(context.Background(), TemplateSelfV1, input)
+		if err != nil {
+			submitErrChan <- err
+			return
+		}
+
+		submitResultChan <- result
+	}()
+
+	<-submitStarted
+
+	storedJob, ok, err := service.store.GetByRouteRequest(TemplateSelfV1, input.RouteRequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected submitted job to exist while submit engine is in flight")
+	}
+
+	pollResultChan := make(chan StepResult, 1)
+	pollErrChan := make(chan error, 1)
+	go func() {
+		result, err := service.Poll(context.Background(), TemplateSelfV1, SignerPollInput{
+			RouteRequestID: input.RouteRequestID,
+			RequestID:      storedJob.RequestID,
+			Stage:          StageSignerCoordination,
+			Request:        input.Request,
+		})
+		if err != nil {
+			pollErrChan <- err
+			return
+		}
+
+		pollResultChan <- result
+	}()
+
+	<-pollStarted
+	close(releasePoll)
+
+	var pollResult StepResult
+	select {
+	case err := <-pollErrChan:
+		t.Fatal(err)
+	case pollResult = <-pollResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected poll to finish after release")
+	}
+
+	close(releaseSubmit)
+
+	var submitResult StepResult
+	select {
+	case err := <-submitErrChan:
+		t.Fatal(err)
+	case submitResult = <-submitResultChan:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected submit to finish after release")
+	}
+
+	if submitResult.Status != StepStatusReady {
+		t.Fatalf("expected stale submit to return latest READY state, got %#v", submitResult)
+	}
+	if submitResult.PSBTHash != pollResult.PSBTHash || submitResult.TransactionHex != pollResult.TransactionHex {
+		t.Fatalf("expected submit to return persisted READY payload, got submit=%#v poll=%#v", submitResult, pollResult)
+	}
+
+	persistedJob, ok, err := service.store.GetByRequestID(storedJob.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected persisted job after stale submit")
+	}
+	if persistedJob.State != JobStateArtifactReady {
+		t.Fatalf("expected persisted READY state, got %s", persistedJob.State)
+	}
+}
+
 func TestServicePollDoesNotOverwriteNewerPersistedStateWithJobNotFound(t *testing.T) {
 	handle := newMemoryHandle()
 	submitStarted := make(chan struct{})
@@ -856,6 +981,16 @@ func TestServiceRejectsInvalidMigrationTransactionPlanVariants(t *testing.T) {
 			expectErr: "request.migrationTransactionPlan.destinationValueSats must be greater than zero",
 		},
 		{
+			name: "zero fee",
+			mutate: func(request *RouteSubmitRequest) {
+				request.MigrationTransactionPlan.FeeSats = 0
+				request.MigrationTransactionPlan.DestinationValueSats =
+					request.MigrationTransactionPlan.InputValueSats -
+						request.MigrationTransactionPlan.AnchorValueSats
+			},
+			expectErr: "request.migrationTransactionPlan.feeSats must be greater than zero",
+		},
+		{
 			name: "wrong anchor value",
 			mutate: func(request *RouteSubmitRequest) {
 				request.MigrationTransactionPlan.AnchorValueSats = 331
@@ -1096,7 +1231,7 @@ func TestServerHandlesSubmitAndPathPoll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, ""))
+	server := httptest.NewServer(newHandler(service, "", true))
 	defer server.Close()
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
@@ -1150,7 +1285,7 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, ""))
+	server := httptest.NewServer(newHandler(service, "", true))
 	defer server.Close()
 
 	base := baseRequest(TemplateSelfV1)
@@ -1246,6 +1381,12 @@ func TestInitializeRejectsInvalidOrUnavailablePort(t *testing.T) {
 	}
 }
 
+func TestIsLoopbackListenAddressAcceptsBracketedIPv6Loopback(t *testing.T) {
+	if !isLoopbackListenAddress("[::1]") {
+		t.Fatal("expected bracketed IPv6 loopback address to be recognized")
+	}
+}
+
 func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -1257,7 +1398,7 @@ func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, "test-token"))
+	server := httptest.NewServer(newHandler(service, "test-token", true))
 	defer server.Close()
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
@@ -1316,5 +1457,58 @@ func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
 	if authorizedResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(authorizedResponse.Body)
 		t.Fatalf("unexpected authorized submit status: %d %s", authorizedResponse.StatusCode, string(body))
+	}
+}
+
+func TestServerCanKeepSelfV1RoutesDark(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, "", false))
+	defer server.Close()
+
+	response, err := http.Post(
+		server.URL+"/v1/self_v1/signer/requests",
+		"application/json",
+		bytes.NewReader(mustJSON(t, SignerSubmitInput{
+			RouteRequestID: "ors_http_self_dark",
+			Stage:          StageSignerCoordination,
+			Request:        baseRequest(TemplateSelfV1),
+		})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected disabled self_v1 route to return 404, got %d %s", response.StatusCode, string(body))
+	}
+
+	qcResponse, err := http.Post(
+		server.URL+"/v1/qc_v1/signer/requests",
+		"application/json",
+		bytes.NewReader(mustJSON(t, SignerSubmitInput{
+			RouteRequestID: "orq_http_qc",
+			Stage:          StageSignerCoordination,
+			Request:        baseRequest(TemplateQcV1),
+		})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer qcResponse.Body.Close()
+
+	if qcResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(qcResponse.Body)
+		t.Fatalf("expected qc_v1 route to remain available, got %d %s", qcResponse.StatusCode, string(body))
 	}
 }

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -57,7 +57,7 @@ func Initialize(
 		service: service,
 		httpServer: &http.Server{
 			Addr:              net.JoinHostPort(listenAddress, strconv.Itoa(config.Port)),
-			Handler:           newHandler(service, config.AuthToken),
+			Handler:           newHandler(service, config.AuthToken, config.EnableSelfV1),
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 	}
@@ -85,15 +85,16 @@ func Initialize(
 	}()
 
 	logger.Infof(
-		"enabled covenant signer provider endpoint on [%v] auth=[%v]",
+		"enabled covenant signer provider endpoint on [%v] auth=[%v] self_v1=[%v]",
 		server.httpServer.Addr,
 		strings.TrimSpace(config.AuthToken) != "",
+		config.EnableSelfV1,
 	)
 
 	return server, true, nil
 }
 
-func newHandler(service *Service, authToken string) http.Handler {
+func newHandler(service *Service, authToken string, enableSelfV1 bool) http.Handler {
 	mux := http.NewServeMux()
 	protectedHandler := withBearerAuth(mux, authToken)
 
@@ -103,12 +104,14 @@ func newHandler(service *Service, authToken string) http.Handler {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	mux.HandleFunc("POST /v1/self_v1/signer/requests", submitHandler(service, TemplateSelfV1))
 	mux.HandleFunc("POST /v1/qc_v1/signer/requests", submitHandler(service, TemplateQcV1))
-	mux.HandleFunc("POST /v1/self_v1/signer/requests:poll", pollBodyHandler(service, TemplateSelfV1))
 	mux.HandleFunc("POST /v1/qc_v1/signer/requests:poll", pollBodyHandler(service, TemplateQcV1))
-	mux.HandleFunc("/v1/self_v1/signer/requests/", pollPathHandler(service, TemplateSelfV1))
 	mux.HandleFunc("/v1/qc_v1/signer/requests/", pollPathHandler(service, TemplateQcV1))
+	if enableSelfV1 {
+		mux.HandleFunc("POST /v1/self_v1/signer/requests", submitHandler(service, TemplateSelfV1))
+		mux.HandleFunc("POST /v1/self_v1/signer/requests:poll", pollBodyHandler(service, TemplateSelfV1))
+		mux.HandleFunc("/v1/self_v1/signer/requests/", pollPathHandler(service, TemplateSelfV1))
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" {
@@ -126,7 +129,12 @@ func isLoopbackListenAddress(address string) bool {
 		return true
 	}
 
-	ip := net.ParseIP(trimmedAddress)
+	normalizedAddress := trimmedAddress
+	if strings.HasPrefix(normalizedAddress, "[") && strings.HasSuffix(normalizedAddress, "]") {
+		normalizedAddress = normalizedAddress[1 : len(normalizedAddress)-1]
+	}
+
+	ip := net.ParseIP(normalizedAddress)
 	return ip != nil && ip.IsLoopback()
 }
 

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -2,11 +2,13 @@ package covenantsigner
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +36,18 @@ func Initialize(
 		return nil, false, fmt.Errorf("invalid covenant signer port [%d]", config.Port)
 	}
 
+	listenAddress := config.ListenAddress
+	if strings.TrimSpace(listenAddress) == "" {
+		listenAddress = DefaultListenAddress
+	}
+
+	if !isLoopbackListenAddress(listenAddress) && strings.TrimSpace(config.AuthToken) == "" {
+		return nil, false, fmt.Errorf(
+			"covenant signer authToken is required for non-loopback listenAddress [%s]",
+			listenAddress,
+		)
+	}
+
 	service, err := NewService(handle, engine)
 	if err != nil {
 		return nil, false, err
@@ -42,8 +56,8 @@ func Initialize(
 	server := &Server{
 		service: service,
 		httpServer: &http.Server{
-			Addr:              fmt.Sprintf(":%d", config.Port),
-			Handler:           newHandler(service),
+			Addr:              net.JoinHostPort(listenAddress, strconv.Itoa(config.Port)),
+			Handler:           newHandler(service, config.AuthToken),
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 	}
@@ -64,13 +78,18 @@ func Initialize(
 		}
 	}()
 
-	logger.Infof("enabled covenant signer provider endpoint on port [%v]", config.Port)
+	logger.Infof(
+		"enabled covenant signer provider endpoint on [%v] auth=[%v]",
+		server.httpServer.Addr,
+		strings.TrimSpace(config.AuthToken) != "",
+	)
 
 	return server, true, nil
 }
 
-func newHandler(service *Service) http.Handler {
+func newHandler(service *Service, authToken string) http.Handler {
 	mux := http.NewServeMux()
+	protectedHandler := withBearerAuth(mux, authToken)
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -85,7 +104,50 @@ func newHandler(service *Service) http.Handler {
 	mux.HandleFunc("/v1/self_v1/signer/requests/", pollPathHandler(service, TemplateSelfV1))
 	mux.HandleFunc("/v1/qc_v1/signer/requests/", pollPathHandler(service, TemplateQcV1))
 
-	return mux
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			mux.ServeHTTP(w, r)
+			return
+		}
+
+		protectedHandler.ServeHTTP(w, r)
+	})
+}
+
+func isLoopbackListenAddress(address string) bool {
+	trimmedAddress := strings.TrimSpace(address)
+	if trimmedAddress == "" || strings.EqualFold(trimmedAddress, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(trimmedAddress)
+	return ip != nil && ip.IsLoopback()
+}
+
+func withBearerAuth(next http.Handler, authToken string) http.Handler {
+	trimmedToken := strings.TrimSpace(authToken)
+	if trimmedToken == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizationHeader := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(authorizationHeader, prefix) {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "missing bearer token", http.StatusUnauthorized)
+			return
+		}
+
+		presentedToken := strings.TrimSpace(strings.TrimPrefix(authorizationHeader, prefix))
+		if subtle.ConstantTimeCompare([]byte(presentedToken), []byte(trimmedToken)) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "invalid bearer token", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 func decodeJSON[T any](w http.ResponseWriter, r *http.Request, target *T) bool {

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -69,7 +69,13 @@ func Initialize(
 
 	go func() {
 		<-ctx.Done()
-		_ = server.httpServer.Shutdown(context.Background())
+		shutdownCtx, cancelShutdown := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			5*time.Second,
+		)
+		defer cancelShutdown()
+
+		_ = server.httpServer.Shutdown(shutdownCtx)
 	}()
 
 	go func() {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -100,16 +100,16 @@ func mapJobResult(job *Job) StepResult {
 }
 
 func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubmitInput) (StepResult, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	if err := validateSubmitInput(route, input); err != nil {
 		return StepResult{}, err
 	}
 
+	s.mutex.Lock()
 	if existing, ok, err := s.store.GetByRouteRequest(route, input.RouteRequestID); err != nil {
+		s.mutex.Unlock()
 		return StepResult{}, err
 	} else if ok {
+		s.mutex.Unlock()
 		return mapJobResult(existing), nil
 	}
 
@@ -122,12 +122,14 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 
 	requestID, err := newRequestID(requestIDPrefix)
 	if err != nil {
+		s.mutex.Unlock()
 		return StepResult{}, err
 	}
 
 	now := s.now()
 	requestDigest, err := requestDigest(input.Request)
 	if err != nil {
+		s.mutex.Unlock()
 		return StepResult{}, err
 	}
 
@@ -146,8 +148,10 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	if err := s.store.Put(job); err != nil {
+		s.mutex.Unlock()
 		return StepResult{}, err
 	}
+	s.mutex.Unlock()
 
 	transition, err := s.engine.OnSubmit(ctx, job)
 	if err != nil {
@@ -160,6 +164,9 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 			Detail: "accepted for covenant signing",
 		}
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	applyTransition(job, transition, s.now())
 	if err := s.store.Put(job); err != nil {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -211,12 +211,27 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	applyTransition(job, transition, s.now())
-	if err := s.store.Put(job); err != nil {
+	currentJob, ok, err := s.store.GetByRequestID(requestID)
+	if err != nil {
+		return StepResult{}, err
+	}
+	if !ok {
+		return StepResult{}, errJobNotFound
+	}
+
+	// Another poll already advanced the stored job while submit was waiting on
+	// signer work. Return the newer durable state instead of overwriting it with
+	// a transition computed from an older snapshot.
+	if !sameJobRevision(currentJob, job) || isTerminalJobState(currentJob.State) {
+		return mapJobResult(currentJob), nil
+	}
+
+	applyTransition(currentJob, transition, s.now())
+	if err := s.store.Put(currentJob); err != nil {
 		return StepResult{}, err
 	}
 
-	return mapJobResult(job), nil
+	return mapJobResult(currentJob), nil
 }
 
 func (s *Service) Poll(ctx context.Context, route TemplateID, input SignerPollInput) (StepResult, error) {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -99,6 +100,48 @@ func mapJobResult(job *Job) StepResult {
 	}
 }
 
+func isTerminalJobState(state JobState) bool {
+	return state == JobStateArtifactReady ||
+		state == JobStateHandoffReady ||
+		state == JobStateFailed
+}
+
+func sameJobRevision(current *Job, snapshot *Job) bool {
+	return current.RequestID == snapshot.RequestID &&
+		current.State == snapshot.State &&
+		current.Detail == snapshot.Detail &&
+		current.Reason == snapshot.Reason &&
+		current.PSBTHash == snapshot.PSBTHash &&
+		current.TransactionHex == snapshot.TransactionHex &&
+		current.UpdatedAt == snapshot.UpdatedAt &&
+		current.CompletedAt == snapshot.CompletedAt &&
+		current.FailedAt == snapshot.FailedAt &&
+		reflect.DeepEqual(current.Handoff, snapshot.Handoff)
+}
+
+func (s *Service) loadPollJob(route TemplateID, input SignerPollInput) (*Job, error) {
+	job, ok, err := s.store.GetByRequestID(input.RequestID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || job.Route != route {
+		return nil, errJobNotFound
+	}
+	if job.RouteRequestID != input.RouteRequestID {
+		return nil, &inputError{"routeRequestId does not match stored job"}
+	}
+
+	digest, err := requestDigest(input.Request)
+	if err != nil {
+		return nil, err
+	}
+	if digest != job.RequestDigest {
+		return nil, &inputError{"request does not match stored job payload"}
+	}
+
+	return job, nil
+}
+
 func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubmitInput) (StepResult, error) {
 	if err := validateSubmitInput(route, input); err != nil {
 		return StepResult{}, err
@@ -181,51 +224,59 @@ func (s *Service) Poll(ctx context.Context, route TemplateID, input SignerPollIn
 		return StepResult{}, err
 	}
 
-	job, ok, err := s.store.GetByRequestID(input.RequestID)
+	s.mutex.Lock()
+	job, err := s.loadPollJob(route, input)
 	if err != nil {
+		s.mutex.Unlock()
 		return StepResult{}, err
 	}
-	if !ok || job.Route != route {
-		return StepResult{}, errJobNotFound
+	if isTerminalJobState(job.State) {
+		result := mapJobResult(job)
+		s.mutex.Unlock()
+		return result, nil
 	}
-	if job.RouteRequestID != input.RouteRequestID {
-		return StepResult{}, &inputError{"routeRequestId does not match stored job"}
-	}
+	s.mutex.Unlock()
 
-	digest, err := requestDigest(input.Request)
-	if err != nil {
-		return StepResult{}, err
-	}
-	if digest != job.RequestDigest {
-		return StepResult{}, &inputError{"request does not match stored job payload"}
-	}
-
-	if job.State == JobStateArtifactReady || job.State == JobStateHandoffReady || job.State == JobStateFailed {
-		return mapJobResult(job), nil
-	}
-
-	transition, err := s.engine.OnPoll(ctx, job)
-	if err != nil {
-		if err == errJobNotFound {
-			applyTransition(job, &Transition{
-				State:  JobStateFailed,
-				Reason: ReasonJobNotFound,
-				Detail: "signer job no longer exists",
-			}, s.now())
-			if storeErr := s.store.Put(job); storeErr != nil {
-				return StepResult{}, storeErr
-			}
-			return mapJobResult(job), nil
+	transition, pollErr := s.engine.OnPoll(ctx, job)
+	if pollErr != nil {
+		if pollErr != errJobNotFound {
+			return StepResult{}, pollErr
 		}
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	currentJob, err := s.loadPollJob(route, input)
+	if err != nil {
 		return StepResult{}, err
+	}
+
+	// Another Submit/Poll already advanced the stored job while this poll was
+	// in-flight. Return the newer durable state instead of overwriting it with a
+	// stale transition computed from an older snapshot.
+	if !sameJobRevision(currentJob, job) || isTerminalJobState(currentJob.State) {
+		return mapJobResult(currentJob), nil
+	}
+
+	if pollErr == errJobNotFound {
+		applyTransition(currentJob, &Transition{
+			State:  JobStateFailed,
+			Reason: ReasonJobNotFound,
+			Detail: "signer job no longer exists",
+		}, s.now())
+		if storeErr := s.store.Put(currentJob); storeErr != nil {
+			return StepResult{}, storeErr
+		}
+		return mapJobResult(currentJob), nil
 	}
 
 	if transition != nil {
-		applyTransition(job, transition, s.now())
-		if err := s.store.Put(job); err != nil {
+		applyTransition(currentJob, transition, s.now())
+		if err := s.store.Put(currentJob); err != nil {
 			return StepResult{}, err
 		}
 	}
 
-	return mapJobResult(job), nil
+	return mapJobResult(currentJob), nil
 }

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -109,7 +109,7 @@ type MigrationTransactionPlan struct {
 	AnchorValueSats      uint64 `json:"anchorValueSats"`
 	FeeSats              uint64 `json:"feeSats"`
 	InputSequence        uint32 `json:"inputSequence"`
-	LockTime             uint64 `json:"lockTime"`
+	LockTime             uint32 `json:"lockTime"`
 }
 
 type SigningRequirements struct {

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -102,6 +102,8 @@ type MigrationDestinationReservation struct {
 }
 
 type MigrationTransactionPlan struct {
+	PlanVersion          uint32 `json:"planVersion"`
+	PlanCommitmentHash   string `json:"planCommitmentHash"`
 	InputValueSats       uint64 `json:"inputValueSats"`
 	DestinationValueSats uint64 `json:"destinationValueSats"`
 	AnchorValueSats      uint64 `json:"anchorValueSats"`

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -251,6 +251,9 @@ func validateMigrationTransactionPlan(
 	if plan.DestinationValueSats == 0 {
 		return &inputError{"request.migrationTransactionPlan.destinationValueSats must be greater than zero"}
 	}
+	if plan.FeeSats == 0 {
+		return &inputError{"request.migrationTransactionPlan.feeSats must be greater than zero"}
+	}
 	if plan.AnchorValueSats != canonicalAnchorValueSats {
 		return &inputError{"request.migrationTransactionPlan.anchorValueSats must equal the canonical 330 sat anchor"}
 	}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -96,7 +97,8 @@ type destinationCommitmentPayload struct {
 
 type migrationPlanCommitmentPayload struct {
 	// Field order is hash-significant and must stay aligned with the TypeScript
-	// migration transaction-plan commitment payload.
+	// migration transaction-plan commitment payload. planCommitmentHash is
+	// intentionally omitted because it is the output of this computation.
 	PlanVersion               uint32 `json:"planVersion"`
 	Reserve                   string `json:"reserve"`
 	Epoch                     uint64 `json:"epoch"`
@@ -108,7 +110,7 @@ type migrationPlanCommitmentPayload struct {
 	AnchorValueSats           uint64 `json:"anchorValueSats"`
 	FeeSats                   uint64 `json:"feeSats"`
 	InputSequence             uint32 `json:"inputSequence"`
-	LockTime                  uint64 `json:"lockTime"`
+	LockTime                  uint32 `json:"lockTime"`
 }
 
 func computeDestinationCommitmentHash(
@@ -255,7 +257,10 @@ func validateMigrationTransactionPlan(
 	if plan.InputSequence != canonicalCovenantInputSequence {
 		return &inputError{"request.migrationTransactionPlan.inputSequence must equal 0xFFFFFFFD"}
 	}
-	if plan.LockTime != request.MaturityHeight {
+	if request.MaturityHeight > math.MaxUint32 {
+		return &inputError{"request.maturityHeight must fit in uint32"}
+	}
+	if uint64(plan.LockTime) != request.MaturityHeight {
 		return &inputError{"request.migrationTransactionPlan.lockTime must match request.maturityHeight"}
 	}
 	if plan.InputValueSats < plan.DestinationValueSats {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	canonicalCovenantInputSequence uint32 = 0xFFFFFFFD
-	canonicalAnchorValueSats       uint64 = 330
+	canonicalCovenantInputSequence  uint32 = 0xFFFFFFFD
+	canonicalAnchorValueSats        uint64 = 330
+	migrationTransactionPlanVersion uint32 = 1
 )
 
 type inputError struct {
@@ -93,6 +94,23 @@ type destinationCommitmentPayload struct {
 	MigrationExtraData string `json:"migrationExtraData"`
 }
 
+type migrationPlanCommitmentPayload struct {
+	// Field order is hash-significant and must stay aligned with the TypeScript
+	// migration transaction-plan commitment payload.
+	PlanVersion               uint32 `json:"planVersion"`
+	Reserve                   string `json:"reserve"`
+	Epoch                     uint64 `json:"epoch"`
+	ActiveOutpointTxID        string `json:"activeOutpointTxid"`
+	ActiveOutpointVout        uint32 `json:"activeOutpointVout"`
+	DestinationCommitmentHash string `json:"destinationCommitmentHash"`
+	InputValueSats            uint64 `json:"inputValueSats"`
+	DestinationValueSats      uint64 `json:"destinationValueSats"`
+	AnchorValueSats           uint64 `json:"anchorValueSats"`
+	FeeSats                   uint64 `json:"feeSats"`
+	InputSequence             uint32 `json:"inputSequence"`
+	LockTime                  uint64 `json:"lockTime"`
+}
+
 func computeDestinationCommitmentHash(
 	reservation *MigrationDestinationReservation,
 ) (string, error) {
@@ -105,6 +123,32 @@ func computeDestinationCommitmentHash(
 		Network:            strings.TrimSpace(reservation.Network),
 		DepositScriptHash:  normalizeLowerHex(reservation.DepositScriptHash),
 		MigrationExtraData: normalizeLowerHex(reservation.MigrationExtraData),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(payload)
+	return "0x" + hex.EncodeToString(sum[:]), nil
+}
+
+func computeMigrationTransactionPlanCommitmentHash(
+	request RouteSubmitRequest,
+	plan *MigrationTransactionPlan,
+) (string, error) {
+	payload, err := json.Marshal(migrationPlanCommitmentPayload{
+		PlanVersion:               plan.PlanVersion,
+		Reserve:                   normalizeLowerHex(request.Reserve),
+		Epoch:                     request.Epoch,
+		ActiveOutpointTxID:        normalizeLowerHex(request.ActiveOutpoint.TxID),
+		ActiveOutpointVout:        request.ActiveOutpoint.Vout,
+		DestinationCommitmentHash: normalizeLowerHex(request.DestinationCommitmentHash),
+		InputValueSats:            plan.InputValueSats,
+		DestinationValueSats:      plan.DestinationValueSats,
+		AnchorValueSats:           plan.AnchorValueSats,
+		FeeSats:                   plan.FeeSats,
+		InputSequence:             plan.InputSequence,
+		LockTime:                  plan.LockTime,
 	})
 	if err != nil {
 		return "", err
@@ -193,6 +237,12 @@ func validateMigrationTransactionPlan(
 	if plan == nil {
 		return &inputError{"request.migrationTransactionPlan is required"}
 	}
+	if plan.PlanVersion != migrationTransactionPlanVersion {
+		return &inputError{"request.migrationTransactionPlan.planVersion must equal 1"}
+	}
+	if err := validateHexString("request.migrationTransactionPlan.planCommitmentHash", plan.PlanCommitmentHash); err != nil {
+		return err
+	}
 	if plan.InputValueSats == 0 {
 		return &inputError{"request.migrationTransactionPlan.inputValueSats must be greater than zero"}
 	}
@@ -218,6 +268,14 @@ func validateMigrationTransactionPlan(
 	remainingAfterAnchor := remainingAfterDestination - plan.AnchorValueSats
 	if remainingAfterAnchor != plan.FeeSats {
 		return &inputError{"request.migrationTransactionPlan values must satisfy inputValueSats = destinationValueSats + anchorValueSats + feeSats"}
+	}
+
+	expectedCommitmentHash, err := computeMigrationTransactionPlanCommitmentHash(request, plan)
+	if err != nil {
+		return err
+	}
+	if normalizeLowerHex(plan.PlanCommitmentHash) != expectedCommitmentHash {
+		return &inputError{"request.migrationTransactionPlan.planCommitmentHash does not match canonical migration transaction plan"}
 	}
 
 	return nil

--- a/pkg/generator/scheduler.go
+++ b/pkg/generator/scheduler.go
@@ -112,6 +112,7 @@ func (s *Scheduler) resume() {
 // This function should be executed only be the Scheduler and when the
 // workMutex is locked.
 func (s *Scheduler) startWorker(workerFn func(context.Context)) {
+	// #nosec G118 -- cancelFn is stored in s.stops and invoked by stop().
 	ctx, cancelFn := context.WithCancel(context.Background())
 	s.stops = append(s.stops, cancelFn)
 

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -523,7 +523,7 @@ func (cse *covenantSignerEngine) buildAndSignSelfV1Transaction(
 	if err := builder.SetInputSequence(0, request.MigrationTransactionPlan.InputSequence); err != nil {
 		return nil, fmt.Errorf("cannot set covenant input sequence: %v", err)
 	}
-	builder.SetLocktime(uint32(request.MigrationTransactionPlan.LockTime))
+	builder.SetLocktime(request.MigrationTransactionPlan.LockTime)
 	builder.AddOutput(&bitcoin.TransactionOutput{
 		Value:           destinationValue,
 		PublicKeyScript: destinationScript,
@@ -614,7 +614,7 @@ func (cse *covenantSignerEngine) buildQcV1SignerHandoff(
 	if err := builder.SetInputSequence(0, request.MigrationTransactionPlan.InputSequence); err != nil {
 		return nil, fmt.Errorf("cannot set covenant input sequence: %v", err)
 	}
-	builder.SetLocktime(uint32(request.MigrationTransactionPlan.LockTime))
+	builder.SetLocktime(request.MigrationTransactionPlan.LockTime)
 	builder.AddOutput(&bitcoin.TransactionOutput{
 		Value:           destinationValue,
 		PublicKeyScript: destinationScript,

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -185,7 +185,7 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 			AnchorValueSats:      anchorValueSats,
 			FeeSats:              feeSats,
 			InputSequence:        0xfffffffd,
-			LockTime:             maturityHeight,
+			LockTime:             uint32(maturityHeight),
 		},
 		ArtifactSignatures: []string{"0x0708"},
 		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
@@ -414,7 +414,7 @@ func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
 			AnchorValueSats:      anchorValueSats,
 			FeeSats:              feeSats,
 			InputSequence:        0xfffffffd,
-			LockTime:             maturityHeight,
+			LockTime:             uint32(maturityHeight),
 		},
 		ArtifactSignatures: []string{"0x090a"},
 		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
@@ -789,7 +789,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsScriptHashMismatch(t *testing.T) 
 			AnchorValueSats:      330,
 			FeeSats:              2_170,
 			InputSequence:        0xfffffffd,
-			LockTime:             maturityHeight,
+			LockTime:             uint32(maturityHeight),
 		},
 		ArtifactSignatures: []string{"0x090a"},
 		Artifacts:          map[covenantsigner.RecoveryPathID]covenantsigner.ArtifactRecord{},
@@ -1086,7 +1086,7 @@ type testMigrationTransactionPlanCommitmentPayload struct {
 	AnchorValueSats           uint64 `json:"anchorValueSats"`
 	FeeSats                   uint64 `json:"feeSats"`
 	InputSequence             uint32 `json:"inputSequence"`
-	LockTime                  uint64 `json:"lockTime"`
+	LockTime                  uint32 `json:"lockTime"`
 }
 
 func testMigrationTransactionPlanCommitmentHash(

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -195,6 +195,7 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 			CustodianRequired: false,
 		},
 	}
+	applyTestMigrationTransactionPlanCommitment(t, &request)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_self_ready",
@@ -423,6 +424,7 @@ func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
 			CustodianRequired: true,
 		},
 	}
+	applyTestMigrationTransactionPlanCommitment(t, &request)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_ready",
@@ -661,6 +663,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsInvalidBeta(t *testing.T) {
 	request.MigrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
 	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
 	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
+	applyTestMigrationTransactionPlanCommitment(t, &request)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_bad_beta",
@@ -796,6 +799,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsScriptHashMismatch(t *testing.T) 
 			CustodianRequired: true,
 		},
 	}
+	applyTestMigrationTransactionPlanCommitment(t, &request)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_bad_script_hash",
@@ -898,6 +902,7 @@ func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T
 	request.MigrationDestination.MigrationExtraData = testMigrationExtraData(revealer)
 	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
 	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
+	applyTestMigrationTransactionPlanCommitment(t, &request)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_self_zero",
@@ -1067,4 +1072,66 @@ func testDestinationCommitmentHash(
 
 	sum := sha256.Sum256(payload)
 	return "0x" + hex.EncodeToString(sum[:])
+}
+
+type testMigrationTransactionPlanCommitmentPayload struct {
+	PlanVersion               uint32 `json:"planVersion"`
+	Reserve                   string `json:"reserve"`
+	Epoch                     uint64 `json:"epoch"`
+	ActiveOutpointTxID        string `json:"activeOutpointTxid"`
+	ActiveOutpointVout        uint32 `json:"activeOutpointVout"`
+	DestinationCommitmentHash string `json:"destinationCommitmentHash"`
+	InputValueSats            uint64 `json:"inputValueSats"`
+	DestinationValueSats      uint64 `json:"destinationValueSats"`
+	AnchorValueSats           uint64 `json:"anchorValueSats"`
+	FeeSats                   uint64 `json:"feeSats"`
+	InputSequence             uint32 `json:"inputSequence"`
+	LockTime                  uint64 `json:"lockTime"`
+}
+
+func testMigrationTransactionPlanCommitmentHash(
+	t *testing.T,
+	request covenantsigner.RouteSubmitRequest,
+	plan *covenantsigner.MigrationTransactionPlan,
+) string {
+	t.Helper()
+
+	payload, err := json.Marshal(testMigrationTransactionPlanCommitmentPayload{
+		PlanVersion:               plan.PlanVersion,
+		Reserve:                   strings.ToLower(request.Reserve),
+		Epoch:                     request.Epoch,
+		ActiveOutpointTxID:        strings.ToLower(request.ActiveOutpoint.TxID),
+		ActiveOutpointVout:        request.ActiveOutpoint.Vout,
+		DestinationCommitmentHash: strings.ToLower(request.DestinationCommitmentHash),
+		InputValueSats:            plan.InputValueSats,
+		DestinationValueSats:      plan.DestinationValueSats,
+		AnchorValueSats:           plan.AnchorValueSats,
+		FeeSats:                   plan.FeeSats,
+		InputSequence:             plan.InputSequence,
+		LockTime:                  plan.LockTime,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(payload)
+	return "0x" + hex.EncodeToString(sum[:])
+}
+
+func applyTestMigrationTransactionPlanCommitment(
+	t *testing.T,
+	request *covenantsigner.RouteSubmitRequest,
+) {
+	t.Helper()
+
+	if request.MigrationTransactionPlan == nil {
+		return
+	}
+
+	request.MigrationTransactionPlan.PlanVersion = 1
+	request.MigrationTransactionPlan.PlanCommitmentHash = testMigrationTransactionPlanCommitmentHash(
+		t,
+		*request,
+		request.MigrationTransactionPlan,
+	)
 }

--- a/pkg/tbtc/dkg_loop.go
+++ b/pkg/tbtc/dkg_loop.go
@@ -199,6 +199,7 @@ func (drl *dkgRetryLoop) start(
 			drl.memberIndex,
 			fmt.Sprintf("%v-%v", drl.seed, drl.attemptCounter),
 		)
+		cancelAnnounceCtx()
 		if err != nil {
 			drl.logger.Warnf(
 				"[member:%v] announcement for attempt [%v] "+

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -1429,6 +1429,8 @@ func withCancelOnBlock(
 	block uint64,
 	waitForBlockFn waitForBlockFn,
 ) (context.Context, context.CancelFunc) {
+	// #nosec G118 -- cancelBlockCtx is returned to the caller and also invoked
+	// by the waiter goroutine when the target block is reached.
 	blockCtx, cancelBlockCtx := context.WithCancel(ctx)
 
 	go func() {


### PR DESCRIPTION
## Summary
- default the covenant signer HTTP listener to loopback and require a bearer auth token for non-loopback exposure
- stop holding the submit mutex across engine.OnSubmit so deduped callers are not serialized behind long signer work
- add focused tests for auth enforcement, config flags, and in-flight submit dedupe semantics

## Testing
- go test ./pkg/covenantsigner -count=1
- go test ./pkg/tbtc -run 'TestCovenantSignerEngine_' -count=1
- go test ./cmd -count=1