### PR TITLE
feat(frost/signing): RFC-21 Phase 4.3 -- submit signed snapshots on attempt completion

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -861,15 +861,19 @@ func buildTaggedTBTCSignerRoundContributions(
 		return nil, fmt.Errorf("cannot send round contribution message: [%w]", err)
 	}
 
-	// RFC-21 Phase 4.2: recorder comes from the roast-retry
-	// registry. NoOp fallback when nothing is registered preserves
-	// Phase 2 receive semantics.
+	// RFC-21 Phase 4.2/4.3: recorder comes from the roast-retry
+	// registry; deferred submission pushes the snapshot into
+	// Coordinator.RecordEvidence at end-of-collect. NoOp fallback
+	// when nothing is registered preserves Phase 2 receive
+	// semantics.
+	contributionsRecorder := roastRetryRecorderForCollect()
+	defer submitSnapshotIfActive(request.SessionID, contributionsRecorder)
 	peerMessages, err := collectBuildTaggedTBTCSignerRoundContributionMessages(
 		ctx,
 		request,
 		includedMembersSet,
 		includedMembersIndexes,
-		roastRetryRecorderForCollect(),
+		contributionsRecorder,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/frost/signing/native_frost_protocol_frost_native.go
+++ b/pkg/frost/signing/native_frost_protocol_frost_native.go
@@ -350,21 +350,23 @@ func executeNativeFROSTSigning(
 		return nil, fmt.Errorf("cannot send native FROST round one message: [%w]", err)
 	}
 
-	// RFC-21 Phase 4.2: the recorder comes from the per-process
+	// RFC-21 Phase 4.2/4.3: the recorder comes from the per-process
 	// roast-retry registry. When the registry is empty (default
 	// build, or no caller has registered a coordinator), the helper
 	// returns attempt.NoOpRecorder() and behaviour matches Phase 2.
 	// When the registry has a coordinator, the helper returns a
 	// fresh BoundedRecorder so overflow drops at the receive
-	// callback are captured. PR 4.3 will read this recorder's
-	// Snapshot at end-of-collect and submit the result via
-	// Coordinator.RecordEvidence.
+	// callback are captured. The deferred submitSnapshotIfActive
+	// reads the recorder's Snapshot at end-of-collect and submits
+	// the result via Coordinator.RecordEvidence.
+	roundOneRecorder := roastRetryRecorderForCollect()
+	defer submitSnapshotIfActive(request.SessionID, roundOneRecorder)
 	roundOneMessages, err := collectNativeFROSTRoundOneMessages(
 		ctx,
 		request,
 		includedMembersSet,
 		includedMembersIndexes,
-		roastRetryRecorderForCollect(),
+		roundOneRecorder,
 	)
 	if err != nil {
 		return nil, err
@@ -440,13 +442,16 @@ func executeNativeFROSTSigning(
 		return nil, fmt.Errorf("cannot send native FROST round two message: [%w]", err)
 	}
 
-	// RFC-21 Phase 4.2 recorder source -- see round-one caller above.
+	// RFC-21 Phase 4.2/4.3 recorder source + deferred submission --
+	// see round-one caller above.
+	roundTwoRecorder := roastRetryRecorderForCollect()
+	defer submitSnapshotIfActive(request.SessionID, roundTwoRecorder)
 	roundTwoMessages, err := collectNativeFROSTRoundTwoMessages(
 		ctx,
 		request,
 		includedMembersSet,
 		includedMembersIndexes,
-		roastRetryRecorderForCollect(),
+		roundTwoRecorder,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
@@ -1,0 +1,36 @@
+//go:build !frost_roast_retry
+
+package signing
+
+import (
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+)
+
+// SetCurrentAttemptHandleForSession is a no-op in the default build:
+// the receive loops will never find a handle for any session, so the
+// snapshot submission path is dormant. The build-tagged
+// implementation does the real registration.
+func SetCurrentAttemptHandleForSession(
+	_ string,
+	_ roast.AttemptHandle,
+	_ attempt.AttemptContext,
+) {
+}
+
+// ClearCurrentAttemptHandleForSession is a no-op in the default
+// build.
+func ClearCurrentAttemptHandleForSession(_ string) {}
+
+// ResetSessionHandleRegistryForTest is a no-op in the default
+// build.
+func ResetSessionHandleRegistryForTest() {}
+
+// currentAttemptHandleForCollect always returns ok=false in the
+// default build, so submitSnapshotIfActive exits without attempting
+// the RecordEvidence call.
+func currentAttemptHandleForCollect(
+	_ string,
+) (roast.AttemptHandle, attempt.AttemptContext, bool) {
+	return roast.AttemptHandle{}, attempt.AttemptContext{}, false
+}

--- a/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
@@ -1,0 +1,82 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"sync"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+)
+
+// sessionAttemptBinding records the current attempt's handle and
+// context for a session. The orchestration layer (Phase 5+) sets
+// the binding via SetCurrentAttemptHandleForSession before driving
+// the round-one / round-two / contribution receive loops; the
+// receive loops read it at end-of-collect to know which attempt to
+// submit their evidence snapshot against.
+type sessionAttemptBinding struct {
+	handle  roast.AttemptHandle
+	context attempt.AttemptContext
+}
+
+var (
+	sessionAttemptBindingMu sync.RWMutex
+	sessionAttemptBindings  = map[string]sessionAttemptBinding{}
+)
+
+// SetCurrentAttemptHandleForSession records the in-flight attempt
+// handle and context for the named session. Callers in the
+// orchestration layer (Phase 5+) invoke this immediately after
+// Coordinator.BeginAttempt so receive loops can correlate their
+// captured evidence with the right attempt.
+//
+// Later calls for the same session overwrite earlier ones (this is
+// the documented behaviour: a session whose attempt has transitioned
+// re-binds to the new attempt's handle).
+func SetCurrentAttemptHandleForSession(
+	sessionID string,
+	handle roast.AttemptHandle,
+	ctx attempt.AttemptContext,
+) {
+	sessionAttemptBindingMu.Lock()
+	defer sessionAttemptBindingMu.Unlock()
+	sessionAttemptBindings[sessionID] = sessionAttemptBinding{
+		handle:  handle,
+		context: ctx,
+	}
+}
+
+// ClearCurrentAttemptHandleForSession removes any binding for the
+// named session. Callers invoke this when a session terminates so
+// the registry does not grow unbounded.
+func ClearCurrentAttemptHandleForSession(sessionID string) {
+	sessionAttemptBindingMu.Lock()
+	defer sessionAttemptBindingMu.Unlock()
+	delete(sessionAttemptBindings, sessionID)
+}
+
+// ResetSessionHandleRegistryForTest clears every binding. Exposed
+// only for tests; not for production code paths.
+func ResetSessionHandleRegistryForTest() {
+	sessionAttemptBindingMu.Lock()
+	defer sessionAttemptBindingMu.Unlock()
+	sessionAttemptBindings = map[string]sessionAttemptBinding{}
+}
+
+// currentAttemptHandleForCollect reads the binding the orchestration
+// layer set for this session. Returns (zero, zero, false) when no
+// binding exists -- the typical Phase-4 state, where no orchestration
+// is wired yet. The submit helper takes ok=false as the signal to
+// skip the RecordEvidence call.
+func currentAttemptHandleForCollect(
+	sessionID string,
+) (roast.AttemptHandle, attempt.AttemptContext, bool) {
+	sessionAttemptBindingMu.RLock()
+	defer sessionAttemptBindingMu.RUnlock()
+	binding, ok := sessionAttemptBindings[sessionID]
+	if !ok {
+		return roast.AttemptHandle{}, attempt.AttemptContext{}, false
+	}
+	return binding.handle, binding.context, true
+}

--- a/pkg/frost/signing/roast_retry_submit.go
+++ b/pkg/frost/signing/roast_retry_submit.go
@@ -1,0 +1,105 @@
+package signing
+
+import (
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// roastRetryLogger is the logger the snapshot-submission path uses
+// for non-fatal diagnostics (submission failures, signature errors).
+// A submission failure does not propagate to the signing flow:
+// Phase 4 ships the submission code path unused in production, and
+// even when wired (Phase 5+) a transient submission failure is
+// recoverable by the next attempt's evidence flow.
+var roastRetryLogger = log.Logger("keep-frost-roast-retry")
+
+// submitSnapshotIfActive is invoked at end-of-collect to push the
+// receive loop's accumulated evidence into the ROAST coordinator's
+// RecordEvidence pipeline. The function is a no-op when any of the
+// following is true:
+//
+//   - the ROAST-retry registry is empty (default build, no caller
+//     has invoked RegisterRoastRetryCoordinator);
+//   - no session-handle binding exists for sessionID (the typical
+//     Phase-4 state, where the orchestration layer that calls
+//     SetCurrentAttemptHandleForSession is not yet implemented);
+//   - the recorder is a NoOp (no events were captured).
+//
+// When all three preconditions hold, the function builds a
+// LocalEvidenceSnapshot, signs it with the registered Signer, and
+// submits it via Coordinator.RecordEvidence. Errors at any step are
+// logged at WARN level and otherwise swallowed -- snapshot
+// submission must not break the receive loop's primary signing
+// behaviour.
+func submitSnapshotIfActive(
+	sessionID string,
+	recorder attempt.EvidenceRecorder,
+) {
+	if recorder == nil {
+		return
+	}
+	deps, ok := RegisteredRoastRetryCoordinator()
+	if !ok {
+		return
+	}
+	handle, ctx, ok := currentAttemptHandleForCollect(sessionID)
+	if !ok {
+		return
+	}
+	evidence := recorder.Snapshot()
+	if len(evidence.Overflows) == 0 {
+		// Nothing observed worth submitting; emitting an empty
+		// snapshot is still meaningful in the ROAST protocol
+		// (proof-of-attendance) but adds noise to the bundle.
+		// Phase 4.3 chooses to skip empty submissions; Phase 5
+		// orchestration may revisit this if attestations need to
+		// be unconditional.
+		return
+	}
+	snap := buildSignedSnapshot(deps, ctx, evidence)
+	if snap == nil {
+		return
+	}
+	if err := deps.Coordinator.RecordEvidence(handle, snap); err != nil {
+		roastRetryLogger.Warnf(
+			"roast-retry: RecordEvidence failed for session %q: %v",
+			sessionID,
+			err,
+		)
+	}
+}
+
+// buildSignedSnapshot constructs and signs a LocalEvidenceSnapshot
+// from the captured evidence. Returns nil and logs on signature
+// failure; callers treat nil as "skip submission" and continue.
+func buildSignedSnapshot(
+	deps RoastRetryDeps,
+	ctx attempt.AttemptContext,
+	evidence attempt.Evidence,
+) *roast.LocalEvidenceSnapshot {
+	snap := roast.NewLocalEvidenceSnapshot(
+		group.MemberIndex(deps.SelfMember),
+		ctx.Hash(),
+		evidence,
+	)
+	payload, err := roast.CanonicalSnapshotBytes(snap)
+	if err != nil {
+		roastRetryLogger.Warnf(
+			"roast-retry: canonicalising snapshot failed: %v",
+			err,
+		)
+		return nil
+	}
+	sig, err := deps.Signer.Sign(payload)
+	if err != nil {
+		roastRetryLogger.Warnf(
+			"roast-retry: signing snapshot failed: %v",
+			err,
+		)
+		return nil
+	}
+	snap.OperatorSignature = sig
+	return snap
+}

--- a/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
@@ -1,0 +1,318 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// captureCoordinator is a roast.Coordinator wrapper that records
+// every RecordEvidence call so tests can assert what was submitted.
+// It delegates everything else to an embedded real coordinator.
+type captureCoordinator struct {
+	inner       roast.Coordinator
+	mu          sync.Mutex
+	recordedFor []roast.AttemptHandle
+	recordedSnp []*roast.LocalEvidenceSnapshot
+	recordErr   error
+}
+
+func newCaptureCoordinator(inner roast.Coordinator) *captureCoordinator {
+	return &captureCoordinator{inner: inner}
+}
+
+func (c *captureCoordinator) BeginAttempt(ctx attempt.AttemptContext) (roast.AttemptHandle, error) {
+	return c.inner.BeginAttempt(ctx)
+}
+func (c *captureCoordinator) State(h roast.AttemptHandle) (roast.AttemptState, error) {
+	return c.inner.State(h)
+}
+func (c *captureCoordinator) SelectedCoordinator(h roast.AttemptHandle) (group.MemberIndex, error) {
+	return c.inner.SelectedCoordinator(h)
+}
+func (c *captureCoordinator) RecordEvidence(h roast.AttemptHandle, s *roast.LocalEvidenceSnapshot) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.recordErr != nil {
+		return c.recordErr
+	}
+	c.recordedFor = append(c.recordedFor, h)
+	c.recordedSnp = append(c.recordedSnp, s)
+	return c.inner.RecordEvidence(h, s)
+}
+func (c *captureCoordinator) AggregateBundle(h roast.AttemptHandle) (*roast.TransitionMessage, error) {
+	return c.inner.AggregateBundle(h)
+}
+func (c *captureCoordinator) VerifyBundle(h roast.AttemptHandle, m *roast.TransitionMessage) error {
+	return c.inner.VerifyBundle(h, m)
+}
+func (c *captureCoordinator) NextAttempt(
+	h roast.AttemptHandle, m *roast.TransitionMessage, t uint, pk []byte,
+) (attempt.AttemptContext, error) {
+	return c.inner.NextAttempt(h, m, t, pk)
+}
+
+// deterministicSigner produces SHA256(memberID || payload)-style
+// signatures the captureSignatureVerifier accepts.
+type deterministicSigner struct {
+	id group.MemberIndex
+}
+
+func (d *deterministicSigner) Sign(payload []byte) ([]byte, error) {
+	out := make([]byte, len(payload)+1)
+	out[0] = byte(d.id)
+	copy(out[1:], payload)
+	return out, nil
+}
+
+type deterministicVerifier struct{}
+
+func (deterministicVerifier) Verify(
+	payload []byte, signature []byte, signer group.MemberIndex,
+) error {
+	if len(signature) != len(payload)+1 {
+		return errors.New("deterministicVerifier: length mismatch")
+	}
+	if signature[0] != byte(signer) {
+		return errors.New("deterministicVerifier: signer byte mismatch")
+	}
+	for i, b := range payload {
+		if signature[i+1] != b {
+			return errors.New("deterministicVerifier: payload byte mismatch")
+		}
+	}
+	return nil
+}
+
+func newTestContextForSubmit(t *testing.T, sessionID string) attempt.AttemptContext {
+	t.Helper()
+	ctx, err := attempt.NewAttemptContext(
+		sessionID,
+		"key-group-submit",
+		[]byte{0xAA},
+		[attempt.MessageDigestLength]byte{0x42},
+		0,
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ctx: %v", err)
+	}
+	return ctx
+}
+
+func TestSubmitSnapshotIfActive_NoOpWhenRegistryEmpty(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	// No registration, no binding. submit should be a no-op.
+	recorder := attempt.NewBoundedRecorder()
+	recorder.RecordOverflow(7)
+	submitSnapshotIfActive("session-x", recorder)
+	// Nothing to assert observably: success is the absence of a
+	// panic and no calls to a non-existent coordinator.
+}
+
+func TestSubmitSnapshotIfActive_NoOpWhenSessionUnbound(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	innerCoord := roast.NewInMemoryCoordinator()
+	cap := newCaptureCoordinator(innerCoord)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: cap,
+		Signer:      &deterministicSigner{id: 1},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  1,
+	})
+
+	recorder := attempt.NewBoundedRecorder()
+	recorder.RecordOverflow(7)
+	submitSnapshotIfActive("session-with-no-binding", recorder)
+
+	if len(cap.recordedFor) != 0 {
+		t.Fatalf(
+			"expected no RecordEvidence calls when session unbound; got %d",
+			len(cap.recordedFor),
+		)
+	}
+}
+
+func TestSubmitSnapshotIfActive_NoOpWhenRecorderEmpty(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	innerCoord := roast.NewInMemoryCoordinatorWithSigning(
+		1,
+		&deterministicSigner{id: 1},
+		deterministicVerifier{},
+	)
+	cap := newCaptureCoordinator(innerCoord)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: cap,
+		Signer:      &deterministicSigner{id: 1},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  1,
+	})
+
+	ctx := newTestContextForSubmit(t, "session-empty")
+	handle, err := cap.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	SetCurrentAttemptHandleForSession("session-empty", handle, ctx)
+
+	// Recorder is bounded but has captured zero events.
+	recorder := attempt.NewBoundedRecorder()
+	submitSnapshotIfActive("session-empty", recorder)
+
+	if len(cap.recordedFor) != 0 {
+		t.Fatalf(
+			"expected no RecordEvidence for empty snapshot; got %d",
+			len(cap.recordedFor),
+		)
+	}
+}
+
+func TestSubmitSnapshotIfActive_SubmitsSignedSnapshotWhenBoundAndPopulated(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	const selfMember group.MemberIndex = 1
+	innerCoord := roast.NewInMemoryCoordinatorWithSigning(
+		selfMember,
+		&deterministicSigner{id: selfMember},
+		deterministicVerifier{},
+	)
+	cap := newCaptureCoordinator(innerCoord)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: cap,
+		Signer:      &deterministicSigner{id: selfMember},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  uint32(selfMember),
+	})
+
+	ctx := newTestContextForSubmit(t, "session-real")
+	handle, err := cap.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	SetCurrentAttemptHandleForSession("session-real", handle, ctx)
+
+	recorder := attempt.NewBoundedRecorder()
+	recorder.RecordOverflow(3)
+	recorder.RecordOverflow(3)
+	recorder.RecordOverflow(5)
+	submitSnapshotIfActive("session-real", recorder)
+
+	if len(cap.recordedFor) != 1 {
+		t.Fatalf("expected 1 RecordEvidence; got %d", len(cap.recordedFor))
+	}
+	if cap.recordedFor[0] != handle {
+		t.Fatal("RecordEvidence handle mismatch")
+	}
+	snap := cap.recordedSnp[0]
+	if snap.SenderID() != selfMember {
+		t.Fatalf("snapshot sender: got %d want %d", snap.SenderID(), selfMember)
+	}
+	if len(snap.OperatorSignature) == 0 {
+		t.Fatal("snapshot must be signed")
+	}
+	// 2 distinct senders observed.
+	if len(snap.Overflows) != 2 {
+		t.Fatalf("expected 2 overflow entries; got %d", len(snap.Overflows))
+	}
+}
+
+func TestSetCurrentAttemptHandleForSession_LaterBindingOverwrites(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	ctxA := newTestContextForSubmit(t, "session-overwrite")
+	ctxB, _ := attempt.NewAttemptContext(
+		"session-overwrite", "key-group-submit", []byte{0xAA},
+		[attempt.MessageDigestLength]byte{0x42}, 1,
+		[]group.MemberIndex{1, 2, 3, 4, 5}, nil,
+	)
+	h1 := roast.AttemptHandle{}
+	h2 := roast.AttemptHandle{}
+
+	SetCurrentAttemptHandleForSession("session-overwrite", h1, ctxA)
+	gotHandle, gotCtx, ok := currentAttemptHandleForCollect("session-overwrite")
+	if !ok {
+		t.Fatal("expected binding after first Set")
+	}
+	if gotHandle != h1 {
+		t.Fatal("first binding handle mismatch")
+	}
+	if gotCtx.AttemptNumber != ctxA.AttemptNumber {
+		t.Fatal("first binding context mismatch")
+	}
+
+	SetCurrentAttemptHandleForSession("session-overwrite", h2, ctxB)
+	_, gotCtx2, ok := currentAttemptHandleForCollect("session-overwrite")
+	if !ok {
+		t.Fatal("expected binding after second Set")
+	}
+	if gotCtx2.AttemptNumber != ctxB.AttemptNumber {
+		t.Fatal("second binding context did not overwrite first")
+	}
+}
+
+func TestClearCurrentAttemptHandleForSession_RemovesBinding(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	ctx := newTestContextForSubmit(t, "session-clear")
+	SetCurrentAttemptHandleForSession("session-clear", roast.AttemptHandle{}, ctx)
+	if _, _, ok := currentAttemptHandleForCollect("session-clear"); !ok {
+		t.Fatal("setup: binding must exist")
+	}
+	ClearCurrentAttemptHandleForSession("session-clear")
+	if _, _, ok := currentAttemptHandleForCollect("session-clear"); ok {
+		t.Fatal("binding must be cleared")
+	}
+}
+
+func TestSubmitSnapshotIfActive_RecordEvidenceFailureIsLoggedNotPropagated(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	innerCoord := roast.NewInMemoryCoordinatorWithSigning(
+		1, &deterministicSigner{id: 1}, deterministicVerifier{},
+	)
+	cap := newCaptureCoordinator(innerCoord)
+	cap.recordErr = errors.New("synthetic RecordEvidence failure")
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: cap,
+		Signer:      &deterministicSigner{id: 1},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  1,
+	})
+
+	ctx := newTestContextForSubmit(t, "session-failure")
+	handle, _ := cap.BeginAttempt(ctx)
+	SetCurrentAttemptHandleForSession("session-failure", handle, ctx)
+
+	recorder := attempt.NewBoundedRecorder()
+	recorder.RecordOverflow(3)
+
+	// Must not panic. Caller is unaffected.
+	submitSnapshotIfActive("session-failure", recorder)
+}


### PR DESCRIPTION
## Summary

Third Phase-4 PR. Wires the three FROST/tbtc-signer receive loops
to push their accumulated evidence into the ROAST coordinator
state machine at end-of-collect.

Submission is a **deferred** call, so it runs on both the success
and error return paths. The orchestration that populates the
session-handle binding is Phase 5 work, so the submission path is
**dormant in production deployments today**: the helper sees no
binding and returns silently. The code path is unit-tested via a
binding installed by the test itself.

Stacked on #3973 (Phase 4.2).

## What lands

| File | Build tag | Role |
|---|---|---|
| \`roast_retry_attempt_handle_default_build.go\` | \`!frost_roast_retry\` | No-op / always-false stubs for \`SetCurrentAttemptHandleForSession\`, \`Clear\`, \`Reset\`, \`currentAttemptHandleForCollect\`. |
| \`roast_retry_attempt_handle_frost_roast_retry.go\` | \`frost_roast_retry\` | \`sync.RWMutex\`-protected map: sessionID → (AttemptHandle, AttemptContext). Later-binding-wins by design (re-binding allowed across attempts). |
| \`roast_retry_submit.go\` | none | \`submitSnapshotIfActive(sessionID, recorder)\`: no-op unless registry populated AND session bound AND recorder non-empty. Builds a signed \`LocalEvidenceSnapshot\` and calls \`Coordinator.RecordEvidence\`. Errors logged at WARN, never propagated. |
| 3 receive-loop callers | n/a | Capture recorder by name; \`defer submitSnapshotIfActive(...)\` before calling collect. |

## Why defer

The submission must happen even on the error return path -- evidence
captured before an early exit is still useful for the next attempt's
exclusion policy. \`defer\` is the simplest way to express that.

## Why dormant in production today

\`currentAttemptHandleForCollect\` returns \`(zero, zero, false)\` when
no session has a binding. In Phase 4 nothing calls
\`SetCurrentAttemptHandleForSession\` in production, so receive loops
always see \`ok=false\` and silently skip submission. Phase 5's retry
adapter is where the orchestration calls \`Begin\` + \`Set\` + drives
the protocol.

This design lets us unit-test the submission pipeline today, *and*
keeps it provably-unused in production until Phase 5.

## Why a session-handle map and not a field on \`NativeExecutionFFISigningRequest\`

Adding a field to the request struct would force every caller (test
and production) to know about ROAST-retry concepts. The
session-handle map sits at the same layer as the existing
ROAST-retry registry, doesn't touch any non-ROAST signature, and is
trivially observable / resettable in tests.

## Test coverage (7 tagged-build cases)

- Registry empty → submission is a no-op
- Session unbound → submission is a no-op
- Recorder empty → submission is a no-op (Phase 4.3 chooses to skip empty snapshots)
- All three preconditions hold → submission posts a signed snapshot with the right SenderID, signature, and overflow contents
- \`SetCurrentAttemptHandleForSession\`: later binding overwrites earlier
- \`Clear\` removes the binding
- \`RecordEvidence\` synthetic failure is logged, not propagated

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/signing/...\` | pass (default build) |
| \`go test -tags 'frost_roast_retry' ./pkg/frost/signing/...\` | pass |
| \`go test -race -tags 'frost_native frost_tbtc_signer frost_roast_retry' ./pkg/frost/signing/...\` | pass |
| \`staticcheck -checks '-SA1019' ./pkg/frost/...\` | silent |
| \`gofmt -l ./pkg/frost/signing/\` | silent |
| \`go vet ./pkg/frost/...\` | clean |

## Phase 4 status

| PR | Scope | State |
|---|---|---|
| 4.1 (#3972) | frost_roast_retry registry | open |
| 4.2 (#3973) | Receive loops opt into bounded recorder | open |
| **4.3 (this)** | **Submit signed snapshots on attempt completion** | **open** |
| 4.4 | Soak / fault-injection harness | next |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the dormant-by-default contract (no orchestration → no submission) is acceptable until Phase 5 lands the retry adapter.
- [ ] Reviewer confirms the choice to skip empty snapshots (no observed events → no submission). Phase 5 may revisit if attestations need to be unconditional ROAST proofs-of-attendance.