### PR TITLE
test(frost): cross-repo walletPubKeyHash derivation fixture

### DIFF
--- a/pkg/frost/testdata/wallet-pubkey-hash-derivation-vectors-v1.json
+++ b/pkg/frost/testdata/wallet-pubkey-hash-derivation-vectors-v1.json
@@ -1,0 +1,71 @@
+{
+  "name": "wallet-pubkey-hash-derivation-vectors",
+  "version": "v1",
+  "description": "Cross-repo test vectors for HASH160-based wallet pubkey hash derivation. Both the tbtc bridge contracts (tlabs-xyz/tbtc) and the keep-core FROST protocol (threshold-network/keep-core) must derive the same 20-byte alias from the same input. Drift between the two derivations silently breaks the bridge-protocol identity contract for any wallet whose canonical identity is established cross-repo. This fixture is the tripwire: identical JSON is checked into both repos; each side has a test that reads it and asserts its own derivation function reproduces the expected output. If the two sides diverge, at least one repo's test fails.",
+  "ecdsa_legacy": [
+    {
+      "name": "secp256k1 generator point (compressed, even y)",
+      "input": {
+        "compressedPubKey": "0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+      },
+      "expected": {
+        "walletPubKeyHash": "0x751e76e8199196d454941c45d1b3a323f1433bd6"
+      },
+      "note": "Bitcoin's classic generator-point compressed pubkey, well-known HASH160. Corresponds to mainnet address 1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2."
+    },
+    {
+      "name": "Near-zero scalar pubkey (compressed, even y)",
+      "input": {
+        "compressedPubKey": "0x02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+      },
+      "expected": {
+        "walletPubKeyHash": "0x06afd46bcdfd22ef94ac122aa11f241244a37ecc"
+      }
+    },
+    {
+      "name": "tBTC fixture pubkey (matches contracts/tbtc-v2/test/data/ecdsa.ts)",
+      "input": {
+        "compressedPubKey": "0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352"
+      },
+      "expected": {
+        "walletPubKeyHash": "0xf54a5851e9372b87810a8e60cdd2e7cfd80b6e31"
+      },
+      "note": "Cross-validates against the existing pubKeyHash160 constant in the tBTC ECDSA test fixture data, ensuring this vector matches what the tBTC test suite already pins."
+    }
+  ],
+  "frost_p2tr": [
+    {
+      "name": "Representative FROST x-only output key",
+      "input": {
+        "xOnlyOutputKey": "0xb1de1afa17e1cbb20d8a4f8e54f8a55fbf5c8d2da9e1c6c4d1f0c7b3a2e5d4c8"
+      },
+      "expected": {
+        "walletPubKeyHash": "0xac756e3ad02acf580218a3ba2232b081906be776"
+      },
+      "note": "The high 12 bytes are non-zero, matching the native-shape constraint required by the FROST wallet registration entry point (see PR #431). The expected pubKeyHash is HASH160(0x02 || xOnlyOutputKey)."
+    },
+    {
+      "name": "All-ones x-only key (regression case)",
+      "input": {
+        "xOnlyOutputKey": "0x0101010101010101010101010101010101010101010101010101010101010101"
+      },
+      "expected": {
+        "walletPubKeyHash": "0x9b596d772a3bfe0335f36c38357f026221212c90"
+      }
+    },
+    {
+      "name": "All-max x-only key (boundary case)",
+      "input": {
+        "xOnlyOutputKey": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      },
+      "expected": {
+        "walletPubKeyHash": "0x2914980c04dec23ab03cfcd610adf39d62d7c5fb"
+      }
+    }
+  ],
+  "drift_check": {
+    "tbtc_path": "docs/test-vectors/wallet-pubkey-hash-derivation-vectors-v1.json",
+    "keep_core_path": "pkg/frost/testdata/wallet-pubkey-hash-derivation-vectors-v1.json",
+    "rule": "The byte-identical JSON file must exist at both paths. A future CI check should compare file hashes between repos; for now, the per-repo tests catch derivation drift even if the JSON itself drifts (the harder failure mode is silently identical JSON with different implementations underneath)."
+  }
+}

--- a/pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
+++ b/pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
@@ -1,0 +1,231 @@
+package frost
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ripemd160" //nolint:staticcheck // RIPEMD-160 is intentional for the HASH160 derivation.
+)
+
+// Cross-repo derivation fixture (also checked into the tbtc bridge repo
+// at docs/test-vectors/wallet-pubkey-hash-derivation-vectors-v1.json).
+// Each repo's test must reproduce the expected output from the same
+// input; if either side drifts from the other, at least one repo's
+// test fails. Drift between bridge and keep-core silently breaks the
+// wallet identity contract for any wallet whose canonical identity is
+// established cross-repo (in particular, FROST wallets registered via
+// the FROST WalletRegistry will use this derivation).
+const walletPubKeyHashDerivationVectorsPath = "testdata/wallet-pubkey-hash-derivation-vectors-v1.json"
+
+type ecdsaVector struct {
+	Name  string `json:"name"`
+	Input struct {
+		CompressedPubKey string `json:"compressedPubKey"`
+	} `json:"input"`
+	Expected struct {
+		WalletPubKeyHash string `json:"walletPubKeyHash"`
+	} `json:"expected"`
+	Note string `json:"note,omitempty"`
+}
+
+type frostVector struct {
+	Name  string `json:"name"`
+	Input struct {
+		XOnlyOutputKey string `json:"xOnlyOutputKey"`
+	} `json:"input"`
+	Expected struct {
+		WalletPubKeyHash string `json:"walletPubKeyHash"`
+	} `json:"expected"`
+	Note string `json:"note,omitempty"`
+}
+
+type derivationFixture struct {
+	Name         string        `json:"name"`
+	Version      string        `json:"version"`
+	Description  string        `json:"description"`
+	EcdsaLegacy  []ecdsaVector `json:"ecdsa_legacy"`
+	FrostP2tr    []frostVector `json:"frost_p2tr"`
+	DriftCheck   struct {
+		TbtcPath     string `json:"tbtc_path"`
+		KeepCorePath string `json:"keep_core_path"`
+		Rule         string `json:"rule"`
+	} `json:"drift_check"`
+}
+
+func loadDerivationFixture(t *testing.T) derivationFixture {
+	t.Helper()
+
+	data, err := os.ReadFile(walletPubKeyHashDerivationVectorsPath)
+	if err != nil {
+		t.Fatalf("fixture read: %v", err)
+	}
+	var fixture derivationFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("fixture parse: %v", err)
+	}
+	if fixture.Version != "v1" {
+		t.Fatalf(
+			"fixture schemaVersion drift: got %q, expected %q -- both repos must update together",
+			fixture.Version,
+			"v1",
+		)
+	}
+	return fixture
+}
+
+// TestFrostWalletPubKeyHashDerivationVectors checks that
+// frost.WalletPublicKeyHashCompatibilityAlias produces the expected
+// 20-byte HASH160(0x02 || xOnlyOutputKey) for every FROST vector in
+// the shared cross-repo fixture. The tbtc bridge runs the equivalent
+// check against its own derivation (BitcoinTx.deriveWalletPubKeyHash-
+// FromXOnly); if either side drifts, the wallet identity contract
+// between the bridge and the protocol silently breaks for any FROST
+// wallet whose canonical identity is established cross-repo.
+func TestFrostWalletPubKeyHashDerivationVectors(t *testing.T) {
+	fixture := loadDerivationFixture(t)
+
+	if len(fixture.FrostP2tr) == 0 {
+		t.Fatal("fixture must contain at least one FROST vector")
+	}
+
+	for _, vector := range fixture.FrostP2tr {
+		vector := vector
+		t.Run(vector.Name, func(t *testing.T) {
+			xOnlyBytes, err := hex.DecodeString(
+				strings.TrimPrefix(vector.Input.XOnlyOutputKey, "0x"),
+			)
+			if err != nil {
+				t.Fatalf("decode xOnlyOutputKey: %v", err)
+			}
+			if len(xOnlyBytes) != OutputKeySize {
+				t.Fatalf(
+					"xOnlyOutputKey length: got %d, expected %d",
+					len(xOnlyBytes),
+					OutputKeySize,
+				)
+			}
+
+			var outputKey OutputKey
+			copy(outputKey[:], xOnlyBytes)
+
+			alias := WalletPublicKeyHashCompatibilityAlias(outputKey)
+			got := "0x" + hex.EncodeToString(alias[:])
+			want := strings.ToLower(vector.Expected.WalletPubKeyHash)
+
+			if got != want {
+				t.Fatalf(
+					"derivation drift for vector %q:\n  got:  %s\n  want: %s\n"+
+						"\nThis test enforces the cross-repo contract that\n"+
+						"frost.WalletPublicKeyHashCompatibilityAlias and the\n"+
+						"tbtc bridge's BitcoinTx.deriveWalletPubKeyHashFromXOnly\n"+
+						"produce the same 20-byte alias for the same input.\n"+
+						"If this test fails, also expect the tbtc-side test to\n"+
+						"fail unless the JSON fixture itself has drifted.",
+					vector.Name,
+					got,
+					want,
+				)
+			}
+		})
+	}
+}
+
+// TestEcdsaCompressedPubKeyHash160Vectors checks the legacy ECDSA
+// derivation path: HASH160 of the compressed pubkey. The tbtc bridge
+// performs this implicitly during registerNewWallet (compress then
+// hash160). The off-chain operator tooling that produces deposit
+// scripts performs the same derivation; this test pins the algorithm
+// from the keep-core side using the same vectors the bridge pins on
+// its side.
+func TestEcdsaCompressedPubKeyHash160Vectors(t *testing.T) {
+	fixture := loadDerivationFixture(t)
+
+	if len(fixture.EcdsaLegacy) == 0 {
+		t.Fatal("fixture must contain at least one ECDSA vector")
+	}
+
+	for _, vector := range fixture.EcdsaLegacy {
+		vector := vector
+		t.Run(vector.Name, func(t *testing.T) {
+			compressed, err := hex.DecodeString(
+				strings.TrimPrefix(vector.Input.CompressedPubKey, "0x"),
+			)
+			if err != nil {
+				t.Fatalf("decode compressedPubKey: %v", err)
+			}
+
+			got := "0x" + hex.EncodeToString(hash160(compressed))
+			want := strings.ToLower(vector.Expected.WalletPubKeyHash)
+
+			if got != want {
+				t.Fatalf(
+					"HASH160 drift for vector %q:\n  got:  %s\n  want: %s",
+					vector.Name,
+					got,
+					want,
+				)
+			}
+		})
+	}
+}
+
+// TestDriftCheckMetadata asserts the fixture declares the tbtc mirror
+// path and a non-empty drift rule. A future CI sync check can use
+// these fields to compare files between repos.
+func TestDriftCheckMetadata(t *testing.T) {
+	fixture := loadDerivationFixture(t)
+
+	if fixture.DriftCheck.TbtcPath != "docs/test-vectors/wallet-pubkey-hash-derivation-vectors-v1.json" {
+		t.Errorf(
+			"drift_check.tbtc_path drift: got %q",
+			fixture.DriftCheck.TbtcPath,
+		)
+	}
+	if fixture.DriftCheck.KeepCorePath != walletPubKeyHashDerivationVectorsPath {
+		t.Errorf(
+			"drift_check.keep_core_path inconsistency: fixture says %q, this test reads from %q",
+			fixture.DriftCheck.KeepCorePath,
+			walletPubKeyHashDerivationVectorsPath,
+		)
+	}
+	if fixture.DriftCheck.Rule == "" {
+		t.Error("drift_check.rule must be non-empty")
+	}
+}
+
+// TestFixtureFileShouldExistAtMirrorPath documents the convention that
+// the file lives at the path the fixture self-declares. Mostly a
+// nudge for anyone moving the file: update the constant AND the
+// fixture metadata together.
+func TestFixtureFileShouldExistAtMirrorPath(t *testing.T) {
+	fixture := loadDerivationFixture(t)
+
+	abs, err := filepath.Abs(fixture.DriftCheck.KeepCorePath)
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf(
+			"fixture self-declares it lives at %q but the file is not there: %v",
+			fixture.DriftCheck.KeepCorePath,
+			err,
+		)
+	}
+}
+
+// hash160 reproduces Bitcoin's HASH160 (RIPEMD160(SHA256(x))) using
+// the same primitive frost.WalletPublicKeyHashCompatibilityAlias
+// invokes via btcutil.Hash160. We compute it directly here so the
+// ECDSA test is self-contained and doesn't pull in btcutil for a one-
+// liner.
+func hash160(b []byte) []byte {
+	sha := sha256.Sum256(b)
+	rip := ripemd160.New()
+	rip.Write(sha[:])
+	return rip.Sum(nil)
+}

--- a/pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
+++ b/pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,7 +21,26 @@ import (
 // wallet identity contract for any wallet whose canonical identity is
 // established cross-repo (in particular, FROST wallets registered via
 // the FROST WalletRegistry will use this derivation).
-const walletPubKeyHashDerivationVectorsPath = "testdata/wallet-pubkey-hash-derivation-vectors-v1.json"
+//
+// Path constants follow two different conventions intentionally:
+//
+//   - walletPubKeyHashDerivationVectorsTestPath: package-relative,
+//     used by os.ReadFile() because `go test ./pkg/frost` runs with
+//     pkg/frost as the working directory. This is the standard Go
+//     testdata convention.
+//
+//   - walletPubKeyHashDerivationVectorsRepoPath: repo-root-relative,
+//     used to compare against fixture.DriftCheck.KeepCorePath
+//     (which declares the canonical location for cross-repo sync
+//     tooling). This is what a cross-repo diff tool would use.
+//
+// The two MUST refer to the same file; the TestDriftCheckMetadata
+// assertions verify the fixture's self-declared path matches the
+// repo-relative constant exactly.
+const (
+	walletPubKeyHashDerivationVectorsTestPath = "testdata/wallet-pubkey-hash-derivation-vectors-v1.json"
+	walletPubKeyHashDerivationVectorsRepoPath = "pkg/frost/testdata/wallet-pubkey-hash-derivation-vectors-v1.json"
+)
 
 type ecdsaVector struct {
 	Name  string `json:"name"`
@@ -60,7 +80,7 @@ type derivationFixture struct {
 func loadDerivationFixture(t *testing.T) derivationFixture {
 	t.Helper()
 
-	data, err := os.ReadFile(walletPubKeyHashDerivationVectorsPath)
+	data, err := os.ReadFile(walletPubKeyHashDerivationVectorsTestPath)
 	if err != nil {
 		t.Fatalf("fixture read: %v", err)
 	}
@@ -176,7 +196,10 @@ func TestEcdsaCompressedPubKeyHash160Vectors(t *testing.T) {
 
 // TestDriftCheckMetadata asserts the fixture declares the tbtc mirror
 // path and a non-empty drift rule. A future CI sync check can use
-// these fields to compare files between repos.
+// these fields to compare files between repos. The fixture's
+// keep_core_path is repo-root-relative by convention; the package-
+// relative testdata constant used by os.ReadFile() is a separate
+// representation of the same file.
 func TestDriftCheckMetadata(t *testing.T) {
 	fixture := loadDerivationFixture(t)
 
@@ -186,11 +209,11 @@ func TestDriftCheckMetadata(t *testing.T) {
 			fixture.DriftCheck.TbtcPath,
 		)
 	}
-	if fixture.DriftCheck.KeepCorePath != walletPubKeyHashDerivationVectorsPath {
+	if fixture.DriftCheck.KeepCorePath != walletPubKeyHashDerivationVectorsRepoPath {
 		t.Errorf(
-			"drift_check.keep_core_path inconsistency: fixture says %q, this test reads from %q",
+			"drift_check.keep_core_path drift: fixture says %q, repo convention is %q",
 			fixture.DriftCheck.KeepCorePath,
-			walletPubKeyHashDerivationVectorsPath,
+			walletPubKeyHashDerivationVectorsRepoPath,
 		)
 	}
 	if fixture.DriftCheck.Rule == "" {
@@ -199,20 +222,29 @@ func TestDriftCheckMetadata(t *testing.T) {
 }
 
 // TestFixtureFileShouldExistAtMirrorPath documents the convention that
-// the file lives at the path the fixture self-declares. Mostly a
-// nudge for anyone moving the file: update the constant AND the
-// fixture metadata together.
+// the file lives at the path the fixture self-declares. Since the
+// fixture's keep_core_path is repo-root-relative but `go test
+// ./pkg/frost` runs with pkg/frost as the working directory, the path
+// is resolved relative to the repo root by walking up from this test
+// file's location.
 func TestFixtureFileShouldExistAtMirrorPath(t *testing.T) {
 	fixture := loadDerivationFixture(t)
 
-	abs, err := filepath.Abs(fixture.DriftCheck.KeepCorePath)
-	if err != nil {
-		t.Fatalf("abs path: %v", err)
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller: cannot locate test source file")
 	}
+	// thisFile points at pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
+	// repo root is two directories up.
+	repoRoot := filepath.Clean(
+		filepath.Join(filepath.Dir(thisFile), "..", ".."),
+	)
+	abs := filepath.Join(repoRoot, fixture.DriftCheck.KeepCorePath)
 	if _, err := os.Stat(abs); err != nil {
 		t.Fatalf(
-			"fixture self-declares it lives at %q but the file is not there: %v",
+			"fixture self-declares it lives at %q (resolved to %q) but the file is not there: %v",
 			fixture.DriftCheck.KeepCorePath,
+			abs,
 			err,
 		)
 	}

--- a/pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
+++ b/pkg/frost/wallet_pubkey_hash_derivation_vectors_test.go
@@ -45,12 +45,12 @@ type frostVector struct {
 }
 
 type derivationFixture struct {
-	Name         string        `json:"name"`
-	Version      string        `json:"version"`
-	Description  string        `json:"description"`
-	EcdsaLegacy  []ecdsaVector `json:"ecdsa_legacy"`
-	FrostP2tr    []frostVector `json:"frost_p2tr"`
-	DriftCheck   struct {
+	Name        string        `json:"name"`
+	Version     string        `json:"version"`
+	Description string        `json:"description"`
+	EcdsaLegacy []ecdsaVector `json:"ecdsa_legacy"`
+	FrostP2tr   []frostVector `json:"frost_p2tr"`
+	DriftCheck  struct {
 		TbtcPath     string `json:"tbtc_path"`
 		KeepCorePath string `json:"keep_core_path"`
 		Rule         string `json:"rule"`


### PR DESCRIPTION
## Why

The bridge contracts (tlabs-xyz/tbtc) and the keep-core FROST protocol (this repo) both derive the 20-byte walletPubKeyHash from cryptographic inputs:

- **Bridge** (\`BitcoinTx.deriveWalletPubKeyHashFromXOnly\`) computes \`bytes20(HASH160(0x02 || xOnlyKey))\` for FROST wallets, and HASH160 of the compressed ECDSA pubkey for legacy wallets.
- **keep-core** (\`frost.WalletPublicKeyHashCompatibilityAlias\` in \`pkg/frost/types.go\`) computes the same HASH160(0x02 || outputKey).

Drift between these two derivations silently breaks the bridge-protocol identity contract for any wallet whose canonical identity is established cross-repo. Today the two agree (both invoke HASH160 the same way) — but there's no enforcement, and a future refactor on either side could introduce silent drift that only surfaces when production traffic doesn't match.

The Phase B-2 work in this repo (the FROST DKG coordination protocol) will produce walletIDs that the bridge must accept. Pre-staging the fixture now lets B-2's implementation be validated as it's built.

## What

Mirrors the cross-repo fixture and adds a Go test that consumes it.

The fixture lives byte-identically in both repos:
- tbtc: \`docs/test-vectors/wallet-pubkey-hash-derivation-vectors-v1.json\` (companion PR [tlabs-xyz/tbtc#432](https://github.com/tlabs-xyz/tbtc/pull/432))
- keep-core: \`pkg/frost/testdata/wallet-pubkey-hash-derivation-vectors-v1.json\` (this PR)

Each repo's test reads its local copy and asserts its own derivation function reproduces the expected output. If either side drifts, at least one repo's test fails.

## Test cases

- **\`TestFrostWalletPubKeyHashDerivationVectors\`** — asserts \`frost.WalletPublicKeyHashCompatibilityAlias\` produces the expected 20-byte alias for every FROST vector (HASH160(0x02 || xOnlyOutputKey)).
- **\`TestEcdsaCompressedPubKeyHash160Vectors\`** — asserts HASH160 of the compressed pubkey matches expected for every ECDSA vector. The bridge performs this implicitly during \`registerNewWallet\` (compress then HASH160); this test pins the algorithm on the keep-core side.
- **\`TestDriftCheckMetadata\`** — pins the \`drift_check.tbtc_path\` / \`drift_check.keep_core_path\` / \`drift_check.rule\` fields so a future cross-repo CI sync check has stable references.
- **\`TestFixtureFileShouldExistAtMirrorPath\`** — documents the convention that the file lives at the path the fixture self-declares.

## Vectors

**ECDSA legacy** (HASH160 of compressed pubkey):
- secp256k1 generator point compressed (well-known Bitcoin vector — produces 1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2)
- Near-zero scalar pubkey
- The tBTC ECDSA test fixture's pubkey (cross-validates against the bridge-side \`ecdsaWalletTestData.pubKeyHash160\` constant)

**FROST P2TR** (HASH160(0x02 || xOnlyOutputKey)):
- Representative key with non-zero high 12 bytes (matches the native-shape constraint on the FROST registration entry point from tlabs-xyz/tbtc#431)
- All-ones x-only key (regression)
- All-max x-only key (boundary)

## Why "fixture lives in both repos" instead of a shared submodule

Considered but rejected:
- **Git submodule** — adds tooling complexity for a 3 KB JSON file
- **Single-source-of-truth repo** — requires bootstrapping a third repo or vendoring; both options add coordination friction
- **Dual-checked file** — simplest; the \`drift_check\` metadata captures the rule, and a future small CI job can hash-compare the two files

The dual-checked approach trades a slightly weaker guarantee (file drift can happen between repos if no one notices) for a much smaller operational footprint. The test-level drift (different derivation algorithms producing different outputs from the same input) is the load-bearing failure mode and is fully covered.

## Companion PR

[tlabs-xyz/tbtc#432](https://github.com/tlabs-xyz/tbtc/pull/432) lands the same JSON fixture and a TypeScript/Hardhat test against \`TestBitcoinTx.deriveWalletPubKeyHashFromXOnly\` and the off-chain HASH160 path. Both PRs are intended to land together — landing only one provides no drift protection.

## Lineage

Surfaced in the cross-PR review re-evaluation, originally flagged as "Cross-repo walletID derivation test fixture — separate effort." Priority was raised when Phase B-2 (this repo's FROST DKG coordinator) became part of the active roadmap.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>