### PR TITLE
feat(frost/roast): RFC-21 Phase 3.2 -- TransitionMessage + LocalEvidenceSnapshot

### DIFF
--- a/pkg/frost/roast/transition_message.go
+++ b/pkg/frost/roast/transition_message.go
@@ -1,0 +1,299 @@
+package roast
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// roastMessageTypePrefix is the per-protocol prefix every ROAST-layer
+// wire message uses for its net.TaggedUnmarshaler Type(). Distinct
+// from frost_signing/native_frost/ and frost_signing/native_tbtc_signer/
+// so the network router can dispatch unambiguously.
+const roastMessageTypePrefix = "frost_signing/roast/"
+
+// LocalEvidenceSnapshotType is the stable Type() string for a single
+// signer's signed evidence snapshot.
+const LocalEvidenceSnapshotType = roastMessageTypePrefix + "local_evidence_snapshot"
+
+// TransitionMessageType is the stable Type() string for the
+// coordinator-aggregated bundle.
+const TransitionMessageType = roastMessageTypePrefix + "transition_message"
+
+// MaxSnapshotsPerBundle caps the number of LocalEvidenceSnapshot
+// entries a TransitionMessage may carry. Sized for the worst-case
+// production signing group plus headroom; rejects pathological
+// bundles at Unmarshal time so a misbehaving peer cannot exhaust
+// memory on the receiver.
+const MaxSnapshotsPerBundle = 256
+
+// MaxOperatorSignatureBytes caps the per-snapshot OperatorSignature
+// length. Sized to accept secp256k1 DER (~72 bytes), ed25519 (64
+// bytes), and reasonable post-quantum candidates without committing
+// to a specific scheme at this layer. Rejects oversize payloads.
+const MaxOperatorSignatureBytes = 256
+
+// MaxCoordinatorSignatureBytes caps the bundle-level
+// CoordinatorSignature. Same justification as
+// MaxOperatorSignatureBytes.
+const MaxCoordinatorSignatureBytes = 256
+
+// OverflowEntry is the JSON-friendly key/value pair representing one
+// per-sender overflow count from an attempt.Evidence map. The slice
+// representation is canonical (sorted by Sender ascending) so any
+// two honest signers serialising the same evidence produce
+// byte-identical JSON.
+type OverflowEntry struct {
+	Sender group.MemberIndex `json:"sender"`
+	Count  uint              `json:"count"`
+}
+
+// LocalEvidenceSnapshot is the per-signer signed evidence produced
+// during a single attempt. It is the input to the coordinator's
+// aggregation and to the receiver-side bundle verification.
+//
+// Phase 3.2 (this file) defines the wire type only. Signature
+// computation and verification land in Phase 3.3.
+type LocalEvidenceSnapshot struct {
+	SenderIDValue uint32 `json:"senderID"`
+	// AttemptContextHash binds the snapshot to the attempt the
+	// evidence describes. Always exactly 32 bytes.
+	AttemptContextHash []byte `json:"attemptContextHash"`
+	// Overflows is the canonical sorted form of the
+	// attempt.Evidence.Overflows map; sorted ascending by Sender.
+	// Omitted when no overflow events were observed.
+	Overflows []OverflowEntry `json:"overflows,omitempty"`
+	// OperatorSignature is the signer's operator-key signature over
+	// the canonical encoding of (senderID, attemptContextHash,
+	// overflows). Phase 3.3 defines the canonical-encoding
+	// algorithm and the verification routine. Phase 3.2 treats this
+	// field as opaque bytes with a length cap.
+	OperatorSignature []byte `json:"operatorSignature,omitempty"`
+}
+
+// NewLocalEvidenceSnapshot converts an attempt.Evidence map into a
+// LocalEvidenceSnapshot ready for signing and broadcast. The
+// resulting snapshot's Overflows field is sorted ascending by
+// Sender for deterministic JSON encoding. The OperatorSignature is
+// left empty -- the caller must sign and populate it (Phase 3.3).
+func NewLocalEvidenceSnapshot(
+	sender group.MemberIndex,
+	attemptContextHash [attempt.MessageDigestLength]byte,
+	evidence attempt.Evidence,
+) *LocalEvidenceSnapshot {
+	overflows := make([]OverflowEntry, 0, len(evidence.Overflows))
+	for s, c := range evidence.Overflows {
+		overflows = append(overflows, OverflowEntry{Sender: s, Count: c})
+	}
+	sort.Slice(overflows, func(i, j int) bool {
+		return overflows[i].Sender < overflows[j].Sender
+	})
+	return &LocalEvidenceSnapshot{
+		SenderIDValue:      uint32(sender),
+		AttemptContextHash: append([]byte{}, attemptContextHash[:]...),
+		Overflows:          overflows,
+	}
+}
+
+// SenderID returns the snapshot's sender as a group.MemberIndex.
+func (s *LocalEvidenceSnapshot) SenderID() group.MemberIndex {
+	return group.MemberIndex(s.SenderIDValue)
+}
+
+// AttemptContextHashArray returns the 32-byte attempt context hash
+// as a fixed-size array. Returns the zero array if the field is
+// malformed (caller should have validated via Unmarshal first).
+func (s *LocalEvidenceSnapshot) AttemptContextHashArray() [attempt.MessageDigestLength]byte {
+	var out [attempt.MessageDigestLength]byte
+	if len(s.AttemptContextHash) == attempt.MessageDigestLength {
+		copy(out[:], s.AttemptContextHash)
+	}
+	return out
+}
+
+// Evidence reconstructs the attempt.Evidence map form from the
+// canonical sorted-slice representation. The returned Evidence
+// shares no state with the snapshot.
+func (s *LocalEvidenceSnapshot) Evidence() attempt.Evidence {
+	out := attempt.Evidence{
+		Overflows: make(map[group.MemberIndex]uint, len(s.Overflows)),
+	}
+	for _, e := range s.Overflows {
+		out.Overflows[e.Sender] = e.Count
+	}
+	return out
+}
+
+// Type implements net.TaggedUnmarshaler.
+func (s *LocalEvidenceSnapshot) Type() string {
+	return LocalEvidenceSnapshotType
+}
+
+// Marshal serialises the snapshot to canonical JSON. The Overflows
+// slice is sorted by Sender ascending in NewLocalEvidenceSnapshot
+// so two honest signers with the same evidence produce
+// byte-identical bytes.
+func (s *LocalEvidenceSnapshot) Marshal() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// Unmarshal parses canonical JSON into the snapshot and validates
+// the resulting structure.
+func (s *LocalEvidenceSnapshot) Unmarshal(data []byte) error {
+	if err := json.Unmarshal(data, s); err != nil {
+		return err
+	}
+	return s.validate()
+}
+
+func (s *LocalEvidenceSnapshot) validate() error {
+	if s.SenderIDValue == 0 {
+		return errors.New("local evidence snapshot: senderID is zero")
+	}
+	if len(s.AttemptContextHash) != attempt.MessageDigestLength {
+		return fmt.Errorf(
+			"local evidence snapshot: attemptContextHash length [%d], expected [%d]",
+			len(s.AttemptContextHash),
+			attempt.MessageDigestLength,
+		)
+	}
+	if len(s.OperatorSignature) > MaxOperatorSignatureBytes {
+		return fmt.Errorf(
+			"local evidence snapshot: operatorSignature length [%d] exceeds cap [%d]",
+			len(s.OperatorSignature),
+			MaxOperatorSignatureBytes,
+		)
+	}
+	for i := 1; i < len(s.Overflows); i++ {
+		if s.Overflows[i].Sender <= s.Overflows[i-1].Sender {
+			return fmt.Errorf(
+				"local evidence snapshot: overflows not sorted ascending or contain duplicate at index %d",
+				i,
+			)
+		}
+	}
+	return nil
+}
+
+// TransitionMessage is the coordinator-aggregated bundle that drives
+// the deterministic NextAttempt transition. It contains every
+// participating signer's signed evidence snapshot for one attempt,
+// plus the coordinator's own signature over the canonical bundle.
+//
+// Phase 3.2 (this file) defines the wire type. Aggregation,
+// canonical encoding, and verification land in Phase 3.3.
+type TransitionMessage struct {
+	// AttemptContextHash identifies the attempt the bundle
+	// describes. Must match every snapshot's AttemptContextHash.
+	// Always exactly 32 bytes.
+	AttemptContextHash []byte `json:"attemptContextHash"`
+	// CoordinatorIDValue is the member index of the elected
+	// coordinator that produced this bundle.
+	CoordinatorIDValue uint32 `json:"coordinatorID"`
+	// Bundle is the canonical sorted-by-SenderID list of signed
+	// evidence snapshots aggregated by the coordinator.
+	Bundle []LocalEvidenceSnapshot `json:"bundle"`
+	// CoordinatorSignature is the coordinator's operator-key
+	// signature over the canonical encoding of the bundle. Phase
+	// 3.3 defines the canonical-encoding algorithm and the
+	// verification routine. Phase 3.2 treats this field as opaque
+	// bytes with a length cap.
+	CoordinatorSignature []byte `json:"coordinatorSignature,omitempty"`
+}
+
+// CoordinatorID returns the coordinator member index as a
+// group.MemberIndex.
+func (m *TransitionMessage) CoordinatorID() group.MemberIndex {
+	return group.MemberIndex(m.CoordinatorIDValue)
+}
+
+// AttemptContextHashArray returns the 32-byte attempt context hash
+// as a fixed-size array. Returns the zero array if the field is
+// malformed (caller should have validated via Unmarshal first).
+func (m *TransitionMessage) AttemptContextHashArray() [attempt.MessageDigestLength]byte {
+	var out [attempt.MessageDigestLength]byte
+	if len(m.AttemptContextHash) == attempt.MessageDigestLength {
+		copy(out[:], m.AttemptContextHash)
+	}
+	return out
+}
+
+// Type implements net.TaggedUnmarshaler.
+func (m *TransitionMessage) Type() string {
+	return TransitionMessageType
+}
+
+// Marshal serialises the message to canonical JSON.
+func (m *TransitionMessage) Marshal() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// Unmarshal parses canonical JSON into the message and validates
+// the structure: hash length, bundle size cap, signature size cap,
+// snapshot validity, bundle ordering by SenderID ascending, and
+// every snapshot binding to the same AttemptContextHash as the
+// bundle.
+func (m *TransitionMessage) Unmarshal(data []byte) error {
+	if err := json.Unmarshal(data, m); err != nil {
+		return err
+	}
+	return m.validate()
+}
+
+func (m *TransitionMessage) validate() error {
+	if len(m.AttemptContextHash) != attempt.MessageDigestLength {
+		return fmt.Errorf(
+			"transition message: attemptContextHash length [%d], expected [%d]",
+			len(m.AttemptContextHash),
+			attempt.MessageDigestLength,
+		)
+	}
+	if m.CoordinatorIDValue == 0 {
+		return errors.New("transition message: coordinatorID is zero")
+	}
+	if len(m.Bundle) == 0 {
+		return errors.New("transition message: bundle must not be empty")
+	}
+	if len(m.Bundle) > MaxSnapshotsPerBundle {
+		return fmt.Errorf(
+			"transition message: bundle length [%d] exceeds cap [%d]",
+			len(m.Bundle),
+			MaxSnapshotsPerBundle,
+		)
+	}
+	if len(m.CoordinatorSignature) > MaxCoordinatorSignatureBytes {
+		return fmt.Errorf(
+			"transition message: coordinatorSignature length [%d] exceeds cap [%d]",
+			len(m.CoordinatorSignature),
+			MaxCoordinatorSignatureBytes,
+		)
+	}
+	for i := range m.Bundle {
+		if err := m.Bundle[i].validate(); err != nil {
+			return fmt.Errorf(
+				"transition message: bundle[%d] invalid: %w",
+				i, err,
+			)
+		}
+		if !bytes.Equal(m.Bundle[i].AttemptContextHash, m.AttemptContextHash) {
+			return fmt.Errorf(
+				"transition message: bundle[%d] attempt context hash does not match bundle hash",
+				i,
+			)
+		}
+		if i > 0 {
+			if m.Bundle[i].SenderIDValue <= m.Bundle[i-1].SenderIDValue {
+				return fmt.Errorf(
+					"transition message: bundle not sorted ascending by senderID or contains duplicate at index %d",
+					i,
+				)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/frost/roast/transition_message_test.go
+++ b/pkg/frost/roast/transition_message_test.go
@@ -1,0 +1,381 @@
+package roast
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+var pinnedContextHash = [attempt.MessageDigestLength]byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+func TestLocalEvidenceSnapshot_TypeIsStable(t *testing.T) {
+	s := &LocalEvidenceSnapshot{}
+	if got := s.Type(); got != LocalEvidenceSnapshotType {
+		t.Fatalf("Type() = %q, want %q", got, LocalEvidenceSnapshotType)
+	}
+	if !strings.HasPrefix(LocalEvidenceSnapshotType, roastMessageTypePrefix) {
+		t.Fatalf(
+			"Type() must be under the %q prefix; got %q",
+			roastMessageTypePrefix, LocalEvidenceSnapshotType,
+		)
+	}
+}
+
+func TestNewLocalEvidenceSnapshot_SortsOverflows(t *testing.T) {
+	evidence := attempt.Evidence{
+		Overflows: map[group.MemberIndex]uint{
+			5: 3,
+			1: 2,
+			3: 1,
+		},
+	}
+	s := NewLocalEvidenceSnapshot(7, pinnedContextHash, evidence)
+
+	if len(s.Overflows) != 3 {
+		t.Fatalf("expected 3 overflow entries, got %d", len(s.Overflows))
+	}
+	for i := 1; i < len(s.Overflows); i++ {
+		if s.Overflows[i].Sender <= s.Overflows[i-1].Sender {
+			t.Fatalf(
+				"overflows not sorted ascending at index %d: %v",
+				i, s.Overflows,
+			)
+		}
+	}
+	if s.SenderIDValue != 7 {
+		t.Fatalf("SenderIDValue = %d, want 7", s.SenderIDValue)
+	}
+	if !bytes.Equal(s.AttemptContextHash, pinnedContextHash[:]) {
+		t.Fatalf(
+			"AttemptContextHash mismatch: got %x want %x",
+			s.AttemptContextHash, pinnedContextHash[:],
+		)
+	}
+}
+
+func TestNewLocalEvidenceSnapshot_EmptyEvidenceOmitsOverflows(t *testing.T) {
+	s := NewLocalEvidenceSnapshot(1, pinnedContextHash, attempt.Evidence{
+		Overflows: map[group.MemberIndex]uint{},
+	})
+	if len(s.Overflows) != 0 {
+		t.Fatalf("expected empty overflows, got %v", s.Overflows)
+	}
+	data, err := s.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "overflows") {
+		t.Fatalf(
+			"empty overflows should be omitted by omitempty; got JSON: %s",
+			string(data),
+		)
+	}
+}
+
+func TestLocalEvidenceSnapshot_RoundTrip(t *testing.T) {
+	original := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{
+		Overflows: map[group.MemberIndex]uint{
+			1: 2,
+			3: 1,
+			5: 3,
+		},
+	})
+	original.OperatorSignature = bytes.Repeat([]byte{0xab}, 64)
+
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	decoded := &LocalEvidenceSnapshot{}
+	if err := decoded.Unmarshal(data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.SenderIDValue != original.SenderIDValue {
+		t.Fatalf("sender mismatch")
+	}
+	if !bytes.Equal(decoded.AttemptContextHash, original.AttemptContextHash) {
+		t.Fatalf("attempt context hash mismatch")
+	}
+	if len(decoded.Overflows) != len(original.Overflows) {
+		t.Fatalf(
+			"overflow length mismatch: %d vs %d",
+			len(decoded.Overflows), len(original.Overflows),
+		)
+	}
+	if !bytes.Equal(decoded.OperatorSignature, original.OperatorSignature) {
+		t.Fatalf("signature mismatch")
+	}
+}
+
+func TestLocalEvidenceSnapshot_RejectsZeroSender(t *testing.T) {
+	s := &LocalEvidenceSnapshot{
+		SenderIDValue:      0,
+		AttemptContextHash: pinnedContextHash[:],
+	}
+	data, _ := json.Marshal(s)
+	err := (&LocalEvidenceSnapshot{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "senderID is zero") {
+		t.Fatalf("expected zero-sender error, got %v", err)
+	}
+}
+
+func TestLocalEvidenceSnapshot_RejectsWrongHashLength(t *testing.T) {
+	bad := []byte(`{
+		"senderID": 1,
+		"attemptContextHash": "AAEC"
+	}`)
+	err := (&LocalEvidenceSnapshot{}).Unmarshal(bad)
+	if err == nil || !strings.Contains(err.Error(), "attemptContextHash length") {
+		t.Fatalf("expected hash-length error, got %v", err)
+	}
+}
+
+func TestLocalEvidenceSnapshot_RejectsOversizeSignature(t *testing.T) {
+	s := NewLocalEvidenceSnapshot(1, pinnedContextHash, attempt.Evidence{})
+	s.OperatorSignature = bytes.Repeat([]byte{0xff}, MaxOperatorSignatureBytes+1)
+	data, _ := json.Marshal(s)
+	err := (&LocalEvidenceSnapshot{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "exceeds cap") {
+		t.Fatalf("expected signature-cap error, got %v", err)
+	}
+}
+
+func TestLocalEvidenceSnapshot_RejectsUnsortedOverflows(t *testing.T) {
+	bad := &LocalEvidenceSnapshot{
+		SenderIDValue:      1,
+		AttemptContextHash: pinnedContextHash[:],
+		Overflows: []OverflowEntry{
+			{Sender: 5, Count: 1},
+			{Sender: 1, Count: 1},
+		},
+	}
+	data, _ := json.Marshal(bad)
+	err := (&LocalEvidenceSnapshot{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "not sorted") {
+		t.Fatalf("expected sort error, got %v", err)
+	}
+}
+
+func TestLocalEvidenceSnapshot_RejectsDuplicateOverflowSender(t *testing.T) {
+	bad := &LocalEvidenceSnapshot{
+		SenderIDValue:      1,
+		AttemptContextHash: pinnedContextHash[:],
+		Overflows: []OverflowEntry{
+			{Sender: 3, Count: 1},
+			{Sender: 3, Count: 1},
+		},
+	}
+	data, _ := json.Marshal(bad)
+	err := (&LocalEvidenceSnapshot{}).Unmarshal(data)
+	if err == nil {
+		t.Fatal("expected duplicate-sender error")
+	}
+}
+
+func TestLocalEvidenceSnapshot_EvidenceReconstructsMap(t *testing.T) {
+	original := attempt.Evidence{
+		Overflows: map[group.MemberIndex]uint{1: 2, 3: 4},
+	}
+	s := NewLocalEvidenceSnapshot(7, pinnedContextHash, original)
+	got := s.Evidence()
+	if len(got.Overflows) != len(original.Overflows) {
+		t.Fatalf(
+			"map size mismatch: got %d want %d",
+			len(got.Overflows), len(original.Overflows),
+		)
+	}
+	for k, v := range original.Overflows {
+		if got.Overflows[k] != v {
+			t.Fatalf("overflow[%d]: got %d want %d", k, got.Overflows[k], v)
+		}
+	}
+}
+
+func TestLocalEvidenceSnapshot_AttemptContextHashArrayHandlesMalformed(t *testing.T) {
+	s := &LocalEvidenceSnapshot{AttemptContextHash: []byte{0x01, 0x02}}
+	arr := s.AttemptContextHashArray()
+	var zero [attempt.MessageDigestLength]byte
+	if arr != zero {
+		t.Fatalf("expected zero array for malformed hash, got %x", arr)
+	}
+}
+
+func TestTransitionMessage_TypeIsStable(t *testing.T) {
+	m := &TransitionMessage{}
+	if got := m.Type(); got != TransitionMessageType {
+		t.Fatalf("Type() = %q, want %q", got, TransitionMessageType)
+	}
+	if !strings.HasPrefix(TransitionMessageType, roastMessageTypePrefix) {
+		t.Fatalf("type prefix mismatch: %q", TransitionMessageType)
+	}
+}
+
+func TestTransitionMessage_RoundTrip(t *testing.T) {
+	m := buildValidTransitionMessage()
+	data, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	decoded := &TransitionMessage{}
+	if err := decoded.Unmarshal(data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.CoordinatorIDValue != m.CoordinatorIDValue {
+		t.Fatalf("coordinator id mismatch")
+	}
+	if len(decoded.Bundle) != len(m.Bundle) {
+		t.Fatalf(
+			"bundle size mismatch: %d vs %d",
+			len(decoded.Bundle), len(m.Bundle),
+		)
+	}
+	for i := range decoded.Bundle {
+		if decoded.Bundle[i].SenderIDValue != m.Bundle[i].SenderIDValue {
+			t.Fatalf("bundle[%d] sender mismatch", i)
+		}
+	}
+}
+
+func TestTransitionMessage_RejectsBadBundleOrdering(t *testing.T) {
+	m := buildValidTransitionMessage()
+	// Swap order to make it unsorted.
+	m.Bundle[0], m.Bundle[1] = m.Bundle[1], m.Bundle[0]
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "not sorted") {
+		t.Fatalf("expected sort error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsMismatchedBundleHash(t *testing.T) {
+	m := buildValidTransitionMessage()
+	// Mutate the first bundled snapshot's hash so it disagrees
+	// with the bundle-level hash.
+	m.Bundle[0].AttemptContextHash = make([]byte, attempt.MessageDigestLength)
+	for i := range m.Bundle[0].AttemptContextHash {
+		m.Bundle[0].AttemptContextHash[i] = 0xff
+	}
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "does not match bundle hash") {
+		t.Fatalf("expected hash-mismatch error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsEmptyBundle(t *testing.T) {
+	m := buildValidTransitionMessage()
+	m.Bundle = nil
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "must not be empty") {
+		t.Fatalf("expected empty-bundle error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsOversizeBundle(t *testing.T) {
+	m := buildValidTransitionMessage()
+	// Grow bundle beyond the cap by duplicating with monotonically
+	// increasing senders.
+	m.Bundle = make([]LocalEvidenceSnapshot, MaxSnapshotsPerBundle+1)
+	for i := range m.Bundle {
+		m.Bundle[i] = LocalEvidenceSnapshot{
+			SenderIDValue:      uint32(i + 1),
+			AttemptContextHash: append([]byte{}, m.AttemptContextHash...),
+		}
+	}
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "exceeds cap") {
+		t.Fatalf("expected oversize-bundle error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsZeroCoordinatorID(t *testing.T) {
+	m := buildValidTransitionMessage()
+	m.CoordinatorIDValue = 0
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "coordinatorID is zero") {
+		t.Fatalf("expected zero-coordinator error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsOversizeCoordinatorSignature(t *testing.T) {
+	m := buildValidTransitionMessage()
+	m.CoordinatorSignature = bytes.Repeat([]byte{0xff}, MaxCoordinatorSignatureBytes+1)
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "exceeds cap") {
+		t.Fatalf("expected oversize-signature error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsBundleWithInvalidSnapshot(t *testing.T) {
+	m := buildValidTransitionMessage()
+	m.Bundle[0].SenderIDValue = 0
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil || !strings.Contains(err.Error(), "senderID is zero") {
+		t.Fatalf("expected invalid-snapshot error, got %v", err)
+	}
+}
+
+func TestTransitionMessage_RejectsDuplicateBundleSender(t *testing.T) {
+	m := buildValidTransitionMessage()
+	m.Bundle[1].SenderIDValue = m.Bundle[0].SenderIDValue
+	data, _ := json.Marshal(m)
+	err := (&TransitionMessage{}).Unmarshal(data)
+	if err == nil {
+		t.Fatal("expected duplicate-sender error")
+	}
+}
+
+func TestTransitionMessage_DeterministicJSONForIdenticalInputs(t *testing.T) {
+	a := buildValidTransitionMessage()
+	b := buildValidTransitionMessage()
+	dataA, err := a.Marshal()
+	if err != nil {
+		t.Fatalf("marshal a: %v", err)
+	}
+	dataB, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("marshal b: %v", err)
+	}
+	if !bytes.Equal(dataA, dataB) {
+		t.Fatalf(
+			"identical inputs produced different JSON:\n a=%s\n b=%s",
+			string(dataA), string(dataB),
+		)
+	}
+}
+
+func buildValidTransitionMessage() *TransitionMessage {
+	mkSnap := func(sender group.MemberIndex) LocalEvidenceSnapshot {
+		return LocalEvidenceSnapshot{
+			SenderIDValue:      uint32(sender),
+			AttemptContextHash: append([]byte{}, pinnedContextHash[:]...),
+			Overflows: []OverflowEntry{
+				{Sender: 99, Count: 1},
+			},
+		}
+	}
+	return &TransitionMessage{
+		AttemptContextHash: append([]byte{}, pinnedContextHash[:]...),
+		CoordinatorIDValue: 1,
+		Bundle: []LocalEvidenceSnapshot{
+			mkSnap(1),
+			mkSnap(2),
+			mkSnap(3),
+		},
+		CoordinatorSignature: bytes.Repeat([]byte{0xee}, 64),
+	}
+}


### PR DESCRIPTION
## Summary

Second Phase-3 implementation PR. Adds the wire types the
coordinator-aggregation flow (RFC-21 Resolved Decisions) needs:

- **\`LocalEvidenceSnapshot\`** — per-signer signed evidence carrying
  \`SenderID\`, \`AttemptContextHash\`, the canonical sorted
  \`OverflowEntry\` slice, and an \`OperatorSignature\` placeholder.
- **\`TransitionMessage\`** — coordinator-aggregated bundle carrying the
  attempt context hash, the elected coordinator's member index, a
  \`SenderID\`-ascending \`Bundle\` of snapshots, and a
  \`CoordinatorSignature\` placeholder.
- **\`OverflowEntry\`** — JSON-friendly canonical key/value pair for one
  \`attempt.Evidence.Overflows\` entry.

**No transport, aggregation, or signature handling yet.** Phase 3.2 is
the wire-type slice only. Phase 3.3 introduces the canonical-encoding
contract those signatures cover plus the aggregate / verify routines.

Stacked on #3968 (Phase 3.1).

## Why this scope

The RFC's Phase 3 work was always going to mix \"new types\" with
\"new behaviour over those types.\" Landing the types first means
Phase 3.3 reviews can focus on the canonical-encoding /
signature-verification logic without rereading the JSON shapes.
Types are small, mechanical, and review-easy.

## What's in the bundle

| Surface | Notes |
|---|---|
| \`LocalEvidenceSnapshot\` | \`SenderIDValue\`, \`AttemptContextHash\` (32 bytes exact), \`Overflows\` (sorted asc by Sender), \`OperatorSignature\` (≤ 256 bytes). |
| \`TransitionMessage\` | \`AttemptContextHash\` (32 bytes exact), \`CoordinatorIDValue\`, \`Bundle\` (sorted asc by Sender, ≤ 256 entries, each binding to the bundle's hash), \`CoordinatorSignature\` (≤ 256 bytes). |
| \`OverflowEntry\` | \`{Sender, Count}\`. |
| Type prefix | \`frost_signing/roast/\` -- distinct from \`native_frost\` / \`native_tbtc_signer\`. |
| Validation in Unmarshal | zero-sender, 32-byte hash, max-snapshots cap, max-signature caps, ordering, intra-bundle hash consistency, snapshot validity. |

## Why JSON

Per RFC-21 Resolved Decision 6: matches Phase 1B's FROST/tbtc-signer
protocol messages and inherits envelope-level operator-key signing
from \`pkg/net\`. Raw JSON never lands on the wire; the messages
implement \`net.TaggedUnmarshaler\` and ride the existing \`pkg/net/gen/pb\`
envelope when sent.

## Test coverage

22 cases across two test surfaces. Highlights:

- Type strings are stable and under the \`frost_signing/roast/\`
  prefix.
- \`NewLocalEvidenceSnapshot\` sorts \`Overflows\` ascending by Sender;
  empty evidence omits the field via \`omitempty\`.
- JSON round-trips preserve all fields.
- Validation rejects every malformed shape: zero sender, wrong
  hash length, oversize signature, unsorted overflows, duplicate
  overflow sender, empty bundle, oversize bundle, zero
  coordinator, oversize coordinator signature, invalid contained
  snapshot, duplicate bundle sender, mismatched bundle-vs-snapshot
  hash.
- Identical inputs produce byte-identical JSON (deterministic
  canonical form).

## Phase 3 status

| PR | Scope | State |
|---|---|---|
| 3.1 (#3968) | Coordinator skeleton + seed bridge | open |
| **3.2 (this)** | **TransitionMessage + LocalEvidenceSnapshot types** | **open** |
| 3.3 | Aggregation + bundle verification | next |
| 3.4 | NextAttempt policy + thresholds | after 3.3 |

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/roast/...\` | pass (29 cases total in this package now) |
| \`go test -race ./pkg/frost/roast/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/roast/...\` | silent |
| \`go vet ./pkg/frost/roast/...\` | clean |
| \`gofmt -l ./pkg/frost/roast/\` | silent |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the size caps (\`MaxSnapshotsPerBundle = 256\`,
  \`MaxOperatorSignatureBytes = 256\`, \`MaxCoordinatorSignatureBytes = 256\`)
  are appropriate ceilings for production signing groups.
- [ ] Reviewer confirms the deferred-signature contract is
  acceptable for Phase 3.2 -- signature computation/verification
  lands in Phase 3.3.