### PR TITLE
fix(frost): prefer FFI error code over substring for replay detection

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -45,6 +45,21 @@ const buildTaggedTBTCSignerSyntheticContributionDomain = "tbtc-signer-bootstrap-
 const buildTaggedTBTCSignerMessageTypePrefix = "frost_signing/native_tbtc_signer/"
 const buildTaggedTBTCSignerConsumedAttemptReplayErrorFragment = "already consumed for sign attempt"
 
+// buildTaggedTBTCSignerConsumedAttemptReplayErrorCode is the structured Rust
+// `ErrorResponse.code` value emitted by tbtc-signer when an `attempt_id` is
+// reused after consumption. Preferred over substring matching on the message
+// because the code is contract-stable: see `EngineError::code()` in the
+// `tbtc-signer` crate.
+const buildTaggedTBTCSignerConsumedAttemptReplayErrorCode = "consumed_attempt_replay"
+
+// buildTaggedTBTCSignerLegacyValidationErrorCode is the structured code
+// emitted by tbtc-signer builds that pre-date the dedicated replay variant.
+// Those builds route the replay path through `EngineError::Validation`, so
+// the code on the wire is `validation_error` and the substring check on the
+// message is the only signal callers have. Once the rolling upgrade is past
+// the minimum-supported signer version, this code can be retired.
+const buildTaggedTBTCSignerLegacyValidationErrorCode = "validation_error"
+
 type nativeTBTCSignerVersionedEngine interface {
 	Version() (string, error)
 }
@@ -397,9 +412,40 @@ func isBuildTaggedTBTCSignerConsumedAttemptReplayError(err error) bool {
 		return false
 	}
 
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "attempt_id") &&
-		strings.Contains(message, buildTaggedTBTCSignerConsumedAttemptReplayErrorFragment)
+	// Prefer the structured `code` field from the FFI error envelope when it
+	// is reachable through the error chain. The Rust signer's
+	// `EngineError::code()` value `"consumed_attempt_replay"` is a
+	// contract-stable identifier; this check survives any cosmetic rewording
+	// of the human-readable message on either side.
+	//
+	// Older signer builds emit `validation_error` for the replay path with
+	// the legacy wording in the message. For those, fall through to the
+	// substring check restricted to the structured message field so a
+	// `validation_error` carrying an unrelated error chain string cannot be
+	// mistaken for a replay. Any other recognized code is authoritative.
+	var structured *buildTaggedTBTCSignerStructuredError
+	if errors.As(err, &structured) && structured.Code != "" {
+		switch structured.Code {
+		case buildTaggedTBTCSignerConsumedAttemptReplayErrorCode:
+			return true
+		case buildTaggedTBTCSignerLegacyValidationErrorCode:
+			return messageMatchesLegacyConsumedAttemptReplay(structured.Message)
+		default:
+			return false
+		}
+	}
+
+	// No structured code reachable — the error chain pre-dates the FFI
+	// envelope. The legacy wording is preserved by the current tbtc-signer
+	// release so this branch continues to work during the rolling upgrade
+	// window. Match on the whole rendered string for maximum compatibility.
+	return messageMatchesLegacyConsumedAttemptReplay(err.Error())
+}
+
+func messageMatchesLegacyConsumedAttemptReplay(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "attempt_id") &&
+		strings.Contains(lower, buildTaggedTBTCSignerConsumedAttemptReplayErrorFragment)
 }
 
 func buildTaggedTBTCSignerRunDKGInputs(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"reflect"
 	"strings"
@@ -2649,6 +2650,190 @@ func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTC
 				t.Fatalf(
 					"did not expect fallback events\nactual: [%v]",
 					observedEvents,
+				)
+			}
+		})
+	}
+}
+
+func TestIsBuildTaggedTBTCSignerConsumedAttemptReplayError(t *testing.T) {
+	// Locking-mutex-free unit-coverage for the replay detector. Each case
+	// constructs an error in the shape that flows out of the FFI bridge today
+	// and asserts the detector's decision.
+	cases := []struct {
+		name  string
+		err   error
+		match bool
+	}{
+		{
+			name:  "nil error is not a replay",
+			err:   nil,
+			match: false,
+		},
+		{
+			name: "structured code wins over message wording",
+			err: fmt.Errorf(
+				"%w: tbtc-signer bridge operation [StartSignRound] failed: [%w]",
+				ErrNativeBridgeOperationFailed,
+				&buildTaggedTBTCSignerStructuredError{
+					Code:    buildTaggedTBTCSignerConsumedAttemptReplayErrorCode,
+					Message: "rust message wording is not load-bearing here",
+				},
+			),
+			match: true,
+		},
+		{
+			name: "structured but different code does not match",
+			err: fmt.Errorf(
+				"%w: tbtc-signer bridge operation [StartSignRound] failed: [%w]",
+				ErrNativeBridgeOperationFailed,
+				&buildTaggedTBTCSignerStructuredError{
+					Code:    "session_conflict",
+					Message: "attempt_id [x] already consumed for sign attempt in session [y]",
+				},
+			),
+			match: false,
+		},
+		{
+			name: "legacy substring still matches when code is missing",
+			err: fmt.Errorf(
+				"%w: tbtc-signer bridge operation [StartSignRound] failed: [%w]",
+				ErrNativeBridgeOperationFailed,
+				&buildTaggedTBTCSignerStructuredError{
+					Code:    "",
+					Message: "attempt_id [att-1] already consumed for sign attempt in session [sess-1]",
+				},
+			),
+			match: true,
+		},
+		{
+			// Pre-dedicated-variant signer builds route the replay path
+			// through Validation, so the code on the wire is
+			// validation_error and only the message identifies replay.
+			name: "validation_error code with legacy wording is a replay",
+			err: fmt.Errorf(
+				"%w: tbtc-signer bridge operation [StartSignRound] failed: [%w]",
+				ErrNativeBridgeOperationFailed,
+				&buildTaggedTBTCSignerStructuredError{
+					Code:    "validation_error",
+					Message: "attempt_id [att-1] already consumed for sign attempt in session [sess-1]",
+				},
+			),
+			match: true,
+		},
+		{
+			// A validation_error that is NOT the replay path must not be
+			// flagged as a replay even if surrounding error chain noise
+			// happens to mention attempt_id elsewhere.
+			name: "validation_error without legacy wording is not a replay",
+			err: fmt.Errorf(
+				"%w: tbtc-signer bridge operation [StartSignRound] failed: [%w]",
+				ErrNativeBridgeOperationFailed,
+				&buildTaggedTBTCSignerStructuredError{
+					Code:    "validation_error",
+					Message: "session_id is empty",
+				},
+			),
+			match: false,
+		},
+		{
+			name: "legacy substring still matches when error is a plain wrapper",
+			err: fmt.Errorf(
+				"native FROST bridge operation failed: tbtc-signer bridge " +
+					"operation [StartSignRound] failed: [validation_error: " +
+					"attempt_id [att-1] already consumed for sign attempt in " +
+					"session [sess-1]]",
+			),
+			match: true,
+		},
+		{
+			name: "unrelated error is not a replay",
+			err: fmt.Errorf(
+				"%w: tbtc-signer bridge operation [StartSignRound] failed: [%w]",
+				ErrNativeBridgeOperationFailed,
+				&buildTaggedTBTCSignerStructuredError{
+					Code:    "validation_error",
+					Message: "session_id is empty",
+				},
+			),
+			match: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isBuildTaggedTBTCSignerConsumedAttemptReplayError(tc.err); got != tc.match {
+				t.Fatalf(
+					"detector returned [%v]; expected [%v] for error [%v]",
+					got,
+					tc.match,
+					tc.err,
+				)
+			}
+		})
+	}
+}
+
+func TestBuildTaggedTBTCSignerErrorPayload(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		code    string
+		// Substring expected in the rendered Message. Empty means we don't
+		// assert beyond Code presence.
+		messageSubstring string
+	}{
+		{
+			name:             "decodes structured envelope",
+			payload:          []byte(`{"code":"consumed_attempt_replay","message":"attempt_id [a] already consumed"}`),
+			code:             "consumed_attempt_replay",
+			messageSubstring: "already consumed",
+		},
+		{
+			name:             "legacy validation_error code is preserved",
+			payload:          []byte(`{"code":"validation_error","message":"session_id is empty"}`),
+			code:             "validation_error",
+			messageSubstring: "session_id is empty",
+		},
+		{
+			name:             "message-only payload leaves Code empty",
+			payload:          []byte(`{"message":"opaque message"}`),
+			code:             "",
+			messageSubstring: "opaque message",
+		},
+		{
+			name:             "completely empty envelope surfaces the raw payload",
+			payload:          []byte(`{}`),
+			code:             "",
+			messageSubstring: "empty error payload",
+		},
+		{
+			name:             "non-JSON payload is reported as a decode failure",
+			payload:          []byte(`not json`),
+			code:             "",
+			messageSubstring: "cannot decode error payload",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			structured := buildTaggedTBTCSignerErrorPayload(tc.payload)
+			if structured == nil {
+				t.Fatal("expected non-nil structured error")
+			}
+			if structured.Code != tc.code {
+				t.Fatalf(
+					"unexpected Code\nexpected: [%s]\nactual:   [%s]",
+					tc.code,
+					structured.Code,
+				)
+			}
+			if tc.messageSubstring != "" &&
+				!strings.Contains(structured.Message, tc.messageSubstring) {
+				t.Fatalf(
+					"Message missing expected substring\nexpected substring: [%s]\nactual:             [%s]",
+					tc.messageSubstring,
+					structured.Message,
 				)
 			}
 		})

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -133,6 +133,27 @@ type buildTaggedTBTCSignerErrorResponse struct {
 	Message string `json:"message"`
 }
 
+// buildTaggedTBTCSignerStructuredError carries the FFI error envelope's
+// structured fields so callers can match on Code via `errors.As` rather than
+// substring-matching the rendered error string. Older signer builds may
+// return errors without a Code field; this type still wraps them via the
+// Message field, and consumers should treat an empty Code as a fall-back
+// signal to apply legacy substring matching.
+type buildTaggedTBTCSignerStructuredError struct {
+	Code    string
+	Message string
+}
+
+func (e *buildTaggedTBTCSignerStructuredError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Code != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	return e.Message
+}
+
 type buildTaggedTBTCSignerRunDKGRequest struct {
 	SessionID    string                                `json:"session_id"`
 	Participants []buildTaggedTBTCSignerDKGParticipant `json:"participants"`
@@ -968,32 +989,44 @@ func buildTaggedTBTCSignerResultStatusError(
 	}
 
 	if statusCode != 0 {
-		return buildTaggedTBTCSignerOperationError(
+		structured := buildTaggedTBTCSignerErrorPayload(payload)
+		return fmt.Errorf(
+			"%w: tbtc-signer bridge operation [%v] failed: [%w]",
+			ErrNativeBridgeOperationFailed,
 			operation,
-			buildTaggedTBTCSignerErrorMessage(payload),
+			structured,
 		)
 	}
 
 	return nil
 }
 
-func buildTaggedTBTCSignerErrorMessage(payload []byte) string {
+// buildTaggedTBTCSignerErrorPayload decodes the FFI error envelope into a
+// structured form so callers can match on the `Code` field via `errors.As`
+// rather than rely on substring matching against the rendered error string.
+// Decode failures and missing-fields edge cases are surfaced via the
+// `Message` field with `Code` left empty so consumers know to fall back to
+// legacy matching.
+func buildTaggedTBTCSignerErrorPayload(payload []byte) *buildTaggedTBTCSignerStructuredError {
 	var errorResponse buildTaggedTBTCSignerErrorResponse
 	if err := json.Unmarshal(payload, &errorResponse); err != nil {
-		return fmt.Sprintf(
-			"cannot decode error payload [%x]: %v",
-			payload,
-			err,
-		)
+		return &buildTaggedTBTCSignerStructuredError{
+			Message: fmt.Sprintf(
+				"cannot decode error payload [%x]: %v",
+				payload,
+				err,
+			),
+		}
 	}
 
 	if errorResponse.Code == "" && errorResponse.Message == "" {
-		return fmt.Sprintf("empty error payload: [%s]", string(payload))
+		return &buildTaggedTBTCSignerStructuredError{
+			Message: fmt.Sprintf("empty error payload: [%s]", string(payload)),
+		}
 	}
 
-	if errorResponse.Code != "" {
-		return fmt.Sprintf("%s: %s", errorResponse.Code, errorResponse.Message)
+	return &buildTaggedTBTCSignerStructuredError{
+		Code:    errorResponse.Code,
+		Message: errorResponse.Message,
 	}
-
-	return errorResponse.Message
 }


### PR DESCRIPTION
## Summary

\`isBuildTaggedTBTCSignerConsumedAttemptReplayError\` previously did a case-insensitive substring match on \`err.Error()\` looking for \`attempt_id\` plus \`already consumed for sign attempt\`. Any cosmetic rewording of the Rust-side format string on either side would silently disable replay detection. This PR makes the detector prefer the structured \`code\` field on the FFI error envelope when it is reachable, falling back to substring matching only for older signer builds.

Stacked on #3960.

The matching Rust-side change is a separate PR on \`tlabs-xyz/tbtc\` that introduces the dedicated \`EngineError::ConsumedAttemptReplay\` variant with stable code \`consumed_attempt_replay\`.

## Changes

- New \`buildTaggedTBTCSignerStructuredError\` type carries \`Code\` and \`Message\` from the FFI envelope. \`buildTaggedTBTCSignerResultStatusError\` wraps it via \`%w\` so callers can extract via \`errors.As\`.
- \`buildTaggedTBTCSignerErrorMessage\` refactored into \`buildTaggedTBTCSignerErrorPayload\` returning the struct. Rendered chain string still formats as \`\"code: message\"\` so log readers see no change.
- Detector implements a small policy ladder:
  1. Structured envelope with \`consumed_attempt_replay\` code → replay.
  2. Structured envelope with legacy \`validation_error\` code → substring-match only the \`Message\` field (pre-dedicated-variant signers route the replay path through Validation).
  3. Any other recognized code → not a replay (authoritative).
  4. No structured envelope reachable → substring-match the whole rendered string (pre-envelope signers).
- Two new tests:
  - \`TestIsBuildTaggedTBTCSignerConsumedAttemptReplayError\` — eight cases covering all four ladder branches.
  - \`TestBuildTaggedTBTCSignerErrorPayload\` — structured / message-only / empty / malformed payloads.

## Verification

- \`go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/... ./pkg/bitcoin\` — PASS
- \`go test -tags 'frost_native frost_tbtc_signer' ./pkg/tbtc -run 'TestConfigureFrostSigningBackend|TestNewNode_ConfiguresFrostSigningBackend|TestSigningExecutor_Sign|TestRegisterSignerMaterialResolverForBuild'\` — PASS