### PR TITLE
Validate role-tagged covenant approvals

### DIFF
--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -163,6 +163,32 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 	return request
 }
 
+func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelope {
+	approvals := []ArtifactRoleApproval{
+		{Role: ArtifactApprovalRoleDepositor, Signature: "0xd0d0"},
+		{Role: ArtifactApprovalRoleSigner, Signature: "0x5050"},
+	}
+
+	if request.Route == TemplateQcV1 {
+		approvals = []ArtifactRoleApproval{
+			{Role: ArtifactApprovalRoleDepositor, Signature: "0xd0d0"},
+			{Role: ArtifactApprovalRoleCustodian, Signature: "0xc0c0"},
+			{Role: ArtifactApprovalRoleSigner, Signature: "0x5050"},
+		}
+	}
+
+	return &ArtifactApprovalEnvelope{
+		Payload: ArtifactApprovalPayload{
+			ApprovalVersion:           artifactApprovalVersion,
+			Route:                     request.Route,
+			ScriptTemplateID:          request.Route,
+			DestinationCommitmentHash: request.DestinationCommitmentHash,
+			PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+		},
+		Approvals: approvals,
+	}
+}
+
 func validMigrationDestination() *MigrationDestinationReservation {
 	reservation := &MigrationDestinationReservation{
 		ReservationID: "cmdr_12345678",
@@ -1092,6 +1118,134 @@ func TestServiceRejectsMigrationTransactionPlanBoundToDifferentDestinationCommit
 	})
 	if err == nil || !strings.Contains(err.Error(), "request.migrationTransactionPlan.planCommitmentHash does not match canonical migration transaction plan") {
 		t.Fatalf("expected plan binding error, got %v", err)
+	}
+}
+
+func TestServiceAcceptsArtifactApprovalsWithCanonicalLegacySignatures(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateQcV1)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+		request.ArtifactApprovals.Approvals[2],
+		request.ArtifactApprovals.Approvals[0],
+		request.ArtifactApprovals.Approvals[1],
+	}
+	request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
+
+	result, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_artifact_approvals",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Status != StepStatusPending {
+		t.Fatalf("expected PENDING, got %#v", result)
+	}
+
+	job, ok, err := service.store.GetByRouteRequest(TemplateQcV1, "orq_artifact_approvals")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected stored job")
+	}
+	if job.Request.ArtifactApprovals == nil {
+		t.Fatal("expected stored artifact approvals")
+	}
+}
+
+func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name      string
+		route     TemplateID
+		mutate    func(request *RouteSubmitRequest)
+		expectErr string
+	}{
+		{
+			name:  "missing qc custodian approval",
+			route: TemplateQcV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = validArtifactApprovals(*request)
+				request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+					request.ArtifactApprovals.Approvals[0],
+					request.ArtifactApprovals.Approvals[2],
+				}
+				request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
+			},
+			expectErr: "request.artifactApprovals.approvals must include role C for qc_v1",
+		},
+		{
+			name:  "self route rejects custodian approval role",
+			route: TemplateSelfV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = validArtifactApprovals(*request)
+				request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+					request.ArtifactApprovals.Approvals[0],
+					{Role: ArtifactApprovalRoleCustodian, Signature: "0xc0c0"},
+					request.ArtifactApprovals.Approvals[1],
+				}
+				request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
+			},
+			expectErr: "request.artifactApprovals.approvals[1].role is not allowed for self_v1",
+		},
+		{
+			name:  "plan commitment mismatch",
+			route: TemplateQcV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = validArtifactApprovals(*request)
+				request.ArtifactApprovals.Payload.PlanCommitmentHash = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+				request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
+			},
+			expectErr: "request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash",
+		},
+		{
+			name:  "legacy signature mismatch",
+			route: TemplateQcV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = validArtifactApprovals(*request)
+				request.ArtifactSignatures = []string{"0x5050", "0xd0d0", "0xc0c0"}
+			},
+			expectErr: "request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals",
+		},
+		{
+			name:  "legacy signatures remain required when approvals are present",
+			route: TemplateSelfV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = validArtifactApprovals(*request)
+				request.ArtifactSignatures = nil
+			},
+			expectErr: "request.artifactSignatures must not be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := baseRequest(testCase.route)
+			testCase.mutate(&request)
+
+			_, err := service.Submit(context.Background(), testCase.route, SignerSubmitInput{
+				RouteRequestID: "ors_invalid_artifact_approval_" + strings.ReplaceAll(testCase.name, " ", "_"),
+				Stage:          StageSignerCoordination,
+				Request:        request,
+			})
+			if err == nil || !strings.Contains(err.Error(), testCase.expectErr) {
+				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
+			}
+		})
 	}
 }
 

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -112,6 +112,32 @@ type MigrationTransactionPlan struct {
 	LockTime             uint32 `json:"lockTime"`
 }
 
+type ArtifactApprovalRole string
+
+const (
+	ArtifactApprovalRoleDepositor ArtifactApprovalRole = "D"
+	ArtifactApprovalRoleCustodian ArtifactApprovalRole = "C"
+	ArtifactApprovalRoleSigner    ArtifactApprovalRole = "S"
+)
+
+type ArtifactApprovalPayload struct {
+	ApprovalVersion           uint32     `json:"approvalVersion"`
+	Route                     TemplateID `json:"route"`
+	ScriptTemplateID          TemplateID `json:"scriptTemplateId"`
+	DestinationCommitmentHash string     `json:"destinationCommitmentHash"`
+	PlanCommitmentHash        string     `json:"planCommitmentHash"`
+}
+
+type ArtifactRoleApproval struct {
+	Role      ArtifactApprovalRole `json:"role"`
+	Signature string               `json:"signature"`
+}
+
+type ArtifactApprovalEnvelope struct {
+	Payload   ArtifactApprovalPayload `json:"payload"`
+	Approvals []ArtifactRoleApproval  `json:"approvals"`
+}
+
 type SigningRequirements struct {
 	SignerRequired    bool `json:"signerRequired"`
 	CustodianRequired bool `json:"custodianRequired"`
@@ -129,6 +155,7 @@ type RouteSubmitRequest struct {
 	DestinationCommitmentHash string                            `json:"destinationCommitmentHash"`
 	MigrationDestination      *MigrationDestinationReservation  `json:"migrationDestination,omitempty"`
 	MigrationTransactionPlan  *MigrationTransactionPlan         `json:"migrationTransactionPlan,omitempty"`
+	ArtifactApprovals         *ArtifactApprovalEnvelope         `json:"artifactApprovals,omitempty"`
 	ArtifactSignatures        []string                          `json:"artifactSignatures"`
 	Artifacts                 map[RecoveryPathID]ArtifactRecord `json:"artifacts"`
 	ScriptTemplate            json.RawMessage                   `json:"scriptTemplate"`

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -14,6 +14,7 @@ const (
 	canonicalCovenantInputSequence  uint32 = 0xFFFFFFFD
 	canonicalAnchorValueSats        uint64 = 330
 	migrationTransactionPlanVersion uint32 = 1
+	artifactApprovalVersion         uint32 = 1
 )
 
 type inputError struct {
@@ -289,6 +290,149 @@ func validateMigrationTransactionPlan(
 	return nil
 }
 
+func validateArtifactSignatures(signatures []string) ([]string, error) {
+	if len(signatures) == 0 {
+		return nil, &inputError{"request.artifactSignatures must not be empty"}
+	}
+
+	normalizedSignatures := make([]string, len(signatures))
+	for i, signature := range signatures {
+		if err := validateHexString(
+			fmt.Sprintf("request.artifactSignatures[%d]", i),
+			signature,
+		); err != nil {
+			return nil, err
+		}
+
+		normalizedSignatures[i] = normalizeLowerHex(signature)
+	}
+
+	return normalizedSignatures, nil
+}
+
+func requiredArtifactApprovalRoles(route TemplateID) ([]ArtifactApprovalRole, error) {
+	switch route {
+	case TemplateQcV1:
+		return []ArtifactApprovalRole{
+			ArtifactApprovalRoleDepositor,
+			ArtifactApprovalRoleCustodian,
+			ArtifactApprovalRoleSigner,
+		}, nil
+	case TemplateSelfV1:
+		return []ArtifactApprovalRole{
+			ArtifactApprovalRoleDepositor,
+			ArtifactApprovalRoleSigner,
+		}, nil
+	default:
+		return nil, &inputError{"unsupported request.route"}
+	}
+}
+
+func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) error {
+	normalizedLegacySignatures, err := validateArtifactSignatures(request.ArtifactSignatures)
+	if err != nil {
+		return err
+	}
+
+	if request.ArtifactApprovals == nil {
+		return nil
+	}
+
+	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {
+		return &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
+	}
+	if request.ArtifactApprovals.Payload.Route != route {
+		return &inputError{"request.artifactApprovals.payload.route must match request.route"}
+	}
+	if request.ArtifactApprovals.Payload.ScriptTemplateID != route {
+		return &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
+	}
+	if err := validateHexString(
+		"request.artifactApprovals.payload.destinationCommitmentHash",
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+	); err != nil {
+		return err
+	}
+	if err := validateHexString(
+		"request.artifactApprovals.payload.planCommitmentHash",
+		request.ArtifactApprovals.Payload.PlanCommitmentHash,
+	); err != nil {
+		return err
+	}
+	if normalizeLowerHex(request.ArtifactApprovals.Payload.DestinationCommitmentHash) !=
+		normalizeLowerHex(request.DestinationCommitmentHash) {
+		return &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
+	}
+	if normalizeLowerHex(request.ArtifactApprovals.Payload.PlanCommitmentHash) !=
+		normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
+		return &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
+	}
+	if len(request.ArtifactApprovals.Approvals) == 0 {
+		return &inputError{"request.artifactApprovals.approvals must not be empty"}
+	}
+
+	requiredRoles, err := requiredArtifactApprovalRoles(route)
+	if err != nil {
+		return err
+	}
+
+	allowedRoles := make(map[ArtifactApprovalRole]struct{}, len(requiredRoles))
+	for _, role := range requiredRoles {
+		allowedRoles[role] = struct{}{}
+	}
+
+	approvalsByRole := make(map[ArtifactApprovalRole]string, len(requiredRoles))
+	for i, approval := range request.ArtifactApprovals.Approvals {
+		if _, ok := allowedRoles[approval.Role]; !ok {
+			return &inputError{fmt.Sprintf(
+				"request.artifactApprovals.approvals[%d].role is not allowed for %s",
+				i,
+				route,
+			)}
+		}
+		if _, ok := approvalsByRole[approval.Role]; ok {
+			return &inputError{fmt.Sprintf(
+				"request.artifactApprovals.approvals[%d].role duplicates role %s",
+				i,
+				approval.Role,
+			)}
+		}
+		if err := validateHexString(
+			fmt.Sprintf("request.artifactApprovals.approvals[%d].signature", i),
+			approval.Signature,
+		); err != nil {
+			return err
+		}
+
+		approvalsByRole[approval.Role] = normalizeLowerHex(approval.Signature)
+	}
+
+	derivedLegacySignatures := make([]string, len(requiredRoles))
+	for i, role := range requiredRoles {
+		signature, ok := approvalsByRole[role]
+		if !ok {
+			return &inputError{fmt.Sprintf(
+				"request.artifactApprovals.approvals must include role %s for %s",
+				role,
+				route,
+			)}
+		}
+
+		derivedLegacySignatures[i] = signature
+	}
+
+	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
+		return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+	}
+	for i := range derivedLegacySignatures {
+		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
+			return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		}
+	}
+
+	return nil
+}
+
 func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if request.FacadeRequestID == "" {
 		return &inputError{"request.facadeRequestId is required"}
@@ -328,13 +472,8 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if err := validateMigrationTransactionPlan(request, request.MigrationTransactionPlan); err != nil {
 		return err
 	}
-	if len(request.ArtifactSignatures) == 0 {
-		return &inputError{"request.artifactSignatures must not be empty"}
-	}
-	for i, signature := range request.ArtifactSignatures {
-		if err := validateHexString(fmt.Sprintf("request.artifactSignatures[%d]", i), signature); err != nil {
-			return err
-		}
+	if err := validateArtifactApprovals(route, request); err != nil {
+		return err
 	}
 
 	switch route {


### PR DESCRIPTION
## Summary
- add optional role-tagged artifact approval envelopes to covenant signer requests
- validate approval payload bindings and required roles by route while keeping legacy artifact signature arrays as the active compatibility contract
- add focused tests for acceptance, rejection paths, and legacy-array mismatch handling

## Testing
- go test ./pkg/covenantsigner
- go test ./pkg/tbtc -run CovenantSigner -count=1

## Notes
- stacked on top of codex/psbt-covenant-signer-hardening
- this is the structural validation slice only; it does not add cryptographic verification of the approvals yet