### PR TITLE
Differentiate self_v1 presign and reconstruction requests

### DIFF
--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -129,7 +129,7 @@ type migrationPlanQuoteSigningVectorsFile struct {
 
 func loadApprovalContractVector(
 	t *testing.T,
-	route TemplateID,
+	key string,
 ) (RouteSubmitRequest, string, string) {
 	t.Helper()
 
@@ -149,9 +149,9 @@ func loadApprovalContractVector(
 		t.Fatalf("unexpected vector scope: %s", vectors.Scope)
 	}
 
-	vector, ok := vectors.Vectors[string(route)]
+	vector, ok := vectors.Vectors[key]
 	if !ok {
-		t.Fatalf("missing vector for route %s", route)
+		t.Fatalf("missing vector %s", key)
 	}
 
 	request := RouteSubmitRequest{}
@@ -2846,9 +2846,9 @@ func TestArtifactApprovalDigestMatchesPhase1Contract(t *testing.T) {
 }
 
 func TestApprovalContractVectorsMatchExpectedRequestDigests(t *testing.T) {
-	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
-		t.Run(string(route), func(t *testing.T) {
-			request, expectedApprovalDigest, expectedDigest := loadApprovalContractVector(t, route)
+	for _, vectorKey := range []string{"qc_v1", "self_v1", "self_v1_presign"} {
+		t.Run(vectorKey, func(t *testing.T) {
+			request, expectedApprovalDigest, expectedDigest := loadApprovalContractVector(t, vectorKey)
 
 			digestBytes, err := artifactApprovalDigest(request.ArtifactApprovals.Payload)
 			if err != nil {
@@ -2875,9 +2875,9 @@ func TestApprovalContractVectorsMatchExpectedRequestDigests(t *testing.T) {
 }
 
 func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
-	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
-		t.Run(string(route), func(t *testing.T) {
-			canonicalRequest, _, expectedDigest := loadApprovalContractVector(t, route)
+	for _, vectorKey := range []string{"qc_v1", "self_v1", "self_v1_presign"} {
+		t.Run(vectorKey, func(t *testing.T) {
+			canonicalRequest, _, expectedDigest := loadApprovalContractVector(t, vectorKey)
 
 			normalizedCanonical, err := normalizeRouteSubmitRequest(canonicalRequest)
 			if err != nil {

--- a/pkg/covenantsigner/covenantsigner_test.go
+++ b/pkg/covenantsigner/covenantsigner_test.go
@@ -374,6 +374,7 @@ func baseRequest(route TemplateID) RouteSubmitRequest {
 	request := RouteSubmitRequest{
 		FacadeRequestID:           "rf_123",
 		IdempotencyKey:            "idem_123",
+		RequestType:               RequestTypeReconstruct,
 		Route:                     route,
 		Strategy:                  "0x1234",
 		Reserve:                   migrationDestination.Reserve,
@@ -2911,6 +2912,65 @@ func TestApprovalContractVectorsNormalizeEquivalentVariants(t *testing.T) {
 	}
 }
 
+func TestRequestDigestDistinguishesSelfV1PresignFromReconstruct(t *testing.T) {
+	reconstructRequest := structuredSignerApprovalRequest(TemplateSelfV1)
+	reconstructRequest.RequestType = RequestTypeReconstruct
+
+	presignRequest := cloneRouteSubmitRequest(t, reconstructRequest)
+	presignRequest.RequestType = RequestTypePresignSelfV1
+
+	reconstructDigest, err := requestDigest(reconstructRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	presignDigest, err := requestDigest(presignRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reconstructDigest == presignDigest {
+		t.Fatalf("expected distinct self_v1 digests, got %s", reconstructDigest)
+	}
+
+	normalizedReconstruct, err := normalizeRouteSubmitRequest(reconstructRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalizedPresign, err := normalizeRouteSubmitRequest(presignRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if normalizedReconstruct.RequestType != RequestTypeReconstruct {
+		t.Fatalf("expected reconstruct requestType, got %s", normalizedReconstruct.RequestType)
+	}
+	if normalizedPresign.RequestType != RequestTypePresignSelfV1 {
+		t.Fatalf("expected presign requestType, got %s", normalizedPresign.RequestType)
+	}
+}
+
+func TestServiceRejectsQcV1PresignRequestType(t *testing.T) {
+	service, err := NewService(newMemoryHandle(), &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := baseRequest(TemplateQcV1)
+	request.RequestType = RequestTypePresignSelfV1
+
+	_, err = service.Submit(context.Background(), TemplateQcV1, SignerSubmitInput{
+		RouteRequestID: "route_qc_invalid_presign",
+		Stage:          StageSignerCoordination,
+		Request:        request,
+	})
+	if err == nil {
+		t.Fatal("expected requestType validation error")
+	}
+	if !strings.Contains(err.Error(), "request.requestType must be reconstruct for qc_v1") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRequestDigestNormalizesMixedCaseArtifactApprovalVariants(t *testing.T) {
 	for _, route := range []TemplateID{TemplateQcV1, TemplateSelfV1} {
 		t.Run(string(route), func(t *testing.T) {
@@ -3169,6 +3229,7 @@ func TestServerIgnoresUnknownFieldsOnSubmit(t *testing.T) {
 			"facadeRequestId":"rf_123",
 			"idempotencyKey":"idem_123",
 			"route":"self_v1",
+			"requestType":"reconstruct",
 			"strategy":"0x1234",
 			"reserve":"0x1111111111111111111111111111111111111111",
 			"epoch":12,

--- a/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
+++ b/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
@@ -8,6 +8,7 @@
         "facadeRequestId": "rf_vector_qc_v1",
         "idempotencyKey": "idem-qc-vector-v1",
         "route": "qc_v1",
+        "requestType": "reconstruct",
         "strategy": "0x1111111111111111111111111111111111111111",
         "reserve": "0x2222222222222222222222222222222222222222",
         "epoch": 12,
@@ -91,7 +92,7 @@
           "custodianRequired": true
         }
       },
-      "expectedRequestDigest": "0x1a435b7fda4d048b8b4b9fb1448c14f581d4b3e38ddfe526b17b3c5ef719498c"
+      "expectedRequestDigest": "0x5cdfdc1861efd8ed59b0ee9b3b2a8583fc787321900fd36f4198db311a22fbcc"
     },
     "self_v1": {
       "expectedApprovalDigest": "0x4820468d065bc627dabac7860ef473ed28806d6352ba3459ff4edfb81e6bb752",
@@ -99,6 +100,7 @@
         "facadeRequestId": "rf_vector_self_v1",
         "idempotencyKey": "idem-self-vector-v1",
         "route": "self_v1",
+        "requestType": "reconstruct",
         "strategy": "0x1111111111111111111111111111111111111111",
         "reserve": "0x2222222222222222222222222222222222222222",
         "epoch": 12,
@@ -175,7 +177,7 @@
           "custodianRequired": false
         }
       },
-      "expectedRequestDigest": "0xb5cd6a894a8e6bb5e68310e9c43560e91de1fc62bf0acf73b63e882332b2138a"
+      "expectedRequestDigest": "0x238153ab33ce630fe44c59da2a42ef3a0eeb106df86c59c893c0047648589e05"
     }
   }
 }

--- a/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
+++ b/pkg/covenantsigner/testdata/covenant_recovery_approval_vectors_v1.json
@@ -178,6 +178,91 @@
         }
       },
       "expectedRequestDigest": "0x238153ab33ce630fe44c59da2a42ef3a0eeb106df86c59c893c0047648589e05"
+    },
+    "self_v1_presign": {
+      "expectedApprovalDigest": "0x4820468d065bc627dabac7860ef473ed28806d6352ba3459ff4edfb81e6bb752",
+      "canonicalSubmitRequest": {
+        "facadeRequestId": "rf_vector_self_v1_presign",
+        "idempotencyKey": "idem-self-presign-vector-v1",
+        "route": "self_v1",
+        "requestType": "presign_self_v1",
+        "strategy": "0x1111111111111111111111111111111111111111",
+        "reserve": "0x2222222222222222222222222222222222222222",
+        "epoch": 12,
+        "maturityHeight": 950000,
+        "activeOutpoint": {
+          "txid": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "vout": 1,
+          "scriptHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+        "migrationDestination": {
+          "reservationId": "cmdr_12345678",
+          "reserve": "0x2222222222222222222222222222222222222222",
+          "epoch": 12,
+          "route": "MIGRATION",
+          "revealer": "0x2222222222222222222222222222222222222222",
+          "vault": "0x3333333333333333333333333333333333333333",
+          "network": "regtest",
+          "status": "RESERVED",
+          "depositScript": "0x0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "depositScriptHash": "0x8532ec6785e391b2af968b5728d574e271c7f46658f5ed10845d9ad5b23ac6d3",
+          "migrationExtraData": "0x41435f4d49475241544556312222222222222222222222222222222222222222",
+          "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9"
+        },
+        "migrationTransactionPlan": {
+          "planVersion": 1,
+          "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969",
+          "inputValueSats": 1000000,
+          "destinationValueSats": 998000,
+          "anchorValueSats": 330,
+          "feeSats": 1670,
+          "inputSequence": 4294967293,
+          "lockTime": 950000
+        },
+        "artifactApprovals": {
+          "payload": {
+            "approvalVersion": 1,
+            "route": "self_v1",
+            "scriptTemplateId": "self_v1",
+            "destinationCommitmentHash": "0x913b832b3736a29966fd53f8a733a7587b150d3dfacb1c2d54994c1d3e56cdf9",
+            "planCommitmentHash": "0xc14b6b7c58211ceaee8f57a39c07481d9835ef959dbd6a02908312db4cf3c969"
+          },
+          "approvals": [
+            {
+              "role": "D",
+              "signature": "0xd0d0"
+            }
+          ]
+        },
+        "signerApproval": {
+          "certificateVersion": 1,
+          "signatureAlgorithm": "tecdsa-secp256k1",
+          "approvalDigest": "0x4820468d065bc627dabac7860ef473ed28806d6352ba3459ff4edfb81e6bb752",
+          "walletPublicKey": "0x04d140d1eedb94f53ce43e0f4d68e8e0de6d6f2a444ef98f2a0e6c0f7fca02ef7dc4cb14e7b0f7c23787c93ca4d978f312c64379f38d9f52f86d1a89f0f8572f9f",
+          "signerSetHash": "0xabababababababababababababababababababababababababababababababab",
+          "signature": "0x5050",
+          "activeMembers": [1, 2, 3],
+          "inactiveMembers": [4, 5],
+          "endBlock": 123
+        },
+        "artifactSignatures": [
+          "0xd0d0",
+          "0x5050"
+        ],
+        "artifacts": {},
+        "scriptTemplate": {
+          "template": "self_v1",
+          "depositorPublicKey": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "signerPublicKey": "0x02eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "delta2": 4320
+        },
+        "signing": {
+          "signerRequired": true,
+          "custodianRequired": false
+        }
+      },
+      "expectedRequestDigest": "0xb44ea2821d1734a8af7a71cb9cf70712f989ac11404222a5315d0db15b248de1"
     }
   }
 }

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -9,6 +9,13 @@ const (
 	TemplateSelfV1 TemplateID = "self_v1"
 )
 
+type RequestType string
+
+const (
+	RequestTypeReconstruct   RequestType = "reconstruct"
+	RequestTypePresignSelfV1 RequestType = "presign_self_v1"
+)
+
 type RecoveryPathID string
 
 const (
@@ -205,6 +212,7 @@ type SigningRequirements struct {
 type RouteSubmitRequest struct {
 	FacadeRequestID           string                            `json:"facadeRequestId"`
 	IdempotencyKey            string                            `json:"idempotencyKey"`
+	RequestType               RequestType                       `json:"requestType"`
 	Route                     TemplateID                        `json:"route"`
 	Strategy                  string                            `json:"strategy"`
 	Reserve                   string                            `json:"reserve"`

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -221,6 +221,23 @@ func normalizeSignerApprovalMemberIndexes(
 	return normalized, nil
 }
 
+func normalizeRequestType(
+	route TemplateID,
+	requestType RequestType,
+) (RequestType, error) {
+	switch requestType {
+	case RequestTypeReconstruct:
+		return requestType, nil
+	case RequestTypePresignSelfV1:
+		if route != TemplateSelfV1 {
+			return "", &inputError{"request.requestType must be reconstruct for qc_v1"}
+		}
+		return requestType, nil
+	default:
+		return "", &inputError{"request.requestType must be reconstruct or presign_self_v1"}
+	}
+}
+
 func normalizeSignerApprovalCertificate(
 	request RouteSubmitRequest,
 ) (*SignerApprovalCertificate, error) {
@@ -1613,10 +1630,15 @@ func normalizeRouteSubmitRequest(
 	if err != nil {
 		return RouteSubmitRequest{}, err
 	}
+	normalizedRequestType, err := normalizeRequestType(request.Route, request.RequestType)
+	if err != nil {
+		return RouteSubmitRequest{}, err
+	}
 
 	return RouteSubmitRequest{
 		FacadeRequestID: request.FacadeRequestID,
 		IdempotencyKey:  request.IdempotencyKey,
+		RequestType:     normalizedRequestType,
 		Route:           request.Route,
 		Strategy:        normalizeLowerHex(request.Strategy),
 		Reserve:         normalizeLowerHex(request.Reserve),
@@ -1659,6 +1681,9 @@ func validateCommonRequest(
 	}
 	if request.Route != route {
 		return &inputError{"request.route does not match endpoint route"}
+	}
+	if _, err := normalizeRequestType(route, request.RequestType); err != nil {
+		return err
 	}
 	if err := validateHexString("request.strategy", request.Strategy); err != nil {
 		return err

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -240,7 +240,12 @@ func (cse *covenantSignerEngine) submitSelfV1(
 
 	return &covenantsigner.Transition{
 		State:          covenantsigner.JobStateArtifactReady,
-		Detail:         "self_v1 artifact ready",
+		Detail: func() string {
+			if job.Request.RequestType == covenantsigner.RequestTypePresignSelfV1 {
+				return "self_v1 presign artifact ready"
+			}
+			return "self_v1 artifact ready"
+		}(),
 		PSBTHash:       psbtHash,
 		TransactionHex: transactionHex,
 	}

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -239,7 +239,7 @@ func (cse *covenantSignerEngine) submitSelfV1(
 	psbtHash := "0x" + transaction.WitnessHash().Hex(bitcoin.InternalByteOrder)
 
 	return &covenantsigner.Transition{
-		State:          covenantsigner.JobStateArtifactReady,
+		State: covenantsigner.JobStateArtifactReady,
 		Detail: func() string {
 			if job.Request.RequestType == covenantsigner.RequestTypePresignSelfV1 {
 				return "self_v1 presign artifact ready"

--- a/pkg/tbtc/covenant_signer_test.go
+++ b/pkg/tbtc/covenant_signer_test.go
@@ -173,6 +173,7 @@ func TestCovenantSignerEngine_SubmitSelfV1Ready(t *testing.T) {
 	request := covenantsigner.RouteSubmitRequest{
 		FacadeRequestID:           "rf_self_1",
 		IdempotencyKey:            "idem_self_1",
+		RequestType:               covenantsigner.RequestTypeReconstruct,
 		Route:                     covenantsigner.TemplateSelfV1,
 		Strategy:                  "0x1234",
 		Reserve:                   reserve,
@@ -410,6 +411,7 @@ func TestCovenantSignerEngine_SubmitQcV1HandoffReady(t *testing.T) {
 	request := covenantsigner.RouteSubmitRequest{
 		FacadeRequestID:           "rf_qc_1",
 		IdempotencyKey:            "idem_qc_1",
+		RequestType:               covenantsigner.RequestTypeReconstruct,
 		Route:                     covenantsigner.TemplateQcV1,
 		Strategy:                  "0x1234",
 		Reserve:                   reserve,
@@ -642,6 +644,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsInvalidBeta(t *testing.T) {
 	request := covenantsigner.RouteSubmitRequest{
 		FacadeRequestID: "rf_qc_bad_beta",
 		IdempotencyKey:  "idem_qc_bad_beta",
+		RequestType:     covenantsigner.RequestTypeReconstruct,
 		Route:           covenantsigner.TemplateQcV1,
 		Strategy:        "0x1234",
 		Reserve:         reserve,
@@ -801,6 +804,7 @@ func TestCovenantSignerEngine_SubmitQcV1RejectsScriptHashMismatch(t *testing.T) 
 	request := covenantsigner.RouteSubmitRequest{
 		FacadeRequestID:           "rf_qc_bad_script_hash",
 		IdempotencyKey:            "idem_qc_bad_script_hash",
+		RequestType:               covenantsigner.RequestTypeReconstruct,
 		Route:                     covenantsigner.TemplateQcV1,
 		Strategy:                  "0x1234",
 		Reserve:                   reserve,
@@ -897,6 +901,7 @@ func TestCovenantSignerEngine_SubmitSelfV1RejectsZeroMaturityHeight(t *testing.T
 	request := covenantsigner.RouteSubmitRequest{
 		FacadeRequestID: "rf_self_zero",
 		IdempotencyKey:  "idem_self_zero",
+		RequestType:     covenantsigner.RequestTypeReconstruct,
 		Route:           covenantsigner.TemplateSelfV1,
 		Strategy:        "0x1234",
 		Reserve:         reserve,

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -43,7 +43,7 @@ func validStructuredSignerApprovalVerificationRequest(
 
 	request := covenantsigner.RouteSubmitRequest{
 		RequestType: covenantsigner.RequestTypeReconstruct,
-		Route: route,
+		Route:       route,
 		ArtifactApprovals: &covenantsigner.ArtifactApprovalEnvelope{
 			Payload: covenantsigner.ArtifactApprovalPayload{
 				ApprovalVersion:           1,

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -42,6 +42,7 @@ func validStructuredSignerApprovalVerificationRequest(
 	)
 
 	request := covenantsigner.RouteSubmitRequest{
+		RequestType: covenantsigner.RequestTypeReconstruct,
 		Route: route,
 		ArtifactApprovals: &covenantsigner.ArtifactApprovalEnvelope{
 			Payload: covenantsigner.ArtifactApprovalPayload{


### PR DESCRIPTION
## Summary
- add requestType to covenant signer requests and make it part of normalization and request digests
- reject invalid qc_v1 + presign_self_v1 combinations while preserving explicit self_v1 presign semantics
- refresh mirrored approval-contract vectors and add requestType regressions in covenantsigner and tbtc engine tests

## Testing
- go test ./pkg/covenantsigner ./pkg/tbtc -run 'SignerApprovalCertificate|CovenantSigner|ApprovalContractVectors|RequestDigestDistinguishesSelfV1PresignFromReconstruct|RejectsQcV1PresignRequestType' -count=1