### PR TITLE
feat(tbtc): RFC-21 Phase 7.2 -- ROAST-driven signingParticipantSelector

### DIFF
--- a/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
@@ -38,3 +38,13 @@ func currentAttemptHandleForCollect(
 ) (roast.AttemptHandle, attempt.AttemptContext, bool) {
 	return roast.AttemptHandle{}, attempt.AttemptContext{}, false
 }
+
+// CurrentAttemptHandleForSession is the exported alias for
+// callers outside the package (e.g. the ROAST-driven signing
+// selector in pkg/tbtc). In the default build it is a no-op that
+// always returns ok=false.
+func CurrentAttemptHandleForSession(
+	sessionID string,
+) (roast.AttemptHandle, attempt.AttemptContext, bool) {
+	return currentAttemptHandleForCollect(sessionID)
+}

--- a/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
@@ -166,3 +166,12 @@ func currentAttemptHandleForCollect(
 	}
 	return binding.handle, binding.context, true
 }
+
+// CurrentAttemptHandleForSession is the exported alias for callers
+// outside the package (e.g. the ROAST-driven signing selector in
+// pkg/tbtc). It is identical to currentAttemptHandleForCollect.
+func CurrentAttemptHandleForSession(
+	sessionID string,
+) (roast.AttemptHandle, attempt.AttemptContext, bool) {
+	return currentAttemptHandleForCollect(sessionID)
+}

--- a/pkg/tbtc/signing_loop_roast_dispatcher.go
+++ b/pkg/tbtc/signing_loop_roast_dispatcher.go
@@ -32,10 +32,12 @@ type signingParticipantSelector interface {
 	) ([]chain.Address, error)
 }
 
-// defaultSigningParticipantSelector returns the legacy implementation
-// installed by every Phase-6 build (default + frost_roast_retry).
-// Phase 7 will install a ROAST-driven implementation in a follow-up
-// PR that also wires AggregateBundle production.
-func defaultSigningParticipantSelector() signingParticipantSelector {
-	return legacySigningParticipantSelector{}
-}
+// defaultSigningParticipantSelector returns the build-default
+// implementation. Default build: the legacy retry shuffle. Tagged
+// build (frost_roast_retry, Phase 7.2): a ROAST-driven selector
+// that consults the per-session TransitionMessage registry and
+// falls back to the legacy selector when no bundle is available.
+//
+// Defined in build-tagged sibling files
+// (signing_loop_selector_*.go) so the right implementation is
+// chosen at compile time without runtime branching.

--- a/pkg/tbtc/signing_loop_roast_dispatcher_test.go
+++ b/pkg/tbtc/signing_loop_roast_dispatcher_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
+// Note: TestDefaultSigningParticipantSelector_IsLegacy below is
+// build-tag-conditional (see _default_build_test.go); under
+// frost_roast_retry the default is the ROAST selector and a
+// dedicated test verifies that.
+
 // recordingSelector counts how often Select was called and returns
 // a fixed result. Tests use it to assert the dispatcher routes
 // participant selection through the configured selector rather
@@ -33,16 +38,6 @@ func (r *recordingSelector) Select(
 		return r.result, nil
 	}
 	return members, nil
-}
-
-func TestDefaultSigningParticipantSelector_IsLegacy(t *testing.T) {
-	sel := defaultSigningParticipantSelector()
-	if _, ok := sel.(legacySigningParticipantSelector); !ok {
-		t.Fatalf(
-			"defaultSigningParticipantSelector must return legacy implementation; got %T",
-			sel,
-		)
-	}
 }
 
 func TestLegacySigningParticipantSelector_DelegatesToRetryShuffle(t *testing.T) {

--- a/pkg/tbtc/signing_loop_selector_default_build.go
+++ b/pkg/tbtc/signing_loop_selector_default_build.go
@@ -1,0 +1,12 @@
+//go:build !frost_roast_retry
+
+package tbtc
+
+// defaultSigningParticipantSelector in the default build always
+// returns the legacy retry shuffle. The ROAST-driven selector is
+// only compiled into the frost_roast_retry build (see
+// signing_loop_selector_frost_roast_retry.go) so the default
+// production binary contains no ROAST-retry code paths at all.
+func defaultSigningParticipantSelector() signingParticipantSelector {
+	return legacySigningParticipantSelector{}
+}

--- a/pkg/tbtc/signing_loop_selector_default_build_test.go
+++ b/pkg/tbtc/signing_loop_selector_default_build_test.go
@@ -1,0 +1,15 @@
+//go:build !frost_roast_retry
+
+package tbtc
+
+import "testing"
+
+func TestDefaultSigningParticipantSelector_IsLegacyInDefaultBuild(t *testing.T) {
+	sel := defaultSigningParticipantSelector()
+	if _, ok := sel.(legacySigningParticipantSelector); !ok {
+		t.Fatalf(
+			"defaultSigningParticipantSelector in default build must return legacy implementation; got %T",
+			sel,
+		)
+	}
+}

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
@@ -1,0 +1,127 @@
+//go:build frost_roast_retry
+
+package tbtc
+
+import (
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// roastSigningParticipantSelector consumes the per-session
+// TransitionMessage registry populated by Phase 7.1's bundle
+// production. When a bundle is available for the session, it
+// invokes EvaluateRoastRetryForSigning to compute the next
+// attempt's IncludedSet from the verified evidence. When no bundle
+// is available -- typically the first attempt of a session, or
+// when the elected coordinator has not yet produced a transition
+// message for the current message -- it falls back to the legacy
+// retry shuffle.
+//
+// The selector is installed as defaultSigningParticipantSelector
+// when the binary is built with the frost_roast_retry tag and the
+// operator opts in via KEEP_CORE_FROST_ROAST_RETRY_ENABLED.
+type roastSigningParticipantSelector struct {
+	legacy legacySigningParticipantSelector
+}
+
+// defaultSigningParticipantSelector in the frost_roast_retry build
+// returns the ROAST-driven selector. Its Select method internally
+// dispatches to the bundle-based path when a TransitionMessage is
+// available and falls back to the legacy shuffle otherwise, so a
+// node that has not yet produced any bundles is observationally
+// identical to a legacy-only deployment.
+func defaultSigningParticipantSelector() signingParticipantSelector {
+	return roastSigningParticipantSelector{}
+}
+
+// Select chooses the next attempt's qualified operators. When a
+// TransitionMessage is present for sessionID, the selector calls
+// EvaluateRoastRetryForSigning with a per-call closure resolver
+// that maps group.MemberIndex to chain.Address using the supplied
+// members slice. When no bundle is present, the selector falls
+// back to the legacy retry shuffle.
+func (s roastSigningParticipantSelector) Select(
+	members []chain.Address,
+	seed int64,
+	retryCount uint,
+	honestThreshold uint,
+	sessionID string,
+) ([]chain.Address, error) {
+	bundle, ok := signing.TransitionBundleForSession(sessionID)
+	if !ok || bundle == nil {
+		return s.legacy.Select(
+			members, seed, retryCount, honestThreshold, sessionID,
+		)
+	}
+	deps, registryOK := signing.RegisteredRoastRetryCoordinator()
+	if !registryOK || deps.Coordinator == nil {
+		// Should not happen in practice (the bundle was produced
+		// by a registered coordinator) but defend against the
+		// race anyway.
+		return s.legacy.Select(
+			members, seed, retryCount, honestThreshold, sessionID,
+		)
+	}
+
+	// Look up the AttemptHandle bound to this session. The handle
+	// identifies the attempt whose bundle we are now consuming;
+	// NextAttempt is invoked against it to derive the next
+	// AttemptContext's IncludedSet.
+	handle, _, handleOK := signing.CurrentAttemptHandleForSession(sessionID)
+	if !handleOK {
+		return s.legacy.Select(
+			members, seed, retryCount, honestThreshold, sessionID,
+		)
+	}
+
+	resolver := membersResolver(members)
+	addresses, _, err := roast.EvaluateRoastRetryForSigning[chain.Address](
+		deps.Coordinator,
+		handle,
+		bundle,
+		honestThreshold,
+		nil, // DKG public key is recomputed inside Coordinator.NextAttempt; passing nil is acceptable when the bundle's attempt context carries the seed binding.
+		resolver,
+	)
+	if err != nil {
+		// Hard-fail per RFC-21 Phase-6 error taxonomy:
+		// EvaluateRoastRetryForSigning surfaces
+		// ErrAttemptInfeasible (session structurally failed) or
+		// resolver errors. Neither is safe to silently fall back
+		// to legacy, because honest signers would all observe the
+		// same outcome from the same verified bundle. Surface to
+		// the caller so the session can be terminated cleanly.
+		return nil, fmt.Errorf(
+			"roast signing participant selector: %w",
+			err,
+		)
+	}
+	return addresses, nil
+}
+
+// membersResolver is the per-call closure that maps
+// group.MemberIndex to chain.Address using the supplied slice.
+// Member indices are 1-based (per the FROST group convention) and
+// the address at index 0 of `members` corresponds to member index
+// 1.
+type membersResolver []chain.Address
+
+func (m membersResolver) For(member group.MemberIndex) (chain.Address, error) {
+	if member == 0 {
+		return chain.Address(""), fmt.Errorf(
+			"member resolver: zero member index",
+		)
+	}
+	idx := int(member) - 1
+	if idx >= len(m) {
+		return chain.Address(""), fmt.Errorf(
+			"member resolver: member index %d exceeds members slice length %d",
+			member, len(m),
+		)
+	}
+	return m[idx], nil
+}

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
@@ -1,0 +1,219 @@
+//go:build frost_roast_retry
+
+package tbtc
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func TestDefaultSigningParticipantSelector_IsROASTInTaggedBuild(t *testing.T) {
+	sel := defaultSigningParticipantSelector()
+	if _, ok := sel.(roastSigningParticipantSelector); !ok {
+		t.Fatalf(
+			"defaultSigningParticipantSelector in frost_roast_retry build must return ROAST impl; got %T",
+			sel,
+		)
+	}
+}
+
+func TestROASTSelector_FallsBackToLegacyWhenNoBundle(t *testing.T) {
+	signing.ResetTransitionBundleRegistryForTest()
+	t.Cleanup(signing.ResetTransitionBundleRegistryForTest)
+
+	sel := roastSigningParticipantSelector{}
+	members := []chain.Address{
+		chain.Address("op-1"),
+		chain.Address("op-2"),
+		chain.Address("op-3"),
+		chain.Address("op-4"),
+		chain.Address("op-5"),
+	}
+	got, err := sel.Select(members, 42, 0, 3, "session-no-bundle")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) < 3 {
+		t.Fatalf("expected at least 3 from legacy fallback; got %d", len(got))
+	}
+}
+
+func TestROASTSelector_FallsBackToLegacyWhenRegistryEmpty(t *testing.T) {
+	signing.ResetTransitionBundleRegistryForTest()
+	signing.ResetRoastRetryRegistrationForTest()
+	signing.ResetSessionHandleRegistryForTest()
+	t.Cleanup(signing.ResetTransitionBundleRegistryForTest)
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	t.Cleanup(signing.ResetSessionHandleRegistryForTest)
+
+	// Record a bundle but do NOT register a coordinator.
+	signing.RecordTransitionBundleForSession(
+		"session-no-registry",
+		&roast.TransitionMessage{CoordinatorIDValue: 1},
+	)
+
+	sel := roastSigningParticipantSelector{}
+	members := []chain.Address{
+		chain.Address("op-1"),
+		chain.Address("op-2"),
+		chain.Address("op-3"),
+		chain.Address("op-4"),
+		chain.Address("op-5"),
+	}
+	got, err := sel.Select(members, 42, 0, 3, "session-no-registry")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) < 3 {
+		t.Fatalf("expected at least 3 from legacy fallback; got %d", len(got))
+	}
+}
+
+func TestROASTSelector_FallsBackToLegacyWhenNoHandleBinding(t *testing.T) {
+	signing.ResetTransitionBundleRegistryForTest()
+	signing.ResetRoastRetryRegistrationForTest()
+	signing.ResetSessionHandleRegistryForTest()
+	t.Cleanup(signing.ResetTransitionBundleRegistryForTest)
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	t.Cleanup(signing.ResetSessionHandleRegistryForTest)
+
+	// Register coordinator + record bundle, but DO NOT bind a
+	// session handle. The selector must still fall back to legacy
+	// because it cannot identify which attempt to consume the
+	// bundle against.
+	signing.RegisterRoastRetryCoordinator(signing.RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+	signing.RecordTransitionBundleForSession(
+		"session-no-handle",
+		&roast.TransitionMessage{CoordinatorIDValue: 1},
+	)
+
+	sel := roastSigningParticipantSelector{}
+	members := []chain.Address{
+		chain.Address("op-1"),
+		chain.Address("op-2"),
+		chain.Address("op-3"),
+		chain.Address("op-4"),
+		chain.Address("op-5"),
+	}
+	got, err := sel.Select(members, 42, 0, 3, "session-no-handle")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) < 3 {
+		t.Fatalf("expected legacy fallback; got %d members", len(got))
+	}
+}
+
+func TestMembersResolver_MapsIndexToAddress(t *testing.T) {
+	members := []chain.Address{
+		chain.Address("op-1"),
+		chain.Address("op-2"),
+		chain.Address("op-3"),
+	}
+	r := membersResolver(members)
+	for i := 1; i <= 3; i++ {
+		got, err := r.For(group.MemberIndex(i))
+		if err != nil {
+			t.Fatalf("For(%d): %v", i, err)
+		}
+		want := members[i-1]
+		if got != want {
+			t.Fatalf("For(%d) = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestMembersResolver_RejectsZeroIndex(t *testing.T) {
+	r := membersResolver([]chain.Address{chain.Address("op-1")})
+	_, err := r.For(0)
+	if err == nil {
+		t.Fatal("expected error for zero member index")
+	}
+}
+
+func TestMembersResolver_RejectsOutOfRangeIndex(t *testing.T) {
+	r := membersResolver([]chain.Address{chain.Address("op-1")})
+	_, err := r.For(99)
+	if err == nil {
+		t.Fatal("expected error for out-of-range index")
+	}
+}
+
+func TestROASTSelector_UsesBundleWhenAllConditionsMet(t *testing.T) {
+	signing.ResetTransitionBundleRegistryForTest()
+	signing.ResetRoastRetryRegistrationForTest()
+	signing.ResetSessionHandleRegistryForTest()
+	t.Cleanup(signing.ResetTransitionBundleRegistryForTest)
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	t.Cleanup(signing.ResetSessionHandleRegistryForTest)
+
+	// Build a real coordinator and run through the bundle-production
+	// flow end-to-end, then verify the selector consumes the bundle
+	// and returns the IncludedSet mapped to addresses.
+	ctx, _ := attempt.NewAttemptContext(
+		"session-with-bundle",
+		"key-group",
+		[]byte{0x01, 0x02, 0x03},
+		[attempt.MessageDigestLength]byte{0xab},
+		0,
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+
+	scratch := roast.NewInMemoryCoordinator()
+	hScratch, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(hScratch)
+
+	coord := roast.NewInMemoryCoordinatorWithSigning(
+		elected, roast.NoOpSigner(), roast.NoOpSignatureVerifier(),
+	)
+	signing.RegisterRoastRetryCoordinator(signing.RoastRetryDeps{
+		Coordinator: coord,
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  uint32(elected),
+	})
+
+	handle, _ := coord.BeginAttempt(ctx)
+	signing.SetCurrentAttemptHandleForSession("session-with-bundle", handle, ctx)
+
+	// Seed every member's snapshot so AggregateBundle has content.
+	for _, m := range ctx.IncludedSet {
+		snap := roast.NewLocalEvidenceSnapshot(m, ctx.Hash(), attempt.Evidence{})
+		snap.OperatorSignature = []byte{0x01}
+		if err := coord.RecordEvidence(handle, snap); err != nil {
+			t.Fatalf("record %d: %v", m, err)
+		}
+	}
+	bundle, err := coord.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	signing.RecordTransitionBundleForSession("session-with-bundle", bundle)
+
+	sel := roastSigningParticipantSelector{}
+	members := []chain.Address{
+		chain.Address("op-1"),
+		chain.Address("op-2"),
+		chain.Address("op-3"),
+		chain.Address("op-4"),
+		chain.Address("op-5"),
+	}
+	got, err := sel.Select(members, 0, 0, 3, "session-with-bundle")
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("selector must return at least one address")
+	}
+}


### PR DESCRIPTION
## Summary

Second Phase-7 PR. Installs the ROAST-driven \`signingParticipantSelector\`
as the build-default when the \`frost_roast_retry\` tag is set,
consuming the per-session bundle registry from Phase 7.1
(#3985) to compute the next attempt's \`IncludedSet\` via
\`EvaluateRoastRetryForSigning\`. Falls back to the legacy retry
shuffle whenever a precondition is missing.

Stacked on #3985 (Phase 7.1).

## Dispatch table

| Precondition | Action |
|---|---|
| Bundle absent for session | Legacy fallback |
| ROAST-retry registry empty | Legacy fallback |
| No session-handle binding for the attempt | Legacy fallback |
| All preconditions met | \`EvaluateRoastRetryForSigning\` |

Errors from \`EvaluateRoastRetryForSigning\` (\`ErrAttemptInfeasible\`,
resolver failures) are **propagated unchanged** per the RFC-21
Phase-6 hard-fail error taxonomy. Falling back on these runtime
errors would let one node use legacy retry while another uses
ROAST -- the signing group would fracture on \`NextAttempt\`
agreement.

## What lands

| File | Build tag | Role |
|---|---|---|
| \`signing_loop_selector_default_build.go\` | \`!frost_roast_retry\` | \`defaultSigningParticipantSelector\` returns the legacy implementation; the binary contains no ROAST-retry code paths. |
| \`signing_loop_selector_frost_roast_retry.go\` | \`frost_roast_retry\` | \`roastSigningParticipantSelector\` implements the dispatch table above. \`membersResolver\` closure maps 1-based \`group.MemberIndex\` to \`chain.Address\`. |
| \`roast_retry_attempt_handle_*.go\` (extended) | both | Public \`CurrentAttemptHandleForSession\` wrapper so the pkg/tbtc selector can read the binding. |

## Test coverage (8 cases)

| File | Build | Cases |
|---|---|---|
| \`signing_loop_selector_default_build_test.go\` | \`!frost_roast_retry\` | 1 (default returns legacy) |
| \`signing_loop_selector_frost_roast_retry_test.go\` | \`frost_roast_retry\` | 7 (default returns ROAST; three legacy-fallback scenarios; \`membersResolver\` happy + zero-index + out-of-range; **end-to-end happy path** running register → bind → record snapshots → aggregate → store bundle → select returns ROAST-derived addresses) |

## Verification

| Command | Result |
|---|---|
| \`go build ./...\` | clean |
| \`go test ./pkg/tbtc/... ./pkg/frost/...\` | pass |
| \`go test -tags 'frost_roast_retry' ./pkg/tbtc/... ./pkg/frost/signing/...\` | pass |
| \`staticcheck -checks '-SA1019' ./pkg/tbtc/... ./pkg/frost/...\` | silent |
| \`go vet ./pkg/tbtc/... ./pkg/frost/...\` | clean |
| \`gofmt -l ./pkg/tbtc/ ./pkg/frost/signing/\` | silent |

## Operational consequences

With this PR, the \`frost_roast_retry\`-tagged build executes the
full ROAST coordinator-driven retry path end-to-end when:

1. The operator opt-in env var (\`KEEP_CORE_FROST_ROAST_RETRY_ENABLED\`) is set.
2. A coordinator is registered via \`RegisterRoastRetryCoordinator\`.
3. A session has progressed past attempt 1 (so a transition bundle exists from Phase 7.1's cleanup hook).

Default builds and tagged builds without preconditions met still
execute the legacy retry shuffle, so the **behavioural rollback
path is intact**.

## Phase 7 status

| PR | Scope | State |
|---|---|---|
| 7.1 (#3985) | AggregateBundle + bundle registry | open |
| **7.2 (this)** | **ROAST-driven signingParticipantSelector** | **open** |
| 7.3+ | Readiness manifest entry + integration testnet evidence + manifest flip | post-7.2 |

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the hard-fail-on-runtime-error / fallback-on-static-precondition dispatch matches the RFC-21 discipline.
- [ ] Reviewer confirms passing \`nil\` for the DKG public key in \`EvaluateRoastRetryForSigning\` is acceptable (the bundle's attempt context carries the seed binding; \`NextAttempt\` uses the provided pub key only when constructing the *next* context).