### PR TITLE
Verify depositor and custodian covenant approvals

### DIFF
--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,6 +93,52 @@ func mustJSON(t *testing.T, value any) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+type approvalContractVector struct {
+	CanonicalSubmitRequest json.RawMessage `json:"canonicalSubmitRequest"`
+	ExpectedRequestDigest  string          `json:"expectedRequestDigest"`
+}
+
+type approvalContractVectorsFile struct {
+	Version int                               `json:"version"`
+	Scope   string                            `json:"scope"`
+	Vectors map[string]approvalContractVector `json:"vectors"`
+}
+
+func loadApprovalContractVector(
+	t *testing.T,
+	route TemplateID,
+) (RouteSubmitRequest, string) {
+	t.Helper()
+
+	data, err := os.ReadFile("testdata/covenant_recovery_approval_vectors_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vectors := approvalContractVectorsFile{}
+	if err := strictUnmarshal(data, &vectors); err != nil {
+		t.Fatal(err)
+	}
+	if vectors.Version != 1 {
+		t.Fatalf("unexpected vector version: %d", vectors.Version)
+	}
+	if vectors.Scope != "covenant_recovery_approval_contract_v1" {
+		t.Fatalf("unexpected vector scope: %s", vectors.Scope)
+	}
+
+	vector, ok := vectors.Vectors[string(route)]
+	if !ok {
+		t.Fatalf("missing vector for route %s", route)
+	}
+
+	request := RouteSubmitRequest{}
+	if err := strictUnmarshal(vector.CanonicalSubmitRequest, &request); err != nil {
+		t.Fatal(err)
+	}
+
+	return request, vector.ExpectedRequestDigest
 }
 
 func validSelfTemplate() json.RawMessage {
@@ -198,6 +245,116 @@ func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
 	}
 
 	return request
+}
+
+func cloneRouteSubmitRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+
+	cloned := RouteSubmitRequest{}
+	if err := strictUnmarshal(mustJSON(t, request), &cloned); err != nil {
+		t.Fatal(err)
+	}
+
+	return cloned
+}
+
+func equivalentArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+
+	variant := cloneRouteSubmitRequest(t, request)
+	variant.Strategy = upperHexBody(variant.Strategy)
+	variant.Reserve = upperHexBody(variant.Reserve)
+	variant.ActiveOutpoint.TxID = upperHexBody(variant.ActiveOutpoint.TxID)
+	if variant.ActiveOutpoint.ScriptHash != "" {
+		variant.ActiveOutpoint.ScriptHash = upperHexBody(variant.ActiveOutpoint.ScriptHash)
+	}
+	variant.DestinationCommitmentHash = upperHexBody(variant.DestinationCommitmentHash)
+
+	if variant.MigrationDestination != nil {
+		variant.MigrationDestination.Reserve = upperHexBody(variant.MigrationDestination.Reserve)
+		variant.MigrationDestination.Revealer = upperHexBody(variant.MigrationDestination.Revealer)
+		variant.MigrationDestination.Vault = upperHexBody(variant.MigrationDestination.Vault)
+		variant.MigrationDestination.DepositScript = upperHexBody(variant.MigrationDestination.DepositScript)
+		variant.MigrationDestination.DepositScriptHash = upperHexBody(variant.MigrationDestination.DepositScriptHash)
+		variant.MigrationDestination.MigrationExtraData = upperHexBody(variant.MigrationDestination.MigrationExtraData)
+		variant.MigrationDestination.DestinationCommitmentHash = upperHexBody(
+			variant.MigrationDestination.DestinationCommitmentHash,
+		)
+	}
+
+	if variant.MigrationTransactionPlan != nil {
+		variant.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(
+			variant.MigrationTransactionPlan.PlanCommitmentHash,
+		)
+	}
+
+	for i := range variant.ArtifactSignatures {
+		variant.ArtifactSignatures[i] = upperHexBody(variant.ArtifactSignatures[i])
+	}
+
+	for pathID, artifact := range variant.Artifacts {
+		artifact.PSBTHash = upperHexBody(artifact.PSBTHash)
+		artifact.DestinationCommitmentHash = upperHexBody(artifact.DestinationCommitmentHash)
+		if artifact.TransactionHex != "" {
+			artifact.TransactionHex = upperHexBody(artifact.TransactionHex)
+		}
+		if artifact.TransactionID != "" {
+			artifact.TransactionID = upperHexBody(artifact.TransactionID)
+		}
+		variant.Artifacts[pathID] = artifact
+	}
+
+	if variant.ArtifactApprovals != nil {
+		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			variant.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		variant.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			variant.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+
+		reorderedApprovals := make(
+			[]ArtifactRoleApproval,
+			len(variant.ArtifactApprovals.Approvals),
+		)
+		for i := range variant.ArtifactApprovals.Approvals {
+			approval := variant.ArtifactApprovals.Approvals[len(variant.ArtifactApprovals.Approvals)-1-i]
+			reorderedApprovals[i] = ArtifactRoleApproval{
+				Role:      approval.Role,
+				Signature: upperHexBody(approval.Signature),
+			}
+		}
+		variant.ArtifactApprovals.Approvals = reorderedApprovals
+	}
+
+	switch variant.Route {
+	case TemplateQcV1:
+		template := &QcV1Template{}
+		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
+			t.Fatal(err)
+		}
+		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
+		template.CustodianPublicKey = upperHexBody(template.CustodianPublicKey)
+		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		variant.ScriptTemplate = mustTemplate(template)
+	case TemplateSelfV1:
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
+			t.Fatal(err)
+		}
+		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
+		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		variant.ScriptTemplate = mustTemplate(template)
+	default:
+		t.Fatalf("unsupported route %s", variant.Route)
+	}
+
+	return variant
 }
 
 func upperHexBody(value string) string {
@@ -1479,6 +1636,61 @@ func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t 
 		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
 	) {
 		t.Fatalf("expected missing plan error, got %v", err)
+	}
+}
+
+func TestApprovalContractVectorsMatchExpectedRequestDigests(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			request, expectedDigest := loadApprovalContractVector(t, route)
+
+			digest, err := requestDigest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if digest != expectedDigest {
+				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
+	}
+}
+
+func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			canonicalRequest, expectedDigest := loadApprovalContractVector(t, route)
+
+			normalizedCanonical, err := normalizeRouteSubmitRequest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			variantRequest := equivalentArtifactApprovalVariantFromRequest(
+				t,
+				canonicalRequest,
+			)
+			normalizedVariant, err := normalizeRouteSubmitRequest(variantRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(normalizedVariant, normalizedCanonical) {
+				t.Fatalf(
+					"expected normalized variant %#v, got %#v",
+					normalizedCanonical,
+					normalizedVariant,
+				)
+			}
+
+			digest, err := requestDigest(variantRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if digest != expectedDigest {
+				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -3,6 +3,7 @@ package covenantsigner
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/keep-network/keep-common/pkg/persistence"
 )
 
@@ -141,11 +143,106 @@ func loadApprovalContractVector(
 	return request, vector.ExpectedRequestDigest
 }
 
+const (
+	testDepositorPrivateKeyHex = "0x1111111111111111111111111111111111111111111111111111111111111111"
+	testSignerPrivateKeyHex    = "0x2222222222222222222222222222222222222222222222222222222222222222"
+	testCustodianPrivateKeyHex = "0x3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+var (
+	testDepositorPrivateKey = mustDeterministicTestPrivateKey(testDepositorPrivateKeyHex)
+	testSignerPrivateKey    = mustDeterministicTestPrivateKey(testSignerPrivateKeyHex)
+	testCustodianPrivateKey = mustDeterministicTestPrivateKey(testCustodianPrivateKeyHex)
+	testDepositorPublicKey  = mustCompressedPublicKeyHex(testDepositorPrivateKey)
+	testSignerPublicKey     = mustCompressedPublicKeyHex(testSignerPrivateKey)
+	testCustodianPublicKey  = mustCompressedPublicKeyHex(testCustodianPrivateKey)
+)
+
+func mustDeterministicTestPrivateKey(encoded string) *btcec.PrivateKey {
+	rawPrivateKey, err := hex.DecodeString(strings.TrimPrefix(encoded, "0x"))
+	if err != nil {
+		panic(err)
+	}
+
+	privateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), rawPrivateKey)
+	return privateKey
+}
+
+func mustCompressedPublicKeyHex(privateKey *btcec.PrivateKey) string {
+	return "0x" + hex.EncodeToString(privateKey.PubKey().SerializeCompressed())
+}
+
+func mustArtifactApprovalSignature(
+	privateKey *btcec.PrivateKey,
+	payload ArtifactApprovalPayload,
+) string {
+	digest, err := artifactApprovalDigest(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	signature, err := privateKey.Sign(digest)
+	if err != nil {
+		panic(err)
+	}
+
+	return "0x" + hex.EncodeToString(signature.Serialize())
+}
+
+func artifactApprovalSignatureByRole(
+	artifactApprovals *ArtifactApprovalEnvelope,
+	role ArtifactApprovalRole,
+) string {
+	for _, approval := range artifactApprovals.Approvals {
+		if approval.Role == role {
+			return approval.Signature
+		}
+	}
+
+	panic(fmt.Sprintf("missing approval role %s", role))
+}
+
+func setArtifactApprovalSignature(
+	artifactApprovals *ArtifactApprovalEnvelope,
+	role ArtifactApprovalRole,
+	signature string,
+) {
+	for i, approval := range artifactApprovals.Approvals {
+		if approval.Role == role {
+			artifactApprovals.Approvals[i].Signature = signature
+			return
+		}
+	}
+
+	panic(fmt.Sprintf("missing approval role %s", role))
+}
+
+func canonicalArtifactSignatures(
+	route TemplateID,
+	artifactApprovals *ArtifactApprovalEnvelope,
+) []string {
+	if artifactApprovals == nil {
+		return nil
+	}
+
+	requiredRoles, err := requiredArtifactApprovalRoles(route)
+	if err != nil {
+		panic(err)
+	}
+
+	signatures := make([]string, len(requiredRoles))
+	for i, role := range requiredRoles {
+		signatures[i] = artifactApprovalSignatureByRole(artifactApprovals, role)
+	}
+
+	return signatures
+}
+
 func validSelfTemplate() json.RawMessage {
 	return mustTemplate(SelfV1Template{
 		Template:           TemplateSelfV1,
-		DepositorPublicKey: "0x021111",
-		SignerPublicKey:    "0x022222",
+		DepositorPublicKey: testDepositorPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
 		Delta2:             4320,
 	})
 }
@@ -153,9 +250,9 @@ func validSelfTemplate() json.RawMessage {
 func validQcTemplate() json.RawMessage {
 	return mustTemplate(QcV1Template{
 		Template:           TemplateQcV1,
-		DepositorPublicKey: "0x021111",
-		CustodianPublicKey: "0x023333",
-		SignerPublicKey:    "0x022222",
+		DepositorPublicKey: testDepositorPublicKey,
+		CustodianPublicKey: testCustodianPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
 		Beta:               144,
 		Delta2:             4320,
 	})
@@ -188,8 +285,7 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 			InputSequence:        canonicalCovenantInputSequence,
 			LockTime:             912345,
 		},
-		ArtifactSignatures: []string{"0x0708"},
-		Artifacts:          map[RecoveryPathID]ArtifactRecord{},
+		Artifacts: map[RecoveryPathID]ArtifactRecord{},
 	}
 
 	switch route {
@@ -206,45 +302,60 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 			request,
 			request.MigrationTransactionPlan,
 		)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactSignatures = canonicalArtifactSignatures(
+		request.Route,
+		request.ArtifactApprovals,
+	)
 
 	return request
 }
 
 func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelope {
+	payload := ArtifactApprovalPayload{
+		ApprovalVersion:           artifactApprovalVersion,
+		Route:                     request.Route,
+		ScriptTemplateID:          request.Route,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+	}
+
 	approvals := []ArtifactRoleApproval{
-		{Role: ArtifactApprovalRoleDepositor, Signature: "0xd0d0"},
-		{Role: ArtifactApprovalRoleSigner, Signature: "0x5050"},
+		{
+			Role:      ArtifactApprovalRoleDepositor,
+			Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+		},
+		{
+			Role:      ArtifactApprovalRoleSigner,
+			Signature: mustArtifactApprovalSignature(testSignerPrivateKey, payload),
+		},
 	}
 
 	if request.Route == TemplateQcV1 {
 		approvals = []ArtifactRoleApproval{
-			{Role: ArtifactApprovalRoleDepositor, Signature: "0xd0d0"},
-			{Role: ArtifactApprovalRoleCustodian, Signature: "0xc0c0"},
-			{Role: ArtifactApprovalRoleSigner, Signature: "0x5050"},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+			},
+			{
+				Role:      ArtifactApprovalRoleCustodian,
+				Signature: mustArtifactApprovalSignature(testCustodianPrivateKey, payload),
+			},
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: mustArtifactApprovalSignature(testSignerPrivateKey, payload),
+			},
 		}
 	}
 
 	return &ArtifactApprovalEnvelope{
-		Payload: ArtifactApprovalPayload{
-			ApprovalVersion:           artifactApprovalVersion,
-			Route:                     request.Route,
-			ScriptTemplateID:          request.Route,
-			DestinationCommitmentHash: request.DestinationCommitmentHash,
-			PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
-		},
+		Payload:   payload,
 		Approvals: approvals,
 	}
 }
 
 func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
-	request := baseRequest(route)
-	request.ArtifactApprovals = validArtifactApprovals(request)
-	request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
-	if route == TemplateQcV1 {
-		request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
-	}
-
-	return request
+	return baseRequest(route)
 }
 
 const (
@@ -474,9 +585,9 @@ func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
 	if route == TemplateQcV1 {
 		request.ScriptTemplate = mustTemplate(QcV1Template{
 			Template:           TemplateQcV1,
-			DepositorPublicKey: upperHexBody("0x021111"),
-			CustodianPublicKey: upperHexBody("0x023333"),
-			SignerPublicKey:    upperHexBody("0x022222"),
+			DepositorPublicKey: upperHexBody(testDepositorPublicKey),
+			CustodianPublicKey: upperHexBody(testCustodianPublicKey),
+			SignerPublicKey:    upperHexBody(testSignerPublicKey),
 			Beta:               144,
 			Delta2:             4320,
 		})
@@ -488,23 +599,38 @@ func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
 		)
 		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 			{
-				Role:      ArtifactApprovalRoleSigner,
-				Signature: upperHexBody("0x5050"),
+				Role: ArtifactApprovalRoleSigner,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleSigner,
+					),
+				),
 			},
 			{
-				Role:      ArtifactApprovalRoleDepositor,
-				Signature: upperHexBody("0xd0d0"),
+				Role: ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleDepositor,
+					),
+				),
 			},
 			{
-				Role:      ArtifactApprovalRoleCustodian,
-				Signature: upperHexBody("0xc0c0"),
+				Role: ArtifactApprovalRoleCustodian,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleCustodian,
+					),
+				),
 			},
 		}
 	} else {
 		request.ScriptTemplate = mustTemplate(SelfV1Template{
 			Template:           TemplateSelfV1,
-			DepositorPublicKey: upperHexBody("0x021111"),
-			SignerPublicKey:    upperHexBody("0x022222"),
+			DepositorPublicKey: upperHexBody(testDepositorPublicKey),
+			SignerPublicKey:    upperHexBody(testSignerPublicKey),
 			Delta2:             4320,
 		})
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
@@ -515,12 +641,22 @@ func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
 		)
 		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 			{
-				Role:      ArtifactApprovalRoleSigner,
-				Signature: upperHexBody("0x5050"),
+				Role: ArtifactApprovalRoleSigner,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleSigner,
+					),
+				),
 			},
 			{
-				Role:      ArtifactApprovalRoleDepositor,
-				Signature: upperHexBody("0xd0d0"),
+				Role: ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleDepositor,
+					),
+				),
 			},
 		}
 	}
@@ -1468,13 +1604,11 @@ func TestServiceAcceptsArtifactApprovalsWithCanonicalLegacySignatures(t *testing
 	}
 
 	request := baseRequest(TemplateQcV1)
-	request.ArtifactApprovals = validArtifactApprovals(request)
 	request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 		request.ArtifactApprovals.Approvals[2],
 		request.ArtifactApprovals.Approvals[0],
 		request.ArtifactApprovals.Approvals[1],
 	}
-	request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
 
 	result, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
 		RouteRequestID: "orq_artifact_approvals",
@@ -1518,12 +1652,14 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "missing qc custodian approval",
 			route: TemplateQcV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 					request.ArtifactApprovals.Approvals[0],
 					request.ArtifactApprovals.Approvals[2],
 				}
-				request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
+				request.ArtifactSignatures = []string{
+					request.ArtifactSignatures[0],
+					request.ArtifactSignatures[2],
+				}
 			},
 			expectErr: "request.artifactApprovals.approvals must include role C for qc_v1",
 		},
@@ -1531,13 +1667,17 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "self route rejects custodian approval role",
 			route: TemplateSelfV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 					request.ArtifactApprovals.Approvals[0],
-					{Role: ArtifactApprovalRoleCustodian, Signature: "0xc0c0"},
+					{
+						Role: ArtifactApprovalRoleCustodian,
+						Signature: mustArtifactApprovalSignature(
+							testCustodianPrivateKey,
+							request.ArtifactApprovals.Payload,
+						),
+					},
 					request.ArtifactApprovals.Approvals[1],
 				}
-				request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
 			},
 			expectErr: "request.artifactApprovals.approvals[1].role is not allowed for self_v1",
 		},
@@ -1545,18 +1685,27 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "plan commitment mismatch",
 			route: TemplateQcV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactApprovals.Payload.PlanCommitmentHash = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-				request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
 			},
 			expectErr: "request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash",
+		},
+		{
+			name:  "artifact approvals required",
+			route: TemplateSelfV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = nil
+			},
+			expectErr: "request.artifactApprovals is required",
 		},
 		{
 			name:  "legacy signature mismatch",
 			route: TemplateQcV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
-				request.ArtifactSignatures = []string{"0x5050", "0xd0d0", "0xc0c0"}
+				request.ArtifactSignatures = []string{
+					request.ArtifactSignatures[2],
+					request.ArtifactSignatures[0],
+					request.ArtifactSignatures[1],
+				}
 			},
 			expectErr: "request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals",
 		},
@@ -1564,10 +1713,47 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "legacy signatures remain required when approvals are present",
 			route: TemplateSelfV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactSignatures = nil
 			},
 			expectErr: "request.artifactSignatures must not be empty",
+		},
+		{
+			name:  "depositor signature does not verify",
+			route: TemplateSelfV1,
+			mutate: func(request *RouteSubmitRequest) {
+				setArtifactApprovalSignature(
+					request.ArtifactApprovals,
+					ArtifactApprovalRoleDepositor,
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleSigner,
+					),
+				)
+				request.ArtifactSignatures = canonicalArtifactSignatures(
+					request.Route,
+					request.ArtifactApprovals,
+				)
+			},
+			expectErr: "request.artifactApprovals.approvals[0].signature does not verify against the required public key",
+		},
+		{
+			name:  "custodian signature does not verify",
+			route: TemplateQcV1,
+			mutate: func(request *RouteSubmitRequest) {
+				setArtifactApprovalSignature(
+					request.ArtifactApprovals,
+					ArtifactApprovalRoleCustodian,
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleDepositor,
+					),
+				)
+				request.ArtifactSignatures = canonicalArtifactSignatures(
+					request.Route,
+					request.ArtifactApprovals,
+				)
+			},
+			expectErr: "request.artifactApprovals.approvals[1].signature does not verify against the required public key",
 		},
 	}
 
@@ -1722,6 +1908,29 @@ func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t 
 		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
 	) {
 		t.Fatalf("expected missing plan error, got %v", err)
+	}
+}
+
+func TestArtifactApprovalDigestMatchesPhase1Contract(t *testing.T) {
+	expectedDigests := map[TemplateID]string{
+		TemplateQcV1:   "0x4e1c72624e85c41d8d8a050d75704dc881ec6cd2dcfe1d240052887feef87ad8",
+		TemplateSelfV1: "0x960d7082d6eac550d7647d8fbeb90781e6cbd001b4d433e6635aa447dd937e79",
+	}
+
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			request := canonicalArtifactApprovalRequest(route)
+
+			digest, err := artifactApprovalDigest(request.ArtifactApprovals.Payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actualDigest := "0x" + hex.EncodeToString(digest)
+			if actualDigest != expectedDigests[route] {
+				t.Fatalf("expected digest %s, got %s", expectedDigests[route], actualDigest)
+			}
+		})
 	}
 }
 
@@ -2027,6 +2236,10 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 	defer server.Close()
 
 	base := baseRequest(TemplateSelfV1)
+	template := &SelfV1Template{}
+	if err := strictUnmarshal(base.ScriptTemplate, template); err != nil {
+		t.Fatal(err)
+	}
 	payload := bytes.NewBufferString(fmt.Sprintf(`{
 		"routeRequestId":"ors_http_unknown",
 		"stage":"SIGNER_COORDINATION",
@@ -2064,14 +2277,39 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 				"inputSequence":4294967293,
 				"lockTime":912345
 			},
-			"artifactSignatures":["0x0708"],
+			"artifactApprovals":{
+				"payload":{
+					"approvalVersion":1,
+					"route":"self_v1",
+					"scriptTemplateId":"self_v1",
+					"destinationCommitmentHash":"%s",
+					"planCommitmentHash":"%s"
+				},
+				"approvals":[
+					{"role":"D","signature":"%s"},
+					{"role":"S","signature":"%s"}
+				]
+			},
+			"artifactSignatures":["%s","%s"],
 			"artifacts":{},
-			"scriptTemplate":{"template":"self_v1","depositorPublicKey":"0x021111","signerPublicKey":"0x022222","delta2":4320},
+			"scriptTemplate":{"template":"self_v1","depositorPublicKey":"%s","signerPublicKey":"%s","delta2":4320},
 			"signing":{"signerRequired":true,"custodianRequired":false},
 			"futureField":"ignored"
 		},
 		"futureTopLevel":"ignored"
-	}`, base.DestinationCommitmentHash, base.DestinationCommitmentHash, base.MigrationTransactionPlan.PlanCommitmentHash))
+	}`,
+		base.DestinationCommitmentHash,
+		base.DestinationCommitmentHash,
+		base.MigrationTransactionPlan.PlanCommitmentHash,
+		base.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		base.ArtifactApprovals.Payload.PlanCommitmentHash,
+		base.ArtifactApprovals.Approvals[0].Signature,
+		base.ArtifactApprovals.Approvals[1].Signature,
+		base.ArtifactSignatures[0],
+		base.ArtifactSignatures[1],
+		template.DepositorPublicKey,
+		template.SignerPublicKey,
+	))
 
 	response, err := http.Post(server.URL+"/v1/self_v1/signer/requests", "application/json", payload)
 	if err != nil {

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -189,6 +189,102 @@ func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelop
 	}
 }
 
+func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
+	request := baseRequest(route)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
+	if route == TemplateQcV1 {
+		request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
+	}
+
+	return request
+}
+
+func upperHexBody(value string) string {
+	if !strings.HasPrefix(value, "0x") {
+		return strings.ToUpper(value)
+	}
+
+	return "0x" + strings.ToUpper(strings.TrimPrefix(value, "0x"))
+}
+
+func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
+	request := canonicalArtifactApprovalRequest(route)
+
+	request.Strategy = upperHexBody(request.Strategy)
+	request.Reserve = upperHexBody(request.Reserve)
+	request.ActiveOutpoint.TxID = upperHexBody(request.ActiveOutpoint.TxID)
+	request.ActiveOutpoint.ScriptHash = upperHexBody(request.ActiveOutpoint.ScriptHash)
+	request.DestinationCommitmentHash = upperHexBody(request.DestinationCommitmentHash)
+	request.MigrationDestination.Reserve = upperHexBody(request.MigrationDestination.Reserve)
+	request.MigrationDestination.Revealer = upperHexBody(request.MigrationDestination.Revealer)
+	request.MigrationDestination.Vault = upperHexBody(request.MigrationDestination.Vault)
+	request.MigrationDestination.DepositScript = upperHexBody(request.MigrationDestination.DepositScript)
+	request.MigrationDestination.DepositScriptHash = upperHexBody(request.MigrationDestination.DepositScriptHash)
+	request.MigrationDestination.MigrationExtraData = upperHexBody(request.MigrationDestination.MigrationExtraData)
+	request.MigrationDestination.DestinationCommitmentHash = upperHexBody(request.MigrationDestination.DestinationCommitmentHash)
+	request.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(request.MigrationTransactionPlan.PlanCommitmentHash)
+	for i := range request.ArtifactSignatures {
+		request.ArtifactSignatures[i] = upperHexBody(request.ArtifactSignatures[i])
+	}
+
+	if route == TemplateQcV1 {
+		request.ScriptTemplate = mustTemplate(QcV1Template{
+			Template:           TemplateQcV1,
+			DepositorPublicKey: upperHexBody("0x021111"),
+			CustodianPublicKey: upperHexBody("0x023333"),
+			SignerPublicKey:    upperHexBody("0x022222"),
+			Beta:               144,
+			Delta2:             4320,
+		})
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		request.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: upperHexBody("0x5050"),
+			},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody("0xd0d0"),
+			},
+			{
+				Role:      ArtifactApprovalRoleCustodian,
+				Signature: upperHexBody("0xc0c0"),
+			},
+		}
+	} else {
+		request.ScriptTemplate = mustTemplate(SelfV1Template{
+			Template:           TemplateSelfV1,
+			DepositorPublicKey: upperHexBody("0x021111"),
+			SignerPublicKey:    upperHexBody("0x022222"),
+			Delta2:             4320,
+		})
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		request.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: upperHexBody("0x5050"),
+			},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody("0xd0d0"),
+			},
+		}
+	}
+
+	return request
+}
+
 func validMigrationDestination() *MigrationDestinationReservation {
 	reservation := &MigrationDestinationReservation{
 		ReservationID: "cmdr_12345678",
@@ -1246,6 +1342,89 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
 			}
 		})
+	}
+}
+
+func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T) {
+	canonicalDigest, err := requestDigest(canonicalArtifactApprovalRequest(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variantDigest, err := requestDigest(equivalentArtifactApprovalVariant(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if canonicalDigest != variantDigest {
+		t.Fatalf("expected matching request digest, got %s vs %s", canonicalDigest, variantDigest)
+	}
+}
+
+func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitRequest := equivalentArtifactApprovalVariant(TemplateQcV1)
+	submitResult, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_equivalent_digest",
+		Stage:          StageSignerCoordination,
+		Request:        submitRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollResult, err := service.Poll(context.Background(), TemplateQcV1, SignerPollInput{
+		RouteRequestID: "orq_equivalent_digest",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        canonicalArtifactApprovalRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pollResult.Status != StepStatusPending {
+		t.Fatalf("expected PENDING, got %#v", pollResult)
+	}
+}
+
+func TestServiceStoresNormalizedArtifactApprovalRequest(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := equivalentArtifactApprovalVariant(TemplateQcV1)
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_normalized_store",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job, ok, err := service.store.GetByRouteRequest(TemplateQcV1, "orq_normalized_store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected stored job")
+	}
+
+	expected := canonicalArtifactApprovalRequest(TemplateQcV1)
+	if !reflect.DeepEqual(job.Request, expected) {
+		t.Fatalf("expected normalized request %#v, got %#v", expected, job.Request)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -1361,6 +1361,47 @@ func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T)
 	}
 }
 
+func TestRequestDigestDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
+	request := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	request.FacadeRequestID = "rf_<tag>&sink"
+	request.IdempotencyKey = "idem_>bridge"
+
+	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := marshalCanonicalJSON(normalizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(payload, []byte(`"facadeRequestId":"rf_<tag>&sink"`)) {
+		t.Fatalf("expected raw HTML-sensitive characters in payload, got %s", payload)
+	}
+	if bytes.Contains(payload, []byte(`\u003c`)) ||
+		bytes.Contains(payload, []byte(`\u003e`)) ||
+		bytes.Contains(payload, []byte(`\u0026`)) {
+		t.Fatalf("expected unescaped HTML-sensitive characters in payload, got %s", payload)
+	}
+
+	digestFromRawRequest, err := requestDigest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestFromNormalizedRequest, err := requestDigestFromNormalized(normalizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digestFromRawRequest != digestFromNormalizedRequest {
+		t.Fatalf(
+			"expected matching digests, got %s vs %s",
+			digestFromRawRequest,
+			digestFromNormalizedRequest,
+		)
+	}
+}
+
 func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -1425,6 +1466,19 @@ func TestServiceStoresNormalizedArtifactApprovalRequest(t *testing.T) {
 	expected := canonicalArtifactApprovalRequest(TemplateQcV1)
 	if !reflect.DeepEqual(job.Request, expected) {
 		t.Fatalf("expected normalized request %#v, got %#v", expected, job.Request)
+	}
+}
+
+func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t *testing.T) {
+	request := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	request.MigrationTransactionPlan = nil
+
+	_, err := requestDigest(request)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
+	) {
+		t.Fatalf("expected missing plan error, got %v", err)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -1831,6 +1831,42 @@ func TestRequestDigestDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
 	}
 }
 
+func TestDestinationCommitmentHashDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
+	destination := validMigrationDestination()
+	destination.Network = "regtest<v2>&sink"
+
+	payload, err := marshalCanonicalJSON(destinationCommitmentPayload{
+		Reserve:            normalizeLowerHex(destination.Reserve),
+		Epoch:              destination.Epoch,
+		Route:              string(destination.Route),
+		Revealer:           normalizeLowerHex(destination.Revealer),
+		Vault:              normalizeLowerHex(destination.Vault),
+		Network:            strings.TrimSpace(destination.Network),
+		DepositScriptHash:  normalizeLowerHex(destination.DepositScriptHash),
+		MigrationExtraData: normalizeLowerHex(destination.MigrationExtraData),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(payload, []byte(`"network":"regtest<v2>&sink"`)) {
+		t.Fatalf("expected raw HTML-sensitive characters in payload, got %s", payload)
+	}
+	if bytes.Contains(payload, []byte(`\u003c`)) ||
+		bytes.Contains(payload, []byte(`\u003e`)) ||
+		bytes.Contains(payload, []byte(`\u0026`)) {
+		t.Fatalf("expected unescaped HTML-sensitive characters in payload, got %s", payload)
+	}
+
+	hash, err := computeDestinationCommitmentHash(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash == "" {
+		t.Fatal("expected destination commitment hash")
+	}
+}
+
 func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -247,6 +247,52 @@ func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
 	return request
 }
 
+const (
+	mixedCaseCoverageStrategy = "0xaabbccddeeff00112233445566778899aabbccdd"
+	mixedCaseCoverageReserve  = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseCoverageRevealer = "0xdecafbaddecafbaddecafbaddecafbaddecafbad"
+	mixedCaseCoverageVault    = "0xbeadfeedbeadfeedbeadfeedbeadfeedbeadfeed"
+)
+
+func canonicalMixedCaseCoverageArtifactApprovalRequest(
+	t *testing.T,
+	route TemplateID,
+) RouteSubmitRequest {
+	t.Helper()
+
+	request := canonicalArtifactApprovalRequest(route)
+	request.Strategy = mixedCaseCoverageStrategy
+	request.Reserve = mixedCaseCoverageReserve
+	request.MigrationDestination.Reserve = mixedCaseCoverageReserve
+	request.MigrationDestination.Revealer = mixedCaseCoverageRevealer
+	request.MigrationDestination.Vault = mixedCaseCoverageVault
+	request.MigrationDestination.MigrationExtraData = computeMigrationExtraData(
+		request.MigrationDestination.Revealer,
+	)
+
+	destinationCommitmentHash, err := computeDestinationCommitmentHash(
+		request.MigrationDestination,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.MigrationDestination.DestinationCommitmentHash = destinationCommitmentHash
+	request.DestinationCommitmentHash = destinationCommitmentHash
+
+	planCommitmentHash, err := computeMigrationTransactionPlanCommitmentHash(
+		request,
+		request.MigrationTransactionPlan,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.MigrationTransactionPlan.PlanCommitmentHash = planCommitmentHash
+	request.ArtifactApprovals.Payload.DestinationCommitmentHash = destinationCommitmentHash
+	request.ArtifactApprovals.Payload.PlanCommitmentHash = planCommitmentHash
+
+	return request
+}
+
 func cloneRouteSubmitRequest(
 	t *testing.T,
 	request RouteSubmitRequest,
@@ -261,60 +307,61 @@ func cloneRouteSubmitRequest(
 	return cloned
 }
 
-func equivalentArtifactApprovalVariantFromRequest(
+func artifactApprovalVariantFromRequest(
 	t *testing.T,
 	request RouteSubmitRequest,
+	transformHex func(string) string,
 ) RouteSubmitRequest {
 	t.Helper()
 
 	variant := cloneRouteSubmitRequest(t, request)
-	variant.Strategy = upperHexBody(variant.Strategy)
-	variant.Reserve = upperHexBody(variant.Reserve)
-	variant.ActiveOutpoint.TxID = upperHexBody(variant.ActiveOutpoint.TxID)
+	variant.Strategy = transformHex(variant.Strategy)
+	variant.Reserve = transformHex(variant.Reserve)
+	variant.ActiveOutpoint.TxID = transformHex(variant.ActiveOutpoint.TxID)
 	if variant.ActiveOutpoint.ScriptHash != "" {
-		variant.ActiveOutpoint.ScriptHash = upperHexBody(variant.ActiveOutpoint.ScriptHash)
+		variant.ActiveOutpoint.ScriptHash = transformHex(variant.ActiveOutpoint.ScriptHash)
 	}
-	variant.DestinationCommitmentHash = upperHexBody(variant.DestinationCommitmentHash)
+	variant.DestinationCommitmentHash = transformHex(variant.DestinationCommitmentHash)
 
 	if variant.MigrationDestination != nil {
-		variant.MigrationDestination.Reserve = upperHexBody(variant.MigrationDestination.Reserve)
-		variant.MigrationDestination.Revealer = upperHexBody(variant.MigrationDestination.Revealer)
-		variant.MigrationDestination.Vault = upperHexBody(variant.MigrationDestination.Vault)
-		variant.MigrationDestination.DepositScript = upperHexBody(variant.MigrationDestination.DepositScript)
-		variant.MigrationDestination.DepositScriptHash = upperHexBody(variant.MigrationDestination.DepositScriptHash)
-		variant.MigrationDestination.MigrationExtraData = upperHexBody(variant.MigrationDestination.MigrationExtraData)
-		variant.MigrationDestination.DestinationCommitmentHash = upperHexBody(
+		variant.MigrationDestination.Reserve = transformHex(variant.MigrationDestination.Reserve)
+		variant.MigrationDestination.Revealer = transformHex(variant.MigrationDestination.Revealer)
+		variant.MigrationDestination.Vault = transformHex(variant.MigrationDestination.Vault)
+		variant.MigrationDestination.DepositScript = transformHex(variant.MigrationDestination.DepositScript)
+		variant.MigrationDestination.DepositScriptHash = transformHex(variant.MigrationDestination.DepositScriptHash)
+		variant.MigrationDestination.MigrationExtraData = transformHex(variant.MigrationDestination.MigrationExtraData)
+		variant.MigrationDestination.DestinationCommitmentHash = transformHex(
 			variant.MigrationDestination.DestinationCommitmentHash,
 		)
 	}
 
 	if variant.MigrationTransactionPlan != nil {
-		variant.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(
+		variant.MigrationTransactionPlan.PlanCommitmentHash = transformHex(
 			variant.MigrationTransactionPlan.PlanCommitmentHash,
 		)
 	}
 
 	for i := range variant.ArtifactSignatures {
-		variant.ArtifactSignatures[i] = upperHexBody(variant.ArtifactSignatures[i])
+		variant.ArtifactSignatures[i] = transformHex(variant.ArtifactSignatures[i])
 	}
 
 	for pathID, artifact := range variant.Artifacts {
-		artifact.PSBTHash = upperHexBody(artifact.PSBTHash)
-		artifact.DestinationCommitmentHash = upperHexBody(artifact.DestinationCommitmentHash)
+		artifact.PSBTHash = transformHex(artifact.PSBTHash)
+		artifact.DestinationCommitmentHash = transformHex(artifact.DestinationCommitmentHash)
 		if artifact.TransactionHex != "" {
-			artifact.TransactionHex = upperHexBody(artifact.TransactionHex)
+			artifact.TransactionHex = transformHex(artifact.TransactionHex)
 		}
 		if artifact.TransactionID != "" {
-			artifact.TransactionID = upperHexBody(artifact.TransactionID)
+			artifact.TransactionID = transformHex(artifact.TransactionID)
 		}
 		variant.Artifacts[pathID] = artifact
 	}
 
 	if variant.ArtifactApprovals != nil {
-		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = transformHex(
 			variant.ArtifactApprovals.Payload.DestinationCommitmentHash,
 		)
-		variant.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+		variant.ArtifactApprovals.Payload.PlanCommitmentHash = transformHex(
 			variant.ArtifactApprovals.Payload.PlanCommitmentHash,
 		)
 
@@ -326,7 +373,7 @@ func equivalentArtifactApprovalVariantFromRequest(
 			approval := variant.ArtifactApprovals.Approvals[len(variant.ArtifactApprovals.Approvals)-1-i]
 			reorderedApprovals[i] = ArtifactRoleApproval{
 				Role:      approval.Role,
-				Signature: upperHexBody(approval.Signature),
+				Signature: transformHex(approval.Signature),
 			}
 		}
 		variant.ArtifactApprovals.Approvals = reorderedApprovals
@@ -338,17 +385,17 @@ func equivalentArtifactApprovalVariantFromRequest(
 		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
 			t.Fatal(err)
 		}
-		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
-		template.CustodianPublicKey = upperHexBody(template.CustodianPublicKey)
-		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		template.DepositorPublicKey = transformHex(template.DepositorPublicKey)
+		template.CustodianPublicKey = transformHex(template.CustodianPublicKey)
+		template.SignerPublicKey = transformHex(template.SignerPublicKey)
 		variant.ScriptTemplate = mustTemplate(template)
 	case TemplateSelfV1:
 		template := &SelfV1Template{}
 		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
 			t.Fatal(err)
 		}
-		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
-		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		template.DepositorPublicKey = transformHex(template.DepositorPublicKey)
+		template.SignerPublicKey = transformHex(template.SignerPublicKey)
 		variant.ScriptTemplate = mustTemplate(template)
 	default:
 		t.Fatalf("unsupported route %s", variant.Route)
@@ -357,12 +404,51 @@ func equivalentArtifactApprovalVariantFromRequest(
 	return variant
 }
 
+func equivalentArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+	return artifactApprovalVariantFromRequest(t, request, upperHexBody)
+}
+
 func upperHexBody(value string) string {
 	if !strings.HasPrefix(value, "0x") {
 		return strings.ToUpper(value)
 	}
 
 	return "0x" + strings.ToUpper(strings.TrimPrefix(value, "0x"))
+}
+
+func mixedCaseHexBody(value string) string {
+	if !strings.HasPrefix(value, "0x") {
+		return value
+	}
+
+	body := strings.ToLower(strings.TrimPrefix(value, "0x"))
+	lettersSeen := 0
+	variant := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'f' {
+			if lettersSeen%2 == 0 {
+				lettersSeen++
+				return r - ('a' - 'A')
+			}
+
+			lettersSeen++
+		}
+
+		return r
+	}, body)
+
+	return "0x" + variant
+}
+
+func mixedCaseArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+	return artifactApprovalVariantFromRequest(t, request, mixedCaseHexBody)
 }
 
 func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
@@ -1689,6 +1775,59 @@ func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
 			}
 			if digest != expectedDigest {
 				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
+	}
+}
+
+func TestRequestDigestNormalizesMixedCaseArtifactApprovalVariants(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			canonicalRequest := canonicalMixedCaseCoverageArtifactApprovalRequest(t, route)
+			mixedCaseRequest := mixedCaseArtifactApprovalVariantFromRequest(
+				t,
+				canonicalRequest,
+			)
+
+			if mixedCaseRequest.Reserve == canonicalRequest.Reserve {
+				t.Fatalf(
+					"expected mixed-case reserve variant, got %s",
+					mixedCaseRequest.Reserve,
+				)
+			}
+
+			normalizedCanonical, err := normalizeRouteSubmitRequest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			normalizedMixedCase, err := normalizeRouteSubmitRequest(mixedCaseRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(normalizedMixedCase, normalizedCanonical) {
+				t.Fatalf(
+					"expected normalized mixed-case request %#v, got %#v",
+					normalizedCanonical,
+					normalizedMixedCase,
+				)
+			}
+
+			canonicalDigest, err := requestDigest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mixedCaseDigest, err := requestDigest(mixedCaseRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if mixedCaseDigest != canonicalDigest {
+				t.Fatalf(
+					"expected matching digest %s, got %s",
+					canonicalDigest,
+					mixedCaseDigest,
+				)
 			}
 		})
 	}

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -147,6 +147,11 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		return StepResult{}, err
 	}
 
+	normalizedRequest, err := normalizeRouteSubmitRequest(input.Request)
+	if err != nil {
+		return StepResult{}, err
+	}
+
 	s.mutex.Lock()
 	if existing, ok, err := s.store.GetByRouteRequest(route, input.RouteRequestID); err != nil {
 		s.mutex.Unlock()
@@ -170,7 +175,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	now := s.now()
-	requestDigest, err := requestDigest(input.Request)
+	requestDigest, err := requestDigest(normalizedRequest)
 	if err != nil {
 		s.mutex.Unlock()
 		return StepResult{}, err
@@ -187,7 +192,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		Detail:          "accepted for covenant signing",
 		CreatedAt:       now.Format(time.RFC3339Nano),
 		UpdatedAt:       now.Format(time.RFC3339Nano),
-		Request:         input.Request,
+		Request:         normalizedRequest,
 	}
 
 	if err := s.store.Put(job); err != nil {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -175,7 +175,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	now := s.now()
-	requestDigest, err := requestDigest(normalizedRequest)
+	requestDigest, err := requestDigestFromNormalized(normalizedRequest)
 	if err != nil {
 		s.mutex.Unlock()
 		return StepResult{}, err

--- a/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
+++ b/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
@@ -1,0 +1,165 @@
+{
+  "version": 1,
+  "scope": "covenant_recovery_approval_contract_v1",
+  "vectors": {
+    "qc_v1": {
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_qc_v1",
+        "idempotencyKey": "idem-qc-vector-v1",
+        "route": "qc_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "qc_v1",
+            "scriptTemplateId": "qc_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            },
+            {
+              "role": "C",
+              "signature": "0xc0c0"
+            },
+            {
+              "role": "S",
+              "signature": "0x5050"
+            }
+          ]
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0xc0c0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "qc_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "custodianPublicKey": "0x02dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "beta": 144,
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": true
+        }
+      },
+      "expectedRequestDigest": "0x4bb14155042065021708e80e35470a27640d68fc3e2a642c3cb2823595ea66b1"
+    },
+    "self_v1": {
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_self_v1",
+        "idempotencyKey": "idem-self-vector-v1",
+        "route": "self_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "self_v1",
+            "scriptTemplateId": "self_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            },
+            {
+              "role": "S",
+              "signature": "0x5050"
+            }
+          ]
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "self_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": false
+        }
+      },
+      "expectedRequestDigest": "0x38c86be37817a1d4ec87bf5ec41a9022f44a03e08d7195c4280b7b91eae5bce2"
+    }
+  }
+}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -32,7 +32,12 @@ func strictUnmarshal(data []byte, target any) error {
 }
 
 func requestDigest(request RouteSubmitRequest) (string, error) {
-	payload, err := json.Marshal(request)
+	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+	if err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(normalizedRequest)
 	if err != nil {
 		return "", err
 	}
@@ -329,51 +334,65 @@ func requiredArtifactApprovalRoles(route TemplateID) ([]ArtifactApprovalRole, er
 }
 
 func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) error {
+	_, _, err := normalizeArtifactApprovals(route, request)
+	return err
+}
+
+func normalizeArtifactApprovals(
+	route TemplateID,
+	request RouteSubmitRequest,
+) (*ArtifactApprovalEnvelope, []string, error) {
 	normalizedLegacySignatures, err := validateArtifactSignatures(request.ArtifactSignatures)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if request.ArtifactApprovals == nil {
-		return nil
+		return nil, normalizedLegacySignatures, nil
 	}
 
 	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {
-		return &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
 	}
 	if request.ArtifactApprovals.Payload.Route != route {
-		return &inputError{"request.artifactApprovals.payload.route must match request.route"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.route must match request.route"}
 	}
 	if request.ArtifactApprovals.Payload.ScriptTemplateID != route {
-		return &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
 	}
 	if err := validateHexString(
 		"request.artifactApprovals.payload.destinationCommitmentHash",
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
 	); err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := validateHexString(
 		"request.artifactApprovals.payload.planCommitmentHash",
 		request.ArtifactApprovals.Payload.PlanCommitmentHash,
 	); err != nil {
-		return err
+		return nil, nil, err
 	}
-	if normalizeLowerHex(request.ArtifactApprovals.Payload.DestinationCommitmentHash) !=
-		normalizeLowerHex(request.DestinationCommitmentHash) {
-		return &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
+
+	normalizedDestinationCommitmentHash := normalizeLowerHex(
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+	)
+	if normalizedDestinationCommitmentHash != normalizeLowerHex(request.DestinationCommitmentHash) {
+		return nil, nil, &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
 	}
-	if normalizeLowerHex(request.ArtifactApprovals.Payload.PlanCommitmentHash) !=
-		normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
-		return &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
+
+	normalizedPlanCommitmentHash := normalizeLowerHex(
+		request.ArtifactApprovals.Payload.PlanCommitmentHash,
+	)
+	if normalizedPlanCommitmentHash != normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
+		return nil, nil, &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
 	}
 	if len(request.ArtifactApprovals.Approvals) == 0 {
-		return &inputError{"request.artifactApprovals.approvals must not be empty"}
+		return nil, nil, &inputError{"request.artifactApprovals.approvals must not be empty"}
 	}
 
 	requiredRoles, err := requiredArtifactApprovalRoles(route)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	allowedRoles := make(map[ArtifactApprovalRole]struct{}, len(requiredRoles))
@@ -384,14 +403,14 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 	approvalsByRole := make(map[ArtifactApprovalRole]string, len(requiredRoles))
 	for i, approval := range request.ArtifactApprovals.Approvals {
 		if _, ok := allowedRoles[approval.Role]; !ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals[%d].role is not allowed for %s",
 				i,
 				route,
 			)}
 		}
 		if _, ok := approvalsByRole[approval.Role]; ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals[%d].role duplicates role %s",
 				i,
 				approval.Role,
@@ -401,17 +420,27 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 			fmt.Sprintf("request.artifactApprovals.approvals[%d].signature", i),
 			approval.Signature,
 		); err != nil {
-			return err
+			return nil, nil, err
 		}
 
 		approvalsByRole[approval.Role] = normalizeLowerHex(approval.Signature)
 	}
 
 	derivedLegacySignatures := make([]string, len(requiredRoles))
+	normalizedApprovals := &ArtifactApprovalEnvelope{
+		Payload: ArtifactApprovalPayload{
+			ApprovalVersion:           artifactApprovalVersion,
+			Route:                     route,
+			ScriptTemplateID:          route,
+			DestinationCommitmentHash: normalizedDestinationCommitmentHash,
+			PlanCommitmentHash:        normalizedPlanCommitmentHash,
+		},
+		Approvals: make([]ArtifactRoleApproval, len(requiredRoles)),
+	}
 	for i, role := range requiredRoles {
 		signature, ok := approvalsByRole[role]
 		if !ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals must include role %s for %s",
 				role,
 				route,
@@ -419,18 +448,159 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 		}
 
 		derivedLegacySignatures[i] = signature
-	}
-
-	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
-		return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
-	}
-	for i := range derivedLegacySignatures {
-		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
-			return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		normalizedApprovals.Approvals[i] = ArtifactRoleApproval{
+			Role:      role,
+			Signature: signature,
 		}
 	}
 
-	return nil
+	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
+		return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+	}
+	for i := range derivedLegacySignatures {
+		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
+			return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		}
+	}
+
+	return normalizedApprovals, derivedLegacySignatures, nil
+}
+
+func normalizeArtifactRecord(record ArtifactRecord) ArtifactRecord {
+	normalized := ArtifactRecord{
+		PSBTHash:                  normalizeLowerHex(record.PSBTHash),
+		DestinationCommitmentHash: normalizeLowerHex(record.DestinationCommitmentHash),
+	}
+	if record.TransactionHex != "" {
+		normalized.TransactionHex = normalizeLowerHex(record.TransactionHex)
+	}
+	if record.TransactionID != "" {
+		normalized.TransactionID = normalizeLowerHex(record.TransactionID)
+	}
+
+	return normalized
+}
+
+func normalizeArtifacts(artifacts map[RecoveryPathID]ArtifactRecord) map[RecoveryPathID]ArtifactRecord {
+	if artifacts == nil {
+		return nil
+	}
+
+	normalized := make(map[RecoveryPathID]ArtifactRecord, len(artifacts))
+	for pathID, artifact := range artifacts {
+		normalized[pathID] = normalizeArtifactRecord(artifact)
+	}
+
+	return normalized
+}
+
+func normalizeMigrationDestination(
+	destination *MigrationDestinationReservation,
+) *MigrationDestinationReservation {
+	if destination == nil {
+		return nil
+	}
+
+	return &MigrationDestinationReservation{
+		ReservationID:             destination.ReservationID,
+		Reserve:                   normalizeLowerHex(destination.Reserve),
+		Epoch:                     destination.Epoch,
+		Route:                     destination.Route,
+		Revealer:                  normalizeLowerHex(destination.Revealer),
+		Vault:                     normalizeLowerHex(destination.Vault),
+		Network:                   strings.TrimSpace(destination.Network),
+		Status:                    destination.Status,
+		DepositScript:             normalizeLowerHex(destination.DepositScript),
+		DepositScriptHash:         normalizeLowerHex(destination.DepositScriptHash),
+		MigrationExtraData:        normalizeLowerHex(destination.MigrationExtraData),
+		DestinationCommitmentHash: normalizeLowerHex(destination.DestinationCommitmentHash),
+	}
+}
+
+func normalizeMigrationTransactionPlan(
+	plan *MigrationTransactionPlan,
+) *MigrationTransactionPlan {
+	if plan == nil {
+		return nil
+	}
+
+	return &MigrationTransactionPlan{
+		PlanVersion:          plan.PlanVersion,
+		PlanCommitmentHash:   normalizeLowerHex(plan.PlanCommitmentHash),
+		InputValueSats:       plan.InputValueSats,
+		DestinationValueSats: plan.DestinationValueSats,
+		AnchorValueSats:      plan.AnchorValueSats,
+		FeeSats:              plan.FeeSats,
+		InputSequence:        plan.InputSequence,
+		LockTime:             plan.LockTime,
+	}
+}
+
+func normalizeScriptTemplate(route TemplateID, rawTemplate json.RawMessage) (json.RawMessage, error) {
+	switch route {
+	case TemplateSelfV1:
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(rawTemplate, template); err != nil {
+			return nil, err
+		}
+		template.DepositorPublicKey = normalizeLowerHex(template.DepositorPublicKey)
+		template.SignerPublicKey = normalizeLowerHex(template.SignerPublicKey)
+		return json.Marshal(template)
+	case TemplateQcV1:
+		template := &QcV1Template{}
+		if err := strictUnmarshal(rawTemplate, template); err != nil {
+			return nil, err
+		}
+		template.DepositorPublicKey = normalizeLowerHex(template.DepositorPublicKey)
+		template.CustodianPublicKey = normalizeLowerHex(template.CustodianPublicKey)
+		template.SignerPublicKey = normalizeLowerHex(template.SignerPublicKey)
+		return json.Marshal(template)
+	default:
+		return nil, &inputError{"unsupported request.route"}
+	}
+}
+
+func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest, error) {
+	normalizedArtifactApprovals, normalizedArtifactSignatures, err := normalizeArtifactApprovals(
+		request.Route,
+		request,
+	)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	normalizedScriptTemplate, err := normalizeScriptTemplate(request.Route, request.ScriptTemplate)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	return RouteSubmitRequest{
+		FacadeRequestID: request.FacadeRequestID,
+		IdempotencyKey:  request.IdempotencyKey,
+		Route:           request.Route,
+		Strategy:        normalizeLowerHex(request.Strategy),
+		Reserve:         normalizeLowerHex(request.Reserve),
+		Epoch:           request.Epoch,
+		MaturityHeight:  request.MaturityHeight,
+		ActiveOutpoint: CovenantOutpoint{
+			TxID: normalizeLowerHex(request.ActiveOutpoint.TxID),
+			Vout: request.ActiveOutpoint.Vout,
+			ScriptHash: func() string {
+				if request.ActiveOutpoint.ScriptHash == "" {
+					return ""
+				}
+				return normalizeLowerHex(request.ActiveOutpoint.ScriptHash)
+			}(),
+		},
+		DestinationCommitmentHash: normalizeLowerHex(request.DestinationCommitmentHash),
+		MigrationDestination:      normalizeMigrationDestination(request.MigrationDestination),
+		MigrationTransactionPlan:  normalizeMigrationTransactionPlan(request.MigrationTransactionPlan),
+		ArtifactApprovals:         normalizedArtifactApprovals,
+		ArtifactSignatures:        normalizedArtifactSignatures,
+		Artifacts:                 normalizeArtifacts(request.Artifacts),
+		ScriptTemplate:            normalizedScriptTemplate,
+		Signing:                   request.Signing,
+	}, nil
 }
 
 func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -31,13 +31,32 @@ func strictUnmarshal(data []byte, target any) error {
 	return decoder.Decode(target)
 }
 
+func marshalCanonicalJSON(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+
+	return bytes.TrimSuffix(buffer.Bytes(), []byte("\n")), nil
+}
+
+// requestDigest accepts raw requests because Poll validates equivalence against
+// whatever the caller resubmits. Submit should use requestDigestFromNormalized
+// after it has already normalized the request once for storage.
 func requestDigest(request RouteSubmitRequest) (string, error) {
 	normalizedRequest, err := normalizeRouteSubmitRequest(request)
 	if err != nil {
 		return "", err
 	}
 
-	payload, err := json.Marshal(normalizedRequest)
+	return requestDigestFromNormalized(normalizedRequest)
+}
+
+func requestDigestFromNormalized(request RouteSubmitRequest) (string, error) {
+	payload, err := marshalCanonicalJSON(request)
 	if err != nil {
 		return "", err
 	}
@@ -349,6 +368,9 @@ func normalizeArtifactApprovals(
 
 	if request.ArtifactApprovals == nil {
 		return nil, normalizedLegacySignatures, nil
+	}
+	if request.MigrationTransactionPlan == nil {
+		return nil, nil, &inputError{"request.migrationTransactionPlan is required when request.artifactApprovals is present"}
 	}
 
 	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -2,12 +2,18 @@ package covenantsigner
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"strings"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -16,6 +22,15 @@ const (
 	migrationTransactionPlanVersion uint32 = 1
 	artifactApprovalVersion         uint32 = 1
 )
+
+var artifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
+	"ArtifactApproval(" +
+		"uint8 approvalVersion," +
+		"bytes32 route," +
+		"bytes32 scriptTemplateId," +
+		"bytes32 destinationCommitmentHash," +
+		"bytes32 planCommitmentHash)",
+))
 
 type inputError struct {
 	message string
@@ -89,8 +104,164 @@ func validateAddressString(name string, value string) error {
 	return nil
 }
 
+func validateBytes32HexString(name string, value string) error {
+	if err := validateHexString(name, value); err != nil {
+		return err
+	}
+
+	if len(value) != 66 {
+		return &inputError{fmt.Sprintf("%s must be a 32-byte 0x-prefixed hex string", name)}
+	}
+
+	return nil
+}
+
+func decodeBytes32HexString(name string, value string) ([32]byte, error) {
+	var decoded [32]byte
+
+	if err := validateBytes32HexString(name, value); err != nil {
+		return decoded, err
+	}
+
+	rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+	if err != nil {
+		return decoded, &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	copy(decoded[:], rawValue)
+	return decoded, nil
+}
+
 func normalizeLowerHex(value string) string {
 	return strings.ToLower(value)
+}
+
+func abiEncodeUint32Word(value uint32) [32]byte {
+	var encoded [32]byte
+	binary.BigEndian.PutUint32(encoded[28:], value)
+	return encoded
+}
+
+func keccakTemplateIdentifier(id TemplateID) [32]byte {
+	hash := crypto.Keccak256Hash([]byte(id))
+
+	var encoded [32]byte
+	copy(encoded[:], hash.Bytes())
+
+	return encoded
+}
+
+// artifactApprovalDigest pins the current phase-1 approval payload contract to
+// a deterministic EIP-712-compatible struct hash, without yet committing to a
+// chain-specific domain separator.
+func artifactApprovalDigest(payload ArtifactApprovalPayload) ([]byte, error) {
+	destinationCommitmentHash, err := decodeBytes32HexString(
+		"request.artifactApprovals.payload.destinationCommitmentHash",
+		payload.DestinationCommitmentHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	planCommitmentHash, err := decodeBytes32HexString(
+		"request.artifactApprovals.payload.planCommitmentHash",
+		payload.PlanCommitmentHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded := make([]byte, 32*6)
+	approvalVersionWord := abiEncodeUint32Word(payload.ApprovalVersion)
+	routeIdentifier := keccakTemplateIdentifier(payload.Route)
+	scriptTemplateIdentifier := keccakTemplateIdentifier(payload.ScriptTemplateID)
+
+	copy(encoded[0:32], artifactApprovalTypeHash.Bytes())
+	copy(encoded[32:64], approvalVersionWord[:])
+	copy(encoded[64:96], routeIdentifier[:])
+	copy(encoded[96:128], scriptTemplateIdentifier[:])
+	copy(encoded[128:160], destinationCommitmentHash[:])
+	copy(encoded[160:192], planCommitmentHash[:])
+
+	digest := crypto.Keccak256Hash(encoded)
+	return digest.Bytes(), nil
+}
+
+func parseCompressedSecp256k1PublicKey(
+	name string,
+	value string,
+) (*btcec.PublicKey, error) {
+	if err := validateHexString(name, value); err != nil {
+		return nil, err
+	}
+
+	rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+	if err != nil {
+		return nil, &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	if len(rawValue) != 33 || (rawValue[0] != 0x02 && rawValue[0] != 0x03) {
+		return nil, &inputError{fmt.Sprintf("%s must be a compressed secp256k1 public key", name)}
+	}
+
+	publicKey, err := btcec.ParsePubKey(rawValue, btcec.S256())
+	if err != nil {
+		return nil, &inputError{fmt.Sprintf("%s must be a compressed secp256k1 public key", name)}
+	}
+
+	return publicKey, nil
+}
+
+func verifyCompactSecp256k1Signature(
+	publicKey *btcec.PublicKey,
+	digest []byte,
+	signature []byte,
+) bool {
+	return ecdsa.Verify(
+		publicKey.ToECDSA(),
+		digest,
+		new(big.Int).SetBytes(signature[:32]),
+		new(big.Int).SetBytes(signature[32:]),
+	)
+}
+
+func verifySecp256k1Signature(
+	name string,
+	publicKey *btcec.PublicKey,
+	digest []byte,
+	signature string,
+) error {
+	rawSignature, err := hex.DecodeString(strings.TrimPrefix(signature, "0x"))
+	if err != nil {
+		return &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	switch {
+	case len(rawSignature) == 64:
+		if verifyCompactSecp256k1Signature(publicKey, digest, rawSignature) {
+			return nil
+		}
+	case len(rawSignature) == 65 &&
+		(rawSignature[64] == 0 || rawSignature[64] == 1 || rawSignature[64] == 27 || rawSignature[64] == 28):
+		if verifyCompactSecp256k1Signature(publicKey, digest, rawSignature[:64]) {
+			return nil
+		}
+	default:
+		parsedSignature, err := btcec.ParseDERSignature(rawSignature, btcec.S256())
+		if err != nil {
+			return &inputError{
+				fmt.Sprintf(
+					"%s must be a DER or 64/65-byte secp256k1 signature",
+					name,
+				),
+			}
+		}
+		if parsedSignature.Verify(digest, publicKey) {
+			return nil
+		}
+	}
+
+	return &inputError{fmt.Sprintf("%s does not verify against the required public key", name)}
 }
 
 func computeMigrationExtraData(revealer string) string {
@@ -382,13 +553,13 @@ func normalizeArtifactApprovals(
 	if request.ArtifactApprovals.Payload.ScriptTemplateID != route {
 		return nil, nil, &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
 	}
-	if err := validateHexString(
+	if err := validateBytes32HexString(
 		"request.artifactApprovals.payload.destinationCommitmentHash",
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
 	); err != nil {
 		return nil, nil, err
 	}
-	if err := validateHexString(
+	if err := validateBytes32HexString(
 		"request.artifactApprovals.payload.planCommitmentHash",
 		request.ArtifactApprovals.Payload.PlanCommitmentHash,
 	); err != nil {
@@ -486,6 +657,71 @@ func normalizeArtifactApprovals(
 	}
 
 	return normalizedApprovals, derivedLegacySignatures, nil
+}
+
+func validateArtifactApprovalAuthenticity(
+	request RouteSubmitRequest,
+	depositorPublicKey string,
+	custodianPublicKey string,
+) error {
+	payloadDigest, err := artifactApprovalDigest(request.ArtifactApprovals.Payload)
+	if err != nil {
+		return err
+	}
+
+	depositorKey, err := parseCompressedSecp256k1PublicKey(
+		"request.scriptTemplate.depositorPublicKey",
+		depositorPublicKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	var custodianKey *btcec.PublicKey
+	if custodianPublicKey != "" {
+		custodianKey, err = parseCompressedSecp256k1PublicKey(
+			"request.scriptTemplate.custodianPublicKey",
+			custodianPublicKey,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i, approval := range request.ArtifactApprovals.Approvals {
+		signaturePath := fmt.Sprintf(
+			"request.artifactApprovals.approvals[%d].signature",
+			i,
+		)
+
+		switch approval.Role {
+		case ArtifactApprovalRoleDepositor:
+			if err := verifySecp256k1Signature(
+				signaturePath,
+				depositorKey,
+				payloadDigest,
+				approval.Signature,
+			); err != nil {
+				return err
+			}
+		case ArtifactApprovalRoleCustodian:
+			if custodianKey == nil {
+				return &inputError{
+					"request.artifactApprovals.approvals includes unexpected custodian role",
+				}
+			}
+			if err := verifySecp256k1Signature(
+				signaturePath,
+				custodianKey,
+				payloadDigest,
+				approval.Signature,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func normalizeArtifactRecord(record ArtifactRecord) ArtifactRecord {
@@ -664,6 +900,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if err := validateMigrationTransactionPlan(request, request.MigrationTransactionPlan); err != nil {
 		return err
 	}
+	if request.ArtifactApprovals == nil {
+		return &inputError{"request.artifactApprovals is required"}
+	}
 	if err := validateArtifactApprovals(route, request); err != nil {
 		return err
 	}
@@ -686,6 +925,13 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
 			return err
 		}
+		if err := validateArtifactApprovalAuthenticity(
+			request,
+			template.DepositorPublicKey,
+			"",
+		); err != nil {
+			return err
+		}
 	case TemplateQcV1:
 		if !request.Signing.SignerRequired || !request.Signing.CustodianRequired {
 			return &inputError{"request.signing must set signerRequired=true and custodianRequired=true for qc_v1"}
@@ -704,6 +950,13 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 			return err
 		}
 		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
+			return err
+		}
+		if err := validateArtifactApprovalAuthenticity(
+			request,
+			template.DepositorPublicKey,
+			template.CustodianPublicKey,
+		); err != nil {
 			return err
 		}
 	default:

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -312,7 +312,7 @@ type migrationPlanCommitmentPayload struct {
 func computeDestinationCommitmentHash(
 	reservation *MigrationDestinationReservation,
 ) (string, error) {
-	payload, err := json.Marshal(destinationCommitmentPayload{
+	payload, err := marshalCanonicalJSON(destinationCommitmentPayload{
 		Reserve:            normalizeLowerHex(reservation.Reserve),
 		Epoch:              reservation.Epoch,
 		Route:              string(reservation.Route),
@@ -334,7 +334,7 @@ func computeMigrationTransactionPlanCommitmentHash(
 	request RouteSubmitRequest,
 	plan *MigrationTransactionPlan,
 ) (string, error) {
-	payload, err := json.Marshal(migrationPlanCommitmentPayload{
+	payload, err := marshalCanonicalJSON(migrationPlanCommitmentPayload{
 		PlanVersion:               plan.PlanVersion,
 		Reserve:                   normalizeLowerHex(request.Reserve),
 		Epoch:                     request.Epoch,
@@ -718,6 +718,12 @@ func validateArtifactApprovalAuthenticity(
 			); err != nil {
 				return err
 			}
+		case ArtifactApprovalRoleSigner:
+			// Phase 1 keeps S structurally required but not cryptographically
+			// verified. Signer approval must eventually bind to quorum or
+			// signer-service trust roots rather than the single signer key in the
+			// script template.
+			continue
 		}
 	}
 

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"math"
@@ -14,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -196,6 +198,7 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 		},
 	}
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, nil)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_self_ready",
@@ -425,6 +428,7 @@ func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
 		},
 	}
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, custodianPrivateKey)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_ready",
@@ -664,6 +668,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsInvalidBeta(t *testing.T) {
 	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
 	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, custodianPrivateKey)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_bad_beta",
@@ -800,6 +805,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsScriptHashMismatch(t *testing.T) 
 		},
 	}
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, custodianPrivateKey)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_bad_script_hash",
@@ -903,6 +909,7 @@ func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T
 	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
 	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, nil)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_self_zero",
@@ -1116,6 +1123,143 @@ func testMigrationTransactionPlanCommitmentHash(
 
 	sum := sha256.Sum256(payload)
 	return "0x" + hex.EncodeToString(sum[:])
+}
+
+var testArtifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
+	"ArtifactApproval(" +
+		"uint8 approvalVersion," +
+		"bytes32 route," +
+		"bytes32 scriptTemplateId," +
+		"bytes32 destinationCommitmentHash," +
+		"bytes32 planCommitmentHash)",
+))
+
+func testArtifactApprovalDigest(
+	t *testing.T,
+	payload covenantsigner.ArtifactApprovalPayload,
+) []byte {
+	t.Helper()
+
+	decodeBytes32 := func(name string, value string) [32]byte {
+		t.Helper()
+
+		rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+		if err != nil {
+			t.Fatalf("cannot decode %s: %v", name, err)
+		}
+		if len(rawValue) != 32 {
+			t.Fatalf("expected %s to be 32 bytes, got %d", name, len(rawValue))
+		}
+
+		var decoded [32]byte
+		copy(decoded[:], rawValue)
+		return decoded
+	}
+
+	encodeUint32 := func(value uint32) [32]byte {
+		var encoded [32]byte
+		binary.BigEndian.PutUint32(encoded[28:], value)
+		return encoded
+	}
+
+	keccakTemplateIdentifier := func(value covenantsigner.TemplateID) [32]byte {
+		hash := crypto.Keccak256Hash([]byte(value))
+		var encoded [32]byte
+		copy(encoded[:], hash.Bytes())
+		return encoded
+	}
+
+	destinationCommitmentHash := decodeBytes32(
+		"destinationCommitmentHash",
+		payload.DestinationCommitmentHash,
+	)
+	planCommitmentHash := decodeBytes32(
+		"planCommitmentHash",
+		payload.PlanCommitmentHash,
+	)
+	approvalVersionWord := encodeUint32(payload.ApprovalVersion)
+	routeIdentifier := keccakTemplateIdentifier(payload.Route)
+	scriptTemplateIdentifier := keccakTemplateIdentifier(payload.ScriptTemplateID)
+
+	encoded := make([]byte, 32*6)
+	copy(encoded[0:32], testArtifactApprovalTypeHash.Bytes())
+	copy(encoded[32:64], approvalVersionWord[:])
+	copy(encoded[64:96], routeIdentifier[:])
+	copy(encoded[96:128], scriptTemplateIdentifier[:])
+	copy(encoded[128:160], destinationCommitmentHash[:])
+	copy(encoded[160:192], planCommitmentHash[:])
+
+	digest := crypto.Keccak256Hash(encoded)
+	return digest.Bytes()
+}
+
+func testSignArtifactApproval(
+	t *testing.T,
+	privateKey *btcec.PrivateKey,
+	payload covenantsigner.ArtifactApprovalPayload,
+) string {
+	t.Helper()
+
+	signature, err := privateKey.Sign(testArtifactApprovalDigest(t, payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return "0x" + hex.EncodeToString(signature.Serialize())
+}
+
+func applyTestArtifactApprovals(
+	t *testing.T,
+	request *covenantsigner.RouteSubmitRequest,
+	depositorPrivateKey *btcec.PrivateKey,
+	custodianPrivateKey *btcec.PrivateKey,
+) {
+	t.Helper()
+
+	payload := covenantsigner.ArtifactApprovalPayload{
+		ApprovalVersion:           1,
+		Route:                     request.Route,
+		ScriptTemplateID:          request.Route,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+	}
+
+	approvals := []covenantsigner.ArtifactRoleApproval{
+		{
+			Role:      covenantsigner.ArtifactApprovalRoleDepositor,
+			Signature: testSignArtifactApproval(t, depositorPrivateKey, payload),
+		},
+		{
+			Role:      covenantsigner.ArtifactApprovalRoleSigner,
+			Signature: "0x5151",
+		},
+	}
+
+	if request.Route == covenantsigner.TemplateQcV1 {
+		approvals = []covenantsigner.ArtifactRoleApproval{
+			{
+				Role:      covenantsigner.ArtifactApprovalRoleDepositor,
+				Signature: testSignArtifactApproval(t, depositorPrivateKey, payload),
+			},
+			{
+				Role:      covenantsigner.ArtifactApprovalRoleCustodian,
+				Signature: testSignArtifactApproval(t, custodianPrivateKey, payload),
+			},
+			{
+				Role:      covenantsigner.ArtifactApprovalRoleSigner,
+				Signature: "0x5151",
+			},
+		}
+	}
+
+	request.ArtifactApprovals = &covenantsigner.ArtifactApprovalEnvelope{
+		Payload:   payload,
+		Approvals: approvals,
+	}
+	request.ArtifactSignatures = make([]string, len(approvals))
+	for i, approval := range approvals {
+		request.ArtifactSignatures[i] = approval.Signature
+	}
 }
 
 func applyTestMigrationTransactionPlanCommitment(


### PR DESCRIPTION
## Summary
- require artifactApprovals on submitted covenant signer requests
- verify depositor and custodian approvals against the script-template secp256k1 public keys over the pinned phase-1 approval digest
- add deterministic approval/signature test fixtures, route coverage, and digest regressions across pkg/covenantsigner and pkg/tbtc

## Testing
- go test ./pkg/covenantsigner
- go test ./pkg/tbtc -run CovenantSigner -count=1