### PR TITLE
Pin covenant approval trust roots

### DIFF
--- a/pkg/covenantsigner/config.go
+++ b/pkg/covenantsigner/config.go
@@ -19,4 +19,10 @@ type Config struct {
 	// trust roots used to verify migration plan quotes when the quote authority
 	// path is enabled.
 	MigrationPlanQuoteTrustRoots []MigrationPlanQuoteTrustRoot `mapstructure:"migrationPlanQuoteTrustRoots"`
+	// DepositorTrustRoots configures independently pinned depositor public keys
+	// by route/reserve/network for self_v1 approval verification.
+	DepositorTrustRoots []DepositorTrustRoot `mapstructure:"depositorTrustRoots"`
+	// CustodianTrustRoots configures independently pinned custodian public keys
+	// by route/reserve/network for qc_v1 approval verification.
+	CustodianTrustRoots []CustodianTrustRoot `mapstructure:"custodianTrustRoots"`
 }

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -2503,6 +2503,32 @@ func TestServiceAcceptsQcV1WithMatchingCustodianTrustRoot(t *testing.T) {
 	}
 }
 
+func TestServiceAcceptsQcV1WithMatchingDepositorAndCustodianTrustRoots(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			testDepositorTrustRoot(TemplateQcV1),
+		}),
+		WithCustodianTrustRoots([]CustodianTrustRoot{
+			testCustodianTrustRoot(TemplateQcV1),
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_qc_depositor_and_custodian_trust_root_match",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestServiceRejectsQcV1WithoutMatchingCustodianTrustRoot(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(
@@ -2539,6 +2565,73 @@ func TestServiceRejectsQcV1WithoutMatchingCustodianTrustRoot(t *testing.T) {
 	}
 }
 
+func TestServiceRejectsQcV1WithoutMatchingDepositorTrustRoot(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			testDepositorTrustRoot(TemplateQcV1),
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateQcV1)
+	request.ScriptTemplate = mustTemplate(QcV1Template{
+		Template:           TemplateQcV1,
+		DepositorPublicKey: testSignerPublicKey,
+		CustodianPublicKey: testCustodianPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
+		Beta:               144,
+		Delta2:             4320,
+	})
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_qc_depositor_trust_root_mismatch",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.scriptTemplate.depositorPublicKey must match the configured depositorTrustRoots publicKey for qc_v1",
+	) {
+		t.Fatalf("expected qc_v1 depositor trust-root mismatch, got %v", err)
+	}
+}
+
+func TestServiceRejectsQcV1WithoutConfiguredDepositorTrustRootMatch(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			{
+				Route:     TemplateQcV1,
+				Reserve:   "0x9999999999999999999999999999999999999999",
+				Network:   "regtest",
+				PublicKey: testDepositorPublicKey,
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_qc_depositor_trust_root_missing",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateQcV1),
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.scriptTemplate.depositorPublicKey requires a matching configured depositorTrustRoots entry for qc_v1",
+	) {
+		t.Fatalf("expected missing qc_v1 depositor trust-root error, got %v", err)
+	}
+}
+
 func TestServiceRejectsQcV1WithoutConfiguredCustodianTrustRootMatch(t *testing.T) {
 	handle := newMemoryHandle()
 	service, err := NewService(
@@ -2567,6 +2660,78 @@ func TestServiceRejectsQcV1WithoutConfiguredCustodianTrustRootMatch(t *testing.T
 		"request.scriptTemplate.custodianPublicKey requires a matching configured custodianTrustRoots entry for qc_v1",
 	) {
 		t.Fatalf("expected missing qc_v1 custodian trust-root error, got %v", err)
+	}
+}
+
+func TestNewServiceRejectsDuplicateDepositorTrustRootScope(t *testing.T) {
+	handle := newMemoryHandle()
+
+	_, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			testDepositorTrustRoot(TemplateSelfV1),
+			testDepositorTrustRoot(TemplateSelfV1),
+		}),
+	)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"duplicates depositorTrustRoots[0]",
+	) {
+		t.Fatalf("expected duplicate depositor trust-root error, got %v", err)
+	}
+}
+
+func TestNewServiceRejectsInvalidCustodianTrustRootPublicKey(t *testing.T) {
+	handle := newMemoryHandle()
+
+	_, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithCustodianTrustRoots([]CustodianTrustRoot{
+			{
+				Route:     TemplateQcV1,
+				Reserve:   validMigrationDestination().Reserve,
+				Network:   validMigrationDestination().Network,
+				PublicKey: "0x1234",
+			},
+		}),
+	)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"custodianTrustRoots[0].publicKey must be a compressed secp256k1 public key",
+	) {
+		t.Fatalf("expected invalid custodian trust-root public key error, got %v", err)
+	}
+}
+
+func TestServiceAcceptsMixedCaseDepositorTrustRootConfig(t *testing.T) {
+	handle := newMemoryHandle()
+	migrationDestination := validMigrationDestination()
+
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			{
+				Route:     TemplateSelfV1,
+				Reserve:   mixedCaseHexBody(migrationDestination.Reserve),
+				Network:   strings.ToUpper(migrationDestination.Network),
+				PublicKey: mixedCaseHexBody(testDepositorPublicKey),
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_self_trust_root_mixed_case_config",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -202,6 +202,28 @@ var (
 	}
 )
 
+func testDepositorTrustRoot(route TemplateID) DepositorTrustRoot {
+	migrationDestination := validMigrationDestination()
+
+	return DepositorTrustRoot{
+		Route:     route,
+		Reserve:   migrationDestination.Reserve,
+		Network:   migrationDestination.Network,
+		PublicKey: testDepositorPublicKey,
+	}
+}
+
+func testCustodianTrustRoot(route TemplateID) CustodianTrustRoot {
+	migrationDestination := validMigrationDestination()
+
+	return CustodianTrustRoot{
+		Route:     route,
+		Reserve:   migrationDestination.Reserve,
+		Network:   migrationDestination.Network,
+		PublicKey: testCustodianPublicKey,
+	}
+}
+
 func mustDeterministicTestPrivateKey(encoded string) *btcec.PrivateKey {
 	rawPrivateKey, err := hex.DecodeString(strings.TrimPrefix(encoded, "0x"))
 	if err != nil {
@@ -2367,6 +2389,184 @@ func TestServicePollAcceptsStoredMigrationPlanQuoteAfterQuoteExpiry(t *testing.T
 	}
 	if pollResult.Status != StepStatusPending {
 		t.Fatalf("expected pending poll result, got %#v", pollResult)
+	}
+}
+
+func TestServiceAcceptsSelfV1WithMatchingDepositorTrustRoot(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			testDepositorTrustRoot(TemplateSelfV1),
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_self_trust_root_match",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServiceRejectsSelfV1WithoutMatchingDepositorTrustRoot(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			testDepositorTrustRoot(TemplateSelfV1),
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateSelfV1)
+	request.ScriptTemplate = mustTemplate(SelfV1Template{
+		Template:           TemplateSelfV1,
+		DepositorPublicKey: testSignerPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
+		Delta2:             4320,
+	})
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_self_trust_root_mismatch",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.scriptTemplate.depositorPublicKey must match the configured depositorTrustRoots publicKey for self_v1",
+	) {
+		t.Fatalf("expected self_v1 depositor trust-root mismatch, got %v", err)
+	}
+}
+
+func TestServiceRejectsSelfV1WithoutConfiguredDepositorTrustRootMatch(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithDepositorTrustRoots([]DepositorTrustRoot{
+			{
+				Route:     TemplateSelfV1,
+				Reserve:   "0x9999999999999999999999999999999999999999",
+				Network:   "regtest",
+				PublicKey: testDepositorPublicKey,
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateSelfV1, SignerSubmitInput{
+		RouteRequestID: "ors_self_trust_root_missing",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateSelfV1),
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.scriptTemplate.depositorPublicKey requires a matching configured depositorTrustRoots entry for self_v1",
+	) {
+		t.Fatalf("expected missing self_v1 depositor trust-root error, got %v", err)
+	}
+}
+
+func TestServiceAcceptsQcV1WithMatchingCustodianTrustRoot(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithCustodianTrustRoots([]CustodianTrustRoot{
+			testCustodianTrustRoot(TemplateQcV1),
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_qc_trust_root_match",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateQcV1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServiceRejectsQcV1WithoutMatchingCustodianTrustRoot(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithCustodianTrustRoots([]CustodianTrustRoot{
+			testCustodianTrustRoot(TemplateQcV1),
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateQcV1)
+	request.ScriptTemplate = mustTemplate(QcV1Template{
+		Template:           TemplateQcV1,
+		DepositorPublicKey: testDepositorPublicKey,
+		CustodianPublicKey: testSignerPublicKey,
+		SignerPublicKey:    testSignerPublicKey,
+		Beta:               144,
+		Delta2:             4320,
+	})
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_qc_trust_root_mismatch",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.scriptTemplate.custodianPublicKey must match the configured custodianTrustRoots publicKey for qc_v1",
+	) {
+		t.Fatalf("expected qc_v1 custodian trust-root mismatch, got %v", err)
+	}
+}
+
+func TestServiceRejectsQcV1WithoutConfiguredCustodianTrustRootMatch(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedEngine{},
+		WithCustodianTrustRoots([]CustodianTrustRoot{
+			{
+				Route:     TemplateQcV1,
+				Reserve:   "0x9999999999999999999999999999999999999999",
+				Network:   "regtest",
+				PublicKey: testCustodianPublicKey,
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "orq_qc_trust_root_missing",
+		Stage:          StageSignerCoordination,
+		Request:        baseRequest(TemplateQcV1),
+	})
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"request.scriptTemplate.custodianPublicKey requires a matching configured custodianTrustRoots entry for qc_v1",
+	) {
+		t.Fatalf("expected missing qc_v1 custodian trust-root error, got %v", err)
 	}
 }
 

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -75,6 +75,15 @@ func Initialize(
 				"self_v1 depositor approvals still rely on request-supplied scriptTemplate keys",
 		)
 	}
+	if !hasDepositorTrustRootForRoute(
+		service.depositorTrustRoots,
+		TemplateQcV1,
+	) {
+		logger.Warn(
+			"covenant signer started without qc_v1 depositorTrustRoots; " +
+				"qc_v1 depositor approvals still rely on request-supplied scriptTemplate keys",
+		)
+	}
 	if !hasCustodianTrustRootForRoute(
 		service.custodianTrustRoots,
 		TemplateQcV1,

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -52,6 +52,8 @@ func Initialize(
 		handle,
 		engine,
 		WithMigrationPlanQuoteTrustRoots(config.MigrationPlanQuoteTrustRoots),
+		WithDepositorTrustRoots(config.DepositorTrustRoots),
+		WithCustodianTrustRoots(config.CustodianTrustRoots),
 	)
 	if err != nil {
 		return nil, false, err
@@ -61,6 +63,25 @@ func Initialize(
 			"covenant signer started without a signer approval verifier; " +
 				"structured signerApproval certificates will not be verified and " +
 				"requests without signerApproval will be accepted",
+		)
+	}
+	if config.EnableSelfV1 &&
+		!hasDepositorTrustRootForRoute(
+			service.depositorTrustRoots,
+			TemplateSelfV1,
+		) {
+		logger.Warn(
+			"covenant signer self_v1 routes are enabled without depositorTrustRoots; " +
+				"self_v1 depositor approvals still rely on request-supplied scriptTemplate keys",
+		)
+	}
+	if !hasCustodianTrustRootForRoute(
+		service.custodianTrustRoots,
+		TemplateQcV1,
+	) {
+		logger.Warn(
+			"covenant signer started without custodianTrustRoots; " +
+				"qc_v1 custodian approvals still rely on request-supplied scriptTemplate keys",
 		)
 	}
 
@@ -103,6 +124,32 @@ func Initialize(
 	)
 
 	return server, true, nil
+}
+
+func hasDepositorTrustRootForRoute(
+	trustRoots []DepositorTrustRoot,
+	route TemplateID,
+) bool {
+	for _, trustRoot := range trustRoots {
+		if trustRoot.Route == route {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasCustodianTrustRootForRoute(
+	trustRoots []CustodianTrustRoot,
+	route TemplateID,
+) bool {
+	for _, trustRoot := range trustRoots {
+		if trustRoot.Route == route {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newHandler(service *Service, authToken string, enableSelfV1 bool) http.Handler {

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -19,6 +19,8 @@ type Service struct {
 	now                          func() time.Time
 	mutex                        sync.Mutex
 	migrationPlanQuoteTrustRoots []MigrationPlanQuoteTrustRoot
+	depositorTrustRoots          []DepositorTrustRoot
+	custodianTrustRoots          []CustodianTrustRoot
 }
 
 type ServiceOption func(*Service)
@@ -30,6 +32,26 @@ func WithMigrationPlanQuoteTrustRoots(
 
 	return func(service *Service) {
 		service.migrationPlanQuoteTrustRoots = cloned
+	}
+}
+
+func WithDepositorTrustRoots(
+	trustRoots []DepositorTrustRoot,
+) ServiceOption {
+	cloned := append([]DepositorTrustRoot{}, trustRoots...)
+
+	return func(service *Service) {
+		service.depositorTrustRoots = cloned
+	}
+}
+
+func WithCustodianTrustRoots(
+	trustRoots []CustodianTrustRoot,
+) ServiceOption {
+	cloned := append([]CustodianTrustRoot{}, trustRoots...)
+
+	return func(service *Service) {
+		service.custodianTrustRoots = cloned
 	}
 }
 
@@ -66,6 +88,22 @@ func NewService(
 	for _, option := range options {
 		option(service)
 	}
+
+	normalizedDepositorTrustRoots, err := normalizeDepositorTrustRoots(
+		service.depositorTrustRoots,
+	)
+	if err != nil {
+		return nil, err
+	}
+	service.depositorTrustRoots = normalizedDepositorTrustRoots
+
+	normalizedCustodianTrustRoots, err := normalizeCustodianTrustRoots(
+		service.custodianTrustRoots,
+	)
+	if err != nil {
+		return nil, err
+	}
+	service.custodianTrustRoots = normalizedCustodianTrustRoots
 
 	return service, nil
 }
@@ -169,6 +207,8 @@ func (s *Service) loadPollJob(route TemplateID, input SignerPollInput) (*Job, er
 		input.Request,
 		validationOptions{
 			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+			depositorTrustRoots:          s.depositorTrustRoots,
+			custodianTrustRoots:          s.custodianTrustRoots,
 			signerApprovalVerifier:       s.signerApprovalVerifier,
 		},
 	)
@@ -185,6 +225,8 @@ func (s *Service) loadPollJob(route TemplateID, input SignerPollInput) (*Job, er
 func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubmitInput) (StepResult, error) {
 	submitValidationOptions := validationOptions{
 		migrationPlanQuoteTrustRoots:      s.migrationPlanQuoteTrustRoots,
+		depositorTrustRoots:               s.depositorTrustRoots,
+		custodianTrustRoots:               s.custodianTrustRoots,
 		requireFreshMigrationPlanQuote:    true,
 		migrationPlanQuoteVerificationNow: s.now(),
 		signerApprovalVerifier:            s.signerApprovalVerifier,
@@ -197,6 +239,8 @@ func (s *Service) Submit(ctx context.Context, route TemplateID, input SignerSubm
 		input.Request,
 		validationOptions{
 			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+			depositorTrustRoots:          s.depositorTrustRoots,
+			custodianTrustRoots:          s.custodianTrustRoots,
 			signerApprovalVerifier:       s.signerApprovalVerifier,
 		},
 	)
@@ -297,6 +341,8 @@ func (s *Service) Poll(ctx context.Context, route TemplateID, input SignerPollIn
 		input,
 		validationOptions{
 			migrationPlanQuoteTrustRoots: s.migrationPlanQuoteTrustRoots,
+			depositorTrustRoots:          s.depositorTrustRoots,
+			custodianTrustRoots:          s.custodianTrustRoots,
 			signerApprovalVerifier:       s.signerApprovalVerifier,
 		},
 	); err != nil {

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -146,6 +146,20 @@ type MigrationPlanQuoteTrustRoot struct {
 	PublicKeyPEM string `json:"publicKeyPem" mapstructure:"publicKeyPem"`
 }
 
+type DepositorTrustRoot struct {
+	Route     TemplateID `json:"route" mapstructure:"route"`
+	Reserve   string     `json:"reserve" mapstructure:"reserve"`
+	Network   string     `json:"network" mapstructure:"network"`
+	PublicKey string     `json:"publicKey" mapstructure:"publicKey"`
+}
+
+type CustodianTrustRoot struct {
+	Route     TemplateID `json:"route" mapstructure:"route"`
+	Reserve   string     `json:"reserve" mapstructure:"reserve"`
+	Network   string     `json:"network" mapstructure:"network"`
+	PublicKey string     `json:"publicKey" mapstructure:"publicKey"`
+}
+
 type ArtifactApprovalRole string
 
 const (

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -84,6 +84,8 @@ func marshalCanonicalJSON(value any) ([]byte, error) {
 
 type validationOptions struct {
 	migrationPlanQuoteTrustRoots      []MigrationPlanQuoteTrustRoot
+	depositorTrustRoots               []DepositorTrustRoot
+	custodianTrustRoots               []CustodianTrustRoot
 	requireFreshMigrationPlanQuote    bool
 	migrationPlanQuoteVerificationNow time.Time
 	signerApprovalVerifier            SignerApprovalVerifier
@@ -550,6 +552,186 @@ func parseMigrationPlanQuoteTrustRoot(
 	}
 
 	return publicKey, nil
+}
+
+func normalizeScopedApprovalTrustRoot(
+	name string,
+	route TemplateID,
+	reserve string,
+	network string,
+	publicKey string,
+) (TemplateID, string, string, string, error) {
+	switch route {
+	case TemplateSelfV1, TemplateQcV1:
+	default:
+		return "", "", "", "", &inputError{
+			fmt.Sprintf("%s.route must be self_v1 or qc_v1", name),
+		}
+	}
+
+	if err := validateHexString(name+".reserve", reserve); err != nil {
+		return "", "", "", "", err
+	}
+
+	trimmedNetwork := strings.TrimSpace(network)
+	if trimmedNetwork == "" {
+		return "", "", "", "", &inputError{
+			fmt.Sprintf("%s.network is required", name),
+		}
+	}
+
+	normalizedPublicKey := normalizeLowerHex(publicKey)
+	if _, err := parseCompressedSecp256k1PublicKey(
+		name+".publicKey",
+		normalizedPublicKey,
+	); err != nil {
+		return "", "", "", "", err
+	}
+
+	return route,
+		normalizeLowerHex(reserve),
+		strings.ToLower(trimmedNetwork),
+		normalizedPublicKey,
+		nil
+}
+
+func normalizeDepositorTrustRoots(
+	trustRoots []DepositorTrustRoot,
+) ([]DepositorTrustRoot, error) {
+	if len(trustRoots) == 0 {
+		return nil, nil
+	}
+
+	normalized := make([]DepositorTrustRoot, len(trustRoots))
+	seen := make(map[string]int, len(trustRoots))
+
+	for i, trustRoot := range trustRoots {
+		name := fmt.Sprintf("depositorTrustRoots[%d]", i)
+		route, reserve, network, publicKey, err := normalizeScopedApprovalTrustRoot(
+			name,
+			trustRoot.Route,
+			trustRoot.Reserve,
+			trustRoot.Network,
+			trustRoot.PublicKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		scopeKey := string(route) + "|" + reserve + "|" + network
+		if previousIndex, ok := seen[scopeKey]; ok {
+			return nil, &inputError{
+				fmt.Sprintf(
+					"%s duplicates depositorTrustRoots[%d] for route %s reserve %s network %s",
+					name,
+					previousIndex,
+					route,
+					reserve,
+					network,
+				),
+			}
+		}
+		seen[scopeKey] = i
+
+		normalized[i] = DepositorTrustRoot{
+			Route:     route,
+			Reserve:   reserve,
+			Network:   network,
+			PublicKey: publicKey,
+		}
+	}
+
+	return normalized, nil
+}
+
+func normalizeCustodianTrustRoots(
+	trustRoots []CustodianTrustRoot,
+) ([]CustodianTrustRoot, error) {
+	if len(trustRoots) == 0 {
+		return nil, nil
+	}
+
+	normalized := make([]CustodianTrustRoot, len(trustRoots))
+	seen := make(map[string]int, len(trustRoots))
+
+	for i, trustRoot := range trustRoots {
+		name := fmt.Sprintf("custodianTrustRoots[%d]", i)
+		route, reserve, network, publicKey, err := normalizeScopedApprovalTrustRoot(
+			name,
+			trustRoot.Route,
+			trustRoot.Reserve,
+			trustRoot.Network,
+			trustRoot.PublicKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		scopeKey := string(route) + "|" + reserve + "|" + network
+		if previousIndex, ok := seen[scopeKey]; ok {
+			return nil, &inputError{
+				fmt.Sprintf(
+					"%s duplicates custodianTrustRoots[%d] for route %s reserve %s network %s",
+					name,
+					previousIndex,
+					route,
+					reserve,
+					network,
+				),
+			}
+		}
+		seen[scopeKey] = i
+
+		normalized[i] = CustodianTrustRoot{
+			Route:     route,
+			Reserve:   reserve,
+			Network:   network,
+			PublicKey: publicKey,
+		}
+	}
+
+	return normalized, nil
+}
+
+func trustRootLookupScope(request RouteSubmitRequest) (TemplateID, string, string) {
+	network := ""
+	if request.MigrationDestination != nil {
+		network = strings.ToLower(strings.TrimSpace(request.MigrationDestination.Network))
+	}
+
+	return request.Route, normalizeLowerHex(request.Reserve), network
+}
+
+func resolveExpectedDepositorPublicKey(
+	request RouteSubmitRequest,
+	trustRoots []DepositorTrustRoot,
+) (string, bool) {
+	route, reserve, network := trustRootLookupScope(request)
+	for _, trustRoot := range trustRoots {
+		if trustRoot.Route == route &&
+			trustRoot.Reserve == reserve &&
+			trustRoot.Network == network {
+			return trustRoot.PublicKey, true
+		}
+	}
+
+	return "", false
+}
+
+func resolveExpectedCustodianPublicKey(
+	request RouteSubmitRequest,
+	trustRoots []CustodianTrustRoot,
+) (string, bool) {
+	route, reserve, network := trustRootLookupScope(request)
+	for _, trustRoot := range trustRoots {
+		if trustRoot.Route == route &&
+			trustRoot.Reserve == reserve &&
+			trustRoot.Network == network {
+			return trustRoot.PublicKey, true
+		}
+	}
+
+	return "", false
 }
 
 func migrationPlanQuoteSigningPayloadBytes(
@@ -1540,9 +1722,29 @@ func validateCommonRequest(
 		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
 			return err
 		}
+
+		depositorPublicKey := template.DepositorPublicKey
+		if len(resolvedOptions.depositorTrustRoots) > 0 {
+			expectedDepositorPublicKey, ok := resolveExpectedDepositorPublicKey(
+				request,
+				resolvedOptions.depositorTrustRoots,
+			)
+			if !ok {
+				return &inputError{
+					"request.scriptTemplate.depositorPublicKey requires a matching configured depositorTrustRoots entry for self_v1",
+				}
+			}
+			if normalizeLowerHex(template.DepositorPublicKey) != expectedDepositorPublicKey {
+				return &inputError{
+					"request.scriptTemplate.depositorPublicKey must match the configured depositorTrustRoots publicKey for self_v1",
+				}
+			}
+			depositorPublicKey = expectedDepositorPublicKey
+		}
+
 		if err := validateArtifactApprovalAuthenticity(
 			request,
-			template.DepositorPublicKey,
+			depositorPublicKey,
 			"",
 		); err != nil {
 			return err
@@ -1567,10 +1769,30 @@ func validateCommonRequest(
 		if err := validateHexString("request.scriptTemplate.signerPublicKey", template.SignerPublicKey); err != nil {
 			return err
 		}
+
+		custodianPublicKey := template.CustodianPublicKey
+		if len(resolvedOptions.custodianTrustRoots) > 0 {
+			expectedCustodianPublicKey, ok := resolveExpectedCustodianPublicKey(
+				request,
+				resolvedOptions.custodianTrustRoots,
+			)
+			if !ok {
+				return &inputError{
+					"request.scriptTemplate.custodianPublicKey requires a matching configured custodianTrustRoots entry for qc_v1",
+				}
+			}
+			if normalizeLowerHex(template.CustodianPublicKey) != expectedCustodianPublicKey {
+				return &inputError{
+					"request.scriptTemplate.custodianPublicKey must match the configured custodianTrustRoots publicKey for qc_v1",
+				}
+			}
+			custodianPublicKey = expectedCustodianPublicKey
+		}
+
 		if err := validateArtifactApprovalAuthenticity(
 			request,
 			template.DepositorPublicKey,
-			template.CustodianPublicKey,
+			custodianPublicKey,
 		); err != nil {
 			return err
 		}

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -1770,6 +1770,25 @@ func validateCommonRequest(
 			return err
 		}
 
+		depositorPublicKey := template.DepositorPublicKey
+		if len(resolvedOptions.depositorTrustRoots) > 0 {
+			expectedDepositorPublicKey, ok := resolveExpectedDepositorPublicKey(
+				request,
+				resolvedOptions.depositorTrustRoots,
+			)
+			if !ok {
+				return &inputError{
+					"request.scriptTemplate.depositorPublicKey requires a matching configured depositorTrustRoots entry for qc_v1",
+				}
+			}
+			if normalizeLowerHex(template.DepositorPublicKey) != expectedDepositorPublicKey {
+				return &inputError{
+					"request.scriptTemplate.depositorPublicKey must match the configured depositorTrustRoots publicKey for qc_v1",
+				}
+			}
+			depositorPublicKey = expectedDepositorPublicKey
+		}
+
 		custodianPublicKey := template.CustodianPublicKey
 		if len(resolvedOptions.custodianTrustRoots) > 0 {
 			expectedCustodianPublicKey, ok := resolveExpectedCustodianPublicKey(
@@ -1791,7 +1810,7 @@ func validateCommonRequest(
 
 		if err := validateArtifactApprovalAuthenticity(
 			request,
-			template.DepositorPublicKey,
+			depositorPublicKey,
 			custodianPublicKey,
 		); err != nil {
 			return err


### PR DESCRIPTION
## Summary
- add config-backed depositor and custodian trust roots keyed by route/reserve/network
- enforce self_v1 depositor key pinning and qc_v1 custodian key pinning before artifact approval signature verification
- add focused covenantsigner coverage for matching, mismatched, and missing trust-root entries

## Testing
- go test ./pkg/covenantsigner -count=1
- go test ./pkg/tbtc -run 'SignerApprovalCertificate|CovenantSigner' -count=1 -timeout=5m