### PR TITLE
docs(rfc): RFC-21 Phase-6 error-handling discipline + V1 prerequisite

### DIFF
--- a/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
+++ b/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
@@ -634,6 +634,65 @@ field on `sessionAttemptBinding`. The eviction does not depend
 on session-completion correctness; it only catches the
 panic-before-defer pathological case.
 
+=== Orchestration error taxonomy
+
+*Decision: orchestration errors are bucketed into two classes, with
+fundamentally different handling.*
+
+When the executor adapter calls `BeginOrchestrationForSession`,
+the call can fail for two distinct reasons that the receiver MUST
+distinguish:
+
+. *Static-configuration errors* -- the build was deployed without
+  the readiness env var, or no caller has registered a coordinator.
+  These errors are fully deterministic: every honest signer
+  observes the same error from the same configuration at the same
+  startup state. Safe to log at INFO and fall back to the legacy
+  retry path. Sentinel errors `ErrRoastRetryReadinessOptOut` and
+  `ErrNoRoastRetryCoordinatorRegistered` (introduced in Phase 6.3)
+  signal this class; `errors.Is` checks identify them.
+
+. *Runtime state-machine errors* -- `Coordinator.BeginAttempt`
+  returned an error (out-of-memory, malformed AttemptContext,
+  internal invariant violated, etc.). These errors are
+  non-deterministic across nodes: node A may experience a runtime
+  failure while node B succeeds. Treat them as hard failures:
+  return an error from the executor adapter, declare the session
+  failed.
+
+The safety reason is load-bearing. If node A falls back to the
+legacy retry shuffle while node B proceeds with the ROAST state
+machine, the two nodes compute different `NextAttempt` participant
+sets, and the signing group fractures permanently. The legacy
+fallback is only acceptable when every honest signer would make
+the same choice, which is true for static configuration and false
+for runtime errors.
+
+This decision applies to Phase 6.3 (orchestration wiring at the
+executor adapter) and Phase 6.4 (call-site migration). Phase 5
+deliberately ships orchestration as best-effort because it has no
+production consumer; Phase 6 is where the safety distinction
+matters.
+
+=== `FrostUniFFIV1` signer-material prerequisite
+
+*Decision: Phase 7's manifest flip is gated on verified migration
+away from `FrostUniFFIV1` signer material across all production
+signers.*
+
+Phase 6.1's `ExtractDkgGroupPublicKeyFromMaterial` switches on
+`NativeSignerMaterial.Format`. The two production-relevant formats
+(`FrostUniFFIV2` and `FrostTBTCSignerV1`) expose the DKG group
+public key on the material directly. The legacy `FrostUniFFIV1`
+format does not include the group key in a form Phase 6.1 can
+extract; the helper returns a descriptive error directing
+operators to migrate.
+
+Until the network has fully migrated off V1, the Phase 7 readiness
+manifest cannot flip to `present`. The migration tracking
+mechanism is out of scope for this RFC; the prerequisite is
+documented here as a hard dependency of Phase 7.
+
 == Open questions
 
 . *Persistence across signer restart.* If a signer crashes mid-attempt,


### PR DESCRIPTION
## Summary

Two new Resolved Decisions in RFC-21, informed by the Phase-6
design review (2026-05-23). Doc-only; +59/-0.

### 1. Orchestration error taxonomy

The orchestration call from the executor adapter into
\`BeginOrchestrationForSession\` can fail for two fundamentally
different reasons that **must not** be collapsed into a single
"fall back to legacy" path:

| Class | Source | Action |
|---|---|---|
| Static-configuration | env var unset, no coordinator registered | Log INFO, fall back to legacy. Deterministic across nodes -- every honest signer observes the same outcome. |
| Runtime state-machine | \`Coordinator.BeginAttempt\` failure, internal invariant violated | **HARD FAIL.** Return error from executor adapter; declare session failed. |

The decision is load-bearing for safety. A fall-back-on-runtime-error
policy lets node A run the legacy shuffle while node B proceeds
with the ROAST state machine, splitting the signing group on
\`NextAttempt\`. Sentinel errors \`ErrRoastRetryReadinessOptOut\` and
\`ErrNoRoastRetryCoordinatorRegistered\` (introduced in Phase 6.3)
identify the static class via \`errors.Is\`.

### 2. \`FrostUniFFIV1\` signer-material prerequisite

Phase 6.1's \`ExtractDkgGroupPublicKeyFromMaterial\` cannot extract
the DKG group public key from V1 material. The Phase 7 readiness
manifest flip is therefore gated on verified migration off V1
across production signers.

The migration tracking mechanism is out of scope for this RFC;
the prerequisite is documented here as a hard dependency of
Phase 7.

## Phase 6 implementation plan (updated)

Adapter wiring uses the new error taxonomy:

\`\`\`go
handle, cleanup, err := BeginOrchestrationForSession(sid, ctx)
switch {
case errors.Is(err, ErrRoastRetryReadinessOptOut),
     errors.Is(err, ErrNoRoastRetryCoordinatorRegistered):
    // Static config: legacy fallback is safe
    log.Infof("ROAST retry disabled: %v", err)
    return legacyParticipantSelection(...)
case err != nil:
    // Runtime error: HARD FAIL, do not fall back
    return nil, fmt.Errorf("orchestration failed: %w", err)
}
defer cleanup()
// Use ROAST path
\`\`\`

## Test plan

- [ ] Reviewer confirms the static-vs-runtime taxonomy is the right safety partition.
- [ ] Reviewer confirms the V1 prerequisite is appropriately scoped to Phase 7 (not earlier).

No code changes; AsciiDoc renders cleanly via the existing docs CI job.