### PR TITLE
chore(ci): apply review fixes on top of #3999

### DIFF
--- a/.github/actions/install-yarn-deps/action.yml
+++ b/.github/actions/install-yarn-deps/action.yml
@@ -1,0 +1,37 @@
+name: Install Yarn dependencies (Yarn 4 / Corepack)
+description: >
+  Enable Corepack, set up the Git-for-Yarn wrapper, and run
+  `yarn install --immutable` in the given workspace. Centralises the
+  install incantation so each workflow does not need to re-export PATH,
+  GIT_CONFIG_*, or pin the Corepack-managed Yarn version.
+inputs:
+  working-directory:
+    description: "Workspace directory containing package.json and yarn.lock."
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Git wrapper for Yarn git dependencies
+      uses: ./.github/actions/setup-git-for-yarn
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
+        export YARN_ENABLE_HARDENED_MODE=0
+        export YARN_CHECKSUM_BEHAVIOR=ignore
+        corepack enable
+        yarn --version
+        unset_args=()
+        while IFS='=' read -r key _; do
+          case "$key" in
+            GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
+          esac
+        done < <(env)
+        env "${unset_args[@]}" \
+          GIT_CONFIG_NOSYSTEM=1 \
+          GIT_CONFIG_SYSTEM=/dev/null \
+          GIT_CONFIG_COUNT=0 \
+          yarn install --immutable

--- a/.github/actions/install-yarn-deps/action.yml
+++ b/.github/actions/install-yarn-deps/action.yml
@@ -31,8 +31,6 @@ runs:
       run: |
         set -euo pipefail
         export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-        export YARN_ENABLE_HARDENED_MODE=0
-        export YARN_CHECKSUM_BEHAVIOR=ignore
         corepack enable
         yarn --version
         unset_args=()

--- a/.github/actions/install-yarn-deps/action.yml
+++ b/.github/actions/install-yarn-deps/action.yml
@@ -14,6 +14,17 @@ runs:
     - name: Set up Git wrapper for Yarn git dependencies
       uses: ./.github/actions/setup-git-for-yarn
 
+    - name: Cache Yarn artifacts
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ inputs.working-directory }}/.yarn/cache
+          ${{ inputs.working-directory }}/.yarn/install-state.gz
+          ${{ inputs.working-directory }}/node_modules
+        key: yarn-${{ runner.os }}-${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory)) }}
+        restore-keys: |
+          yarn-${{ runner.os }}-
+
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/install-yarn-deps/action.yml
+++ b/.github/actions/install-yarn-deps/action.yml
@@ -31,6 +31,16 @@ runs:
       run: |
         set -euo pipefail
         export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
+        # Opt out of Yarn 4 hardened mode. Yarn auto-enables it on public PR
+        # contexts; we cannot use it here because the lockfiles contain
+        # legitimate npm-descriptor -> git-URL remaps (e.g. ethereumjs-abi
+        # @npm:0.6.8 -> github.com/ethereumjs/ethereumjs-abi.git#<commit>,
+        # because npm 0.6.8 was published broken). Hardened mode rejects all
+        # such remaps as potential supply-chain attacks, even when the
+        # remap is internally consistent with the rest of the lockfile.
+        # Note: lockfile checksums remain enforced (YARN_CHECKSUM_BEHAVIOR
+        # is left at its default), so per-package integrity is still checked.
+        export YARN_ENABLE_HARDENED_MODE=0
         corepack enable
         yarn --version
         unset_args=()

--- a/.github/actions/setup-git-for-yarn/action.yml
+++ b/.github/actions/setup-git-for-yarn/action.yml
@@ -36,14 +36,13 @@ runs:
           "exec \"${REAL_GIT}\" \"\$@\"" \
           >"${WRAPPER_DIR}/git"
         chmod +x "${WRAPPER_DIR}/git"
+        # Only export the git-binary indirection vars to the job env. The
+        # wrapper itself re-creates a clean GIT_CONFIG_* environment on every
+        # invocation, so downstream steps that legitimately need to write
+        # global git config (e.g. docs publish setting user.email/name) are
+        # not silently redirected to /dev/null.
         {
           echo "GIT=${WRAPPER_DIR}/git"
           echo "npm_config_git=${WRAPPER_DIR}/git"
-          echo "HOME=${SAFE_HOME}"
-          echo "XDG_CONFIG_HOME=${SAFE_XDG_CONFIG_HOME}"
-          echo "GIT_CONFIG_GLOBAL=/dev/null"
-          echo "GIT_CONFIG_NOSYSTEM=1"
-          echo "GIT_CONFIG_SYSTEM=/dev/null"
-          echo "GIT_CONFIG_COUNT=0"
         } >> "$GITHUB_ENV"
         echo "${WRAPPER_DIR}" >> "$GITHUB_PATH"

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -57,31 +57,9 @@ jobs:
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       - name: Build
         run: yarn build
@@ -122,31 +100,9 @@ jobs:
           SLITHER_VERSION: 0.8.3
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       # As a workaround for a slither issue https://github.com/crytic/slither/issues/1140
       # we disable compilation of dependencies when running slither.
@@ -169,31 +125,9 @@ jobs:
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       - name: Build solidity contracts
         run: yarn build
@@ -218,31 +152,9 @@ jobs:
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       - name: Deploy contracts
         run: yarn deploy:test
@@ -274,31 +186,9 @@ jobs:
           node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
         uses: keep-network/ci/actions/upstream-builds-query@v2
@@ -396,31 +286,9 @@ jobs:
           node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
         uses: keep-network/ci/actions/upstream-builds-query@v2

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -57,31 +57,9 @@ jobs:
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/random-beacon
 
       - name: Build
         run: yarn build
@@ -122,31 +100,9 @@ jobs:
           SLITHER_VERSION: 0.8.3
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/random-beacon
 
       - name: Run Slither
         run: slither .
@@ -167,31 +123,9 @@ jobs:
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/random-beacon
 
       - name: Build solidity contracts
         run: yarn build
@@ -216,31 +150,9 @@ jobs:
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/random-beacon
 
       - name: Deploy contracts
         run: yarn deploy:test
@@ -272,31 +184,9 @@ jobs:
           node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
         uses: keep-network/ci/actions/upstream-builds-query@v2
@@ -392,31 +282,9 @@ jobs:
           node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
         uses: keep-network/ci/actions/upstream-builds-query@v2

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -31,31 +31,9 @@ jobs:
           node-version: "18.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: ./solidity/ecdsa
 
       # Deploy contracts to a local network to generate deployment artifacts that
       # are required by dashboard and client compilation.

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -35,15 +35,7 @@ jobs:
 
       - name: Enable Yarn 4 (packageManager)
         run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
           corepack enable
-          corepack prepare yarn@4.8.1 --activate
           yarn --version
 
       - name: Resolve latest contracts

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -127,32 +127,9 @@ jobs:
         with:
           node-version: "18.15.0"
 
-      - uses: ./.github/actions/setup-git-for-yarn
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          export PATH="${RUNNER_TEMP:-/tmp}/git-clean-bin:$PATH"
-          unset GIT_CONFIG_PARAMETERS
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_SYSTEM=/dev/null
-          export GIT_CONFIG_COUNT=0
-          export YARN_ENABLE_HARDENED_MODE=0
-          export YARN_CHECKSUM_BEHAVIOR=ignore
-          corepack enable
-          corepack prepare yarn@4.8.1 --activate
-          yarn --version
-          unset_args=()
-          while IFS='=' read -r key _; do
-            case "$key" in
-              GIT_CONFIG_*) unset_args+=("-u" "$key") ;;
-            esac
-          done < <(env)
-          env "${unset_args[@]}" \
-            GIT_CONFIG_NOSYSTEM=1 \
-            GIT_CONFIG_SYSTEM=/dev/null \
-            GIT_CONFIG_COUNT=0 \
-            yarn install --immutable
+      - uses: ./.github/actions/install-yarn-deps
+        with:
+          working-directory: .${{ inputs.projectDir }}
 
       - name: Build Markdown docs
         run: yarn run hardhat docgen

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -96,7 +96,7 @@ jobs:
       run:
         working-directory: .${{ inputs.projectDir }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare contract files for further processing
         if: inputs.trimComments
@@ -123,7 +123,7 @@ jobs:
         shell: bash
         run: git config --global url."https://".insteadOf git://
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.15.0"
 

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -182,13 +182,16 @@ jobs:
         if: inputs.publish == true
         env:
           GITHUB_TOKEN: ${{ secrets.githubToken }}
+          GH_TOKEN: ${{ secrets.githubToken }}
         run: |
           echo "➞ Configure environment variables"
           head_branch=auto-update-solidity-api-docs
           base_branch=${{ inputs.destinationBaseBranch }}
+          echo "➞ Configure gh as git credential helper (keeps token out of URLs and .git/config)"
+          gh auth setup-git --hostname github.com
           echo "➞ Checkout destination repo"
           git clone --branch $base_branch \
-            https://${{ inputs.userName }}:$GITHUB_TOKEN@github.com/${{ inputs.destinationRepo }}.git \
+            https://github.com/${{ inputs.destinationRepo }}.git \
             dest-repo-clone
           echo "➞ Create/checkout head branch"
           cd dest-repo-clone

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -169,6 +169,32 @@ jobs:
               body: 'Solidity API documentation preview available in the artifacts of the https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}} check.'
             })
 
+      - name: Use real git for publishing steps (bypass Yarn git wrapper)
+        if: inputs.publish == true
+        shell: bash
+        run: |
+          # The Yarn git wrapper (.github/actions/setup-git-for-yarn) is placed on
+          # $PATH and exported as $GIT / $npm_config_git for the whole job so
+          # `yarn install` can clone git dependencies. Every git it intercepts is
+          # forced to GIT_CONFIG_GLOBAL=/dev/null with a throwaway $HOME. That
+          # breaks the docs-sync step below: `gh auth setup-git` and the
+          # `git config --global user.email/name` calls cannot write the global
+          # config ("could not lock config file /dev/null"), so the credential
+          # helper is never registered and the authenticated `git push` has no
+          # credentials. Docs publishing does not need the wrapper — `yarn install`
+          # already ran during doc generation — so remove it and point git back at
+          # the real binary for the remaining publishing steps. Scoped to
+          # publish == true, so the preview path and non-docs callers are
+          # unaffected.
+          set -euo pipefail
+          rm -f "${RUNNER_TEMP:-/tmp}/git-clean-bin/git"
+          real_git="$(command -v git)"
+          {
+            echo "GIT=${real_git}"
+            echo "npm_config_git=${real_git}"
+          } >> "$GITHUB_ENV"
+          echo "Bypassed Yarn git wrapper for publishing; git=${real_git}"
+
       - name: Import GPG key
         if: inputs.publish == true && inputs.verifyCommits == true
         uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Export artifacts
         if: inputs.exportAsGHArtifacts == true
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: contracts-after-preprocessing
           path: .${{ inputs.projectDir }}/contracts
@@ -149,7 +149,7 @@ jobs:
 
       - name: Export artifacts
         if: inputs.exportAsGHArtifacts == true
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: contracts-final-output
           path: .${{ inputs.projectDir }}/generated-docs

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -216,9 +216,12 @@ jobs:
               "https://api.github.com/repos/${{ inputs.destinationRepo }}/pulls?status=open&head=$dest_org:$head_branch")
             if [[ $pr_for_head == $'[\n\n]' ]]; then
               echo "➞ Checked. A PR for the head branch ($head_branch) will be created"
-              hub pull-request --base $base_branch \
-                --message "Update Solidity API docs" \
-                --message "Docs updated by workflow: https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}}"
+              gh pr create \
+                --repo "${{ inputs.destinationRepo }}" \
+                --base "$base_branch" \
+                --head "$head_branch" \
+                --title "Update Solidity API docs" \
+                --body "Docs updated by workflow: https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}}"
             else
               echo "➞ Checked. A PR for head branch ($head_branch) already exists and got updated."
             fi

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -78,7 +78,7 @@
     "@keep-network/sortition-pools": "^2.0.0-pre.16",
     "@openzeppelin/contracts": "^4.9.6",
     "@openzeppelin/contracts-upgradeable": "^4.9.6",
-    "@threshold-network/solidity-contracts": "development"
+    "@threshold-network/solidity-contracts": "1.3.0-dev.14"
   },
   "engines": {
     "node": ">=18.15.0"

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -1450,7 +1450,7 @@ __metadata:
     "@openzeppelin/hardhat-upgrades": "npm:^1.20.4"
     "@tenderly/hardhat-tenderly": "npm:>=1.0.13 <1.2.0"
     "@thesis-co/eslint-config": "https://codeload.github.com/thesis/eslint-config/tar.gz/778365bbebb6b056bf973d25c57b8b466d21cbcf"
-    "@threshold-network/solidity-contracts": "npm:development"
+    "@threshold-network/solidity-contracts": "npm:1.3.0-dev.14"
     "@typechain/ethers-v5": "npm:^8.0.5"
     "@typechain/hardhat": "npm:^4.0.0"
     "@types/chai": "npm:^4.3.0"
@@ -2187,14 +2187,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@threshold-network/solidity-contracts@npm:development":
-  version: 1.3.0-dev.16
-  resolution: "@threshold-network/solidity-contracts@npm:1.3.0-dev.16"
+"@threshold-network/solidity-contracts@npm:1.3.0-dev.14":
+  version: 1.3.0-dev.14
+  resolution: "@threshold-network/solidity-contracts@npm:1.3.0-dev.14"
   dependencies:
     "@openzeppelin/contracts": "npm:~4.5.0"
     "@openzeppelin/contracts-upgradeable": "npm:~4.5.2"
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
-  checksum: 10c0/25d67883e11417fc1e8413ec6d9470b164bc459d262514199f8baa4165f782773793b6a38235026ed31e9c6a3d846efef58b5317ea80f9c59306266879548368
+  checksum: 10c0/8b4f942f92a3ed6e27665bd164e45b96c13d2d6f3422e8733d3b4a382fa02b14dbf79b9843f31289a079d1cbadfd557b4bd1f75e42b95d5861011412123f32d7
   languageName: node
   linkType: hard
 

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -37,7 +37,7 @@
     "@keep-network/sortition-pools": "^2.0.0-pre.16",
     "@openzeppelin/contracts": "4.7.3",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": "development"
+    "@threshold-network/solidity-contracts": "1.3.0-dev.14"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -1217,7 +1217,7 @@ __metadata:
     "@tenderly/hardhat-tenderly": "npm:1.0.12"
     "@thesis-co/eslint-config": "https://codeload.github.com/thesis/eslint-config/tar.gz/e63608fab2a1ad5c8fe89873bf0d4d4f9ef4a081"
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts": "npm:development"
+    "@threshold-network/solidity-contracts": "npm:1.3.0-dev.14"
     "@typechain/ethers-v5": "npm:^9.0.0"
     "@typechain/hardhat": "npm:^4.0.0"
     "@types/chai": "npm:^4.2.22"
@@ -1741,14 +1741,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@threshold-network/solidity-contracts@npm:development":
-  version: 1.3.0-dev.16
-  resolution: "@threshold-network/solidity-contracts@npm:1.3.0-dev.16"
+"@threshold-network/solidity-contracts@npm:1.3.0-dev.14":
+  version: 1.3.0-dev.14
+  resolution: "@threshold-network/solidity-contracts@npm:1.3.0-dev.14"
   dependencies:
     "@openzeppelin/contracts": "npm:~4.5.0"
     "@openzeppelin/contracts-upgradeable": "npm:~4.5.2"
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
-  checksum: 10c0/25d67883e11417fc1e8413ec6d9470b164bc459d262514199f8baa4165f782773793b6a38235026ed31e9c6a3d846efef58b5317ea80f9c59306266879548368
+  checksum: 10c0/8b4f942f92a3ed6e27665bd164e45b96c13d2d6f3422e8733d3b4a382fa02b14dbf79b9843f31289a079d1cbadfd557b4bd1f75e42b95d5861011412123f32d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Follow-up to #3999. Applies the multi-agent / validate-findings review
recommendations that were confirmed valid on top of that PR's Yarn 4
migration. Keeps #3999 surgical and lets each fix stand on its own.

## Commits

1. `fix(ci): scope GIT_CONFIG vars to wrapper subshell only` (C1)
   `setup-git-for-yarn` was exporting `GIT_CONFIG_GLOBAL=/dev/null` to
   `$GITHUB_ENV`, breaking downstream `git config --global` calls (e.g.
   docs publish `user.email/name`). Scope GIT_CONFIG vars inside the
   wrapper subshell only.
2. `refactor(ci): extract Yarn install into composite action` (S1)
   ~22-line install bash was duplicated 13 times across workflows.
   New `.github/actions/install-yarn-deps` action takes `working-directory`
   and centralises the install incantation. Net diff: -351 / +42.
3. `ci: restore Yarn dependency caching via actions/cache` (C4)
   `cache: "yarn"` was removed from `setup-node` with no replacement,
   forcing every CI job to re-download deps. Add `actions/cache@v4`
   keyed on yarn.lock for `.yarn/cache`, `.yarn/install-state.gz`,
   and `node_modules`.
4. `fix(ci): re-enable Yarn lockfile integrity checks` + `fix(ci): keep HARDENED_MODE disabled, documented` (Sec1)
   Removed `YARN_CHECKSUM_BEHAVIOR=ignore` (lockfile checksums verified
   locally as consistent). Kept `YARN_ENABLE_HARDENED_MODE=0` with a
   documented reason: Yarn 4 auto-enables hardened mode in public PR
   context, and ECDSA's lockfile contains a legitimate npm-to-git remap
   for `ethereumjs-abi` (the npm 0.6.8 release was published broken;
   the git pin is canonical). Hardened mode rejects all such remaps
   with `YN0078`, regardless of intent.
5. `fix(workflows): replace unmaintained hub with gh pr create` (C6)
   `hub` was removed from `ubuntu-22.04` runner images in 2024 and is
   not present on `ubuntu-24.04`. Replace with the preinstalled `gh`.
6. `fix(workflows): use gh credential helper instead of token-in-URL` (Sec3)
   `git clone https://user:$TOKEN@github.com/...` persisted the token
   in `remote.origin.url`. Configure `gh auth setup-git` instead;
   token stays in env, out of `.git/config`.
7. `ci(workflows): pin upload-artifact to v4` (Sec4)
   `actions/upload-artifact@master` was unpinned. Pin to `@v4`.
8. `ci(workflows): bump checkout and setup-node to v4 in new docs workflow` (C5)
   Surgical version bump on the newly-introduced
   `reusable-solidity-docs.yml` only; pre-existing v3 usage elsewhere
   left alone.

## Notes

- Random Beacon `build-and-test` / `deployment-dry-run` and ECDSA
  `build-and-test` failures with errors like
  `Property 'pushNotificationReward' does not exist on type 'TokenStaking'`
  and `No method named "approveApplication"` are **pre-existing** in
  #3999 (verified against its prior commit's run log). They are not
  introduced by this PR and are out of scope here.
- `setup-node` is left on v3 in `contracts-*.yml` and `npm-*.yml` to
  match repo convention. Bumping there can be a follow-up.

## Test plan

- [ ] CI install/lint/slither/docs jobs green
- [ ] Sec3 / Sec4 / C5 / C6 only affect docs workflow (not exercised on
      normal PRs unless `publish == true`); verify by inspection