### PR TITLE
Add covenant signer contract vectors

### DIFF
--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,6 +93,52 @@ func mustJSON(t *testing.T, value any) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+type approvalContractVector struct {
+	CanonicalSubmitRequest json.RawMessage `json:"canonicalSubmitRequest"`
+	ExpectedRequestDigest  string          `json:"expectedRequestDigest"`
+}
+
+type approvalContractVectorsFile struct {
+	Version int                               `json:"version"`
+	Scope   string                            `json:"scope"`
+	Vectors map[string]approvalContractVector `json:"vectors"`
+}
+
+func loadApprovalContractVector(
+	t *testing.T,
+	route TemplateID,
+) (RouteSubmitRequest, string) {
+	t.Helper()
+
+	data, err := os.ReadFile("testdata/covenant_recovery_approval_vectors_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vectors := approvalContractVectorsFile{}
+	if err := strictUnmarshal(data, &vectors); err != nil {
+		t.Fatal(err)
+	}
+	if vectors.Version != 1 {
+		t.Fatalf("unexpected vector version: %d", vectors.Version)
+	}
+	if vectors.Scope != "covenant_recovery_approval_contract_v1" {
+		t.Fatalf("unexpected vector scope: %s", vectors.Scope)
+	}
+
+	vector, ok := vectors.Vectors[string(route)]
+	if !ok {
+		t.Fatalf("missing vector for route %s", route)
+	}
+
+	request := RouteSubmitRequest{}
+	if err := strictUnmarshal(vector.CanonicalSubmitRequest, &request); err != nil {
+		t.Fatal(err)
+	}
+
+	return request, vector.ExpectedRequestDigest
 }
 
 func validSelfTemplate() json.RawMessage {
@@ -198,6 +245,116 @@ func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
 	}
 
 	return request
+}
+
+func cloneRouteSubmitRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+
+	cloned := RouteSubmitRequest{}
+	if err := strictUnmarshal(mustJSON(t, request), &cloned); err != nil {
+		t.Fatal(err)
+	}
+
+	return cloned
+}
+
+func equivalentArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+
+	variant := cloneRouteSubmitRequest(t, request)
+	variant.Strategy = upperHexBody(variant.Strategy)
+	variant.Reserve = upperHexBody(variant.Reserve)
+	variant.ActiveOutpoint.TxID = upperHexBody(variant.ActiveOutpoint.TxID)
+	if variant.ActiveOutpoint.ScriptHash != "" {
+		variant.ActiveOutpoint.ScriptHash = upperHexBody(variant.ActiveOutpoint.ScriptHash)
+	}
+	variant.DestinationCommitmentHash = upperHexBody(variant.DestinationCommitmentHash)
+
+	if variant.MigrationDestination != nil {
+		variant.MigrationDestination.Reserve = upperHexBody(variant.MigrationDestination.Reserve)
+		variant.MigrationDestination.Revealer = upperHexBody(variant.MigrationDestination.Revealer)
+		variant.MigrationDestination.Vault = upperHexBody(variant.MigrationDestination.Vault)
+		variant.MigrationDestination.DepositScript = upperHexBody(variant.MigrationDestination.DepositScript)
+		variant.MigrationDestination.DepositScriptHash = upperHexBody(variant.MigrationDestination.DepositScriptHash)
+		variant.MigrationDestination.MigrationExtraData = upperHexBody(variant.MigrationDestination.MigrationExtraData)
+		variant.MigrationDestination.DestinationCommitmentHash = upperHexBody(
+			variant.MigrationDestination.DestinationCommitmentHash,
+		)
+	}
+
+	if variant.MigrationTransactionPlan != nil {
+		variant.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(
+			variant.MigrationTransactionPlan.PlanCommitmentHash,
+		)
+	}
+
+	for i := range variant.ArtifactSignatures {
+		variant.ArtifactSignatures[i] = upperHexBody(variant.ArtifactSignatures[i])
+	}
+
+	for pathID, artifact := range variant.Artifacts {
+		artifact.PSBTHash = upperHexBody(artifact.PSBTHash)
+		artifact.DestinationCommitmentHash = upperHexBody(artifact.DestinationCommitmentHash)
+		if artifact.TransactionHex != "" {
+			artifact.TransactionHex = upperHexBody(artifact.TransactionHex)
+		}
+		if artifact.TransactionID != "" {
+			artifact.TransactionID = upperHexBody(artifact.TransactionID)
+		}
+		variant.Artifacts[pathID] = artifact
+	}
+
+	if variant.ArtifactApprovals != nil {
+		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			variant.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		variant.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			variant.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+
+		reorderedApprovals := make(
+			[]ArtifactRoleApproval,
+			len(variant.ArtifactApprovals.Approvals),
+		)
+		for i := range variant.ArtifactApprovals.Approvals {
+			approval := variant.ArtifactApprovals.Approvals[len(variant.ArtifactApprovals.Approvals)-1-i]
+			reorderedApprovals[i] = ArtifactRoleApproval{
+				Role:      approval.Role,
+				Signature: upperHexBody(approval.Signature),
+			}
+		}
+		variant.ArtifactApprovals.Approvals = reorderedApprovals
+	}
+
+	switch variant.Route {
+	case TemplateQcV1:
+		template := &QcV1Template{}
+		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
+			t.Fatal(err)
+		}
+		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
+		template.CustodianPublicKey = upperHexBody(template.CustodianPublicKey)
+		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		variant.ScriptTemplate = mustTemplate(template)
+	case TemplateSelfV1:
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
+			t.Fatal(err)
+		}
+		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
+		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		variant.ScriptTemplate = mustTemplate(template)
+	default:
+		t.Fatalf("unsupported route %s", variant.Route)
+	}
+
+	return variant
 }
 
 func upperHexBody(value string) string {
@@ -1479,6 +1636,61 @@ func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t 
 		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
 	) {
 		t.Fatalf("expected missing plan error, got %v", err)
+	}
+}
+
+func TestApprovalContractVectorsMatchExpectedRequestDigests(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			request, expectedDigest := loadApprovalContractVector(t, route)
+
+			digest, err := requestDigest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if digest != expectedDigest {
+				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
+	}
+}
+
+func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			canonicalRequest, expectedDigest := loadApprovalContractVector(t, route)
+
+			normalizedCanonical, err := normalizeRouteSubmitRequest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			variantRequest := equivalentArtifactApprovalVariantFromRequest(
+				t,
+				canonicalRequest,
+			)
+			normalizedVariant, err := normalizeRouteSubmitRequest(variantRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(normalizedVariant, normalizedCanonical) {
+				t.Fatalf(
+					"expected normalized variant %#v, got %#v",
+					normalizedCanonical,
+					normalizedVariant,
+				)
+			}
+
+			digest, err := requestDigest(variantRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if digest != expectedDigest {
+				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -189,6 +189,102 @@ func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelop
 	}
 }
 
+func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
+	request := baseRequest(route)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
+	if route == TemplateQcV1 {
+		request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
+	}
+
+	return request
+}
+
+func upperHexBody(value string) string {
+	if !strings.HasPrefix(value, "0x") {
+		return strings.ToUpper(value)
+	}
+
+	return "0x" + strings.ToUpper(strings.TrimPrefix(value, "0x"))
+}
+
+func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
+	request := canonicalArtifactApprovalRequest(route)
+
+	request.Strategy = upperHexBody(request.Strategy)
+	request.Reserve = upperHexBody(request.Reserve)
+	request.ActiveOutpoint.TxID = upperHexBody(request.ActiveOutpoint.TxID)
+	request.ActiveOutpoint.ScriptHash = upperHexBody(request.ActiveOutpoint.ScriptHash)
+	request.DestinationCommitmentHash = upperHexBody(request.DestinationCommitmentHash)
+	request.MigrationDestination.Reserve = upperHexBody(request.MigrationDestination.Reserve)
+	request.MigrationDestination.Revealer = upperHexBody(request.MigrationDestination.Revealer)
+	request.MigrationDestination.Vault = upperHexBody(request.MigrationDestination.Vault)
+	request.MigrationDestination.DepositScript = upperHexBody(request.MigrationDestination.DepositScript)
+	request.MigrationDestination.DepositScriptHash = upperHexBody(request.MigrationDestination.DepositScriptHash)
+	request.MigrationDestination.MigrationExtraData = upperHexBody(request.MigrationDestination.MigrationExtraData)
+	request.MigrationDestination.DestinationCommitmentHash = upperHexBody(request.MigrationDestination.DestinationCommitmentHash)
+	request.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(request.MigrationTransactionPlan.PlanCommitmentHash)
+	for i := range request.ArtifactSignatures {
+		request.ArtifactSignatures[i] = upperHexBody(request.ArtifactSignatures[i])
+	}
+
+	if route == TemplateQcV1 {
+		request.ScriptTemplate = mustTemplate(QcV1Template{
+			Template:           TemplateQcV1,
+			DepositorPublicKey: upperHexBody("0x021111"),
+			CustodianPublicKey: upperHexBody("0x023333"),
+			SignerPublicKey:    upperHexBody("0x022222"),
+			Beta:               144,
+			Delta2:             4320,
+		})
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		request.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: upperHexBody("0x5050"),
+			},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody("0xd0d0"),
+			},
+			{
+				Role:      ArtifactApprovalRoleCustodian,
+				Signature: upperHexBody("0xc0c0"),
+			},
+		}
+	} else {
+		request.ScriptTemplate = mustTemplate(SelfV1Template{
+			Template:           TemplateSelfV1,
+			DepositorPublicKey: upperHexBody("0x021111"),
+			SignerPublicKey:    upperHexBody("0x022222"),
+			Delta2:             4320,
+		})
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		request.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: upperHexBody("0x5050"),
+			},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody("0xd0d0"),
+			},
+		}
+	}
+
+	return request
+}
+
 func validMigrationDestination() *MigrationDestinationReservation {
 	reservation := &MigrationDestinationReservation{
 		ReservationID: "cmdr_12345678",
@@ -1246,6 +1342,89 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
 			}
 		})
+	}
+}
+
+func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T) {
+	canonicalDigest, err := requestDigest(canonicalArtifactApprovalRequest(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variantDigest, err := requestDigest(equivalentArtifactApprovalVariant(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if canonicalDigest != variantDigest {
+		t.Fatalf("expected matching request digest, got %s vs %s", canonicalDigest, variantDigest)
+	}
+}
+
+func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitRequest := equivalentArtifactApprovalVariant(TemplateQcV1)
+	submitResult, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_equivalent_digest",
+		Stage:          StageSignerCoordination,
+		Request:        submitRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollResult, err := service.Poll(context.Background(), TemplateQcV1, SignerPollInput{
+		RouteRequestID: "orq_equivalent_digest",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        canonicalArtifactApprovalRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pollResult.Status != StepStatusPending {
+		t.Fatalf("expected PENDING, got %#v", pollResult)
+	}
+}
+
+func TestServiceStoresNormalizedArtifactApprovalRequest(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := equivalentArtifactApprovalVariant(TemplateQcV1)
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_normalized_store",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job, ok, err := service.store.GetByRouteRequest(TemplateQcV1, "orq_normalized_store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected stored job")
+	}
+
+	expected := canonicalArtifactApprovalRequest(TemplateQcV1)
+	if !reflect.DeepEqual(job.Request, expected) {
+		t.Fatalf("expected normalized request %#v, got %#v", expected, job.Request)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -1361,6 +1361,47 @@ func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T)
 	}
 }
 
+func TestRequestDigestDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
+	request := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	request.FacadeRequestID = "rf_<tag>&sink"
+	request.IdempotencyKey = "idem_>bridge"
+
+	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := marshalCanonicalJSON(normalizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(payload, []byte(`"facadeRequestId":"rf_<tag>&sink"`)) {
+		t.Fatalf("expected raw HTML-sensitive characters in payload, got %s", payload)
+	}
+	if bytes.Contains(payload, []byte(`\u003c`)) ||
+		bytes.Contains(payload, []byte(`\u003e`)) ||
+		bytes.Contains(payload, []byte(`\u0026`)) {
+		t.Fatalf("expected unescaped HTML-sensitive characters in payload, got %s", payload)
+	}
+
+	digestFromRawRequest, err := requestDigest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestFromNormalizedRequest, err := requestDigestFromNormalized(normalizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digestFromRawRequest != digestFromNormalizedRequest {
+		t.Fatalf(
+			"expected matching digests, got %s vs %s",
+			digestFromRawRequest,
+			digestFromNormalizedRequest,
+		)
+	}
+}
+
 func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -1425,6 +1466,19 @@ func TestServiceStoresNormalizedArtifactApprovalRequest(t *testing.T) {
 	expected := canonicalArtifactApprovalRequest(TemplateQcV1)
 	if !reflect.DeepEqual(job.Request, expected) {
 		t.Fatalf("expected normalized request %#v, got %#v", expected, job.Request)
+	}
+}
+
+func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t *testing.T) {
+	request := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	request.MigrationTransactionPlan = nil
+
+	_, err := requestDigest(request)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
+	) {
+		t.Fatalf("expected missing plan error, got %v", err)
 	}
 }
 

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -147,6 +147,11 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		return StepResult{}, err
 	}
 
+	normalizedRequest, err := normalizeRouteSubmitRequest(input.Request)
+	if err != nil {
+		return StepResult{}, err
+	}
+
 	s.mutex.Lock()
 	if existing, ok, err := s.store.GetByRouteRequest(route, input.RouteRequestID); err != nil {
 		s.mutex.Unlock()
@@ -170,7 +175,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	now := s.now()
-	requestDigest, err := requestDigest(input.Request)
+	requestDigest, err := requestDigest(normalizedRequest)
 	if err != nil {
 		s.mutex.Unlock()
 		return StepResult{}, err
@@ -187,7 +192,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		Detail:          "accepted for covenant signing",
 		CreatedAt:       now.Format(time.RFC3339Nano),
 		UpdatedAt:       now.Format(time.RFC3339Nano),
-		Request:         input.Request,
+		Request:         normalizedRequest,
 	}
 
 	if err := s.store.Put(job); err != nil {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -175,7 +175,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	now := s.now()
-	requestDigest, err := requestDigest(normalizedRequest)
+	requestDigest, err := requestDigestFromNormalized(normalizedRequest)
 	if err != nil {
 		s.mutex.Unlock()
 		return StepResult{}, err

--- a/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
+++ b/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
@@ -1,0 +1,165 @@
+{
+  "version": 1,
+  "scope": "covenant_recovery_approval_contract_v1",
+  "vectors": {
+    "qc_v1": {
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_qc_v1",
+        "idempotencyKey": "idem-qc-vector-v1",
+        "route": "qc_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "qc_v1",
+            "scriptTemplateId": "qc_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            },
+            {
+              "role": "C",
+              "signature": "0xc0c0"
+            },
+            {
+              "role": "S",
+              "signature": "0x5050"
+            }
+          ]
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0xc0c0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "qc_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "custodianPublicKey": "0x02dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "beta": 144,
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": true
+        }
+      },
+      "expectedRequestDigest": "0x4bb14155042065021708e80e35470a27640d68fc3e2a642c3cb2823595ea66b1"
+    },
+    "self_v1": {
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_self_v1",
+        "idempotencyKey": "idem-self-vector-v1",
+        "route": "self_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "self_v1",
+            "scriptTemplateId": "self_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            },
+            {
+              "role": "S",
+              "signature": "0x5050"
+            }
+          ]
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "self_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": false
+        }
+      },
+      "expectedRequestDigest": "0x38c86be37817a1d4ec87bf5ec41a9022f44a03e08d7195c4280b7b91eae5bce2"
+    }
+  }
+}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -32,7 +32,12 @@ func strictUnmarshal(data []byte, target any) error {
 }
 
 func requestDigest(request RouteSubmitRequest) (string, error) {
-	payload, err := json.Marshal(request)
+	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+	if err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(normalizedRequest)
 	if err != nil {
 		return "", err
 	}
@@ -329,51 +334,65 @@ func requiredArtifactApprovalRoles(route TemplateID) ([]ArtifactApprovalRole, er
 }
 
 func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) error {
+	_, _, err := normalizeArtifactApprovals(route, request)
+	return err
+}
+
+func normalizeArtifactApprovals(
+	route TemplateID,
+	request RouteSubmitRequest,
+) (*ArtifactApprovalEnvelope, []string, error) {
 	normalizedLegacySignatures, err := validateArtifactSignatures(request.ArtifactSignatures)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if request.ArtifactApprovals == nil {
-		return nil
+		return nil, normalizedLegacySignatures, nil
 	}
 
 	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {
-		return &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
 	}
 	if request.ArtifactApprovals.Payload.Route != route {
-		return &inputError{"request.artifactApprovals.payload.route must match request.route"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.route must match request.route"}
 	}
 	if request.ArtifactApprovals.Payload.ScriptTemplateID != route {
-		return &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
 	}
 	if err := validateHexString(
 		"request.artifactApprovals.payload.destinationCommitmentHash",
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
 	); err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := validateHexString(
 		"request.artifactApprovals.payload.planCommitmentHash",
 		request.ArtifactApprovals.Payload.PlanCommitmentHash,
 	); err != nil {
-		return err
+		return nil, nil, err
 	}
-	if normalizeLowerHex(request.ArtifactApprovals.Payload.DestinationCommitmentHash) !=
-		normalizeLowerHex(request.DestinationCommitmentHash) {
-		return &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
+
+	normalizedDestinationCommitmentHash := normalizeLowerHex(
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+	)
+	if normalizedDestinationCommitmentHash != normalizeLowerHex(request.DestinationCommitmentHash) {
+		return nil, nil, &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
 	}
-	if normalizeLowerHex(request.ArtifactApprovals.Payload.PlanCommitmentHash) !=
-		normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
-		return &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
+
+	normalizedPlanCommitmentHash := normalizeLowerHex(
+		request.ArtifactApprovals.Payload.PlanCommitmentHash,
+	)
+	if normalizedPlanCommitmentHash != normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
+		return nil, nil, &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
 	}
 	if len(request.ArtifactApprovals.Approvals) == 0 {
-		return &inputError{"request.artifactApprovals.approvals must not be empty"}
+		return nil, nil, &inputError{"request.artifactApprovals.approvals must not be empty"}
 	}
 
 	requiredRoles, err := requiredArtifactApprovalRoles(route)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	allowedRoles := make(map[ArtifactApprovalRole]struct{}, len(requiredRoles))
@@ -384,14 +403,14 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 	approvalsByRole := make(map[ArtifactApprovalRole]string, len(requiredRoles))
 	for i, approval := range request.ArtifactApprovals.Approvals {
 		if _, ok := allowedRoles[approval.Role]; !ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals[%d].role is not allowed for %s",
 				i,
 				route,
 			)}
 		}
 		if _, ok := approvalsByRole[approval.Role]; ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals[%d].role duplicates role %s",
 				i,
 				approval.Role,
@@ -401,17 +420,27 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 			fmt.Sprintf("request.artifactApprovals.approvals[%d].signature", i),
 			approval.Signature,
 		); err != nil {
-			return err
+			return nil, nil, err
 		}
 
 		approvalsByRole[approval.Role] = normalizeLowerHex(approval.Signature)
 	}
 
 	derivedLegacySignatures := make([]string, len(requiredRoles))
+	normalizedApprovals := &ArtifactApprovalEnvelope{
+		Payload: ArtifactApprovalPayload{
+			ApprovalVersion:           artifactApprovalVersion,
+			Route:                     route,
+			ScriptTemplateID:          route,
+			DestinationCommitmentHash: normalizedDestinationCommitmentHash,
+			PlanCommitmentHash:        normalizedPlanCommitmentHash,
+		},
+		Approvals: make([]ArtifactRoleApproval, len(requiredRoles)),
+	}
 	for i, role := range requiredRoles {
 		signature, ok := approvalsByRole[role]
 		if !ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals must include role %s for %s",
 				role,
 				route,
@@ -419,18 +448,159 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 		}
 
 		derivedLegacySignatures[i] = signature
-	}
-
-	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
-		return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
-	}
-	for i := range derivedLegacySignatures {
-		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
-			return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		normalizedApprovals.Approvals[i] = ArtifactRoleApproval{
+			Role:      role,
+			Signature: signature,
 		}
 	}
 
-	return nil
+	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
+		return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+	}
+	for i := range derivedLegacySignatures {
+		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
+			return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		}
+	}
+
+	return normalizedApprovals, derivedLegacySignatures, nil
+}
+
+func normalizeArtifactRecord(record ArtifactRecord) ArtifactRecord {
+	normalized := ArtifactRecord{
+		PSBTHash:                  normalizeLowerHex(record.PSBTHash),
+		DestinationCommitmentHash: normalizeLowerHex(record.DestinationCommitmentHash),
+	}
+	if record.TransactionHex != "" {
+		normalized.TransactionHex = normalizeLowerHex(record.TransactionHex)
+	}
+	if record.TransactionID != "" {
+		normalized.TransactionID = normalizeLowerHex(record.TransactionID)
+	}
+
+	return normalized
+}
+
+func normalizeArtifacts(artifacts map[RecoveryPathID]ArtifactRecord) map[RecoveryPathID]ArtifactRecord {
+	if artifacts == nil {
+		return nil
+	}
+
+	normalized := make(map[RecoveryPathID]ArtifactRecord, len(artifacts))
+	for pathID, artifact := range artifacts {
+		normalized[pathID] = normalizeArtifactRecord(artifact)
+	}
+
+	return normalized
+}
+
+func normalizeMigrationDestination(
+	destination *MigrationDestinationReservation,
+) *MigrationDestinationReservation {
+	if destination == nil {
+		return nil
+	}
+
+	return &MigrationDestinationReservation{
+		ReservationID:             destination.ReservationID,
+		Reserve:                   normalizeLowerHex(destination.Reserve),
+		Epoch:                     destination.Epoch,
+		Route:                     destination.Route,
+		Revealer:                  normalizeLowerHex(destination.Revealer),
+		Vault:                     normalizeLowerHex(destination.Vault),
+		Network:                   strings.TrimSpace(destination.Network),
+		Status:                    destination.Status,
+		DepositScript:             normalizeLowerHex(destination.DepositScript),
+		DepositScriptHash:         normalizeLowerHex(destination.DepositScriptHash),
+		MigrationExtraData:        normalizeLowerHex(destination.MigrationExtraData),
+		DestinationCommitmentHash: normalizeLowerHex(destination.DestinationCommitmentHash),
+	}
+}
+
+func normalizeMigrationTransactionPlan(
+	plan *MigrationTransactionPlan,
+) *MigrationTransactionPlan {
+	if plan == nil {
+		return nil
+	}
+
+	return &MigrationTransactionPlan{
+		PlanVersion:          plan.PlanVersion,
+		PlanCommitmentHash:   normalizeLowerHex(plan.PlanCommitmentHash),
+		InputValueSats:       plan.InputValueSats,
+		DestinationValueSats: plan.DestinationValueSats,
+		AnchorValueSats:      plan.AnchorValueSats,
+		FeeSats:              plan.FeeSats,
+		InputSequence:        plan.InputSequence,
+		LockTime:             plan.LockTime,
+	}
+}
+
+func normalizeScriptTemplate(route TemplateID, rawTemplate json.RawMessage) (json.RawMessage, error) {
+	switch route {
+	case TemplateSelfV1:
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(rawTemplate, template); err != nil {
+			return nil, err
+		}
+		template.DepositorPublicKey = normalizeLowerHex(template.DepositorPublicKey)
+		template.SignerPublicKey = normalizeLowerHex(template.SignerPublicKey)
+		return json.Marshal(template)
+	case TemplateQcV1:
+		template := &QcV1Template{}
+		if err := strictUnmarshal(rawTemplate, template); err != nil {
+			return nil, err
+		}
+		template.DepositorPublicKey = normalizeLowerHex(template.DepositorPublicKey)
+		template.CustodianPublicKey = normalizeLowerHex(template.CustodianPublicKey)
+		template.SignerPublicKey = normalizeLowerHex(template.SignerPublicKey)
+		return json.Marshal(template)
+	default:
+		return nil, &inputError{"unsupported request.route"}
+	}
+}
+
+func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest, error) {
+	normalizedArtifactApprovals, normalizedArtifactSignatures, err := normalizeArtifactApprovals(
+		request.Route,
+		request,
+	)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	normalizedScriptTemplate, err := normalizeScriptTemplate(request.Route, request.ScriptTemplate)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	return RouteSubmitRequest{
+		FacadeRequestID: request.FacadeRequestID,
+		IdempotencyKey:  request.IdempotencyKey,
+		Route:           request.Route,
+		Strategy:        normalizeLowerHex(request.Strategy),
+		Reserve:         normalizeLowerHex(request.Reserve),
+		Epoch:           request.Epoch,
+		MaturityHeight:  request.MaturityHeight,
+		ActiveOutpoint: CovenantOutpoint{
+			TxID: normalizeLowerHex(request.ActiveOutpoint.TxID),
+			Vout: request.ActiveOutpoint.Vout,
+			ScriptHash: func() string {
+				if request.ActiveOutpoint.ScriptHash == "" {
+					return ""
+				}
+				return normalizeLowerHex(request.ActiveOutpoint.ScriptHash)
+			}(),
+		},
+		DestinationCommitmentHash: normalizeLowerHex(request.DestinationCommitmentHash),
+		MigrationDestination:      normalizeMigrationDestination(request.MigrationDestination),
+		MigrationTransactionPlan:  normalizeMigrationTransactionPlan(request.MigrationTransactionPlan),
+		ArtifactApprovals:         normalizedArtifactApprovals,
+		ArtifactSignatures:        normalizedArtifactSignatures,
+		Artifacts:                 normalizeArtifacts(request.Artifacts),
+		ScriptTemplate:            normalizedScriptTemplate,
+		Signing:                   request.Signing,
+	}, nil
 }
 
 func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -31,13 +31,32 @@ func strictUnmarshal(data []byte, target any) error {
 	return decoder.Decode(target)
 }
 
+func marshalCanonicalJSON(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+
+	return bytes.TrimSuffix(buffer.Bytes(), []byte("\n")), nil
+}
+
+// requestDigest accepts raw requests because Poll validates equivalence against
+// whatever the caller resubmits. Submit should use requestDigestFromNormalized
+// after it has already normalized the request once for storage.
 func requestDigest(request RouteSubmitRequest) (string, error) {
 	normalizedRequest, err := normalizeRouteSubmitRequest(request)
 	if err != nil {
 		return "", err
 	}
 
-	payload, err := json.Marshal(normalizedRequest)
+	return requestDigestFromNormalized(normalizedRequest)
+}
+
+func requestDigestFromNormalized(request RouteSubmitRequest) (string, error) {
+	payload, err := marshalCanonicalJSON(request)
 	if err != nil {
 		return "", err
 	}
@@ -349,6 +368,9 @@ func normalizeArtifactApprovals(
 
 	if request.ArtifactApprovals == nil {
 		return nil, normalizedLegacySignatures, nil
+	}
+	if request.MigrationTransactionPlan == nil {
+		return nil, nil, &inputError{"request.migrationTransactionPlan is required when request.artifactApprovals is present"}
 	}
 
 	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {


### PR DESCRIPTION
## Summary
- add checked-in qc_v1 and self_v1 covenant signer contract vectors
- prove equivalent approval-envelope variants normalize to the fixture request shape
- pin the expected request digests used for cross-repo contract coverage

## Testing
- go test ./pkg/covenantsigner
- go test ./pkg/tbtc -run CovenantSigner -count=1