### PR TITLE
Verify structured covenant signer approvals

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1464,7 +1464,16 @@ func (tc *TbtcChain) GetWallet(
 	if wallet.CreatedAt == 0 {
 		return nil, fmt.Errorf(
 			"no wallet for public key hash [0x%x]",
-			wallet,
+			walletPublicKeyHash,
+		)
+	}
+
+	walletRegistryWallet, err := tc.walletRegistry.GetWallet(wallet.EcdsaWalletID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot get wallet registry data for wallet [0x%x]: [%v]",
+			wallet.EcdsaWalletID,
+			err,
 		)
 	}
 
@@ -1475,6 +1484,7 @@ func (tc *TbtcChain) GetWallet(
 
 	return &tbtc.WalletChainData{
 		EcdsaWalletID:                          wallet.EcdsaWalletID,
+		MembersIDsHash:                         walletRegistryWallet.MembersIdsHash,
 		MainUtxoHash:                           wallet.MainUtxoHash,
 		PendingRedemptionsValue:                wallet.PendingRedemptionsValue,
 		CreatedAt:                              time.Unix(int64(wallet.CreatedAt), 0),

--- a/pkg/covenantsigner/config.go
+++ b/pkg/covenantsigner/config.go
@@ -15,4 +15,8 @@ type Config struct {
 	// EnableSelfV1 exposes the self_v1 signer HTTP routes. Keep this disabled
 	// for a qc_v1-first launch unless self_v1 has cleared its own go-live gate.
 	EnableSelfV1 bool
+	// MigrationPlanQuoteTrustRoots configures the destination-service plan-quote
+	// trust roots used to verify migration plan quotes when the quote authority
+	// path is enabled.
+	MigrationPlanQuoteTrustRoots []MigrationPlanQuoteTrustRoot `mapstructure:"migrationPlanQuoteTrustRoots"`
 }

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,6 +93,52 @@ func mustJSON(t *testing.T, value any) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+type approvalContractVector struct {
+	CanonicalSubmitRequest json.RawMessage `json:"canonicalSubmitRequest"`
+	ExpectedRequestDigest  string          `json:"expectedRequestDigest"`
+}
+
+type approvalContractVectorsFile struct {
+	Version int                               `json:"version"`
+	Scope   string                            `json:"scope"`
+	Vectors map[string]approvalContractVector `json:"vectors"`
+}
+
+func loadApprovalContractVector(
+	t *testing.T,
+	route TemplateID,
+) (RouteSubmitRequest, string) {
+	t.Helper()
+
+	data, err := os.ReadFile("testdata/covenant_recovery_approval_vectors_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vectors := approvalContractVectorsFile{}
+	if err := strictUnmarshal(data, &vectors); err != nil {
+		t.Fatal(err)
+	}
+	if vectors.Version != 1 {
+		t.Fatalf("unexpected vector version: %d", vectors.Version)
+	}
+	if vectors.Scope != "covenant_recovery_approval_contract_v1" {
+		t.Fatalf("unexpected vector scope: %s", vectors.Scope)
+	}
+
+	vector, ok := vectors.Vectors[string(route)]
+	if !ok {
+		t.Fatalf("missing vector for route %s", route)
+	}
+
+	request := RouteSubmitRequest{}
+	if err := strictUnmarshal(vector.CanonicalSubmitRequest, &request); err != nil {
+		t.Fatal(err)
+	}
+
+	return request, vector.ExpectedRequestDigest
 }
 
 func validSelfTemplate() json.RawMessage {
@@ -198,6 +245,116 @@ func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
 	}
 
 	return request
+}
+
+func cloneRouteSubmitRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+
+	cloned := RouteSubmitRequest{}
+	if err := strictUnmarshal(mustJSON(t, request), &cloned); err != nil {
+		t.Fatal(err)
+	}
+
+	return cloned
+}
+
+func equivalentArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+
+	variant := cloneRouteSubmitRequest(t, request)
+	variant.Strategy = upperHexBody(variant.Strategy)
+	variant.Reserve = upperHexBody(variant.Reserve)
+	variant.ActiveOutpoint.TxID = upperHexBody(variant.ActiveOutpoint.TxID)
+	if variant.ActiveOutpoint.ScriptHash != "" {
+		variant.ActiveOutpoint.ScriptHash = upperHexBody(variant.ActiveOutpoint.ScriptHash)
+	}
+	variant.DestinationCommitmentHash = upperHexBody(variant.DestinationCommitmentHash)
+
+	if variant.MigrationDestination != nil {
+		variant.MigrationDestination.Reserve = upperHexBody(variant.MigrationDestination.Reserve)
+		variant.MigrationDestination.Revealer = upperHexBody(variant.MigrationDestination.Revealer)
+		variant.MigrationDestination.Vault = upperHexBody(variant.MigrationDestination.Vault)
+		variant.MigrationDestination.DepositScript = upperHexBody(variant.MigrationDestination.DepositScript)
+		variant.MigrationDestination.DepositScriptHash = upperHexBody(variant.MigrationDestination.DepositScriptHash)
+		variant.MigrationDestination.MigrationExtraData = upperHexBody(variant.MigrationDestination.MigrationExtraData)
+		variant.MigrationDestination.DestinationCommitmentHash = upperHexBody(
+			variant.MigrationDestination.DestinationCommitmentHash,
+		)
+	}
+
+	if variant.MigrationTransactionPlan != nil {
+		variant.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(
+			variant.MigrationTransactionPlan.PlanCommitmentHash,
+		)
+	}
+
+	for i := range variant.ArtifactSignatures {
+		variant.ArtifactSignatures[i] = upperHexBody(variant.ArtifactSignatures[i])
+	}
+
+	for pathID, artifact := range variant.Artifacts {
+		artifact.PSBTHash = upperHexBody(artifact.PSBTHash)
+		artifact.DestinationCommitmentHash = upperHexBody(artifact.DestinationCommitmentHash)
+		if artifact.TransactionHex != "" {
+			artifact.TransactionHex = upperHexBody(artifact.TransactionHex)
+		}
+		if artifact.TransactionID != "" {
+			artifact.TransactionID = upperHexBody(artifact.TransactionID)
+		}
+		variant.Artifacts[pathID] = artifact
+	}
+
+	if variant.ArtifactApprovals != nil {
+		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			variant.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		variant.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			variant.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+
+		reorderedApprovals := make(
+			[]ArtifactRoleApproval,
+			len(variant.ArtifactApprovals.Approvals),
+		)
+		for i := range variant.ArtifactApprovals.Approvals {
+			approval := variant.ArtifactApprovals.Approvals[len(variant.ArtifactApprovals.Approvals)-1-i]
+			reorderedApprovals[i] = ArtifactRoleApproval{
+				Role:      approval.Role,
+				Signature: upperHexBody(approval.Signature),
+			}
+		}
+		variant.ArtifactApprovals.Approvals = reorderedApprovals
+	}
+
+	switch variant.Route {
+	case TemplateQcV1:
+		template := &QcV1Template{}
+		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
+			t.Fatal(err)
+		}
+		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
+		template.CustodianPublicKey = upperHexBody(template.CustodianPublicKey)
+		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		variant.ScriptTemplate = mustTemplate(template)
+	case TemplateSelfV1:
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
+			t.Fatal(err)
+		}
+		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
+		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		variant.ScriptTemplate = mustTemplate(template)
+	default:
+		t.Fatalf("unsupported route %s", variant.Route)
+	}
+
+	return variant
 }
 
 func upperHexBody(value string) string {
@@ -1479,6 +1636,61 @@ func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t 
 		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
 	) {
 		t.Fatalf("expected missing plan error, got %v", err)
+	}
+}
+
+func TestApprovalContractVectorsMatchExpectedRequestDigests(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			request, expectedDigest := loadApprovalContractVector(t, route)
+
+			digest, err := requestDigest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if digest != expectedDigest {
+				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
+	}
+}
+
+func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			canonicalRequest, expectedDigest := loadApprovalContractVector(t, route)
+
+			normalizedCanonical, err := normalizeRouteSubmitRequest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			variantRequest := equivalentArtifactApprovalVariantFromRequest(
+				t,
+				canonicalRequest,
+			)
+			normalizedVariant, err := normalizeRouteSubmitRequest(variantRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(normalizedVariant, normalizedCanonical) {
+				t.Fatalf(
+					"expected normalized variant %#v, got %#v",
+					normalizedCanonical,
+					normalizedVariant,
+				)
+			}
+
+			digest, err := requestDigest(variantRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if digest != expectedDigest {
+				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -3,6 +3,7 @@ package covenantsigner
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/keep-network/keep-common/pkg/persistence"
 )
 
@@ -141,11 +143,106 @@ func loadApprovalContractVector(
 	return request, vector.ExpectedRequestDigest
 }
 
+const (
+	testDepositorPrivateKeyHex = "0x1111111111111111111111111111111111111111111111111111111111111111"
+	testSignerPrivateKeyHex    = "0x2222222222222222222222222222222222222222222222222222222222222222"
+	testCustodianPrivateKeyHex = "0x3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+var (
+	testDepositorPrivateKey = mustDeterministicTestPrivateKey(testDepositorPrivateKeyHex)
+	testSignerPrivateKey    = mustDeterministicTestPrivateKey(testSignerPrivateKeyHex)
+	testCustodianPrivateKey = mustDeterministicTestPrivateKey(testCustodianPrivateKeyHex)
+	testDepositorPublicKey  = mustCompressedPublicKeyHex(testDepositorPrivateKey)
+	testSignerPublicKey     = mustCompressedPublicKeyHex(testSignerPrivateKey)
+	testCustodianPublicKey  = mustCompressedPublicKeyHex(testCustodianPrivateKey)
+)
+
+func mustDeterministicTestPrivateKey(encoded string) *btcec.PrivateKey {
+	rawPrivateKey, err := hex.DecodeString(strings.TrimPrefix(encoded, "0x"))
+	if err != nil {
+		panic(err)
+	}
+
+	privateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), rawPrivateKey)
+	return privateKey
+}
+
+func mustCompressedPublicKeyHex(privateKey *btcec.PrivateKey) string {
+	return "0x" + hex.EncodeToString(privateKey.PubKey().SerializeCompressed())
+}
+
+func mustArtifactApprovalSignature(
+	privateKey *btcec.PrivateKey,
+	payload ArtifactApprovalPayload,
+) string {
+	digest, err := artifactApprovalDigest(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	signature, err := privateKey.Sign(digest)
+	if err != nil {
+		panic(err)
+	}
+
+	return "0x" + hex.EncodeToString(signature.Serialize())
+}
+
+func artifactApprovalSignatureByRole(
+	artifactApprovals *ArtifactApprovalEnvelope,
+	role ArtifactApprovalRole,
+) string {
+	for _, approval := range artifactApprovals.Approvals {
+		if approval.Role == role {
+			return approval.Signature
+		}
+	}
+
+	panic(fmt.Sprintf("missing approval role %s", role))
+}
+
+func setArtifactApprovalSignature(
+	artifactApprovals *ArtifactApprovalEnvelope,
+	role ArtifactApprovalRole,
+	signature string,
+) {
+	for i, approval := range artifactApprovals.Approvals {
+		if approval.Role == role {
+			artifactApprovals.Approvals[i].Signature = signature
+			return
+		}
+	}
+
+	panic(fmt.Sprintf("missing approval role %s", role))
+}
+
+func canonicalArtifactSignatures(
+	route TemplateID,
+	artifactApprovals *ArtifactApprovalEnvelope,
+) []string {
+	if artifactApprovals == nil {
+		return nil
+	}
+
+	requiredRoles, err := requiredArtifactApprovalRoles(route)
+	if err != nil {
+		panic(err)
+	}
+
+	signatures := make([]string, len(requiredRoles))
+	for i, role := range requiredRoles {
+		signatures[i] = artifactApprovalSignatureByRole(artifactApprovals, role)
+	}
+
+	return signatures
+}
+
 func validSelfTemplate() json.RawMessage {
 	return mustTemplate(SelfV1Template{
 		Template:           TemplateSelfV1,
-		DepositorPublicKey: "0x021111",
-		SignerPublicKey:    "0x022222",
+		DepositorPublicKey: testDepositorPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
 		Delta2:             4320,
 	})
 }
@@ -153,9 +250,9 @@ func validSelfTemplate() json.RawMessage {
 func validQcTemplate() json.RawMessage {
 	return mustTemplate(QcV1Template{
 		Template:           TemplateQcV1,
-		DepositorPublicKey: "0x021111",
-		CustodianPublicKey: "0x023333",
-		SignerPublicKey:    "0x022222",
+		DepositorPublicKey: testDepositorPublicKey,
+		CustodianPublicKey: testCustodianPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
 		Beta:               144,
 		Delta2:             4320,
 	})
@@ -188,8 +285,7 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 			InputSequence:        canonicalCovenantInputSequence,
 			LockTime:             912345,
 		},
-		ArtifactSignatures: []string{"0x0708"},
-		Artifacts:          map[RecoveryPathID]ArtifactRecord{},
+		Artifacts: map[RecoveryPathID]ArtifactRecord{},
 	}
 
 	switch route {
@@ -206,45 +302,60 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 			request,
 			request.MigrationTransactionPlan,
 		)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactSignatures = canonicalArtifactSignatures(
+		request.Route,
+		request.ArtifactApprovals,
+	)
 
 	return request
 }
 
 func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelope {
+	payload := ArtifactApprovalPayload{
+		ApprovalVersion:           artifactApprovalVersion,
+		Route:                     request.Route,
+		ScriptTemplateID:          request.Route,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+	}
+
 	approvals := []ArtifactRoleApproval{
-		{Role: ArtifactApprovalRoleDepositor, Signature: "0xd0d0"},
-		{Role: ArtifactApprovalRoleSigner, Signature: "0x5050"},
+		{
+			Role:      ArtifactApprovalRoleDepositor,
+			Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+		},
+		{
+			Role:      ArtifactApprovalRoleSigner,
+			Signature: mustArtifactApprovalSignature(testSignerPrivateKey, payload),
+		},
 	}
 
 	if request.Route == TemplateQcV1 {
 		approvals = []ArtifactRoleApproval{
-			{Role: ArtifactApprovalRoleDepositor, Signature: "0xd0d0"},
-			{Role: ArtifactApprovalRoleCustodian, Signature: "0xc0c0"},
-			{Role: ArtifactApprovalRoleSigner, Signature: "0x5050"},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+			},
+			{
+				Role:      ArtifactApprovalRoleCustodian,
+				Signature: mustArtifactApprovalSignature(testCustodianPrivateKey, payload),
+			},
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: mustArtifactApprovalSignature(testSignerPrivateKey, payload),
+			},
 		}
 	}
 
 	return &ArtifactApprovalEnvelope{
-		Payload: ArtifactApprovalPayload{
-			ApprovalVersion:           artifactApprovalVersion,
-			Route:                     request.Route,
-			ScriptTemplateID:          request.Route,
-			DestinationCommitmentHash: request.DestinationCommitmentHash,
-			PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
-		},
+		Payload:   payload,
 		Approvals: approvals,
 	}
 }
 
 func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
-	request := baseRequest(route)
-	request.ArtifactApprovals = validArtifactApprovals(request)
-	request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
-	if route == TemplateQcV1 {
-		request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
-	}
-
-	return request
+	return baseRequest(route)
 }
 
 const (
@@ -474,9 +585,9 @@ func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
 	if route == TemplateQcV1 {
 		request.ScriptTemplate = mustTemplate(QcV1Template{
 			Template:           TemplateQcV1,
-			DepositorPublicKey: upperHexBody("0x021111"),
-			CustodianPublicKey: upperHexBody("0x023333"),
-			SignerPublicKey:    upperHexBody("0x022222"),
+			DepositorPublicKey: upperHexBody(testDepositorPublicKey),
+			CustodianPublicKey: upperHexBody(testCustodianPublicKey),
+			SignerPublicKey:    upperHexBody(testSignerPublicKey),
 			Beta:               144,
 			Delta2:             4320,
 		})
@@ -488,23 +599,38 @@ func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
 		)
 		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 			{
-				Role:      ArtifactApprovalRoleSigner,
-				Signature: upperHexBody("0x5050"),
+				Role: ArtifactApprovalRoleSigner,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleSigner,
+					),
+				),
 			},
 			{
-				Role:      ArtifactApprovalRoleDepositor,
-				Signature: upperHexBody("0xd0d0"),
+				Role: ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleDepositor,
+					),
+				),
 			},
 			{
-				Role:      ArtifactApprovalRoleCustodian,
-				Signature: upperHexBody("0xc0c0"),
+				Role: ArtifactApprovalRoleCustodian,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleCustodian,
+					),
+				),
 			},
 		}
 	} else {
 		request.ScriptTemplate = mustTemplate(SelfV1Template{
 			Template:           TemplateSelfV1,
-			DepositorPublicKey: upperHexBody("0x021111"),
-			SignerPublicKey:    upperHexBody("0x022222"),
+			DepositorPublicKey: upperHexBody(testDepositorPublicKey),
+			SignerPublicKey:    upperHexBody(testSignerPublicKey),
 			Delta2:             4320,
 		})
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
@@ -515,12 +641,22 @@ func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
 		)
 		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 			{
-				Role:      ArtifactApprovalRoleSigner,
-				Signature: upperHexBody("0x5050"),
+				Role: ArtifactApprovalRoleSigner,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleSigner,
+					),
+				),
 			},
 			{
-				Role:      ArtifactApprovalRoleDepositor,
-				Signature: upperHexBody("0xd0d0"),
+				Role: ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody(
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleDepositor,
+					),
+				),
 			},
 		}
 	}
@@ -1468,13 +1604,11 @@ func TestServiceAcceptsArtifactApprovalsWithCanonicalLegacySignatures(t *testing
 	}
 
 	request := baseRequest(TemplateQcV1)
-	request.ArtifactApprovals = validArtifactApprovals(request)
 	request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 		request.ArtifactApprovals.Approvals[2],
 		request.ArtifactApprovals.Approvals[0],
 		request.ArtifactApprovals.Approvals[1],
 	}
-	request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
 
 	result, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
 		RouteRequestID: "orq_artifact_approvals",
@@ -1518,12 +1652,14 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "missing qc custodian approval",
 			route: TemplateQcV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 					request.ArtifactApprovals.Approvals[0],
 					request.ArtifactApprovals.Approvals[2],
 				}
-				request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
+				request.ArtifactSignatures = []string{
+					request.ArtifactSignatures[0],
+					request.ArtifactSignatures[2],
+				}
 			},
 			expectErr: "request.artifactApprovals.approvals must include role C for qc_v1",
 		},
@@ -1531,13 +1667,17 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "self route rejects custodian approval role",
 			route: TemplateSelfV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
 					request.ArtifactApprovals.Approvals[0],
-					{Role: ArtifactApprovalRoleCustodian, Signature: "0xc0c0"},
+					{
+						Role: ArtifactApprovalRoleCustodian,
+						Signature: mustArtifactApprovalSignature(
+							testCustodianPrivateKey,
+							request.ArtifactApprovals.Payload,
+						),
+					},
 					request.ArtifactApprovals.Approvals[1],
 				}
-				request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
 			},
 			expectErr: "request.artifactApprovals.approvals[1].role is not allowed for self_v1",
 		},
@@ -1545,18 +1685,27 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "plan commitment mismatch",
 			route: TemplateQcV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactApprovals.Payload.PlanCommitmentHash = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-				request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
 			},
 			expectErr: "request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash",
+		},
+		{
+			name:  "artifact approvals required",
+			route: TemplateSelfV1,
+			mutate: func(request *RouteSubmitRequest) {
+				request.ArtifactApprovals = nil
+			},
+			expectErr: "request.artifactApprovals is required",
 		},
 		{
 			name:  "legacy signature mismatch",
 			route: TemplateQcV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
-				request.ArtifactSignatures = []string{"0x5050", "0xd0d0", "0xc0c0"}
+				request.ArtifactSignatures = []string{
+					request.ArtifactSignatures[2],
+					request.ArtifactSignatures[0],
+					request.ArtifactSignatures[1],
+				}
 			},
 			expectErr: "request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals",
 		},
@@ -1564,10 +1713,47 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 			name:  "legacy signatures remain required when approvals are present",
 			route: TemplateSelfV1,
 			mutate: func(request *RouteSubmitRequest) {
-				request.ArtifactApprovals = validArtifactApprovals(*request)
 				request.ArtifactSignatures = nil
 			},
 			expectErr: "request.artifactSignatures must not be empty",
+		},
+		{
+			name:  "depositor signature does not verify",
+			route: TemplateSelfV1,
+			mutate: func(request *RouteSubmitRequest) {
+				setArtifactApprovalSignature(
+					request.ArtifactApprovals,
+					ArtifactApprovalRoleDepositor,
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleSigner,
+					),
+				)
+				request.ArtifactSignatures = canonicalArtifactSignatures(
+					request.Route,
+					request.ArtifactApprovals,
+				)
+			},
+			expectErr: "request.artifactApprovals.approvals[0].signature does not verify against the required public key",
+		},
+		{
+			name:  "custodian signature does not verify",
+			route: TemplateQcV1,
+			mutate: func(request *RouteSubmitRequest) {
+				setArtifactApprovalSignature(
+					request.ArtifactApprovals,
+					ArtifactApprovalRoleCustodian,
+					artifactApprovalSignatureByRole(
+						request.ArtifactApprovals,
+						ArtifactApprovalRoleDepositor,
+					),
+				)
+				request.ArtifactSignatures = canonicalArtifactSignatures(
+					request.Route,
+					request.ArtifactApprovals,
+				)
+			},
+			expectErr: "request.artifactApprovals.approvals[1].signature does not verify against the required public key",
 		},
 	}
 
@@ -1722,6 +1908,29 @@ func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t 
 		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
 	) {
 		t.Fatalf("expected missing plan error, got %v", err)
+	}
+}
+
+func TestArtifactApprovalDigestMatchesPhase1Contract(t *testing.T) {
+	expectedDigests := map[TemplateID]string{
+		TemplateQcV1:   "0x4e1c72624e85c41d8d8a050d75704dc881ec6cd2dcfe1d240052887feef87ad8",
+		TemplateSelfV1: "0x960d7082d6eac550d7647d8fbeb90781e6cbd001b4d433e6635aa447dd937e79",
+	}
+
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			request := canonicalArtifactApprovalRequest(route)
+
+			digest, err := artifactApprovalDigest(request.ArtifactApprovals.Payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actualDigest := "0x" + hex.EncodeToString(digest)
+			if actualDigest != expectedDigests[route] {
+				t.Fatalf("expected digest %s, got %s", expectedDigests[route], actualDigest)
+			}
+		})
 	}
 }
 
@@ -2027,6 +2236,10 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 	defer server.Close()
 
 	base := baseRequest(TemplateSelfV1)
+	template := &SelfV1Template{}
+	if err := strictUnmarshal(base.ScriptTemplate, template); err != nil {
+		t.Fatal(err)
+	}
 	payload := bytes.NewBufferString(fmt.Sprintf(`{
 		"routeRequestId":"ors_http_unknown",
 		"stage":"SIGNER_COORDINATION",
@@ -2064,14 +2277,39 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 				"inputSequence":4294967293,
 				"lockTime":912345
 			},
-			"artifactSignatures":["0x0708"],
+			"artifactApprovals":{
+				"payload":{
+					"approvalVersion":1,
+					"route":"self_v1",
+					"scriptTemplateId":"self_v1",
+					"destinationCommitmentHash":"%s",
+					"planCommitmentHash":"%s"
+				},
+				"approvals":[
+					{"role":"D","signature":"%s"},
+					{"role":"S","signature":"%s"}
+				]
+			},
+			"artifactSignatures":["%s","%s"],
 			"artifacts":{},
-			"scriptTemplate":{"template":"self_v1","depositorPublicKey":"0x021111","signerPublicKey":"0x022222","delta2":4320},
+			"scriptTemplate":{"template":"self_v1","depositorPublicKey":"%s","signerPublicKey":"%s","delta2":4320},
 			"signing":{"signerRequired":true,"custodianRequired":false},
 			"futureField":"ignored"
 		},
 		"futureTopLevel":"ignored"
-	}`, base.DestinationCommitmentHash, base.DestinationCommitmentHash, base.MigrationTransactionPlan.PlanCommitmentHash))
+	}`,
+		base.DestinationCommitmentHash,
+		base.DestinationCommitmentHash,
+		base.MigrationTransactionPlan.PlanCommitmentHash,
+		base.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		base.ArtifactApprovals.Payload.PlanCommitmentHash,
+		base.ArtifactApprovals.Approvals[0].Signature,
+		base.ArtifactApprovals.Approvals[1].Signature,
+		base.ArtifactSignatures[0],
+		base.ArtifactSignatures[1],
+		template.DepositorPublicKey,
+		template.SignerPublicKey,
+	))
 
 	response, err := http.Post(server.URL+"/v1/self_v1/signer/requests", "application/json", payload)
 	if err != nil {

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -189,6 +189,102 @@ func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelop
 	}
 }
 
+func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
+	request := baseRequest(route)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactSignatures = []string{"0xd0d0", "0x5050"}
+	if route == TemplateQcV1 {
+		request.ArtifactSignatures = []string{"0xd0d0", "0xc0c0", "0x5050"}
+	}
+
+	return request
+}
+
+func upperHexBody(value string) string {
+	if !strings.HasPrefix(value, "0x") {
+		return strings.ToUpper(value)
+	}
+
+	return "0x" + strings.ToUpper(strings.TrimPrefix(value, "0x"))
+}
+
+func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
+	request := canonicalArtifactApprovalRequest(route)
+
+	request.Strategy = upperHexBody(request.Strategy)
+	request.Reserve = upperHexBody(request.Reserve)
+	request.ActiveOutpoint.TxID = upperHexBody(request.ActiveOutpoint.TxID)
+	request.ActiveOutpoint.ScriptHash = upperHexBody(request.ActiveOutpoint.ScriptHash)
+	request.DestinationCommitmentHash = upperHexBody(request.DestinationCommitmentHash)
+	request.MigrationDestination.Reserve = upperHexBody(request.MigrationDestination.Reserve)
+	request.MigrationDestination.Revealer = upperHexBody(request.MigrationDestination.Revealer)
+	request.MigrationDestination.Vault = upperHexBody(request.MigrationDestination.Vault)
+	request.MigrationDestination.DepositScript = upperHexBody(request.MigrationDestination.DepositScript)
+	request.MigrationDestination.DepositScriptHash = upperHexBody(request.MigrationDestination.DepositScriptHash)
+	request.MigrationDestination.MigrationExtraData = upperHexBody(request.MigrationDestination.MigrationExtraData)
+	request.MigrationDestination.DestinationCommitmentHash = upperHexBody(request.MigrationDestination.DestinationCommitmentHash)
+	request.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(request.MigrationTransactionPlan.PlanCommitmentHash)
+	for i := range request.ArtifactSignatures {
+		request.ArtifactSignatures[i] = upperHexBody(request.ArtifactSignatures[i])
+	}
+
+	if route == TemplateQcV1 {
+		request.ScriptTemplate = mustTemplate(QcV1Template{
+			Template:           TemplateQcV1,
+			DepositorPublicKey: upperHexBody("0x021111"),
+			CustodianPublicKey: upperHexBody("0x023333"),
+			SignerPublicKey:    upperHexBody("0x022222"),
+			Beta:               144,
+			Delta2:             4320,
+		})
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		request.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: upperHexBody("0x5050"),
+			},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody("0xd0d0"),
+			},
+			{
+				Role:      ArtifactApprovalRoleCustodian,
+				Signature: upperHexBody("0xc0c0"),
+			},
+		}
+	} else {
+		request.ScriptTemplate = mustTemplate(SelfV1Template{
+			Template:           TemplateSelfV1,
+			DepositorPublicKey: upperHexBody("0x021111"),
+			SignerPublicKey:    upperHexBody("0x022222"),
+			Delta2:             4320,
+		})
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+		)
+		request.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+			request.ArtifactApprovals.Payload.PlanCommitmentHash,
+		)
+		request.ArtifactApprovals.Approvals = []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleSigner,
+				Signature: upperHexBody("0x5050"),
+			},
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: upperHexBody("0xd0d0"),
+			},
+		}
+	}
+
+	return request
+}
+
 func validMigrationDestination() *MigrationDestinationReservation {
 	reservation := &MigrationDestinationReservation{
 		ReservationID: "cmdr_12345678",
@@ -1246,6 +1342,89 @@ func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 				t.Fatalf("expected %q, got %v", testCase.expectErr, err)
 			}
 		})
+	}
+}
+
+func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T) {
+	canonicalDigest, err := requestDigest(canonicalArtifactApprovalRequest(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variantDigest, err := requestDigest(equivalentArtifactApprovalVariant(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if canonicalDigest != variantDigest {
+		t.Fatalf("expected matching request digest, got %s vs %s", canonicalDigest, variantDigest)
+	}
+}
+
+func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{
+		submit: func(*Job) (*Transition, error) {
+			return &Transition{State: JobStatePending, Detail: "queued"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitRequest := equivalentArtifactApprovalVariant(TemplateQcV1)
+	submitResult, err := service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_equivalent_digest",
+		Stage:          StageSignerCoordination,
+		Request:        submitRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollResult, err := service.Poll(context.Background(), TemplateQcV1, SignerPollInput{
+		RouteRequestID: "orq_equivalent_digest",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        canonicalArtifactApprovalRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pollResult.Status != StepStatusPending {
+		t.Fatalf("expected PENDING, got %#v", pollResult)
+	}
+}
+
+func TestServiceStoresNormalizedArtifactApprovalRequest(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := equivalentArtifactApprovalVariant(TemplateQcV1)
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_normalized_store",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job, ok, err := service.store.GetByRouteRequest(TemplateQcV1, "orq_normalized_store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected stored job")
+	}
+
+	expected := canonicalArtifactApprovalRequest(TemplateQcV1)
+	if !reflect.DeepEqual(job.Request, expected) {
+		t.Fatalf("expected normalized request %#v, got %#v", expected, job.Request)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -3,8 +3,11 @@ package covenantsigner
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net"
@@ -150,12 +153,18 @@ const (
 )
 
 var (
-	testDepositorPrivateKey = mustDeterministicTestPrivateKey(testDepositorPrivateKeyHex)
-	testSignerPrivateKey    = mustDeterministicTestPrivateKey(testSignerPrivateKeyHex)
-	testCustodianPrivateKey = mustDeterministicTestPrivateKey(testCustodianPrivateKeyHex)
-	testDepositorPublicKey  = mustCompressedPublicKeyHex(testDepositorPrivateKey)
-	testSignerPublicKey     = mustCompressedPublicKeyHex(testSignerPrivateKey)
-	testCustodianPublicKey  = mustCompressedPublicKeyHex(testCustodianPrivateKey)
+	testDepositorPrivateKey          = mustDeterministicTestPrivateKey(testDepositorPrivateKeyHex)
+	testSignerPrivateKey             = mustDeterministicTestPrivateKey(testSignerPrivateKeyHex)
+	testCustodianPrivateKey          = mustDeterministicTestPrivateKey(testCustodianPrivateKeyHex)
+	testDepositorPublicKey           = mustCompressedPublicKeyHex(testDepositorPrivateKey)
+	testSignerPublicKey              = mustCompressedPublicKeyHex(testSignerPrivateKey)
+	testCustodianPublicKey           = mustCompressedPublicKeyHex(testCustodianPrivateKey)
+	testMigrationPlanQuoteSeed       = bytes.Repeat([]byte{0x44}, ed25519.SeedSize)
+	testMigrationPlanQuotePrivateKey = ed25519.NewKeyFromSeed(testMigrationPlanQuoteSeed)
+	testMigrationPlanQuoteTrustRoot  = MigrationPlanQuoteTrustRoot{
+		KeyID:        "test-plan-quote-key",
+		PublicKeyPEM: mustMigrationPlanQuoteTrustRootPEM(testMigrationPlanQuotePrivateKey.Public().(ed25519.PublicKey)),
+	}
 )
 
 func mustDeterministicTestPrivateKey(encoded string) *btcec.PrivateKey {
@@ -170,6 +179,18 @@ func mustDeterministicTestPrivateKey(encoded string) *btcec.PrivateKey {
 
 func mustCompressedPublicKeyHex(privateKey *btcec.PrivateKey) string {
 	return "0x" + hex.EncodeToString(privateKey.PubKey().SerializeCompressed())
+}
+
+func mustMigrationPlanQuoteTrustRootPEM(publicKey ed25519.PublicKey) string {
+	encodedPublicKey, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: encodedPublicKey,
+	}))
 }
 
 func mustArtifactApprovalSignature(
@@ -682,6 +703,65 @@ func validMigrationDestination() *MigrationDestinationReservation {
 	reservation.DestinationCommitmentHash, _ = computeDestinationCommitmentHash(reservation)
 
 	return reservation
+}
+
+func validMigrationPlanQuote(
+	request RouteSubmitRequest,
+) *MigrationDestinationPlanQuote {
+	quote := &MigrationDestinationPlanQuote{
+		QuoteID:                   "cmdq_12345678",
+		QuoteVersion:              migrationPlanQuoteVersion,
+		ReservationID:             request.MigrationDestination.ReservationID,
+		Reserve:                   request.Reserve,
+		Epoch:                     request.Epoch,
+		Route:                     ReservationRouteMigration,
+		Revealer:                  request.MigrationDestination.Revealer,
+		Vault:                     request.MigrationDestination.Vault,
+		Network:                   request.MigrationDestination.Network,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		ActiveOutpointTxID:        request.ActiveOutpoint.TxID,
+		ActiveOutpointVout:        request.ActiveOutpoint.Vout,
+		PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+		MigrationTransactionPlan:  normalizeMigrationTransactionPlan(request.MigrationTransactionPlan),
+		IdempotencyKey:            "0x75a998ac6951c2776f3a85f6430fb41321c28c1113a71a52c754806c7a3de9c9",
+		ExpiresInSeconds:          900,
+		IssuedAt:                  "2099-03-09T00:00:00.000Z",
+		ExpiresAt:                 "2099-03-09T00:15:00.000Z",
+		Signature: MigrationDestinationPlanQuoteSignature{
+			SignatureVersion: migrationPlanQuoteSignatureVersion,
+			Algorithm:        migrationPlanQuoteSignatureAlgorithm,
+			KeyID:            testMigrationPlanQuoteTrustRoot.KeyID,
+		},
+	}
+
+	signingHash, err := migrationPlanQuoteSigningHash(quote)
+	if err != nil {
+		panic(err)
+	}
+	quote.Signature.Signature = "0x" + hex.EncodeToString(
+		ed25519.Sign(testMigrationPlanQuotePrivateKey, signingHash),
+	)
+
+	return quote
+}
+
+func requestWithValidMigrationPlanQuote(route TemplateID) RouteSubmitRequest {
+	request := baseRequest(route)
+	request.ActiveOutpoint.TxID = "0x" + strings.Repeat("aa", 32)
+	request.ActiveOutpoint.ScriptHash = "0x" + strings.Repeat("bb", 32)
+	request.MigrationTransactionPlan.PlanCommitmentHash, _ =
+		computeMigrationTransactionPlanCommitmentHash(
+			request,
+			request.MigrationTransactionPlan,
+		)
+	request.ArtifactApprovals = validArtifactApprovals(request)
+	request.ArtifactSignatures = canonicalArtifactSignatures(
+		request.Route,
+		request.ArtifactApprovals,
+	)
+	request.MigrationPlanQuote = validMigrationPlanQuote(request)
+
+	return request
 }
 
 func TestServiceSubmitDeduplicatesByRouteRequestID(t *testing.T) {
@@ -1864,6 +1944,174 @@ func TestDestinationCommitmentHashDoesNotEscapeHTMLSensitiveCharacters(t *testin
 	}
 	if hash == "" {
 		t.Fatal("expected destination commitment hash")
+	}
+}
+
+func TestMigrationPlanQuoteSigningHashMatchesTbtcVectors(t *testing.T) {
+	baseRequest := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	baseRequest.MigrationPlanQuote = &MigrationDestinationPlanQuote{
+		QuoteID:                   "cmdq_testvector",
+		QuoteVersion:              migrationPlanQuoteVersion,
+		ReservationID:             "cmdr_testvector",
+		Reserve:                   "0x1111111111111111111111111111111111111111",
+		Epoch:                     7,
+		Route:                     ReservationRouteMigration,
+		Revealer:                  "0x2222222222222222222222222222222222222222",
+		Vault:                     "0x3333333333333333333333333333333333333333",
+		Network:                   "regtest",
+		DestinationCommitmentHash: "0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7",
+		ActiveOutpointTxID:        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ActiveOutpointVout:        1,
+		PlanCommitmentHash:        "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
+		MigrationTransactionPlan: &MigrationTransactionPlan{
+			PlanVersion:          migrationTransactionPlanVersion,
+			PlanCommitmentHash:   "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
+			InputValueSats:       100000,
+			DestinationValueSats: 99250,
+			AnchorValueSats:      canonicalAnchorValueSats,
+			FeeSats:              420,
+			InputSequence:        canonicalCovenantInputSequence,
+			LockTime:             950000,
+		},
+		IdempotencyKey:   "0x75a998ac6951c2776f3a85f6430fb41321c28c1113a71a52c754806c7a3de9c9",
+		ExpiresInSeconds: 900,
+		IssuedAt:         "2026-03-09T00:00:00.000Z",
+		ExpiresAt:        "2026-03-09T00:15:00.000Z",
+		Signature: MigrationDestinationPlanQuoteSignature{
+			SignatureVersion: migrationPlanQuoteSignatureVersion,
+			Algorithm:        migrationPlanQuoteSignatureAlgorithm,
+			KeyID:            testMigrationPlanQuoteTrustRoot.KeyID,
+			Signature:        "0x00",
+		},
+	}
+
+	payload, err := migrationPlanQuoteSigningPayloadBytes(baseRequest.MigrationPlanQuote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(payload) != "{\"quoteVersion\":1,\"quoteId\":\"cmdq_testvector\",\"reservationId\":\"cmdr_testvector\",\"reserve\":\"0x1111111111111111111111111111111111111111\",\"epoch\":7,\"route\":\"MIGRATION\",\"revealer\":\"0x2222222222222222222222222222222222222222\",\"vault\":\"0x3333333333333333333333333333333333333333\",\"network\":\"regtest\",\"destinationCommitmentHash\":\"0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7\",\"activeOutpointTxid\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"activeOutpointVout\":1,\"planCommitmentHash\":\"0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09\",\"issuedAt\":\"2026-03-09T00:00:00.000Z\",\"expiresAt\":\"2026-03-09T00:15:00.000Z\",\"expiresInSeconds\":900}" {
+		t.Fatalf("unexpected signing payload: %s", payload)
+	}
+
+	signingHash, err := migrationPlanQuoteSigningHash(baseRequest.MigrationPlanQuote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if "0x"+hex.EncodeToString(signingHash) != "0x4707935286fa15edf3f95485297307734b122f7dc1761e6fc023e9d5cc7a935a" {
+		t.Fatalf("unexpected signing hash: 0x%s", hex.EncodeToString(signingHash))
+	}
+
+	mixedCaseQuote := *baseRequest.MigrationPlanQuote
+	mixedCaseQuote.Reserve = "0xAaBbCcDdEeFf00112233445566778899AaBbCcDd"
+	mixedCaseQuote.Revealer = "0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd"
+	mixedCaseQuote.Vault = "0x0011AaBbCcDdEeFf0011AaBbCcDdEeFf0011AaBb"
+
+	mixedCaseHash, err := migrationPlanQuoteSigningHash(&mixedCaseQuote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if "0x"+hex.EncodeToString(mixedCaseHash) != "0x13a05f7e9caa244c446b65c2812095210cb321451d9eb9b735e60ffdd76e693d" {
+		t.Fatalf("unexpected mixed-case signing hash: 0x%s", hex.EncodeToString(mixedCaseHash))
+	}
+}
+
+func TestServiceRequiresMigrationPlanQuoteWhenTrustRootsConfigured(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithMigrationPlanQuoteTrustRoots([]MigrationPlanQuoteTrustRoot{
+			testMigrationPlanQuoteTrustRoot,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_quote_required",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.migrationPlanQuote is required when migrationPlanQuoteTrustRoots are configured",
+	) {
+		t.Fatalf("expected missing quote error, got %v", err)
+	}
+}
+
+func TestServiceAcceptsValidMigrationPlanQuoteWhenTrustRootsConfigured(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithMigrationPlanQuoteTrustRoots([]MigrationPlanQuoteTrustRoot{
+			testMigrationPlanQuoteTrustRoot,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := requestWithValidMigrationPlanQuote(TemplateSelfV1)
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_quote_valid",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServicePollAcceptsStoredMigrationPlanQuoteAfterQuoteExpiry(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{
+			submit: func(*Job) (*Transition, error) {
+				return &Transition{State: JobStatePending, Detail: "queued"}, nil
+			},
+		},
+		WithMigrationPlanQuoteTrustRoots([]MigrationPlanQuoteTrustRoot{
+			testMigrationPlanQuoteTrustRoot,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.now = func() time.Time {
+		return time.Date(2099, time.March, 9, 0, 10, 0, 0, time.UTC)
+	}
+
+	request := requestWithValidMigrationPlanQuote(TemplateSelfV1)
+
+	submitResult, err := service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_quote_poll",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	service.now = func() time.Time {
+		return time.Date(2099, time.March, 9, 0, 16, 0, 0, time.UTC)
+	}
+
+	pollResult, err := service.Poll(context.Background(), TemplateSelfV1, SignerPollInput{
+		RouteRequestID: "ors_quote_poll",
+		RequestID:      submitResult.RequestID,
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pollResult.Status != StepStatusPending {
+		t.Fatalf("expected pending poll result, got %#v", pollResult)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -1361,6 +1361,47 @@ func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T)
 	}
 }
 
+func TestRequestDigestDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
+	request := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	request.FacadeRequestID = "rf_<tag>&sink"
+	request.IdempotencyKey = "idem_>bridge"
+
+	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := marshalCanonicalJSON(normalizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(payload, []byte(`"facadeRequestId":"rf_<tag>&sink"`)) {
+		t.Fatalf("expected raw HTML-sensitive characters in payload, got %s", payload)
+	}
+	if bytes.Contains(payload, []byte(`\u003c`)) ||
+		bytes.Contains(payload, []byte(`\u003e`)) ||
+		bytes.Contains(payload, []byte(`\u0026`)) {
+		t.Fatalf("expected unescaped HTML-sensitive characters in payload, got %s", payload)
+	}
+
+	digestFromRawRequest, err := requestDigest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestFromNormalizedRequest, err := requestDigestFromNormalized(normalizedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digestFromRawRequest != digestFromNormalizedRequest {
+		t.Fatalf(
+			"expected matching digests, got %s vs %s",
+			digestFromRawRequest,
+			digestFromNormalizedRequest,
+		)
+	}
+}
+
 func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{
@@ -1425,6 +1466,19 @@ func TestServiceStoresNormalizedArtifactApprovalRequest(t *testing.T) {
 	expected := canonicalArtifactApprovalRequest(TemplateQcV1)
 	if !reflect.DeepEqual(job.Request, expected) {
 		t.Fatalf("expected normalized request %#v, got %#v", expected, job.Request)
+	}
+}
+
+func TestRequestDigestRejectsArtifactApprovalsWithoutMigrationTransactionPlan(t *testing.T) {
+	request := canonicalArtifactApprovalRequest(TemplateSelfV1)
+	request.MigrationTransactionPlan = nil
+
+	_, err := requestDigest(request)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.migrationTransactionPlan is required when request.artifactApprovals is present",
+	) {
+		t.Fatalf("expected missing plan error, got %v", err)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -191,6 +191,7 @@ var (
 	testCustodianPrivateKey          = mustDeterministicTestPrivateKey(testCustodianPrivateKeyHex)
 	testDepositorPublicKey           = mustCompressedPublicKeyHex(testDepositorPrivateKey)
 	testSignerPublicKey              = mustCompressedPublicKeyHex(testSignerPrivateKey)
+	testSignerUncompressedPublicKey  = mustUncompressedPublicKeyHex(testSignerPrivateKey)
 	testCustodianPublicKey           = mustCompressedPublicKeyHex(testCustodianPrivateKey)
 	testMigrationPlanQuoteSeed       = bytes.Repeat([]byte{0x44}, ed25519.SeedSize)
 	testMigrationPlanQuotePrivateKey = ed25519.NewKeyFromSeed(testMigrationPlanQuoteSeed)
@@ -212,6 +213,10 @@ func mustDeterministicTestPrivateKey(encoded string) *btcec.PrivateKey {
 
 func mustCompressedPublicKeyHex(privateKey *btcec.PrivateKey) string {
 	return "0x" + hex.EncodeToString(privateKey.PubKey().SerializeCompressed())
+}
+
+func mustUncompressedPublicKeyHex(privateKey *btcec.PrivateKey) string {
+	return "0x" + hex.EncodeToString(privateKey.PubKey().SerializeUncompressed())
 }
 
 func mustMigrationPlanQuoteTrustRootPEM(publicKey ed25519.PublicKey) string {
@@ -290,6 +295,30 @@ func canonicalArtifactSignatures(
 	}
 
 	return signatures
+}
+
+func canonicalArtifactSignaturesWithSignerApproval(
+	route TemplateID,
+	artifactApprovals *ArtifactApprovalEnvelope,
+	signerApproval *SignerApprovalCertificate,
+) []string {
+	requiredRoles, err := requiredStructuredArtifactApprovalRoles(route)
+	if err != nil {
+		panic(err)
+	}
+
+	signatures := make([]string, 0, len(requiredRoles)+1)
+	for _, role := range requiredRoles {
+		signatures = append(
+			signatures,
+			artifactApprovalSignatureByRole(artifactApprovals, role),
+		)
+	}
+	if signerApproval == nil {
+		return signatures
+	}
+
+	return append(signatures, signerApproval.Signature)
 }
 
 func validSelfTemplate() json.RawMessage {
@@ -408,6 +437,76 @@ func validArtifactApprovals(request RouteSubmitRequest) *ArtifactApprovalEnvelop
 	}
 }
 
+func validStructuredArtifactApprovals(
+	request RouteSubmitRequest,
+) *ArtifactApprovalEnvelope {
+	payload := ArtifactApprovalPayload{
+		ApprovalVersion:           artifactApprovalVersion,
+		Route:                     request.Route,
+		ScriptTemplateID:          request.Route,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+	}
+
+	approvals := []ArtifactRoleApproval{
+		{
+			Role:      ArtifactApprovalRoleDepositor,
+			Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+		},
+	}
+
+	if request.Route == TemplateQcV1 {
+		approvals = append(approvals, ArtifactRoleApproval{
+			Role:      ArtifactApprovalRoleCustodian,
+			Signature: mustArtifactApprovalSignature(testCustodianPrivateKey, payload),
+		})
+	}
+
+	return &ArtifactApprovalEnvelope{
+		Payload:   payload,
+		Approvals: approvals,
+	}
+}
+
+func validSignerApproval(
+	artifactApprovals *ArtifactApprovalEnvelope,
+) *SignerApprovalCertificate {
+	if artifactApprovals == nil {
+		panic("artifact approvals are required")
+	}
+
+	digest, err := artifactApprovalDigest(artifactApprovals.Payload)
+	if err != nil {
+		panic(err)
+	}
+
+	endBlock := uint64(123456)
+	return &SignerApprovalCertificate{
+		CertificateVersion: signerApprovalCertificateVersion,
+		SignatureAlgorithm: signerApprovalSignatureAlgorithm,
+		ApprovalDigest:     "0x" + hex.EncodeToString(digest),
+		WalletPublicKey:    testSignerUncompressedPublicKey,
+		SignerSetHash:      "0x" + strings.Repeat("ab", 32),
+		Signature:          "0x304402200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2002202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40",
+		ActiveMembers:      []uint32{2, 1},
+		InactiveMembers:    []uint32{4, 3},
+		EndBlock:           &endBlock,
+	}
+}
+
+func structuredSignerApprovalRequest(route TemplateID) RouteSubmitRequest {
+	request := baseRequest(route)
+	request.ArtifactApprovals = validStructuredArtifactApprovals(request)
+	request.SignerApproval = validSignerApproval(request.ArtifactApprovals)
+	request.ArtifactSignatures = canonicalArtifactSignaturesWithSignerApproval(
+		request.Route,
+		request.ArtifactApprovals,
+		request.SignerApproval,
+	)
+
+	return request
+}
+
 func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
 	return baseRequest(route)
 }
@@ -508,6 +607,37 @@ func artifactApprovalVariantFromRequest(
 
 	for i := range variant.ArtifactSignatures {
 		variant.ArtifactSignatures[i] = transformHex(variant.ArtifactSignatures[i])
+	}
+
+	if variant.SignerApproval != nil {
+		variant.SignerApproval.ApprovalDigest = transformHex(
+			variant.SignerApproval.ApprovalDigest,
+		)
+		variant.SignerApproval.WalletPublicKey = transformHex(
+			variant.SignerApproval.WalletPublicKey,
+		)
+		variant.SignerApproval.SignerSetHash = transformHex(
+			variant.SignerApproval.SignerSetHash,
+		)
+		variant.SignerApproval.Signature = transformHex(
+			variant.SignerApproval.Signature,
+		)
+		if len(variant.SignerApproval.ActiveMembers) > 1 {
+			variant.SignerApproval.ActiveMembers = append(
+				[]uint32{
+					variant.SignerApproval.ActiveMembers[len(variant.SignerApproval.ActiveMembers)-1],
+				},
+				variant.SignerApproval.ActiveMembers[:len(variant.SignerApproval.ActiveMembers)-1]...,
+			)
+		}
+		if len(variant.SignerApproval.InactiveMembers) > 1 {
+			variant.SignerApproval.InactiveMembers = append(
+				[]uint32{
+					variant.SignerApproval.InactiveMembers[len(variant.SignerApproval.InactiveMembers)-1],
+				},
+				variant.SignerApproval.InactiveMembers[:len(variant.SignerApproval.InactiveMembers)-1]...,
+			)
+		}
 	}
 
 	for pathID, artifact := range variant.Artifacts {
@@ -1748,6 +1878,128 @@ func TestServiceAcceptsArtifactApprovalsWithCanonicalLegacySignatures(t *testing
 	}
 }
 
+func TestServiceAcceptsStructuredSignerApprovalWhenVerifierConfigured(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithSignerApprovalVerifier(SignerApprovalVerifierFunc(func(request RouteSubmitRequest) error {
+			if request.SignerApproval == nil {
+				t.Fatal("expected signer approval")
+			}
+			return nil
+		})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := structuredSignerApprovalRequest(TemplateQcV1)
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_structured_signer_approval",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job, ok, err := service.store.GetByRouteRequest(
+		TemplateQcV1,
+		"orq_structured_signer_approval",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected stored job")
+	}
+	if job.Request.SignerApproval == nil {
+		t.Fatal("expected stored signer approval")
+	}
+	if !reflect.DeepEqual(
+		job.Request.SignerApproval.ActiveMembers,
+		[]uint32{1, 2},
+	) {
+		t.Fatalf(
+			"unexpected active members: %#v",
+			job.Request.SignerApproval.ActiveMembers,
+		)
+	}
+	if !reflect.DeepEqual(
+		job.Request.SignerApproval.InactiveMembers,
+		[]uint32{3, 4},
+	) {
+		t.Fatalf(
+			"unexpected inactive members: %#v",
+			job.Request.SignerApproval.InactiveMembers,
+		)
+	}
+}
+
+func TestServiceRejectsStructuredSignerApprovalWithoutVerifier(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := structuredSignerApprovalRequest(TemplateSelfV1)
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_structured_signer_approval_unsupported",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.signerApproval cannot be verified by this signer deployment",
+	) {
+		t.Fatalf("expected unsupported signer approval error, got %v", err)
+	}
+}
+
+func TestServiceRejectsStructuredSignerApprovalWithLegacySignerRole(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithSignerApprovalVerifier(SignerApprovalVerifierFunc(func(RouteSubmitRequest) error {
+			return nil
+		})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := structuredSignerApprovalRequest(TemplateSelfV1)
+	request.ArtifactApprovals.Approvals = append(
+		request.ArtifactApprovals.Approvals,
+		ArtifactRoleApproval{
+			Role:      ArtifactApprovalRoleSigner,
+			Signature: "0x5151",
+		},
+	)
+	request.ArtifactSignatures = append(
+		request.ArtifactSignatures[:len(request.ArtifactSignatures)-1],
+		"0x5151",
+		request.ArtifactSignatures[len(request.ArtifactSignatures)-1],
+	)
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_structured_signer_approval_legacy_role",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.artifactApprovals.approvals[1].role is not allowed for self_v1",
+	) {
+		t.Fatalf("expected structured signer-role rejection, got %v", err)
+	}
+}
+
 func TestServiceRejectsInvalidArtifactApprovalVariants(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{})
@@ -1900,6 +2152,31 @@ func TestRequestDigestNormalizesEquivalentArtifactApprovalVariants(t *testing.T)
 
 	if canonicalDigest != variantDigest {
 		t.Fatalf("expected matching request digest, got %s vs %s", canonicalDigest, variantDigest)
+	}
+}
+
+func TestRequestDigestNormalizesEquivalentStructuredSignerApprovalVariants(t *testing.T) {
+	canonicalDigest, err := requestDigest(structuredSignerApprovalRequest(TemplateQcV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variantDigest, err := requestDigest(
+		equivalentArtifactApprovalVariantFromRequest(
+			t,
+			structuredSignerApprovalRequest(TemplateQcV1),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if canonicalDigest != variantDigest {
+		t.Fatalf(
+			"expected matching structured request digest, got %s vs %s",
+			canonicalDigest,
+			variantDigest,
+		)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -1831,6 +1831,42 @@ func TestRequestDigestDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
 	}
 }
 
+func TestDestinationCommitmentHashDoesNotEscapeHTMLSensitiveCharacters(t *testing.T) {
+	destination := validMigrationDestination()
+	destination.Network = "regtest<v2>&sink"
+
+	payload, err := marshalCanonicalJSON(destinationCommitmentPayload{
+		Reserve:            normalizeLowerHex(destination.Reserve),
+		Epoch:              destination.Epoch,
+		Route:              string(destination.Route),
+		Revealer:           normalizeLowerHex(destination.Revealer),
+		Vault:              normalizeLowerHex(destination.Vault),
+		Network:            strings.TrimSpace(destination.Network),
+		DepositScriptHash:  normalizeLowerHex(destination.DepositScriptHash),
+		MigrationExtraData: normalizeLowerHex(destination.MigrationExtraData),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(payload, []byte(`"network":"regtest<v2>&sink"`)) {
+		t.Fatalf("expected raw HTML-sensitive characters in payload, got %s", payload)
+	}
+	if bytes.Contains(payload, []byte(`\u003c`)) ||
+		bytes.Contains(payload, []byte(`\u003e`)) ||
+		bytes.Contains(payload, []byte(`\u0026`)) {
+		t.Fatalf("expected unescaped HTML-sensitive characters in payload, got %s", payload)
+	}
+
+	hash, err := computeDestinationCommitmentHash(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash == "" {
+		t.Fatal("expected destination commitment hash")
+	}
+}
+
 func TestServicePollAcceptsEquivalentArtifactApprovalRequestVariants(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(handle, &scriptedEngine{

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -111,6 +111,21 @@ type approvalContractVectorsFile struct {
 	Vectors map[string]approvalContractVector `json:"vectors"`
 }
 
+type migrationPlanQuoteSigningVector struct {
+	UnsignedQuote     MigrationDestinationPlanQuote `json:"unsignedQuote"`
+	ExpectedPayload   string                        `json:"expectedPayload"`
+	ExpectedPreimage  string                        `json:"expectedPreimage"`
+	ExpectedHash      string                        `json:"expectedHash"`
+	ExpectedSignature string                        `json:"expectedSignature"`
+}
+
+type migrationPlanQuoteSigningVectorsFile struct {
+	Version   int                                        `json:"version"`
+	Scope     string                                     `json:"scope"`
+	TrustRoot MigrationPlanQuoteTrustRoot                `json:"trustRoot"`
+	Vectors   map[string]migrationPlanQuoteSigningVector `json:"vectors"`
+}
+
 func loadApprovalContractVector(
 	t *testing.T,
 	route TemplateID,
@@ -144,6 +159,24 @@ func loadApprovalContractVector(
 	}
 
 	return request, vector.ExpectedRequestDigest
+}
+
+func loadMigrationPlanQuoteSigningVectors(
+	t *testing.T,
+) migrationPlanQuoteSigningVectorsFile {
+	t.Helper()
+
+	data, err := os.ReadFile("testdata/migration_plan_quote_signing_vectors_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vectors := migrationPlanQuoteSigningVectorsFile{}
+	if err := strictUnmarshal(data, &vectors); err != nil {
+		t.Fatal(err)
+	}
+
+	return vectors
 }
 
 const (
@@ -1947,71 +1980,62 @@ func TestDestinationCommitmentHashDoesNotEscapeHTMLSensitiveCharacters(t *testin
 	}
 }
 
-func TestMigrationPlanQuoteSigningHashMatchesTbtcVectors(t *testing.T) {
-	baseRequest := canonicalArtifactApprovalRequest(TemplateSelfV1)
-	baseRequest.MigrationPlanQuote = &MigrationDestinationPlanQuote{
-		QuoteID:                   "cmdq_testvector",
-		QuoteVersion:              migrationPlanQuoteVersion,
-		ReservationID:             "cmdr_testvector",
-		Reserve:                   "0x1111111111111111111111111111111111111111",
-		Epoch:                     7,
-		Route:                     ReservationRouteMigration,
-		Revealer:                  "0x2222222222222222222222222222222222222222",
-		Vault:                     "0x3333333333333333333333333333333333333333",
-		Network:                   "regtest",
-		DestinationCommitmentHash: "0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7",
-		ActiveOutpointTxID:        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		ActiveOutpointVout:        1,
-		PlanCommitmentHash:        "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
-		MigrationTransactionPlan: &MigrationTransactionPlan{
-			PlanVersion:          migrationTransactionPlanVersion,
-			PlanCommitmentHash:   "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
-			InputValueSats:       100000,
-			DestinationValueSats: 99250,
-			AnchorValueSats:      canonicalAnchorValueSats,
-			FeeSats:              420,
-			InputSequence:        canonicalCovenantInputSequence,
-			LockTime:             950000,
-		},
-		IdempotencyKey:   "0x75a998ac6951c2776f3a85f6430fb41321c28c1113a71a52c754806c7a3de9c9",
-		ExpiresInSeconds: 900,
-		IssuedAt:         "2026-03-09T00:00:00.000Z",
-		ExpiresAt:        "2026-03-09T00:15:00.000Z",
-		Signature: MigrationDestinationPlanQuoteSignature{
-			SignatureVersion: migrationPlanQuoteSignatureVersion,
-			Algorithm:        migrationPlanQuoteSignatureAlgorithm,
-			KeyID:            testMigrationPlanQuoteTrustRoot.KeyID,
-			Signature:        "0x00",
-		},
+func TestMigrationPlanQuoteSigningVectorsMatchFixture(t *testing.T) {
+	vectors := loadMigrationPlanQuoteSigningVectors(t)
+	if vectors.Version != 1 {
+		t.Fatalf("unexpected vector version: %d", vectors.Version)
+	}
+	if vectors.Scope != "migration_plan_quote_signing_contract_v1" {
+		t.Fatalf("unexpected vector scope: %s", vectors.Scope)
 	}
 
-	payload, err := migrationPlanQuoteSigningPayloadBytes(baseRequest.MigrationPlanQuote)
+	block, _ := pem.Decode([]byte(vectors.TrustRoot.PublicKeyPEM))
+	if block == nil {
+		t.Fatal("expected migration plan quote fixture to contain a PEM public key")
+	}
+	parsedPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(payload) != "{\"quoteVersion\":1,\"quoteId\":\"cmdq_testvector\",\"reservationId\":\"cmdr_testvector\",\"reserve\":\"0x1111111111111111111111111111111111111111\",\"epoch\":7,\"route\":\"MIGRATION\",\"revealer\":\"0x2222222222222222222222222222222222222222\",\"vault\":\"0x3333333333333333333333333333333333333333\",\"network\":\"regtest\",\"destinationCommitmentHash\":\"0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7\",\"activeOutpointTxid\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"activeOutpointVout\":1,\"planCommitmentHash\":\"0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09\",\"issuedAt\":\"2026-03-09T00:00:00.000Z\",\"expiresAt\":\"2026-03-09T00:15:00.000Z\",\"expiresInSeconds\":900}" {
-		t.Fatalf("unexpected signing payload: %s", payload)
+	publicKey, ok := parsedPublicKey.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("expected Ed25519 public key, got %T", parsedPublicKey)
 	}
 
-	signingHash, err := migrationPlanQuoteSigningHash(baseRequest.MigrationPlanQuote)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if "0x"+hex.EncodeToString(signingHash) != "0x4707935286fa15edf3f95485297307734b122f7dc1761e6fc023e9d5cc7a935a" {
-		t.Fatalf("unexpected signing hash: 0x%s", hex.EncodeToString(signingHash))
-	}
+	for name, vector := range vectors.Vectors {
+		t.Run(name, func(t *testing.T) {
+			payload, err := migrationPlanQuoteSigningPayloadBytes(&vector.UnsignedQuote)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(payload) != vector.ExpectedPayload {
+				t.Fatalf("unexpected signing payload: %s", payload)
+			}
 
-	mixedCaseQuote := *baseRequest.MigrationPlanQuote
-	mixedCaseQuote.Reserve = "0xAaBbCcDdEeFf00112233445566778899AaBbCcDd"
-	mixedCaseQuote.Revealer = "0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd"
-	mixedCaseQuote.Vault = "0x0011AaBbCcDdEeFf0011AaBbCcDdEeFf0011AaBb"
+			preimage, err := migrationPlanQuoteSigningPreimage(&vector.UnsignedQuote)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(preimage) != vector.ExpectedPreimage {
+				t.Fatalf("unexpected signing preimage: %s", preimage)
+			}
 
-	mixedCaseHash, err := migrationPlanQuoteSigningHash(&mixedCaseQuote)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if "0x"+hex.EncodeToString(mixedCaseHash) != "0x13a05f7e9caa244c446b65c2812095210cb321451d9eb9b735e60ffdd76e693d" {
-		t.Fatalf("unexpected mixed-case signing hash: 0x%s", hex.EncodeToString(mixedCaseHash))
+			signingHash, err := migrationPlanQuoteSigningHash(&vector.UnsignedQuote)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if "0x"+hex.EncodeToString(signingHash) != vector.ExpectedHash {
+				t.Fatalf("unexpected signing hash: 0x%s", hex.EncodeToString(signingHash))
+			}
+
+			rawSignature, err := hex.DecodeString(strings.TrimPrefix(vector.ExpectedSignature, "0x"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ed25519.Verify(publicKey, signingHash, rawSignature) {
+				t.Fatal("expected fixture signature to verify against the fixture trust root")
+			}
+		})
 	}
 }
 
@@ -2066,6 +2090,34 @@ func TestServiceAcceptsValidMigrationPlanQuoteWhenTrustRootsConfigured(t *testin
 	}
 }
 
+func TestServiceRejectsExpiredMigrationPlanQuoteOnSubmit(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithMigrationPlanQuoteTrustRoots([]MigrationPlanQuoteTrustRoot{
+			testMigrationPlanQuoteTrustRoot,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.now = func() time.Time {
+		return time.Date(2099, time.March, 9, 0, 16, 0, 0, time.UTC)
+	}
+
+	request := requestWithValidMigrationPlanQuote(TemplateSelfV1)
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_quote_expired",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(err.Error(), "request.migrationPlanQuote is expired") {
+		t.Fatalf("expected expired quote error, got %v", err)
+	}
+}
+
 func TestServicePollAcceptsStoredMigrationPlanQuoteAfterQuoteExpiry(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(
@@ -2112,6 +2164,40 @@ func TestServicePollAcceptsStoredMigrationPlanQuoteAfterQuoteExpiry(t *testing.T
 	}
 	if pollResult.Status != StepStatusPending {
 		t.Fatalf("expected pending poll result, got %#v", pollResult)
+	}
+}
+
+func TestServiceAcceptsKnownBadSignerApprovalSignatureInPhase1(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithMigrationPlanQuoteTrustRoots([]MigrationPlanQuoteTrustRoot{
+			testMigrationPlanQuoteTrustRoot,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := requestWithValidMigrationPlanQuote(TemplateSelfV1)
+	for i := range request.ArtifactApprovals.Approvals {
+		if request.ArtifactApprovals.Approvals[i].Role == ArtifactApprovalRoleSigner {
+			request.ArtifactApprovals.Approvals[i].Signature = "0xdeadbeef"
+		}
+	}
+	request.ArtifactSignatures = canonicalArtifactSignatures(
+		request.Route,
+		request.ArtifactApprovals,
+	)
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_signer_gap",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err != nil {
+		t.Fatalf("expected phase-1 signer approval gap to remain non-fatal, got %v", err)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -247,6 +247,52 @@ func canonicalArtifactApprovalRequest(route TemplateID) RouteSubmitRequest {
 	return request
 }
 
+const (
+	mixedCaseCoverageStrategy = "0xaabbccddeeff00112233445566778899aabbccdd"
+	mixedCaseCoverageReserve  = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mixedCaseCoverageRevealer = "0xdecafbaddecafbaddecafbaddecafbaddecafbad"
+	mixedCaseCoverageVault    = "0xbeadfeedbeadfeedbeadfeedbeadfeedbeadfeed"
+)
+
+func canonicalMixedCaseCoverageArtifactApprovalRequest(
+	t *testing.T,
+	route TemplateID,
+) RouteSubmitRequest {
+	t.Helper()
+
+	request := canonicalArtifactApprovalRequest(route)
+	request.Strategy = mixedCaseCoverageStrategy
+	request.Reserve = mixedCaseCoverageReserve
+	request.MigrationDestination.Reserve = mixedCaseCoverageReserve
+	request.MigrationDestination.Revealer = mixedCaseCoverageRevealer
+	request.MigrationDestination.Vault = mixedCaseCoverageVault
+	request.MigrationDestination.MigrationExtraData = computeMigrationExtraData(
+		request.MigrationDestination.Revealer,
+	)
+
+	destinationCommitmentHash, err := computeDestinationCommitmentHash(
+		request.MigrationDestination,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.MigrationDestination.DestinationCommitmentHash = destinationCommitmentHash
+	request.DestinationCommitmentHash = destinationCommitmentHash
+
+	planCommitmentHash, err := computeMigrationTransactionPlanCommitmentHash(
+		request,
+		request.MigrationTransactionPlan,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.MigrationTransactionPlan.PlanCommitmentHash = planCommitmentHash
+	request.ArtifactApprovals.Payload.DestinationCommitmentHash = destinationCommitmentHash
+	request.ArtifactApprovals.Payload.PlanCommitmentHash = planCommitmentHash
+
+	return request
+}
+
 func cloneRouteSubmitRequest(
 	t *testing.T,
 	request RouteSubmitRequest,
@@ -261,60 +307,61 @@ func cloneRouteSubmitRequest(
 	return cloned
 }
 
-func equivalentArtifactApprovalVariantFromRequest(
+func artifactApprovalVariantFromRequest(
 	t *testing.T,
 	request RouteSubmitRequest,
+	transformHex func(string) string,
 ) RouteSubmitRequest {
 	t.Helper()
 
 	variant := cloneRouteSubmitRequest(t, request)
-	variant.Strategy = upperHexBody(variant.Strategy)
-	variant.Reserve = upperHexBody(variant.Reserve)
-	variant.ActiveOutpoint.TxID = upperHexBody(variant.ActiveOutpoint.TxID)
+	variant.Strategy = transformHex(variant.Strategy)
+	variant.Reserve = transformHex(variant.Reserve)
+	variant.ActiveOutpoint.TxID = transformHex(variant.ActiveOutpoint.TxID)
 	if variant.ActiveOutpoint.ScriptHash != "" {
-		variant.ActiveOutpoint.ScriptHash = upperHexBody(variant.ActiveOutpoint.ScriptHash)
+		variant.ActiveOutpoint.ScriptHash = transformHex(variant.ActiveOutpoint.ScriptHash)
 	}
-	variant.DestinationCommitmentHash = upperHexBody(variant.DestinationCommitmentHash)
+	variant.DestinationCommitmentHash = transformHex(variant.DestinationCommitmentHash)
 
 	if variant.MigrationDestination != nil {
-		variant.MigrationDestination.Reserve = upperHexBody(variant.MigrationDestination.Reserve)
-		variant.MigrationDestination.Revealer = upperHexBody(variant.MigrationDestination.Revealer)
-		variant.MigrationDestination.Vault = upperHexBody(variant.MigrationDestination.Vault)
-		variant.MigrationDestination.DepositScript = upperHexBody(variant.MigrationDestination.DepositScript)
-		variant.MigrationDestination.DepositScriptHash = upperHexBody(variant.MigrationDestination.DepositScriptHash)
-		variant.MigrationDestination.MigrationExtraData = upperHexBody(variant.MigrationDestination.MigrationExtraData)
-		variant.MigrationDestination.DestinationCommitmentHash = upperHexBody(
+		variant.MigrationDestination.Reserve = transformHex(variant.MigrationDestination.Reserve)
+		variant.MigrationDestination.Revealer = transformHex(variant.MigrationDestination.Revealer)
+		variant.MigrationDestination.Vault = transformHex(variant.MigrationDestination.Vault)
+		variant.MigrationDestination.DepositScript = transformHex(variant.MigrationDestination.DepositScript)
+		variant.MigrationDestination.DepositScriptHash = transformHex(variant.MigrationDestination.DepositScriptHash)
+		variant.MigrationDestination.MigrationExtraData = transformHex(variant.MigrationDestination.MigrationExtraData)
+		variant.MigrationDestination.DestinationCommitmentHash = transformHex(
 			variant.MigrationDestination.DestinationCommitmentHash,
 		)
 	}
 
 	if variant.MigrationTransactionPlan != nil {
-		variant.MigrationTransactionPlan.PlanCommitmentHash = upperHexBody(
+		variant.MigrationTransactionPlan.PlanCommitmentHash = transformHex(
 			variant.MigrationTransactionPlan.PlanCommitmentHash,
 		)
 	}
 
 	for i := range variant.ArtifactSignatures {
-		variant.ArtifactSignatures[i] = upperHexBody(variant.ArtifactSignatures[i])
+		variant.ArtifactSignatures[i] = transformHex(variant.ArtifactSignatures[i])
 	}
 
 	for pathID, artifact := range variant.Artifacts {
-		artifact.PSBTHash = upperHexBody(artifact.PSBTHash)
-		artifact.DestinationCommitmentHash = upperHexBody(artifact.DestinationCommitmentHash)
+		artifact.PSBTHash = transformHex(artifact.PSBTHash)
+		artifact.DestinationCommitmentHash = transformHex(artifact.DestinationCommitmentHash)
 		if artifact.TransactionHex != "" {
-			artifact.TransactionHex = upperHexBody(artifact.TransactionHex)
+			artifact.TransactionHex = transformHex(artifact.TransactionHex)
 		}
 		if artifact.TransactionID != "" {
-			artifact.TransactionID = upperHexBody(artifact.TransactionID)
+			artifact.TransactionID = transformHex(artifact.TransactionID)
 		}
 		variant.Artifacts[pathID] = artifact
 	}
 
 	if variant.ArtifactApprovals != nil {
-		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = upperHexBody(
+		variant.ArtifactApprovals.Payload.DestinationCommitmentHash = transformHex(
 			variant.ArtifactApprovals.Payload.DestinationCommitmentHash,
 		)
-		variant.ArtifactApprovals.Payload.PlanCommitmentHash = upperHexBody(
+		variant.ArtifactApprovals.Payload.PlanCommitmentHash = transformHex(
 			variant.ArtifactApprovals.Payload.PlanCommitmentHash,
 		)
 
@@ -326,7 +373,7 @@ func equivalentArtifactApprovalVariantFromRequest(
 			approval := variant.ArtifactApprovals.Approvals[len(variant.ArtifactApprovals.Approvals)-1-i]
 			reorderedApprovals[i] = ArtifactRoleApproval{
 				Role:      approval.Role,
-				Signature: upperHexBody(approval.Signature),
+				Signature: transformHex(approval.Signature),
 			}
 		}
 		variant.ArtifactApprovals.Approvals = reorderedApprovals
@@ -338,17 +385,17 @@ func equivalentArtifactApprovalVariantFromRequest(
 		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
 			t.Fatal(err)
 		}
-		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
-		template.CustodianPublicKey = upperHexBody(template.CustodianPublicKey)
-		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		template.DepositorPublicKey = transformHex(template.DepositorPublicKey)
+		template.CustodianPublicKey = transformHex(template.CustodianPublicKey)
+		template.SignerPublicKey = transformHex(template.SignerPublicKey)
 		variant.ScriptTemplate = mustTemplate(template)
 	case TemplateSelfV1:
 		template := &SelfV1Template{}
 		if err := strictUnmarshal(variant.ScriptTemplate, template); err != nil {
 			t.Fatal(err)
 		}
-		template.DepositorPublicKey = upperHexBody(template.DepositorPublicKey)
-		template.SignerPublicKey = upperHexBody(template.SignerPublicKey)
+		template.DepositorPublicKey = transformHex(template.DepositorPublicKey)
+		template.SignerPublicKey = transformHex(template.SignerPublicKey)
 		variant.ScriptTemplate = mustTemplate(template)
 	default:
 		t.Fatalf("unsupported route %s", variant.Route)
@@ -357,12 +404,51 @@ func equivalentArtifactApprovalVariantFromRequest(
 	return variant
 }
 
+func equivalentArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+	return artifactApprovalVariantFromRequest(t, request, upperHexBody)
+}
+
 func upperHexBody(value string) string {
 	if !strings.HasPrefix(value, "0x") {
 		return strings.ToUpper(value)
 	}
 
 	return "0x" + strings.ToUpper(strings.TrimPrefix(value, "0x"))
+}
+
+func mixedCaseHexBody(value string) string {
+	if !strings.HasPrefix(value, "0x") {
+		return value
+	}
+
+	body := strings.ToLower(strings.TrimPrefix(value, "0x"))
+	lettersSeen := 0
+	variant := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'f' {
+			if lettersSeen%2 == 0 {
+				lettersSeen++
+				return r - ('a' - 'A')
+			}
+
+			lettersSeen++
+		}
+
+		return r
+	}, body)
+
+	return "0x" + variant
+}
+
+func mixedCaseArtifactApprovalVariantFromRequest(
+	t *testing.T,
+	request RouteSubmitRequest,
+) RouteSubmitRequest {
+	t.Helper()
+	return artifactApprovalVariantFromRequest(t, request, mixedCaseHexBody)
 }
 
 func equivalentArtifactApprovalVariant(route TemplateID) RouteSubmitRequest {
@@ -1689,6 +1775,59 @@ func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
 			}
 			if digest != expectedDigest {
 				t.Fatalf("expected digest %s, got %s", expectedDigest, digest)
+			}
+		})
+	}
+}
+
+func TestRequestDigestNormalizesMixedCaseArtifactApprovalVariants(t *testing.T) {
+	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
+		t.Run(string(route), func(t *testing.T) {
+			canonicalRequest := canonicalMixedCaseCoverageArtifactApprovalRequest(t, route)
+			mixedCaseRequest := mixedCaseArtifactApprovalVariantFromRequest(
+				t,
+				canonicalRequest,
+			)
+
+			if mixedCaseRequest.Reserve == canonicalRequest.Reserve {
+				t.Fatalf(
+					"expected mixed-case reserve variant, got %s",
+					mixedCaseRequest.Reserve,
+				)
+			}
+
+			normalizedCanonical, err := normalizeRouteSubmitRequest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			normalizedMixedCase, err := normalizeRouteSubmitRequest(mixedCaseRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(normalizedMixedCase, normalizedCanonical) {
+				t.Fatalf(
+					"expected normalized mixed-case request %#v, got %#v",
+					normalizedCanonical,
+					normalizedMixedCase,
+				)
+			}
+
+			canonicalDigest, err := requestDigest(canonicalRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mixedCaseDigest, err := requestDigest(mixedCaseRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if mixedCaseDigest != canonicalDigest {
+				t.Fatalf(
+					"expected matching digest %s, got %s",
+					canonicalDigest,
+					mixedCaseDigest,
+				)
 			}
 		})
 	}

--- a/pkg/covenantsigner/engine.go
+++ b/pkg/covenantsigner/engine.go
@@ -21,6 +21,18 @@ type Engine interface {
 	OnPoll(ctx context.Context, job *Job) (*Transition, error)
 }
 
+type SignerApprovalVerifier interface {
+	VerifySignerApproval(request RouteSubmitRequest) error
+}
+
+type SignerApprovalVerifierFunc func(request RouteSubmitRequest) error
+
+func (savf SignerApprovalVerifierFunc) VerifySignerApproval(
+	request RouteSubmitRequest,
+) error {
+	return savf(request)
+}
+
 type passiveEngine struct{}
 
 func NewPassiveEngine() Engine {

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -48,7 +48,11 @@ func Initialize(
 		)
 	}
 
-	service, err := NewService(handle, engine)
+	service, err := NewService(
+		handle,
+		engine,
+		WithMigrationPlanQuoteTrustRoots(config.MigrationPlanQuoteTrustRoots),
+	)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -147,6 +147,11 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		return StepResult{}, err
 	}
 
+	normalizedRequest, err := normalizeRouteSubmitRequest(input.Request)
+	if err != nil {
+		return StepResult{}, err
+	}
+
 	s.mutex.Lock()
 	if existing, ok, err := s.store.GetByRouteRequest(route, input.RouteRequestID); err != nil {
 		s.mutex.Unlock()
@@ -170,7 +175,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	now := s.now()
-	requestDigest, err := requestDigest(input.Request)
+	requestDigest, err := requestDigest(normalizedRequest)
 	if err != nil {
 		s.mutex.Unlock()
 		return StepResult{}, err
@@ -187,7 +192,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		Detail:          "accepted for covenant signing",
 		CreatedAt:       now.Format(time.RFC3339Nano),
 		UpdatedAt:       now.Format(time.RFC3339Nano),
-		Request:         input.Request,
+		Request:         normalizedRequest,
 	}
 
 	if err := s.store.Put(job); err != nil {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -15,6 +15,7 @@ import (
 type Service struct {
 	store                        *Store
 	engine                       Engine
+	signerApprovalVerifier       SignerApprovalVerifier
 	now                          func() time.Time
 	mutex                        sync.Mutex
 	migrationPlanQuoteTrustRoots []MigrationPlanQuoteTrustRoot
@@ -29,6 +30,14 @@ func WithMigrationPlanQuoteTrustRoots(
 
 	return func(service *Service) {
 		service.migrationPlanQuoteTrustRoots = cloned
+	}
+}
+
+func WithSignerApprovalVerifier(
+	verifier SignerApprovalVerifier,
+) ServiceOption {
+	return func(service *Service) {
+		service.signerApprovalVerifier = verifier
 	}
 }
 
@@ -50,6 +59,9 @@ func NewService(
 		store:  store,
 		engine: engine,
 		now:    func() time.Time { return time.Now().UTC() },
+	}
+	if verifier, ok := engine.(SignerApprovalVerifier); ok {
+		service.signerApprovalVerifier = verifier
 	}
 	for _, option := range options {
 		option(service)
@@ -157,6 +169,7 @@ func (s *Service) loadPollJob(route TemplateID, input SignerPollInput) (*Job, er
 		input.Request,
 		validationOptions{
 			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+			signerApprovalVerifier:       s.signerApprovalVerifier,
 		},
 	)
 	if err != nil {
@@ -174,6 +187,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		migrationPlanQuoteTrustRoots:      s.migrationPlanQuoteTrustRoots,
 		requireFreshMigrationPlanQuote:    true,
 		migrationPlanQuoteVerificationNow: s.now(),
+		signerApprovalVerifier:            s.signerApprovalVerifier,
 	}
 	if err := validateSubmitInput(route, input, submitValidationOptions); err != nil {
 		return StepResult{}, err
@@ -183,6 +197,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		input.Request,
 		validationOptions{
 			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+			signerApprovalVerifier:       s.signerApprovalVerifier,
 		},
 	)
 	if err != nil {
@@ -282,6 +297,7 @@ func (s *Service) Poll(ctx context.Context, route TemplateID, input SignerPollIn
 		input,
 		validationOptions{
 			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+			signerApprovalVerifier:       s.signerApprovalVerifier,
 		},
 	); err != nil {
 		return StepResult{}, err

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -13,13 +13,30 @@ import (
 )
 
 type Service struct {
-	store  *Store
-	engine Engine
-	now    func() time.Time
-	mutex  sync.Mutex
+	store                        *Store
+	engine                       Engine
+	now                          func() time.Time
+	mutex                        sync.Mutex
+	migrationPlanQuoteTrustRoots []MigrationPlanQuoteTrustRoot
 }
 
-func NewService(handle persistence.BasicHandle, engine Engine) (*Service, error) {
+type ServiceOption func(*Service)
+
+func WithMigrationPlanQuoteTrustRoots(
+	trustRoots []MigrationPlanQuoteTrustRoot,
+) ServiceOption {
+	cloned := append([]MigrationPlanQuoteTrustRoot{}, trustRoots...)
+
+	return func(service *Service) {
+		service.migrationPlanQuoteTrustRoots = cloned
+	}
+}
+
+func NewService(
+	handle persistence.BasicHandle,
+	engine Engine,
+	options ...ServiceOption,
+) (*Service, error) {
 	if engine == nil {
 		engine = NewPassiveEngine()
 	}
@@ -29,11 +46,16 @@ func NewService(handle persistence.BasicHandle, engine Engine) (*Service, error)
 		return nil, err
 	}
 
-	return &Service{
+	service := &Service{
 		store:  store,
 		engine: engine,
 		now:    func() time.Time { return time.Now().UTC() },
-	}, nil
+	}
+	for _, option := range options {
+		option(service)
+	}
+
+	return service, nil
 }
 
 func newRequestID(prefix string) (string, error) {
@@ -131,7 +153,12 @@ func (s *Service) loadPollJob(route TemplateID, input SignerPollInput) (*Job, er
 		return nil, &inputError{"routeRequestId does not match stored job"}
 	}
 
-	digest, err := requestDigest(input.Request)
+	digest, err := requestDigest(
+		input.Request,
+		validationOptions{
+			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +170,21 @@ func (s *Service) loadPollJob(route TemplateID, input SignerPollInput) (*Job, er
 }
 
 func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubmitInput) (StepResult, error) {
-	if err := validateSubmitInput(route, input); err != nil {
+	submitValidationOptions := validationOptions{
+		migrationPlanQuoteTrustRoots:      s.migrationPlanQuoteTrustRoots,
+		requireFreshMigrationPlanQuote:    true,
+		migrationPlanQuoteVerificationNow: s.now(),
+	}
+	if err := validateSubmitInput(route, input, submitValidationOptions); err != nil {
 		return StepResult{}, err
 	}
 
-	normalizedRequest, err := normalizeRouteSubmitRequest(input.Request)
+	normalizedRequest, err := normalizeRouteSubmitRequest(
+		input.Request,
+		validationOptions{
+			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+		},
+	)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -240,7 +277,13 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 }
 
 func (s *Service) Poll(ctx context.Context, route TemplateID, input SignerPollInput) (StepResult, error) {
-	if err := validatePollInput(route, input); err != nil {
+	if err := validatePollInput(
+		route,
+		input,
+		validationOptions{
+			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+		},
+	); err != nil {
 		return StepResult{}, err
 	}
 

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -175,7 +175,7 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 	}
 
 	now := s.now()
-	requestDigest, err := requestDigest(normalizedRequest)
+	requestDigest, err := requestDigestFromNormalized(normalizedRequest)
 	if err != nil {
 		s.mutex.Unlock()
 		return StepResult{}, err

--- a/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
+++ b/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
@@ -1,0 +1,165 @@
+{
+  "version": 1,
+  "scope": "covenant_recovery_approval_contract_v1",
+  "vectors": {
+    "qc_v1": {
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_qc_v1",
+        "idempotencyKey": "idem-qc-vector-v1",
+        "route": "qc_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "qc_v1",
+            "scriptTemplateId": "qc_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            },
+            {
+              "role": "C",
+              "signature": "0xc0c0"
+            },
+            {
+              "role": "S",
+              "signature": "0x5050"
+            }
+          ]
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0xc0c0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "qc_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "custodianPublicKey": "0x02dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "beta": 144,
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": true
+        }
+      },
+      "expectedRequestDigest": "0x4bb14155042065021708e80e35470a27640d68fc3e2a642c3cb2823595ea66b1"
+    },
+    "self_v1": {
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_self_v1",
+        "idempotencyKey": "idem-self-vector-v1",
+        "route": "self_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "self_v1",
+            "scriptTemplateId": "self_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            },
+            {
+              "role": "S",
+              "signature": "0x5050"
+            }
+          ]
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "self_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": false
+        }
+      },
+      "expectedRequestDigest": "0x38c86be37817a1d4ec87bf5ec41a9022f44a03e08d7195c4280b7b91eae5bce2"
+    }
+  }
+}

--- a/pkg/covenantsigner/testdata/migration_plan_quote_signing_vectors_v1.json
+++ b/pkg/covenantsigner/testdata/migration_plan_quote_signing_vectors_v1.json
@@ -1,0 +1,80 @@
+{
+  "version": 1,
+  "scope": "migration_plan_quote_signing_contract_v1",
+  "trustRoot": {
+    "keyId": "test-plan-quote-key",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAbp6B4Eys+80lvGkOsR8p2QQPadm+ocqA4/V7bhQBHBc=\n-----END PUBLIC KEY-----\n"
+  },
+  "vectors": {
+    "base": {
+      "unsignedQuote": {
+        "quoteId": "cmdq_testvector",
+        "quoteVersion": 1,
+        "reservationId": "cmdr_testvector",
+        "reserve": "0x1111111111111111111111111111111111111111",
+        "epoch": 7,
+        "route": "MIGRATION",
+        "revealer": "0x2222222222222222222222222222222222222222",
+        "vault": "0x3333333333333333333333333333333333333333",
+        "network": "regtest",
+        "destinationCommitmentHash": "0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7",
+        "activeOutpointTxid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "activeOutpointVout": 1,
+        "planCommitmentHash": "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
+          "inputValueSats": 100000,
+          "destinationValueSats": 99250,
+          "anchorValueSats": 330,
+          "feeSats": 420,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "idempotencyKey": "0x75a998ac6951c2776f3a85f6430fb41321c28c1113a71a52c754806c7a3de9c9",
+        "expiresInSeconds": 900,
+        "issuedAt": "2026-03-09T00:00:00.000Z",
+        "expiresAt": "2026-03-09T00:15:00.000Z"
+      },
+      "expectedPayload": "{\"quoteVersion\":1,\"quoteId\":\"cmdq_testvector\",\"reservationId\":\"cmdr_testvector\",\"reserve\":\"0x1111111111111111111111111111111111111111\",\"epoch\":7,\"route\":\"MIGRATION\",\"revealer\":\"0x2222222222222222222222222222222222222222\",\"vault\":\"0x3333333333333333333333333333333333333333\",\"network\":\"regtest\",\"destinationCommitmentHash\":\"0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7\",\"activeOutpointTxid\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"activeOutpointVout\":1,\"planCommitmentHash\":\"0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09\",\"issuedAt\":\"2026-03-09T00:00:00.000Z\",\"expiresAt\":\"2026-03-09T00:15:00.000Z\",\"expiresInSeconds\":900}",
+      "expectedPreimage": "migration-plan-quote-v1:{\"quoteVersion\":1,\"quoteId\":\"cmdq_testvector\",\"reservationId\":\"cmdr_testvector\",\"reserve\":\"0x1111111111111111111111111111111111111111\",\"epoch\":7,\"route\":\"MIGRATION\",\"revealer\":\"0x2222222222222222222222222222222222222222\",\"vault\":\"0x3333333333333333333333333333333333333333\",\"network\":\"regtest\",\"destinationCommitmentHash\":\"0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7\",\"activeOutpointTxid\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"activeOutpointVout\":1,\"planCommitmentHash\":\"0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09\",\"issuedAt\":\"2026-03-09T00:00:00.000Z\",\"expiresAt\":\"2026-03-09T00:15:00.000Z\",\"expiresInSeconds\":900}",
+      "expectedHash": "0x4707935286fa15edf3f95485297307734b122f7dc1761e6fc023e9d5cc7a935a",
+      "expectedSignature": "0xaae307e9daa2f42f718e8a247c59002a3af7c63f7dd3c67aaa7643d470e787315a5e8f7e330d41c311def8dbf9892bee7d4b86992b81d62a3c194b68c3f0cd03"
+    },
+    "mixed_case": {
+      "unsignedQuote": {
+        "quoteId": "cmdq_testvector",
+        "quoteVersion": 1,
+        "reservationId": "cmdr_testvector",
+        "reserve": "0xAaBbCcDdEeFf00112233445566778899AaBbCcDd",
+        "epoch": 7,
+        "route": "MIGRATION",
+        "revealer": "0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd",
+        "vault": "0x0011AaBbCcDdEeFf0011AaBbCcDdEeFf0011AaBb",
+        "network": "regtest",
+        "destinationCommitmentHash": "0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7",
+        "activeOutpointTxid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "activeOutpointVout": 1,
+        "planCommitmentHash": "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09",
+          "inputValueSats": 100000,
+          "destinationValueSats": 99250,
+          "anchorValueSats": 330,
+          "feeSats": 420,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "idempotencyKey": "0x75a998ac6951c2776f3a85f6430fb41321c28c1113a71a52c754806c7a3de9c9",
+        "expiresInSeconds": 900,
+        "issuedAt": "2026-03-09T00:00:00.000Z",
+        "expiresAt": "2026-03-09T00:15:00.000Z"
+      },
+      "expectedPayload": "{\"quoteVersion\":1,\"quoteId\":\"cmdq_testvector\",\"reservationId\":\"cmdr_testvector\",\"reserve\":\"0xaabbccddeeff00112233445566778899aabbccdd\",\"epoch\":7,\"route\":\"MIGRATION\",\"revealer\":\"0xabcdefabcdefabcdefabcdefabcdefabcdefabcd\",\"vault\":\"0x0011aabbccddeeff0011aabbccddeeff0011aabb\",\"network\":\"regtest\",\"destinationCommitmentHash\":\"0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7\",\"activeOutpointTxid\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"activeOutpointVout\":1,\"planCommitmentHash\":\"0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09\",\"issuedAt\":\"2026-03-09T00:00:00.000Z\",\"expiresAt\":\"2026-03-09T00:15:00.000Z\",\"expiresInSeconds\":900}",
+      "expectedPreimage": "migration-plan-quote-v1:{\"quoteVersion\":1,\"quoteId\":\"cmdq_testvector\",\"reservationId\":\"cmdr_testvector\",\"reserve\":\"0xaabbccddeeff00112233445566778899aabbccdd\",\"epoch\":7,\"route\":\"MIGRATION\",\"revealer\":\"0xabcdefabcdefabcdefabcdefabcdefabcdefabcd\",\"vault\":\"0x0011aabbccddeeff0011aabbccddeeff0011aabb\",\"network\":\"regtest\",\"destinationCommitmentHash\":\"0x10f6ea91bee183fc004591fb6a93495d166ff646df25eb6a3c6324b40d51ebc7\",\"activeOutpointTxid\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"activeOutpointVout\":1,\"planCommitmentHash\":\"0x9ef0621c394dea9e399b4d7a44e41814a2f1bcc163abb18ec897d3f77f144b09\",\"issuedAt\":\"2026-03-09T00:00:00.000Z\",\"expiresAt\":\"2026-03-09T00:15:00.000Z\",\"expiresInSeconds\":900}",
+      "expectedHash": "0x13a05f7e9caa244c446b65c2812095210cb321451d9eb9b735e60ffdd76e693d",
+      "expectedSignature": "0x99ece768accfd8ae222ae2ecba80585fc3664cd84277e53248a4d5d37c48961e20547d66d8acc511ada8b5c0a76d2e22477402f6649d6e2193165f078f6cfe02"
+    }
+  }
+}

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -112,6 +112,40 @@ type MigrationTransactionPlan struct {
 	LockTime             uint32 `json:"lockTime"`
 }
 
+type MigrationDestinationPlanQuoteSignature struct {
+	SignatureVersion uint32 `json:"signatureVersion"`
+	Algorithm        string `json:"algorithm"`
+	KeyID            string `json:"keyId"`
+	Signature        string `json:"signature"`
+}
+
+type MigrationDestinationPlanQuote struct {
+	QuoteID                   string                                 `json:"quoteId"`
+	QuoteVersion              uint32                                 `json:"quoteVersion"`
+	ReservationID             string                                 `json:"reservationId"`
+	Reserve                   string                                 `json:"reserve"`
+	Epoch                     uint64                                 `json:"epoch"`
+	Route                     ReservationRoute                       `json:"route"`
+	Revealer                  string                                 `json:"revealer"`
+	Vault                     string                                 `json:"vault"`
+	Network                   string                                 `json:"network"`
+	DestinationCommitmentHash string                                 `json:"destinationCommitmentHash"`
+	ActiveOutpointTxID        string                                 `json:"activeOutpointTxid"`
+	ActiveOutpointVout        uint32                                 `json:"activeOutpointVout"`
+	PlanCommitmentHash        string                                 `json:"planCommitmentHash"`
+	MigrationTransactionPlan  *MigrationTransactionPlan              `json:"migrationTransactionPlan"`
+	IdempotencyKey            string                                 `json:"idempotencyKey"`
+	ExpiresInSeconds          uint64                                 `json:"expiresInSeconds"`
+	IssuedAt                  string                                 `json:"issuedAt"`
+	ExpiresAt                 string                                 `json:"expiresAt"`
+	Signature                 MigrationDestinationPlanQuoteSignature `json:"signature"`
+}
+
+type MigrationPlanQuoteTrustRoot struct {
+	KeyID        string `json:"keyId" mapstructure:"keyId"`
+	PublicKeyPEM string `json:"publicKeyPem" mapstructure:"publicKeyPem"`
+}
+
 type ArtifactApprovalRole string
 
 const (
@@ -154,6 +188,7 @@ type RouteSubmitRequest struct {
 	ActiveOutpoint            CovenantOutpoint                  `json:"activeOutpoint"`
 	DestinationCommitmentHash string                            `json:"destinationCommitmentHash"`
 	MigrationDestination      *MigrationDestinationReservation  `json:"migrationDestination,omitempty"`
+	MigrationPlanQuote        *MigrationDestinationPlanQuote    `json:"migrationPlanQuote,omitempty"`
 	MigrationTransactionPlan  *MigrationTransactionPlan         `json:"migrationTransactionPlan,omitempty"`
 	ArtifactApprovals         *ArtifactApprovalEnvelope         `json:"artifactApprovals,omitempty"`
 	ArtifactSignatures        []string                          `json:"artifactSignatures"`

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -172,6 +172,18 @@ type ArtifactApprovalEnvelope struct {
 	Approvals []ArtifactRoleApproval  `json:"approvals"`
 }
 
+type SignerApprovalCertificate struct {
+	CertificateVersion uint32   `json:"certificateVersion"`
+	SignatureAlgorithm string   `json:"signatureAlgorithm"`
+	ApprovalDigest     string   `json:"approvalDigest"`
+	WalletPublicKey    string   `json:"walletPublicKey"`
+	SignerSetHash      string   `json:"signerSetHash"`
+	Signature          string   `json:"signature"`
+	ActiveMembers      []uint32 `json:"activeMembers,omitempty"`
+	InactiveMembers    []uint32 `json:"inactiveMembers,omitempty"`
+	EndBlock           *uint64  `json:"endBlock,omitempty"`
+}
+
 type SigningRequirements struct {
 	SignerRequired    bool `json:"signerRequired"`
 	CustodianRequired bool `json:"custodianRequired"`
@@ -191,6 +203,7 @@ type RouteSubmitRequest struct {
 	MigrationPlanQuote        *MigrationDestinationPlanQuote    `json:"migrationPlanQuote,omitempty"`
 	MigrationTransactionPlan  *MigrationTransactionPlan         `json:"migrationTransactionPlan,omitempty"`
 	ArtifactApprovals         *ArtifactApprovalEnvelope         `json:"artifactApprovals,omitempty"`
+	SignerApproval            *SignerApprovalCertificate        `json:"signerApproval,omitempty"`
 	ArtifactSignatures        []string                          `json:"artifactSignatures"`
 	Artifacts                 map[RecoveryPathID]ArtifactRecord `json:"artifacts"`
 	ScriptTemplate            json.RawMessage                   `json:"scriptTemplate"`

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -632,6 +632,10 @@ func normalizeMigrationPlanQuote(
 		if verificationNow.IsZero() {
 			verificationNow = time.Now().UTC()
 		}
+		// Submit freshness is intentionally strict. Poll omits this check so
+		// already-accepted jobs remain addressable after quote expiry; operators
+		// must keep the destination service and keep-core on synchronized UTC
+		// time when enforcing quote freshness.
 		if expiresAt.Before(verificationNow) {
 			return nil, &inputError{"request.migrationPlanQuote is expired"}
 		}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ const (
 	canonicalAnchorValueSats           uint64 = 330
 	migrationTransactionPlanVersion    uint32 = 1
 	artifactApprovalVersion            uint32 = 1
+	signerApprovalCertificateVersion   uint32 = 1
 	migrationPlanQuoteVersion          uint32 = 1
 	migrationPlanQuoteSignatureVersion uint32 = 1
 )
@@ -34,6 +36,7 @@ const (
 const (
 	migrationPlanQuoteSignatureAlgorithm = "ed25519"
 	migrationPlanQuoteSigningDomain      = "migration-plan-quote-v1:"
+	signerApprovalSignatureAlgorithm     = "tecdsa-secp256k1"
 )
 
 var artifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
@@ -55,6 +58,10 @@ type inputError struct {
 
 func (ie *inputError) Error() string {
 	return ie.message
+}
+
+func NewInputError(message string) error {
+	return &inputError{message: message}
 }
 
 func strictUnmarshal(data []byte, target any) error {
@@ -79,6 +86,7 @@ type validationOptions struct {
 	migrationPlanQuoteTrustRoots      []MigrationPlanQuoteTrustRoot
 	requireFreshMigrationPlanQuote    bool
 	migrationPlanQuoteVerificationNow time.Time
+	signerApprovalVerifier            SignerApprovalVerifier
 }
 
 func resolveValidationOptions(options []validationOptions) validationOptions {
@@ -153,6 +161,14 @@ func validateBytes32HexString(name string, value string) error {
 	return nil
 }
 
+func validateUint32Range(name string, value uint64) error {
+	if value > math.MaxUint32 {
+		return &inputError{fmt.Sprintf("%s must fit in uint32", name)}
+	}
+
+	return nil
+}
+
 func decodeBytes32HexString(name string, value string) ([32]byte, error) {
 	var decoded [32]byte
 
@@ -167,6 +183,176 @@ func decodeBytes32HexString(name string, value string) ([32]byte, error) {
 
 	copy(decoded[:], rawValue)
 	return decoded, nil
+}
+
+func normalizeSignerApprovalMemberIndexes(
+	name string,
+	values []uint32,
+) ([]uint32, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	normalized := append([]uint32{}, values...)
+	seen := make(map[uint32]struct{}, len(normalized))
+	for i, value := range normalized {
+		if value == 0 {
+			return nil, &inputError{
+				fmt.Sprintf("%s[%d] must be greater than zero", name, i),
+			}
+		}
+		if err := validateUint32Range(name, uint64(value)); err != nil {
+			return nil, err
+		}
+		if _, ok := seen[value]; ok {
+			return nil, &inputError{
+				fmt.Sprintf("%s[%d] duplicates member %d", name, i, value),
+			}
+		}
+		seen[value] = struct{}{}
+	}
+
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i] < normalized[j]
+	})
+
+	return normalized, nil
+}
+
+func normalizeSignerApprovalCertificate(
+	request RouteSubmitRequest,
+) (*SignerApprovalCertificate, error) {
+	if request.SignerApproval == nil {
+		return nil, nil
+	}
+	if request.ArtifactApprovals == nil {
+		return nil, &inputError{
+			"request.artifactApprovals is required when request.signerApproval is present",
+		}
+	}
+
+	signerApproval := request.SignerApproval
+	if signerApproval.CertificateVersion != signerApprovalCertificateVersion {
+		return nil, &inputError{
+			fmt.Sprintf(
+				"request.signerApproval.certificateVersion must equal %d",
+				signerApprovalCertificateVersion,
+			),
+		}
+	}
+	if signerApproval.SignatureAlgorithm != signerApprovalSignatureAlgorithm {
+		return nil, &inputError{
+			fmt.Sprintf(
+				"request.signerApproval.signatureAlgorithm must equal %s",
+				signerApprovalSignatureAlgorithm,
+			),
+		}
+	}
+	if err := validateBytes32HexString(
+		"request.signerApproval.approvalDigest",
+		signerApproval.ApprovalDigest,
+	); err != nil {
+		return nil, err
+	}
+	if err := validateHexString(
+		"request.signerApproval.walletPublicKey",
+		signerApproval.WalletPublicKey,
+	); err != nil {
+		return nil, err
+	}
+	if len(signerApproval.WalletPublicKey) != 132 {
+		return nil, &inputError{
+			"request.signerApproval.walletPublicKey must be a 65-byte uncompressed secp256k1 public key",
+		}
+	}
+	normalizedWalletPublicKey := normalizeLowerHex(signerApproval.WalletPublicKey)
+	if !strings.HasPrefix(normalizedWalletPublicKey, "0x04") {
+		return nil, &inputError{
+			"request.signerApproval.walletPublicKey must be a 65-byte uncompressed secp256k1 public key",
+		}
+	}
+	if err := validateBytes32HexString(
+		"request.signerApproval.signerSetHash",
+		signerApproval.SignerSetHash,
+	); err != nil {
+		return nil, err
+	}
+	if err := validateHexString(
+		"request.signerApproval.signature",
+		signerApproval.Signature,
+	); err != nil {
+		return nil, err
+	}
+
+	expectedApprovalDigest, err := artifactApprovalDigest(request.ArtifactApprovals.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedApprovalDigest := normalizeLowerHex(signerApproval.ApprovalDigest)
+	if normalizedApprovalDigest != "0x"+hex.EncodeToString(expectedApprovalDigest) {
+		return nil, &inputError{
+			"request.signerApproval.approvalDigest must match the canonical artifactApprovals payload digest",
+		}
+	}
+
+	normalizedSignerApproval := &SignerApprovalCertificate{
+		CertificateVersion: signerApprovalCertificateVersion,
+		SignatureAlgorithm: signerApprovalSignatureAlgorithm,
+		ApprovalDigest:     normalizedApprovalDigest,
+		WalletPublicKey:    normalizedWalletPublicKey,
+		SignerSetHash:      normalizeLowerHex(signerApproval.SignerSetHash),
+		Signature:          normalizeLowerHex(signerApproval.Signature),
+	}
+
+	activeMembers, err := normalizeSignerApprovalMemberIndexes(
+		"request.signerApproval.activeMembers",
+		signerApproval.ActiveMembers,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(activeMembers) > 0 {
+		normalizedSignerApproval.ActiveMembers = activeMembers
+	}
+
+	inactiveMembers, err := normalizeSignerApprovalMemberIndexes(
+		"request.signerApproval.inactiveMembers",
+		signerApproval.InactiveMembers,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(inactiveMembers) > 0 {
+		normalizedSignerApproval.InactiveMembers = inactiveMembers
+	}
+
+	if len(activeMembers) > 0 && len(inactiveMembers) > 0 {
+		activeSet := make(map[uint32]struct{}, len(activeMembers))
+		for _, value := range activeMembers {
+			activeSet[value] = struct{}{}
+		}
+		for _, value := range inactiveMembers {
+			if _, ok := activeSet[value]; ok {
+				return nil, &inputError{
+					"request.signerApproval.activeMembers and request.signerApproval.inactiveMembers must not overlap",
+				}
+			}
+		}
+	}
+
+	if signerApproval.EndBlock != nil {
+		if err := validateUint32Range(
+			"request.signerApproval.endBlock",
+			*signerApproval.EndBlock,
+		); err != nil {
+			return nil, err
+		}
+		endBlock := *signerApproval.EndBlock
+		normalizedSignerApproval.EndBlock = &endBlock
+	}
+
+	return normalizedSignerApproval, nil
 }
 
 func normalizeLowerHex(value string) string {
@@ -885,6 +1071,22 @@ func validateArtifactSignatures(signatures []string) ([]string, error) {
 	return normalizedSignatures, nil
 }
 
+func requiredStructuredArtifactApprovalRoles(route TemplateID) ([]ArtifactApprovalRole, error) {
+	switch route {
+	case TemplateQcV1:
+		return []ArtifactApprovalRole{
+			ArtifactApprovalRoleDepositor,
+			ArtifactApprovalRoleCustodian,
+		}, nil
+	case TemplateSelfV1:
+		return []ArtifactApprovalRole{
+			ArtifactApprovalRoleDepositor,
+		}, nil
+	default:
+		return nil, &inputError{"unsupported request.route"}
+	}
+}
+
 func requiredArtifactApprovalRoles(route TemplateID) ([]ArtifactApprovalRole, error) {
 	switch route {
 	case TemplateQcV1:
@@ -912,6 +1114,11 @@ func normalizeArtifactApprovals(
 	route TemplateID,
 	request RouteSubmitRequest,
 ) (*ArtifactApprovalEnvelope, []string, error) {
+	normalizedSignerApproval, err := normalizeSignerApprovalCertificate(request)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	normalizedLegacySignatures, err := validateArtifactSignatures(request.ArtifactSignatures)
 	if err != nil {
 		return nil, nil, err
@@ -964,6 +1171,9 @@ func normalizeArtifactApprovals(
 	}
 
 	requiredRoles, err := requiredArtifactApprovalRoles(route)
+	if normalizedSignerApproval != nil {
+		requiredRoles, err = requiredStructuredArtifactApprovalRoles(route)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -999,7 +1209,7 @@ func normalizeArtifactApprovals(
 		approvalsByRole[approval.Role] = normalizeLowerHex(approval.Signature)
 	}
 
-	derivedLegacySignatures := make([]string, len(requiredRoles))
+	derivedLegacySignatures := make([]string, 0, len(requiredRoles)+1)
 	normalizedApprovals := &ArtifactApprovalEnvelope{
 		Payload: ArtifactApprovalPayload{
 			ApprovalVersion:           artifactApprovalVersion,
@@ -1020,19 +1230,31 @@ func normalizeArtifactApprovals(
 			)}
 		}
 
-		derivedLegacySignatures[i] = signature
+		derivedLegacySignatures = append(derivedLegacySignatures, signature)
 		normalizedApprovals.Approvals[i] = ArtifactRoleApproval{
 			Role:      role,
 			Signature: signature,
 		}
 	}
 
+	if normalizedSignerApproval != nil {
+		derivedLegacySignatures = append(
+			derivedLegacySignatures,
+			normalizedSignerApproval.Signature,
+		)
+	}
+
+	canonicalSignatureError := "request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"
+	if normalizedSignerApproval != nil {
+		canonicalSignatureError = "request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals and request.signerApproval"
+	}
+
 	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
-		return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		return nil, nil, &inputError{canonicalSignatureError}
 	}
 	for i := range derivedLegacySignatures {
 		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
-			return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+			return nil, nil, &inputError{canonicalSignatureError}
 		}
 	}
 
@@ -1216,6 +1438,10 @@ func normalizeRouteSubmitRequest(
 	if err != nil {
 		return RouteSubmitRequest{}, err
 	}
+	normalizedSignerApproval, err := normalizeSignerApprovalCertificate(request)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
 
 	normalizedScriptTemplate, err := normalizeScriptTemplate(request.Route, request.ScriptTemplate)
 	if err != nil {
@@ -1253,6 +1479,7 @@ func normalizeRouteSubmitRequest(
 		MigrationPlanQuote:        normalizedMigrationPlanQuote,
 		MigrationTransactionPlan:  normalizeMigrationTransactionPlan(request.MigrationTransactionPlan),
 		ArtifactApprovals:         normalizedArtifactApprovals,
+		SignerApproval:            normalizedSignerApproval,
 		ArtifactSignatures:        normalizedArtifactSignatures,
 		Artifacts:                 normalizeArtifacts(request.Artifacts),
 		ScriptTemplate:            normalizedScriptTemplate,
@@ -1368,6 +1595,25 @@ func validateCommonRequest(
 		}
 	default:
 		return &inputError{"unsupported request.route"}
+	}
+
+	if request.SignerApproval != nil {
+		if resolvedOptions.signerApprovalVerifier == nil {
+			return &inputError{
+				"request.signerApproval cannot be verified by this signer deployment",
+			}
+		}
+
+		normalizedRequest, err := normalizeRouteSubmitRequest(request, resolvedOptions)
+		if err != nil {
+			return err
+		}
+
+		if err := resolvedOptions.signerApprovalVerifier.VerifySignerApproval(
+			normalizedRequest,
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -32,7 +32,12 @@ func strictUnmarshal(data []byte, target any) error {
 }
 
 func requestDigest(request RouteSubmitRequest) (string, error) {
-	payload, err := json.Marshal(request)
+	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+	if err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(normalizedRequest)
 	if err != nil {
 		return "", err
 	}
@@ -329,51 +334,65 @@ func requiredArtifactApprovalRoles(route TemplateID) ([]ArtifactApprovalRole, er
 }
 
 func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) error {
+	_, _, err := normalizeArtifactApprovals(route, request)
+	return err
+}
+
+func normalizeArtifactApprovals(
+	route TemplateID,
+	request RouteSubmitRequest,
+) (*ArtifactApprovalEnvelope, []string, error) {
 	normalizedLegacySignatures, err := validateArtifactSignatures(request.ArtifactSignatures)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if request.ArtifactApprovals == nil {
-		return nil
+		return nil, normalizedLegacySignatures, nil
 	}
 
 	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {
-		return &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.approvalVersion must equal 1"}
 	}
 	if request.ArtifactApprovals.Payload.Route != route {
-		return &inputError{"request.artifactApprovals.payload.route must match request.route"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.route must match request.route"}
 	}
 	if request.ArtifactApprovals.Payload.ScriptTemplateID != route {
-		return &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
+		return nil, nil, &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
 	}
 	if err := validateHexString(
 		"request.artifactApprovals.payload.destinationCommitmentHash",
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
 	); err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := validateHexString(
 		"request.artifactApprovals.payload.planCommitmentHash",
 		request.ArtifactApprovals.Payload.PlanCommitmentHash,
 	); err != nil {
-		return err
+		return nil, nil, err
 	}
-	if normalizeLowerHex(request.ArtifactApprovals.Payload.DestinationCommitmentHash) !=
-		normalizeLowerHex(request.DestinationCommitmentHash) {
-		return &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
+
+	normalizedDestinationCommitmentHash := normalizeLowerHex(
+		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
+	)
+	if normalizedDestinationCommitmentHash != normalizeLowerHex(request.DestinationCommitmentHash) {
+		return nil, nil, &inputError{"request.artifactApprovals.payload.destinationCommitmentHash must match request.destinationCommitmentHash"}
 	}
-	if normalizeLowerHex(request.ArtifactApprovals.Payload.PlanCommitmentHash) !=
-		normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
-		return &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
+
+	normalizedPlanCommitmentHash := normalizeLowerHex(
+		request.ArtifactApprovals.Payload.PlanCommitmentHash,
+	)
+	if normalizedPlanCommitmentHash != normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
+		return nil, nil, &inputError{"request.artifactApprovals.payload.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
 	}
 	if len(request.ArtifactApprovals.Approvals) == 0 {
-		return &inputError{"request.artifactApprovals.approvals must not be empty"}
+		return nil, nil, &inputError{"request.artifactApprovals.approvals must not be empty"}
 	}
 
 	requiredRoles, err := requiredArtifactApprovalRoles(route)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	allowedRoles := make(map[ArtifactApprovalRole]struct{}, len(requiredRoles))
@@ -384,14 +403,14 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 	approvalsByRole := make(map[ArtifactApprovalRole]string, len(requiredRoles))
 	for i, approval := range request.ArtifactApprovals.Approvals {
 		if _, ok := allowedRoles[approval.Role]; !ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals[%d].role is not allowed for %s",
 				i,
 				route,
 			)}
 		}
 		if _, ok := approvalsByRole[approval.Role]; ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals[%d].role duplicates role %s",
 				i,
 				approval.Role,
@@ -401,17 +420,27 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 			fmt.Sprintf("request.artifactApprovals.approvals[%d].signature", i),
 			approval.Signature,
 		); err != nil {
-			return err
+			return nil, nil, err
 		}
 
 		approvalsByRole[approval.Role] = normalizeLowerHex(approval.Signature)
 	}
 
 	derivedLegacySignatures := make([]string, len(requiredRoles))
+	normalizedApprovals := &ArtifactApprovalEnvelope{
+		Payload: ArtifactApprovalPayload{
+			ApprovalVersion:           artifactApprovalVersion,
+			Route:                     route,
+			ScriptTemplateID:          route,
+			DestinationCommitmentHash: normalizedDestinationCommitmentHash,
+			PlanCommitmentHash:        normalizedPlanCommitmentHash,
+		},
+		Approvals: make([]ArtifactRoleApproval, len(requiredRoles)),
+	}
 	for i, role := range requiredRoles {
 		signature, ok := approvalsByRole[role]
 		if !ok {
-			return &inputError{fmt.Sprintf(
+			return nil, nil, &inputError{fmt.Sprintf(
 				"request.artifactApprovals.approvals must include role %s for %s",
 				role,
 				route,
@@ -419,18 +448,159 @@ func validateArtifactApprovals(route TemplateID, request RouteSubmitRequest) err
 		}
 
 		derivedLegacySignatures[i] = signature
-	}
-
-	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
-		return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
-	}
-	for i := range derivedLegacySignatures {
-		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
-			return &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		normalizedApprovals.Approvals[i] = ArtifactRoleApproval{
+			Role:      role,
+			Signature: signature,
 		}
 	}
 
-	return nil
+	if len(normalizedLegacySignatures) != len(derivedLegacySignatures) {
+		return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+	}
+	for i := range derivedLegacySignatures {
+		if normalizedLegacySignatures[i] != derivedLegacySignatures[i] {
+			return nil, nil, &inputError{"request.artifactSignatures must match canonical approval role order derived from request.artifactApprovals"}
+		}
+	}
+
+	return normalizedApprovals, derivedLegacySignatures, nil
+}
+
+func normalizeArtifactRecord(record ArtifactRecord) ArtifactRecord {
+	normalized := ArtifactRecord{
+		PSBTHash:                  normalizeLowerHex(record.PSBTHash),
+		DestinationCommitmentHash: normalizeLowerHex(record.DestinationCommitmentHash),
+	}
+	if record.TransactionHex != "" {
+		normalized.TransactionHex = normalizeLowerHex(record.TransactionHex)
+	}
+	if record.TransactionID != "" {
+		normalized.TransactionID = normalizeLowerHex(record.TransactionID)
+	}
+
+	return normalized
+}
+
+func normalizeArtifacts(artifacts map[RecoveryPathID]ArtifactRecord) map[RecoveryPathID]ArtifactRecord {
+	if artifacts == nil {
+		return nil
+	}
+
+	normalized := make(map[RecoveryPathID]ArtifactRecord, len(artifacts))
+	for pathID, artifact := range artifacts {
+		normalized[pathID] = normalizeArtifactRecord(artifact)
+	}
+
+	return normalized
+}
+
+func normalizeMigrationDestination(
+	destination *MigrationDestinationReservation,
+) *MigrationDestinationReservation {
+	if destination == nil {
+		return nil
+	}
+
+	return &MigrationDestinationReservation{
+		ReservationID:             destination.ReservationID,
+		Reserve:                   normalizeLowerHex(destination.Reserve),
+		Epoch:                     destination.Epoch,
+		Route:                     destination.Route,
+		Revealer:                  normalizeLowerHex(destination.Revealer),
+		Vault:                     normalizeLowerHex(destination.Vault),
+		Network:                   strings.TrimSpace(destination.Network),
+		Status:                    destination.Status,
+		DepositScript:             normalizeLowerHex(destination.DepositScript),
+		DepositScriptHash:         normalizeLowerHex(destination.DepositScriptHash),
+		MigrationExtraData:        normalizeLowerHex(destination.MigrationExtraData),
+		DestinationCommitmentHash: normalizeLowerHex(destination.DestinationCommitmentHash),
+	}
+}
+
+func normalizeMigrationTransactionPlan(
+	plan *MigrationTransactionPlan,
+) *MigrationTransactionPlan {
+	if plan == nil {
+		return nil
+	}
+
+	return &MigrationTransactionPlan{
+		PlanVersion:          plan.PlanVersion,
+		PlanCommitmentHash:   normalizeLowerHex(plan.PlanCommitmentHash),
+		InputValueSats:       plan.InputValueSats,
+		DestinationValueSats: plan.DestinationValueSats,
+		AnchorValueSats:      plan.AnchorValueSats,
+		FeeSats:              plan.FeeSats,
+		InputSequence:        plan.InputSequence,
+		LockTime:             plan.LockTime,
+	}
+}
+
+func normalizeScriptTemplate(route TemplateID, rawTemplate json.RawMessage) (json.RawMessage, error) {
+	switch route {
+	case TemplateSelfV1:
+		template := &SelfV1Template{}
+		if err := strictUnmarshal(rawTemplate, template); err != nil {
+			return nil, err
+		}
+		template.DepositorPublicKey = normalizeLowerHex(template.DepositorPublicKey)
+		template.SignerPublicKey = normalizeLowerHex(template.SignerPublicKey)
+		return json.Marshal(template)
+	case TemplateQcV1:
+		template := &QcV1Template{}
+		if err := strictUnmarshal(rawTemplate, template); err != nil {
+			return nil, err
+		}
+		template.DepositorPublicKey = normalizeLowerHex(template.DepositorPublicKey)
+		template.CustodianPublicKey = normalizeLowerHex(template.CustodianPublicKey)
+		template.SignerPublicKey = normalizeLowerHex(template.SignerPublicKey)
+		return json.Marshal(template)
+	default:
+		return nil, &inputError{"unsupported request.route"}
+	}
+}
+
+func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest, error) {
+	normalizedArtifactApprovals, normalizedArtifactSignatures, err := normalizeArtifactApprovals(
+		request.Route,
+		request,
+	)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	normalizedScriptTemplate, err := normalizeScriptTemplate(request.Route, request.ScriptTemplate)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	return RouteSubmitRequest{
+		FacadeRequestID: request.FacadeRequestID,
+		IdempotencyKey:  request.IdempotencyKey,
+		Route:           request.Route,
+		Strategy:        normalizeLowerHex(request.Strategy),
+		Reserve:         normalizeLowerHex(request.Reserve),
+		Epoch:           request.Epoch,
+		MaturityHeight:  request.MaturityHeight,
+		ActiveOutpoint: CovenantOutpoint{
+			TxID: normalizeLowerHex(request.ActiveOutpoint.TxID),
+			Vout: request.ActiveOutpoint.Vout,
+			ScriptHash: func() string {
+				if request.ActiveOutpoint.ScriptHash == "" {
+					return ""
+				}
+				return normalizeLowerHex(request.ActiveOutpoint.ScriptHash)
+			}(),
+		},
+		DestinationCommitmentHash: normalizeLowerHex(request.DestinationCommitmentHash),
+		MigrationDestination:      normalizeMigrationDestination(request.MigrationDestination),
+		MigrationTransactionPlan:  normalizeMigrationTransactionPlan(request.MigrationTransactionPlan),
+		ArtifactApprovals:         normalizedArtifactApprovals,
+		ArtifactSignatures:        normalizedArtifactSignatures,
+		Artifacts:                 normalizeArtifacts(request.Artifacts),
+		ScriptTemplate:            normalizedScriptTemplate,
+		Signing:                   request.Signing,
+	}, nil
 }
 
 func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -31,13 +31,32 @@ func strictUnmarshal(data []byte, target any) error {
 	return decoder.Decode(target)
 }
 
+func marshalCanonicalJSON(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+
+	return bytes.TrimSuffix(buffer.Bytes(), []byte("\n")), nil
+}
+
+// requestDigest accepts raw requests because Poll validates equivalence against
+// whatever the caller resubmits. Submit should use requestDigestFromNormalized
+// after it has already normalized the request once for storage.
 func requestDigest(request RouteSubmitRequest) (string, error) {
 	normalizedRequest, err := normalizeRouteSubmitRequest(request)
 	if err != nil {
 		return "", err
 	}
 
-	payload, err := json.Marshal(normalizedRequest)
+	return requestDigestFromNormalized(normalizedRequest)
+}
+
+func requestDigestFromNormalized(request RouteSubmitRequest) (string, error) {
+	payload, err := marshalCanonicalJSON(request)
 	if err != nil {
 		return "", err
 	}
@@ -349,6 +368,9 @@ func normalizeArtifactApprovals(
 
 	if request.ArtifactApprovals == nil {
 		return nil, normalizedLegacySignatures, nil
+	}
+	if request.MigrationTransactionPlan == nil {
+		return nil, nil, &inputError{"request.migrationTransactionPlan is required when request.artifactApprovals is present"}
 	}
 
 	if request.ArtifactApprovals.Payload.ApprovalVersion != artifactApprovalVersion {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -3,24 +3,37 @@ package covenantsigner
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
-	canonicalCovenantInputSequence  uint32 = 0xFFFFFFFD
-	canonicalAnchorValueSats        uint64 = 330
-	migrationTransactionPlanVersion uint32 = 1
-	artifactApprovalVersion         uint32 = 1
+	canonicalCovenantInputSequence     uint32 = 0xFFFFFFFD
+	canonicalAnchorValueSats           uint64 = 330
+	migrationTransactionPlanVersion    uint32 = 1
+	artifactApprovalVersion            uint32 = 1
+	migrationPlanQuoteVersion          uint32 = 1
+	migrationPlanQuoteSignatureVersion uint32 = 1
+)
+
+const (
+	migrationPlanQuoteSignatureAlgorithm = "ed25519"
+	migrationPlanQuoteSigningDomain      = "migration-plan-quote-v1:"
 )
 
 var artifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
@@ -31,6 +44,10 @@ var artifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
 		"bytes32 destinationCommitmentHash," +
 		"bytes32 planCommitmentHash)",
 ))
+
+var canonicalTimestampPattern = regexp.MustCompile(
+	`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`,
+)
 
 type inputError struct {
 	message string
@@ -58,11 +75,31 @@ func marshalCanonicalJSON(value any) ([]byte, error) {
 	return bytes.TrimSuffix(buffer.Bytes(), []byte("\n")), nil
 }
 
+type validationOptions struct {
+	migrationPlanQuoteTrustRoots      []MigrationPlanQuoteTrustRoot
+	requireFreshMigrationPlanQuote    bool
+	migrationPlanQuoteVerificationNow time.Time
+}
+
+func resolveValidationOptions(options []validationOptions) validationOptions {
+	if len(options) == 0 {
+		return validationOptions{}
+	}
+
+	return options[0]
+}
+
 // requestDigest accepts raw requests because Poll validates equivalence against
 // whatever the caller resubmits. Submit should use requestDigestFromNormalized
 // after it has already normalized the request once for storage.
-func requestDigest(request RouteSubmitRequest) (string, error) {
-	normalizedRequest, err := normalizeRouteSubmitRequest(request)
+func requestDigest(
+	request RouteSubmitRequest,
+	options ...validationOptions,
+) (string, error) {
+	normalizedRequest, err := normalizeRouteSubmitRequest(
+		request,
+		resolveValidationOptions(options),
+	)
 	if err != nil {
 		return "", err
 	}
@@ -262,6 +299,345 @@ func verifySecp256k1Signature(
 	}
 
 	return &inputError{fmt.Sprintf("%s does not verify against the required public key", name)}
+}
+
+type migrationPlanQuoteSigningPayload struct {
+	QuoteVersion              uint32 `json:"quoteVersion"`
+	QuoteID                   string `json:"quoteId"`
+	ReservationID             string `json:"reservationId"`
+	Reserve                   string `json:"reserve"`
+	Epoch                     uint64 `json:"epoch"`
+	Route                     string `json:"route"`
+	Revealer                  string `json:"revealer"`
+	Vault                     string `json:"vault"`
+	Network                   string `json:"network"`
+	DestinationCommitmentHash string `json:"destinationCommitmentHash"`
+	ActiveOutpointTxID        string `json:"activeOutpointTxid"`
+	ActiveOutpointVout        uint32 `json:"activeOutpointVout"`
+	PlanCommitmentHash        string `json:"planCommitmentHash"`
+	IssuedAt                  string `json:"issuedAt"`
+	ExpiresAt                 string `json:"expiresAt"`
+	ExpiresInSeconds          uint64 `json:"expiresInSeconds"`
+}
+
+func normalizeCanonicalTimestamp(name string, value string) (string, error) {
+	if !canonicalTimestampPattern.MatchString(value) {
+		return "", &inputError{
+			fmt.Sprintf(
+				"%s must be a UTC ISO-8601 timestamp from Date.toISOString()",
+				name,
+			),
+		}
+	}
+
+	return value, nil
+}
+
+func normalizeMigrationPlanQuotePublicKeyPEM(value string) string {
+	return strings.TrimSpace(strings.ReplaceAll(value, "\\n", "\n"))
+}
+
+func parseMigrationPlanQuoteTrustRoot(
+	name string,
+	trustRoot MigrationPlanQuoteTrustRoot,
+) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(normalizeMigrationPlanQuotePublicKeyPEM(trustRoot.PublicKeyPEM)))
+	if block == nil {
+		return nil, &inputError{fmt.Sprintf("%s.publicKeyPem must be a PEM-encoded public key", name)}
+	}
+
+	publicKeyValue, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, &inputError{fmt.Sprintf("%s.publicKeyPem must be a PEM-encoded Ed25519 public key", name)}
+	}
+
+	publicKey, ok := publicKeyValue.(ed25519.PublicKey)
+	if !ok {
+		return nil, &inputError{fmt.Sprintf("%s.publicKeyPem must be a PEM-encoded Ed25519 public key", name)}
+	}
+
+	return publicKey, nil
+}
+
+func migrationPlanQuoteSigningPayloadBytes(
+	quote *MigrationDestinationPlanQuote,
+) ([]byte, error) {
+	return marshalCanonicalJSON(migrationPlanQuoteSigningPayload{
+		QuoteVersion:              quote.QuoteVersion,
+		QuoteID:                   quote.QuoteID,
+		ReservationID:             quote.ReservationID,
+		Reserve:                   normalizeLowerHex(quote.Reserve),
+		Epoch:                     quote.Epoch,
+		Route:                     string(quote.Route),
+		Revealer:                  normalizeLowerHex(quote.Revealer),
+		Vault:                     normalizeLowerHex(quote.Vault),
+		Network:                   quote.Network,
+		DestinationCommitmentHash: normalizeLowerHex(quote.DestinationCommitmentHash),
+		ActiveOutpointTxID:        normalizeLowerHex(quote.ActiveOutpointTxID),
+		ActiveOutpointVout:        quote.ActiveOutpointVout,
+		PlanCommitmentHash:        normalizeLowerHex(quote.PlanCommitmentHash),
+		IssuedAt:                  quote.IssuedAt,
+		ExpiresAt:                 quote.ExpiresAt,
+		ExpiresInSeconds:          quote.ExpiresInSeconds,
+	})
+}
+
+func migrationPlanQuoteSigningPreimage(
+	quote *MigrationDestinationPlanQuote,
+) ([]byte, error) {
+	payload, err := migrationPlanQuoteSigningPayloadBytes(quote)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(migrationPlanQuoteSigningDomain + string(payload)), nil
+}
+
+func migrationPlanQuoteSigningHash(
+	quote *MigrationDestinationPlanQuote,
+) ([]byte, error) {
+	preimage, err := migrationPlanQuoteSigningPreimage(quote)
+	if err != nil {
+		return nil, err
+	}
+
+	sum := sha256.Sum256(preimage)
+	return sum[:], nil
+}
+
+func normalizeMigrationPlanQuote(
+	request RouteSubmitRequest,
+	options validationOptions,
+) (*MigrationDestinationPlanQuote, error) {
+	quote := request.MigrationPlanQuote
+	if quote == nil {
+		if len(options.migrationPlanQuoteTrustRoots) > 0 {
+			return nil, &inputError{
+				"request.migrationPlanQuote is required when migrationPlanQuoteTrustRoots are configured",
+			}
+		}
+
+		return nil, nil
+	}
+	if len(options.migrationPlanQuoteTrustRoots) == 0 {
+		return nil, &inputError{"request.migrationPlanQuote verification requires configured trust roots"}
+	}
+	if request.MigrationDestination == nil {
+		return nil, &inputError{"request.migrationDestination is required when request.migrationPlanQuote is present"}
+	}
+	if request.MigrationTransactionPlan == nil {
+		return nil, &inputError{"request.migrationTransactionPlan is required when request.migrationPlanQuote is present"}
+	}
+	if quote.QuoteVersion != migrationPlanQuoteVersion {
+		return nil, &inputError{"request.migrationPlanQuote.quoteVersion must equal 1"}
+	}
+	if strings.TrimSpace(quote.QuoteID) == "" {
+		return nil, &inputError{"request.migrationPlanQuote.quoteId is required"}
+	}
+	if strings.TrimSpace(quote.ReservationID) == "" {
+		return nil, &inputError{"request.migrationPlanQuote.reservationId is required"}
+	}
+	if strings.TrimSpace(quote.IdempotencyKey) == "" {
+		return nil, &inputError{"request.migrationPlanQuote.idempotencyKey is required"}
+	}
+	if quote.Route != ReservationRouteMigration {
+		return nil, &inputError{"request.migrationPlanQuote.route must be MIGRATION"}
+	}
+	if err := validateAddressString("request.migrationPlanQuote.reserve", quote.Reserve); err != nil {
+		return nil, err
+	}
+	if err := validateAddressString("request.migrationPlanQuote.revealer", quote.Revealer); err != nil {
+		return nil, err
+	}
+	if err := validateAddressString("request.migrationPlanQuote.vault", quote.Vault); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(quote.Network) == "" {
+		return nil, &inputError{"request.migrationPlanQuote.network is required"}
+	}
+	if err := validateBytes32HexString(
+		"request.migrationPlanQuote.destinationCommitmentHash",
+		quote.DestinationCommitmentHash,
+	); err != nil {
+		return nil, err
+	}
+	if err := validateBytes32HexString(
+		"request.migrationPlanQuote.activeOutpointTxid",
+		quote.ActiveOutpointTxID,
+	); err != nil {
+		return nil, err
+	}
+	if err := validateBytes32HexString(
+		"request.migrationPlanQuote.planCommitmentHash",
+		quote.PlanCommitmentHash,
+	); err != nil {
+		return nil, err
+	}
+	if quote.ExpiresInSeconds == 0 {
+		return nil, &inputError{"request.migrationPlanQuote.expiresInSeconds must be greater than zero"}
+	}
+	if quote.Signature.SignatureVersion != migrationPlanQuoteSignatureVersion {
+		return nil, &inputError{"request.migrationPlanQuote.signature.signatureVersion must equal 1"}
+	}
+	if quote.Signature.Algorithm != migrationPlanQuoteSignatureAlgorithm {
+		return nil, &inputError{"request.migrationPlanQuote.signature.algorithm must equal ed25519"}
+	}
+	if strings.TrimSpace(quote.Signature.KeyID) == "" {
+		return nil, &inputError{"request.migrationPlanQuote.signature.keyId is required"}
+	}
+	if err := validateHexString("request.migrationPlanQuote.signature.signature", quote.Signature.Signature); err != nil {
+		return nil, err
+	}
+
+	normalizedIssuedAt, err := normalizeCanonicalTimestamp(
+		"request.migrationPlanQuote.issuedAt",
+		quote.IssuedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	issuedAt, err := time.Parse(time.RFC3339Nano, normalizedIssuedAt)
+	if err != nil {
+		return nil, &inputError{
+			"request.migrationPlanQuote.issuedAt must be a parseable UTC ISO-8601 timestamp",
+		}
+	}
+	normalizedExpiresAt, err := normalizeCanonicalTimestamp(
+		"request.migrationPlanQuote.expiresAt",
+		quote.ExpiresAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, normalizedExpiresAt)
+	if err != nil {
+		return nil, &inputError{
+			"request.migrationPlanQuote.expiresAt must be a parseable UTC ISO-8601 timestamp",
+		}
+	}
+	if !expiresAt.After(issuedAt) {
+		return nil, &inputError{"request.migrationPlanQuote.expiresAt must be after request.migrationPlanQuote.issuedAt"}
+	}
+	if expiresAt.Sub(issuedAt) != time.Duration(quote.ExpiresInSeconds)*time.Second {
+		return nil, &inputError{"request.migrationPlanQuote.expiresAt must equal request.migrationPlanQuote.issuedAt + expiresInSeconds"}
+	}
+	if quote.Epoch != request.Epoch {
+		return nil, &inputError{"request.migrationPlanQuote.epoch must match request.epoch"}
+	}
+	if normalizeLowerHex(quote.Reserve) != normalizeLowerHex(request.Reserve) {
+		return nil, &inputError{"request.migrationPlanQuote.reserve must match request.reserve"}
+	}
+	if quote.ReservationID != request.MigrationDestination.ReservationID {
+		return nil, &inputError{"request.migrationPlanQuote.reservationId must match request.migrationDestination.reservationId"}
+	}
+	if normalizeLowerHex(quote.Revealer) != normalizeLowerHex(request.MigrationDestination.Revealer) {
+		return nil, &inputError{"request.migrationPlanQuote.revealer must match request.migrationDestination.revealer"}
+	}
+	if normalizeLowerHex(quote.Vault) != normalizeLowerHex(request.MigrationDestination.Vault) {
+		return nil, &inputError{"request.migrationPlanQuote.vault must match request.migrationDestination.vault"}
+	}
+	if strings.TrimSpace(quote.Network) != strings.TrimSpace(request.MigrationDestination.Network) {
+		return nil, &inputError{"request.migrationPlanQuote.network must match request.migrationDestination.network"}
+	}
+	if normalizeLowerHex(quote.DestinationCommitmentHash) != normalizeLowerHex(request.DestinationCommitmentHash) {
+		return nil, &inputError{"request.migrationPlanQuote.destinationCommitmentHash must match request.destinationCommitmentHash"}
+	}
+	if normalizeLowerHex(quote.DestinationCommitmentHash) != normalizeLowerHex(request.MigrationDestination.DestinationCommitmentHash) {
+		return nil, &inputError{"request.migrationPlanQuote.destinationCommitmentHash must match request.migrationDestination.destinationCommitmentHash"}
+	}
+	if normalizeLowerHex(quote.ActiveOutpointTxID) != normalizeLowerHex(request.ActiveOutpoint.TxID) {
+		return nil, &inputError{"request.migrationPlanQuote.activeOutpointTxid must match request.activeOutpoint.txid"}
+	}
+	if quote.ActiveOutpointVout != request.ActiveOutpoint.Vout {
+		return nil, &inputError{"request.migrationPlanQuote.activeOutpointVout must match request.activeOutpoint.vout"}
+	}
+	if normalizeLowerHex(quote.PlanCommitmentHash) != normalizeLowerHex(request.MigrationTransactionPlan.PlanCommitmentHash) {
+		return nil, &inputError{"request.migrationPlanQuote.planCommitmentHash must match request.migrationTransactionPlan.planCommitmentHash"}
+	}
+
+	normalizedQuotePlan := normalizeMigrationTransactionPlan(quote.MigrationTransactionPlan)
+	if normalizedQuotePlan == nil {
+		return nil, &inputError{"request.migrationPlanQuote.migrationTransactionPlan is required"}
+	}
+	if err := validateMigrationTransactionPlan(request, quote.MigrationTransactionPlan); err != nil {
+		return nil, err
+	}
+	if !reflect.DeepEqual(normalizedQuotePlan, normalizeMigrationTransactionPlan(request.MigrationTransactionPlan)) {
+		return nil, &inputError{"request.migrationPlanQuote.migrationTransactionPlan must match request.migrationTransactionPlan"}
+	}
+
+	var publicKey ed25519.PublicKey
+	foundTrustRoot := false
+	for i, trustRoot := range options.migrationPlanQuoteTrustRoots {
+		if trustRoot.KeyID != quote.Signature.KeyID {
+			continue
+		}
+
+		publicKey, err = parseMigrationPlanQuoteTrustRoot(
+			fmt.Sprintf("migrationPlanQuoteTrustRoots[%d]", i),
+			trustRoot,
+		)
+		if err != nil {
+			return nil, err
+		}
+		foundTrustRoot = true
+		break
+	}
+	if !foundTrustRoot {
+		return nil, &inputError{"request.migrationPlanQuote.signature.keyId does not match a configured trust root"}
+	}
+
+	normalizedQuote := &MigrationDestinationPlanQuote{
+		QuoteID:                   strings.TrimSpace(quote.QuoteID),
+		QuoteVersion:              migrationPlanQuoteVersion,
+		ReservationID:             strings.TrimSpace(quote.ReservationID),
+		Reserve:                   normalizeLowerHex(quote.Reserve),
+		Epoch:                     quote.Epoch,
+		Route:                     ReservationRouteMigration,
+		Revealer:                  normalizeLowerHex(quote.Revealer),
+		Vault:                     normalizeLowerHex(quote.Vault),
+		Network:                   strings.TrimSpace(quote.Network),
+		DestinationCommitmentHash: normalizeLowerHex(quote.DestinationCommitmentHash),
+		ActiveOutpointTxID:        normalizeLowerHex(quote.ActiveOutpointTxID),
+		ActiveOutpointVout:        quote.ActiveOutpointVout,
+		PlanCommitmentHash:        normalizeLowerHex(quote.PlanCommitmentHash),
+		MigrationTransactionPlan:  normalizedQuotePlan,
+		IdempotencyKey:            strings.TrimSpace(quote.IdempotencyKey),
+		ExpiresInSeconds:          quote.ExpiresInSeconds,
+		IssuedAt:                  normalizedIssuedAt,
+		ExpiresAt:                 normalizedExpiresAt,
+		Signature: MigrationDestinationPlanQuoteSignature{
+			SignatureVersion: migrationPlanQuoteSignatureVersion,
+			Algorithm:        migrationPlanQuoteSignatureAlgorithm,
+			KeyID:            strings.TrimSpace(quote.Signature.KeyID),
+			Signature:        normalizeLowerHex(quote.Signature.Signature),
+		},
+	}
+
+	signingHash, err := migrationPlanQuoteSigningHash(normalizedQuote)
+	if err != nil {
+		return nil, err
+	}
+
+	rawSignature, err := hex.DecodeString(strings.TrimPrefix(normalizedQuote.Signature.Signature, "0x"))
+	if err != nil {
+		return nil, &inputError{"request.migrationPlanQuote.signature.signature must be valid hex"}
+	}
+	if !ed25519.Verify(publicKey, signingHash, rawSignature) {
+		return nil, &inputError{"request.migrationPlanQuote.signature does not verify against the configured trust root"}
+	}
+
+	if options.requireFreshMigrationPlanQuote {
+		verificationNow := options.migrationPlanQuoteVerificationNow
+		if verificationNow.IsZero() {
+			verificationNow = time.Now().UTC()
+		}
+		if expiresAt.Before(verificationNow) {
+			return nil, &inputError{"request.migrationPlanQuote is expired"}
+		}
+	}
+
+	return normalizedQuote, nil
 }
 
 func computeMigrationExtraData(revealer string) string {
@@ -824,7 +1200,11 @@ func normalizeScriptTemplate(route TemplateID, rawTemplate json.RawMessage) (jso
 	}
 }
 
-func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest, error) {
+func normalizeRouteSubmitRequest(
+	request RouteSubmitRequest,
+	options ...validationOptions,
+) (RouteSubmitRequest, error) {
+	resolvedOptions := resolveValidationOptions(options)
 	normalizedArtifactApprovals, normalizedArtifactSignatures, err := normalizeArtifactApprovals(
 		request.Route,
 		request,
@@ -834,6 +1214,14 @@ func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest
 	}
 
 	normalizedScriptTemplate, err := normalizeScriptTemplate(request.Route, request.ScriptTemplate)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
+
+	normalizedMigrationPlanQuote, err := normalizeMigrationPlanQuote(
+		request,
+		resolvedOptions,
+	)
 	if err != nil {
 		return RouteSubmitRequest{}, err
 	}
@@ -858,6 +1246,7 @@ func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest
 		},
 		DestinationCommitmentHash: normalizeLowerHex(request.DestinationCommitmentHash),
 		MigrationDestination:      normalizeMigrationDestination(request.MigrationDestination),
+		MigrationPlanQuote:        normalizedMigrationPlanQuote,
 		MigrationTransactionPlan:  normalizeMigrationTransactionPlan(request.MigrationTransactionPlan),
 		ArtifactApprovals:         normalizedArtifactApprovals,
 		ArtifactSignatures:        normalizedArtifactSignatures,
@@ -867,7 +1256,12 @@ func normalizeRouteSubmitRequest(request RouteSubmitRequest) (RouteSubmitRequest
 	}, nil
 }
 
-func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
+func validateCommonRequest(
+	route TemplateID,
+	request RouteSubmitRequest,
+	options ...validationOptions,
+) error {
+	resolvedOptions := resolveValidationOptions(options)
 	if request.FacadeRequestID == "" {
 		return &inputError{"request.facadeRequestId is required"}
 	}
@@ -904,6 +1298,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	// orchestrator must supply the canonical migration transaction plan before
 	// this signer version can accept requests.
 	if err := validateMigrationTransactionPlan(request, request.MigrationTransactionPlan); err != nil {
+		return err
+	}
+	if _, err := normalizeMigrationPlanQuote(request, resolvedOptions); err != nil {
 		return err
 	}
 	if request.ArtifactApprovals == nil {
@@ -972,17 +1369,25 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	return nil
 }
 
-func validateSubmitInput(route TemplateID, input SignerSubmitInput) error {
+func validateSubmitInput(
+	route TemplateID,
+	input SignerSubmitInput,
+	options ...validationOptions,
+) error {
 	if input.RouteRequestID == "" {
 		return &inputError{"routeRequestId is required"}
 	}
 	if input.Stage != StageSignerCoordination {
 		return &inputError{"stage must be SIGNER_COORDINATION"}
 	}
-	return validateCommonRequest(route, input.Request)
+	return validateCommonRequest(route, input.Request, resolveValidationOptions(options))
 }
 
-func validatePollInput(route TemplateID, input SignerPollInput) error {
+func validatePollInput(
+	route TemplateID,
+	input SignerPollInput,
+	options ...validationOptions,
+) error {
 	if input.RequestID == "" {
 		return &inputError{"requestId is required"}
 	}
@@ -990,7 +1395,7 @@ func validatePollInput(route TemplateID, input SignerPollInput) error {
 		RouteRequestID: input.RouteRequestID,
 		Request:        input.Request,
 		Stage:          input.Stage,
-	}); err != nil {
+	}, resolveValidationOptions(options)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -2,12 +2,18 @@ package covenantsigner
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"strings"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -16,6 +22,15 @@ const (
 	migrationTransactionPlanVersion uint32 = 1
 	artifactApprovalVersion         uint32 = 1
 )
+
+var artifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
+	"ArtifactApproval(" +
+		"uint8 approvalVersion," +
+		"bytes32 route," +
+		"bytes32 scriptTemplateId," +
+		"bytes32 destinationCommitmentHash," +
+		"bytes32 planCommitmentHash)",
+))
 
 type inputError struct {
 	message string
@@ -89,8 +104,164 @@ func validateAddressString(name string, value string) error {
 	return nil
 }
 
+func validateBytes32HexString(name string, value string) error {
+	if err := validateHexString(name, value); err != nil {
+		return err
+	}
+
+	if len(value) != 66 {
+		return &inputError{fmt.Sprintf("%s must be a 32-byte 0x-prefixed hex string", name)}
+	}
+
+	return nil
+}
+
+func decodeBytes32HexString(name string, value string) ([32]byte, error) {
+	var decoded [32]byte
+
+	if err := validateBytes32HexString(name, value); err != nil {
+		return decoded, err
+	}
+
+	rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+	if err != nil {
+		return decoded, &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	copy(decoded[:], rawValue)
+	return decoded, nil
+}
+
 func normalizeLowerHex(value string) string {
 	return strings.ToLower(value)
+}
+
+func abiEncodeUint32Word(value uint32) [32]byte {
+	var encoded [32]byte
+	binary.BigEndian.PutUint32(encoded[28:], value)
+	return encoded
+}
+
+func keccakTemplateIdentifier(id TemplateID) [32]byte {
+	hash := crypto.Keccak256Hash([]byte(id))
+
+	var encoded [32]byte
+	copy(encoded[:], hash.Bytes())
+
+	return encoded
+}
+
+// artifactApprovalDigest pins the current phase-1 approval payload contract to
+// a deterministic EIP-712-compatible struct hash, without yet committing to a
+// chain-specific domain separator.
+func artifactApprovalDigest(payload ArtifactApprovalPayload) ([]byte, error) {
+	destinationCommitmentHash, err := decodeBytes32HexString(
+		"request.artifactApprovals.payload.destinationCommitmentHash",
+		payload.DestinationCommitmentHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	planCommitmentHash, err := decodeBytes32HexString(
+		"request.artifactApprovals.payload.planCommitmentHash",
+		payload.PlanCommitmentHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded := make([]byte, 32*6)
+	approvalVersionWord := abiEncodeUint32Word(payload.ApprovalVersion)
+	routeIdentifier := keccakTemplateIdentifier(payload.Route)
+	scriptTemplateIdentifier := keccakTemplateIdentifier(payload.ScriptTemplateID)
+
+	copy(encoded[0:32], artifactApprovalTypeHash.Bytes())
+	copy(encoded[32:64], approvalVersionWord[:])
+	copy(encoded[64:96], routeIdentifier[:])
+	copy(encoded[96:128], scriptTemplateIdentifier[:])
+	copy(encoded[128:160], destinationCommitmentHash[:])
+	copy(encoded[160:192], planCommitmentHash[:])
+
+	digest := crypto.Keccak256Hash(encoded)
+	return digest.Bytes(), nil
+}
+
+func parseCompressedSecp256k1PublicKey(
+	name string,
+	value string,
+) (*btcec.PublicKey, error) {
+	if err := validateHexString(name, value); err != nil {
+		return nil, err
+	}
+
+	rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+	if err != nil {
+		return nil, &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	if len(rawValue) != 33 || (rawValue[0] != 0x02 && rawValue[0] != 0x03) {
+		return nil, &inputError{fmt.Sprintf("%s must be a compressed secp256k1 public key", name)}
+	}
+
+	publicKey, err := btcec.ParsePubKey(rawValue, btcec.S256())
+	if err != nil {
+		return nil, &inputError{fmt.Sprintf("%s must be a compressed secp256k1 public key", name)}
+	}
+
+	return publicKey, nil
+}
+
+func verifyCompactSecp256k1Signature(
+	publicKey *btcec.PublicKey,
+	digest []byte,
+	signature []byte,
+) bool {
+	return ecdsa.Verify(
+		publicKey.ToECDSA(),
+		digest,
+		new(big.Int).SetBytes(signature[:32]),
+		new(big.Int).SetBytes(signature[32:]),
+	)
+}
+
+func verifySecp256k1Signature(
+	name string,
+	publicKey *btcec.PublicKey,
+	digest []byte,
+	signature string,
+) error {
+	rawSignature, err := hex.DecodeString(strings.TrimPrefix(signature, "0x"))
+	if err != nil {
+		return &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	switch {
+	case len(rawSignature) == 64:
+		if verifyCompactSecp256k1Signature(publicKey, digest, rawSignature) {
+			return nil
+		}
+	case len(rawSignature) == 65 &&
+		(rawSignature[64] == 0 || rawSignature[64] == 1 || rawSignature[64] == 27 || rawSignature[64] == 28):
+		if verifyCompactSecp256k1Signature(publicKey, digest, rawSignature[:64]) {
+			return nil
+		}
+	default:
+		parsedSignature, err := btcec.ParseDERSignature(rawSignature, btcec.S256())
+		if err != nil {
+			return &inputError{
+				fmt.Sprintf(
+					"%s must be a DER or 64/65-byte secp256k1 signature",
+					name,
+				),
+			}
+		}
+		if parsedSignature.Verify(digest, publicKey) {
+			return nil
+		}
+	}
+
+	return &inputError{fmt.Sprintf("%s does not verify against the required public key", name)}
 }
 
 func computeMigrationExtraData(revealer string) string {
@@ -382,13 +553,13 @@ func normalizeArtifactApprovals(
 	if request.ArtifactApprovals.Payload.ScriptTemplateID != route {
 		return nil, nil, &inputError{"request.artifactApprovals.payload.scriptTemplateId must match request.route"}
 	}
-	if err := validateHexString(
+	if err := validateBytes32HexString(
 		"request.artifactApprovals.payload.destinationCommitmentHash",
 		request.ArtifactApprovals.Payload.DestinationCommitmentHash,
 	); err != nil {
 		return nil, nil, err
 	}
-	if err := validateHexString(
+	if err := validateBytes32HexString(
 		"request.artifactApprovals.payload.planCommitmentHash",
 		request.ArtifactApprovals.Payload.PlanCommitmentHash,
 	); err != nil {
@@ -486,6 +657,71 @@ func normalizeArtifactApprovals(
 	}
 
 	return normalizedApprovals, derivedLegacySignatures, nil
+}
+
+func validateArtifactApprovalAuthenticity(
+	request RouteSubmitRequest,
+	depositorPublicKey string,
+	custodianPublicKey string,
+) error {
+	payloadDigest, err := artifactApprovalDigest(request.ArtifactApprovals.Payload)
+	if err != nil {
+		return err
+	}
+
+	depositorKey, err := parseCompressedSecp256k1PublicKey(
+		"request.scriptTemplate.depositorPublicKey",
+		depositorPublicKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	var custodianKey *btcec.PublicKey
+	if custodianPublicKey != "" {
+		custodianKey, err = parseCompressedSecp256k1PublicKey(
+			"request.scriptTemplate.custodianPublicKey",
+			custodianPublicKey,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i, approval := range request.ArtifactApprovals.Approvals {
+		signaturePath := fmt.Sprintf(
+			"request.artifactApprovals.approvals[%d].signature",
+			i,
+		)
+
+		switch approval.Role {
+		case ArtifactApprovalRoleDepositor:
+			if err := verifySecp256k1Signature(
+				signaturePath,
+				depositorKey,
+				payloadDigest,
+				approval.Signature,
+			); err != nil {
+				return err
+			}
+		case ArtifactApprovalRoleCustodian:
+			if custodianKey == nil {
+				return &inputError{
+					"request.artifactApprovals.approvals includes unexpected custodian role",
+				}
+			}
+			if err := verifySecp256k1Signature(
+				signaturePath,
+				custodianKey,
+				payloadDigest,
+				approval.Signature,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func normalizeArtifactRecord(record ArtifactRecord) ArtifactRecord {
@@ -664,6 +900,9 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 	if err := validateMigrationTransactionPlan(request, request.MigrationTransactionPlan); err != nil {
 		return err
 	}
+	if request.ArtifactApprovals == nil {
+		return &inputError{"request.artifactApprovals is required"}
+	}
 	if err := validateArtifactApprovals(route, request); err != nil {
 		return err
 	}
@@ -686,6 +925,13 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
 			return err
 		}
+		if err := validateArtifactApprovalAuthenticity(
+			request,
+			template.DepositorPublicKey,
+			"",
+		); err != nil {
+			return err
+		}
 	case TemplateQcV1:
 		if !request.Signing.SignerRequired || !request.Signing.CustodianRequired {
 			return &inputError{"request.signing must set signerRequired=true and custodianRequired=true for qc_v1"}
@@ -704,6 +950,13 @@ func validateCommonRequest(route TemplateID, request RouteSubmitRequest) error {
 			return err
 		}
 		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
+			return err
+		}
+		if err := validateArtifactApprovalAuthenticity(
+			request,
+			template.DepositorPublicKey,
+			template.CustodianPublicKey,
+		); err != nil {
 			return err
 		}
 	default:

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -312,7 +312,7 @@ type migrationPlanCommitmentPayload struct {
 func computeDestinationCommitmentHash(
 	reservation *MigrationDestinationReservation,
 ) (string, error) {
-	payload, err := json.Marshal(destinationCommitmentPayload{
+	payload, err := marshalCanonicalJSON(destinationCommitmentPayload{
 		Reserve:            normalizeLowerHex(reservation.Reserve),
 		Epoch:              reservation.Epoch,
 		Route:              string(reservation.Route),
@@ -334,7 +334,7 @@ func computeMigrationTransactionPlanCommitmentHash(
 	request RouteSubmitRequest,
 	plan *MigrationTransactionPlan,
 ) (string, error) {
-	payload, err := json.Marshal(migrationPlanCommitmentPayload{
+	payload, err := marshalCanonicalJSON(migrationPlanCommitmentPayload{
 		PlanVersion:               plan.PlanVersion,
 		Reserve:                   normalizeLowerHex(request.Reserve),
 		Epoch:                     request.Epoch,
@@ -718,6 +718,12 @@ func validateArtifactApprovalAuthenticity(
 			); err != nil {
 				return err
 			}
+		case ArtifactApprovalRoleSigner:
+			// Phase 1 keeps S structurally required but not cryptographically
+			// verified. Signer approval must eventually bind to quorum or
+			// signer-service trust roots rather than the single signer key in the
+			// script template.
+			continue
 		}
 	}
 

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -414,6 +414,7 @@ type DepositChainRequest struct {
 // WalletChainData represents wallet data stored on-chain.
 type WalletChainData struct {
 	EcdsaWalletID                          [32]byte
+	MembersIDsHash                         [32]byte
 	MainUtxoHash                           [32]byte
 	PendingRedemptionsValue                uint64
 	CreatedAt                              time.Time

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -42,6 +42,97 @@ func newCovenantSignerEngine(node *node) covenantsigner.Engine {
 	return &covenantSignerEngine{node: node}
 }
 
+func (cse *covenantSignerEngine) VerifySignerApproval(
+	request covenantsigner.RouteSubmitRequest,
+) error {
+	if request.SignerApproval == nil {
+		return nil
+	}
+
+	signerPublicKey, err := cse.resolveSignerApprovalTemplatePublicKey(request)
+	if err != nil {
+		return covenantsigner.NewInputError(err.Error())
+	}
+
+	expectedWalletPublicKeyBytes, err := marshalPublicKey(signerPublicKey)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot marshal signer public key for signer approval verification: %w",
+			err,
+		)
+	}
+
+	expectedWalletPublicKey := "0x" + hex.EncodeToString(expectedWalletPublicKeyBytes)
+	if !strings.EqualFold(
+		request.SignerApproval.WalletPublicKey,
+		expectedWalletPublicKey,
+	) {
+		return covenantsigner.NewInputError(
+			"request.signerApproval.walletPublicKey must match request.scriptTemplate.signerPublicKey",
+		)
+	}
+
+	walletChainData, err := cse.node.chain.GetWallet(
+		bitcoin.PublicKeyHash(signerPublicKey),
+	)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no wallet") {
+			return covenantsigner.NewInputError(
+				"request.signerApproval.walletPublicKey must resolve to a registered on-chain wallet",
+			)
+		}
+
+		return fmt.Errorf(
+			"cannot resolve on-chain wallet for signer approval verification: %w",
+			err,
+		)
+	}
+
+	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
+		signerPublicKey,
+		walletChainData,
+		cse.node.groupParameters,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot compute signer approval signer set hash: %w",
+			err,
+		)
+	}
+
+	if err := verifySignerApprovalCertificate(
+		request.SignerApproval,
+		expectedSignerSetHash,
+	); err != nil {
+		return covenantsigner.NewInputError(
+			fmt.Sprintf("request.signerApproval is invalid: %v", err),
+		)
+	}
+
+	return nil
+}
+
+func (cse *covenantSignerEngine) resolveSignerApprovalTemplatePublicKey(
+	request covenantsigner.RouteSubmitRequest,
+) (*ecdsa.PublicKey, error) {
+	switch request.Route {
+	case covenantsigner.TemplateSelfV1:
+		template, err := decodeSelfV1Template(request.ScriptTemplate)
+		if err != nil {
+			return nil, err
+		}
+		return parseCompressedPublicKey(template.SignerPublicKey)
+	case covenantsigner.TemplateQcV1:
+		template, err := decodeQcV1Template(request.ScriptTemplate)
+		if err != nil {
+			return nil, err
+		}
+		return parseCompressedPublicKey(template.SignerPublicKey)
+	default:
+		return nil, fmt.Errorf("unsupported covenant route")
+	}
+}
+
 func (cse *covenantSignerEngine) OnSubmit(
 	ctx context.Context,
 	job *covenantsigner.Job,

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"math"
@@ -14,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -196,6 +198,7 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 		},
 	}
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, nil)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_self_ready",
@@ -425,6 +428,7 @@ func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
 		},
 	}
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, custodianPrivateKey)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_ready",
@@ -664,6 +668,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsInvalidBeta(t *testing.T) {
 	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
 	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, custodianPrivateKey)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_bad_beta",
@@ -800,6 +805,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsScriptHashMismatch(t *testing.T) 
 		},
 	}
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, custodianPrivateKey)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateQcV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_qc_bad_script_hash",
@@ -903,6 +909,7 @@ func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T
 	request.MigrationDestination.DestinationCommitmentHash = testDestinationCommitmentHash(t, request.MigrationDestination)
 	request.DestinationCommitmentHash = request.MigrationDestination.DestinationCommitmentHash
 	applyTestMigrationTransactionPlanCommitment(t, &request)
+	applyTestArtifactApprovals(t, &request, depositorPrivateKey, nil)
 
 	result, err := service.Submit(context.Background(), covenantsigner.TemplateSelfV1, covenantsigner.SignerSubmitInput{
 		RouteRequestID: "ors_self_zero",
@@ -1116,6 +1123,143 @@ func testMigrationTransactionPlanCommitmentHash(
 
 	sum := sha256.Sum256(payload)
 	return "0x" + hex.EncodeToString(sum[:])
+}
+
+var testArtifactApprovalTypeHash = crypto.Keccak256Hash([]byte(
+	"ArtifactApproval(" +
+		"uint8 approvalVersion," +
+		"bytes32 route," +
+		"bytes32 scriptTemplateId," +
+		"bytes32 destinationCommitmentHash," +
+		"bytes32 planCommitmentHash)",
+))
+
+func testArtifactApprovalDigest(
+	t *testing.T,
+	payload covenantsigner.ArtifactApprovalPayload,
+) []byte {
+	t.Helper()
+
+	decodeBytes32 := func(name string, value string) [32]byte {
+		t.Helper()
+
+		rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+		if err != nil {
+			t.Fatalf("cannot decode %s: %v", name, err)
+		}
+		if len(rawValue) != 32 {
+			t.Fatalf("expected %s to be 32 bytes, got %d", name, len(rawValue))
+		}
+
+		var decoded [32]byte
+		copy(decoded[:], rawValue)
+		return decoded
+	}
+
+	encodeUint32 := func(value uint32) [32]byte {
+		var encoded [32]byte
+		binary.BigEndian.PutUint32(encoded[28:], value)
+		return encoded
+	}
+
+	keccakTemplateIdentifier := func(value covenantsigner.TemplateID) [32]byte {
+		hash := crypto.Keccak256Hash([]byte(value))
+		var encoded [32]byte
+		copy(encoded[:], hash.Bytes())
+		return encoded
+	}
+
+	destinationCommitmentHash := decodeBytes32(
+		"destinationCommitmentHash",
+		payload.DestinationCommitmentHash,
+	)
+	planCommitmentHash := decodeBytes32(
+		"planCommitmentHash",
+		payload.PlanCommitmentHash,
+	)
+	approvalVersionWord := encodeUint32(payload.ApprovalVersion)
+	routeIdentifier := keccakTemplateIdentifier(payload.Route)
+	scriptTemplateIdentifier := keccakTemplateIdentifier(payload.ScriptTemplateID)
+
+	encoded := make([]byte, 32*6)
+	copy(encoded[0:32], testArtifactApprovalTypeHash.Bytes())
+	copy(encoded[32:64], approvalVersionWord[:])
+	copy(encoded[64:96], routeIdentifier[:])
+	copy(encoded[96:128], scriptTemplateIdentifier[:])
+	copy(encoded[128:160], destinationCommitmentHash[:])
+	copy(encoded[160:192], planCommitmentHash[:])
+
+	digest := crypto.Keccak256Hash(encoded)
+	return digest.Bytes()
+}
+
+func testSignArtifactApproval(
+	t *testing.T,
+	privateKey *btcec.PrivateKey,
+	payload covenantsigner.ArtifactApprovalPayload,
+) string {
+	t.Helper()
+
+	signature, err := privateKey.Sign(testArtifactApprovalDigest(t, payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return "0x" + hex.EncodeToString(signature.Serialize())
+}
+
+func applyTestArtifactApprovals(
+	t *testing.T,
+	request *covenantsigner.RouteSubmitRequest,
+	depositorPrivateKey *btcec.PrivateKey,
+	custodianPrivateKey *btcec.PrivateKey,
+) {
+	t.Helper()
+
+	payload := covenantsigner.ArtifactApprovalPayload{
+		ApprovalVersion:           1,
+		Route:                     request.Route,
+		ScriptTemplateID:          request.Route,
+		DestinationCommitmentHash: request.DestinationCommitmentHash,
+		PlanCommitmentHash:        request.MigrationTransactionPlan.PlanCommitmentHash,
+	}
+
+	approvals := []covenantsigner.ArtifactRoleApproval{
+		{
+			Role:      covenantsigner.ArtifactApprovalRoleDepositor,
+			Signature: testSignArtifactApproval(t, depositorPrivateKey, payload),
+		},
+		{
+			Role:      covenantsigner.ArtifactApprovalRoleSigner,
+			Signature: "0x5151",
+		},
+	}
+
+	if request.Route == covenantsigner.TemplateQcV1 {
+		approvals = []covenantsigner.ArtifactRoleApproval{
+			{
+				Role:      covenantsigner.ArtifactApprovalRoleDepositor,
+				Signature: testSignArtifactApproval(t, depositorPrivateKey, payload),
+			},
+			{
+				Role:      covenantsigner.ArtifactApprovalRoleCustodian,
+				Signature: testSignArtifactApproval(t, custodianPrivateKey, payload),
+			},
+			{
+				Role:      covenantsigner.ArtifactApprovalRoleSigner,
+				Signature: "0x5151",
+			},
+		}
+	}
+
+	request.ArtifactApprovals = &covenantsigner.ArtifactApprovalEnvelope{
+		Payload:   payload,
+		Approvals: approvals,
+	}
+	request.ArtifactSignatures = make([]string, len(approvals))
+	for i, approval := range approvals {
+		request.ArtifactSignatures[i] = approval.Signature
+	}
 }
 
 func applyTestMigrationTransactionPlanCommitment(

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -999,12 +999,14 @@ func setupCovenantSignerTestNode(
 	if err != nil {
 		t.Fatal(err)
 	}
+	membersIDsHash := sha256.Sum256([]byte("covenant-signer-test-members"))
 
 	localChain.setWallet(
 		walletPublicKeyHash,
 		&WalletChainData{
-			EcdsaWalletID: walletID,
-			State:         StateLive,
+			EcdsaWalletID:  walletID,
+			MembersIDsHash: membersIDsHash,
+			State:          StateLive,
 		},
 	)
 

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -394,6 +394,7 @@ func (n *node) getSigningExecutor(
 	}
 
 	executor := newSigningExecutor(
+		n.chain,
 		signers,
 		broadcastChannel,
 		membershipValidator,

--- a/pkg/tbtc/signer_approval_certificate.go
+++ b/pkg/tbtc/signer_approval_certificate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
@@ -22,21 +23,6 @@ const (
 	signerApprovalCertificateSignatureAlgorithm        = "tecdsa-secp256k1"
 	signerApprovalCertificateSignerSetDomain           = "covenant-signer-set-v1:"
 )
-
-// signerApprovalCertificate is a spike artifact for evaluating whether the
-// current tECDSA signer stack can emit a single offline-verifiable `S`
-// approval over an arbitrary approval digest.
-type signerApprovalCertificate struct {
-	CertificateVersion uint32   `json:"certificateVersion"`
-	SignatureAlgorithm string   `json:"signatureAlgorithm"`
-	WalletPublicKey    string   `json:"walletPublicKey"`
-	SignerSetHash      string   `json:"signerSetHash"`
-	ApprovalDigest     string   `json:"approvalDigest"`
-	Signature          string   `json:"signature"`
-	ActiveMembers      []uint32 `json:"activeMembers,omitempty"`
-	InactiveMembers    []uint32 `json:"inactiveMembers,omitempty"`
-	EndBlock           uint64   `json:"endBlock"`
-}
 
 type signerApprovalCertificateSignerSetPayload struct {
 	WalletID        string `json:"walletId"`
@@ -49,7 +35,7 @@ func (se *signingExecutor) issueSignerApprovalCertificate(
 	ctx context.Context,
 	approvalDigest []byte,
 	startBlock uint64,
-) (*signerApprovalCertificate, error) {
+) (*covenantsigner.SignerApprovalCertificate, error) {
 	if len(approvalDigest) != sha256.Size {
 		return nil, fmt.Errorf(
 			"approval digest must be exactly %d bytes",
@@ -94,7 +80,7 @@ func buildSignerApprovalCertificate(
 	signature *tecdsa.Signature,
 	activityReport *signingActivityReport,
 	endBlock uint64,
-) (*signerApprovalCertificate, error) {
+) (*covenantsigner.SignerApprovalCertificate, error) {
 	if len(approvalDigest) != sha256.Size {
 		return nil, fmt.Errorf(
 			"approval digest must be exactly %d bytes",
@@ -117,7 +103,7 @@ func buildSignerApprovalCertificate(
 	}
 
 	signerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
-		wallet,
+		wallet.publicKey,
 		walletChainData,
 		groupParameters,
 	)
@@ -130,15 +116,15 @@ func buildSignerApprovalCertificate(
 		S: signature.S,
 	}).Serialize()
 
-	certificate := &signerApprovalCertificate{
+	certificate := &covenantsigner.SignerApprovalCertificate{
 		CertificateVersion: signerApprovalCertificateVersion,
 		SignatureAlgorithm: signerApprovalCertificateSignatureAlgorithm,
 		WalletPublicKey:    "0x" + hex.EncodeToString(walletPublicKeyBytes),
 		SignerSetHash:      signerSetHash,
 		ApprovalDigest:     "0x" + hex.EncodeToString(approvalDigest),
 		Signature:          "0x" + hex.EncodeToString(signatureBytes),
-		EndBlock:           endBlock,
 	}
+	certificate.EndBlock = &endBlock
 
 	if activityReport != nil {
 		certificate.ActiveMembers = normalizeSignerApprovalMemberIndexes(
@@ -153,7 +139,7 @@ func buildSignerApprovalCertificate(
 }
 
 func computeSignerApprovalCertificateSignerSetHash(
-	wallet wallet,
+	walletPublicKey *ecdsa.PublicKey,
 	walletChainData *WalletChainData,
 	groupParameters *GroupParameters,
 ) (string, error) {
@@ -170,7 +156,7 @@ func computeSignerApprovalCertificateSignerSetHash(
 		return "", fmt.Errorf("wallet chain data must include members IDs hash")
 	}
 
-	walletPublicKeyBytes, err := marshalPublicKey(wallet.publicKey)
+	walletPublicKeyBytes, err := marshalPublicKey(walletPublicKey)
 	if err != nil {
 		return "", err
 	}
@@ -193,7 +179,7 @@ func computeSignerApprovalCertificateSignerSetHash(
 }
 
 func verifySignerApprovalCertificate(
-	certificate *signerApprovalCertificate,
+	certificate *covenantsigner.SignerApprovalCertificate,
 	expectedSignerSetHash string,
 ) error {
 	if certificate == nil {

--- a/pkg/tbtc/signer_approval_certificate.go
+++ b/pkg/tbtc/signer_approval_certificate.go
@@ -1,0 +1,264 @@
+package tbtc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+	"github.com/keep-network/keep-core/pkg/tecdsa"
+)
+
+const (
+	signerApprovalCertificateVersion            uint32 = 1
+	signerApprovalCertificateSignatureAlgorithm        = "tecdsa-secp256k1"
+	signerApprovalCertificateSignerSetDomain           = "covenant-signer-set-v1:"
+)
+
+// signerApprovalCertificate is a spike artifact for evaluating whether the
+// current tECDSA signer stack can emit a single offline-verifiable `S`
+// approval over an arbitrary approval digest.
+type signerApprovalCertificate struct {
+	CertificateVersion uint32   `json:"certificateVersion"`
+	SignatureAlgorithm string   `json:"signatureAlgorithm"`
+	WalletPublicKey    string   `json:"walletPublicKey"`
+	SignerSetHash      string   `json:"signerSetHash"`
+	ApprovalDigest     string   `json:"approvalDigest"`
+	Signature          string   `json:"signature"`
+	ActiveMembers      []uint32 `json:"activeMembers,omitempty"`
+	InactiveMembers    []uint32 `json:"inactiveMembers,omitempty"`
+	EndBlock           uint64   `json:"endBlock"`
+}
+
+type signerApprovalCertificateSignerSetPayload struct {
+	WalletPublicKey       string   `json:"walletPublicKey"`
+	SigningGroupOperators []string `json:"signingGroupOperators"`
+	HonestThreshold       int      `json:"honestThreshold"`
+}
+
+func (se *signingExecutor) issueSignerApprovalCertificate(
+	ctx context.Context,
+	approvalDigest []byte,
+	startBlock uint64,
+) (*signerApprovalCertificate, error) {
+	if len(approvalDigest) != sha256.Size {
+		return nil, fmt.Errorf(
+			"approval digest must be exactly %d bytes",
+			sha256.Size,
+		)
+	}
+
+	signature, activityReport, endBlock, err := se.sign(
+		ctx,
+		new(big.Int).SetBytes(approvalDigest),
+		startBlock,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildSignerApprovalCertificate(
+		se.wallet(),
+		se.groupParameters,
+		approvalDigest,
+		signature,
+		activityReport,
+		endBlock,
+	)
+}
+
+func buildSignerApprovalCertificate(
+	wallet wallet,
+	groupParameters *GroupParameters,
+	approvalDigest []byte,
+	signature *tecdsa.Signature,
+	activityReport *signingActivityReport,
+	endBlock uint64,
+) (*signerApprovalCertificate, error) {
+	if len(approvalDigest) != sha256.Size {
+		return nil, fmt.Errorf(
+			"approval digest must be exactly %d bytes",
+			sha256.Size,
+		)
+	}
+	if groupParameters == nil {
+		return nil, fmt.Errorf("group parameters are required")
+	}
+	if signature == nil || signature.R == nil || signature.S == nil {
+		return nil, fmt.Errorf("threshold signature is required")
+	}
+
+	walletPublicKeyBytes, err := marshalPublicKey(wallet.publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	signerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
+		wallet,
+		groupParameters,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	signatureBytes := (&btcec.Signature{
+		R: signature.R,
+		S: signature.S,
+	}).Serialize()
+
+	certificate := &signerApprovalCertificate{
+		CertificateVersion: signerApprovalCertificateVersion,
+		SignatureAlgorithm: signerApprovalCertificateSignatureAlgorithm,
+		WalletPublicKey:    "0x" + hex.EncodeToString(walletPublicKeyBytes),
+		SignerSetHash:      signerSetHash,
+		ApprovalDigest:     "0x" + hex.EncodeToString(approvalDigest),
+		Signature:          "0x" + hex.EncodeToString(signatureBytes),
+		EndBlock:           endBlock,
+	}
+
+	if activityReport != nil {
+		certificate.ActiveMembers = normalizeSignerApprovalMemberIndexes(
+			activityReport.activeMembers,
+		)
+		certificate.InactiveMembers = normalizeSignerApprovalMemberIndexes(
+			activityReport.inactiveMembers,
+		)
+	}
+
+	return certificate, nil
+}
+
+func computeSignerApprovalCertificateSignerSetHash(
+	wallet wallet,
+	groupParameters *GroupParameters,
+) (string, error) {
+	if groupParameters == nil {
+		return "", fmt.Errorf("group parameters are required")
+	}
+
+	walletPublicKeyBytes, err := marshalPublicKey(wallet.publicKey)
+	if err != nil {
+		return "", err
+	}
+
+	signingGroupOperators := make([]string, len(wallet.signingGroupOperators))
+	for i, operator := range wallet.signingGroupOperators {
+		signingGroupOperators[i] = operator.String()
+	}
+
+	payload, err := json.Marshal(signerApprovalCertificateSignerSetPayload{
+		WalletPublicKey:       "0x" + hex.EncodeToString(walletPublicKeyBytes),
+		SigningGroupOperators: signingGroupOperators,
+		HonestThreshold:       groupParameters.HonestThreshold,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(
+		append([]byte(signerApprovalCertificateSignerSetDomain), payload...),
+	)
+
+	return "0x" + hex.EncodeToString(sum[:]), nil
+}
+
+func verifySignerApprovalCertificate(
+	certificate *signerApprovalCertificate,
+	expectedSignerSetHash string,
+) error {
+	if certificate == nil {
+		return fmt.Errorf("certificate is required")
+	}
+	if certificate.CertificateVersion != signerApprovalCertificateVersion {
+		return fmt.Errorf("unsupported certificate version: %d", certificate.CertificateVersion)
+	}
+	if certificate.SignatureAlgorithm != signerApprovalCertificateSignatureAlgorithm {
+		return fmt.Errorf("unsupported signature algorithm: %s", certificate.SignatureAlgorithm)
+	}
+	if expectedSignerSetHash != "" &&
+		strings.ToLower(expectedSignerSetHash) != strings.ToLower(certificate.SignerSetHash) {
+		return fmt.Errorf("signer set hash does not match the expected signer set")
+	}
+
+	approvalDigest, err := decodeSignerApprovalCertificateHex(
+		certificate.ApprovalDigest,
+		sha256.Size,
+	)
+	if err != nil {
+		return fmt.Errorf("invalid approval digest: %w", err)
+	}
+	signatureBytes, err := decodeSignerApprovalCertificateHex(
+		certificate.Signature,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("invalid threshold signature: %w", err)
+	}
+	walletPublicKeyBytes, err := decodeSignerApprovalCertificateHex(
+		certificate.WalletPublicKey,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("invalid wallet public key: %w", err)
+	}
+
+	walletPublicKey := unmarshalPublicKey(walletPublicKeyBytes)
+	if walletPublicKey == nil || walletPublicKey.X == nil || walletPublicKey.Y == nil {
+		return fmt.Errorf("wallet public key is not a valid uncompressed secp256k1 key")
+	}
+
+	parsedSignature, err := btcec.ParseDERSignature(signatureBytes, btcec.S256())
+	if err != nil {
+		return fmt.Errorf("cannot parse threshold signature: %w", err)
+	}
+
+	if !ecdsa.Verify(walletPublicKey, approvalDigest, parsedSignature.R, parsedSignature.S) {
+		return fmt.Errorf("threshold signature does not verify against wallet public key")
+	}
+
+	return nil
+}
+
+func decodeSignerApprovalCertificateHex(
+	value string,
+	expectedBytes int,
+) ([]byte, error) {
+	normalized := strings.TrimSpace(value)
+	if !strings.HasPrefix(normalized, "0x") {
+		return nil, fmt.Errorf("value must be 0x-prefixed")
+	}
+
+	decoded, err := hex.DecodeString(strings.TrimPrefix(normalized, "0x"))
+	if err != nil {
+		return nil, err
+	}
+	if expectedBytes > 0 && len(decoded) != expectedBytes {
+		return nil, fmt.Errorf(
+			"value must be exactly %d bytes, got %d",
+			expectedBytes,
+			len(decoded),
+		)
+	}
+
+	return decoded, nil
+}
+
+func normalizeSignerApprovalMemberIndexes(
+	memberIndexes []group.MemberIndex,
+) []uint32 {
+	normalized := make([]uint32, len(memberIndexes))
+	for i, memberIndex := range memberIndexes {
+		normalized[i] = uint32(memberIndex)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i] < normalized[j]
+	})
+	return normalized
+}

--- a/pkg/tbtc/signer_approval_certificate.go
+++ b/pkg/tbtc/signer_approval_certificate.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
@@ -38,9 +39,10 @@ type signerApprovalCertificate struct {
 }
 
 type signerApprovalCertificateSignerSetPayload struct {
-	WalletPublicKey       string   `json:"walletPublicKey"`
-	SigningGroupOperators []string `json:"signingGroupOperators"`
-	HonestThreshold       int      `json:"honestThreshold"`
+	WalletID        string `json:"walletId"`
+	WalletPublicKey string `json:"walletPublicKey"`
+	MembersIDsHash  string `json:"membersIdsHash"`
+	HonestThreshold int    `json:"honestThreshold"`
 }
 
 func (se *signingExecutor) issueSignerApprovalCertificate(
@@ -55,6 +57,15 @@ func (se *signingExecutor) issueSignerApprovalCertificate(
 		)
 	}
 
+	wallet := se.wallet()
+	walletChainData, err := se.chain.GetWallet(bitcoin.PublicKeyHash(wallet.publicKey))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot get on-chain wallet data for signer approval certificate: %w",
+			err,
+		)
+	}
+
 	signature, activityReport, endBlock, err := se.sign(
 		ctx,
 		new(big.Int).SetBytes(approvalDigest),
@@ -65,7 +76,8 @@ func (se *signingExecutor) issueSignerApprovalCertificate(
 	}
 
 	return buildSignerApprovalCertificate(
-		se.wallet(),
+		wallet,
+		walletChainData,
 		se.groupParameters,
 		approvalDigest,
 		signature,
@@ -76,6 +88,7 @@ func (se *signingExecutor) issueSignerApprovalCertificate(
 
 func buildSignerApprovalCertificate(
 	wallet wallet,
+	walletChainData *WalletChainData,
 	groupParameters *GroupParameters,
 	approvalDigest []byte,
 	signature *tecdsa.Signature,
@@ -91,6 +104,9 @@ func buildSignerApprovalCertificate(
 	if groupParameters == nil {
 		return nil, fmt.Errorf("group parameters are required")
 	}
+	if walletChainData == nil {
+		return nil, fmt.Errorf("wallet chain data is required")
+	}
 	if signature == nil || signature.R == nil || signature.S == nil {
 		return nil, fmt.Errorf("threshold signature is required")
 	}
@@ -102,6 +118,7 @@ func buildSignerApprovalCertificate(
 
 	signerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
 		wallet,
+		walletChainData,
 		groupParameters,
 	)
 	if err != nil {
@@ -137,10 +154,20 @@ func buildSignerApprovalCertificate(
 
 func computeSignerApprovalCertificateSignerSetHash(
 	wallet wallet,
+	walletChainData *WalletChainData,
 	groupParameters *GroupParameters,
 ) (string, error) {
 	if groupParameters == nil {
 		return "", fmt.Errorf("group parameters are required")
+	}
+	if walletChainData == nil {
+		return "", fmt.Errorf("wallet chain data is required")
+	}
+	if walletChainData.EcdsaWalletID == ([32]byte{}) {
+		return "", fmt.Errorf("wallet chain data must include wallet ID")
+	}
+	if walletChainData.MembersIDsHash == ([32]byte{}) {
+		return "", fmt.Errorf("wallet chain data must include members IDs hash")
 	}
 
 	walletPublicKeyBytes, err := marshalPublicKey(wallet.publicKey)
@@ -148,15 +175,11 @@ func computeSignerApprovalCertificateSignerSetHash(
 		return "", err
 	}
 
-	signingGroupOperators := make([]string, len(wallet.signingGroupOperators))
-	for i, operator := range wallet.signingGroupOperators {
-		signingGroupOperators[i] = operator.String()
-	}
-
 	payload, err := json.Marshal(signerApprovalCertificateSignerSetPayload{
-		WalletPublicKey:       "0x" + hex.EncodeToString(walletPublicKeyBytes),
-		SigningGroupOperators: signingGroupOperators,
-		HonestThreshold:       groupParameters.HonestThreshold,
+		WalletID:        "0x" + hex.EncodeToString(walletChainData.EcdsaWalletID[:]),
+		WalletPublicKey: "0x" + hex.EncodeToString(walletPublicKeyBytes),
+		MembersIDsHash:  "0x" + hex.EncodeToString(walletChainData.MembersIDsHash[:]),
+		HonestThreshold: groupParameters.HonestThreshold,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -1,0 +1,180 @@
+package tbtc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+)
+
+func TestSigningExecutorCanIssueSignerApprovalCertificateForArbitraryDigest(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	executor, ok, err := node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("node is supposed to control wallet signers")
+	}
+
+	startBlock, err := executor.getCurrentBlockFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	approvalDigest := sha256.Sum256(
+		[]byte("psbt-covenant-signer-approval-certificate-spike"),
+	)
+
+	certificate, err := executor.issueSignerApprovalCertificate(
+		context.Background(),
+		approvalDigest[:],
+		startBlock,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
+		executor.wallet(),
+		executor.groupParameters,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifySignerApprovalCertificate(certificate, expectedSignerSetHash); err != nil {
+		t.Fatalf("expected certificate verification to succeed: %v", err)
+	}
+
+	expectedDigest := "0x" + hex.EncodeToString(approvalDigest[:])
+	if certificate.ApprovalDigest != expectedDigest {
+		t.Fatalf(
+			"unexpected approval digest\nexpected: %s\nactual:   %s",
+			expectedDigest,
+			certificate.ApprovalDigest,
+		)
+	}
+	if certificate.SignerSetHash != expectedSignerSetHash {
+		t.Fatalf(
+			"unexpected signer set hash\nexpected: %s\nactual:   %s",
+			expectedSignerSetHash,
+			certificate.SignerSetHash,
+		)
+	}
+	if len(certificate.ActiveMembers) < executor.groupParameters.HonestThreshold {
+		t.Fatalf(
+			"expected at least honest threshold active members, got %v",
+			certificate.ActiveMembers,
+		)
+	}
+	if certificate.EndBlock < startBlock {
+		t.Fatalf(
+			"expected end block [%v] to be >= start block [%v]",
+			certificate.EndBlock,
+			startBlock,
+		)
+	}
+}
+
+func TestSignerApprovalCertificateVerificationRejectsTamperedDigest(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	executor, ok, err := node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("node is supposed to control wallet signers")
+	}
+
+	startBlock, err := executor.getCurrentBlockFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	approvalDigest := sha256.Sum256([]byte("psbt-covenant-signer-approval-certificate"))
+	certificate, err := executor.issueSignerApprovalCertificate(
+		context.Background(),
+		approvalDigest[:],
+		startBlock,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
+		executor.wallet(),
+		executor.groupParameters,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tampered := *certificate
+	tamperedDigest := sha256.Sum256([]byte("tampered"))
+	tampered.ApprovalDigest = "0x" + hex.EncodeToString(tamperedDigest[:])
+	if err := verifySignerApprovalCertificate(&tampered, expectedSignerSetHash); err == nil {
+		t.Fatal("expected tampered approval digest to fail verification")
+	}
+}
+
+func TestSignerApprovalCertificateSignerSetHashBindsRosterAndThreshold(t *testing.T) {
+	_, _, walletPublicKey := setupCovenantSignerTestNode(t)
+
+	baseWallet := wallet{
+		publicKey: walletPublicKey,
+		signingGroupOperators: []chain.Address{
+			"operator-1",
+			"operator-2",
+			"operator-3",
+		},
+	}
+	baseGroupParameters := &GroupParameters{
+		GroupSize:       3,
+		GroupQuorum:     2,
+		HonestThreshold: 2,
+	}
+
+	baseHash, err := computeSignerApprovalCertificateSignerSetHash(
+		baseWallet,
+		baseGroupParameters,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reorderedWallet := baseWallet
+	reorderedWallet.signingGroupOperators = []chain.Address{
+		"operator-2",
+		"operator-1",
+		"operator-3",
+	}
+	reorderedHash, err := computeSignerApprovalCertificateSignerSetHash(
+		reorderedWallet,
+		baseGroupParameters,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reorderedHash == baseHash {
+		t.Fatal("expected signer set hash to change when operator seat order changes")
+	}
+
+	thresholdChangedHash, err := computeSignerApprovalCertificateSignerSetHash(
+		baseWallet,
+		&GroupParameters{
+			GroupSize:       3,
+			GroupQuorum:     2,
+			HonestThreshold: 3,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thresholdChangedHash == baseHash {
+		t.Fatal("expected signer set hash to change when honest threshold changes")
+	}
+}

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -1,13 +1,132 @@
 package tbtc
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/covenantsigner"
 )
+
+func validStructuredSignerApprovalVerificationRequest(
+	t *testing.T,
+	node *node,
+	walletPublicKey *ecdsa.PublicKey,
+	route covenantsigner.TemplateID,
+) covenantsigner.RouteSubmitRequest {
+	t.Helper()
+
+	executor, ok, err := node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("node is supposed to control wallet signers")
+	}
+
+	startBlock, err := executor.getCurrentBlockFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorPrivateKey, _ := btcec.PrivKeyFromBytes(
+		btcec.S256(),
+		bytes.Repeat([]byte{0xaa}, 32),
+	)
+
+	request := covenantsigner.RouteSubmitRequest{
+		Route: route,
+		ArtifactApprovals: &covenantsigner.ArtifactApprovalEnvelope{
+			Payload: covenantsigner.ArtifactApprovalPayload{
+				ApprovalVersion:           1,
+				Route:                     route,
+				ScriptTemplateID:          route,
+				DestinationCommitmentHash: "0x" + strings.Repeat("11", 32),
+				PlanCommitmentHash:        "0x" + strings.Repeat("22", 32),
+			},
+		},
+	}
+
+	switch route {
+	case covenantsigner.TemplateSelfV1:
+		templateJSON, err := json.Marshal(&covenantsigner.SelfV1Template{
+			Template:           covenantsigner.TemplateSelfV1,
+			DepositorPublicKey: "0x" + hex.EncodeToString(depositorPrivateKey.PubKey().SerializeCompressed()),
+			SignerPublicKey:    "0x" + hex.EncodeToString((*btcec.PublicKey)(walletPublicKey).SerializeCompressed()),
+			Delta2:             4320,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.ScriptTemplate = templateJSON
+		request.ArtifactApprovals.Approvals = []covenantsigner.ArtifactRoleApproval{
+			{
+				Role: covenantsigner.ArtifactApprovalRoleDepositor,
+				Signature: testSignArtifactApproval(
+					t,
+					depositorPrivateKey,
+					request.ArtifactApprovals.Payload,
+				),
+			},
+		}
+	case covenantsigner.TemplateQcV1:
+		custodianPrivateKey, _ := btcec.PrivKeyFromBytes(
+			btcec.S256(),
+			bytes.Repeat([]byte{0xbb}, 32),
+		)
+		templateJSON, err := json.Marshal(&covenantsigner.QcV1Template{
+			Template:           covenantsigner.TemplateQcV1,
+			DepositorPublicKey: "0x" + hex.EncodeToString(depositorPrivateKey.PubKey().SerializeCompressed()),
+			CustodianPublicKey: "0x" + hex.EncodeToString(custodianPrivateKey.PubKey().SerializeCompressed()),
+			SignerPublicKey:    "0x" + hex.EncodeToString((*btcec.PublicKey)(walletPublicKey).SerializeCompressed()),
+			Beta:               144,
+			Delta2:             4320,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.ScriptTemplate = templateJSON
+		request.ArtifactApprovals.Approvals = []covenantsigner.ArtifactRoleApproval{
+			{
+				Role: covenantsigner.ArtifactApprovalRoleDepositor,
+				Signature: testSignArtifactApproval(
+					t,
+					depositorPrivateKey,
+					request.ArtifactApprovals.Payload,
+				),
+			},
+			{
+				Role: covenantsigner.ArtifactApprovalRoleCustodian,
+				Signature: testSignArtifactApproval(
+					t,
+					custodianPrivateKey,
+					request.ArtifactApprovals.Payload,
+				),
+			},
+		}
+	default:
+		t.Fatalf("unsupported route %s", route)
+	}
+
+	certificate, err := executor.issueSignerApprovalCertificate(
+		context.Background(),
+		testArtifactApprovalDigest(t, request.ArtifactApprovals.Payload),
+		startBlock,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SignerApproval = certificate
+
+	return request
+}
 
 func TestSigningExecutorCanIssueSignerApprovalCertificateForArbitraryDigest(t *testing.T) {
 	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
@@ -46,7 +165,7 @@ func TestSigningExecutorCanIssueSignerApprovalCertificateForArbitraryDigest(t *t
 	}
 
 	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
-		executor.wallet(),
+		executor.wallet().publicKey,
 		walletChainData,
 		executor.groupParameters,
 	)
@@ -78,7 +197,7 @@ func TestSigningExecutorCanIssueSignerApprovalCertificateForArbitraryDigest(t *t
 			certificate.ActiveMembers,
 		)
 	}
-	if certificate.EndBlock < startBlock {
+	if certificate.EndBlock == nil || *certificate.EndBlock < startBlock {
 		t.Fatalf(
 			"expected end block [%v] to be >= start block [%v]",
 			certificate.EndBlock,
@@ -121,7 +240,7 @@ func TestSignerApprovalCertificateVerificationRejectsTamperedDigest(t *testing.T
 	}
 
 	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
-		executor.wallet(),
+		executor.wallet().publicKey,
 		walletChainData,
 		executor.groupParameters,
 	)
@@ -140,9 +259,6 @@ func TestSignerApprovalCertificateVerificationRejectsTamperedDigest(t *testing.T
 func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThreshold(t *testing.T) {
 	_, _, walletPublicKey := setupCovenantSignerTestNode(t)
 
-	baseWallet := wallet{
-		publicKey: walletPublicKey,
-	}
 	baseWalletChainData := &WalletChainData{
 		EcdsaWalletID:  sha256.Sum256([]byte("wallet-id-base")),
 		MembersIDsHash: sha256.Sum256([]byte("members-hash-base")),
@@ -154,7 +270,7 @@ func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThre
 	}
 
 	baseHash, err := computeSignerApprovalCertificateSignerSetHash(
-		baseWallet,
+		walletPublicKey,
 		baseWalletChainData,
 		baseGroupParameters,
 	)
@@ -163,7 +279,7 @@ func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThre
 	}
 
 	changedMembersHash, err := computeSignerApprovalCertificateSignerSetHash(
-		baseWallet,
+		walletPublicKey,
 		&WalletChainData{
 			EcdsaWalletID:  baseWalletChainData.EcdsaWalletID,
 			MembersIDsHash: sha256.Sum256([]byte("members-hash-changed")),
@@ -178,7 +294,7 @@ func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThre
 	}
 
 	changedWalletIDHash, err := computeSignerApprovalCertificateSignerSetHash(
-		baseWallet,
+		walletPublicKey,
 		&WalletChainData{
 			EcdsaWalletID:  sha256.Sum256([]byte("wallet-id-changed")),
 			MembersIDsHash: baseWalletChainData.MembersIDsHash,
@@ -193,7 +309,7 @@ func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThre
 	}
 
 	thresholdChangedHash, err := computeSignerApprovalCertificateSignerSetHash(
-		baseWallet,
+		walletPublicKey,
 		baseWalletChainData,
 		&GroupParameters{
 			GroupSize:       3,
@@ -206,5 +322,38 @@ func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThre
 	}
 	if thresholdChangedHash == baseHash {
 		t.Fatal("expected signer set hash to change when honest threshold changes")
+	}
+}
+
+func TestCovenantSignerEngineVerifySignerApprovalAcceptsValidCertificate(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	request := validStructuredSignerApprovalVerificationRequest(
+		t,
+		node,
+		walletPublicKey,
+		covenantsigner.TemplateSelfV1,
+	)
+
+	if err := (&covenantSignerEngine{node: node}).VerifySignerApproval(request); err != nil {
+		t.Fatalf("expected signer approval verification to succeed: %v", err)
+	}
+}
+
+func TestCovenantSignerEngineVerifySignerApprovalRejectsWalletPublicKeyMismatch(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	request := validStructuredSignerApprovalVerificationRequest(
+		t,
+		node,
+		walletPublicKey,
+		covenantsigner.TemplateSelfV1,
+	)
+	request.SignerApproval.WalletPublicKey = "0x04" + strings.Repeat("55", 64)
+
+	err := (&covenantSignerEngine{node: node}).VerifySignerApproval(request)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.signerApproval.walletPublicKey must match request.scriptTemplate.signerPublicKey",
+	) {
+		t.Fatalf("expected wallet public key mismatch error, got %v", err)
 	}
 }

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 )
 
 func TestSigningExecutorCanIssueSignerApprovalCertificateForArbitraryDigest(t *testing.T) {
@@ -38,8 +38,16 @@ func TestSigningExecutorCanIssueSignerApprovalCertificateForArbitraryDigest(t *t
 		t.Fatal(err)
 	}
 
+	walletChainData, err := executor.chain.GetWallet(
+		bitcoin.PublicKeyHash(executor.wallet().publicKey),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
 		executor.wallet(),
+		walletChainData,
 		executor.groupParameters,
 	)
 	if err != nil {
@@ -105,8 +113,16 @@ func TestSignerApprovalCertificateVerificationRejectsTamperedDigest(t *testing.T
 		t.Fatal(err)
 	}
 
+	walletChainData, err := executor.chain.GetWallet(
+		bitcoin.PublicKeyHash(executor.wallet().publicKey),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expectedSignerSetHash, err := computeSignerApprovalCertificateSignerSetHash(
 		executor.wallet(),
+		walletChainData,
 		executor.groupParameters,
 	)
 	if err != nil {
@@ -121,16 +137,15 @@ func TestSignerApprovalCertificateVerificationRejectsTamperedDigest(t *testing.T
 	}
 }
 
-func TestSignerApprovalCertificateSignerSetHashBindsRosterAndThreshold(t *testing.T) {
+func TestSignerApprovalCertificateSignerSetHashBindsOnChainWalletIdentityAndThreshold(t *testing.T) {
 	_, _, walletPublicKey := setupCovenantSignerTestNode(t)
 
 	baseWallet := wallet{
 		publicKey: walletPublicKey,
-		signingGroupOperators: []chain.Address{
-			"operator-1",
-			"operator-2",
-			"operator-3",
-		},
+	}
+	baseWalletChainData := &WalletChainData{
+		EcdsaWalletID:  sha256.Sum256([]byte("wallet-id-base")),
+		MembersIDsHash: sha256.Sum256([]byte("members-hash-base")),
 	}
 	baseGroupParameters := &GroupParameters{
 		GroupSize:       3,
@@ -140,31 +155,46 @@ func TestSignerApprovalCertificateSignerSetHashBindsRosterAndThreshold(t *testin
 
 	baseHash, err := computeSignerApprovalCertificateSignerSetHash(
 		baseWallet,
+		baseWalletChainData,
 		baseGroupParameters,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	reorderedWallet := baseWallet
-	reorderedWallet.signingGroupOperators = []chain.Address{
-		"operator-2",
-		"operator-1",
-		"operator-3",
-	}
-	reorderedHash, err := computeSignerApprovalCertificateSignerSetHash(
-		reorderedWallet,
+	changedMembersHash, err := computeSignerApprovalCertificateSignerSetHash(
+		baseWallet,
+		&WalletChainData{
+			EcdsaWalletID:  baseWalletChainData.EcdsaWalletID,
+			MembersIDsHash: sha256.Sum256([]byte("members-hash-changed")),
+		},
 		baseGroupParameters,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reorderedHash == baseHash {
-		t.Fatal("expected signer set hash to change when operator seat order changes")
+	if changedMembersHash == baseHash {
+		t.Fatal("expected signer set hash to change when members IDs hash changes")
+	}
+
+	changedWalletIDHash, err := computeSignerApprovalCertificateSignerSetHash(
+		baseWallet,
+		&WalletChainData{
+			EcdsaWalletID:  sha256.Sum256([]byte("wallet-id-changed")),
+			MembersIDsHash: baseWalletChainData.MembersIDsHash,
+		},
+		baseGroupParameters,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedWalletIDHash == baseHash {
+		t.Fatal("expected signer set hash to change when wallet ID changes")
 	}
 
 	thresholdChangedHash, err := computeSignerApprovalCertificateSignerSetHash(
 		baseWallet,
+		baseWalletChainData,
 		&GroupParameters{
 			GroupSize:       3,
 			GroupQuorum:     2,

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -45,6 +45,7 @@ var errSigningExecutorBusy = fmt.Errorf("signing executor is busy")
 type signingExecutor struct {
 	lock *semaphore.Weighted
 
+	chain               Chain
 	signers             []*signer
 	broadcastChannel    net.BroadcastChannel
 	membershipValidator *group.MembershipValidator
@@ -70,6 +71,7 @@ type signingExecutor struct {
 }
 
 func newSigningExecutor(
+	chain Chain,
 	signers []*signer,
 	broadcastChannel net.BroadcastChannel,
 	membershipValidator *group.MembershipValidator,
@@ -81,6 +83,7 @@ func newSigningExecutor(
 ) *signingExecutor {
 	return &signingExecutor{
 		lock:                 semaphore.NewWeighted(1),
+		chain:                chain,
 		signers:              signers,
 		broadcastChannel:     broadcastChannel,
 		membershipValidator:  membershipValidator,


### PR DESCRIPTION
## Summary
- add structured signerApproval support to covenant signer requests and normalize it into request digests
- verify signerApproval through the tbtc engine against the on-chain wallet identity anchored by wallet ID, members IDs hash, and honest threshold
- keep the legacy signer approval role path temporarily for compatibility while adding focused tests for the new contract

## Testing
- go test ./pkg/covenantsigner
- go test ./pkg/tbtc -run 'SignerApprovalCertificate|CovenantSigner' -count=1