### PR TITLE
feat(frost/signing): RFC-21 Phase 6.2 -- BuildAttemptContextFromRequest

### DIFF
--- a/pkg/frost/signing/attempt_context_from_request.go
+++ b/pkg/frost/signing/attempt_context_from_request.go
@@ -1,0 +1,223 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/keep-network/keep-core/pkg/frost"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+)
+
+// ErrAttemptContextConstruction is the sentinel error class returned
+// by BuildAttemptContextFromRequest for any failure during
+// construction. Callers can match with errors.Is to distinguish
+// it from runtime ROAST errors.
+var ErrAttemptContextConstruction = errors.New(
+	"attempt context: construction failed",
+)
+
+// BuildAttemptContextFromRequest converts a
+// NativeExecutionFFISigningRequest into an attempt.AttemptContext
+// suitable for Coordinator.BeginAttempt. The conversion:
+//
+//   - SessionID, AttemptNumber, IncludedSet, ExcludedSet come from
+//     the request and its Attempt sub-struct directly.
+//   - TransientlyParked is empty: the existing Attempt struct does
+//     not carry parking info. Phase-7+ orchestration that drives
+//     multi-attempt sessions will need to thread parking metadata
+//     through; Phase 6 only handles attempt-zero shape.
+//   - MessageDigest is the request.Message bytes left-padded with
+//     zeros to 32 bytes, then truncated if longer. In BIP-340
+//     production, request.Message is already a 32-byte digest of
+//     the tagged payload, so padding is a no-op.
+//   - DkgGroupPublicKey is extracted via
+//     ExtractDkgGroupPublicKeyFromMaterial.
+//   - KeyGroupID is derived format-aware:
+//     FrostUniFFIV2: HASH160(0x02 || xOnlyOutputKey) -- matches
+//     RFC-20's compatibility-alias scheme for legacy
+//     20-byte wallet key hashes.
+//     FrostTBTCSignerV1: the raw KeyGroup string identifier from
+//     the tbtc-signer material, which is already a canonical
+//     per-group handle.
+//   - AttemptSeed = SHA256(DkgGroupPublicKey || SessionID ||
+//     MessageDigest) per RFC-21 Decision 2.
+//
+// Critically, the FFI signer material is decoded *first* so any
+// extraction failure is surfaced before the AttemptContext is
+// constructed. This enforces the ordering Gemini flagged in the
+// Phase-6 design review: AttemptContext must never be built from
+// undecoded material because the seed derivation would silently
+// fail.
+//
+// Returns ErrAttemptContextConstruction-wrapped errors for any
+// failure during the construction. Returns ErrUnsupportedSignerMaterialFormat
+// (via errors.Is) when the material's format is not extractable
+// (e.g. FrostUniFFIV1 today).
+func BuildAttemptContextFromRequest(
+	request *NativeExecutionFFISigningRequest,
+) (attempt.AttemptContext, error) {
+	if request == nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: request is nil",
+			ErrAttemptContextConstruction,
+		)
+	}
+	if request.Message == nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: request message is nil",
+			ErrAttemptContextConstruction,
+		)
+	}
+	if request.SignerMaterial == nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: signer material is nil",
+			ErrAttemptContextConstruction,
+		)
+	}
+	if request.Attempt == nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: attempt metadata is nil",
+			ErrAttemptContextConstruction,
+		)
+	}
+
+	// Strict ordering: extract DKG group public key (which decodes
+	// the signer material) BEFORE deriving the context. A failure
+	// here propagates directly without leaving a half-built
+	// context.
+	dkgPub, err := ExtractDkgGroupPublicKeyFromMaterial(request.SignerMaterial)
+	if err != nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: %w",
+			ErrAttemptContextConstruction,
+			err,
+		)
+	}
+
+	keyGroupID, err := deriveKeyGroupID(request.SignerMaterial, dkgPub)
+	if err != nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: %w",
+			ErrAttemptContextConstruction,
+			err,
+		)
+	}
+
+	digest, err := messageDigestFromBigInt(request.Message)
+	if err != nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: %w",
+			ErrAttemptContextConstruction,
+			err,
+		)
+	}
+
+	// AttemptNumber on the keep-core Attempt struct is 1-based
+	// (1 = first attempt). RFC-21's AttemptContext.AttemptNumber is
+	// 0-based. Convert by subtracting 1 (Attempt.Number must be
+	// >= 1).
+	if request.Attempt.Number == 0 {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: request.Attempt.Number is zero (must be >= 1)",
+			ErrAttemptContextConstruction,
+		)
+	}
+	attemptNumber := uint32(request.Attempt.Number - 1)
+
+	ctx, err := attempt.NewAttemptContextWithParking(
+		request.SessionID,
+		keyGroupID,
+		dkgPub,
+		digest,
+		attemptNumber,
+		request.Attempt.IncludedMembersIndexes,
+		request.Attempt.ExcludedMembersIndexes,
+		nil, // Phase 6 ships attempt-zero shape; parking lands in Phase 7+ orchestration.
+	)
+	if err != nil {
+		return attempt.AttemptContext{}, fmt.Errorf(
+			"%w: %w",
+			ErrAttemptContextConstruction,
+			err,
+		)
+	}
+	return ctx, nil
+}
+
+// deriveKeyGroupID computes the AttemptContext KeyGroupID field
+// from the signer material plus the already-extracted DKG group
+// public key. The derivation is format-aware:
+//
+//   - FrostUniFFIV2: HASH160(0x02 || dkgPub) -- the compressed
+//     33-byte form prefixed with 0x02 matches the legacy
+//     compatibility-alias scheme RFC-20 introduced for 20-byte
+//     wallet pub-key-hashes. dkgPub here is the 32-byte x-only
+//     output key.
+//   - FrostTBTCSignerV1: the raw KeyGroup string from the tbtc-
+//     signer material. That string is the canonical handle.
+//
+// Returns an error for unknown formats; the caller will already
+// have rejected unsupported formats via ExtractDkgGroupPublicKeyFromMaterial,
+// so reaching the default arm here is an internal consistency
+// error.
+func deriveKeyGroupID(
+	signerMaterial *NativeSignerMaterial,
+	dkgPub []byte,
+) (string, error) {
+	switch signerMaterial.Format {
+	case NativeSignerMaterialFormatFrostUniFFIV2:
+		if len(dkgPub) != frost.OutputKeySize {
+			return "", fmt.Errorf(
+				"derive key group id: FrostUniFFIV2 x-only key length %d, expected %d",
+				len(dkgPub),
+				frost.OutputKeySize,
+			)
+		}
+		var outputKey frost.OutputKey
+		copy(outputKey[:], dkgPub)
+		alias := frost.WalletPublicKeyHashCompatibilityAlias(outputKey)
+		return fmt.Sprintf("%x", alias[:]), nil
+	case NativeSignerMaterialFormatFrostTBTCSignerV1:
+		payload, err := decodeBuildTaggedTBTCSignerMaterialPayload(signerMaterial)
+		if err != nil {
+			return "", fmt.Errorf("derive key group id: %w", err)
+		}
+		return payload.KeyGroup, nil
+	default:
+		return "", fmt.Errorf(
+			"derive key group id: cannot derive id from format %q",
+			signerMaterial.Format,
+		)
+	}
+}
+
+// messageDigestFromBigInt converts a *big.Int message to the
+// 32-byte digest shape AttemptContext expects. Big-int values
+// shorter than 32 bytes are left-padded with zeros (big.Int.Bytes
+// strips leading zeros). Values longer than 32 bytes return an
+// error -- a real digest never exceeds 32 bytes for SHA-256.
+func messageDigestFromBigInt(
+	message *big.Int,
+) ([attempt.MessageDigestLength]byte, error) {
+	var out [attempt.MessageDigestLength]byte
+	if message == nil {
+		return out, fmt.Errorf("message is nil")
+	}
+	bz := message.Bytes()
+	if len(bz) > attempt.MessageDigestLength {
+		return out, fmt.Errorf(
+			"message digest length %d exceeds expected %d",
+			len(bz),
+			attempt.MessageDigestLength,
+		)
+	}
+	// Left-pad with zeros: big.Int.Bytes strips leading zeros, so a
+	// 32-byte digest with a leading zero byte returns a 31-byte
+	// slice. Copy into the tail of `out` to restore canonical
+	// alignment.
+	copy(out[attempt.MessageDigestLength-len(bz):], bz)
+	return out, nil
+}

--- a/pkg/frost/signing/attempt_context_from_request_test.go
+++ b/pkg/frost/signing/attempt_context_from_request_test.go
@@ -1,0 +1,289 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func newTestRequestWithUniFFIV2Material(t *testing.T, attemptNumber uint) *NativeExecutionFFISigningRequest {
+	t.Helper()
+	const hexKey = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+	payload, _ := json.Marshal(&nativeFROSTUniFFIV2SignerMaterial{
+		KeyPackage: &NativeFROSTKeyPackage{
+			Identifier: "id-1",
+			Data:       []byte{0x01},
+		},
+		PublicKeyPackage: &NativeFROSTPublicKeyPackage{
+			VerifyingKey: hexKey,
+		},
+	})
+	return &NativeExecutionFFISigningRequest{
+		Message:     new(big.Int).SetBytes([]byte{0xab, 0xcd}),
+		SessionID:   "session-test",
+		MemberIndex: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostUniFFIV2,
+			Payload: payload,
+		},
+		Attempt: &Attempt{
+			Number:                 attemptNumber,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2, 3, 4, 5},
+			ExcludedMembersIndexes: nil,
+		},
+	}
+}
+
+func newTestRequestWithTBTCSignerV1Material(t *testing.T, attemptNumber uint) *NativeExecutionFFISigningRequest {
+	t.Helper()
+	payload, _ := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup: "tbtc-group-A",
+	})
+	return &NativeExecutionFFISigningRequest{
+		Message:     new(big.Int).SetBytes([]byte{0xab, 0xcd}),
+		SessionID:   "session-test",
+		MemberIndex: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: payload,
+		},
+		Attempt: &Attempt{
+			Number:                 attemptNumber,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2, 3},
+			ExcludedMembersIndexes: nil,
+		},
+	}
+}
+
+func TestBuildAttemptContextFromRequest_UniFFIV2_HappyPath(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	ctx, err := BuildAttemptContextFromRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.SessionID != req.SessionID {
+		t.Fatalf("session id: got %q want %q", ctx.SessionID, req.SessionID)
+	}
+	if ctx.AttemptNumber != 0 {
+		t.Fatalf("attempt number: got %d, want 0 (Attempt.Number=1 maps to 0-based 0)", ctx.AttemptNumber)
+	}
+	if len(ctx.IncludedSet) != 5 {
+		t.Fatalf("included set: got %d, want 5", len(ctx.IncludedSet))
+	}
+	if len(ctx.TransientlyParked) != 0 {
+		t.Fatalf("parked: got %d, want 0 (Phase 6 ships attempt-zero shape)", len(ctx.TransientlyParked))
+	}
+}
+
+func TestBuildAttemptContextFromRequest_UniFFIV2_KeyGroupIDDerivation(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	ctx, err := BuildAttemptContextFromRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Reproduce the expected derivation: HASH160(0x02 || dkgPub).
+	dkgPub, _ := ExtractDkgGroupPublicKeyFromMaterial(req.SignerMaterial)
+	var outputKey frost.OutputKey
+	copy(outputKey[:], dkgPub)
+	want := fmt.Sprintf("%x", frost.WalletPublicKeyHashCompatibilityAlias(outputKey))
+	if ctx.KeyGroupID != want {
+		t.Fatalf(
+			"key group id: got %s, want %s",
+			ctx.KeyGroupID, want,
+		)
+	}
+	if len(ctx.KeyGroupID) != 40 {
+		t.Fatalf("key group id hex length: got %d, want 40 (20 bytes)", len(ctx.KeyGroupID))
+	}
+}
+
+func TestBuildAttemptContextFromRequest_TBTCSignerV1_KeyGroupIDIsRawIdentifier(t *testing.T) {
+	req := newTestRequestWithTBTCSignerV1Material(t, 1)
+	ctx, err := BuildAttemptContextFromRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx.KeyGroupID != "tbtc-group-A" {
+		t.Fatalf(
+			"key group id: got %q, want %q",
+			ctx.KeyGroupID,
+			"tbtc-group-A",
+		)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_RejectsNilRequest(t *testing.T) {
+	_, err := BuildAttemptContextFromRequest(nil)
+	if !errors.Is(err, ErrAttemptContextConstruction) {
+		t.Fatalf("expected ErrAttemptContextConstruction, got %v", err)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_RejectsNilMessage(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	req.Message = nil
+	_, err := BuildAttemptContextFromRequest(req)
+	if err == nil {
+		t.Fatal("expected error for nil message")
+	}
+	if !strings.Contains(err.Error(), "message is nil") {
+		t.Fatalf("error must mention nil message; got %v", err)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_RejectsNilSignerMaterial(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	req.SignerMaterial = nil
+	_, err := BuildAttemptContextFromRequest(req)
+	if err == nil {
+		t.Fatal("expected error for nil signer material")
+	}
+	if !strings.Contains(err.Error(), "signer material is nil") {
+		t.Fatalf("error must mention nil signer material; got %v", err)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_RejectsNilAttempt(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	req.Attempt = nil
+	_, err := BuildAttemptContextFromRequest(req)
+	if err == nil {
+		t.Fatal("expected error for nil attempt metadata")
+	}
+}
+
+func TestBuildAttemptContextFromRequest_RejectsZeroAttemptNumber(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 0)
+	_, err := BuildAttemptContextFromRequest(req)
+	if err == nil {
+		t.Fatal("expected error for zero attempt number")
+	}
+	if !strings.Contains(err.Error(), "Attempt.Number is zero") {
+		t.Fatalf("error must mention zero attempt; got %v", err)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_PropagatesExtractionErrors(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	req.SignerMaterial = &NativeSignerMaterial{
+		Format:  NativeSignerMaterialFormatFrostUniFFIV1,
+		Payload: []byte("{}"),
+	}
+	_, err := BuildAttemptContextFromRequest(req)
+	if !errors.Is(err, ErrUnsupportedSignerMaterialFormat) {
+		t.Fatalf("expected ErrUnsupportedSignerMaterialFormat, got %v", err)
+	}
+	if !errors.Is(err, ErrAttemptContextConstruction) {
+		t.Fatalf("expected ErrAttemptContextConstruction wrapper, got %v", err)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_AttemptNumberIsZeroBased(t *testing.T) {
+	cases := []struct {
+		legacyNumber      uint
+		expectedZeroBased uint32
+	}{
+		{1, 0},
+		{2, 1},
+		{5, 4},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("legacy=%d", tc.legacyNumber), func(t *testing.T) {
+			req := newTestRequestWithUniFFIV2Material(t, tc.legacyNumber)
+			ctx, err := BuildAttemptContextFromRequest(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ctx.AttemptNumber != tc.expectedZeroBased {
+				t.Fatalf(
+					"got attempt number %d, want %d (legacy 1-based input %d)",
+					ctx.AttemptNumber, tc.expectedZeroBased, tc.legacyNumber,
+				)
+			}
+		})
+	}
+}
+
+func TestMessageDigestFromBigInt_PadsShortBigInts(t *testing.T) {
+	bi := new(big.Int).SetBytes([]byte{0x01, 0x02})
+	digest, err := messageDigestFromBigInt(bi)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [attempt.MessageDigestLength]byte{}
+	want[30] = 0x01
+	want[31] = 0x02
+	if digest != want {
+		t.Fatalf("padding wrong: got %x, want %x", digest, want)
+	}
+}
+
+func TestMessageDigestFromBigInt_RejectsLongBigInts(t *testing.T) {
+	bi := new(big.Int).SetBytes(make([]byte, 33))
+	bi.SetBit(bi, 264, 1) // 33-byte length
+	_, err := messageDigestFromBigInt(bi)
+	if err == nil {
+		t.Fatal("expected error for over-long message")
+	}
+}
+
+func TestBuildAttemptContextFromRequest_DeterministicAcrossInvocations(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	a, err := BuildAttemptContextFromRequest(req)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	b, err := BuildAttemptContextFromRequest(req)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if a.Hash() != b.Hash() {
+		t.Fatalf(
+			"two calls with same request produced different hashes: %x vs %x",
+			a.Hash(), b.Hash(),
+		)
+	}
+}
+
+func TestBuildAttemptContextFromRequest_HashChangesWhenMessageDigestChanges(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	a, _ := BuildAttemptContextFromRequest(req)
+	req.Message = new(big.Int).SetBytes([]byte{0x99, 0x88, 0x77})
+	b, _ := BuildAttemptContextFromRequest(req)
+	if a.Hash() == b.Hash() {
+		t.Fatal("hash must change when message digest changes")
+	}
+}
+
+func TestBuildAttemptContextFromRequest_HashChangesWhenIncludedSetChanges(t *testing.T) {
+	req := newTestRequestWithUniFFIV2Material(t, 1)
+	a, _ := BuildAttemptContextFromRequest(req)
+	req.Attempt.IncludedMembersIndexes = []group.MemberIndex{1, 2, 3}
+	b, _ := BuildAttemptContextFromRequest(req)
+	if a.Hash() == b.Hash() {
+		t.Fatal("hash must change when included set changes")
+	}
+}
+
+// Sanity check that the message digest padding produces the same
+// bytes as a direct SHA-256 (just a smoke test on the constants).
+func TestMessageDigestFromBigInt_SmokeTestSha256Length(t *testing.T) {
+	if attempt.MessageDigestLength != sha256.Size {
+		t.Fatalf(
+			"AttemptContext digest length %d != SHA-256 size %d",
+			attempt.MessageDigestLength, sha256.Size,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Second Phase-6 PR. Adds the bridge that converts a
\`NativeExecutionFFISigningRequest\` (legacy shape) into an
\`attempt.AttemptContext\` (RFC-21 shape). Phase 6.3 calls this from
the executor adapter; Phase 6.4 may use it from migration call
sites.

Stacked on #3981 (Phase 6.1).

## What lands

\`pkg/frost/signing/attempt_context_from_request.go\` (new, gated \`frost_native\`):

| Surface | Notes |
|---|---|
| \`BuildAttemptContextFromRequest(*NativeExecutionFFISigningRequest)\` | Returns \`(AttemptContext, error)\`. Strict ordering: decodes signer material BEFORE constructing AttemptContext, surfacing extraction failures cleanly rather than producing half-built contexts (Gemini's Phase-6 review concern). |
| Format-aware \`KeyGroupID\` derivation | UniFFIV2: \`HASH160(0x02 \|\| xOnlyOutputKey)\` via \`frost.WalletPublicKeyHashCompatibilityAlias\`. TBTCSignerV1: raw \`KeyGroup\` string from payload. |
| 1-based → 0-based attempt-number conversion | keep-core's \`Attempt.Number\` is 1-based; RFC-21's \`AttemptContext.AttemptNumber\` is 0-based. Rejects \`Number == 0\`. |
| \`messageDigestFromBigInt\` helper | converts \`*big.Int\` to 32-byte canonical digest, left-padding short values, rejecting >32 bytes |
| \`ErrAttemptContextConstruction\` sentinel | wraps every construction failure; distinguishable from runtime ROAST errors via \`errors.Is\` |

## Test coverage (15 cases)

- UniFFIV2 happy path
- UniFFIV2 KeyGroupID exactly matches \`HASH160(0x02 \|\| key)\` via reference function
- TBTCSignerV1 KeyGroupID is raw identifier
- Rejects nil request, nil message, nil signer material, nil attempt
- Rejects \`Attempt.Number == 0\`
- Propagates \`ErrUnsupportedSignerMaterialFormat\` unchanged through the construction wrapper
- Attempt-number conversion (1→0, 2→1, 5→4)
- Deterministic across invocations (same request → same hash)
- Hash changes when message digest changes
- Hash changes when included set changes
- Digest padding for short big.Int values
- Digest rejection for >32-byte big.Int values
- AttemptContext digest length matches \`sha256.Size\`

## Phase 6 status

| PR | Scope | State |
|---|---|---|
| 6.1 (#3981) | DKG group-public-key extraction | open |
| **6.2 (this)** | **BuildAttemptContextFromRequest** | **open** |
| 6.3 | Wire orchestration at executor adapter (strict error taxonomy from #3980) | next |
| 6.4 | Migrate three call sites onto \`EvaluateRoastRetryForSigning\` | after 6.3 |

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test -tags 'frost_native frost_tbtc_signer' ./pkg/frost/signing/...\` | pass |
| \`go test -tags 'frost_native frost_tbtc_signer frost_roast_retry' -race ./pkg/frost/...\` | pass (5 packages) |
| \`staticcheck -checks '-SA1019' ./pkg/frost/...\` | silent |
| \`go vet ./pkg/frost/...\` | clean |
| \`gofmt -l ./pkg/frost/signing/\` | silent |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the format-aware KeyGroupID derivation matches the RFC-21 Resolved Decision intent.
- [ ] Reviewer confirms the strict ordering (extract first, construct second) is the right defence against half-built contexts.