### PR TITLE
fix(libp2p): bound Keep authentication handshake with SetDeadline

### DIFF
--- a/pkg/net/libp2p/transport.go
+++ b/pkg/net/libp2p/transport.go
@@ -2,6 +2,7 @@ package libp2p
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync/atomic"
 	"time"
@@ -23,6 +24,17 @@ const (
 	// authProtocolID is the ID of the authentication protocol.
 	authProtocolID = "keep"
 )
+
+// keepHandshakeTimeout bounds the post-TLS Keep authentication handshake
+// (Act 1 + Act 2 + Act 3). Chosen to match go-libp2p's upgrader default
+// accept timeout (15s, defined as `defaultAcceptTimeout` in
+// github.com/libp2p/go-libp2p/p2p/net/upgrader, configurable via
+// upgrader.WithAcceptTimeout), comfortably above realistic single-RTT
+// budgets across global peers while preventing indefinite stalls that
+// would otherwise saturate the resource-manager transient-inbound slot
+// pool. Declared as `var` (not `const`) solely to allow test code to
+// shorten it under `t.Cleanup`.
+var keepHandshakeTimeout = 15 * time.Second
 
 // Compile time assertions of custom types
 var _ sec.SecureTransport = (*transport)(nil)
@@ -94,6 +106,35 @@ func (t *transport) getMetricsRecorder() MetricsRecorder {
 	return nil
 }
 
+// applyHandshakeDeadline sets an absolute read+write deadline on conn that is
+// the minimum of (now+keepHandshakeTimeout) and any deadline already attached
+// to ctx. It returns a cleanup function that restores the connection to a
+// no-deadline state — callers MUST invoke the cleanup on success so that
+// subsequent application I/O is not subject to the handshake budget.
+//
+// The deadline is absolute (per net.Conn semantics): once set, it does not
+// extend with successful intermediate reads, which is exactly the property we
+// want — a partial-byte trickle attack cannot keep the connection alive past
+// the cap.
+//
+// Returns an error only if SetDeadline fails on the underlying connection,
+// which would itself indicate a closed or non-functional connection. Callers
+// should propagate this error.
+func applyHandshakeDeadline(ctx context.Context, conn net.Conn) (clear func(), err error) {
+	deadline := time.Now().Add(keepHandshakeTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("set handshake deadline: %w", err)
+	}
+	return func() {
+		// Best-effort clear; the only failure mode is a closed connection,
+		// in which case the deadline is irrelevant anyway.
+		_ = conn.SetDeadline(time.Time{})
+	}, nil
+}
+
 // SecureInbound secures an inbound connection.
 func (t *transport) SecureInbound(
 	ctx context.Context,
@@ -105,7 +146,14 @@ func (t *transport) SecureInbound(
 		return nil, err
 	}
 
-	return newAuthenticatedInboundConnection(
+	clear, err := applyHandshakeDeadline(ctx, encryptedConnection)
+	if err != nil {
+		_ = encryptedConnection.Close()
+		return nil, fmt.Errorf("inbound handshake setup: %w", err)
+	}
+	defer clear()
+
+	ac, err := newAuthenticatedInboundConnection(
 		encryptedConnection,
 		encryptedConnection.ConnState(),
 		t.localPeerID,
@@ -114,6 +162,13 @@ func (t *transport) SecureInbound(
 		t.authProtocolID,
 		t.getMetricsRecorder(),
 	)
+	if err != nil {
+		// newAuthenticatedInboundConnection already closes the conn on its
+		// internal failure paths; the deferred clear() above is a no-op on
+		// a closed conn (SetDeadline returns an error which we swallow).
+		return nil, err
+	}
+	return ac, nil
 }
 
 // SecureOutbound secures an outbound connection.
@@ -131,7 +186,14 @@ func (t *transport) SecureOutbound(
 		return nil, err
 	}
 
-	return newAuthenticatedOutboundConnection(
+	clear, err := applyHandshakeDeadline(ctx, encryptedConnection)
+	if err != nil {
+		_ = encryptedConnection.Close()
+		return nil, fmt.Errorf("outbound handshake setup: %w", err)
+	}
+	defer clear()
+
+	ac, err := newAuthenticatedOutboundConnection(
 		encryptedConnection,
 		encryptedConnection.ConnState(),
 		t.localPeerID,
@@ -141,6 +203,10 @@ func (t *transport) SecureOutbound(
 		t.authProtocolID,
 		t.getMetricsRecorder(),
 	)
+	if err != nil {
+		return nil, err
+	}
+	return ac, nil
 }
 
 // ID is the protocol ID of the security protocol.

--- a/pkg/net/libp2p/transport_test.go
+++ b/pkg/net/libp2p/transport_test.go
@@ -1,0 +1,489 @@
+package libp2p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/sec"
+
+	keepNet "github.com/keep-network/keep-core/pkg/net"
+)
+
+// mockSecureConn wraps a net.Conn (e.g. one end of net.Pipe()) and satisfies
+// libp2p's sec.SecureConn interface by embedding net.Conn for the byte-stream
+// half and providing the four ConnSecurity methods explicitly. It is used by
+// mockEncryptionLayer to bypass libp2p-TLS while still letting transport.go
+// drive the Keep authentication handshake over a synthetic in-memory pipe.
+type mockSecureConn struct {
+	net.Conn
+	localPeerID  peer.ID
+	remotePeerID peer.ID
+	remotePubKey libp2pcrypto.PubKey
+}
+
+func (m *mockSecureConn) LocalPeer() peer.ID                   { return m.localPeerID }
+func (m *mockSecureConn) RemotePeer() peer.ID                  { return m.remotePeerID }
+func (m *mockSecureConn) RemotePublicKey() libp2pcrypto.PubKey { return m.remotePubKey }
+func (m *mockSecureConn) ConnState() libp2pnetwork.ConnectionState {
+	return libp2pnetwork.ConnectionState{}
+}
+
+// Compile-time assertion that mockSecureConn satisfies sec.SecureConn.
+var _ sec.SecureConn = (*mockSecureConn)(nil)
+
+// mockEncryptionLayer satisfies sec.SecureTransport by returning the supplied
+// net.Conn (already presumed connected) wrapped as a mockSecureConn. It does
+// no TLS — the Keep authentication handshake test fixtures rely on this so
+// they can stall, partial-byte, or run the handshake to completion without
+// needing libp2p-TLS to complete over net.Pipe().
+type mockEncryptionLayer struct {
+	localPeerID  peer.ID
+	remotePeerID peer.ID
+	remotePubKey libp2pcrypto.PubKey
+}
+
+func (m *mockEncryptionLayer) SecureInbound(
+	_ context.Context,
+	insecure net.Conn,
+	_ peer.ID,
+) (sec.SecureConn, error) {
+	return &mockSecureConn{
+		Conn:         insecure,
+		localPeerID:  m.localPeerID,
+		remotePeerID: m.remotePeerID,
+		remotePubKey: m.remotePubKey,
+	}, nil
+}
+
+func (m *mockEncryptionLayer) SecureOutbound(
+	_ context.Context,
+	insecure net.Conn,
+	_ peer.ID,
+) (sec.SecureConn, error) {
+	return &mockSecureConn{
+		Conn:         insecure,
+		localPeerID:  m.localPeerID,
+		remotePeerID: m.remotePeerID,
+		remotePubKey: m.remotePubKey,
+	}, nil
+}
+
+func (m *mockEncryptionLayer) ID() protocol.ID { return securityProtocolID }
+
+// Compile-time assertion that mockEncryptionLayer satisfies sec.SecureTransport.
+var _ sec.SecureTransport = (*mockEncryptionLayer)(nil)
+
+// newTestTransport constructs a *transport literal with a mockEncryptionLayer
+// injected via the package-private encryptionLayer field. The metricsRecorderRef
+// is intentionally nil — getMetricsRecorder() handles nil safely.
+func newTestTransport(
+	cfg *testConnectionConfig,
+	remotePeerID peer.ID,
+	remotePubKey libp2pcrypto.PubKey,
+	firewall keepNet.Firewall,
+) *transport {
+	return &transport{
+		protocolID:     securityProtocolID,
+		authProtocolID: authProtocolID,
+		localPeerID:    cfg.peerID,
+		privateKey:     cfg.networkPrivateKey,
+		encryptionLayer: &mockEncryptionLayer{
+			localPeerID:  cfg.peerID,
+			remotePeerID: remotePeerID,
+			remotePubKey: remotePubKey,
+		},
+		firewall:           firewall,
+		metricsRecorderRef: nil,
+	}
+}
+
+// withShortenedHandshakeTimeout overrides keepHandshakeTimeout to d for the
+// duration of the test, restoring the original via t.Cleanup. MUST be used
+// in every test that asserts deadline-driven behavior. Do NOT call
+// t.Parallel() in any test that uses this — all tests mutate the same
+// package-level var.
+func withShortenedHandshakeTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	original := keepHandshakeTimeout
+	keepHandshakeTimeout = d
+	t.Cleanup(func() { keepHandshakeTimeout = original })
+}
+
+// assertHandshakeTimedOut fails the test if err is nil or elapsed reached the
+// ceiling. label identifies the scenario in failure messages (e.g. "stalled
+// inbound handshake"). Callers that also need a lower-bound sanity check on
+// elapsed (to prove the deadline actually fired rather than the handshake
+// returning instantly via some unrelated error path) keep that check inline
+// so the floor value remains visible at the call site.
+func assertHandshakeTimedOut(
+	t *testing.T,
+	elapsed time.Duration,
+	ceiling time.Duration,
+	label string,
+	err error,
+) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected non-nil error from %s", label)
+	}
+	if elapsed >= ceiling {
+		t.Fatalf(
+			"expected %s to fail within %v; got elapsed=%v",
+			label, ceiling, elapsed,
+		)
+	}
+}
+
+// TestSecureInbound_StallsTimeOut verifies that when an attacker completes
+// the (mocked) encryption layer but then sends zero bytes for the Keep
+// handshake Act 1, SecureInbound returns within the shortened deadline.
+func TestSecureInbound_StallsTimeOut(t *testing.T) {
+	withShortenedHandshakeTimeout(t, 250*time.Millisecond)
+
+	responder := createTestConnectionConfig(t)
+	initiator := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+
+	attackerConn, victimConn := newConnPair()
+	defer attackerConn.Close()
+
+	tr := newTestTransport(
+		responder,
+		initiator.peerID,
+		initiator.networkPrivateKey.GetPublic(),
+		firewall,
+	)
+
+	// No peer activity: attackerConn is held open by the test (via defer
+	// Close) and writes nothing. This mimics the "completes TLS then silent"
+	// attack profile. The victim's handshake read must hit the deadline.
+
+	start := time.Now()
+	_, err := tr.SecureInbound(context.Background(), victimConn, "")
+	elapsed := time.Since(start)
+
+	assertHandshakeTimedOut(t, elapsed, 500*time.Millisecond, "stalled inbound handshake", err)
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf(
+			"handshake returned too quickly (%v) — deadline likely did not fire; expected ≥200ms",
+			elapsed,
+		)
+	}
+}
+
+// TestSecureInbound_PartialBytesTimeOut verifies that when an attacker sends
+// a single byte of an unterminated varint then sleeps, the absolute deadline
+// still fires (partial progress does not extend per-read timers).
+func TestSecureInbound_PartialBytesTimeOut(t *testing.T) {
+	withShortenedHandshakeTimeout(t, 250*time.Millisecond)
+
+	responder := createTestConnectionConfig(t)
+	initiator := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+
+	attackerConn, victimConn := newConnPair()
+	defer attackerConn.Close()
+
+	tr := newTestTransport(
+		responder,
+		initiator.peerID,
+		initiator.networkPrivateKey.GetPublic(),
+		firewall,
+	)
+
+	// Attacker goroutine: writes 1 byte of a varint with the continuation
+	// bit set (0x80) — protodelim will keep blocking waiting for the rest
+	// of the length-prefix that never arrives.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = attackerConn.Write([]byte{0x80})
+		// Sleep well past the handshake deadline so we test the deadline,
+		// not the attacker's eventual close.
+		time.Sleep(2 * time.Second)
+	}()
+
+	start := time.Now()
+	_, err := tr.SecureInbound(context.Background(), victimConn, "")
+	elapsed := time.Since(start)
+
+	assertHandshakeTimedOut(t, elapsed, 500*time.Millisecond, "partial-byte inbound handshake", err)
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf(
+			"handshake returned too quickly (%v) — deadline likely did not fire; expected ≥200ms",
+			elapsed,
+		)
+	}
+
+	// Allow the attacker goroutine to terminate before test exit.
+	attackerConn.Close()
+	<-done
+}
+
+// TestSecureInbound_SuccessClearsDeadline verifies that a real successful
+// Keep handshake completes and that, after SecureInbound returns, post-handshake
+// reads on the returned connection are no longer subject to the handshake
+// deadline.
+func TestSecureInbound_SuccessClearsDeadline(t *testing.T) {
+	withShortenedHandshakeTimeout(t, 250*time.Millisecond)
+
+	responder := createTestConnectionConfig(t)
+	initiator := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+	if err := firewall.updatePeer(initiator.networkPublicKey, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := firewall.updatePeer(responder.networkPublicKey, true); err != nil {
+		t.Fatal(err)
+	}
+
+	initiatorConn, responderConn := newConnPair()
+
+	tr := newTestTransport(
+		responder,
+		initiator.peerID,
+		initiator.networkPrivateKey.GetPublic(),
+		firewall,
+	)
+
+	// Honest initiator runs the 3-act handshake directly via
+	// newAuthenticatedOutboundConnection (same-package, no need to wrap
+	// in transport for the peer side). After the handshake completes the
+	// initiator writes a probe payload, sleeps past the handshake deadline,
+	// then closes its end so the responder's later read returns io.EOF.
+	probe := []byte("clear-deadline-probe")
+	peerDone := make(chan error, 1)
+	go func() {
+		outConn, err := newAuthenticatedOutboundConnection(
+			initiatorConn,
+			libp2pnetwork.ConnectionState{},
+			initiator.peerID,
+			initiator.networkPrivateKey,
+			responder.peerID,
+			firewall,
+			authProtocolID,
+			nil,
+		)
+		if err != nil {
+			peerDone <- err
+			return
+		}
+		if _, err := outConn.Write(probe); err != nil {
+			peerDone <- err
+			return
+		}
+		// Hold the conn open past the original deadline so the responder
+		// can verify that the deadline has been cleared. Then close it.
+		time.Sleep(2 * keepHandshakeTimeout)
+		_ = initiatorConn.Close()
+		peerDone <- nil
+	}()
+
+	secureConn, err := tr.SecureInbound(context.Background(), responderConn, "")
+	if err != nil {
+		t.Fatalf("unexpected handshake error: %v", err)
+	}
+	if secureConn == nil {
+		t.Fatal("expected non-nil secure connection on successful handshake")
+	}
+
+	// Sleep past the original handshake deadline before reading. If the
+	// deadline had not been cleared, any subsequent Read would surface
+	// os.ErrDeadlineExceeded (or a net.Error timeout) at this point.
+	time.Sleep(2 * keepHandshakeTimeout)
+
+	buf := make([]byte, len(probe))
+	_, readErr := io.ReadFull(secureConn, buf)
+	if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+		// Tolerate EOF variants (peer closed) but never a timeout.
+		if errors.Is(readErr, os.ErrDeadlineExceeded) {
+			t.Fatalf("post-handshake read hit deadline: %v", readErr)
+		}
+		var netErr net.Error
+		if errors.As(readErr, &netErr) && netErr.Timeout() {
+			t.Fatalf("post-handshake read hit net.Error timeout: %v", readErr)
+		}
+	}
+
+	if err := <-peerDone; err != nil {
+		t.Fatalf("peer goroutine error: %v", err)
+	}
+}
+
+// TestSecureInbound_HonorsCtxDeadline verifies that the helper takes the
+// tighter of (now + keepHandshakeTimeout, ctx.Deadline()). With the package
+// var at its default 15s and a 100ms ctx deadline, the timeout must fire
+// well under the package default.
+func TestSecureInbound_HonorsCtxDeadline(t *testing.T) {
+	// Intentionally do NOT override keepHandshakeTimeout; the test must
+	// observe the ctx-side bound dominating.
+	responder := createTestConnectionConfig(t)
+	initiator := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+
+	attackerConn, victimConn := newConnPair()
+	defer attackerConn.Close()
+
+	tr := newTestTransport(
+		responder,
+		initiator.peerID,
+		initiator.networkPrivateKey.GetPublic(),
+		firewall,
+	)
+
+	// No peer activity: attackerConn is held open by the test (via defer
+	// Close) and writes nothing. The ctx-side deadline must dominate over
+	// the default 15s package-level timeout.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := tr.SecureInbound(ctx, victimConn, "")
+	elapsed := time.Since(start)
+
+	assertHandshakeTimedOut(t, elapsed, 300*time.Millisecond, "ctx-bounded inbound handshake", err)
+}
+
+// TestSecureOutbound_StallsTimeOut verifies that when the responder side
+// stalls after the (mocked) encryption layer completes, SecureOutbound
+// returns within the shortened deadline.
+func TestSecureOutbound_StallsTimeOut(t *testing.T) {
+	withShortenedHandshakeTimeout(t, 250*time.Millisecond)
+
+	initiator := createTestConnectionConfig(t)
+	responder := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+
+	initiatorConn, attackerConn := newConnPair()
+	defer attackerConn.Close()
+
+	tr := newTestTransport(
+		initiator,
+		responder.peerID,
+		responder.networkPrivateKey.GetPublic(),
+		firewall,
+	)
+
+	// Attacker goroutine: drains anything the initiator writes (so the
+	// synchronous net.Pipe Act 1 send does not block) but never replies.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(io.Discard, attackerConn)
+	}()
+
+	start := time.Now()
+	_, err := tr.SecureOutbound(context.Background(), initiatorConn, responder.peerID)
+	elapsed := time.Since(start)
+
+	assertHandshakeTimedOut(t, elapsed, 500*time.Millisecond, "stalled outbound handshake", err)
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf(
+			"handshake returned too quickly (%v) — deadline likely did not fire; expected ≥200ms",
+			elapsed,
+		)
+	}
+
+	// Closing attackerConn unblocks the io.Copy goroutine.
+	attackerConn.Close()
+	<-done
+}
+
+// TestSecureInbound_FastHandshakeUnaffected verifies that a real handshake
+// which completes well under the default 15s timeout does not spuriously
+// fail with a timeout error.
+func TestSecureInbound_FastHandshakeUnaffected(t *testing.T) {
+	// Intentionally do NOT override keepHandshakeTimeout; we want to prove
+	// the default 15s does not cause spurious timeouts on a fast handshake.
+	responder := createTestConnectionConfig(t)
+	initiator := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+	if err := firewall.updatePeer(initiator.networkPublicKey, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := firewall.updatePeer(responder.networkPublicKey, true); err != nil {
+		t.Fatal(err)
+	}
+
+	initiatorConn, responderConn := newConnPair()
+
+	tr := newTestTransport(
+		responder,
+		initiator.peerID,
+		initiator.networkPrivateKey.GetPublic(),
+		firewall,
+	)
+
+	peerDone := make(chan error, 1)
+	go func() {
+		_, err := newAuthenticatedOutboundConnection(
+			initiatorConn,
+			libp2pnetwork.ConnectionState{},
+			initiator.peerID,
+			initiator.networkPrivateKey,
+			responder.peerID,
+			firewall,
+			authProtocolID,
+			nil,
+		)
+		peerDone <- err
+	}()
+
+	start := time.Now()
+	secureConn, err := tr.SecureInbound(context.Background(), responderConn, "")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected handshake error: %v", err)
+	}
+	if secureConn == nil {
+		t.Fatal("expected non-nil secure connection on successful handshake")
+	}
+	if elapsed >= 1*time.Second {
+		t.Fatalf(
+			"fast handshake took too long (%v); expected well under 1s",
+			elapsed,
+		)
+	}
+
+	if peerErr := <-peerDone; peerErr != nil {
+		t.Fatalf("peer goroutine error: %v", peerErr)
+	}
+}
+
+// TestApplyHandshakeDeadline_FailsOnClosedConn verifies that calling the
+// helper directly on a closed net.Pipe connection returns an error chain
+// that satisfies errors.Is(err, io.ErrClosedPipe). The helper wraps its
+// underlying SetDeadline failure with %w so the chain is preserved.
+func TestApplyHandshakeDeadline_FailsOnClosedConn(t *testing.T) {
+	a, b := net.Pipe()
+	_ = a.Close()
+	_ = b.Close()
+
+	clear, err := applyHandshakeDeadline(context.Background(), a)
+	if clear != nil {
+		t.Fatal("expected nil clear closure on SetDeadline failure")
+	}
+	if err == nil {
+		t.Fatal("expected non-nil error from applyHandshakeDeadline on closed conn")
+	}
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("expected error chain to contain io.ErrClosedPipe; got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The post-TLS Keep authentication handshake on inbound and outbound secure connections runs with no read or write deadline on the underlying `net.Conn`. The 15-second context budget supplied by go-libp2p's `Upgrader` (via `defaultAcceptTimeout` in `p2p/net/upgrader/upgrader.go`) is honored only during the TLS handshake itself; once TLS completes, cancelling that context is a no-op because Go's `net.Conn` deadlines are independent of `context.Context`. An unauthenticated peer that completes TLS within the 15s budget but then stalls during Act 1, Act 2, or Act 3 of the Keep handshake — by sending nothing, or by trickling partial bytes — therefore holds a go-libp2p resource-manager transient-inbound slot indefinitely. At the default capacity of approximately 48 transient-inbound slots per host on 8 GiB AutoScale machines, saturating bootstrap peers' pools blocks new and restarting peers from joining the mesh. The impact is most acute during mandatory upgrade restart windows when threshold-signing groups must reform across the network. The authorization-ordering aggravates this: keep-core's firewall `IsRecognized()` check runs after the handshake completes, so an attacker stalled mid-handshake never reaches that gate, and unstaked or unrecognized peers can hold slots without ever being filtered out.

## Solution

Introduce a package-level `keepHandshakeTimeout` variable (15s, matching go-libp2p's `defaultAcceptTimeout`) and an `applyHandshakeDeadline(ctx, conn)` helper in `pkg/net/libp2p/transport.go` that sets `min(ctx.Deadline(), now+keepHandshakeTimeout)` on the connection via `SetDeadline` and returns a clear function that resets the deadline to zero on success. Both `SecureInbound` and `SecureOutbound` invoke the helper immediately after the libp2p-TLS layer returns and `defer clear()` so that successful post-handshake application I/O is unbounded, exactly as before. `SetDeadline` (rather than `SetReadDeadline` alone) is used because Act 2 on the responder and Acts 1 and 3 on the initiator write to the peer; bounding both directions with a single absolute deadline closes both read-stall and write-stall variants under one invariant. The helper wraps `SetDeadline` errors with `%w` to preserve the error chain for callers that rely on `errors.Is`. The deadline is absolute per `net.Conn` semantics, so a partial-byte trickle cannot extend the dwell time past the cap. The variable is declared as `var` rather than `const` solely so unit tests can shorten it under `t.Cleanup`; production code never mutates it. No protocol-level changes, no wire-format changes, no `go.mod` changes, no new dependencies.

## Tests

The new `pkg/net/libp2p/transport_test.go` adds seven unit tests covering: a full inbound stall after TLS (zero bytes for Act 1), partial-byte trickle attacks, post-success-clear (verifying that a successful handshake does not leave a deadline on the connection that would break later application I/O), explicit `ctx.Deadline()` honoring (a 100ms context deadline fires before the 15s package-level timeout), the symmetric outbound stall path, a fast-handshake-no-spurious-timeout regression check, and a direct helper-on-closed-conn assertion that returns the expected error through `errors.Is(err, io.ErrClosedPipe)`. Tests inject a mock `encryptionLayer` via the package-private field so the suite isolates the Keep handshake from libp2p-TLS's TCP-socket dependency, and override `keepHandshakeTimeout` via `t.Cleanup` to preserve test isolation across the suite. All seven new tests pass under `go test -race -count=1`. Full keep-core unit-test suite passes locally (matching CI: `go test -timeout 15m ./...`, `gofmt -l .`, `go vet`, staticcheck with `-SA1019`, gosec with the CI exclusion set). The existing `pkg/net/libp2p` tests pass without modification.

## Residual Risk and Follow-Up

This patch closes the catastrophic indefinite-stall vector but does not close a residual continuous-churn DoS in which an attacker sustains roughly `transientInboundLimit / keepHandshakeTimeout` ≈ 3 stalled accepts per second, keeping the transient pool saturated for as long as the rate is maintained. The deadline bounds per-connection dwell time, not steady-state occupancy. Closing that residual class requires architectural follow-up — either earlier IP-layer gating via `ConnectionGater.InterceptAccept`, a split of the security transport into pure-TLS plus a separately-gated post-TLS authentication layer, or simplification onto libp2p-TLS-only peer authentication. That decision is out of scope for this hotfix and should be handled as a separate RFC PR. Also note: this branch is forked from `feature/decouple-firewall-allowlist` (PR #3909) and targets that branch as its merge base because PR #3909 is landing on `main` this week; once #3909 merges, the base of this PR will be re-targeted to `main`. PR #3909 does not touch `pkg/net/libp2p/transport.go` or `pkg/net/libp2p/authenticated_connection.go`, so no file overlap is expected in either merge direction.
