### PR TITLE
feat(frost/roast): RFC-21 Phase 3.3 -- aggregation + bundle verification

### DIFF
--- a/pkg/frost/roast/bundle_aggregation_test.go
+++ b/pkg/frost/roast/bundle_aggregation_test.go
@@ -1,0 +1,564 @@
+package roast
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// pickNonCoordinatorMember returns the first member of `set` that is
+// not equal to `elected`. Fatals if no such member exists. Used by
+// receiver-side tests that need a member distinct from the
+// aggregator.
+func pickNonCoordinatorMember(
+	t *testing.T,
+	set []group.MemberIndex,
+	elected group.MemberIndex,
+) group.MemberIndex {
+	t.Helper()
+	for _, m := range set {
+		if m != elected {
+			return m
+		}
+	}
+	t.Fatalf("no non-coordinator member available; set=%v elected=%d", set, elected)
+	return 0
+}
+
+// signSnapshotForTest mints a fakeSigner signature on a snapshot and
+// stores it on the snapshot's OperatorSignature field. Returns the
+// snapshot for chaining.
+func signSnapshotForTest(
+	t *testing.T,
+	snap *LocalEvidenceSnapshot,
+) *LocalEvidenceSnapshot {
+	t.Helper()
+	signer := &fakeSigner{id: snap.SenderID()}
+	payload, err := CanonicalSnapshotBytes(snap)
+	if err != nil {
+		t.Fatalf("canonical: %v", err)
+	}
+	sig, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	snap.OperatorSignature = sig
+	return snap
+}
+
+// newSignedCoordinatorForMember returns an inMemoryCoordinator wired
+// for the named member to act as self -- meaning AggregateBundle is
+// only callable when that member is the elected coordinator for the
+// attempt under test.
+func newSignedCoordinatorForMember(
+	self group.MemberIndex,
+) *inMemoryCoordinator {
+	return NewInMemoryCoordinatorWithSigning(
+		self,
+		&fakeSigner{id: self},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+}
+
+func TestRecordEvidence_RejectsNilSnapshot(t *testing.T) {
+	c := newSignedCoordinatorForMember(0)
+	handle, err := c.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := c.RecordEvidence(handle, nil); err == nil {
+		t.Fatal("expected nil snapshot error")
+	}
+}
+
+func TestRecordEvidence_RejectsUnknownHandle(t *testing.T) {
+	c := newSignedCoordinatorForMember(0)
+	snap := signSnapshotForTest(t, NewLocalEvidenceSnapshot(1, pinnedContextHash, attempt.Evidence{}))
+	bogus := AttemptHandle{id: 999}
+	err := c.RecordEvidence(bogus, snap)
+	if !errors.Is(err, ErrUnknownAttempt) {
+		t.Fatalf("expected ErrUnknownAttempt, got %v", err)
+	}
+}
+
+func TestRecordEvidence_RejectsContextHashMismatch(t *testing.T) {
+	c := newSignedCoordinatorForMember(0)
+	handle, err := c.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Build a snapshot bound to a *different* context hash.
+	wrongHash := [attempt.MessageDigestLength]byte{0xff}
+	snap := signSnapshotForTest(t, NewLocalEvidenceSnapshot(1, wrongHash, attempt.Evidence{}))
+	if err := c.RecordEvidence(handle, snap); !errors.Is(err, ErrAttemptContextMismatch) {
+		t.Fatalf("expected ErrAttemptContextMismatch, got %v", err)
+	}
+}
+
+func TestRecordEvidence_RejectsBadSignature(t *testing.T) {
+	c := newSignedCoordinatorForMember(0)
+	ctx := newTestContext(t)
+	handle, err := c.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	snap := NewLocalEvidenceSnapshot(1, ctx.Hash(), attempt.Evidence{})
+	snap.OperatorSignature = []byte{0xff, 0xee}
+	err = c.RecordEvidence(handle, snap)
+	if !errors.Is(err, ErrSignatureInvalid) {
+		t.Fatalf("expected ErrSignatureInvalid, got %v", err)
+	}
+}
+
+func TestRecordEvidence_AcceptsValidSnapshotAndIsIdempotent(t *testing.T) {
+	c := newSignedCoordinatorForMember(0)
+	ctx := newTestContext(t)
+	handle, err := c.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	snap := signSnapshotForTest(
+		t,
+		NewLocalEvidenceSnapshot(1, ctx.Hash(), attempt.Evidence{}),
+	)
+	if err := c.RecordEvidence(handle, snap); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	// Identical re-submission must be idempotent.
+	if err := c.RecordEvidence(handle, snap); err != nil {
+		t.Fatalf("idempotent re-record: %v", err)
+	}
+}
+
+func TestRecordEvidence_RejectsConflict(t *testing.T) {
+	c := newSignedCoordinatorForMember(0)
+	ctx := newTestContext(t)
+	handle, err := c.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	first := signSnapshotForTest(
+		t,
+		NewLocalEvidenceSnapshot(1, ctx.Hash(), attempt.Evidence{}),
+	)
+	if err := c.RecordEvidence(handle, first); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	// Same sender, different evidence -> conflict.
+	conflicting := signSnapshotForTest(
+		t,
+		NewLocalEvidenceSnapshot(1, ctx.Hash(), attempt.Evidence{
+			Overflows: map[group.MemberIndex]uint{5: 3},
+		}),
+	)
+	if err := c.RecordEvidence(handle, conflicting); !errors.Is(err, ErrSnapshotConflict) {
+		t.Fatalf("expected ErrSnapshotConflict, got %v", err)
+	}
+}
+
+func TestRecordEvidence_TracksSelfSubmission(t *testing.T) {
+	const self group.MemberIndex = 3
+	c := newSignedCoordinatorForMember(self)
+	ctx := newTestContext(t)
+	handle, err := c.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	selfSnap := signSnapshotForTest(
+		t,
+		NewLocalEvidenceSnapshot(self, ctx.Hash(), attempt.Evidence{}),
+	)
+	if err := c.RecordEvidence(handle, selfSnap); err != nil {
+		t.Fatalf("record self: %v", err)
+	}
+	record := c.attempts[handle.id]
+	if record.selfSubmission == nil {
+		t.Fatal("expected selfSubmission to be set")
+	}
+	if record.selfSubmission.SenderID() != self {
+		t.Fatalf("self submission member mismatch: got %d", record.selfSubmission.SenderID())
+	}
+}
+
+func TestAggregateBundle_RejectsNonAggregator(t *testing.T) {
+	// Two coordinator instances, both begin the same attempt. Only
+	// the elected one can aggregate. We force the election by
+	// building a context where SelectCoordinator will pick member 1.
+	c := NewInMemoryCoordinatorWithSigning(99, &fakeSigner{id: 99}, fakeVerifier{}).(*inMemoryCoordinator)
+	handle, err := c.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// member 99 is not in the IncludedSet, so it cannot be the
+	// elected coordinator.
+	_, err = c.AggregateBundle(handle)
+	if !errors.Is(err, ErrNotAggregator) {
+		t.Fatalf("expected ErrNotAggregator, got %v", err)
+	}
+}
+
+func TestAggregateBundle_BuildsSignedBundle(t *testing.T) {
+	// Pick the elected coordinator: run BeginAttempt once with a
+	// throwaway coordinator instance to discover the elected member,
+	// then build a real coordinator bound to that self.
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	c := newSignedCoordinatorForMember(elected)
+	handle, err := c.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Record snapshots from every included member.
+	for _, m := range ctx.IncludedSet {
+		snap := signSnapshotForTest(
+			t,
+			NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+		)
+		if err := c.RecordEvidence(handle, snap); err != nil {
+			t.Fatalf("record %d: %v", m, err)
+		}
+	}
+	bundle, err := c.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	if len(bundle.Bundle) != len(ctx.IncludedSet) {
+		t.Fatalf(
+			"bundle size: got %d want %d",
+			len(bundle.Bundle), len(ctx.IncludedSet),
+		)
+	}
+	for i := 1; i < len(bundle.Bundle); i++ {
+		if bundle.Bundle[i].SenderIDValue <= bundle.Bundle[i-1].SenderIDValue {
+			t.Fatalf("bundle not sorted ascending at %d", i)
+		}
+	}
+	if bundle.CoordinatorID() != elected {
+		t.Fatalf("bundle coordinator id %d != elected %d", bundle.CoordinatorID(), elected)
+	}
+	if len(bundle.CoordinatorSignature) == 0 {
+		t.Fatal("expected coordinator signature to be populated")
+	}
+	state, _ := c.State(handle)
+	if state != AttemptStateTransitioned {
+		t.Fatalf("expected state Transitioned, got %v", state)
+	}
+}
+
+func TestAggregateBundle_ProducesDeterministicBundleAcrossOrderings(t *testing.T) {
+	// Two coordinators aggregate the same evidence in different
+	// arrival orders. The resulting bundles must be byte-identical
+	// after JSON marshal.
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	make := func(
+		t *testing.T,
+		recordOrder []group.MemberIndex,
+	) []byte {
+		t.Helper()
+		c := newSignedCoordinatorForMember(elected)
+		handle, err := c.BeginAttempt(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		for _, m := range recordOrder {
+			snap := signSnapshotForTest(
+				t,
+				NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+			)
+			if err := c.RecordEvidence(handle, snap); err != nil {
+				t.Fatalf("record %d: %v", m, err)
+			}
+		}
+		bundle, err := c.AggregateBundle(handle)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		data, err := bundle.Marshal()
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return data
+	}
+	ordering1 := []group.MemberIndex{1, 2, 3, 4, 5}
+	ordering2 := []group.MemberIndex{5, 3, 1, 4, 2}
+	a := make(t, ordering1)
+	b := make(t, ordering2)
+	if !bytes.Equal(a, b) {
+		t.Fatalf(
+			"identical evidence in different arrival order produced "+
+				"different bundles:\n a=%s\n b=%s",
+			string(a), string(b),
+		)
+	}
+}
+
+func TestVerifyBundle_AcceptsValidBundle(t *testing.T) {
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, err := aggregator.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("aggregator begin: %v", err)
+	}
+	for _, m := range ctx.IncludedSet {
+		snap := signSnapshotForTest(
+			t,
+			NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+		)
+		if err := aggregator.RecordEvidence(handle, snap); err != nil {
+			t.Fatalf("record %d: %v", m, err)
+		}
+	}
+	bundle, err := aggregator.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+
+	// Receiver: a different coordinator instance bound to a
+	// non-coordinator member that has not submitted its own snapshot.
+	// The receiver must accept the bundle.
+	receiverID := pickNonCoordinatorMember(t, ctx.IncludedSet, elected)
+	receiver := NewInMemoryCoordinatorWithSigning(
+		receiverID,
+		&fakeSigner{id: receiverID},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+	rh, err := receiver.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("receiver begin: %v", err)
+	}
+	if err := receiver.VerifyBundle(rh, bundle); err != nil {
+		t.Fatalf("expected verify success, got %v", err)
+	}
+}
+
+func TestVerifyBundle_DetectsCensorship(t *testing.T) {
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, err := aggregator.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("agg begin: %v", err)
+	}
+	// Record snapshots from every member EXCEPT receiverID.
+	receiverID := pickNonCoordinatorMember(t, ctx.IncludedSet, elected)
+	for _, m := range ctx.IncludedSet {
+		if m == receiverID {
+			continue
+		}
+		snap := signSnapshotForTest(
+			t,
+			NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+		)
+		if err := aggregator.RecordEvidence(handle, snap); err != nil {
+			t.Fatalf("record: %v", err)
+		}
+	}
+	bundle, err := aggregator.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+
+	// Receiver: bound to receiverID, has submitted its own snapshot,
+	// but the coordinator chose to censor it.
+	receiver := NewInMemoryCoordinatorWithSigning(
+		receiverID,
+		&fakeSigner{id: receiverID},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+	rh, err := receiver.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("receiver begin: %v", err)
+	}
+	selfSnap := signSnapshotForTest(
+		t,
+		NewLocalEvidenceSnapshot(receiverID, ctx.Hash(), attempt.Evidence{}),
+	)
+	if err := receiver.RecordEvidence(rh, selfSnap); err != nil {
+		t.Fatalf("receiver record self: %v", err)
+	}
+	err = receiver.VerifyBundle(rh, bundle)
+	if !errors.Is(err, ErrCensorshipDetected) {
+		t.Fatalf("expected ErrCensorshipDetected, got %v", err)
+	}
+}
+
+func TestVerifyBundle_DetectsCoordinatorSignatureForgery(t *testing.T) {
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, _ := aggregator.BeginAttempt(ctx)
+	for _, m := range ctx.IncludedSet {
+		_ = aggregator.RecordEvidence(handle, signSnapshotForTest(
+			t,
+			NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+		))
+	}
+	bundle, _ := aggregator.AggregateBundle(handle)
+	// Tamper: re-sign the bundle as a different (non-elected) member.
+	const wrongSigner group.MemberIndex = 99
+	bundle.CoordinatorIDValue = uint32(wrongSigner)
+	payload, _ := CanonicalBundleBytes(bundle)
+	forged, _ := (&fakeSigner{id: wrongSigner}).Sign(payload)
+	bundle.CoordinatorSignature = forged
+
+	receiver := NewInMemoryCoordinatorWithSigning(
+		7,
+		&fakeSigner{id: 7},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+	rh, _ := receiver.BeginAttempt(ctx)
+	err := receiver.VerifyBundle(rh, bundle)
+	if err == nil {
+		t.Fatal("expected verification failure")
+	}
+}
+
+func TestVerifyBundle_DetectsSnapshotSignatureForgery(t *testing.T) {
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, _ := aggregator.BeginAttempt(ctx)
+	for _, m := range ctx.IncludedSet {
+		_ = aggregator.RecordEvidence(handle, signSnapshotForTest(
+			t,
+			NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+		))
+	}
+	bundle, _ := aggregator.AggregateBundle(handle)
+
+	// Tamper: replace one snapshot's signature with garbage. The
+	// bundle's coordinator signature still validates (since the
+	// canonical bundle bytes include the snapshot signature, an
+	// integrated bundle would have detected the change at the
+	// coordinator-signature layer). For this test we re-sign the
+	// bundle with the new garbage signature so the bundle-level
+	// signature appears valid but the snapshot signature does not.
+	bundle.Bundle[0].OperatorSignature = []byte{0xde, 0xad}
+	payload, _ := CanonicalBundleBytes(bundle)
+	resign, _ := (&fakeSigner{id: elected}).Sign(payload)
+	bundle.CoordinatorSignature = resign
+
+	receiver := NewInMemoryCoordinatorWithSigning(
+		7,
+		&fakeSigner{id: 7},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+	rh, _ := receiver.BeginAttempt(ctx)
+	err := receiver.VerifyBundle(rh, bundle)
+	if !errors.Is(err, ErrSignatureInvalid) {
+		t.Fatalf("expected ErrSignatureInvalid, got %v", err)
+	}
+}
+
+func TestVerifyBundle_RejectsAttemptContextMismatch(t *testing.T) {
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, _ := aggregator.BeginAttempt(ctx)
+	for _, m := range ctx.IncludedSet {
+		_ = aggregator.RecordEvidence(handle, signSnapshotForTest(
+			t,
+			NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}),
+		))
+	}
+	bundle, _ := aggregator.AggregateBundle(handle)
+
+	receiver := NewInMemoryCoordinatorWithSigning(
+		7,
+		&fakeSigner{id: 7},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+
+	// Receiver begins a different attempt context.
+	wrongCtx, _ := attempt.NewAttemptContext(
+		"different-session",
+		"key-group-test",
+		[]byte{0xab, 0xcd, 0xef},
+		[attempt.MessageDigestLength]byte{0x42},
+		0,
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+	rh, _ := receiver.BeginAttempt(wrongCtx)
+	err := receiver.VerifyBundle(rh, bundle)
+	if !errors.Is(err, ErrAttemptContextMismatch) {
+		t.Fatalf("expected ErrAttemptContextMismatch, got %v", err)
+	}
+}
+
+func TestVerifyBundle_RejectsNilMessage(t *testing.T) {
+	c := newSignedCoordinatorForMember(7)
+	handle, _ := c.BeginAttempt(newTestContext(t))
+	if err := c.VerifyBundle(handle, nil); err == nil {
+		t.Fatal("expected error for nil message")
+	}
+}
+
+func TestVerifyBundle_RejectsUnknownAttempt(t *testing.T) {
+	c := newSignedCoordinatorForMember(7)
+	bundle := buildValidTransitionMessage()
+	bogus := AttemptHandle{id: 999}
+	if err := c.VerifyBundle(bogus, bundle); !errors.Is(err, ErrUnknownAttempt) {
+		t.Fatalf("expected ErrUnknownAttempt, got %v", err)
+	}
+}
+
+func TestCoordinator_ConcurrentRecordAndVerifyAreRaceSafe(t *testing.T) {
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, _ := aggregator.BeginAttempt(ctx)
+	var wg sync.WaitGroup
+	for _, m := range ctx.IncludedSet {
+		wg.Add(1)
+		mLocal := m
+		go func() {
+			defer wg.Done()
+			snap := signSnapshotForTest(t, NewLocalEvidenceSnapshot(mLocal, ctx.Hash(), attempt.Evidence{}))
+			if err := aggregator.RecordEvidence(handle, snap); err != nil {
+				t.Errorf("concurrent record %d: %v", mLocal, err)
+			}
+		}()
+	}
+	wg.Wait()
+	bundle, err := aggregator.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate after concurrent records: %v", err)
+	}
+	if len(bundle.Bundle) != len(ctx.IncludedSet) {
+		t.Fatalf(
+			"bundle size after concurrent records: got %d want %d",
+			len(bundle.Bundle), len(ctx.IncludedSet),
+		)
+	}
+}

--- a/pkg/frost/roast/coordinator_state.go
+++ b/pkg/frost/roast/coordinator_state.go
@@ -1,8 +1,10 @@
 package roast
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -82,18 +84,13 @@ func (h AttemptHandle) ContextHash() [attempt.MessageDigestLength]byte {
 // Coordinator is the ROAST coordinator state machine introduced by
 // RFC-21 Phase 3. It owns per-attempt state, the deterministic
 // participant selection (via the existing SelectCoordinator helper),
-// and -- in later Phase-3 PRs -- signed-evidence aggregation,
-// transition-message construction, and the NextAttempt policy.
+// signed-evidence aggregation, transition-message construction, and
+// -- in Phase 3.4 -- the NextAttempt policy.
 //
-// Phase 3.1 (this file) introduces only:
-//   - BeginAttempt: initialise tracking for a new attempt.
-//   - State: read the current AttemptState for a handle.
-//   - SelectedCoordinator: report the member elected as coordinator
-//     for the attempt.
-//
-// Phase 3.2 adds the TransitionMessage / LocalEvidenceSnapshot types.
-// Phase 3.3 adds AggregateBundle and VerifyBundle. Phase 3.4 adds the
-// NextAttempt policy function.
+// Phase 3.1 introduced BeginAttempt, State, and SelectedCoordinator.
+// Phase 3.3 (this commit) adds RecordEvidence, AggregateBundle, and
+// VerifyBundle.
+// Phase 3.4 will add NextAttempt.
 //
 // Implementations must be safe for concurrent calls from multiple
 // goroutines; production keep-core code paths are network-driven.
@@ -112,7 +109,65 @@ type Coordinator interface {
 	// for the attempt identified by the handle. Returns
 	// ErrUnknownAttempt if the handle is not tracked.
 	SelectedCoordinator(handle AttemptHandle) (group.MemberIndex, error)
+	// RecordEvidence stores a peer's signed LocalEvidenceSnapshot
+	// against the named attempt. The snapshot is validated for
+	// structural correctness, its OperatorSignature is verified
+	// against the configured SignatureVerifier, and its
+	// AttemptContextHash is checked to match the handle's bound
+	// context. First-write-wins / equal-or-reject semantics apply:
+	// a peer that re-submits the same byte-identical snapshot is
+	// idempotent; a peer that mutates its snapshot returns an error
+	// without overwriting the originally accepted one.
+	RecordEvidence(handle AttemptHandle, snapshot *LocalEvidenceSnapshot) error
+	// AggregateBundle is called by the elected coordinator's node
+	// to produce a TransitionMessage from the accumulated evidence
+	// snapshots. The bundle is sorted ascending by SenderID, signed
+	// with the coordinator's Signer, and the attempt state is
+	// transitioned to AttemptStateAggregating then
+	// AttemptStateTransitioned.
+	//
+	// Returns ErrNotAggregator if the caller is not the elected
+	// coordinator for the attempt (the Coordinator's selfMember
+	// must equal SelectedCoordinator(handle)).
+	AggregateBundle(handle AttemptHandle) (*TransitionMessage, error)
+	// VerifyBundle is called by every receiver of a
+	// TransitionMessage. It validates the structural invariants of
+	// the bundle, verifies the coordinator-level signature against
+	// the attempt's elected coordinator, verifies each contained
+	// snapshot's operator signature, and -- if the receiver has
+	// already submitted its own snapshot via RecordEvidence with
+	// the local Signer applied -- verifies that the receiver's own
+	// snapshot is present and byte-identical in the bundle
+	// (censorship detection).
+	//
+	// Returns ErrCensorshipDetected when the receiver's own
+	// submitted snapshot is missing or mutated. Returns
+	// ErrSignatureInvalid when any signature fails verification.
+	VerifyBundle(handle AttemptHandle, msg *TransitionMessage) error
 }
+
+// ErrNotAggregator is returned by AggregateBundle when the caller
+// is not the elected coordinator for the named attempt.
+var ErrNotAggregator = errors.New(
+	"coordinator: caller is not the elected coordinator for this attempt",
+)
+
+// ErrAttemptStateInvalid is returned when an operation is requested
+// against an attempt in a state that does not permit it (e.g.
+// AggregateBundle on an attempt already transitioned, or
+// RecordEvidence on an attempt past Collecting).
+var ErrAttemptStateInvalid = errors.New("coordinator: attempt state does not permit operation")
+
+// ErrAttemptContextMismatch is returned when a snapshot's
+// AttemptContextHash does not match the handle's bound context.
+var ErrAttemptContextMismatch = errors.New("coordinator: snapshot attempt context hash does not match attempt")
+
+// ErrSnapshotConflict is returned by RecordEvidence when a peer
+// re-submits a snapshot whose canonical bytes differ from the
+// previously-accepted snapshot for that peer in this attempt. The
+// originally accepted snapshot is retained; the new submission is
+// rejected (first-write-wins).
+var ErrSnapshotConflict = errors.New("coordinator: snapshot conflicts with previously recorded one (first-write-wins)")
 
 // ErrUnknownAttempt indicates an AttemptHandle does not correspond to
 // any attempt tracked by this Coordinator. Either the handle was
@@ -121,26 +176,58 @@ type Coordinator interface {
 var ErrUnknownAttempt = errors.New("coordinator: unknown attempt handle")
 
 // NewInMemoryCoordinator returns a Coordinator that tracks attempts
-// in-process. Phase 3 production paths use this implementation.
-// Later phases may add persistent variants once persistence is
-// designed (RFC-21 Open question on signer restart).
+// in-process with no operator-key signing wired in (NoOpSigner +
+// NoOpSignatureVerifier). Suitable for tests that exercise only the
+// structural state-machine surface; bundle verification will accept
+// any signature.
+//
+// Production Phase-4 callers should use
+// NewInMemoryCoordinatorWithSigning to inject the node's real
+// operator-key signer and the network's member-key-resolving
+// verifier.
 func NewInMemoryCoordinator() Coordinator {
+	return NewInMemoryCoordinatorWithSigning(
+		0,
+		NoOpSigner(),
+		NoOpSignatureVerifier(),
+	)
+}
+
+// NewInMemoryCoordinatorWithSigning returns an in-memory Coordinator
+// bound to the node's own member index, the node's operator-key
+// Signer, and a SignatureVerifier capable of resolving every member's
+// operator key. selfMember = 0 disables the censorship-detection
+// check in VerifyBundle (Phase 3.3 default for unit tests; Phase 4
+// always supplies a non-zero value).
+func NewInMemoryCoordinatorWithSigning(
+	selfMember group.MemberIndex,
+	signer Signer,
+	verifier SignatureVerifier,
+) Coordinator {
 	return &inMemoryCoordinator{
-		attempts: map[uint64]*attemptRecord{},
+		attempts:   map[uint64]*attemptRecord{},
+		selfMember: selfMember,
+		signer:     signer,
+		verifier:   verifier,
 	}
 }
 
 type attemptRecord struct {
-	handle      AttemptHandle
-	context     attempt.AttemptContext
-	coordinator group.MemberIndex
-	state       AttemptState
+	handle         AttemptHandle
+	context        attempt.AttemptContext
+	coordinator    group.MemberIndex
+	state          AttemptState
+	snapshots      map[group.MemberIndex]*LocalEvidenceSnapshot
+	selfSubmission *LocalEvidenceSnapshot
 }
 
 type inMemoryCoordinator struct {
-	mu       sync.Mutex
-	nextID   atomic.Uint64
-	attempts map[uint64]*attemptRecord
+	mu         sync.Mutex
+	nextID     atomic.Uint64
+	attempts   map[uint64]*attemptRecord
+	selfMember group.MemberIndex
+	signer     Signer
+	verifier   SignatureVerifier
 }
 
 func (c *inMemoryCoordinator) BeginAttempt(
@@ -171,6 +258,7 @@ func (c *inMemoryCoordinator) BeginAttempt(
 		context:     ctx,
 		coordinator: coord,
 		state:       AttemptStateCollecting,
+		snapshots:   map[group.MemberIndex]*LocalEvidenceSnapshot{},
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -200,4 +288,172 @@ func (c *inMemoryCoordinator) SelectedCoordinator(
 		return 0, ErrUnknownAttempt
 	}
 	return record.coordinator, nil
+}
+
+func (c *inMemoryCoordinator) RecordEvidence(
+	handle AttemptHandle,
+	snapshot *LocalEvidenceSnapshot,
+) error {
+	if snapshot == nil {
+		return errors.New("coordinator: snapshot is nil")
+	}
+	if err := snapshot.Validate(); err != nil {
+		return fmt.Errorf("coordinator: snapshot invalid: %w", err)
+	}
+	if err := verifySnapshotSignature(c.verifier, snapshot); err != nil {
+		return fmt.Errorf("coordinator: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record, ok := c.attempts[handle.id]
+	if !ok {
+		return ErrUnknownAttempt
+	}
+	if record.state != AttemptStateCollecting {
+		return fmt.Errorf(
+			"%w: state is %v, want %v",
+			ErrAttemptStateInvalid,
+			record.state,
+			AttemptStateCollecting,
+		)
+	}
+	if !bytes.Equal(
+		snapshot.AttemptContextHash,
+		record.handle.contextHash[:],
+	) {
+		return ErrAttemptContextMismatch
+	}
+
+	if existing, present := record.snapshots[snapshot.SenderID()]; present {
+		existingBytes, err := CanonicalSnapshotBytes(existing)
+		if err != nil {
+			return fmt.Errorf("coordinator: canonical existing: %w", err)
+		}
+		newBytes, err := CanonicalSnapshotBytes(snapshot)
+		if err != nil {
+			return fmt.Errorf("coordinator: canonical new: %w", err)
+		}
+		if !bytes.Equal(existingBytes, newBytes) ||
+			!bytes.Equal(existing.OperatorSignature, snapshot.OperatorSignature) {
+			return ErrSnapshotConflict
+		}
+		// Identical re-submission: idempotent no-op.
+		return nil
+	}
+	record.snapshots[snapshot.SenderID()] = snapshot
+	if c.selfMember != 0 && snapshot.SenderID() == c.selfMember {
+		record.selfSubmission = snapshot
+	}
+	return nil
+}
+
+func (c *inMemoryCoordinator) AggregateBundle(
+	handle AttemptHandle,
+) (*TransitionMessage, error) {
+	c.mu.Lock()
+	record, ok := c.attempts[handle.id]
+	if !ok {
+		c.mu.Unlock()
+		return nil, ErrUnknownAttempt
+	}
+	if c.selfMember == 0 || record.coordinator != c.selfMember {
+		c.mu.Unlock()
+		return nil, ErrNotAggregator
+	}
+	if record.state != AttemptStateCollecting {
+		c.mu.Unlock()
+		return nil, fmt.Errorf(
+			"%w: state is %v, want %v",
+			ErrAttemptStateInvalid,
+			record.state,
+			AttemptStateCollecting,
+		)
+	}
+
+	senders := make([]group.MemberIndex, 0, len(record.snapshots))
+	for s := range record.snapshots {
+		senders = append(senders, s)
+	}
+	sort.Slice(senders, func(i, j int) bool { return senders[i] < senders[j] })
+
+	bundle := make([]LocalEvidenceSnapshot, 0, len(senders))
+	for _, s := range senders {
+		bundle = append(bundle, *record.snapshots[s])
+	}
+
+	record.state = AttemptStateAggregating
+	hash := record.handle.contextHash
+	coord := record.coordinator
+	c.mu.Unlock()
+
+	msg := &TransitionMessage{
+		AttemptContextHash: append([]byte{}, hash[:]...),
+		CoordinatorIDValue: uint32(coord),
+		Bundle:             bundle,
+	}
+	payload, err := CanonicalBundleBytes(msg)
+	if err != nil {
+		c.markTransitionedLocked(handle.id)
+		return nil, fmt.Errorf("coordinator: canonical bundle: %w", err)
+	}
+	sig, err := c.signer.Sign(payload)
+	if err != nil {
+		c.markTransitionedLocked(handle.id)
+		return nil, fmt.Errorf("coordinator: sign bundle: %w", err)
+	}
+	msg.CoordinatorSignature = sig
+	if err := msg.Validate(); err != nil {
+		c.markTransitionedLocked(handle.id)
+		return nil, fmt.Errorf("coordinator: aggregated bundle invalid: %w", err)
+	}
+	c.markTransitionedLocked(handle.id)
+	return msg, nil
+}
+
+func (c *inMemoryCoordinator) markTransitionedLocked(id uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if record, ok := c.attempts[id]; ok {
+		record.state = AttemptStateTransitioned
+	}
+}
+
+func (c *inMemoryCoordinator) VerifyBundle(
+	handle AttemptHandle,
+	msg *TransitionMessage,
+) error {
+	if msg == nil {
+		return errors.New("coordinator: transition message is nil")
+	}
+	if err := msg.Validate(); err != nil {
+		return fmt.Errorf("coordinator: transition message invalid: %w", err)
+	}
+
+	c.mu.Lock()
+	record, ok := c.attempts[handle.id]
+	if !ok {
+		c.mu.Unlock()
+		return ErrUnknownAttempt
+	}
+	expectedCoordinator := record.coordinator
+	expectedHash := record.handle.contextHash
+	selfSubmission := record.selfSubmission
+	c.mu.Unlock()
+
+	if !bytes.Equal(msg.AttemptContextHash, expectedHash[:]) {
+		return ErrAttemptContextMismatch
+	}
+	if err := verifyBundleSignature(c.verifier, msg, expectedCoordinator); err != nil {
+		return fmt.Errorf("coordinator: %w", err)
+	}
+	for i := range msg.Bundle {
+		if err := verifySnapshotSignature(c.verifier, &msg.Bundle[i]); err != nil {
+			return fmt.Errorf("coordinator: bundle[%d]: %w", i, err)
+		}
+	}
+	if err := verifyOwnObservationsPresent(msg, c.selfMember, selfSubmission); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/frost/roast/signature.go
+++ b/pkg/frost/roast/signature.go
@@ -1,0 +1,257 @@
+package roast
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// Signer produces operator-key signatures over canonical-encoded
+// payloads. The ROAST coordinator state machine uses one Signer per
+// node to sign its own LocalEvidenceSnapshot before broadcast, and
+// the elected coordinator uses the same Signer to sign the assembled
+// TransitionMessage bundle.
+//
+// Phase 3.3 (this file) defines the interface. Phase 4 wires it to
+// pkg/net's operator-key signing surface so signatures are
+// automatically attributable to the node's libp2p identity.
+//
+// Implementations must be safe for concurrent calls from multiple
+// goroutines.
+type Signer interface {
+	// Sign returns a signature over the canonical payload produced
+	// by CanonicalSnapshotBytes or CanonicalBundleBytes. The
+	// returned signature is treated as opaque bytes by the
+	// coordinator state machine; the SignatureVerifier is the only
+	// component that interprets the byte sequence.
+	Sign(payload []byte) ([]byte, error)
+}
+
+// SignatureVerifier verifies a signature attributed to a specific
+// member. The verifier owns the member-to-public-key mapping; the
+// coordinator state machine does not see public keys directly.
+//
+// Phase 3.3 (this file) defines the interface. Phase 4 wires it to
+// pkg/net's member-keys table.
+//
+// Implementations must be safe for concurrent calls from multiple
+// goroutines.
+type SignatureVerifier interface {
+	// Verify returns nil if signature is a valid signature over
+	// payload produced by the operator key of signer. Returns a
+	// descriptive error otherwise.
+	Verify(payload []byte, signature []byte, signer group.MemberIndex) error
+}
+
+// ErrSignatureInvalid is the canonical sentinel a SignatureVerifier
+// returns when a signature does not validate against the supplied
+// payload and signer. Callers that want to distinguish
+// signature-verification failure from other errors should use
+// errors.Is(err, ErrSignatureInvalid).
+var ErrSignatureInvalid = errors.New("roast: signature is invalid")
+
+// ErrSignatureMissing is returned by VerifyBundle when a snapshot
+// or bundle lacks the signature the protocol requires.
+var ErrSignatureMissing = errors.New("roast: signature missing")
+
+// ErrCensorshipDetected is returned by VerifyBundle when a receiver
+// finds its own LocalEvidenceSnapshot absent from a bundle the
+// receiver expected to be present in. The receiver's snapshot is
+// missing either because the elected coordinator dropped it
+// (malicious or otherwise) or because the bundle was constructed
+// before the receiver's submission arrived. In either case, the
+// receiver must not feed the bundle into NextAttempt.
+var ErrCensorshipDetected = errors.New(
+	"roast: own evidence snapshot missing from transition bundle (censorship or race)",
+)
+
+// NoOpSigner returns a Signer whose Sign returns an empty signature.
+// Suitable as a default in tests that do not exercise the signature
+// pipeline, and as the implicit default of NewInMemoryCoordinator
+// (which is preserved for backward compatibility with Phase 3.1
+// callers).
+//
+// A NoOpSigner-produced bundle is rejected by any non-NoOp verifier:
+// the verifier sees a missing signature and fails closed. So the
+// pair {NoOpSigner, NoOpSignatureVerifier} is only suitable when the
+// caller wants to test the structural-aggregation pipeline in
+// isolation from the crypto pipeline.
+func NoOpSigner() Signer { return noOpSigner{} }
+
+// NoOpSignatureVerifier returns a SignatureVerifier that accepts
+// every signature, including empty ones. Use ONLY in tests that do
+// not exercise the signature pipeline.
+func NoOpSignatureVerifier() SignatureVerifier { return noOpSignatureVerifier{} }
+
+type noOpSigner struct{}
+
+func (noOpSigner) Sign(_ []byte) ([]byte, error) { return nil, nil }
+
+type noOpSignatureVerifier struct{}
+
+func (noOpSignatureVerifier) Verify(_, _ []byte, _ group.MemberIndex) error {
+	return nil
+}
+
+// CanonicalSnapshotBytes returns the byte stream over which a signer
+// signs a LocalEvidenceSnapshot. The encoding excludes the
+// OperatorSignature field so a verifier can recompute the bytes from
+// the snapshot it received over the wire.
+//
+// The encoding is canonical JSON: the Overflows slice must already
+// be sorted ascending by Sender (NewLocalEvidenceSnapshot guarantees
+// this; Unmarshal enforces it). Any two honest signers seeing the
+// same snapshot fields produce byte-identical canonical bytes.
+func CanonicalSnapshotBytes(s *LocalEvidenceSnapshot) ([]byte, error) {
+	if s == nil {
+		return nil, errors.New("roast: cannot canonicalise a nil snapshot")
+	}
+	clone := LocalEvidenceSnapshot{
+		SenderIDValue:      s.SenderIDValue,
+		AttemptContextHash: s.AttemptContextHash,
+		Overflows:          s.Overflows,
+		// OperatorSignature intentionally omitted -- it is the
+		// signature *over* this canonical encoding, not part of it.
+	}
+	return json.Marshal(&clone)
+}
+
+// CanonicalBundleBytes returns the byte stream over which the elected
+// coordinator signs a TransitionMessage. The encoding excludes the
+// CoordinatorSignature field but *includes* every snapshot's
+// OperatorSignature -- the coordinator's signature attests that
+// these specific signed snapshots were assembled in this specific
+// order.
+//
+// The Bundle slice must already be sorted ascending by SenderID; the
+// canonical encoding assumes that invariant holds.
+func CanonicalBundleBytes(m *TransitionMessage) ([]byte, error) {
+	if m == nil {
+		return nil, errors.New("roast: cannot canonicalise a nil transition message")
+	}
+	clone := TransitionMessage{
+		AttemptContextHash: m.AttemptContextHash,
+		CoordinatorIDValue: m.CoordinatorIDValue,
+		Bundle:             m.Bundle,
+		// CoordinatorSignature intentionally omitted.
+	}
+	return json.Marshal(&clone)
+}
+
+// verifySnapshotSignature checks the OperatorSignature on a single
+// LocalEvidenceSnapshot against the verifier's record of the
+// snapshot's sender's operator key.
+func verifySnapshotSignature(
+	verifier SignatureVerifier,
+	snapshot *LocalEvidenceSnapshot,
+) error {
+	if len(snapshot.OperatorSignature) == 0 {
+		return fmt.Errorf(
+			"%w: snapshot from sender %d has no operator signature",
+			ErrSignatureMissing,
+			snapshot.SenderID(),
+		)
+	}
+	payload, err := CanonicalSnapshotBytes(snapshot)
+	if err != nil {
+		return fmt.Errorf("canonical snapshot bytes: %w", err)
+	}
+	if err := verifier.Verify(
+		payload,
+		snapshot.OperatorSignature,
+		snapshot.SenderID(),
+	); err != nil {
+		return fmt.Errorf(
+			"%w: sender %d: %s",
+			ErrSignatureInvalid,
+			snapshot.SenderID(),
+			err.Error(),
+		)
+	}
+	return nil
+}
+
+// verifyBundleSignature checks the CoordinatorSignature on a
+// TransitionMessage against the verifier's record of the bundle's
+// declared coordinator's operator key. The coordinator member index
+// passed in must match the elected coordinator for the attempt; the
+// caller (Coordinator.VerifyBundle) resolves this from the
+// AttemptHandle.
+func verifyBundleSignature(
+	verifier SignatureVerifier,
+	msg *TransitionMessage,
+	expectedCoordinator group.MemberIndex,
+) error {
+	if len(msg.CoordinatorSignature) == 0 {
+		return fmt.Errorf(
+			"%w: transition message has no coordinator signature",
+			ErrSignatureMissing,
+		)
+	}
+	if msg.CoordinatorID() != expectedCoordinator {
+		return fmt.Errorf(
+			"transition message coordinator id %d does not match expected %d for the attempt",
+			msg.CoordinatorID(),
+			expectedCoordinator,
+		)
+	}
+	payload, err := CanonicalBundleBytes(msg)
+	if err != nil {
+		return fmt.Errorf("canonical bundle bytes: %w", err)
+	}
+	if err := verifier.Verify(
+		payload,
+		msg.CoordinatorSignature,
+		msg.CoordinatorID(),
+	); err != nil {
+		return fmt.Errorf(
+			"%w: coordinator %d: %s",
+			ErrSignatureInvalid,
+			msg.CoordinatorID(),
+			err.Error(),
+		)
+	}
+	return nil
+}
+
+// verifyOwnObservationsPresent is the receiver-side censorship-
+// detection check: every receiver that has already submitted its
+// own LocalEvidenceSnapshot to the elected coordinator must find
+// that snapshot in the resulting bundle. A coordinator that drops a
+// receiver's snapshot is detected here.
+//
+// When selfMember is zero, the check is skipped: that signals a
+// caller that has not (yet) submitted its own snapshot and therefore
+// has no censorship claim to verify.
+func verifyOwnObservationsPresent(
+	msg *TransitionMessage,
+	selfMember group.MemberIndex,
+	selfSubmission *LocalEvidenceSnapshot,
+) error {
+	if selfMember == 0 || selfSubmission == nil {
+		return nil
+	}
+	for i := range msg.Bundle {
+		if msg.Bundle[i].SenderID() != selfMember {
+			continue
+		}
+		// Found the receiver's snapshot. The submitted-vs-bundled
+		// signature must be byte-identical -- a coordinator that
+		// re-signed or mutated the submission has tampered with
+		// observed evidence.
+		if !bytes.Equal(
+			msg.Bundle[i].OperatorSignature,
+			selfSubmission.OperatorSignature,
+		) {
+			return fmt.Errorf(
+				"%w: own evidence snapshot signature mutated in bundle",
+				ErrCensorshipDetected,
+			)
+		}
+		return nil
+	}
+	return ErrCensorshipDetected
+}

--- a/pkg/frost/roast/signature_test.go
+++ b/pkg/frost/roast/signature_test.go
@@ -1,0 +1,252 @@
+package roast
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// fakeSigner produces deterministic signatures of the form
+// SHA256(memberID || payload) so tests can exercise the sign / verify
+// pipeline without real crypto. Two fakeSigners with the same member
+// id produce identical signatures.
+type fakeSigner struct {
+	id group.MemberIndex
+}
+
+func (f *fakeSigner) Sign(payload []byte) ([]byte, error) {
+	h := sha256.New()
+	h.Write([]byte{byte(f.id)})
+	h.Write(payload)
+	return h.Sum(nil), nil
+}
+
+// fakeVerifier mirrors fakeSigner's deterministic signature scheme so
+// every member's signatures verify against the same recomputation.
+// A signature attributed to memberID is valid iff it equals
+// SHA256(memberID || payload).
+type fakeVerifier struct{}
+
+func (fakeVerifier) Verify(payload, signature []byte, signer group.MemberIndex) error {
+	h := sha256.New()
+	h.Write([]byte{byte(signer)})
+	h.Write(payload)
+	expected := h.Sum(nil)
+	if !bytes.Equal(expected, signature) {
+		return errors.New("fakeVerifier: signature does not match recomputed value")
+	}
+	return nil
+}
+
+func TestNoOpSigner_ReturnsEmptySignature(t *testing.T) {
+	sig, err := NoOpSigner().Sign([]byte("payload"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sig) != 0 {
+		t.Fatalf("expected empty signature, got %x", sig)
+	}
+}
+
+func TestNoOpSignatureVerifier_AcceptsEverything(t *testing.T) {
+	v := NoOpSignatureVerifier()
+	if err := v.Verify([]byte("a"), []byte("b"), 1); err != nil {
+		t.Fatalf("NoOp must accept everything: %v", err)
+	}
+	if err := v.Verify(nil, nil, 1); err != nil {
+		t.Fatalf("NoOp must accept nil payload + nil sig: %v", err)
+	}
+}
+
+func TestNoOpSigner_IsConcurrencySafe(t *testing.T) {
+	signer := NoOpSigner()
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 32; j++ {
+				if _, err := signer.Sign([]byte("payload")); err != nil {
+					t.Errorf("Sign error under concurrency: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCanonicalSnapshotBytes_ExcludesOperatorSignature(t *testing.T) {
+	snap := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{
+		Overflows: map[group.MemberIndex]uint{1: 2, 3: 4},
+	})
+	withoutSig, err := CanonicalSnapshotBytes(snap)
+	if err != nil {
+		t.Fatalf("canonical bytes (no sig): %v", err)
+	}
+	snap.OperatorSignature = []byte{0xff, 0xee}
+	withSig, err := CanonicalSnapshotBytes(snap)
+	if err != nil {
+		t.Fatalf("canonical bytes (with sig): %v", err)
+	}
+	if !bytes.Equal(withoutSig, withSig) {
+		t.Fatalf(
+			"adding OperatorSignature changed canonical bytes; got %s vs %s",
+			string(withoutSig), string(withSig),
+		)
+	}
+}
+
+func TestCanonicalSnapshotBytes_RejectsNil(t *testing.T) {
+	if _, err := CanonicalSnapshotBytes(nil); err == nil {
+		t.Fatal("expected error for nil snapshot")
+	}
+}
+
+func TestCanonicalBundleBytes_ExcludesCoordinatorSignatureButIncludesSnapshots(t *testing.T) {
+	msg := buildValidTransitionMessage()
+	// Make sure each snapshot's OperatorSignature is non-empty so we
+	// can verify they appear in the canonical bytes.
+	for i := range msg.Bundle {
+		msg.Bundle[i].OperatorSignature = []byte{byte(i + 1)}
+	}
+	msg.CoordinatorSignature = []byte{0xaa, 0xbb}
+	canonical, err := CanonicalBundleBytes(msg)
+	if err != nil {
+		t.Fatalf("canonical bundle: %v", err)
+	}
+	// CoordinatorSignature bytes should not appear in the canonical
+	// payload (omitempty + nil in clone).
+	if bytes.Contains(canonical, []byte{0xaa, 0xbb}) {
+		t.Fatalf(
+			"CoordinatorSignature 0xaabb leaked into canonical bytes: %s",
+			string(canonical),
+		)
+	}
+	// Each snapshot's OperatorSignature should appear via base64
+	// "AQ==", "Ag==", "Aw==" (1, 2, 3 → 0x01, 0x02, 0x03).
+	for _, want := range []string{`"AQ=="`, `"Ag=="`, `"Aw=="`} {
+		if !bytes.Contains(canonical, []byte(want)) {
+			t.Fatalf(
+				"expected per-snapshot OperatorSignature %q in canonical bundle: %s",
+				want, string(canonical),
+			)
+		}
+	}
+}
+
+func TestCanonicalBundleBytes_RejectsNil(t *testing.T) {
+	if _, err := CanonicalBundleBytes(nil); err == nil {
+		t.Fatal("expected error for nil message")
+	}
+}
+
+func TestVerifySnapshotSignature_RoundTripsThroughFakeSignerVerifier(t *testing.T) {
+	signer := &fakeSigner{id: 7}
+	snap := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{})
+	payload, err := CanonicalSnapshotBytes(snap)
+	if err != nil {
+		t.Fatalf("canonical: %v", err)
+	}
+	sig, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	snap.OperatorSignature = sig
+	if err := verifySnapshotSignature(fakeVerifier{}, snap); err != nil {
+		t.Fatalf("expected valid signature, got %v", err)
+	}
+}
+
+func TestVerifySnapshotSignature_RejectsMissingSignature(t *testing.T) {
+	snap := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{})
+	err := verifySnapshotSignature(fakeVerifier{}, snap)
+	if !errors.Is(err, ErrSignatureMissing) {
+		t.Fatalf("expected ErrSignatureMissing, got %v", err)
+	}
+}
+
+func TestVerifySnapshotSignature_RejectsTamperedPayload(t *testing.T) {
+	signer := &fakeSigner{id: 7}
+	snap := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{})
+	payload, _ := CanonicalSnapshotBytes(snap)
+	sig, _ := signer.Sign(payload)
+	snap.OperatorSignature = sig
+	// Tamper: change the overflow set; the recomputed canonical
+	// bytes will no longer match.
+	snap.Overflows = []OverflowEntry{{Sender: 99, Count: 1}}
+	if err := verifySnapshotSignature(fakeVerifier{}, snap); !errors.Is(err, ErrSignatureInvalid) {
+		t.Fatalf("expected ErrSignatureInvalid, got %v", err)
+	}
+}
+
+func TestVerifyBundleSignature_RoundTrip(t *testing.T) {
+	signer := &fakeSigner{id: 11}
+	msg := buildValidTransitionMessage()
+	msg.CoordinatorIDValue = 11
+	msg.CoordinatorSignature = nil
+	payload, _ := CanonicalBundleBytes(msg)
+	sig, _ := signer.Sign(payload)
+	msg.CoordinatorSignature = sig
+	if err := verifyBundleSignature(fakeVerifier{}, msg, 11); err != nil {
+		t.Fatalf("expected verified, got %v", err)
+	}
+}
+
+func TestVerifyBundleSignature_RejectsCoordinatorMismatch(t *testing.T) {
+	msg := buildValidTransitionMessage()
+	msg.CoordinatorIDValue = 1
+	msg.CoordinatorSignature = []byte{0x01}
+	err := verifyBundleSignature(fakeVerifier{}, msg, 99)
+	if err == nil {
+		t.Fatal("expected coordinator mismatch error")
+	}
+}
+
+func TestVerifyOwnObservationsPresent_RequiresIdenticalSignature(t *testing.T) {
+	selfSubmission := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{})
+	selfSubmission.OperatorSignature = []byte{0xab}
+	bundle := &TransitionMessage{
+		Bundle: []LocalEvidenceSnapshot{
+			func() LocalEvidenceSnapshot {
+				s := *selfSubmission
+				s.OperatorSignature = []byte{0xff}
+				return s
+			}(),
+		},
+	}
+	if err := verifyOwnObservationsPresent(bundle, 7, selfSubmission); !errors.Is(err, ErrCensorshipDetected) {
+		t.Fatalf("expected ErrCensorshipDetected on mutated sig, got %v", err)
+	}
+}
+
+func TestVerifyOwnObservationsPresent_DetectsMissingSnapshot(t *testing.T) {
+	selfSubmission := NewLocalEvidenceSnapshot(7, pinnedContextHash, attempt.Evidence{})
+	bundle := &TransitionMessage{
+		Bundle: []LocalEvidenceSnapshot{
+			*NewLocalEvidenceSnapshot(8, pinnedContextHash, attempt.Evidence{}),
+		},
+	}
+	if err := verifyOwnObservationsPresent(bundle, 7, selfSubmission); !errors.Is(err, ErrCensorshipDetected) {
+		t.Fatalf("expected ErrCensorshipDetected, got %v", err)
+	}
+}
+
+func TestVerifyOwnObservationsPresent_SkipsWhenSelfZero(t *testing.T) {
+	bundle := &TransitionMessage{Bundle: []LocalEvidenceSnapshot{}}
+	if err := verifyOwnObservationsPresent(bundle, 0, nil); err != nil {
+		t.Fatalf("expected skip, got %v", err)
+	}
+}
+
+func TestVerifyOwnObservationsPresent_SkipsWhenNoSelfSubmission(t *testing.T) {
+	bundle := &TransitionMessage{Bundle: []LocalEvidenceSnapshot{}}
+	if err := verifyOwnObservationsPresent(bundle, 7, nil); err != nil {
+		t.Fatalf("expected skip when no self submission, got %v", err)
+	}
+}

--- a/pkg/frost/roast/transition_message.go
+++ b/pkg/frost/roast/transition_message.go
@@ -148,10 +148,14 @@ func (s *LocalEvidenceSnapshot) Unmarshal(data []byte) error {
 	if err := json.Unmarshal(data, s); err != nil {
 		return err
 	}
-	return s.validate()
+	return s.Validate()
 }
 
-func (s *LocalEvidenceSnapshot) validate() error {
+// Validate runs the structural checks Unmarshal applies after a JSON
+// decode. Exposed publicly so callers that construct snapshots in
+// memory (e.g. the Coordinator state machine) can validate without
+// a marshal/unmarshal round-trip.
+func (s *LocalEvidenceSnapshot) Validate() error {
 	if s.SenderIDValue == 0 {
 		return errors.New("local evidence snapshot: senderID is zero")
 	}
@@ -242,10 +246,15 @@ func (m *TransitionMessage) Unmarshal(data []byte) error {
 	if err := json.Unmarshal(data, m); err != nil {
 		return err
 	}
-	return m.validate()
+	return m.Validate()
 }
 
-func (m *TransitionMessage) validate() error {
+// Validate runs the structural checks Unmarshal applies after a JSON
+// decode: bundle hash length, bundle size cap, coordinator id, every
+// snapshot's validity, bundle ordering, and intra-bundle hash
+// consistency. Exposed publicly so callers that construct messages
+// in memory can validate without a marshal/unmarshal round-trip.
+func (m *TransitionMessage) Validate() error {
 	if len(m.AttemptContextHash) != attempt.MessageDigestLength {
 		return fmt.Errorf(
 			"transition message: attemptContextHash length [%d], expected [%d]",
@@ -274,7 +283,7 @@ func (m *TransitionMessage) validate() error {
 		)
 	}
 	for i := range m.Bundle {
-		if err := m.Bundle[i].validate(); err != nil {
+		if err := m.Bundle[i].Validate(); err != nil {
 			return fmt.Errorf(
 				"transition message: bundle[%d] invalid: %w",
 				i, err,


### PR DESCRIPTION
## Summary

Third Phase-3 implementation PR. Adds the methods that drive the
ROAST coordinator-aggregation flow defined in RFC-21's **Resolved
Decisions** section:

| Method | Role |
|---|---|
| \`RecordEvidence(handle, snap)\` | Accept a peer's signed \`LocalEvidenceSnapshot\`. Validates structure, verifies the operator signature, checks the snapshot's \`AttemptContextHash\` matches the handle's bound context, applies first-write-wins / equal-or-reject. |
| \`AggregateBundle(handle)\` | Called by the elected coordinator. Sorts accumulated snapshots ascending by \`SenderID\`, builds the \`TransitionMessage\`, signs the canonical bundle bytes, transitions state to \`Transitioned\`. |
| \`VerifyBundle(handle, msg)\` | Called by every receiver. Verifies coordinator signature, every snapshot's operator signature, and -- if the receiver has submitted its own snapshot -- presence of that snapshot in the bundle (censorship detection). |

**Stacked on #3969 (Phase 3.2).**

## What's new

### \`pkg/frost/roast/signature.go\`

- \`Signer\` / \`SignatureVerifier\` interfaces (Phase 4 wires them to \`pkg/net\`'s operator-key + member-keys surfaces).
- \`NoOpSigner\` / \`NoOpSignatureVerifier\` for tests that don't exercise the crypto pipeline.
- \`CanonicalSnapshotBytes\` -- JSON of snapshot fields *excluding* \`OperatorSignature\`.
- \`CanonicalBundleBytes\` -- JSON of bundle fields *excluding* \`CoordinatorSignature\` but *including* every snapshot's \`OperatorSignature\`, so the coordinator's signature attests to the exact assembled set.
- \`verifySnapshotSignature\` / \`verifyBundleSignature\` / \`verifyOwnObservationsPresent\` -- the receiver-side checks, each testable in isolation.
- Sentinels: \`ErrSignatureInvalid\`, \`ErrSignatureMissing\`, \`ErrCensorshipDetected\`.

### \`pkg/frost/roast/coordinator_state.go\` (extended)

- \`Coordinator\` interface gains \`RecordEvidence\`, \`AggregateBundle\`, \`VerifyBundle\`.
- \`NewInMemoryCoordinatorWithSigning(selfMember, signer, verifier)\` -- production constructor (Phase 4 callers).
- \`NewInMemoryCoordinator()\` preserved as a Phase-3.1-compatible convenience that uses no-op signing.
- New sentinels: \`ErrNotAggregator\`, \`ErrAttemptStateInvalid\`, \`ErrAttemptContextMismatch\`, \`ErrSnapshotConflict\`.

### \`pkg/frost/roast/transition_message.go\` (touched)

- \`validate()\` methods promoted to public \`Validate()\` on both \`LocalEvidenceSnapshot\` and \`TransitionMessage\` so callers that construct messages in memory can validate without a marshal/unmarshal round-trip.

## What's tested

### \`signature_test.go\` (13 cases)

Signature interfaces, canonical encodings, signature verification round-trips (via a deterministic SHA-256 fake signer/verifier), tampered-payload rejection, coordinator-mismatch rejection, censorship-detection helper (missing snapshot, mutated signature, skip semantics).

### \`bundle_aggregation_test.go\` (11 cases)

- \`RecordEvidence\`: nil rejection, unknown handle, context hash mismatch, bad signature, valid-and-idempotent re-submission, conflict rejection, self-submission tracking.
- \`AggregateBundle\`: non-aggregator rejection, signed bundle build (size, ordering, signature, terminal state), **deterministic bundle JSON across different record orderings**.
- \`VerifyBundle\`: valid acceptance, **censorship detection**, coordinator-signature forgery, snapshot-signature forgery, attempt-context mismatch, nil message, unknown attempt, concurrent record-and-aggregate safety.

### Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/roast/...\` | pass |
| \`go test -race ./pkg/frost/roast/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/roast/...\` | silent |
| \`go vet ./pkg/frost/roast/...\` | clean |
| \`gofmt -l ./pkg/frost/roast/\` | silent |

## Why the censorship-detection check is what it is

A receiver that has submitted its own snapshot but is missing from
the bundle has two possible explanations: (1) the elected coordinator
maliciously dropped the snapshot, or (2) the bundle was assembled
before the receiver's submission arrived. In either case, feeding
the bundle into \`NextAttempt\` would penalise the receiver (via
silence-parking), so the bundle must be rejected pending re-broadcast
on the next attempt. \`ErrCensorshipDetected\` is the unambiguous
signal.

When the receiver has not yet submitted (selfMember == 0 or
selfSubmission == nil), the check is skipped: there is no submitted
snapshot whose presence to verify.

## Phase 3 status

| PR | Scope | State |
|---|---|---|
| 3.1 (#3968) | Coordinator skeleton + seed bridge | open |
| 3.2 (#3969) | TransitionMessage + LocalEvidenceSnapshot | open |
| **3.3 (this)** | **Aggregation + bundle verification** | **open** |
| 3.4 | NextAttempt policy + thresholds | next |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the censorship-detection semantics are
  acceptable (specifically that we *reject* the bundle on missing
  self-snapshot rather than accept it and let silence-parking
  catch it).
- [ ] Reviewer confirms the canonical-encoding contract (snapshot
  omits its own signature; bundle includes snapshot signatures but
  omits its own).