### PR TITLE
feat(frost/roast): RFC-21 Phase 3.1 -- coordinator skeleton + seed bridge

### DIFF
--- a/pkg/frost/roast/coordinator_state.go
+++ b/pkg/frost/roast/coordinator_state.go
@@ -1,0 +1,203 @@
+package roast
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// AttemptState is the phase an attempt is in within the Coordinator
+// state machine. The lifecycle is monotonic:
+//
+//	AttemptStatePending -> AttemptStateCollecting -> AttemptStateAggregating
+//	    -> {AttemptStateSucceeded, AttemptStateTransitioned}
+//
+// AttemptStateSucceeded means the attempt produced a final signature.
+// AttemptStateTransitioned means the attempt timed out or hit an
+// unrecoverable reject and the coordinator emitted a
+// TransitionMessage that drives the next attempt's context. Phase 3.1
+// (this file) introduces the state surface only; later phases drive
+// the transitions.
+type AttemptState uint8
+
+const (
+	// AttemptStatePending is the zero value -- not a real state, used
+	// only as the default-initialised "unknown" sentinel returned with
+	// ErrUnknownAttempt.
+	AttemptStatePending AttemptState = iota
+	// AttemptStateCollecting -- the attempt has been started, the
+	// included set is fixed, and the coordinator is accepting signed
+	// evidence snapshots from peers.
+	AttemptStateCollecting
+	// AttemptStateAggregating -- the coordinator has stopped
+	// accepting evidence and is building the TransitionMessage
+	// bundle.
+	AttemptStateAggregating
+	// AttemptStateSucceeded -- the attempt produced a final
+	// signature; no transition message is needed.
+	AttemptStateSucceeded
+	// AttemptStateTransitioned -- the attempt timed out or failed
+	// and the coordinator has emitted a TransitionMessage; the next
+	// attempt's context can now be computed by NextAttempt.
+	AttemptStateTransitioned
+)
+
+func (s AttemptState) String() string {
+	switch s {
+	case AttemptStatePending:
+		return "pending"
+	case AttemptStateCollecting:
+		return "collecting"
+	case AttemptStateAggregating:
+		return "aggregating"
+	case AttemptStateSucceeded:
+		return "succeeded"
+	case AttemptStateTransitioned:
+		return "transitioned"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(s))
+	}
+}
+
+// AttemptHandle is the opaque per-attempt identity returned by
+// Coordinator.BeginAttempt. Handles are not interchangeable across
+// coordinator instances: a handle minted by coordinator A cannot be
+// passed to coordinator B. Callers must not mutate handles directly.
+type AttemptHandle struct {
+	id          uint64
+	contextHash [attempt.MessageDigestLength]byte
+}
+
+// ContextHash returns the canonical AttemptContext.Hash() value bound
+// to this handle. Useful for cross-checking a handle against a
+// context after the fact.
+func (h AttemptHandle) ContextHash() [attempt.MessageDigestLength]byte {
+	return h.contextHash
+}
+
+// Coordinator is the ROAST coordinator state machine introduced by
+// RFC-21 Phase 3. It owns per-attempt state, the deterministic
+// participant selection (via the existing SelectCoordinator helper),
+// and -- in later Phase-3 PRs -- signed-evidence aggregation,
+// transition-message construction, and the NextAttempt policy.
+//
+// Phase 3.1 (this file) introduces only:
+//   - BeginAttempt: initialise tracking for a new attempt.
+//   - State: read the current AttemptState for a handle.
+//   - SelectedCoordinator: report the member elected as coordinator
+//     for the attempt.
+//
+// Phase 3.2 adds the TransitionMessage / LocalEvidenceSnapshot types.
+// Phase 3.3 adds AggregateBundle and VerifyBundle. Phase 3.4 adds the
+// NextAttempt policy function.
+//
+// Implementations must be safe for concurrent calls from multiple
+// goroutines; production keep-core code paths are network-driven.
+type Coordinator interface {
+	// BeginAttempt initialises tracking for a new attempt with the
+	// given context. It selects the attempt's coordinator
+	// deterministically from ctx.IncludedSet via SelectCoordinator
+	// (with the legacy int64 seed produced by foldAttemptSeed) and
+	// stores the result on the returned handle.
+	BeginAttempt(ctx attempt.AttemptContext) (AttemptHandle, error)
+	// State returns the current AttemptState for the given handle.
+	// Returns ErrUnknownAttempt if the handle was not produced by
+	// this Coordinator instance.
+	State(handle AttemptHandle) (AttemptState, error)
+	// SelectedCoordinator returns the member elected as coordinator
+	// for the attempt identified by the handle. Returns
+	// ErrUnknownAttempt if the handle is not tracked.
+	SelectedCoordinator(handle AttemptHandle) (group.MemberIndex, error)
+}
+
+// ErrUnknownAttempt indicates an AttemptHandle does not correspond to
+// any attempt tracked by this Coordinator. Either the handle was
+// minted by a different coordinator instance, or the attempt has
+// been pruned.
+var ErrUnknownAttempt = errors.New("coordinator: unknown attempt handle")
+
+// NewInMemoryCoordinator returns a Coordinator that tracks attempts
+// in-process. Phase 3 production paths use this implementation.
+// Later phases may add persistent variants once persistence is
+// designed (RFC-21 Open question on signer restart).
+func NewInMemoryCoordinator() Coordinator {
+	return &inMemoryCoordinator{
+		attempts: map[uint64]*attemptRecord{},
+	}
+}
+
+type attemptRecord struct {
+	handle      AttemptHandle
+	context     attempt.AttemptContext
+	coordinator group.MemberIndex
+	state       AttemptState
+}
+
+type inMemoryCoordinator struct {
+	mu       sync.Mutex
+	nextID   atomic.Uint64
+	attempts map[uint64]*attemptRecord
+}
+
+func (c *inMemoryCoordinator) BeginAttempt(
+	ctx attempt.AttemptContext,
+) (AttemptHandle, error) {
+	if len(ctx.IncludedSet) == 0 {
+		return AttemptHandle{}, fmt.Errorf(
+			"coordinator: cannot begin attempt with empty included set",
+		)
+	}
+	coord, err := SelectCoordinator(
+		ctx.IncludedSet,
+		foldAttemptSeed(ctx.AttemptSeed),
+		uint(ctx.AttemptNumber),
+	)
+	if err != nil {
+		return AttemptHandle{}, fmt.Errorf(
+			"coordinator: selection failed: %w",
+			err,
+		)
+	}
+	handle := AttemptHandle{
+		id:          c.nextID.Add(1),
+		contextHash: ctx.Hash(),
+	}
+	record := &attemptRecord{
+		handle:      handle,
+		context:     ctx,
+		coordinator: coord,
+		state:       AttemptStateCollecting,
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.attempts[handle.id] = record
+	return handle, nil
+}
+
+func (c *inMemoryCoordinator) State(
+	handle AttemptHandle,
+) (AttemptState, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record, ok := c.attempts[handle.id]
+	if !ok {
+		return AttemptStatePending, ErrUnknownAttempt
+	}
+	return record.state, nil
+}
+
+func (c *inMemoryCoordinator) SelectedCoordinator(
+	handle AttemptHandle,
+) (group.MemberIndex, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record, ok := c.attempts[handle.id]
+	if !ok {
+		return 0, ErrUnknownAttempt
+	}
+	return record.coordinator, nil
+}

--- a/pkg/frost/roast/coordinator_state_test.go
+++ b/pkg/frost/roast/coordinator_state_test.go
@@ -248,12 +248,12 @@ func TestInMemoryCoordinator_ConcurrentBeginAttemptsAreRaceSafe(t *testing.T) {
 
 func TestAttemptState_String(t *testing.T) {
 	cases := map[AttemptState]string{
-		AttemptStatePending:       "pending",
-		AttemptStateCollecting:    "collecting",
-		AttemptStateAggregating:   "aggregating",
-		AttemptStateSucceeded:     "succeeded",
-		AttemptStateTransitioned:  "transitioned",
-		AttemptState(99):          "unknown(99)",
+		AttemptStatePending:      "pending",
+		AttemptStateCollecting:   "collecting",
+		AttemptStateAggregating:  "aggregating",
+		AttemptStateSucceeded:    "succeeded",
+		AttemptStateTransitioned: "transitioned",
+		AttemptState(99):         "unknown(99)",
 	}
 	for state, want := range cases {
 		if got := state.String(); got != want {

--- a/pkg/frost/roast/coordinator_state_test.go
+++ b/pkg/frost/roast/coordinator_state_test.go
@@ -1,0 +1,263 @@
+package roast
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func newTestContext(t *testing.T) attempt.AttemptContext {
+	t.Helper()
+	ctx, err := attempt.NewAttemptContext(
+		"session-test",
+		"key-group-test",
+		[]byte{0xab, 0xcd, 0xef},
+		[attempt.MessageDigestLength]byte{0x42},
+		0,
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("test context: %v", err)
+	}
+	return ctx
+}
+
+func TestBeginAttempt_ReturnsHandleWithMatchingContextHash(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	ctx := newTestContext(t)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handle.ContextHash() != ctx.Hash() {
+		t.Fatalf(
+			"handle hash mismatch: got %x want %x",
+			handle.ContextHash(), ctx.Hash(),
+		)
+	}
+}
+
+func TestBeginAttempt_HandlesAreDistinctAcrossAttempts(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	a, err := coord.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("first begin: %v", err)
+	}
+	b, err := coord.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("second begin: %v", err)
+	}
+	if a.id == b.id {
+		t.Fatalf("two attempts shared handle id %d", a.id)
+	}
+}
+
+func TestBeginAttempt_RejectsEmptyIncludedSet(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	// We bypass NewAttemptContext (which forbids empty included set)
+	// to assert BeginAttempt's defence-in-depth check.
+	ctx := attempt.AttemptContext{}
+	_, err := coord.BeginAttempt(ctx)
+	if err == nil {
+		t.Fatal("expected error on empty included set")
+	}
+}
+
+func TestState_ReturnsCollectingAfterBegin(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	handle, err := coord.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	state, err := coord.State(handle)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if state != AttemptStateCollecting {
+		t.Fatalf(
+			"expected collecting, got %v",
+			state,
+		)
+	}
+}
+
+func TestState_UnknownHandleReturnsSentinel(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	bogus := AttemptHandle{id: 999}
+	state, err := coord.State(bogus)
+	if !errors.Is(err, ErrUnknownAttempt) {
+		t.Fatalf("expected ErrUnknownAttempt, got %v", err)
+	}
+	if state != AttemptStatePending {
+		t.Fatalf("expected pending sentinel, got %v", state)
+	}
+}
+
+func TestSelectedCoordinator_ReturnsMemberFromIncludedSet(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	ctx := newTestContext(t)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	got, err := coord.SelectedCoordinator(handle)
+	if err != nil {
+		t.Fatalf("selected coordinator: %v", err)
+	}
+	found := false
+	for _, m := range ctx.IncludedSet {
+		if m == got {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf(
+			"selected coordinator %d not in included set %v",
+			got, ctx.IncludedSet,
+		)
+	}
+}
+
+func TestSelectedCoordinator_IsDeterministicForSameContext(t *testing.T) {
+	a := NewInMemoryCoordinator()
+	b := NewInMemoryCoordinator()
+	ctx := newTestContext(t)
+	ha, err := a.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("a.begin: %v", err)
+	}
+	hb, err := b.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("b.begin: %v", err)
+	}
+	ca, err := a.SelectedCoordinator(ha)
+	if err != nil {
+		t.Fatalf("a.selected: %v", err)
+	}
+	cb, err := b.SelectedCoordinator(hb)
+	if err != nil {
+		t.Fatalf("b.selected: %v", err)
+	}
+	if ca != cb {
+		t.Fatalf(
+			"two coordinators disagreed on same context: %d != %d",
+			ca, cb,
+		)
+	}
+}
+
+func TestSelectedCoordinator_DifferentAttemptNumbersCanProduceDifferentLeaders(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	build := func(attemptNumber uint32) attempt.AttemptContext {
+		ctx, err := attempt.NewAttemptContext(
+			"session-test",
+			"key-group-test",
+			[]byte{0x01},
+			[attempt.MessageDigestLength]byte{0x42},
+			attemptNumber,
+			[]group.MemberIndex{1, 2, 3, 4, 5},
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("build ctx: %v", err)
+		}
+		return ctx
+	}
+
+	// Sweep a few attempt numbers; verify the elected coordinator is
+	// not always the same member -- otherwise the retry-rotation
+	// property of ROAST does not hold.
+	seen := map[group.MemberIndex]struct{}{}
+	for n := uint32(0); n < 16; n++ {
+		ctx := build(n)
+		handle, err := coord.BeginAttempt(ctx)
+		if err != nil {
+			t.Fatalf("begin n=%d: %v", n, err)
+		}
+		c, err := coord.SelectedCoordinator(handle)
+		if err != nil {
+			t.Fatalf("selected n=%d: %v", n, err)
+		}
+		seen[c] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Fatalf(
+			"coordinator rotation broken: 16 different attempts all "+
+				"elected the same leader; seen=%v",
+			seen,
+		)
+	}
+}
+
+func TestSelectedCoordinator_UnknownHandleReturnsSentinel(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	bogus := AttemptHandle{id: 999}
+	got, err := coord.SelectedCoordinator(bogus)
+	if !errors.Is(err, ErrUnknownAttempt) {
+		t.Fatalf("expected ErrUnknownAttempt, got %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("expected zero member index, got %d", got)
+	}
+}
+
+func TestInMemoryCoordinator_ConcurrentBeginAttemptsAreRaceSafe(t *testing.T) {
+	const numGoroutines = 16
+	const beginsPerGoroutine = 50
+
+	coord := NewInMemoryCoordinator()
+	var wg sync.WaitGroup
+	handles := make(chan AttemptHandle, numGoroutines*beginsPerGoroutine)
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < beginsPerGoroutine; i++ {
+				h, err := coord.BeginAttempt(newTestContext(t))
+				if err != nil {
+					t.Errorf("concurrent begin: %v", err)
+					return
+				}
+				handles <- h
+			}
+		}()
+	}
+	wg.Wait()
+	close(handles)
+
+	ids := map[uint64]struct{}{}
+	for h := range handles {
+		if _, dup := ids[h.id]; dup {
+			t.Fatalf("duplicate handle id %d under concurrency", h.id)
+		}
+		ids[h.id] = struct{}{}
+	}
+	if len(ids) != numGoroutines*beginsPerGoroutine {
+		t.Fatalf(
+			"expected %d unique handles, got %d",
+			numGoroutines*beginsPerGoroutine, len(ids),
+		)
+	}
+}
+
+func TestAttemptState_String(t *testing.T) {
+	cases := map[AttemptState]string{
+		AttemptStatePending:       "pending",
+		AttemptStateCollecting:    "collecting",
+		AttemptStateAggregating:   "aggregating",
+		AttemptStateSucceeded:     "succeeded",
+		AttemptStateTransitioned:  "transitioned",
+		AttemptState(99):          "unknown(99)",
+	}
+	for state, want := range cases {
+		if got := state.String(); got != want {
+			t.Errorf("State %d: got %q want %q", state, got, want)
+		}
+	}
+}

--- a/pkg/frost/roast/seed_bridge.go
+++ b/pkg/frost/roast/seed_bridge.go
@@ -1,0 +1,33 @@
+package roast
+
+import (
+	"encoding/binary"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+)
+
+// foldAttemptSeed reduces an RFC-21 [32]byte AttemptSeed to the legacy
+// int64 seed accepted by SelectCoordinator. The reduction takes the
+// first 8 bytes of the seed as a big-endian uint64 and re-interprets
+// the bits as int64.
+//
+// This is a sterile, named adapter, *not* a cryptographic reduction.
+// Its only contract is determinism: byte-identical input must produce
+// byte-identical int64 output on every honest signer, so the
+// SelectCoordinator shuffle remains in agreement across the network.
+//
+// The remaining 24 bytes of the seed are deliberately ignored. They
+// are still part of the seed binding (so any change to those bytes is
+// detected at the AttemptContext.Hash() layer, which protocol
+// messages already verify in Phase 1B), but they do not influence the
+// shuffle. SelectCoordinator's math.Rand source is non-cryptographic
+// and 64 bits of entropy are sufficient for its purpose.
+//
+// Callers must not compose foldAttemptSeed with additional hashing.
+// If a future RFC requires a different reduction it must be a new
+// named bridge with its own tests and migration story.
+func foldAttemptSeed(seed [attempt.AttemptSeedLength]byte) int64 {
+	// #nosec G115 -- intentional uint64-to-int64 reinterpretation; the
+	// downstream rand.Source accepts any int64, including negative.
+	return int64(binary.BigEndian.Uint64(seed[:8]))
+}

--- a/pkg/frost/roast/seed_bridge_test.go
+++ b/pkg/frost/roast/seed_bridge_test.go
@@ -1,0 +1,107 @@
+package roast
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+)
+
+func TestFoldAttemptSeed_IsDeterministic(t *testing.T) {
+	seed := [attempt.AttemptSeedLength]byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	}
+	a := foldAttemptSeed(seed)
+	b := foldAttemptSeed(seed)
+	if a != b {
+		t.Fatalf("foldAttemptSeed not deterministic: %d != %d", a, b)
+	}
+}
+
+func TestFoldAttemptSeed_TakesFirst8BytesBigEndian(t *testing.T) {
+	seed := [attempt.AttemptSeedLength]byte{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	}
+	got := foldAttemptSeed(seed)
+	if got != 1 {
+		t.Fatalf("first-8 BE decode wrong: got %d want 1", got)
+	}
+}
+
+func TestFoldAttemptSeed_IgnoresBytesAfterIndex7(t *testing.T) {
+	// Document the contract: bytes 8..31 do not influence the output.
+	// Any change to those bytes is still caught at the
+	// AttemptContext.Hash() layer; the bridge merely surfaces the
+	// first 8.
+	base := [attempt.AttemptSeedLength]byte{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	mutated := base
+	for i := 8; i < attempt.AttemptSeedLength; i++ {
+		mutated[i] ^= 0xff
+	}
+	if foldAttemptSeed(base) != foldAttemptSeed(mutated) {
+		t.Fatal(
+			"bridge must ignore bytes 8..31 by contract; honest signers " +
+				"will desynchronise if this assumption changes",
+		)
+	}
+}
+
+func TestFoldAttemptSeed_FirstByteSwept(t *testing.T) {
+	// Sweep the high byte of the leading uint64; every value must
+	// produce a distinct int64.
+	seen := map[int64]struct{}{}
+	for hi := 0; hi < 256; hi++ {
+		var seed [attempt.AttemptSeedLength]byte
+		seed[0] = byte(hi)
+		got := foldAttemptSeed(seed)
+		if _, dup := seen[got]; dup {
+			t.Fatalf("collision on high-byte sweep at %d", hi)
+		}
+		seen[got] = struct{}{}
+	}
+	if len(seen) != 256 {
+		t.Fatalf("expected 256 distinct outputs, got %d", len(seen))
+	}
+}
+
+func TestFoldAttemptSeed_GoldenFixture(t *testing.T) {
+	// Locks the wire-format reduction so any future change to the
+	// bridge implementation is caught at code review. Two coordinator
+	// instances that disagree on this constant will produce
+	// divergent SelectCoordinator outputs and fracture the network.
+	seed := [attempt.AttemptSeedLength]byte{
+		0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe,
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+		0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+	}
+	want := int64(binary.BigEndian.Uint64(seed[:8]))
+	got := foldAttemptSeed(seed)
+	if got != want {
+		t.Fatalf(
+			"golden fixture drift: got %d want %d (seed=%x)",
+			got, want, seed[:8],
+		)
+	}
+	// Also assert the literal integer so a typo in the reference
+	// computation above is caught: 0xdeadbeefcafebabe (16045690984503098046
+	// as uint64) reinterpreted as int64.
+	const wantLiteral int64 = -2401053089206453570
+	if got != wantLiteral {
+		t.Fatalf(
+			"golden fixture int64 drift: got %d want %d",
+			got, wantLiteral,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

First Phase-3 implementation PR for **RFC-21**. Introduces the ROAST
coordinator state-machine surface (`Coordinator` interface, in-memory
implementation, attempt-handle identity, state enum) plus the sterile
seed-folding adapter that lets the new `[32]byte` `AttemptSeed` drive
the legacy `SelectCoordinator` helper without modifying it.

**No production code path uses the new \`Coordinator\` yet.** Phase 3
"ships unused" per the RFC. Phase 4 wires it into receivers behind the
\`frost_roast_retry\` build tag.

## What lands

### \`pkg/frost/roast/coordinator_state.go\`

| Surface | Role |
|---|---|
| \`AttemptState\` enum | \`Pending / Collecting / Aggregating / Succeeded / Transitioned\` with \`String()\`. |
| \`AttemptHandle\` | Opaque per-attempt identity. \`ContextHash()\` accessor cross-checks the bound context. |
| \`Coordinator\` interface | \`BeginAttempt(ctx) → handle\`, \`State(handle) → state\`, \`SelectedCoordinator(handle) → member\`. Later Phase-3 PRs (3.2 / 3.3 / 3.4) extend with \`TransitionMessage\`, \`AggregateBundle\`, \`VerifyBundle\`, and \`NextAttempt\`. |
| \`NewInMemoryCoordinator()\` | Concurrent-safe via \`sync.Mutex\` + \`atomic.Uint64\` next-id counter. |
| \`ErrUnknownAttempt\` | Sentinel for handle/instance mismatch. |

### \`pkg/frost/roast/seed_bridge.go\`

| Surface | Role |
|---|---|
| \`foldAttemptSeed(seed [32]byte) int64\` | First 8 bytes BE → int64 reinterpretation. Sterile, named, non-cryptographic adapter. Documented contract: byte-identical input must produce byte-identical output on every honest signer. |

\`BeginAttempt\` calls \`foldAttemptSeed\` and forwards to the existing
\`SelectCoordinator\` to elect the attempt's coordinator. The legacy
helper itself is **not modified** -- the bridge is the only thing
between RFC-21 contexts and the legacy seed format.

## Why the seed bridge

The legacy \`SelectCoordinator\` takes \`(seed int64, attemptNumber uint)\`
and is correct in isolation. RFC-21 widens \`AttemptSeed\` to
\`[32]byte\` for the canonical-hash binding. We could rewrite the
shuffle, but rewriting cryptographic-consensus logic that already
agrees across the network is the wrong trade-off; the audit and
behaviour are settled.

The bridge satisfies the resolved decision in RFC-21:
> \"BeginAttempt wraps it with a sterile bridge that folds the new
> [32]byte AttemptSeed into the legacy parameter shape... The bridge
> is named, isolated, and exhaustively tested so later edits cannot
> accidentally desynchronise it.\"

## Test coverage

### \`coordinator_state_test.go\` (9 tests)

- \`TestBeginAttempt_ReturnsHandleWithMatchingContextHash\`
- \`TestBeginAttempt_HandlesAreDistinctAcrossAttempts\`
- \`TestBeginAttempt_RejectsEmptyIncludedSet\` (defence-in-depth)
- \`TestState_ReturnsCollectingAfterBegin\`
- \`TestState_UnknownHandleReturnsSentinel\`
- \`TestSelectedCoordinator_ReturnsMemberFromIncludedSet\`
- \`TestSelectedCoordinator_IsDeterministicForSameContext\` -- two
  independent \`Coordinator\` instances agree on the elected member
- \`TestSelectedCoordinator_DifferentAttemptNumbersCanProduceDifferentLeaders\`
  -- 16 attempts produce ≥2 distinct leaders, defending the ROAST
  leader-rotation property
- \`TestSelectedCoordinator_UnknownHandleReturnsSentinel\`
- \`TestInMemoryCoordinator_ConcurrentBeginAttemptsAreRaceSafe\` --
  16 goroutines × 50 calls each, all handles unique
- \`TestAttemptState_String\` -- all enum values + unknown sentinel

### \`seed_bridge_test.go\` (5 tests)

- \`TestFoldAttemptSeed_IsDeterministic\`
- \`TestFoldAttemptSeed_TakesFirst8BytesBigEndian\` -- specific
  byte pattern verified
- \`TestFoldAttemptSeed_IgnoresBytesAfterIndex7\` -- documents the
  contract: bytes 8..31 don't influence output (still bound at
  the \`AttemptContext.Hash()\` layer)
- \`TestFoldAttemptSeed_FirstByteSwept\` -- 256-value sweep of the
  high byte produces 256 distinct outputs (no collisions)
- \`TestFoldAttemptSeed_GoldenFixture\` -- literal int64 value
  locks the wire-format reduction; literal drift caught at
  code review

### Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/roast/...\` | pass (14 cases) |
| \`go test -race ./pkg/frost/roast/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/roast/...\` | silent |
| \`go vet ./pkg/frost/roast/...\` | clean |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the seed bridge's discard of bytes 8..31 is
  acceptable. (Bytes 8..31 still appear in \`AttemptContext.Hash()\`,
  so any mutation is detected at the protocol-message layer in
  Phase 1B; the bridge merely reduces 256-bit input to the 64-bit
  width \`SelectCoordinator\` needs.)
- [ ] Reviewer confirms the \`Coordinator\` interface scope is
  appropriate for Phase 3.1 (state surface only). Phase 3.2 will
  extend with \`TransitionMessage\` types.

Refs RFC-21 Phase 3 (\`docs/rfc/rfc-21-*\`). Stacked at the integration
tip after #3967 merged.