### PR TITLE
feat(frost/signing): RFC-21 Phase 5.2 -- orchestration helpers + TTL sweep

### DIFF
--- a/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
@@ -26,6 +26,10 @@ func ClearCurrentAttemptHandleForSession(_ string) {}
 // build.
 func ResetSessionHandleRegistryForTest() {}
 
+// StartSessionHandleSweeper is a no-op in the default build: with
+// no real registry there is nothing to sweep.
+func StartSessionHandleSweeper() {}
+
 // currentAttemptHandleForCollect always returns ok=false in the
 // default build, so submitSnapshotIfActive exits without attempting
 // the RecordEvidence call.

--- a/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
@@ -4,10 +4,26 @@ package signing
 
 import (
 	"sync"
+	"time"
 
 	"github.com/keep-network/keep-core/pkg/frost/roast"
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
 )
+
+// SessionHandleBindingTTL is the maximum age the eviction sweep
+// tolerates for a sessionAttemptBinding before treating it as
+// orphaned. The two-hour default is documented in RFC-21's
+// Resolved decisions section: long enough that no real signing
+// session reaches it, short enough that a leaked binding cannot
+// accumulate across days of node uptime.
+const SessionHandleBindingTTL = 2 * time.Hour
+
+// SessionHandleSweepInterval is how often the background sweeper
+// goroutine wakes up to evict stale bindings. Coarse-grained on
+// purpose: the sweep is a defence-in-depth backstop, not a tight
+// liveness mechanism. 15 minutes balances responsiveness against
+// goroutine churn.
+const SessionHandleSweepInterval = 15 * time.Minute
 
 // sessionAttemptBinding records the current attempt's handle and
 // context for a session. The orchestration layer (Phase 5+) sets
@@ -15,14 +31,22 @@ import (
 // the round-one / round-two / contribution receive loops; the
 // receive loops read it at end-of-collect to know which attempt to
 // submit their evidence snapshot against.
+//
+// createdAt is the wall-clock time at which the binding was last
+// (re)set. The background sweeper evicts bindings older than
+// SessionHandleBindingTTL.
 type sessionAttemptBinding struct {
-	handle  roast.AttemptHandle
-	context attempt.AttemptContext
+	handle    roast.AttemptHandle
+	context   attempt.AttemptContext
+	createdAt time.Time
 }
 
 var (
 	sessionAttemptBindingMu sync.RWMutex
 	sessionAttemptBindings  = map[string]sessionAttemptBinding{}
+
+	sweeperOnce sync.Once
+	sweeperStop chan struct{}
 )
 
 // SetCurrentAttemptHandleForSession records the in-flight attempt
@@ -34,6 +58,10 @@ var (
 // Later calls for the same session overwrite earlier ones (this is
 // the documented behaviour: a session whose attempt has transitioned
 // re-binds to the new attempt's handle).
+//
+// The binding's createdAt is set to the current wall-clock time so
+// the background sweeper can evict it if Clear is never called
+// (panic before the deferred clear, etc.).
 func SetCurrentAttemptHandleForSession(
 	sessionID string,
 	handle roast.AttemptHandle,
@@ -42,8 +70,9 @@ func SetCurrentAttemptHandleForSession(
 	sessionAttemptBindingMu.Lock()
 	defer sessionAttemptBindingMu.Unlock()
 	sessionAttemptBindings[sessionID] = sessionAttemptBinding{
-		handle:  handle,
-		context: ctx,
+		handle:    handle,
+		context:   ctx,
+		createdAt: time.Now(),
 	}
 }
 
@@ -56,12 +85,69 @@ func ClearCurrentAttemptHandleForSession(sessionID string) {
 	delete(sessionAttemptBindings, sessionID)
 }
 
-// ResetSessionHandleRegistryForTest clears every binding. Exposed
-// only for tests; not for production code paths.
+// ResetSessionHandleRegistryForTest clears every binding and stops
+// the background sweeper if one is running. Exposed only for
+// tests; not for production code paths.
 func ResetSessionHandleRegistryForTest() {
 	sessionAttemptBindingMu.Lock()
 	defer sessionAttemptBindingMu.Unlock()
 	sessionAttemptBindings = map[string]sessionAttemptBinding{}
+	if sweeperStop != nil {
+		close(sweeperStop)
+		sweeperStop = nil
+		sweeperOnce = sync.Once{}
+	}
+}
+
+// StartSessionHandleSweeper launches the background goroutine that
+// evicts sessionAttemptBindings older than SessionHandleBindingTTL.
+// Idempotent via sync.Once: the first caller starts the sweeper;
+// subsequent calls are no-ops. The sweeper runs for the lifetime of
+// the process (until ResetSessionHandleRegistryForTest stops it,
+// which only tests do).
+//
+// Phase 5.2 starts the sweeper from RegisterRoastRetryCoordinator
+// so the defence-in-depth backstop is active whenever orchestration
+// could plausibly run.
+func StartSessionHandleSweeper() {
+	sweeperOnce.Do(func() {
+		sessionAttemptBindingMu.Lock()
+		sweeperStop = make(chan struct{})
+		stop := sweeperStop
+		sessionAttemptBindingMu.Unlock()
+		go sessionHandleSweepLoop(stop)
+	})
+}
+
+func sessionHandleSweepLoop(stop <-chan struct{}) {
+	ticker := time.NewTicker(SessionHandleSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			evictStaleSessionHandleBindings(SessionHandleBindingTTL)
+		}
+	}
+}
+
+// evictStaleSessionHandleBindings sweeps the binding map and
+// removes entries older than maxAge. Exposed at the package level
+// so tests can invoke it directly with small maxAge values without
+// waiting for the sweeper ticker.
+func evictStaleSessionHandleBindings(maxAge time.Duration) int {
+	cutoff := time.Now().Add(-maxAge)
+	sessionAttemptBindingMu.Lock()
+	defer sessionAttemptBindingMu.Unlock()
+	evicted := 0
+	for sessionID, binding := range sessionAttemptBindings {
+		if binding.createdAt.Before(cutoff) {
+			delete(sessionAttemptBindings, sessionID)
+			evicted++
+		}
+	}
+	return evicted
 }
 
 // currentAttemptHandleForCollect reads the binding the orchestration

--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -1,0 +1,64 @@
+package signing
+
+import (
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+)
+
+// BeginOrchestrationForSession encapsulates the per-session
+// BeginAttempt + binding-population step the RFC-21 Phase 5
+// orchestration layer performs. Callers in the layer above the
+// FROST signing primitive invoke it at session start; the returned
+// cleanup function is the matching unbinding step the caller
+// defers.
+//
+// Phase 5.2 ships the helper; Phase 6 wires production call sites
+// to invoke it (and to feed the AttemptContext from the resolver
+// adapter, etc.).
+//
+// When the ROAST-retry registry is empty (default build, no caller
+// has registered a coordinator), the helper returns an error so
+// the caller can fall back to legacy behaviour. The two-arg
+// "shape" -- (handle, cleanup, error) -- forces the caller to
+// handle the absence of a coordinator explicitly rather than
+// silently dropping the orchestration.
+func BeginOrchestrationForSession(
+	sessionID string,
+	ctx attempt.AttemptContext,
+) (roast.AttemptHandle, func(), error) {
+	deps, ok := RegisteredRoastRetryCoordinator()
+	if !ok {
+		return roast.AttemptHandle{}, nil, fmt.Errorf(
+			"roast orchestration: no coordinator registered; caller should fall back to legacy behaviour",
+		)
+	}
+	if deps.Coordinator == nil {
+		return roast.AttemptHandle{}, nil, fmt.Errorf(
+			"roast orchestration: registered RoastRetryDeps has nil Coordinator",
+		)
+	}
+	handle, err := deps.Coordinator.BeginAttempt(ctx)
+	if err != nil {
+		return roast.AttemptHandle{}, nil, fmt.Errorf(
+			"roast orchestration: begin attempt for session %q: %w",
+			sessionID,
+			err,
+		)
+	}
+	SetCurrentAttemptHandleForSession(sessionID, handle, ctx)
+	cleanup := func() {
+		ClearCurrentAttemptHandleForSession(sessionID)
+	}
+	return handle, cleanup, nil
+}
+
+// EndOrchestrationForSession is a convenience for callers that
+// did not capture the cleanup function from
+// BeginOrchestrationForSession (e.g. callers that pass session
+// ownership across function boundaries). It is equivalent to
+// invoking the cleanup function returned by Begin.
+func EndOrchestrationForSession(sessionID string) {
+	ClearCurrentAttemptHandleForSession(sessionID)
+}

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -1,0 +1,271 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func newOrchestrationTestContext(t *testing.T) attempt.AttemptContext {
+	t.Helper()
+	ctx, err := attempt.NewAttemptContext(
+		"orchestration-session",
+		"key-group-orchestration",
+		[]byte{0x01, 0x02},
+		[attempt.MessageDigestLength]byte{0x77},
+		0,
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ctx: %v", err)
+	}
+	return ctx
+}
+
+func TestBeginOrchestrationForSession_HappyPath(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	ctx := newOrchestrationTestContext(t)
+	handle, cleanup, err := BeginOrchestrationForSession("session-A", ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup must not be nil")
+	}
+
+	// Binding must exist.
+	gotHandle, gotCtx, ok := currentAttemptHandleForCollect("session-A")
+	if !ok {
+		t.Fatal("binding must exist after Begin")
+	}
+	if gotHandle != handle {
+		t.Fatal("binding handle mismatch")
+	}
+	if gotCtx.Hash() != ctx.Hash() {
+		t.Fatal("binding context mismatch")
+	}
+
+	cleanup()
+	if _, _, ok := currentAttemptHandleForCollect("session-A"); ok {
+		t.Fatal("binding must be cleared after cleanup")
+	}
+}
+
+func TestBeginOrchestrationForSession_ErrorsWhenRegistryEmpty(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	_, _, err := BeginOrchestrationForSession("session-X", newOrchestrationTestContext(t))
+	if err == nil {
+		t.Fatal("expected error when registry is empty")
+	}
+	if !strings.Contains(err.Error(), "no coordinator registered") {
+		t.Fatalf("error must mention missing registration; got %v", err)
+	}
+}
+
+func TestBeginOrchestrationForSession_ErrorsWhenCoordinatorNil(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: nil,
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	_, _, err := BeginOrchestrationForSession("session-Y", newOrchestrationTestContext(t))
+	if err == nil {
+		t.Fatal("expected error when Coordinator is nil")
+	}
+	if !strings.Contains(err.Error(), "nil Coordinator") {
+		t.Fatalf("error must mention nil coordinator; got %v", err)
+	}
+}
+
+func TestBeginOrchestrationForSession_PropagatesBeginAttemptError(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	// A coordinator whose BeginAttempt always fails.
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: &erroringCoordinator{err: errors.New("synthetic begin failure")},
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	_, _, err := BeginOrchestrationForSession("session-Z", newOrchestrationTestContext(t))
+	if err == nil {
+		t.Fatal("expected error from coordinator")
+	}
+	if !strings.Contains(err.Error(), "synthetic begin failure") {
+		t.Fatalf("error must wrap underlying cause; got %v", err)
+	}
+}
+
+func TestEndOrchestrationForSession_RemovesBinding(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	ctx := newOrchestrationTestContext(t)
+	SetCurrentAttemptHandleForSession("session-end", roast.AttemptHandle{}, ctx)
+
+	if _, _, ok := currentAttemptHandleForCollect("session-end"); !ok {
+		t.Fatal("setup: binding must exist")
+	}
+	EndOrchestrationForSession("session-end")
+	if _, _, ok := currentAttemptHandleForCollect("session-end"); ok {
+		t.Fatal("binding must be removed after End")
+	}
+}
+
+func TestEvictStaleSessionHandleBindings_RemovesOldEntries(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	// Two bindings with different ages.
+	ctx := newOrchestrationTestContext(t)
+	SetCurrentAttemptHandleForSession("session-old", roast.AttemptHandle{}, ctx)
+	// Backdate by forcing the timestamp.
+	sessionAttemptBindingMu.Lock()
+	b := sessionAttemptBindings["session-old"]
+	b.createdAt = time.Now().Add(-10 * time.Minute)
+	sessionAttemptBindings["session-old"] = b
+	sessionAttemptBindingMu.Unlock()
+
+	SetCurrentAttemptHandleForSession("session-new", roast.AttemptHandle{}, ctx)
+
+	// Sweep with 5-minute TTL: old must be evicted, new must survive.
+	evicted := evictStaleSessionHandleBindings(5 * time.Minute)
+	if evicted != 1 {
+		t.Fatalf("expected 1 eviction, got %d", evicted)
+	}
+	if _, _, ok := currentAttemptHandleForCollect("session-old"); ok {
+		t.Fatal("session-old must be evicted")
+	}
+	if _, _, ok := currentAttemptHandleForCollect("session-new"); !ok {
+		t.Fatal("session-new must survive")
+	}
+}
+
+func TestEvictStaleSessionHandleBindings_LeavesFreshEntries(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	ctx := newOrchestrationTestContext(t)
+	SetCurrentAttemptHandleForSession("session-fresh", roast.AttemptHandle{}, ctx)
+
+	// Sweep with the default 2-hour TTL: nothing should be evicted.
+	evicted := evictStaleSessionHandleBindings(SessionHandleBindingTTL)
+	if evicted != 0 {
+		t.Fatalf("expected 0 evictions for fresh binding, got %d", evicted)
+	}
+}
+
+func TestSessionHandleBindingTTL_MatchesRFC(t *testing.T) {
+	if SessionHandleBindingTTL != 2*time.Hour {
+		t.Fatalf(
+			"RFC-21 specifies a 2-hour default TTL; constant is %s",
+			SessionHandleBindingTTL,
+		)
+	}
+}
+
+func TestStartSessionHandleSweeper_IsIdempotent(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	StartSessionHandleSweeper()
+	StartSessionHandleSweeper()
+	StartSessionHandleSweeper()
+	// sync.Once means only one goroutine started; we don't have a
+	// direct observable, but ResetSessionHandleRegistryForTest will
+	// close the stop channel and the goroutine will exit cleanly.
+	// If sync.Once were broken, double-close on the stop channel
+	// would panic during cleanup.
+}
+
+func TestRegisterRoastRetryCoordinator_StartsSweeper(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	// Register again to verify sync.Once prevents a second
+	// sweeper.
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  2,
+	})
+
+	// Reset should not panic (would panic on double-close if
+	// sync.Once failed).
+	ResetSessionHandleRegistryForTest()
+}
+
+// erroringCoordinator returns a synthetic error from BeginAttempt.
+// Other methods return zero values or nil; tests that need them
+// should use a real coordinator.
+type erroringCoordinator struct {
+	err error
+}
+
+func (e *erroringCoordinator) BeginAttempt(_ attempt.AttemptContext) (roast.AttemptHandle, error) {
+	return roast.AttemptHandle{}, e.err
+}
+func (e *erroringCoordinator) State(_ roast.AttemptHandle) (roast.AttemptState, error) {
+	return roast.AttemptStatePending, nil
+}
+func (e *erroringCoordinator) SelectedCoordinator(_ roast.AttemptHandle) (group.MemberIndex, error) {
+	return 0, nil
+}
+func (e *erroringCoordinator) RecordEvidence(_ roast.AttemptHandle, _ *roast.LocalEvidenceSnapshot) error {
+	return nil
+}
+func (e *erroringCoordinator) AggregateBundle(_ roast.AttemptHandle) (*roast.TransitionMessage, error) {
+	return nil, nil
+}
+func (e *erroringCoordinator) VerifyBundle(_ roast.AttemptHandle, _ *roast.TransitionMessage) error {
+	return nil
+}
+func (e *erroringCoordinator) NextAttempt(
+	_ roast.AttemptHandle, _ *roast.TransitionMessage, _ uint, _ []byte,
+) (attempt.AttemptContext, error) {
+	return attempt.AttemptContext{}, nil
+}

--- a/pkg/frost/signing/roast_retry_orchestration_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_test.go
@@ -1,0 +1,37 @@
+package signing
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func TestBeginOrchestrationForSession_DefaultBuildReturnsError(t *testing.T) {
+	// In the default build, RegisteredRoastRetryCoordinator always
+	// returns (zero, false), so the orchestration helper must
+	// return an error directing the caller to fall back to legacy
+	// behaviour. This guarantees no production caller can
+	// accidentally "succeed" into orchestration when the build tag
+	// is off.
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+
+	ctx, err := attempt.NewAttemptContext(
+		"session-default-build",
+		"key-group",
+		[]byte{0x01},
+		[attempt.MessageDigestLength]byte{0x77},
+		0,
+		[]group.MemberIndex{1, 2, 3},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ctx: %v", err)
+	}
+
+	_, _, err = BeginOrchestrationForSession("session-default-build", ctx)
+	if err == nil {
+		t.Fatal("default build must return error from BeginOrchestrationForSession")
+	}
+}

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -34,11 +34,17 @@ var (
 // Safe for concurrent registration / lookup; a later registration
 // fully replaces an earlier one (this is the documented behaviour --
 // reconfiguring at runtime is intentional).
+//
+// As a side effect, the first registration starts the
+// session-handle sweeper goroutine that evicts orphaned bindings
+// (RFC-21 Phase 5.2 defence-in-depth backstop). Subsequent
+// registrations do not restart the sweeper.
 func RegisterRoastRetryCoordinator(deps RoastRetryDeps) {
 	roastRetryRegistrationMu.Lock()
-	defer roastRetryRegistrationMu.Unlock()
 	roastRetryRegistration = deps
 	roastRetryRegistered = true
+	roastRetryRegistrationMu.Unlock()
+	StartSessionHandleSweeper()
 }
 
 // RegisteredRoastRetryCoordinator returns the currently-registered


### PR DESCRIPTION
## Summary

Second Phase-5 PR. Adds the session-orchestration entry points
Phase 6 will wire from production call sites, plus the background
TTL-eviction sweeper documented in RFC-21's Resolved Decisions
section (the defence-in-depth backstop against
panic-before-deferred-clear leaks).

Stacked on #3977 (Phase 5.1).

## What lands

### Orchestration helpers (untagged)

\`pkg/frost/signing/roast_retry_orchestration.go\`:

- \`BeginOrchestrationForSession(sessionID, ctx) → (handle, cleanup, error)\` — calls \`Coordinator.BeginAttempt\` and \`SetCurrentAttemptHandleForSession\`; returns a cleanup function the caller defers.
- \`EndOrchestrationForSession(sessionID)\` — cleanup convenience when the cleanup function can't be captured.
- In the **default build** the helper returns an error directing the caller to fall back to legacy behaviour. Production code paths cannot accidentally succeed into orchestration when the build tag is off.

### TTL sweeper (tagged build)

\`pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go\` (extended):

| Surface | Notes |
|---|---|
| \`SessionHandleBindingTTL\` constant | 2 hours, matches RFC-21 spec |
| \`SessionHandleSweepInterval\` constant | 15 minutes |
| \`StartSessionHandleSweeper()\` | sync.Once-protected goroutine launcher |
| \`evictStaleSessionHandleBindings(maxAge) int\` | exposed for tests |
| Reset stops the sweeper + resets the sync.Once | test isolation |
| \`RegisterRoastRetryCoordinator\` now also calls \`StartSessionHandleSweeper()\` | backstop active whenever orchestration could plausibly run |

### Sessionbinding gains \`createdAt time.Time\`

Set on every \`SetCurrentAttemptHandleForSession\` call; consumed by the sweeper to evict bindings older than the TTL.

## Test coverage

| Suite | Build | Cases |
|---|---|---|
| \`roast_retry_orchestration_test.go\` | default | 1 (BeginOrchestrationForSession errors when registry empty) |
| \`roast_retry_orchestration_frost_roast_retry_test.go\` | tagged | 9 (happy path, three error modes, end cleanup, eviction with old + fresh entries, fresh-only sweep, RFC constant match, sweeper idempotence, register-starts-sweeper) |

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/signing/...\` | pass (default build) |
| \`go test -tags 'frost_roast_retry' ./pkg/frost/signing/...\` | pass |
| \`go test -race -tags 'frost_native frost_tbtc_signer frost_roast_retry' ./pkg/frost/signing/...\` | pass |
| \`staticcheck -checks '-SA1019' ./pkg/frost/...\` | silent |
| \`go vet ./pkg/frost/...\` | clean |
| \`gofmt -l ./pkg/frost/signing/\` | silent |

## Why the helpers ship untagged but the backing implementation is tagged

The default-build stub for \`RegisteredRoastRetryCoordinator\`
always returns \`(zero, false)\`, so the orchestration helper's
first check fails and returns an error before any tagged code path
executes. The untagged helper file compiles in both builds; only
the tagged sweeper and binding-map machinery require the
\`frost_roast_retry\` tag.

## Phase 5 status

| PR | Scope | State |
|---|---|---|
| 5.1 (#3977) | Retry adapter scaffolding | open |
| **5.2 (this)** | **Orchestration helpers + TTL sweep** | **open** |
| 5.3 | Readiness-gate env-var guard | next |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the 2-hour TTL + 15-minute sweep interval are reasonable defaults.
- [ ] Reviewer confirms the sweeper-starts-on-register pattern is acceptable (alternatives: explicit-start-by-caller, init-time-start).