### PR TITLE
feat(frost/roast): RFC-21 Phase 2 -- receiver overflow tracking (no-op default)

### DIFF
--- a/pkg/frost/roast/attempt/evidence_recorder.go
+++ b/pkg/frost/roast/attempt/evidence_recorder.go
@@ -1,0 +1,115 @@
+package attempt
+
+import (
+	"sync"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// OverflowQuotaDefault is the default per-sender overflow event quota
+// enforced by NewBoundedRecorder. It matches the categoryQuota.Overflow
+// value documented in RFC-21 Layer A.
+//
+// A peer that overflows the inbound message channel more than the
+// quota allows in a single attempt is recorded only up to the quota:
+// further overflows are silently dropped by the recorder. This bounds
+// the per-attempt evidence size to O(|IncludedSet| * quota) regardless
+// of how aggressively a peer (or its network link) misbehaves.
+const OverflowQuotaDefault uint = 8
+
+// EvidenceRecorder collects bounded, per-attempt evidence of receive-
+// path anomalies that the ROAST coordinator's exclusion policy may
+// later consume.
+//
+// Phase 2 introduces only the overflow channel; future phases extend
+// the interface with separate methods for reject events, first-write-
+// wins conflicts, and silent peers.
+//
+// Implementations must be safe for concurrent calls from multiple
+// goroutines, since the receive-callback closure in pkg/frost/signing
+// is driven by network goroutines.
+type EvidenceRecorder interface {
+	// RecordOverflow notes that the inbound message channel was full
+	// when a payload from the named sender arrived, causing the
+	// payload to be dropped at the receive callback. The recorder
+	// applies its own quota; callers do not need to suppress at the
+	// call site.
+	RecordOverflow(sender group.MemberIndex)
+	// Snapshot returns a copy of the recorded evidence so far. The
+	// returned value does not alias internal state; the recorder may
+	// continue receiving events after Snapshot is called.
+	Snapshot() Evidence
+}
+
+// Evidence is the per-attempt snapshot of receive-path anomalies
+// captured by an EvidenceRecorder. It is the value the ROAST
+// coordinator's NextAttempt policy consumes (in a later RFC-21
+// phase) to derive the next attempt's ExcludedSet.
+type Evidence struct {
+	// Overflows maps each sender to the number of overflow events
+	// observed for that sender during the attempt, saturated at the
+	// recorder's overflow quota. A missing key means the sender did
+	// not overflow at all during the attempt.
+	Overflows map[group.MemberIndex]uint
+}
+
+// NewBoundedRecorder returns an EvidenceRecorder with default
+// per-sender quotas. The recorder is safe for concurrent use.
+//
+// Phase 2 wiring uses NoOpRecorder by default at every call site;
+// real use of the bounded recorder lands in a later phase behind a
+// build tag, when the coordinator state machine arrives.
+func NewBoundedRecorder() EvidenceRecorder {
+	return NewBoundedRecorderWithQuota(OverflowQuotaDefault)
+}
+
+// NewBoundedRecorderWithQuota returns a recorder with a custom
+// overflow quota. Intended for tests; production callers should use
+// NewBoundedRecorder so the per-attempt evidence size is uniform
+// across the network.
+func NewBoundedRecorderWithQuota(overflowQuota uint) EvidenceRecorder {
+	return &boundedRecorder{
+		overflowQuota: overflowQuota,
+		overflows:     map[group.MemberIndex]uint{},
+	}
+}
+
+// NoOpRecorder returns a recorder that discards every event and
+// reports an empty Evidence on Snapshot. It is the default at every
+// Phase 2 call site so the receive loops' observable behaviour stays
+// identical to pre-Phase-2 until a later phase wires real recorders.
+func NoOpRecorder() EvidenceRecorder {
+	return noOpRecorder{}
+}
+
+type boundedRecorder struct {
+	mu            sync.Mutex
+	overflowQuota uint
+	overflows     map[group.MemberIndex]uint
+}
+
+func (r *boundedRecorder) RecordOverflow(sender group.MemberIndex) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.overflows[sender] < r.overflowQuota {
+		r.overflows[sender]++
+	}
+}
+
+func (r *boundedRecorder) Snapshot() Evidence {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[group.MemberIndex]uint, len(r.overflows))
+	for sender, count := range r.overflows {
+		out[sender] = count
+	}
+	return Evidence{Overflows: out}
+}
+
+type noOpRecorder struct{}
+
+func (noOpRecorder) RecordOverflow(group.MemberIndex) {}
+
+func (noOpRecorder) Snapshot() Evidence {
+	return Evidence{Overflows: map[group.MemberIndex]uint{}}
+}

--- a/pkg/frost/roast/attempt/evidence_recorder_test.go
+++ b/pkg/frost/roast/attempt/evidence_recorder_test.go
@@ -1,0 +1,141 @@
+package attempt
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func TestNoOpRecorder_IsObservablyInert(t *testing.T) {
+	rec := NoOpRecorder()
+	for i := 0; i < 1000; i++ {
+		rec.RecordOverflow(group.MemberIndex(i%5 + 1))
+	}
+	snap := rec.Snapshot()
+	if len(snap.Overflows) != 0 {
+		t.Fatalf(
+			"NoOp recorder must report zero overflows; got %d entries",
+			len(snap.Overflows),
+		)
+	}
+}
+
+func TestBoundedRecorder_CountsOverflowsBySender(t *testing.T) {
+	rec := NewBoundedRecorder()
+	rec.RecordOverflow(1)
+	rec.RecordOverflow(2)
+	rec.RecordOverflow(1)
+
+	snap := rec.Snapshot()
+	if got := snap.Overflows[1]; got != 2 {
+		t.Fatalf("sender 1 overflow count: got %d want 2", got)
+	}
+	if got := snap.Overflows[2]; got != 1 {
+		t.Fatalf("sender 2 overflow count: got %d want 1", got)
+	}
+	if _, ok := snap.Overflows[3]; ok {
+		t.Fatal("sender 3 should have no entry")
+	}
+}
+
+func TestBoundedRecorder_SaturatesAtQuota(t *testing.T) {
+	const quota uint = 4
+	rec := NewBoundedRecorderWithQuota(quota)
+
+	for i := uint(0); i < quota+10; i++ {
+		rec.RecordOverflow(1)
+	}
+	snap := rec.Snapshot()
+	if got := snap.Overflows[1]; got != quota {
+		t.Fatalf(
+			"overflow count must saturate at quota %d; got %d",
+			quota, got,
+		)
+	}
+}
+
+func TestBoundedRecorder_DefaultQuotaIs8(t *testing.T) {
+	rec := NewBoundedRecorder()
+	for i := 0; i < 100; i++ {
+		rec.RecordOverflow(1)
+	}
+	if got := rec.Snapshot().Overflows[1]; got != OverflowQuotaDefault {
+		t.Fatalf(
+			"default quota mismatch; got %d want %d",
+			got, OverflowQuotaDefault,
+		)
+	}
+	if OverflowQuotaDefault != 8 {
+		t.Fatalf(
+			"RFC-21 Layer A specifies overflow quota = 8; constant is %d",
+			OverflowQuotaDefault,
+		)
+	}
+}
+
+func TestBoundedRecorder_SnapshotIsDeepCopy(t *testing.T) {
+	rec := NewBoundedRecorder()
+	rec.RecordOverflow(1)
+	rec.RecordOverflow(1)
+
+	snap := rec.Snapshot()
+	snap.Overflows[1] = 999
+	snap.Overflows[42] = 7
+
+	freshSnap := rec.Snapshot()
+	if got := freshSnap.Overflows[1]; got != 2 {
+		t.Fatalf(
+			"snapshot mutation leaked into recorder state: got %d want 2",
+			got,
+		)
+	}
+	if _, ok := freshSnap.Overflows[42]; ok {
+		t.Fatal("snapshot mutation leaked a new key into recorder state")
+	}
+}
+
+func TestBoundedRecorder_ConcurrentRecordersAreRaceSafe(t *testing.T) {
+	const (
+		recordersPerSender = 8
+		sendersN           = 16
+		recordsPerRecorder = 200
+	)
+	rec := NewBoundedRecorderWithQuota(uint(recordersPerSender * recordsPerRecorder * 10))
+
+	var wg sync.WaitGroup
+	for senderIdx := 1; senderIdx <= sendersN; senderIdx++ {
+		sender := group.MemberIndex(senderIdx)
+		for w := 0; w < recordersPerSender; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for n := 0; n < recordsPerRecorder; n++ {
+					rec.RecordOverflow(sender)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	snap := rec.Snapshot()
+	for senderIdx := 1; senderIdx <= sendersN; senderIdx++ {
+		want := uint(recordersPerSender * recordsPerRecorder)
+		if got := snap.Overflows[group.MemberIndex(senderIdx)]; got != want {
+			t.Fatalf(
+				"sender %d concurrent count: got %d want %d",
+				senderIdx, got, want,
+			)
+		}
+	}
+}
+
+func TestNoOpRecorder_DistinctInstancesShareSemantics(t *testing.T) {
+	a := NoOpRecorder()
+	b := NoOpRecorder()
+	a.RecordOverflow(1)
+	b.RecordOverflow(2)
+	if len(a.Snapshot().Overflows) != 0 || len(b.Snapshot().Overflows) != 0 {
+		t.Fatal("NoOp instances must not retain state")
+	}
+}

--- a/pkg/frost/signing/evidence_overflow.go
+++ b/pkg/frost/signing/evidence_overflow.go
@@ -1,0 +1,43 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// senderIndexedMessage is the minimal contract a protocol message must
+// satisfy for enqueueOrRecordOverflow to handle it: the message must
+// expose its sender so the recorder can attribute overflow events to a
+// specific member.
+type senderIndexedMessage interface {
+	SenderID() group.MemberIndex
+}
+
+// enqueueOrRecordOverflow attempts to enqueue payload onto target. If
+// the channel is full, the overflow is recorded against the payload's
+// sender on the supplied recorder instead. Returns true if the payload
+// was enqueued, false if the overflow was recorded.
+//
+// This is the shared select-or-record body that replaces the three
+// inline select { default } drop sites in the FROST/tbtc-signer
+// receive loops. Pulling it out lets the recorder integration be unit-
+// tested directly without spinning up a network channel.
+//
+// Phase 2 callers pass attempt.NoOpRecorder(), so behaviour is
+// observably unchanged from before RFC-21 wiring. A coordinator-aware
+// caller in a later phase injects a real recorder.
+func enqueueOrRecordOverflow[T senderIndexedMessage](
+	payload T,
+	target chan<- T,
+	recorder attempt.EvidenceRecorder,
+) bool {
+	select {
+	case target <- payload:
+		return true
+	default:
+		recorder.RecordOverflow(payload.SenderID())
+		return false
+	}
+}

--- a/pkg/frost/signing/evidence_overflow_test.go
+++ b/pkg/frost/signing/evidence_overflow_test.go
@@ -1,0 +1,154 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func TestEnqueueOrRecordOverflow_EnqueuesWhenChannelHasRoom(t *testing.T) {
+	ch := make(chan *nativeFROSTRoundOneCommitmentMessage, 4)
+	rec := attempt.NewBoundedRecorder()
+	payload := &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 1}
+
+	if !enqueueOrRecordOverflow(payload, ch, rec) {
+		t.Fatal("enqueue should succeed when channel has room")
+	}
+	if got := rec.Snapshot().Overflows[1]; got != 0 {
+		t.Fatalf("no overflow expected on successful enqueue; got %d", got)
+	}
+	if len(ch) != 1 {
+		t.Fatalf("channel length expected 1, got %d", len(ch))
+	}
+}
+
+func TestEnqueueOrRecordOverflow_RecordsOverflowWhenChannelIsFull(t *testing.T) {
+	ch := make(chan *nativeFROSTRoundOneCommitmentMessage, 1)
+	ch <- &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 99} // fill it
+	rec := attempt.NewBoundedRecorder()
+
+	payload := &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 7}
+	if enqueueOrRecordOverflow(payload, ch, rec) {
+		t.Fatal("enqueue should fail when channel is full")
+	}
+	if got := rec.Snapshot().Overflows[7]; got != 1 {
+		t.Fatalf(
+			"overflow should be recorded against sender 7; got count %d",
+			got,
+		)
+	}
+	if got := rec.Snapshot().Overflows[99]; got != 0 {
+		t.Fatal(
+			"sender 99 is the pre-filled payload's sender, not the overflow sender",
+		)
+	}
+}
+
+func TestEnqueueOrRecordOverflow_NoOpRecorderHasNoObservableEffect(t *testing.T) {
+	ch := make(chan *nativeFROSTRoundOneCommitmentMessage, 1)
+	ch <- &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 1}
+	rec := attempt.NoOpRecorder()
+
+	payload := &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 7}
+	if enqueueOrRecordOverflow(payload, ch, rec) {
+		t.Fatal("enqueue should fail when channel is full")
+	}
+	if got := rec.Snapshot().Overflows[7]; got != 0 {
+		t.Fatalf(
+			"NoOp recorder must show zero overflow count even when called; got %d",
+			got,
+		)
+	}
+}
+
+func TestEnqueueOrRecordOverflow_WorksForRoundTwoMessages(t *testing.T) {
+	ch := make(chan *nativeFROSTRoundTwoSignatureShareMessage, 1)
+	ch <- &nativeFROSTRoundTwoSignatureShareMessage{SenderIDValue: 1}
+	rec := attempt.NewBoundedRecorder()
+
+	payload := &nativeFROSTRoundTwoSignatureShareMessage{SenderIDValue: 4}
+	if enqueueOrRecordOverflow(payload, ch, rec) {
+		t.Fatal("enqueue should fail when channel is full")
+	}
+	if got := rec.Snapshot().Overflows[4]; got != 1 {
+		t.Fatalf("expected overflow count 1 for sender 4, got %d", got)
+	}
+}
+
+func TestEnqueueOrRecordOverflow_WorksForTBTCSignerContributionMessages(t *testing.T) {
+	ch := make(chan *buildTaggedTBTCSignerRoundContributionMessage, 1)
+	ch <- &buildTaggedTBTCSignerRoundContributionMessage{SenderIDValue: 1}
+	rec := attempt.NewBoundedRecorder()
+
+	payload := &buildTaggedTBTCSignerRoundContributionMessage{SenderIDValue: 5}
+	if enqueueOrRecordOverflow(payload, ch, rec) {
+		t.Fatal("enqueue should fail when channel is full")
+	}
+	if got := rec.Snapshot().Overflows[5]; got != 1 {
+		t.Fatalf("expected overflow count 1 for sender 5, got %d", got)
+	}
+}
+
+func TestEnqueueOrRecordOverflow_RepeatedOverflowsSaturateAtQuota(t *testing.T) {
+	ch := make(chan *nativeFROSTRoundOneCommitmentMessage, 1)
+	ch <- &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 1}
+	rec := attempt.NewBoundedRecorderWithQuota(3)
+
+	for i := 0; i < 10; i++ {
+		_ = enqueueOrRecordOverflow(
+			&nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 2},
+			ch,
+			rec,
+		)
+	}
+	if got := rec.Snapshot().Overflows[2]; got != 3 {
+		t.Fatalf("expected saturation at quota 3, got %d", got)
+	}
+}
+
+func TestEnqueueOrRecordOverflow_ConcurrentCallersAreRaceSafe(t *testing.T) {
+	const numProducers = 8
+	const recordsPerProducer = 100
+	ch := make(chan *nativeFROSTRoundOneCommitmentMessage, 1)
+	ch <- &nativeFROSTRoundOneCommitmentMessage{SenderIDValue: 1} // fill it once
+	rec := attempt.NewBoundedRecorderWithQuota(uint(numProducers * recordsPerProducer))
+
+	var wg sync.WaitGroup
+	for p := 0; p < numProducers; p++ {
+		wg.Add(1)
+		sender := group.MemberIndex(p + 2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < recordsPerProducer; i++ {
+				_ = enqueueOrRecordOverflow(
+					&nativeFROSTRoundOneCommitmentMessage{SenderIDValue: uint32(sender)},
+					ch,
+					rec,
+				)
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := rec.Snapshot()
+	totalRecorded := uint(0)
+	for _, v := range snap.Overflows {
+		totalRecorded += v
+	}
+	// Every producer's records either enqueued (replacing previously-
+	// dequeued items, but there's no consumer here so the channel stays
+	// full and all subsequent enqueue attempts fall to the default
+	// branch) or recorded. Since the channel starts pre-filled and has
+	// no consumer, all 800 records hit the overflow path.
+	const expected = numProducers * recordsPerProducer
+	if totalRecorded != expected {
+		t.Fatalf(
+			"concurrent overflow count: got %d, want %d (sum across senders)",
+			totalRecorded, expected,
+		)
+	}
+}

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/frost"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
@@ -860,11 +861,15 @@ func buildTaggedTBTCSignerRoundContributions(
 		return nil, fmt.Errorf("cannot send round contribution message: [%w]", err)
 	}
 
+	// Phase 2 default: NoOp recorder preserves pre-RFC-21 behaviour.
+	// A coordinator-aware caller in a later phase injects a real
+	// recorder so overflow drops feed into NextAttempt evidence.
 	peerMessages, err := collectBuildTaggedTBTCSignerRoundContributionMessages(
 		ctx,
 		request,
 		includedMembersSet,
 		includedMembersIndexes,
+		attempt.NoOpRecorder(),
 	)
 	if err != nil {
 		return nil, err
@@ -961,6 +966,7 @@ func collectBuildTaggedTBTCSignerRoundContributionMessages(
 	request *NativeExecutionFFISigningRequest,
 	includedMembersSet map[group.MemberIndex]struct{},
 	includedMembersIndexes []group.MemberIndex,
+	evidence attempt.EvidenceRecorder,
 ) (map[group.MemberIndex]*buildTaggedTBTCSignerRoundContributionMessage, error) {
 	expectedMessagesCount := len(includedMembersIndexes) - 1
 	if expectedMessagesCount <= 0 {
@@ -991,10 +997,7 @@ func collectBuildTaggedTBTCSignerRoundContributionMessages(
 			return
 		}
 
-		select {
-		case messageChan <- payload:
-		default:
-		}
+		_ = enqueueOrRecordOverflow(payload, messageChan, evidence)
 	})
 
 	receivedMessages := make(

--- a/pkg/frost/signing/native_frost_protocol_frost_native.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/frost"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
@@ -349,11 +350,16 @@ func executeNativeFROSTSigning(
 		return nil, fmt.Errorf("cannot send native FROST round one message: [%w]", err)
 	}
 
+	// Phase 2 default: NoOp recorder preserves pre-RFC-21 behaviour.
+	// A coordinator-aware caller in a later phase will inject a real
+	// recorder via the request (or a sibling parameter) so overflow
+	// drops at the receive callback feed into NextAttempt evidence.
 	roundOneMessages, err := collectNativeFROSTRoundOneMessages(
 		ctx,
 		request,
 		includedMembersSet,
 		includedMembersIndexes,
+		attempt.NoOpRecorder(),
 	)
 	if err != nil {
 		return nil, err
@@ -429,11 +435,13 @@ func executeNativeFROSTSigning(
 		return nil, fmt.Errorf("cannot send native FROST round two message: [%w]", err)
 	}
 
+	// Phase 2 default: NoOp recorder. See round-one caller above.
 	roundTwoMessages, err := collectNativeFROSTRoundTwoMessages(
 		ctx,
 		request,
 		includedMembersSet,
 		includedMembersIndexes,
+		attempt.NoOpRecorder(),
 	)
 	if err != nil {
 		return nil, err
@@ -593,6 +601,7 @@ func collectNativeFROSTRoundOneMessages(
 	request *NativeExecutionFFISigningRequest,
 	includedMembersSet map[group.MemberIndex]struct{},
 	includedMembersIndexes []group.MemberIndex,
+	evidence attempt.EvidenceRecorder,
 ) (map[group.MemberIndex]*nativeFROSTRoundOneCommitmentMessage, error) {
 	expectedMessagesCount := len(includedMembersIndexes) - 1
 	if expectedMessagesCount <= 0 {
@@ -620,10 +629,7 @@ func collectNativeFROSTRoundOneMessages(
 			return
 		}
 
-		select {
-		case messageChan <- payload:
-		default:
-		}
+		_ = enqueueOrRecordOverflow(payload, messageChan, evidence)
 	})
 
 	receivedMessages := make(map[group.MemberIndex]*nativeFROSTRoundOneCommitmentMessage)
@@ -675,6 +681,7 @@ func collectNativeFROSTRoundTwoMessages(
 	request *NativeExecutionFFISigningRequest,
 	includedMembersSet map[group.MemberIndex]struct{},
 	includedMembersIndexes []group.MemberIndex,
+	evidence attempt.EvidenceRecorder,
 ) (map[group.MemberIndex]*nativeFROSTRoundTwoSignatureShareMessage, error) {
 	expectedMessagesCount := len(includedMembersIndexes) - 1
 	if expectedMessagesCount <= 0 {
@@ -702,10 +709,7 @@ func collectNativeFROSTRoundTwoMessages(
 			return
 		}
 
-		select {
-		case messageChan <- payload:
-		default:
-		}
+		_ = enqueueOrRecordOverflow(payload, messageChan, evidence)
 	})
 
 	receivedMessages := make(map[group.MemberIndex]*nativeFROSTRoundTwoSignatureShareMessage)


### PR DESCRIPTION
## Summary

RFC-21 Phase 2: introduces the **`EvidenceRecorder`** interface and a
bounded reference implementation in `pkg/frost/roast/attempt`, then
plumbs it through the three FROST/tbtc-signer receive loops so the
previously silent `select { default }` drops become bounded
transition-evidence recording sites.

**No protocol behaviour change.** All three call sites pass
`attempt.NoOpRecorder()` as the recorder, so overflow-path
observability is identical to before. A coordinator-aware caller in
a later RFC-21 phase will inject a real recorder.

## What lands

### New package surface (`pkg/frost/roast/attempt`)

| Surface | Role |
|---|---|
| `EvidenceRecorder` interface | `RecordOverflow(sender)` + `Snapshot() Evidence`. Phase 2 covers overflow only; later phases extend with reject / conflict / silence. |
| `Evidence` snapshot | `Overflows map[group.MemberIndex]uint`. Empty map when no overflow. |
| `NewBoundedRecorder()` | Thread-safe recorder with default per-sender quota of 8 (matches `categoryQuota.Overflow` in RFC-21 Layer A). |
| `NewBoundedRecorderWithQuota(q)` | Test seam for non-default quotas. |
| `NoOpRecorder()` | Discards events; returns an empty snapshot. The Phase 2 default at every call site. |

### New signing-package helper

`pkg/frost/signing/evidence_overflow.go` adds `enqueueOrRecordOverflow[T senderIndexedMessage](payload, target, recorder) bool`. This is the shared select-or-record body that replaces the inline `select { default }` drops. Pulling it out lets the recorder integration be unit-tested in isolation without spinning up a network channel.

### Plumbing

- `collectNativeFROSTRoundOneMessages`
- `collectNativeFROSTRoundTwoMessages`
- `collectBuildTaggedTBTCSignerRoundContributionMessages`

Each now accepts an `attempt.EvidenceRecorder` parameter and calls `enqueueOrRecordOverflow` in place of the inline select. All three callers pass `attempt.NoOpRecorder()`.

## Why the helper refactor

The original inline `select { default }` drops cannot be tested without a real channel / network. Extracting the body into `enqueueOrRecordOverflow[T]` makes the integration testable directly, which is what gives us confidence that overflow drops actually reach the recorder.

## Test coverage

### Recorder unit tests (7) under `pkg/frost/roast/attempt/evidence_recorder_test.go`

- `TestNoOpRecorder_IsObservablyInert`
- `TestBoundedRecorder_CountsOverflowsBySender`
- `TestBoundedRecorder_SaturatesAtQuota`
- `TestBoundedRecorder_DefaultQuotaIs8` (asserts the constant matches the RFC literal)
- `TestBoundedRecorder_SnapshotIsDeepCopy`
- `TestBoundedRecorder_ConcurrentRecordersAreRaceSafe` (8 producers × 16 senders × 200 records)
- `TestNoOpRecorder_DistinctInstancesShareSemantics`

### Helper unit tests (8) under `pkg/frost/signing/evidence_overflow_test.go`

- `TestEnqueueOrRecordOverflow_EnqueuesWhenChannelHasRoom`
- `TestEnqueueOrRecordOverflow_RecordsOverflowWhenChannelIsFull`
- `TestEnqueueOrRecordOverflow_NoOpRecorderHasNoObservableEffect`
- `TestEnqueueOrRecordOverflow_WorksForRoundTwoMessages`
- `TestEnqueueOrRecordOverflow_WorksForTBTCSignerContributionMessages`
- `TestEnqueueOrRecordOverflow_RepeatedOverflowsSaturateAtQuota`
- `TestEnqueueOrRecordOverflow_ConcurrentCallersAreRaceSafe`

### Verification

| Command | Result |
|---|---|
| `go build ./...` | clean |
| `go build -tags 'frost_native frost_tbtc_signer' ./pkg/frost/...` | clean |
| `go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/...` | pass (5 packages) |
| `go test -race -run TestEnqueueOrRecordOverflow_ConcurrentCallersAreRaceSafe` | pass |
| `staticcheck -checks '-SA1019' ./pkg/frost/...` | silent |
| `pkg/tbtc` regression subset | pass (91s) |

## Test plan

- [ ] CI green: build/test/lint/scan/vet.
- [ ] Reviewer confirms the NoOp-default approach is acceptable for
  Phase 2 (no behaviour change is the explicit goal).
- [ ] Reviewer confirms the bounded recorder's default quota of 8
  matches the RFC-21 specification.