### PR TITLE
Remove dead Thesis/Staked Electrum URLs

### DIFF
--- a/config/_electrum_urls/mainnet
+++ b/config/_electrum_urls/mainnet
@@ -1,4 +1,1 @@
-wss://electrumx-server.tbtc.network:8443
 wss://electrum.boar.network:2083
-wss://bitcoin.threshold.p2p.org:50004
-wss://electrumx.prod-utility-eks-us-west-2.staked.cloud:443

--- a/config/_electrum_urls/testnet
+++ b/config/_electrum_urls/testnet
@@ -1,1 +1,1 @@
-wss://electrumx-server.test.tbtc.network:8443
+wss://electrum.testnet.boar.network:443/QxbJgaSLUHqrgAa9BW7bDpnGPxrlhnCa

--- a/config/electrum_test.go
+++ b/config/electrum_test.go
@@ -19,25 +19,17 @@ func TestResolveElectrum(t *testing.T) {
 		bitcoin.Mainnet: {
 			expectedConfig: []electrum.Config{
 				{
-					URL: "wss://electrumx-server.tbtc.network:8443",
-				},
-				{
 					URL: "wss://electrum.boar.network:2083",
-				},
-				{
-					URL: "wss://bitcoin.threshold.p2p.org:50004",
-				},
-				{
-					URL: "wss://electrumx.prod-utility-eks-us-west-2.staked.cloud:443",
 				},
 			},
 		},
 		bitcoin.Testnet: {
 			expectedConfig: []electrum.Config{
 				{
-					URL: "wss://electrumx-server.test.tbtc.network:8443",
+					URL: "wss://electrum.testnet.boar.network:443/QxbJgaSLUHqrgAa9BW7bDpnGPxrlhnCa",
 				},
-			}},
+			},
+		},
 		bitcoin.Regtest: {
 			expectedConfig: []electrum.Config{
 				{

--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -58,7 +58,7 @@ var testConfigs = map[string]testConfig{
 	},
 	"electrumx wss": {
 		clientConfig: electrum.Config{
-			URL:                 "wss://electrumx-server.test.tbtc.network:8443",
+			URL:                 "wss://electrum.testnet.boar.network:443/QxbJgaSLUHqrgAa9BW7bDpnGPxrlhnCa",
 			RequestTimeout:      requestTimeout,
 			RequestRetryTimeout: requestRetryTimeout,
 		},


### PR DESCRIPTION
## Issue

The mainnet Electrum configuration embeds three defunct servers (`electrumx-server.tbtc.network`, `bitcoin.threshold.p2p.org`, `electrumx.prod-utility-eks-us-west-2.staked.cloud`) and the testnet config points to a dead Thesis server (`electrumx-server.test.tbtc.network`). These endpoints are unreachable following the Thesis infrastructure sunset.

## Solution

- **Mainnet**: Remove the 3 dead URLs, keeping only the active BOAR server (`wss://electrum.boar.network:2083`)
- **Testnet**: Replace the dead Thesis URL with the BOAR testnet server (`wss://electrum.testnet.boar.network:443/...`)
- Update test fixtures in `electrum_test.go` to match the new URL configuration