### PR TITLE
feat(frost/signing): RFC-21 Phase 4.1 -- frost_roast_retry registry

### DIFF
--- a/pkg/frost/signing/roast_retry_registration_default_build.go
+++ b/pkg/frost/signing/roast_retry_registration_default_build.go
@@ -1,0 +1,54 @@
+//go:build !frost_roast_retry
+
+package signing
+
+import "github.com/keep-network/keep-core/pkg/frost/roast"
+
+// RoastRetryDeps bundles the per-process dependencies the FROST
+// receive loops need to participate in RFC-21 Phase-4 coordinator-
+// driven evidence flow:
+//
+//   - Coordinator drives BeginAttempt / RecordEvidence / AggregateBundle
+//     / VerifyBundle / NextAttempt.
+//   - Signer produces operator-key signatures over canonical
+//     snapshot and bundle bytes.
+//   - Verifier validates signatures on inbound snapshots and bundles.
+//
+// The type is exported in every build so callers can construct it
+// without conditional compilation. In the default build the registry
+// is a permanent no-op stub: the receive loops cannot find a
+// registered coordinator and therefore fall back to the Phase-2
+// `attempt.NoOpRecorder()` behaviour, preserving exact pre-RFC-21
+// receive semantics.
+//
+// The real registry behind the `frost_roast_retry` build tag is in
+// roast_retry_registration_frost_roast_retry.go.
+type RoastRetryDeps struct {
+	Coordinator roast.Coordinator
+	Signer      roast.Signer
+	Verifier    roast.SignatureVerifier
+	// SelfMember is the local node's member index. The Coordinator
+	// is already bound to this value via NewInMemoryCoordinatorWithSigning,
+	// but receivers need it independently so they can correlate
+	// AttemptHandles with their own snapshots in later Phase-4 PRs.
+	SelfMember uint32
+}
+
+// RegisterRoastRetryCoordinator is a no-op in the default build.
+// Callers in production code may invoke it unconditionally; the
+// registration only takes effect when the `frost_roast_retry` build
+// tag is active.
+func RegisterRoastRetryCoordinator(_ RoastRetryDeps) {}
+
+// RegisteredRoastRetryCoordinator returns (zero, false) in the
+// default build, signalling to receivers that ROAST-retry plumbing
+// is not active and they should continue to use the Phase-2
+// NoOpRecorder fallback.
+func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
+	return RoastRetryDeps{}, false
+}
+
+// ResetRoastRetryRegistrationForTest is a no-op in the default
+// build. Exposed so tests can call it unconditionally regardless of
+// which build is active.
+func ResetRoastRetryRegistrationForTest() {}

--- a/pkg/frost/signing/roast_retry_registration_default_build_test.go
+++ b/pkg/frost/signing/roast_retry_registration_default_build_test.go
@@ -1,0 +1,27 @@
+//go:build !frost_roast_retry
+
+package signing
+
+import "testing"
+
+func TestRoastRetryRegistration_DefaultBuildIsStub(t *testing.T) {
+	// Register a non-zero dependency set. Because the default build
+	// is a no-op stub, the registry must remain empty.
+	deps := RoastRetryDeps{SelfMember: 7}
+	RegisterRoastRetryCoordinator(deps)
+	got, ok := RegisteredRoastRetryCoordinator()
+	if ok {
+		t.Fatalf("default build must report not-registered; got ok=true, deps=%+v", got)
+	}
+	if got != (RoastRetryDeps{}) {
+		t.Fatalf("default build must return zero value; got %+v", got)
+	}
+}
+
+func TestRoastRetryRegistration_DefaultBuildResetIsNoOp(t *testing.T) {
+	// Reset should not panic even though there is no real state.
+	ResetRoastRetryRegistrationForTest()
+	if _, ok := RegisteredRoastRetryCoordinator(); ok {
+		t.Fatal("default build registry should remain empty after reset")
+	}
+}

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -1,0 +1,65 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"sync"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+)
+
+// RoastRetryDeps bundles the per-process dependencies the FROST
+// receive loops need under the frost_roast_retry build tag. See the
+// default-build file for the doc contract; this declaration is the
+// real one used when the build tag is active.
+type RoastRetryDeps struct {
+	Coordinator roast.Coordinator
+	Signer      roast.Signer
+	Verifier    roast.SignatureVerifier
+	SelfMember  uint32
+}
+
+// roastRetryRegistration is the package-private registry slot. Only
+// one set of dependencies can be registered at a time; later
+// registrations overwrite earlier ones. Callers wanting to test
+// reset behaviour use ResetRoastRetryRegistrationForTest.
+var (
+	roastRetryRegistrationMu sync.RWMutex
+	roastRetryRegistration   RoastRetryDeps
+	roastRetryRegistered     bool
+)
+
+// RegisterRoastRetryCoordinator stores the per-process ROAST-retry
+// dependencies the receive loops will pick up on their next call.
+// Safe for concurrent registration / lookup; a later registration
+// fully replaces an earlier one (this is the documented behaviour --
+// reconfiguring at runtime is intentional).
+func RegisterRoastRetryCoordinator(deps RoastRetryDeps) {
+	roastRetryRegistrationMu.Lock()
+	defer roastRetryRegistrationMu.Unlock()
+	roastRetryRegistration = deps
+	roastRetryRegistered = true
+}
+
+// RegisteredRoastRetryCoordinator returns the currently-registered
+// dependencies and true, or the zero value and false if nothing has
+// been registered yet. Receivers use the boolean to decide between
+// the bounded recorder path and the Phase-2 NoOp fallback.
+func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
+	roastRetryRegistrationMu.RLock()
+	defer roastRetryRegistrationMu.RUnlock()
+	if !roastRetryRegistered {
+		return RoastRetryDeps{}, false
+	}
+	return roastRetryRegistration, true
+}
+
+// ResetRoastRetryRegistrationForTest clears the registry. Exposed
+// so tests in this and downstream packages can reset between cases
+// without leaking state. Not intended for production code paths.
+func ResetRoastRetryRegistrationForTest() {
+	roastRetryRegistrationMu.Lock()
+	defer roastRetryRegistrationMu.Unlock()
+	roastRetryRegistration = RoastRetryDeps{}
+	roastRetryRegistered = false
+}

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
@@ -1,0 +1,97 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+)
+
+func TestRoastRetryRegistration_TaggedBuildRoundTrip(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	if _, ok := RegisteredRoastRetryCoordinator(); ok {
+		t.Fatal("registry must start empty")
+	}
+
+	coord := roast.NewInMemoryCoordinator()
+	deps := RoastRetryDeps{
+		Coordinator: coord,
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  7,
+	}
+	RegisterRoastRetryCoordinator(deps)
+
+	got, ok := RegisteredRoastRetryCoordinator()
+	if !ok {
+		t.Fatal("expected ok=true after register")
+	}
+	if got.SelfMember != 7 {
+		t.Fatalf("self member mismatch: got %d want 7", got.SelfMember)
+	}
+	if got.Coordinator == nil {
+		t.Fatal("coordinator must round-trip")
+	}
+}
+
+func TestRoastRetryRegistration_LaterRegistrationOverwrites(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: 1})
+	RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: 2})
+	got, ok := RegisteredRoastRetryCoordinator()
+	if !ok {
+		t.Fatal("expected ok=true after register")
+	}
+	if got.SelfMember != 2 {
+		t.Fatalf("later registration must win: got %d want 2", got.SelfMember)
+	}
+}
+
+func TestRoastRetryRegistration_ResetClearsRegistry(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: 1})
+	ResetRoastRetryRegistrationForTest()
+	if _, ok := RegisteredRoastRetryCoordinator(); ok {
+		t.Fatal("registry must be empty after reset")
+	}
+}
+
+func TestRoastRetryRegistration_ConcurrentRegisterAndLookupIsRaceSafe(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	var wg sync.WaitGroup
+	const registers = 32
+	const lookups = 64
+	for i := 0; i < registers; i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: uint32(i + 1)})
+		}()
+	}
+	for i := 0; i < lookups; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = RegisteredRoastRetryCoordinator()
+		}()
+	}
+	wg.Wait()
+
+	// We don't assert a specific SelfMember -- registers race against
+	// each other and any of them can land last. We assert only that
+	// SOME registration succeeded.
+	if _, ok := RegisteredRoastRetryCoordinator(); !ok {
+		t.Fatal("expected at least one register to take effect")
+	}
+}


### PR DESCRIPTION
## Summary

First Phase-4 PR. Introduces the per-process registry the FROST
receive loops will use to plumb evidence into the ROAST coordinator
state machine.

**No production code path consults the registry yet.** PR 4.2 wires
the three FROST receive loops to look up the registered recorder; PR
4.3 wires snapshot submission to \`RecordEvidence\`; PR 4.4 adds the
soak harness.

## What lands

| Surface | Notes |
|---|---|
| New build tag \`frost_roast_retry\` | matches the precedent set by \`frost_native\` / \`frost_tbtc_signer\` |
| \`RoastRetryDeps\` struct | bundles \`Coordinator\` + \`Signer\` + \`SignatureVerifier\` + \`SelfMember\`. Exported in every build so callers construct without conditional compilation. |
| \`RegisterRoastRetryCoordinator(deps)\` | stores the dependencies; later registrations overwrite earlier ones (runtime reconfiguration supported) |
| \`RegisteredRoastRetryCoordinator() (deps, ok)\` | report current state so receivers can decide between the bounded-recorder path and the Phase-2 NoOp fallback |
| \`ResetRoastRetryRegistrationForTest()\` | test seam |

## Build separation

| File | Build tag | Behaviour |
|---|---|---|
| \`roast_retry_registration_default_build.go\` | \`!frost_roast_retry\` | permanent no-op stub. \`Register\` silently discards; \`Registered\` always returns \`(zero, false)\`. The default build preserves exact Phase-2 receive semantics. |
| \`roast_retry_registration_frost_roast_retry.go\` | \`frost_roast_retry\` | real registry, mutex-protected for concurrent register / lookup |

## Test coverage

| Surface | Cases |
|---|---|
| Default build | 2 (registration discarded; reset no-ops; \`Registered\` returns zero) |
| Tagged build | 4 (round-trip; later-write-wins; reset clears; concurrent register-vs-lookup under \`-race\`) |

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/signing/...\` | pass (default build) |
| \`go test -tags 'frost_roast_retry' ./pkg/frost/signing/...\` | pass |
| \`go test -race -tags 'frost_roast_retry' ./pkg/frost/signing/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer frost_roast_retry' ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/...\` | silent |
| \`gofmt -l ./pkg/frost/signing/\` | silent |

## Phase 4 plan (4 PRs total)

| PR | Scope | State |
|---|---|---|
| **4.1 (this)** | **frost_roast_retry registry** | **open** |
| 4.2 | Receive loops opt into bounded recorder when registered | next |
| 4.3 | Submit signed snapshots to Coordinator on attempt completion | after 4.2 |
| 4.4 | Soak / fault-injection harness | after 4.3 |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the build-tag pattern matches keep-core's existing convention (\`frost_native\` / \`frost_tbtc_signer\` use the same default-build-stub + tagged-real-impl shape).
- [ ] Reviewer confirms the runtime-reconfiguration semantic (later \`Register\` overwrites earlier) is what we want.