### PR TITLE
docs(frost/signing): canonicalize the static-vs-runtime error taxonomy

### DIFF
--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -1,5 +1,54 @@
 package signing
 
+// Static-vs-runtime error taxonomy (RFC-21 Phase 6 — Resolved Decision).
+//
+// The orchestration layer in this file participates in a load-bearing
+// decision that prevents split-brain group fracture in the ROAST retry
+// path. Errors returned through the orchestration boundary are
+// classified into one of two categories, and the consumer (the
+// signing-loop dispatcher) routes them accordingly:
+//
+//   STATIC errors  -> safe to fall back to the legacy retry path.
+//                     Every honest signer observes the same node-local
+//                     configuration state (registry population, build
+//                     tags) at the same startup, so a fallback decision
+//                     is deterministic across the group. No participant
+//                     fork can arise from a static-error fallback.
+//                     Sentinel: ErrNoRoastRetryCoordinatorRegistered.
+//                     Detected via errors.Is in
+//                     signing_loop_roast_dispatcher.go.
+//
+//   RUNTIME errors -> HARD FAIL. No fallback. Any error that arises
+//                     from per-attempt protocol state (BeginAttempt
+//                     internals, AttemptContext binding mismatches,
+//                     transition-bundle verification failures, etc.)
+//                     can be observed by some participants and not
+//                     others within the same attempt. Falling back to
+//                     legacy under those conditions would leave some
+//                     operators running the new code path and others
+//                     running legacy on the same attempt -- the canonical
+//                     definition of split-brain fracture. The
+//                     orchestration layer therefore returns these as
+//                     bare (non-sentinel) errors that the dispatcher
+//                     treats as terminal.
+//
+// The classification is enforced at this file's boundary: any error
+// surfaced from this package that is intended to permit fallback MUST
+// be the ErrNoRoastRetryCoordinatorRegistered sentinel (or wrap it for
+// errors.Is matching). Wrapping ANY runtime error in the sentinel is a
+// safety regression that re-enables split-brain risk; PR reviewers
+// should reject it.
+//
+// Background: this decision was redirected during Phase 5/6 review.
+// The earlier design had Coordinator.BeginAttempt failures fall back to
+// the legacy retry path on the assumption that BeginAttempt was a
+// cheap idempotent setup. Review identified that BeginAttempt mutates
+// per-attempt state (session bindings, evidence recorder) and can fail
+// from races with concurrent receives or from peer-supplied protocol
+// messages -- both of which produce non-deterministic per-participant
+// outcomes. The taxonomy was tightened so only true configuration
+// errors are fallback-eligible.
+
 import (
 	"errors"
 	"fmt"


### PR DESCRIPTION
## Why

The RFC-21 Phase 6 review decided which orchestration errors are fallback-eligible (static config errors → safe to fall back to legacy retry path) and which must hard-fail (runtime per-attempt errors → no fallback, since per-participant divergence creates split-brain group fracture). The rationale lived in commit messages, the RFC text, and inline comments on individual sentinels — distributed enough that a future maintainer reading just \`roast_retry_orchestration.go\` could miss the load-bearing constraint.

This PR adds a top-of-file design-rationale block that centralises the decision in the place that enforces it.

## What changed

- One file changed: \`pkg/frost/signing/roast_retry_orchestration.go\`
- Pure documentation: no behavior change, no test changes, no API change
- 49 lines added (one comment block)

## What it captures

1. **STATIC vs RUNTIME classification** — explicit definitions, with the sentinel (\`ErrNoRoastRetryCoordinatorRegistered\`) and detection mechanism (\`errors.Is\` in \`signing_loop_roast_dispatcher.go\`) named.
2. **Why static-error fallback is safe** — every honest signer observes the same node-local config at startup, so the fallback decision is deterministic across the group.
3. **Why runtime-error fallback is unsafe** — per-attempt protocol state errors can be observed by some participants and not others within the same attempt; fallback would put some operators on new code and others on legacy for the same attempt.
4. **Enforcement rule** — any error surfaced from this package that is intended to permit fallback MUST be the sentinel; wrapping ANY runtime error in the sentinel is a safety regression that PR reviewers should reject.
5. **Historical redirect** — the earlier design had \`BeginAttempt\` failures fall back, on the assumption that BeginAttempt was cheap idempotent setup. Review identified that BeginAttempt mutates per-attempt state and can fail from races with concurrent receives; the taxonomy was tightened so only true configuration errors are fallback-eligible.

## Lineage

Surfaced in the cross-PR review re-evaluation following PR #3866 follow-up landings. Originally tracked as "Document static-vs-runtime classification canonically" — initially flagged as "available if you want," now elevated because the rationale was the most important architectural decision in the RFC-21 stack and is currently the easiest piece of design context to lose.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>