### PR TITLE
feat(frost/roast): RFC-21 Phase 5.1 -- retry adapter scaffolding

### DIFF
--- a/pkg/frost/roast/signing_retry_adapter.go
+++ b/pkg/frost/roast/signing_retry_adapter.go
@@ -1,0 +1,142 @@
+package roast
+
+import (
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// MemberToParticipantResolver maps a ROAST group.MemberIndex to the
+// participant-identifier type the legacy signing-retry path uses
+// (typically chain.Address in keep-core production flows, but the
+// interface is intentionally generic in T so pkg/frost/roast does
+// not import any caller-side type).
+//
+// Implementations are wallet-scoped: each FROST signing flow
+// constructs a resolver from its existing wallet/group state at the
+// call site and passes it to EvaluateRoastRetryForSigning or
+// SigningRetryAdapter.
+type MemberToParticipantResolver[T any] interface {
+	// For returns the participant identifier corresponding to the
+	// given member index. Returns an error if the member is unknown
+	// to the resolver (out-of-range index, evicted member, etc.).
+	For(member group.MemberIndex) (T, error)
+}
+
+// EvaluateRoastRetryForSigning bridges the ROAST coordinator state
+// machine with the legacy signing-retry shape. Given the previous
+// attempt's handle and a verified TransitionMessage, it computes
+// the next attempt's IncludedSet, converts each member index to its
+// resolver-supplied participant identifier, and returns both the
+// participant list and the full AttemptContext.
+//
+// Callers MUST call Coordinator.VerifyBundle on bundle before
+// passing it to this function; the bundle is the load-bearing
+// authoritative input to NextAttempt and an unverified bundle would
+// silently fracture multi-instance agreement.
+//
+// Returns ErrAttemptInfeasible directly when the next attempt's
+// included set would drop below threshold; the caller must
+// propagate that to the session manager rather than swallow it.
+// See RFC-21 Phase-5 Resolved Decision on infeasibility.
+//
+// The function is generic in T so it can be used with chain.Address
+// in production keep-core flows and with simple test types
+// (strings, ints) in unit tests.
+func EvaluateRoastRetryForSigning[T any](
+	coord Coordinator,
+	handle AttemptHandle,
+	bundle *TransitionMessage,
+	threshold uint,
+	dkgGroupPublicKey []byte,
+	resolver MemberToParticipantResolver[T],
+) ([]T, attempt.AttemptContext, error) {
+	if coord == nil {
+		return nil, attempt.AttemptContext{}, fmt.Errorf(
+			"roast retry adapter: coordinator is nil",
+		)
+	}
+	if resolver == nil {
+		var zero T
+		_ = zero
+		return nil, attempt.AttemptContext{}, fmt.Errorf(
+			"roast retry adapter: resolver is nil",
+		)
+	}
+	nextCtx, err := coord.NextAttempt(handle, bundle, threshold, dkgGroupPublicKey)
+	if err != nil {
+		return nil, attempt.AttemptContext{}, err
+	}
+	participants := make([]T, 0, len(nextCtx.IncludedSet))
+	for _, m := range nextCtx.IncludedSet {
+		t, err := resolver.For(m)
+		if err != nil {
+			return nil, attempt.AttemptContext{}, fmt.Errorf(
+				"roast retry adapter: resolver failed for member %d: %w",
+				m,
+				err,
+			)
+		}
+		participants = append(participants, t)
+	}
+	return participants, nextCtx, nil
+}
+
+// SigningRetryAdapter binds the inputs to EvaluateRoastRetryForSigning
+// onto a struct so call sites can hold the configuration once and
+// call EvaluateRetryParticipantsForSigning (legacy-shaped) per
+// retry. Phase 6 migrates call sites to either the function or the
+// struct -- whichever fits the existing call shape.
+type SigningRetryAdapter[T any] struct {
+	Coordinator       Coordinator
+	Handle            AttemptHandle
+	Bundle            *TransitionMessage
+	Threshold         uint
+	DkgGroupPublicKey []byte
+	Resolver          MemberToParticipantResolver[T]
+}
+
+// EvaluateRetryParticipantsForSigning matches the shape of the
+// legacy helper in pkg/frost/retry so call sites can adopt the
+// adapter without changing their function-call surface. The legacy
+// signature's parameters (groupMembers, seed, retryCount,
+// retryParticipantsCount) are ignored: the AttemptContext bound to
+// the handle is the source of truth for next-attempt selection.
+//
+// Returns the next IncludedSet's participants and any error from
+// NextAttempt (typically ErrAttemptInfeasible).
+func (a SigningRetryAdapter[T]) EvaluateRetryParticipantsForSigning(
+	_ []T,
+	_ int64,
+	_ uint,
+	_ uint,
+) ([]T, error) {
+	participants, _, err := EvaluateRoastRetryForSigning(
+		a.Coordinator,
+		a.Handle,
+		a.Bundle,
+		a.Threshold,
+		a.DkgGroupPublicKey,
+		a.Resolver,
+	)
+	return participants, err
+}
+
+// NextAttemptContext returns the AttemptContext the adapter would
+// transition to. Useful when callers need both the participant
+// list and the context (e.g. to re-bind session orchestration to
+// the new attempt's handle).
+func (a SigningRetryAdapter[T]) NextAttemptContext() (
+	attempt.AttemptContext, error,
+) {
+	_, ctx, err := EvaluateRoastRetryForSigning(
+		a.Coordinator,
+		a.Handle,
+		a.Bundle,
+		a.Threshold,
+		a.DkgGroupPublicKey,
+		a.Resolver,
+	)
+	return ctx, err
+}

--- a/pkg/frost/roast/signing_retry_adapter_test.go
+++ b/pkg/frost/roast/signing_retry_adapter_test.go
@@ -1,0 +1,251 @@
+package roast
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// addressResolverString is a deterministic resolver that maps
+// member index N to the string "addr-N". Used by the adapter
+// tests to verify the conversion path without needing chain types.
+type addressResolverString struct{}
+
+func (addressResolverString) For(m group.MemberIndex) (string, error) {
+	if m == 0 {
+		return "", fmt.Errorf("zero member index")
+	}
+	return fmt.Sprintf("addr-%d", m), nil
+}
+
+// failingResolver always errors. Used to verify that resolver
+// failures propagate cleanly through the adapter.
+type failingResolver struct{ err error }
+
+func (f failingResolver) For(_ group.MemberIndex) (string, error) {
+	return "", f.err
+}
+
+// retryAdapterFixture provides a previously-completed attempt with
+// a verified bundle that NextAttempt can transition from.
+type retryAdapterFixture struct {
+	coord     Coordinator
+	handle    AttemptHandle
+	bundle    *TransitionMessage
+	threshold uint
+	dkgPub    []byte
+}
+
+func newRetryAdapterFixture(t *testing.T) *retryAdapterFixture {
+	t.Helper()
+	members := []group.MemberIndex{1, 2, 3, 4, 5}
+
+	// Use a throwaway coordinator to discover the elected
+	// coordinator, then build a real coordinator bound to that
+	// member as the aggregator.
+	scratch := NewInMemoryCoordinator()
+	ctx := mustBuildContext(t, members, nil, nil)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+
+	aggregator := newSignedCoordinatorForMember(elected)
+	handle, err := aggregator.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	for _, m := range members {
+		snap := signSnapshotForTest(t, NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{}))
+		if err := aggregator.RecordEvidence(handle, snap); err != nil {
+			t.Fatalf("record %d: %v", m, err)
+		}
+	}
+	bundle, err := aggregator.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	return &retryAdapterFixture{
+		coord:     aggregator,
+		handle:    handle,
+		bundle:    bundle,
+		threshold: 3,
+		dkgPub:    []byte{0xab, 0xcd, 0xef},
+	}
+}
+
+func mustBuildContext(
+	t *testing.T,
+	included, excluded, parked []group.MemberIndex,
+) attempt.AttemptContext {
+	t.Helper()
+	ctx, err := attempt.NewAttemptContextWithParking(
+		"session-test",
+		"key-group-test",
+		[]byte{0xab, 0xcd, 0xef},
+		[attempt.MessageDigestLength]byte{0x42},
+		0,
+		included,
+		excluded,
+		parked,
+	)
+	if err != nil {
+		t.Fatalf("build ctx: %v", err)
+	}
+	return ctx
+}
+
+func TestEvaluateRoastRetryForSigning_HappyPath(t *testing.T) {
+	f := newRetryAdapterFixture(t)
+
+	addresses, nextCtx, err := EvaluateRoastRetryForSigning[string](
+		f.coord, f.handle, f.bundle, f.threshold, f.dkgPub,
+		addressResolverString{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addresses) != 5 {
+		t.Fatalf("expected 5 addresses, got %d", len(addresses))
+	}
+	for i, a := range addresses {
+		want := fmt.Sprintf("addr-%d", nextCtx.IncludedSet[i])
+		if a != want {
+			t.Fatalf(
+				"address[%d]: got %q want %q",
+				i, a, want,
+			)
+		}
+	}
+	if nextCtx.AttemptNumber != 1 {
+		t.Fatalf("attempt number: got %d want 1", nextCtx.AttemptNumber)
+	}
+}
+
+func TestEvaluateRoastRetryForSigning_PropagatesInfeasibility(t *testing.T) {
+	f := newRetryAdapterFixture(t)
+
+	_, _, err := EvaluateRoastRetryForSigning[string](
+		f.coord, f.handle, f.bundle, 99, f.dkgPub,
+		addressResolverString{},
+	)
+	if !errors.Is(err, ErrAttemptInfeasible) {
+		t.Fatalf("expected ErrAttemptInfeasible, got %v", err)
+	}
+}
+
+func TestEvaluateRoastRetryForSigning_PropagatesResolverError(t *testing.T) {
+	f := newRetryAdapterFixture(t)
+
+	sentinel := errors.New("resolver lookup failed")
+	_, _, err := EvaluateRoastRetryForSigning[string](
+		f.coord, f.handle, f.bundle, f.threshold, f.dkgPub,
+		failingResolver{err: sentinel},
+	)
+	if err == nil {
+		t.Fatal("expected resolver error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel, got %v", err)
+	}
+}
+
+func TestEvaluateRoastRetryForSigning_RejectsNilCoordinator(t *testing.T) {
+	_, _, err := EvaluateRoastRetryForSigning[string](
+		nil, AttemptHandle{}, &TransitionMessage{}, 3, []byte{0x01},
+		addressResolverString{},
+	)
+	if err == nil {
+		t.Fatal("expected nil-coordinator error")
+	}
+}
+
+func TestEvaluateRoastRetryForSigning_RejectsNilResolver(t *testing.T) {
+	_, _, err := EvaluateRoastRetryForSigning[string](
+		NewInMemoryCoordinator(),
+		AttemptHandle{}, &TransitionMessage{}, 3, []byte{0x01},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected nil-resolver error")
+	}
+}
+
+func TestSigningRetryAdapter_LegacyShapeMatchesPureFunction(t *testing.T) {
+	f := newRetryAdapterFixture(t)
+	resolver := addressResolverString{}
+
+	adapter := SigningRetryAdapter[string]{
+		Coordinator:       f.coord,
+		Handle:            f.handle,
+		Bundle:            f.bundle,
+		Threshold:         f.threshold,
+		DkgGroupPublicKey: f.dkgPub,
+		Resolver:          resolver,
+	}
+
+	// Legacy parameters are ignored.
+	viaAdapter, err := adapter.EvaluateRetryParticipantsForSigning(
+		nil, 0, 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("adapter: %v", err)
+	}
+	viaFunc, _, err := EvaluateRoastRetryForSigning[string](
+		f.coord, f.handle, f.bundle, f.threshold, f.dkgPub, resolver,
+	)
+	if err != nil {
+		t.Fatalf("function: %v", err)
+	}
+	if len(viaAdapter) != len(viaFunc) {
+		t.Fatalf(
+			"adapter and function disagree on participant count: %d vs %d",
+			len(viaAdapter), len(viaFunc),
+		)
+	}
+	for i := range viaAdapter {
+		if viaAdapter[i] != viaFunc[i] {
+			t.Fatalf("adapter[%d] = %q, function[%d] = %q", i, viaAdapter[i], i, viaFunc[i])
+		}
+	}
+}
+
+func TestSigningRetryAdapter_NextAttemptContextRoundTrip(t *testing.T) {
+	f := newRetryAdapterFixture(t)
+	adapter := SigningRetryAdapter[string]{
+		Coordinator:       f.coord,
+		Handle:            f.handle,
+		Bundle:            f.bundle,
+		Threshold:         f.threshold,
+		DkgGroupPublicKey: f.dkgPub,
+		Resolver:          addressResolverString{},
+	}
+	ctx1, err := adapter.NextAttemptContext()
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	ctx2, err := adapter.NextAttemptContext()
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if ctx1.Hash() != ctx2.Hash() {
+		t.Fatal("NextAttemptContext must be deterministic across calls")
+	}
+}
+
+func TestSigningRetryAdapter_PropagatesInfeasibility(t *testing.T) {
+	f := newRetryAdapterFixture(t)
+	adapter := SigningRetryAdapter[string]{
+		Coordinator:       f.coord,
+		Handle:            f.handle,
+		Bundle:            f.bundle,
+		Threshold:         99,
+		DkgGroupPublicKey: f.dkgPub,
+		Resolver:          addressResolverString{},
+	}
+	_, err := adapter.EvaluateRetryParticipantsForSigning(nil, 0, 0, 0)
+	if !errors.Is(err, ErrAttemptInfeasible) {
+		t.Fatalf("expected ErrAttemptInfeasible, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

First Phase-5 implementation PR. Adds the bridge between the new
ROAST coordinator state machine and the legacy signing-retry shape.

**No consumer wired yet.** Phase 6 migrates the three production
call sites onto the adapter in a single coordinated change (per the
RFC update in #3976).

Stacked on #3976 (RFC update).

## What lands

| Surface | Role |
|---|---|
| \`MemberToParticipantResolver[T]\` interface | Bridges \`group.MemberIndex\` (ROAST namespace) to \`T\` (legacy namespace -- typically \`chain.Address\` in production). Generic in T so \`pkg/frost/roast\` stays decoupled from \`pkg/chain\`. |
| \`EvaluateRoastRetryForSigning[T]\` (pure function) | Calls \`Coordinator.NextAttempt\`, converts the next IncludedSet via the resolver, returns \`([]T, AttemptContext, error)\`. Propagates \`ErrAttemptInfeasible\` unchanged so callers cannot accidentally swallow the threshold-floor failure. |
| \`SigningRetryAdapter[T]\` struct | Binds the inputs onto a value so call sites can hold the configuration once. Exposes both a legacy-shaped \`EvaluateRetryParticipantsForSigning(...)\` method and a \`NextAttemptContext()\` accessor. |

## Why generic in T

Per Gemini's Phase-5 design review feedback (Decision 2): the
resolver interface keeps \`pkg/frost/roast\` decoupled from
\`pkg/chain\`. The legacy retry path returns \`[]chain.Address\`; the
adapter is generic so:

- Production callers instantiate as \`SigningRetryAdapter[chain.Address]\`
- Tests use \`SigningRetryAdapter[string]\` or \`[int]\` for simplicity
- The roast package's import graph is unaffected

## Test coverage (9 cases)

- HappyPath: 5-member group → 5 addresses in IncludedSet order
- ErrAttemptInfeasible propagated unchanged (high threshold)
- Resolver failure wraps with member-index context; \`errors.Is\` sentinel passes
- Nil coordinator rejected
- Nil resolver rejected
- \`SigningRetryAdapter\` legacy-shaped method returns same participants as pure function
- \`NextAttemptContext\` is deterministic across repeated calls
- Adapter struct also propagates ErrAttemptInfeasible

## Phase 5 plan (3 PRs total under the refined scope from #3976)

| PR | Scope | State |
|---|---|---|
| **5.1 (this)** | **Retry adapter scaffolding** | **open** |
| 5.2 | Session orchestration (Begin/Set/Clear) + TTL eviction sweep | next |
| 5.3 | Readiness-gate guard | after 5.2 |

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/roast/...\` | pass |
| \`go test -race ./pkg/frost/roast/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer frost_roast_retry' ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/...\` | silent |
| \`go vet ./pkg/frost/...\` | clean |
| \`gofmt -l ./pkg/frost/roast/\` | silent |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the generics-based decoupling is the right pattern for the resolver.
- [ ] Reviewer confirms \`ErrAttemptInfeasible\` should propagate unchanged (no silent fallback).