### PR TITLE
feat(frost/signing): RFC-21 Phase 6.1 -- DKG group-public-key extraction

### DIFF
--- a/pkg/frost/signing/dkg_group_pubkey_extraction.go
+++ b/pkg/frost/signing/dkg_group_pubkey_extraction.go
@@ -1,0 +1,131 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// ErrUnsupportedSignerMaterialFormat is returned by
+// ExtractDkgGroupPublicKeyFromMaterial when the material's Format
+// field names a signer-material variant the helper cannot extract
+// a DKG group public key from. The current implementation accepts
+// FrostUniFFIV2 and FrostTBTCSignerV1; FrostUniFFIV1 is rejected
+// because the legacy bridge format does not expose the group key.
+//
+// Per RFC-21 Phase-6 Resolved Decision: the Phase 7 manifest flip
+// is gated on verified migration off V1 across production signers,
+// so this error class is expected to disappear by the time ROAST
+// retry ships unconditionally.
+var ErrUnsupportedSignerMaterialFormat = errors.New(
+	"dkg group public key: unsupported signer-material format for extraction",
+)
+
+// ExtractDkgGroupPublicKeyFromMaterial returns the DKG-validated
+// group public key from the supplied NativeSignerMaterial in the
+// canonical byte representation that attempt.DeriveAttemptSeed
+// consumes. Two honest signers feeding the same material into this
+// helper produce byte-identical outputs.
+//
+// Format handling:
+//
+//   - FrostUniFFIV2: decode payload as nativeFROSTUniFFIV2SignerMaterial;
+//     hex-decode PublicKeyPackage.VerifyingKey. This is the x-only
+//     output key produced by the native FROST DKG.
+//
+//   - FrostTBTCSignerV1: decode payload as NativeTBTCSignerMaterialPayload;
+//     return the raw bytes of the KeyGroup identifier. The tbtc-signer
+//     engine treats KeyGroup as the canonical handle for the FROST
+//     key group; every honest signer running the same tbtc-signer
+//     build agrees on its bytes.
+//
+//   - FrostUniFFIV1: returns ErrUnsupportedSignerMaterialFormat.
+//     V1 material is the legacy bridge format that does not carry
+//     the group public key in a form Phase 6 can extract.
+//
+// Callers MUST use the returned bytes only as the
+// DkgGroupPublicKey input to attempt.DeriveAttemptSeed; the bytes
+// are not interchangeable across format boundaries (a UniFFIV2 key
+// and a TBTCSignerV1 key for the "same" logical group produce
+// different bytes -- they are different formats). Production
+// signing groups must run on a single uniform format.
+func ExtractDkgGroupPublicKeyFromMaterial(
+	signerMaterial *NativeSignerMaterial,
+) ([]byte, error) {
+	if signerMaterial == nil {
+		return nil, fmt.Errorf(
+			"dkg group public key: signer material is nil",
+		)
+	}
+	switch signerMaterial.Format {
+	case NativeSignerMaterialFormatFrostUniFFIV2:
+		return extractDkgGroupPublicKeyFromUniFFIV2(signerMaterial)
+	case NativeSignerMaterialFormatFrostTBTCSignerV1:
+		return extractDkgGroupPublicKeyFromTBTCSignerV1(signerMaterial)
+	case NativeSignerMaterialFormatFrostUniFFIV1:
+		return nil, fmt.Errorf(
+			"%w: %s (migrate to %s or %s before enabling ROAST retry)",
+			ErrUnsupportedSignerMaterialFormat,
+			signerMaterial.Format,
+			NativeSignerMaterialFormatFrostUniFFIV2,
+			NativeSignerMaterialFormatFrostTBTCSignerV1,
+		)
+	default:
+		return nil, fmt.Errorf(
+			"%w: unknown format %q",
+			ErrUnsupportedSignerMaterialFormat,
+			signerMaterial.Format,
+		)
+	}
+}
+
+func extractDkgGroupPublicKeyFromUniFFIV2(
+	signerMaterial *NativeSignerMaterial,
+) ([]byte, error) {
+	decoded, err := decodeNativeFROSTUniFFIV2SignerMaterial(signerMaterial)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"dkg group public key: decode FrostUniFFIV2: %w",
+			err,
+		)
+	}
+	if decoded.PublicKeyPackage == nil {
+		return nil, fmt.Errorf(
+			"dkg group public key: FrostUniFFIV2 public key package is nil",
+		)
+	}
+	verifyingKey := decoded.PublicKeyPackage.VerifyingKey
+	if verifyingKey == "" {
+		return nil, fmt.Errorf(
+			"dkg group public key: FrostUniFFIV2 verifying key is empty",
+		)
+	}
+	raw, err := hex.DecodeString(verifyingKey)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"dkg group public key: FrostUniFFIV2 verifying key is not hex: %w",
+			err,
+		)
+	}
+	return raw, nil
+}
+
+func extractDkgGroupPublicKeyFromTBTCSignerV1(
+	signerMaterial *NativeSignerMaterial,
+) ([]byte, error) {
+	payload, err := decodeBuildTaggedTBTCSignerMaterialPayload(signerMaterial)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"dkg group public key: decode FrostTBTCSignerV1: %w",
+			err,
+		)
+	}
+	if payload.KeyGroup == "" {
+		return nil, fmt.Errorf(
+			"dkg group public key: FrostTBTCSignerV1 key group is empty",
+		)
+	}
+	return []byte(payload.KeyGroup), nil
+}

--- a/pkg/frost/signing/dkg_group_pubkey_extraction_test.go
+++ b/pkg/frost/signing/dkg_group_pubkey_extraction_test.go
@@ -1,0 +1,205 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExtractDkgGroupPublicKey_RejectsNilMaterial(t *testing.T) {
+	_, err := ExtractDkgGroupPublicKeyFromMaterial(nil)
+	if err == nil {
+		t.Fatal("expected error for nil material")
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostUniFFIV2_HexDecodes(t *testing.T) {
+	const hexKey = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+	payload, err := json.Marshal(&nativeFROSTUniFFIV2SignerMaterial{
+		KeyPackage: &NativeFROSTKeyPackage{
+			Identifier: "id-1",
+			Data:       []byte{0x01},
+		},
+		PublicKeyPackage: &NativeFROSTPublicKeyPackage{
+			VerifyingKey: hexKey,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostUniFFIV2,
+		Payload: payload,
+	}
+	got, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	want, _ := hex.DecodeString(hexKey)
+	if !bytes.Equal(got, want) {
+		t.Fatalf(
+			"hex decode mismatch: got %x, want %x",
+			got, want,
+		)
+	}
+	if len(got) != 32 {
+		t.Fatalf("expected 32 bytes, got %d", len(got))
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostUniFFIV2_RejectsEmptyVerifyingKey(t *testing.T) {
+	payload, _ := json.Marshal(&nativeFROSTUniFFIV2SignerMaterial{
+		KeyPackage: &NativeFROSTKeyPackage{
+			Identifier: "id-1",
+			Data:       []byte{0x01},
+		},
+		PublicKeyPackage: &NativeFROSTPublicKeyPackage{
+			VerifyingKey: "",
+		},
+	})
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostUniFFIV2,
+		Payload: payload,
+	}
+	// The pre-existing decodeNativeFROSTUniFFIV2SignerMaterial
+	// validator may reject this before our helper sees it; either
+	// way an error must be returned.
+	_, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if err == nil {
+		t.Fatal("expected error for empty VerifyingKey")
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostUniFFIV2_RejectsNonHexVerifyingKey(t *testing.T) {
+	payload, _ := json.Marshal(&nativeFROSTUniFFIV2SignerMaterial{
+		KeyPackage: &NativeFROSTKeyPackage{
+			Identifier: "id-1",
+			Data:       []byte{0x01},
+		},
+		PublicKeyPackage: &NativeFROSTPublicKeyPackage{
+			VerifyingKey: "not-hex-zzz!",
+		},
+	})
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostUniFFIV2,
+		Payload: payload,
+	}
+	_, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if err == nil {
+		t.Fatal("expected error for non-hex VerifyingKey")
+	}
+	if !strings.Contains(err.Error(), "not hex") {
+		t.Fatalf("error must mention hex problem; got %v", err)
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostTBTCSignerV1_ReturnsKeyGroupBytes(t *testing.T) {
+	const keyGroup = "group-A"
+	payload, _ := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup: keyGroup,
+	})
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+		Payload: payload,
+	}
+	got, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if string(got) != keyGroup {
+		t.Fatalf("got %q, want %q", string(got), keyGroup)
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostTBTCSignerV1_DeterministicAcrossCalls(t *testing.T) {
+	payload, _ := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup: "deterministic-group",
+	})
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+		Payload: payload,
+	}
+	a, _ := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	b, _ := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if !bytes.Equal(a, b) {
+		t.Fatalf("extraction is non-deterministic: %x vs %x", a, b)
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostTBTCSignerV1_RejectsEmptyKeyGroup(t *testing.T) {
+	payload, _ := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup: "",
+	})
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+		Payload: payload,
+	}
+	_, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if err == nil {
+		t.Fatal("expected error for empty KeyGroup")
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostUniFFIV1_ReturnsUnsupportedSentinel(t *testing.T) {
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostUniFFIV1,
+		Payload: []byte("{}"),
+	}
+	_, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if !errors.Is(err, ErrUnsupportedSignerMaterialFormat) {
+		t.Fatalf("expected ErrUnsupportedSignerMaterialFormat, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "migrate to") {
+		t.Fatalf("error must guide operator to migration; got %v", err)
+	}
+}
+
+func TestExtractDkgGroupPublicKey_UnknownFormat_ReturnsUnsupportedSentinel(t *testing.T) {
+	mat := &NativeSignerMaterial{
+		Format:  "frost-some-future-format-v0",
+		Payload: []byte("{}"),
+	}
+	_, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if !errors.Is(err, ErrUnsupportedSignerMaterialFormat) {
+		t.Fatalf("expected ErrUnsupportedSignerMaterialFormat, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "frost-some-future-format-v0") {
+		t.Fatalf("error must mention the unknown format; got %v", err)
+	}
+}
+
+func TestExtractDkgGroupPublicKey_FrostUniFFIV2_GoldenFixture(t *testing.T) {
+	// Lock the canonical byte output for a specific hex input. If a
+	// future change to extractDkgGroupPublicKeyFromUniFFIV2 alters
+	// the result, this test catches the drift at code review.
+	const hexKey = "deadbeefcafebabe0000000000000000000000000000000000000000000000ff"
+	payload, _ := json.Marshal(&nativeFROSTUniFFIV2SignerMaterial{
+		KeyPackage: &NativeFROSTKeyPackage{
+			Identifier: "fixture",
+			Data:       []byte{0xFF},
+		},
+		PublicKeyPackage: &NativeFROSTPublicKeyPackage{
+			VerifyingKey: hexKey,
+		},
+	})
+	mat := &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostUniFFIV2,
+		Payload: payload,
+	}
+	got, err := ExtractDkgGroupPublicKeyFromMaterial(mat)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	want, _ := hex.DecodeString(hexKey)
+	if !bytes.Equal(got, want) {
+		t.Fatalf(
+			"golden fixture mismatch: got %x, want %x",
+			got, want,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

First Phase-6 implementation PR. Adds the helper Phase 6.2 will use
to derive \`AttemptSeed\` inputs from \`NativeSignerMaterial\`. No
consumer wired yet.

Stacked on #3980 (RFC update).

## What lands

\`pkg/frost/signing/dkg_group_pubkey_extraction.go\` (new, gated \`frost_native\`):

| Format | Extraction |
|---|---|
| \`FrostUniFFIV2\` | hex-decode \`PublicKeyPackage.VerifyingKey\` (production materials use hex-encoded x-only output keys) |
| \`FrostTBTCSignerV1\` | raw bytes of \`payload.KeyGroup\` -- tbtc-signer engine's canonical handle for the FROST key group |
| \`FrostUniFFIV1\` | returns \`ErrUnsupportedSignerMaterialFormat\` with operator-guidance text; RFC-21 Resolved Decision says Phase 7's manifest flip is gated on migration off V1 |
| Unknown | sentinel error with bad-format-name context |

## Why two different extractions

UniFFIV2 carries the raw cryptographic group public key on the
material (hex-encoded). TBTCSignerV1 carries an opaque
\`KeyGroup\` string identifier -- the actual public key lives in the
tbtc-signer engine and is referenced by KeyGroup. Both
representations are deterministic *within* a format, so two honest
signers running the same format and material derive the same
\`AttemptSeed\`.

**Important constraint:** production signing groups must run on a
single uniform format. A UniFFIV2 hex-decoded key and a
TBTCSignerV1 raw KeyGroup byte string for the "same" logical group
produce different bytes -- they are different formats. Mixed-format
groups would silently desynchronise \`AttemptSeed\` derivation;
they are not supported. Phase 6.2's helper enforces this at the
boundary.

## Test coverage (10 cases)

- Rejects nil material
- UniFFIV2 hex-decodes to 32-byte canonical x-only key
- UniFFIV2 rejects empty VerifyingKey
- UniFFIV2 rejects non-hex VerifyingKey
- TBTCSignerV1 returns KeyGroup bytes
- TBTCSignerV1 deterministic across calls
- TBTCSignerV1 rejects empty KeyGroup
- UniFFIV1 returns \`ErrUnsupportedSignerMaterialFormat\` (errors.Is sentinel + migration-guidance text)
- Unknown format returns sentinel with bad-format-name context
- UniFFIV2 golden-fixture locks the hex-decode behaviour

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/frost/signing/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer frost_roast_retry' -race ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/...\` | silent |
| \`go vet ./pkg/frost/...\` | clean |
| \`gofmt -l ./pkg/frost/signing/\` | silent |

## Phase 6 plan

| PR | Scope | State |
|---|---|---|
| **6.1 (this)** | **DKG group-public-key extraction** | **open** |
| 6.2 | \`BuildAttemptContextFromRequest\` helper | next |
| 6.3 | Wire orchestration at executor adapter (strict error taxonomy per #3980) | after 6.2 |
| 6.4 | Migrate three call sites onto \`EvaluateRoastRetryForSigning\` | after 6.3 |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the UniFFIV1-as-error decision (alternative: silent-ignore for graceful degradation).
- [ ] Reviewer confirms the format-bytes-as-canonical approach (alternative: derive a uniform representation across formats).