### PR TITLE
Support Taproot tweaked signer rounds

### DIFF
--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -29,6 +29,8 @@ pub struct StartSignRoundRequest {
     pub message_hex: String,
     pub key_group: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub taproot_merkle_root_hex: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signing_participants: Option<Vec<u16>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attempt_context: Option<AttemptContext>,
@@ -61,6 +63,8 @@ pub struct RoundState {
     pub required_contributions: u16,
     pub message_digest_hex: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub taproot_merkle_root_hex: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signing_participants: Option<Vec<u16>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attempt_transition_telemetry: Option<AttemptTransitionTelemetry>,
@@ -70,6 +74,8 @@ pub struct RoundState {
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct FinalizeSignRoundRequest {
     pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub taproot_merkle_root_hex: Option<String>,
     pub round_contributions: Vec<RoundContribution>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attempt_context: Option<AttemptContext>,

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -11,6 +11,8 @@ pub struct RunDkgRequest {
     pub session_id: String,
     pub participants: Vec<DkgParticipant>,
     pub threshold: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dkg_seed_hex: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -5257,6 +5257,10 @@ pub fn run_dkg(request: RunDkgRequest) -> Result<DkgResult, EngineError> {
         ));
     }
 
+    // The `frost-secp256k1-tr` ciphersuite post-processes DKG output before
+    // returning these packages. This serialized verifying key is the protocol
+    // wallet key exported to Go/on-chain; later Taproot tweaks are applied
+    // relative to this exported key.
     let key_group = public_key_package
         .verifying_key()
         .serialize()
@@ -11775,7 +11779,7 @@ mod tests {
             session_id: "session-real-finalize".to_string(),
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
-            key_group: dkg_result.key_group,
+            key_group: dkg_result.key_group.clone(),
             taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
@@ -11855,10 +11859,26 @@ mod tests {
         let signature_bytes = hex::decode(&first_result.signature_hex).expect("signature decode");
         assert_eq!(signature_bytes.len(), 64);
         let signature = frost::Signature::deserialize(&signature_bytes).expect("signature parse");
+        let exported_key_group_bytes =
+            hex::decode(&dkg_result.key_group).expect("decode exported key group");
+        let exported_verifying_key = frost::VerifyingKey::deserialize(&exported_key_group_bytes)
+            .expect("deserialize exported key group");
+        assert_eq!(
+            dkg_result.key_group,
+            hex::encode(
+                dkg_public_key_package
+                    .verifying_key()
+                    .serialize()
+                    .expect("serialize DKG verifying key")
+            )
+        );
         dkg_public_key_package
             .verifying_key()
             .verify(&sign_message_bytes, &signature)
             .expect("signature verification");
+        exported_verifying_key
+            .verify(&sign_message_bytes, &signature)
+            .expect("signature verifies under exported key group");
         assert!(
             dkg_public_key_package
                 .clone()
@@ -11907,7 +11927,7 @@ mod tests {
             session_id: "session-real-taproot-tweak".to_string(),
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
-            key_group: dkg_result.key_group,
+            key_group: dkg_result.key_group.clone(),
             taproot_merkle_root_hex: Some(taproot_merkle_root_hex.to_string()),
             signing_participants: None,
             attempt_context: None,
@@ -11989,6 +12009,24 @@ mod tests {
         let signature_bytes = hex::decode(&result.signature_hex).expect("signature decode");
         assert_eq!(signature_bytes.len(), 64);
         let signature = frost::Signature::deserialize(&signature_bytes).expect("signature parse");
+        let exported_key_group_bytes =
+            hex::decode(&dkg_result.key_group).expect("decode exported key group");
+        let exported_verifying_key = frost::VerifyingKey::deserialize(&exported_key_group_bytes)
+            .expect("deserialize exported key group");
+        let exported_public_key_package = frost::keys::PublicKeyPackage::new(
+            BTreeMap::<frost::Identifier, frost::keys::VerifyingShare>::new(),
+            exported_verifying_key,
+            Some(dkg_result.threshold),
+        );
+        assert_eq!(
+            dkg_result.key_group,
+            hex::encode(
+                dkg_public_key_package
+                    .verifying_key()
+                    .serialize()
+                    .expect("serialize DKG verifying key")
+            )
+        );
         let tweaked_public_key_package = dkg_public_key_package
             .clone()
             .tweak(Some(taproot_merkle_root.as_slice()));
@@ -11996,6 +12034,11 @@ mod tests {
             .verifying_key()
             .verify(&sign_message_bytes, &signature)
             .expect("tweaked signature verification");
+        exported_public_key_package
+            .tweak(Some(taproot_merkle_root.as_slice()))
+            .verifying_key()
+            .verify(&sign_message_bytes, &signature)
+            .expect("tweaked signature verifies under exported key group");
         assert!(
             dkg_public_key_package
                 .verifying_key()

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -4250,6 +4250,32 @@ fn canonicalize_refresh_shares_request_for_fingerprint(
     canonical_request
 }
 
+fn canonicalize_taproot_merkle_root_hex(
+    taproot_merkle_root_hex: &mut Option<String>,
+) -> Result<Option<[u8; 32]>, EngineError> {
+    let Some(raw_taproot_merkle_root_hex) = taproot_merkle_root_hex.as_mut() else {
+        return Ok(None);
+    };
+
+    let normalized_taproot_merkle_root_hex =
+        raw_taproot_merkle_root_hex.trim().to_ascii_lowercase();
+    let taproot_merkle_root_bytes =
+        hex::decode(&normalized_taproot_merkle_root_hex).map_err(|_| {
+            EngineError::Validation("taproot_merkle_root_hex must be valid hex".to_string())
+        })?;
+    if taproot_merkle_root_bytes.len() != 32 {
+        return Err(EngineError::Validation(
+            "taproot_merkle_root_hex must decode to 32 bytes".to_string(),
+        ));
+    }
+
+    let mut taproot_merkle_root = [0_u8; 32];
+    taproot_merkle_root.copy_from_slice(&taproot_merkle_root_bytes);
+    *raw_taproot_merkle_root_hex = normalized_taproot_merkle_root_hex;
+
+    Ok(Some(taproot_merkle_root))
+}
+
 fn truthy_env_flag(raw_value: &str) -> bool {
     matches!(
         raw_value.trim().to_ascii_lowercase().as_str(),
@@ -4316,16 +4342,19 @@ fn derive_round_id(
     session_id: &str,
     key_group: &str,
     message_hex: &str,
+    taproot_merkle_root_hex: Option<&str>,
     signing_participants_fingerprint: &str,
     attempt_context: Option<&AttemptContext>,
 ) -> String {
     let attempt_id_component = round_attempt_id_component(attempt_context);
+    let taproot_merkle_root_component = taproot_merkle_root_hex.unwrap_or("no-taproot-merkle-root");
     hash_hex(
         format!(
-            "round:{}:{}:{}:{}:{}",
+            "round:{}:{}:{}:{}:{}:{}",
             session_id,
             key_group,
             message_hex,
+            taproot_merkle_root_component,
             signing_participants_fingerprint,
             attempt_id_component
         )
@@ -5276,7 +5305,7 @@ fn enforce_bootstrap_dealer_dkg_disabled_in_production(
     Ok(())
 }
 
-pub fn start_sign_round(request: StartSignRoundRequest) -> Result<RoundState, EngineError> {
+pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState, EngineError> {
     record_hardening_telemetry(|telemetry| {
         telemetry.start_sign_round_calls_total =
             telemetry.start_sign_round_calls_total.saturating_add(1);
@@ -5294,6 +5323,8 @@ pub fn start_sign_round(request: StartSignRoundRequest) -> Result<RoundState, En
     let message_bytes = hex::decode(&request.message_hex)
         .map_err(|_| EngineError::Validation("message_hex must be valid hex".to_string()))?;
     let message_digest_hex = hash_hex(&message_bytes);
+    let taproot_merkle_root =
+        canonicalize_taproot_merkle_root_hex(&mut request.taproot_merkle_root_hex)?;
     let strict_roast_mode_enabled = roast_strict_mode_enabled();
 
     let request_fingerprint = {
@@ -5494,6 +5525,7 @@ pub fn start_sign_round(request: StartSignRoundRequest) -> Result<RoundState, En
                 &request.session_id,
                 &request.key_group,
                 &request.message_hex,
+                request.taproot_merkle_root_hex.as_deref(),
                 &signing_participants_fingerprint,
                 canonical_attempt_context.as_ref(),
             );
@@ -5519,6 +5551,7 @@ pub fn start_sign_round(request: StartSignRoundRequest) -> Result<RoundState, En
                     &request,
                     &round_id,
                     &message_bytes,
+                    taproot_merkle_root.as_ref(),
                 )?
             };
 
@@ -5548,6 +5581,7 @@ pub fn start_sign_round(request: StartSignRoundRequest) -> Result<RoundState, En
                 round_id: round_id.clone(),
                 required_contributions: dkg.threshold,
                 message_digest_hex: message_digest_hex.clone(),
+                taproot_merkle_root_hex: request.taproot_merkle_root_hex.clone(),
                 signing_participants: Some(signing_participants),
                 attempt_transition_telemetry,
                 own_contribution,
@@ -5645,6 +5679,7 @@ fn build_real_signature_share_contribution(
     request: &StartSignRoundRequest,
     round_id: &str,
     message_bytes: &[u8],
+    taproot_merkle_root: Option<&[u8; 32]>,
 ) -> Result<RoundContribution, EngineError> {
     let mut commitments = BTreeMap::new();
     let mut own_nonces = None;
@@ -5693,8 +5728,16 @@ fn build_real_signature_share_contribution(
         })?;
 
     let signing_package = frost::SigningPackage::new(commitments, message_bytes);
-    let signature_share_result =
-        frost::round2::sign(&signing_package, &own_nonces, own_key_package);
+    let signature_share_result = if let Some(taproot_merkle_root) = taproot_merkle_root {
+        frost::round2::sign_with_tweak(
+            &signing_package,
+            &own_nonces,
+            own_key_package,
+            Some(taproot_merkle_root.as_slice()),
+        )
+    } else {
+        frost::round2::sign(&signing_package, &own_nonces, own_key_package)
+    };
     own_nonces.zeroize();
     let signature_share = signature_share_result
         .map_err(|e| EngineError::Internal(format!("failed to create signature share: {e}")))?;
@@ -5710,7 +5753,7 @@ fn build_real_signature_share_contribution(
 }
 
 pub fn finalize_sign_round(
-    request: FinalizeSignRoundRequest,
+    mut request: FinalizeSignRoundRequest,
     bootstrap_mode_enabled: bool,
 ) -> Result<SignatureResult, EngineError> {
     record_hardening_telemetry(|telemetry| {
@@ -5721,6 +5764,8 @@ pub fn finalize_sign_round(
     enforce_provenance_gate()?;
     validate_session_id(&request.session_id)?;
     let strict_roast_mode_enabled = roast_strict_mode_enabled();
+    let finalize_taproot_merkle_root =
+        canonicalize_taproot_merkle_root_hex(&mut request.taproot_merkle_root_hex)?;
 
     let request_fingerprint = {
         let mut canonical_attempt_context = request.attempt_context.clone();
@@ -5735,6 +5780,7 @@ pub fn finalize_sign_round(
 
         fingerprint(&FinalizeSignRoundRequest {
             session_id: request.session_id.clone(),
+            taproot_merkle_root_hex: request.taproot_merkle_root_hex.clone(),
             round_contributions: canonical_contributions,
             attempt_context: canonical_attempt_context,
         })?
@@ -5806,6 +5852,11 @@ pub fn finalize_sign_round(
             .ok_or_else(|| EngineError::SignRoundNotStarted {
                 session_id: request.session_id.clone(),
             })?;
+    if request.taproot_merkle_root_hex != round_state.taproot_merkle_root_hex {
+        return Err(EngineError::Validation(
+            "taproot_merkle_root_hex does not match active signing round".to_string(),
+        ));
+    }
     if signing_policy_firewall_enforced() {
         let sign_message_hex = session
             .sign_message_bytes
@@ -5875,6 +5926,11 @@ pub fn finalize_sign_round(
         return Err(EngineError::SyntheticContributionRejected {
             session_id: request.session_id,
         });
+    }
+    if is_synthetic && round_state.taproot_merkle_root_hex.is_some() {
+        return Err(EngineError::Validation(
+            "synthetic contributions do not support taproot tweaked signing".to_string(),
+        ));
     }
 
     let signature_result = if is_synthetic {
@@ -5984,10 +6040,19 @@ pub fn finalize_sign_round(
         }
 
         let signing_package = frost::SigningPackage::new(commitments, sign_message_bytes);
-        let signature =
-            frost::aggregate(&signing_package, &signature_shares, dkg_public_key_package).map_err(
-                |e| EngineError::Validation(format!("failed to aggregate signature shares: {e}")),
-            )?;
+        let signature = if let Some(taproot_merkle_root) = finalize_taproot_merkle_root.as_ref() {
+            frost::aggregate_with_tweak(
+                &signing_package,
+                &signature_shares,
+                dkg_public_key_package,
+                Some(taproot_merkle_root.as_slice()),
+            )
+        } else {
+            frost::aggregate(&signing_package, &signature_shares, dkg_public_key_package)
+        }
+        .map_err(|e| {
+            EngineError::Validation(format!("failed to aggregate signature shares: {e}"))
+        })?;
         let signature_bytes = signature.serialize().map_err(|e| {
             EngineError::Internal(format!("failed to serialize aggregate signature: {e}"))
         })?;
@@ -6606,6 +6671,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -7951,6 +8017,7 @@ mod tests {
         let finalize_err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: "session-metrics-provenance-finalize".to_string(),
+                taproot_merkle_root_hex: None,
                 round_contributions: vec![],
                 attempt_context: None,
             },
@@ -8004,6 +8071,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -8064,6 +8132,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -8085,6 +8154,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -8174,6 +8244,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -8194,6 +8265,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -8255,6 +8327,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -8276,6 +8349,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -8389,6 +8463,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -8410,6 +8485,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -8555,6 +8631,7 @@ mod tests {
             key_group: post_rekey_status
                 .continuity_reference_key_group
                 .expect("continuity reference key group"),
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -8677,6 +8754,7 @@ mod tests {
         let finalize_err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: round_state.session_id.clone(),
+                taproot_merkle_root_hex: None,
                 round_contributions: vec![
                     RoundContribution {
                         identifier: 1,
@@ -8857,6 +8935,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -8904,6 +8983,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -8955,6 +9035,7 @@ mod tests {
             member_identifier: 1,
             message_hex,
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -8999,6 +9080,7 @@ mod tests {
             member_identifier: 1,
             message_hex,
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -9018,6 +9100,7 @@ mod tests {
         let err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 round_contributions: vec![
                     RoundContribution {
                         identifier: 1,
@@ -9075,6 +9158,7 @@ mod tests {
             member_identifier: 1,
             message_hex,
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -9096,6 +9180,7 @@ mod tests {
         let err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 round_contributions: vec![
                     RoundContribution {
                         identifier: 1,
@@ -9525,6 +9610,7 @@ mod tests {
             request_session_id,
             key_group,
             message_hex,
+            None,
             signing_participants_fingerprint,
             Some(&lowercase_attempt_context),
         );
@@ -9532,6 +9618,7 @@ mod tests {
             request_session_id,
             key_group,
             message_hex,
+            None,
             signing_participants_fingerprint,
             Some(&uppercase_attempt_context),
         );
@@ -9545,6 +9632,7 @@ mod tests {
             request_session_id,
             key_group,
             message_hex,
+            None,
             signing_participants_fingerprint,
             Some(&different_attempt_context),
         );
@@ -9554,6 +9642,7 @@ mod tests {
             request_session_id,
             key_group,
             message_hex,
+            None,
             signing_participants_fingerprint,
             None,
         );
@@ -9668,6 +9757,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -9724,6 +9814,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -9775,6 +9866,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -9818,6 +9910,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -9867,6 +9960,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -9916,6 +10010,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -9965,6 +10060,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10026,6 +10122,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(invalid_attempt_context),
             attempt_transition_evidence: None,
@@ -10074,6 +10171,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10127,6 +10225,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10180,6 +10279,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(uppercase_attempt_context),
             attempt_transition_evidence: None,
@@ -10193,6 +10293,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![2, 1]),
             attempt_context: Some(lowercase_attempt_context),
             attempt_transition_evidence: None,
@@ -10234,6 +10335,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10243,6 +10345,7 @@ mod tests {
         let err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 attempt_context: None,
                 round_contributions: vec![
                     RoundContribution {
@@ -10301,6 +10404,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10310,6 +10414,7 @@ mod tests {
         let signature_result = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 attempt_context: None,
                 round_contributions: vec![
                     RoundContribution {
@@ -10364,6 +10469,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10375,6 +10481,7 @@ mod tests {
         let signature_result = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 attempt_context: None,
                 round_contributions: vec![
                     RoundContribution {
@@ -10431,6 +10538,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -10442,6 +10550,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -10484,6 +10593,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: None,
@@ -10497,6 +10607,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10544,6 +10655,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10557,6 +10669,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: None,
@@ -10604,6 +10717,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10618,6 +10732,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -10643,6 +10758,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(stale_attempt),
             attempt_transition_evidence: None,
@@ -10691,6 +10807,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10707,6 +10824,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -10753,6 +10871,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one.clone()),
             attempt_transition_evidence: None,
@@ -10767,6 +10886,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -10780,6 +10900,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10831,6 +10952,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10848,6 +10970,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(invalid_transition_evidence),
@@ -10895,6 +11018,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10909,6 +11033,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_three),
             attempt_transition_evidence: Some(transition_evidence),
@@ -10956,6 +11081,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -10973,6 +11099,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -11020,6 +11147,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -11041,6 +11169,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -11092,6 +11221,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -11113,6 +11243,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -11168,6 +11299,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -11189,6 +11321,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -11240,6 +11373,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2, 3]),
             attempt_context: Some(attempt_one),
             attempt_transition_evidence: None,
@@ -11261,6 +11395,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_two),
             attempt_transition_evidence: Some(transition_evidence),
@@ -11308,6 +11443,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(start_attempt),
             attempt_transition_evidence: None,
@@ -11318,6 +11454,7 @@ mod tests {
         let err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 attempt_context: Some(mismatched_attempt),
                 round_contributions: vec![
                     round_state.own_contribution.clone(),
@@ -11372,6 +11509,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(start_attempt),
             attempt_transition_evidence: None,
@@ -11383,6 +11521,7 @@ mod tests {
         let err = finalize_sign_round(
             FinalizeSignRoundRequest {
                 session_id: session_id.to_string(),
+                taproot_merkle_root_hex: None,
                 attempt_context: Some(stale_attempt),
                 round_contributions: vec![
                     round_state.own_contribution.clone(),
@@ -11413,6 +11552,7 @@ mod tests {
 
         let request = FinalizeSignRoundRequest {
             session_id: "session-synthetic-rejected".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -11441,6 +11581,7 @@ mod tests {
 
         let request = FinalizeSignRoundRequest {
             session_id: "session-synthetic-accepted".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -11489,6 +11630,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -11530,6 +11672,7 @@ mod tests {
             &member_two_request,
             &round_state.round_id,
             &hex::decode(&member_two_request.message_hex).expect("message decode"),
+            None,
         )
         .expect("member two contribution");
         let member_three_request = StartSignRoundRequest {
@@ -11543,11 +11686,13 @@ mod tests {
             &member_three_request,
             &round_state.round_id,
             &hex::decode(&member_three_request.message_hex).expect("message decode"),
+            None,
         )
         .expect("member three contribution");
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-real-finalize".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 round_state.own_contribution.clone(),
@@ -11568,6 +11713,142 @@ mod tests {
             .verifying_key()
             .verify(&sign_message_bytes, &signature)
             .expect("signature verification");
+    }
+
+    #[test]
+    fn finalize_aggregates_real_taproot_tweaked_contributions() {
+        use frost::keys::Tweak;
+
+        let _guard = lock_test_state();
+        reset_for_tests();
+
+        let run_dkg_request = RunDkgRequest {
+            session_id: "session-real-taproot-tweak".to_string(),
+            participants: vec![
+                crate::api::DkgParticipant {
+                    identifier: 1,
+                    public_key_hex: "02aa".to_string(),
+                },
+                crate::api::DkgParticipant {
+                    identifier: 2,
+                    public_key_hex: "02bb".to_string(),
+                },
+                crate::api::DkgParticipant {
+                    identifier: 3,
+                    public_key_hex: "02cc".to_string(),
+                },
+            ],
+            threshold: 2,
+        };
+
+        let taproot_merkle_root_hex =
+            "37a57b86de2819d2b72a173df46238a7ad295ea1485d3b40e9415daa82b4fdcb";
+        let taproot_merkle_root_bytes =
+            hex::decode(taproot_merkle_root_hex).expect("taproot merkle root");
+        let mut taproot_merkle_root = [0_u8; 32];
+        taproot_merkle_root.copy_from_slice(&taproot_merkle_root_bytes);
+
+        let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
+        let start_request = StartSignRoundRequest {
+            session_id: "session-real-taproot-tweak".to_string(),
+            member_identifier: 1,
+            message_hex: "deadbeef".to_string(),
+            key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: Some(taproot_merkle_root_hex.to_string()),
+            signing_participants: None,
+            attempt_context: None,
+            attempt_transition_evidence: None,
+        };
+        let round_state = start_sign_round(start_request.clone()).expect("start sign round");
+        assert_eq!(
+            round_state.taproot_merkle_root_hex.as_deref(),
+            Some(taproot_merkle_root_hex)
+        );
+        let signing_participants = round_state
+            .signing_participants
+            .clone()
+            .expect("round signing participants");
+
+        let (dkg_key_packages, dkg_public_key_package, sign_message_bytes) = {
+            let guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get(&start_request.session_id)
+                .expect("session state");
+
+            (
+                session.dkg_key_packages.clone().expect("dkg key packages"),
+                session
+                    .dkg_public_key_package
+                    .clone()
+                    .expect("dkg public key package"),
+                session
+                    .sign_message_bytes
+                    .clone()
+                    .expect("sign message bytes"),
+            )
+        };
+
+        let member_two_request = StartSignRoundRequest {
+            member_identifier: 2,
+            attempt_transition_evidence: None,
+            ..start_request.clone()
+        };
+        let member_two_contribution = build_real_signature_share_contribution(
+            &dkg_key_packages,
+            &signing_participants,
+            &member_two_request,
+            &round_state.round_id,
+            &hex::decode(&member_two_request.message_hex).expect("message decode"),
+            Some(&taproot_merkle_root),
+        )
+        .expect("member two contribution");
+        let member_three_request = StartSignRoundRequest {
+            member_identifier: 3,
+            attempt_transition_evidence: None,
+            ..member_two_request.clone()
+        };
+        let member_three_contribution = build_real_signature_share_contribution(
+            &dkg_key_packages,
+            &signing_participants,
+            &member_three_request,
+            &round_state.round_id,
+            &hex::decode(&member_three_request.message_hex).expect("message decode"),
+            Some(&taproot_merkle_root),
+        )
+        .expect("member three contribution");
+
+        let finalize_request = FinalizeSignRoundRequest {
+            session_id: "session-real-taproot-tweak".to_string(),
+            taproot_merkle_root_hex: Some(taproot_merkle_root_hex.to_string()),
+            attempt_context: None,
+            round_contributions: vec![
+                round_state.own_contribution.clone(),
+                member_two_contribution,
+                member_three_contribution,
+            ],
+        };
+
+        let result = finalize_sign_round(finalize_request, false).expect("finalize");
+
+        assert_eq!(result.round_id, round_state.round_id);
+        let signature_bytes = hex::decode(&result.signature_hex).expect("signature decode");
+        assert_eq!(signature_bytes.len(), 64);
+        let signature = frost::Signature::deserialize(&signature_bytes).expect("signature parse");
+        let tweaked_public_key_package = dkg_public_key_package
+            .clone()
+            .tweak(Some(taproot_merkle_root.as_slice()));
+        tweaked_public_key_package
+            .verifying_key()
+            .verify(&sign_message_bytes, &signature)
+            .expect("tweaked signature verification");
+        assert!(
+            dkg_public_key_package
+                .verifying_key()
+                .verify(&sign_message_bytes, &signature)
+                .is_err(),
+            "tweaked signature must not verify under the untweaked key"
+        );
     }
 
     #[test]
@@ -11600,6 +11881,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "cafef00d".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -11641,11 +11923,13 @@ mod tests {
             &member_two_request,
             &round_state.round_id,
             &hex::decode(&member_two_request.message_hex).expect("message decode"),
+            None,
         )
         .expect("member two contribution");
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-real-threshold-subset".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 round_state.own_contribution.clone(),
@@ -11771,6 +12055,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -11802,6 +12087,7 @@ mod tests {
             &member_two_request,
             &round_state.round_id,
             &hex::decode(&member_two_request.message_hex).expect("message decode"),
+            None,
         )
         .expect("member two contribution");
 
@@ -11819,6 +12105,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-message-tamper".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 round_state.own_contribution.clone(),
@@ -11867,6 +12154,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "b16b00b5".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -11898,11 +12186,13 @@ mod tests {
             &member_two_request,
             &round_state.round_id,
             &hex::decode(&member_two_request.message_hex).expect("message decode"),
+            None,
         )
         .expect("member two contribution");
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-real-contributor-set-mismatch".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 round_state.own_contribution.clone(),
@@ -11961,6 +12251,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "facefeed".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -11969,6 +12260,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-real-outside-signing-cohort".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 round_state.own_contribution,
@@ -12464,6 +12756,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -12476,6 +12769,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-persisted-idempotency".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -12700,6 +12994,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -12766,6 +13061,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -12840,6 +13136,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -12908,6 +13205,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -13079,6 +13377,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -13147,6 +13446,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -13215,6 +13515,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context),
             attempt_transition_evidence: None,
@@ -13264,6 +13565,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -13272,6 +13574,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-consumed-round".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -13305,6 +13608,7 @@ mod tests {
 
         let round_only_replay_request = FinalizeSignRoundRequest {
             session_id: finalize_request.session_id.clone(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -13449,6 +13753,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -13473,6 +13778,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-consumed-request-capacity".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -13544,6 +13850,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(uppercase_attempt_context.clone()),
             attempt_transition_evidence: None,
@@ -13565,6 +13872,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: session_id.to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: Some(uppercase_attempt_context),
             round_contributions: vec![
                 RoundContribution {
@@ -13623,6 +13931,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -13647,6 +13956,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-consumed-round-capacity".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -13722,6 +14032,7 @@ mod tests {
             member_identifier: 1,
             message_hex: message_hex.to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: Some(attempt_context.clone()),
             attempt_transition_evidence: None,
@@ -13743,6 +14054,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: session_id.to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: Some(attempt_context),
             round_contributions: vec![
                 RoundContribution {
@@ -13808,6 +14120,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -13816,6 +14129,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-consumed-request-fingerprint".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -13836,6 +14150,7 @@ mod tests {
         });
         let expected_request_fingerprint = fingerprint(&FinalizeSignRoundRequest {
             session_id: finalize_request.session_id.clone(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: canonical_contributions,
         })
@@ -13912,6 +14227,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -13920,6 +14236,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-consumed-request-fingerprint-restart".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -13940,6 +14257,7 @@ mod tests {
         });
         let expected_request_fingerprint = fingerprint(&FinalizeSignRoundRequest {
             session_id: finalize_request.session_id.clone(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: canonical_contributions,
         })
@@ -14021,6 +14339,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![3, 1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14032,6 +14351,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![2, 3, 1]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14072,6 +14392,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![3, 1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14083,6 +14404,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "cafebabe".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![2, 3, 1]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14117,6 +14439,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14125,6 +14448,7 @@ mod tests {
 
         let first_finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-reordered-idempotency".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -14140,6 +14464,7 @@ mod tests {
 
         let second_finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-reordered-idempotency".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -14187,6 +14512,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14195,6 +14521,7 @@ mod tests {
 
         let first_finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-canonicalization-conflict".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -14211,6 +14538,7 @@ mod tests {
 
         let second_finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-canonicalization-conflict".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -14375,6 +14703,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: finalize_dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14383,6 +14712,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-restart-finalize".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -14606,6 +14936,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14614,6 +14945,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-clears-signing-material".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -14680,6 +15012,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -14688,6 +15021,7 @@ mod tests {
 
         let finalize_request = FinalizeSignRoundRequest {
             session_id: "session-finalize-purge-persist-reload".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -15073,6 +15073,16 @@ mod tests {
             attempt_transition_evidence: None,
         };
         let first_round_state = start_sign_round(first_request).expect("first start sign round");
+        let consumed_round_ids_after_first = {
+            let guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get("session-start-round-reordered-idempotency")
+                .expect("session state");
+            session.consumed_sign_round_ids.clone()
+        };
+        assert_eq!(consumed_round_ids_after_first.len(), 1);
+        assert!(consumed_round_ids_after_first.contains(&first_round_state.round_id));
 
         let second_request = StartSignRoundRequest {
             session_id: "session-start-round-reordered-idempotency".to_string(),
@@ -15088,6 +15098,18 @@ mod tests {
             start_sign_round(second_request).expect("second start sign round retry");
 
         assert_eq!(first_round_state, second_round_state);
+        let consumed_round_ids_after_second = {
+            let guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get("session-start-round-reordered-idempotency")
+                .expect("session state");
+            session.consumed_sign_round_ids.clone()
+        };
+        assert_eq!(
+            consumed_round_ids_after_first,
+            consumed_round_ids_after_second
+        );
     }
 
     #[test]

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -5194,8 +5194,8 @@ pub fn run_dkg(request: RunDkgRequest) -> Result<DkgResult, EngineError> {
         .map(|identifier| participant_identifier_to_frost_identifier(*identifier))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut keygen_rng_seed = [0u8; 32];
-    OsRng.fill_bytes(&mut keygen_rng_seed);
+    let mut keygen_rng_seed =
+        development_dealer_dkg_seed(request.dkg_seed_hex.as_deref(), &request_fingerprint)?;
     let keygen_rng = ZeroizingChaCha20Rng::from_seed(keygen_rng_seed);
     keygen_rng_seed.zeroize();
 
@@ -5303,6 +5303,30 @@ fn enforce_bootstrap_dealer_dkg_disabled_in_production(
     }
 
     Ok(())
+}
+
+fn development_dealer_dkg_seed(
+    dkg_seed_hex: Option<&str>,
+    request_fingerprint: &str,
+) -> Result<[u8; 32], EngineError> {
+    let (seed_source, seed_hex) = match dkg_seed_hex {
+        Some(seed) => ("DKG seed", seed),
+        None => ("DKG request fingerprint", request_fingerprint),
+    };
+
+    let seed = hex::decode(seed_hex)
+        .map_err(|e| EngineError::Internal(format!("failed to decode {seed_source}: {e}")))?;
+    if seed.len() != 32 {
+        return Err(EngineError::Internal(format!(
+            "{seed_source} decoded to [{}] bytes, expected 32",
+            seed.len()
+        )));
+    }
+
+    let mut output = [0u8; 32];
+    output.copy_from_slice(&seed);
+
+    Ok(output)
 }
 
 pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState, EngineError> {
@@ -6662,6 +6686,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -6887,6 +6912,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("production profile should reject bootstrap dealer DKG");
 
@@ -6924,6 +6950,7 @@ mod tests {
                     },
                 ],
                 threshold: 2,
+                dkg_seed_hex: None,
             })
             .expect_err("missing/empty profile should reject bootstrap dealer DKG");
 
@@ -6974,6 +7001,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected provenance gate rejection");
 
@@ -7044,6 +7072,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         });
         assert!(result.is_ok(), "expected signed attestation acceptance");
 
@@ -7087,6 +7116,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected missing signature rejection");
 
@@ -7149,6 +7179,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected signature verification rejection");
 
@@ -7202,6 +7233,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected attestation expiry rejection");
 
@@ -7255,6 +7287,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected attestation missing expiry rejection");
 
@@ -7311,6 +7344,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected attestation expiry too far rejection");
 
@@ -7373,6 +7407,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected trust-root mismatch rejection");
 
@@ -7426,6 +7461,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected runtime version mismatch rejection");
 
@@ -7479,6 +7515,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected status mismatch rejection");
 
@@ -7525,6 +7562,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected invalid trust root rejection");
 
@@ -7572,6 +7610,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected session_id validation rejection");
 
@@ -7608,6 +7647,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected admission policy rejection");
 
@@ -7641,6 +7681,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected admission policy config rejection");
 
@@ -7679,6 +7720,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected admission policy config rejection");
 
@@ -7988,6 +8030,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected run_dkg provenance gate rejection");
         assert!(matches!(
@@ -8063,6 +8106,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8122,6 +8166,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8234,6 +8279,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8317,6 +8363,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8379,6 +8426,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected auto-quarantine rejection");
         let EngineError::QuarantinePolicyRejected { reason_code, .. } = err else {
@@ -8410,6 +8458,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("allowlisted operator should bypass quarantine rejection");
 
@@ -8453,6 +8502,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8521,6 +8571,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect_err("expected quarantine rejection after reload");
         let EngineError::QuarantinePolicyRejected { reason_code, .. } = err else {
@@ -8555,6 +8606,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8927,6 +8979,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -8973,6 +9026,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9024,6 +9078,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9070,6 +9125,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9148,6 +9204,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9749,6 +9806,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9800,6 +9858,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed non-production dkg");
 
@@ -9856,6 +9915,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9898,6 +9958,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9948,6 +10009,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -9998,6 +10060,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10048,6 +10111,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10098,6 +10162,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10160,6 +10225,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10209,6 +10275,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10263,6 +10330,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10325,6 +10393,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10394,6 +10463,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10459,6 +10529,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10528,6 +10599,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10583,6 +10655,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10645,6 +10718,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10707,6 +10781,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10797,6 +10872,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10861,6 +10937,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -10942,6 +11019,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11008,6 +11086,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11071,6 +11150,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11137,6 +11217,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11211,6 +11292,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11289,6 +11371,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11363,6 +11446,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11433,6 +11517,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11499,6 +11584,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("run dkg");
 
@@ -11622,6 +11708,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -11739,6 +11826,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let taproot_merkle_root_hex =
@@ -11873,6 +11961,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -11969,6 +12058,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         run_dkg(run_dkg_request).expect("run dkg");
@@ -12047,6 +12137,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -12146,6 +12237,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -12243,6 +12335,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -12300,6 +12393,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let mut request_b = request_a.clone();
         request_b.participants.push(crate::api::DkgParticipant {
@@ -12429,6 +12523,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         run_dkg(request_a.clone()).expect("initial run dkg");
@@ -12447,6 +12542,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let err = run_dkg(request_b).expect_err("expected session cap rejection");
         let EngineError::Internal(message) = err else {
@@ -12485,6 +12581,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let mut request_b = request_a.clone();
         request_b.session_id = "session-secret-entropy-b".to_string();
@@ -12527,6 +12624,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let mut retry_request = request.clone();
         retry_request.participants.reverse();
@@ -12748,6 +12846,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -12986,6 +13085,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13053,6 +13153,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13125,6 +13226,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13194,6 +13296,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13262,6 +13365,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         run_dkg(existing_request).expect("seed existing persisted session");
 
@@ -13278,6 +13382,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         set_persist_fault_injection_for_tests(
@@ -13326,6 +13431,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("post-fault recovery run dkg");
 
@@ -13353,6 +13459,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13423,6 +13530,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13492,6 +13600,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -13557,6 +13666,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -13664,6 +13774,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         run_dkg(existing_request).expect("seed existing persisted session");
 
@@ -13680,6 +13791,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         set_persist_fault_injection_for_tests(
@@ -13745,6 +13857,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -13834,6 +13947,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -13923,6 +14037,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -14022,6 +14137,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -14112,6 +14228,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -14219,6 +14336,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -14331,6 +14449,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -14384,6 +14503,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -14431,6 +14551,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -14504,6 +14625,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
 
@@ -14656,6 +14778,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let dkg_result = run_dkg(dkg_request.clone()).expect("run dkg");
 
@@ -14696,6 +14819,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let finalize_dkg_result = run_dkg(finalize_dkg_request).expect("run finalize dkg");
         let start_request = StartSignRoundRequest {
@@ -14765,6 +14889,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("post-restart run dkg");
         assert!(!new_session_result.key_group.is_empty());
@@ -14928,6 +15053,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -15004,6 +15130,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
@@ -15109,6 +15236,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed persisted state");
 
@@ -15188,6 +15316,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed persisted state");
 
@@ -15345,6 +15474,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed persisted encrypted state");
 
@@ -15434,6 +15564,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed encrypted state file");
 
@@ -15472,6 +15603,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed encrypted state file");
 
@@ -15724,6 +15856,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         })
         .expect("seed encrypted state file");
 

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -4333,6 +4333,23 @@ fn canonicalize_attempt_transition_evidence_for_fingerprint(
     }
 }
 
+fn start_sign_round_request_fingerprint(
+    request: &StartSignRoundRequest,
+    member_identifier: u16,
+) -> Result<String, EngineError> {
+    let mut canonical_request = request.clone();
+    canonical_request.member_identifier = member_identifier;
+    if let Some(signing_participants) = canonical_request.signing_participants.as_mut() {
+        signing_participants.sort_unstable();
+    }
+    canonicalize_attempt_context_for_fingerprint(&mut canonical_request.attempt_context);
+    canonicalize_attempt_transition_evidence_for_fingerprint(
+        &mut canonical_request.attempt_transition_evidence,
+    );
+
+    fingerprint(&canonical_request)
+}
+
 fn round_attempt_id_component(attempt_context: Option<&AttemptContext>) -> String {
     attempt_context
         .map(|attempt_context| attempt_context.attempt_id.to_ascii_lowercase())
@@ -5349,18 +5366,12 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
         canonicalize_taproot_merkle_root_hex(&mut request.taproot_merkle_root_hex)?;
     let strict_roast_mode_enabled = roast_strict_mode_enabled();
 
-    let request_fingerprint = {
-        let mut canonical_request = request.clone();
-        canonical_request.member_identifier = 0;
-        if let Some(signing_participants) = canonical_request.signing_participants.as_mut() {
-            signing_participants.sort_unstable();
-        }
-        canonicalize_attempt_context_for_fingerprint(&mut canonical_request.attempt_context);
-        canonicalize_attempt_transition_evidence_for_fingerprint(
-            &mut canonical_request.attempt_transition_evidence,
-        );
-        fingerprint(&canonical_request)?
-    };
+    let request_fingerprint = start_sign_round_request_fingerprint(&request, 0)?;
+    // Before multi-seat round reuse, persisted active rounds were bound to the
+    // concrete member identifier. Accept that legacy fingerprint so an upgrade
+    // does not invalidate an in-flight signing round.
+    let legacy_member_request_fingerprint =
+        start_sign_round_request_fingerprint(&request, request.member_identifier)?;
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
@@ -5488,7 +5499,10 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
         }
 
         if let Some(existing) = &session.sign_request_fingerprint {
-            if existing == &request_fingerprint {
+            let matches_canonical_fingerprint = existing == &request_fingerprint;
+            let matches_legacy_member_fingerprint = existing == &legacy_member_request_fingerprint;
+
+            if matches_canonical_fingerprint || matches_legacy_member_fingerprint {
                 let mut round_state = session.round_state.clone().ok_or_else(|| {
                     EngineError::Internal("missing round state cache".to_string())
                 })?;
@@ -5513,6 +5527,11 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                     sign_message_bytes,
                     taproot_merkle_root.as_ref(),
                 )?;
+
+                if matches_legacy_member_fingerprint {
+                    session.sign_request_fingerprint = Some(request_fingerprint.clone());
+                    persist_engine_state_to_storage(&guard)?;
+                }
 
                 return Ok(round_state);
             }
@@ -11840,6 +11859,15 @@ mod tests {
             .verifying_key()
             .verify(&sign_message_bytes, &signature)
             .expect("signature verification");
+        assert!(
+            dkg_public_key_package
+                .clone()
+                .tweak::<&[u8]>(None)
+                .verifying_key()
+                .verify(&sign_message_bytes, &signature)
+                .is_err(),
+            "no-root signature must not verify under an additional BIP-86 empty-root tweak"
+        );
     }
 
     #[test]
@@ -13179,6 +13207,96 @@ mod tests {
         let second_signature =
             finalize_sign_round(finalize_request, true).expect("persisted finalize retry");
         assert_eq!(first_signature, second_signature);
+
+        reset_for_tests();
+        cleanup_test_state_artifacts(&state_path);
+        clear_state_storage_policy_overrides();
+    }
+
+    #[test]
+    fn start_sign_round_accepts_persisted_legacy_member_bound_fingerprint() {
+        let _guard = lock_test_state();
+        let state_path = configure_test_state_path("sign_legacy_member_fingerprint");
+        reset_for_tests();
+
+        let run_dkg_request = RunDkgRequest {
+            session_id: "session-legacy-member-fingerprint".to_string(),
+            participants: vec![
+                crate::api::DkgParticipant {
+                    identifier: 1,
+                    public_key_hex: "02aa".to_string(),
+                },
+                crate::api::DkgParticipant {
+                    identifier: 2,
+                    public_key_hex: "02bb".to_string(),
+                },
+            ],
+            threshold: 2,
+            dkg_seed_hex: None,
+        };
+        let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
+
+        let start_request = StartSignRoundRequest {
+            session_id: "session-legacy-member-fingerprint".to_string(),
+            member_identifier: 1,
+            message_hex: "baddcafe".to_string(),
+            key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
+            signing_participants: Some(vec![1, 2]),
+            attempt_context: None,
+            attempt_transition_evidence: None,
+        };
+        let first_round_state = start_sign_round(start_request.clone()).expect("start sign round");
+
+        let canonical_fingerprint =
+            start_sign_round_request_fingerprint(&start_request, 0).expect("canonical fingerprint");
+        let legacy_member_fingerprint =
+            start_sign_round_request_fingerprint(&start_request, start_request.member_identifier)
+                .expect("legacy member fingerprint");
+        assert_ne!(canonical_fingerprint, legacy_member_fingerprint);
+
+        {
+            let mut guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get_mut(&start_request.session_id)
+                .expect("session state");
+            assert_eq!(
+                session.sign_request_fingerprint.as_deref(),
+                Some(canonical_fingerprint.as_str())
+            );
+            session.sign_request_fingerprint = Some(legacy_member_fingerprint.clone());
+            persist_engine_state_to_storage(&guard).expect("persist legacy fingerprint");
+        }
+
+        reload_state_from_storage_for_tests();
+        let retry_round_state =
+            start_sign_round(start_request.clone()).expect("legacy fingerprint retry");
+        assert_eq!(first_round_state, retry_round_state);
+
+        reload_state_from_storage_for_tests();
+        {
+            let guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get(&start_request.session_id)
+                .expect("session state");
+            assert_eq!(
+                session.sign_request_fingerprint.as_deref(),
+                Some(canonical_fingerprint.as_str())
+            );
+        }
+
+        let second_member_round_state = start_sign_round(StartSignRoundRequest {
+            member_identifier: 2,
+            ..start_request.clone()
+        })
+        .expect("second member after fingerprint migration");
+        assert_eq!(
+            first_round_state.round_id,
+            second_member_round_state.round_id
+        );
+        assert_eq!(second_member_round_state.own_contribution.identifier, 2);
 
         reset_for_tests();
         cleanup_test_state_artifacts(&state_path);

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -4337,15 +4337,37 @@ fn start_sign_round_request_fingerprint(
     request: &StartSignRoundRequest,
     member_identifier: u16,
 ) -> Result<String, EngineError> {
+    start_sign_round_request_fingerprint_internal(request, member_identifier, false)
+}
+
+fn start_sign_round_request_fingerprint_including_transition_evidence(
+    request: &StartSignRoundRequest,
+    member_identifier: u16,
+) -> Result<String, EngineError> {
+    start_sign_round_request_fingerprint_internal(request, member_identifier, true)
+}
+
+fn start_sign_round_request_fingerprint_internal(
+    request: &StartSignRoundRequest,
+    member_identifier: u16,
+    include_transition_evidence: bool,
+) -> Result<String, EngineError> {
     let mut canonical_request = request.clone();
     canonical_request.member_identifier = member_identifier;
     if let Some(signing_participants) = canonical_request.signing_participants.as_mut() {
         signing_participants.sort_unstable();
     }
     canonicalize_attempt_context_for_fingerprint(&mut canonical_request.attempt_context);
-    canonicalize_attempt_transition_evidence_for_fingerprint(
-        &mut canonical_request.attempt_transition_evidence,
-    );
+    if include_transition_evidence {
+        canonicalize_attempt_transition_evidence_for_fingerprint(
+            &mut canonical_request.attempt_transition_evidence,
+        );
+    } else {
+        // Transition evidence authorizes creation of a new active attempt but is
+        // one-shot material. Once the active attempt context is established,
+        // other members may reuse the round without resending the evidence.
+        canonical_request.attempt_transition_evidence = None;
+    }
 
     fingerprint(&canonical_request)
 }
@@ -5333,8 +5355,10 @@ fn development_dealer_dkg_seed(dkg_seed_hex: Option<&str>) -> Result<[u8; 32], E
         return Ok(seed);
     };
 
-    let seed = hex::decode(seed_hex)
-        .map_err(|e| EngineError::Internal(format!("failed to decode DKG seed: {e}")))?;
+    let seed = Zeroizing::new(
+        hex::decode(seed_hex)
+            .map_err(|e| EngineError::Internal(format!("failed to decode DKG seed: {e}")))?,
+    );
     if seed.len() != 32 {
         return Err(EngineError::Internal(format!(
             "DKG seed decoded to [{}] bytes, expected 32",
@@ -5376,6 +5400,16 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
     // does not invalidate an in-flight signing round.
     let legacy_member_request_fingerprint =
         start_sign_round_request_fingerprint(&request, request.member_identifier)?;
+    // The previous round-reuse implementation included one-shot transition
+    // evidence in the persisted active-round fingerprint. Accept that shape
+    // when callers still resend the evidence, then migrate to the stable form.
+    let legacy_canonical_with_transition_evidence_fingerprint =
+        start_sign_round_request_fingerprint_including_transition_evidence(&request, 0)?;
+    let legacy_member_with_transition_evidence_fingerprint =
+        start_sign_round_request_fingerprint_including_transition_evidence(
+            &request,
+            request.member_identifier,
+        )?;
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
@@ -5504,9 +5538,12 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
 
         if let Some(existing) = &session.sign_request_fingerprint {
             let matches_canonical_fingerprint = existing == &request_fingerprint;
-            let matches_legacy_member_fingerprint = existing == &legacy_member_request_fingerprint;
+            let matches_legacy_fingerprint = !matches_canonical_fingerprint
+                && (existing == &legacy_member_request_fingerprint
+                    || existing == &legacy_canonical_with_transition_evidence_fingerprint
+                    || existing == &legacy_member_with_transition_evidence_fingerprint);
 
-            if matches_canonical_fingerprint || matches_legacy_member_fingerprint {
+            if matches_canonical_fingerprint || matches_legacy_fingerprint {
                 let mut round_state = session.round_state.clone().ok_or_else(|| {
                     EngineError::Internal("missing round state cache".to_string())
                 })?;
@@ -5532,7 +5569,7 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                     taproot_merkle_root.as_ref(),
                 )?;
 
-                if matches_legacy_member_fingerprint {
+                if matches_legacy_fingerprint {
                     session.sign_request_fingerprint = Some(request_fingerprint.clone());
                     persist_engine_state_to_storage(&guard)?;
                 }
@@ -10909,6 +10946,89 @@ mod tests {
         assert!(
             message.contains("stale"),
             "expected stale-attempt validation message, got: {message}"
+        );
+    }
+
+    #[test]
+    fn start_sign_round_allows_member_reuse_after_transition_without_resending_evidence() {
+        let _guard = lock_test_state();
+        reset_for_tests();
+        let _roast_strict_mode = RoastStrictModeGuard::enable();
+
+        let session_id = "session-roast-transition-reuse-without-evidence";
+        let message_hex = "deadbeef";
+
+        let dkg_result = run_dkg(RunDkgRequest {
+            session_id: session_id.to_string(),
+            participants: vec![
+                crate::api::DkgParticipant {
+                    identifier: 1,
+                    public_key_hex: "02aa".to_string(),
+                },
+                crate::api::DkgParticipant {
+                    identifier: 2,
+                    public_key_hex: "02bb".to_string(),
+                },
+            ],
+            threshold: 2,
+            dkg_seed_hex: None,
+        })
+        .expect("run dkg");
+
+        let attempt_one =
+            build_deterministic_attempt_context(session_id, message_hex, 1, vec![1, 2]);
+        start_sign_round(StartSignRoundRequest {
+            session_id: session_id.to_string(),
+            member_identifier: 1,
+            message_hex: message_hex.to_string(),
+            key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
+            signing_participants: Some(vec![1, 2]),
+            attempt_context: Some(attempt_one),
+            attempt_transition_evidence: None,
+        })
+        .expect("start sign round for attempt 1");
+
+        let transition_evidence = build_attempt_transition_evidence_from_active_session(session_id);
+        let attempt_two =
+            build_deterministic_attempt_context(session_id, message_hex, 2, vec![1, 2]);
+        let transitioned_round_state = start_sign_round(StartSignRoundRequest {
+            session_id: session_id.to_string(),
+            member_identifier: 1,
+            message_hex: message_hex.to_string(),
+            key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
+            signing_participants: Some(vec![1, 2]),
+            attempt_context: Some(attempt_two.clone()),
+            attempt_transition_evidence: Some(transition_evidence),
+        })
+        .expect("start sign round for authorized attempt 2");
+
+        let reused_round_state = start_sign_round(StartSignRoundRequest {
+            session_id: session_id.to_string(),
+            member_identifier: 2,
+            message_hex: message_hex.to_string(),
+            key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
+            signing_participants: Some(vec![1, 2]),
+            attempt_context: Some(attempt_two),
+            attempt_transition_evidence: None,
+        })
+        .expect("reuse active attempt without transition evidence");
+
+        assert_eq!(
+            transitioned_round_state.round_id,
+            reused_round_state.round_id
+        );
+        assert_eq!(transitioned_round_state.required_contributions, 2);
+        assert_eq!(reused_round_state.required_contributions, 2);
+        assert_eq!(transitioned_round_state.own_contribution.identifier, 1);
+        assert_eq!(reused_round_state.own_contribution.identifier, 2);
+        assert_ne!(
+            transitioned_round_state
+                .own_contribution
+                .signature_share_hex,
+            reused_round_state.own_contribution.signature_share_hex
         );
     }
 

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -5355,13 +5355,13 @@ fn development_dealer_dkg_seed(dkg_seed_hex: Option<&str>) -> Result<[u8; 32], E
         return Ok(seed);
     };
 
-    let seed = Zeroizing::new(
-        hex::decode(seed_hex)
-            .map_err(|e| EngineError::Internal(format!("failed to decode DKG seed: {e}")))?,
-    );
+    let seed =
+        Zeroizing::new(hex::decode(seed_hex).map_err(|e| {
+            EngineError::Validation(format!("dkg_seed_hex must be valid hex: {e}"))
+        })?);
     if seed.len() != 32 {
-        return Err(EngineError::Internal(format!(
-            "DKG seed decoded to [{}] bytes, expected 32",
+        return Err(EngineError::Validation(format!(
+            "dkg_seed_hex decoded to [{}] bytes, expected 32",
             seed.len()
         )));
     }
@@ -7076,6 +7076,43 @@ mod tests {
 
         std::env::set_var(TBTC_SIGNER_PROFILE_ENV, TBTC_SIGNER_PROFILE_DEVELOPMENT);
         assert!(!provenance_gate_enforced());
+    }
+
+    #[test]
+    fn run_dkg_rejects_malformed_seed_as_validation_input() {
+        let _guard = lock_test_state();
+        reset_for_tests();
+        clear_state_storage_policy_overrides();
+
+        for (index, seed_hex, expected_message) in [
+            (1, "not-hex", "dkg_seed_hex must be valid hex"),
+            (2, "0102", "dkg_seed_hex decoded to [2] bytes, expected 32"),
+        ] {
+            let err = run_dkg(RunDkgRequest {
+                session_id: format!("session-malformed-dkg-seed-{index}"),
+                participants: vec![
+                    crate::api::DkgParticipant {
+                        identifier: 1,
+                        public_key_hex: "02aa".to_string(),
+                    },
+                    crate::api::DkgParticipant {
+                        identifier: 2,
+                        public_key_hex: "02bb".to_string(),
+                    },
+                ],
+                threshold: 2,
+                dkg_seed_hex: Some(seed_hex.to_string()),
+            })
+            .expect_err("malformed DKG seed should be rejected");
+
+            let EngineError::Validation(message) = err else {
+                panic!("unexpected error variant");
+            };
+            assert!(
+                message.contains(expected_message),
+                "unexpected validation message: {message}"
+            );
+        }
     }
 
     #[test]

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -5353,6 +5353,7 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
 
     let request_fingerprint = {
         let mut canonical_request = request.clone();
+        canonical_request.member_identifier = 0;
         if let Some(signing_participants) = canonical_request.signing_participants.as_mut() {
             signing_participants.sort_unstable();
         }
@@ -5369,97 +5370,97 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
     let quarantined_operator_identifiers = guard.quarantined_operator_identifiers.clone();
 
     let mut pending_transition_record = None;
-    let round_state =
-        {
-            let session = guard.sessions.get_mut(&request.session_id).ok_or_else(|| {
-                EngineError::SessionNotFound {
-                    session_id: request.session_id.clone(),
-                }
+    let round_state = {
+        let session = guard.sessions.get_mut(&request.session_id).ok_or_else(|| {
+            EngineError::SessionNotFound {
+                session_id: request.session_id.clone(),
+            }
+        })?;
+
+        let dkg = session
+            .dkg_result
+            .clone()
+            .ok_or_else(|| EngineError::DkgNotReady {
+                session_id: request.session_id.clone(),
             })?;
 
-            let dkg = session
-                .dkg_result
-                .clone()
-                .ok_or_else(|| EngineError::DkgNotReady {
-                    session_id: request.session_id.clone(),
-                })?;
+        if let Some(emergency_rekey_event) = session.emergency_rekey_event.as_ref() {
+            return Err(EngineError::LifecyclePolicyRejected {
+                session_id: request.session_id.clone(),
+                reason_code: "emergency_rekey_required".to_string(),
+                detail: format!(
+                    "emergency rekey required for session [{}] since [{}]: {}",
+                    request.session_id,
+                    emergency_rekey_event.triggered_at_unix,
+                    emergency_rekey_event.reason
+                ),
+            });
+        }
 
-            if let Some(emergency_rekey_event) = session.emergency_rekey_event.as_ref() {
-                return Err(EngineError::LifecyclePolicyRejected {
-                    session_id: request.session_id.clone(),
-                    reason_code: "emergency_rekey_required".to_string(),
-                    detail: format!(
-                        "emergency rekey required for session [{}] since [{}]: {}",
-                        request.session_id,
-                        emergency_rekey_event.triggered_at_unix,
-                        emergency_rekey_event.reason
-                    ),
-                });
-            }
+        if session.finalize_request_fingerprint.is_some() {
+            // Lifecycle terminal state: once finalize succeeds for a session, we
+            // intentionally return SessionFinalized and require a new session_id
+            // for any subsequent StartSignRound call on that session ID.
+            return Err(EngineError::SessionFinalized {
+                session_id: request.session_id,
+            });
+        }
 
-            if session.finalize_request_fingerprint.is_some() {
-                // Lifecycle terminal state: once finalize succeeds for a session, we
-                // intentionally return SessionFinalized and require a new session_id
-                // for any subsequent StartSignRound call on that session ID.
-                return Err(EngineError::SessionFinalized {
-                    session_id: request.session_id,
-                });
-            }
+        if request.key_group != dkg.key_group {
+            return Err(EngineError::Validation(
+                "key_group does not match DKG output for this session".to_string(),
+            ));
+        }
 
-            if request.key_group != dkg.key_group {
+        {
+            let dkg_key_packages = session.dkg_key_packages.as_ref().ok_or_else(|| {
+                EngineError::Internal("missing DKG key package cache".to_string())
+            })?;
+
+            if !dkg_key_packages.contains_key(&request.member_identifier) {
                 return Err(EngineError::Validation(
-                    "key_group does not match DKG output for this session".to_string(),
+                    "member_identifier is not a DKG participant for this session".to_string(),
                 ));
             }
+        }
+        enforce_signing_message_binding_to_policy_checked_build_tx(
+            &request.session_id,
+            &request.message_hex,
+            session.tx_result.as_ref(),
+        )?;
 
-            {
-                let dkg_key_packages = session.dkg_key_packages.as_ref().ok_or_else(|| {
-                    EngineError::Internal("missing DKG key package cache".to_string())
-                })?;
+        // Guard against partial legacy state where sign material was cleared but
+        // active attempt context was not.
+        if session.sign_request_fingerprint.is_none() || session.round_state.is_none() {
+            session.active_attempt_context = None;
+        }
 
-                if !dkg_key_packages.contains_key(&request.member_identifier) {
-                    return Err(EngineError::Validation(
-                        "member_identifier is not a DKG participant for this session".to_string(),
-                    ));
-                }
-            }
-            enforce_signing_message_binding_to_policy_checked_build_tx(
-                &request.session_id,
-                &request.message_hex,
-                session.tx_result.as_ref(),
+        let canonical_attempt_context = request
+            .attempt_context
+            .as_ref()
+            .map(canonical_attempt_context);
+        let mut attempt_transition_telemetry = None;
+        let mut attempt_transition_record = None;
+        if let Some(active_attempt_context) = session.active_attempt_context.as_ref() {
+            let active_attempt_match_outcome = enforce_active_attempt_context_match(
+                active_attempt_context,
+                canonical_attempt_context.as_ref(),
+                request.attempt_transition_evidence.as_ref(),
+                session.round_state.as_ref(),
+                session.sign_request_fingerprint.as_deref(),
+                strict_roast_mode_enabled,
             )?;
 
-            // Guard against partial legacy state where sign material was cleared but
-            // active attempt context was not.
-            if session.sign_request_fingerprint.is_none() || session.round_state.is_none() {
-                session.active_attempt_context = None;
-            }
-
-            let canonical_attempt_context = request
-                .attempt_context
-                .as_ref()
-                .map(canonical_attempt_context);
-            let mut attempt_transition_telemetry = None;
-            let mut attempt_transition_record = None;
-            if let Some(active_attempt_context) = session.active_attempt_context.as_ref() {
-                let active_attempt_match_outcome = enforce_active_attempt_context_match(
-                    active_attempt_context,
-                    canonical_attempt_context.as_ref(),
-                    request.attempt_transition_evidence.as_ref(),
-                    session.round_state.as_ref(),
-                    session.sign_request_fingerprint.as_deref(),
-                    strict_roast_mode_enabled,
-                )?;
-
-                if let ActiveAttemptMatchOutcome::AdvanceAuthorized = active_attempt_match_outcome {
-                    let incoming_attempt_context =
-                        canonical_attempt_context.as_ref().ok_or_else(|| {
-                            EngineError::Internal(
-                                "missing incoming attempt context for authorized transition"
-                                    .to_string(),
-                            )
-                        })?;
-                    let transition_evidence = request
+            if let ActiveAttemptMatchOutcome::AdvanceAuthorized = active_attempt_match_outcome {
+                let incoming_attempt_context =
+                    canonical_attempt_context.as_ref().ok_or_else(|| {
+                        EngineError::Internal(
+                            "missing incoming attempt context for authorized transition"
+                                .to_string(),
+                        )
+                    })?;
+                let transition_evidence =
+                    request
                         .attempt_transition_evidence
                         .as_ref()
                         .ok_or_else(|| {
@@ -5468,160 +5469,183 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                                     .to_string(),
                             )
                         })?;
-                    attempt_transition_telemetry = build_attempt_transition_telemetry(
-                        active_attempt_context,
-                        incoming_attempt_context,
-                        Some(transition_evidence),
-                    );
-                    if attempt_transition_telemetry.is_none() {
-                        return Err(EngineError::Internal(
-                            "missing transition telemetry evidence for authorized transition"
-                                .to_string(),
-                        ));
-                    }
-                    attempt_transition_record = Some(build_transcript_audit_record(
-                        active_attempt_context,
-                        incoming_attempt_context,
-                        transition_evidence,
-                    )?);
-                    clear_active_sign_round_for_attempt_transition(session);
+                attempt_transition_telemetry = build_attempt_transition_telemetry(
+                    active_attempt_context,
+                    incoming_attempt_context,
+                    Some(transition_evidence),
+                );
+                if attempt_transition_telemetry.is_none() {
+                    return Err(EngineError::Internal(
+                        "missing transition telemetry evidence for authorized transition"
+                            .to_string(),
+                    ));
                 }
+                attempt_transition_record = Some(build_transcript_audit_record(
+                    active_attempt_context,
+                    incoming_attempt_context,
+                    transition_evidence,
+                )?);
+                clear_active_sign_round_for_attempt_transition(session);
             }
+        }
 
-            if let Some(existing) = &session.sign_request_fingerprint {
-                if existing == &request_fingerprint {
-                    return session.round_state.clone().ok_or_else(|| {
-                        EngineError::Internal("missing round state cache".to_string())
-                    });
-                }
-
-                return Err(EngineError::SessionConflict {
-                    session_id: request.session_id,
-                });
-            }
-
-            let signing_participants = {
+        if let Some(existing) = &session.sign_request_fingerprint {
+            if existing == &request_fingerprint {
+                let mut round_state = session.round_state.clone().ok_or_else(|| {
+                    EngineError::Internal("missing round state cache".to_string())
+                })?;
+                let sign_message_bytes = session.sign_message_bytes.as_ref().ok_or_else(|| {
+                    EngineError::Internal("missing sign message cache".to_string())
+                })?;
+                let signing_participants =
+                    round_state.signing_participants.clone().ok_or_else(|| {
+                        EngineError::Internal(
+                            "missing round signing participants cache".to_string(),
+                        )
+                    })?;
                 let dkg_key_packages = session.dkg_key_packages.as_ref().ok_or_else(|| {
                     EngineError::Internal("missing DKG key package cache".to_string())
                 })?;
-                resolve_signing_participants(&request, dkg.threshold, dkg_key_packages)?
-            };
-            if let Some(canonical_attempt_signing_participants) = validate_attempt_context(
-                &request.session_id,
-                &message_digest_hex,
-                dkg.threshold,
-                request.attempt_context.as_ref(),
-                strict_roast_mode_enabled,
-            )? {
-                if canonical_attempt_signing_participants != signing_participants {
-                    return Err(EngineError::Validation(
-                    "attempt_context.included_participants must match resolved signing_participants"
-                        .to_string(),
-                ));
-                }
-            }
-            enforce_not_quarantined_identifiers(
-                &request.session_id,
-                &signing_participants,
-                &quarantined_operator_identifiers,
-                auto_quarantine_config.as_ref(),
-            )?;
 
-            let signing_participants_fingerprint = fingerprint(&signing_participants)?;
-            let consumed_attempt_id = canonical_attempt_context
-                .as_ref()
-                .map(|attempt_context| attempt_context.attempt_id.clone());
-            if let Some(attempt_id) = consumed_attempt_id.as_ref() {
-                if session.consumed_attempt_ids.contains(attempt_id) {
-                    return Err(EngineError::ConsumedAttemptReplay {
-                        session_id: request.session_id.clone(),
-                        attempt_id: attempt_id.clone(),
-                    });
-                }
-                ensure_consumed_registry_insert_capacity(
-                    &session.consumed_attempt_ids,
-                    attempt_id,
-                    "consumed_attempt_ids",
-                    &request.session_id,
-                )?;
-            }
-            let round_id = derive_round_id(
-                &request.session_id,
-                &request.key_group,
-                &request.message_hex,
-                request.taproot_merkle_root_hex.as_deref(),
-                &signing_participants_fingerprint,
-                canonical_attempt_context.as_ref(),
-            );
-            if session.consumed_sign_round_ids.contains(&round_id) {
-                return Err(EngineError::ConsumedRoundReplay {
-                    session_id: request.session_id.clone(),
-                    round_id: round_id.clone(),
-                });
-            }
-            ensure_consumed_registry_insert_capacity(
-                &session.consumed_sign_round_ids,
-                &round_id,
-                "consumed_sign_round_ids",
-                &request.session_id,
-            )?;
-            let own_contribution = {
-                let dkg_key_packages = session.dkg_key_packages.as_ref().ok_or_else(|| {
-                    EngineError::Internal("missing DKG key package cache".to_string())
-                })?;
-                build_real_signature_share_contribution(
+                round_state.own_contribution = build_real_signature_share_contribution(
                     dkg_key_packages,
                     &signing_participants,
                     &request,
-                    &round_id,
-                    &message_bytes,
+                    &round_state.round_id,
+                    sign_message_bytes,
                     taproot_merkle_root.as_ref(),
-                )?
-            };
+                )?;
 
-            if let Some(transition_telemetry) = attempt_transition_telemetry.as_ref() {
-                record_hardening_telemetry(|telemetry| {
-                    telemetry.attempt_transition_total =
-                        telemetry.attempt_transition_total.saturating_add(1);
-                    if transition_telemetry.coordinator_rotated {
-                        telemetry.coordinator_failover_total =
-                            telemetry.coordinator_failover_total.saturating_add(1);
-                    }
+                return Ok(round_state);
+            }
+
+            return Err(EngineError::SessionConflict {
+                session_id: request.session_id,
+            });
+        }
+
+        let signing_participants = {
+            let dkg_key_packages = session.dkg_key_packages.as_ref().ok_or_else(|| {
+                EngineError::Internal("missing DKG key package cache".to_string())
+            })?;
+            resolve_signing_participants(&request, dkg.threshold, dkg_key_packages)?
+        };
+        if let Some(canonical_attempt_signing_participants) = validate_attempt_context(
+            &request.session_id,
+            &message_digest_hex,
+            dkg.threshold,
+            request.attempt_context.as_ref(),
+            strict_roast_mode_enabled,
+        )? {
+            if canonical_attempt_signing_participants != signing_participants {
+                return Err(EngineError::Validation(
+                    "attempt_context.included_participants must match resolved signing_participants"
+                        .to_string(),
+                ));
+            }
+        }
+        enforce_not_quarantined_identifiers(
+            &request.session_id,
+            &signing_participants,
+            &quarantined_operator_identifiers,
+            auto_quarantine_config.as_ref(),
+        )?;
+
+        let signing_participants_fingerprint = fingerprint(&signing_participants)?;
+        let consumed_attempt_id = canonical_attempt_context
+            .as_ref()
+            .map(|attempt_context| attempt_context.attempt_id.clone());
+        if let Some(attempt_id) = consumed_attempt_id.as_ref() {
+            if session.consumed_attempt_ids.contains(attempt_id) {
+                return Err(EngineError::ConsumedAttemptReplay {
+                    session_id: request.session_id.clone(),
+                    attempt_id: attempt_id.clone(),
                 });
             }
-            if let Some(transition_record) = attempt_transition_record.as_ref() {
-                ensure_attempt_transition_record_insert_capacity(
-                    &session.attempt_transition_records,
-                    &request.session_id,
-                )?;
-                session
-                    .attempt_transition_records
-                    .push(transition_record.clone());
-                pending_transition_record = Some(transition_record.clone());
-            }
-
-            let round_state = RoundState {
+            ensure_consumed_registry_insert_capacity(
+                &session.consumed_attempt_ids,
+                attempt_id,
+                "consumed_attempt_ids",
+                &request.session_id,
+            )?;
+        }
+        let round_id = derive_round_id(
+            &request.session_id,
+            &request.key_group,
+            &request.message_hex,
+            request.taproot_merkle_root_hex.as_deref(),
+            &signing_participants_fingerprint,
+            canonical_attempt_context.as_ref(),
+        );
+        if session.consumed_sign_round_ids.contains(&round_id) {
+            return Err(EngineError::ConsumedRoundReplay {
                 session_id: request.session_id.clone(),
                 round_id: round_id.clone(),
-                required_contributions: dkg.threshold,
-                message_digest_hex: message_digest_hex.clone(),
-                taproot_merkle_root_hex: request.taproot_merkle_root_hex.clone(),
-                signing_participants: Some(signing_participants),
-                attempt_transition_telemetry,
-                own_contribution,
-            };
-
-            session.sign_request_fingerprint = Some(request_fingerprint);
-            session.sign_message_bytes = Some(Zeroizing::new(message_bytes));
-            session.round_state = Some(round_state.clone());
-            session.active_attempt_context = canonical_attempt_context;
-            if let Some(attempt_id) = consumed_attempt_id {
-                session.consumed_attempt_ids.insert(attempt_id);
-            }
-            session.consumed_sign_round_ids.insert(round_id);
-
-            round_state
+            });
+        }
+        ensure_consumed_registry_insert_capacity(
+            &session.consumed_sign_round_ids,
+            &round_id,
+            "consumed_sign_round_ids",
+            &request.session_id,
+        )?;
+        let own_contribution = {
+            let dkg_key_packages = session.dkg_key_packages.as_ref().ok_or_else(|| {
+                EngineError::Internal("missing DKG key package cache".to_string())
+            })?;
+            build_real_signature_share_contribution(
+                dkg_key_packages,
+                &signing_participants,
+                &request,
+                &round_id,
+                &message_bytes,
+                taproot_merkle_root.as_ref(),
+            )?
         };
+
+        if let Some(transition_telemetry) = attempt_transition_telemetry.as_ref() {
+            record_hardening_telemetry(|telemetry| {
+                telemetry.attempt_transition_total =
+                    telemetry.attempt_transition_total.saturating_add(1);
+                if transition_telemetry.coordinator_rotated {
+                    telemetry.coordinator_failover_total =
+                        telemetry.coordinator_failover_total.saturating_add(1);
+                }
+            });
+        }
+        if let Some(transition_record) = attempt_transition_record.as_ref() {
+            ensure_attempt_transition_record_insert_capacity(
+                &session.attempt_transition_records,
+                &request.session_id,
+            )?;
+            session
+                .attempt_transition_records
+                .push(transition_record.clone());
+            pending_transition_record = Some(transition_record.clone());
+        }
+
+        let round_state = RoundState {
+            session_id: request.session_id.clone(),
+            round_id: round_id.clone(),
+            required_contributions: dkg.threshold,
+            message_digest_hex: message_digest_hex.clone(),
+            taproot_merkle_root_hex: request.taproot_merkle_root_hex.clone(),
+            signing_participants: Some(signing_participants),
+            attempt_transition_telemetry,
+            own_contribution,
+        };
+
+        session.sign_request_fingerprint = Some(request_fingerprint);
+        session.sign_message_bytes = Some(Zeroizing::new(message_bytes));
+        session.round_state = Some(round_state.clone());
+        session.active_attempt_context = canonical_attempt_context;
+        if let Some(attempt_id) = consumed_attempt_id {
+            session.consumed_attempt_ids.insert(attempt_id);
+        }
+        session.consumed_sign_round_ids.insert(round_id);
+
+        round_state
+    };
 
     if let Some(transition_record) = pending_transition_record.as_ref() {
         apply_auto_quarantine_faults_for_transition(
@@ -12038,6 +12062,233 @@ mod tests {
             .verifying_key()
             .verify(&sign_message_bytes, &signature)
             .expect("signature verification");
+    }
+
+    #[test]
+    fn start_sign_round_allows_distinct_members_for_same_active_round() {
+        let _guard = lock_test_state();
+        reset_for_tests();
+
+        let run_dkg_request = RunDkgRequest {
+            session_id: "session-real-multi-member-process".to_string(),
+            participants: vec![
+                crate::api::DkgParticipant {
+                    identifier: 1,
+                    public_key_hex: "02aa".to_string(),
+                },
+                crate::api::DkgParticipant {
+                    identifier: 2,
+                    public_key_hex: "02bb".to_string(),
+                },
+            ],
+            threshold: 2,
+            dkg_seed_hex: None,
+        };
+
+        let dkg_result = run_dkg(run_dkg_request).expect("run dkg");
+        let start_request = StartSignRoundRequest {
+            session_id: "session-real-multi-member-process".to_string(),
+            member_identifier: 1,
+            message_hex: "baddcafe".to_string(),
+            key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
+            signing_participants: Some(vec![1, 2]),
+            attempt_context: None,
+            attempt_transition_evidence: None,
+        };
+        let first_round_state =
+            start_sign_round(start_request.clone()).expect("first member start sign round");
+
+        let second_round_state = start_sign_round(StartSignRoundRequest {
+            member_identifier: 2,
+            ..start_request.clone()
+        })
+        .expect("second member start sign round");
+
+        assert_eq!(first_round_state.session_id, second_round_state.session_id);
+        assert_eq!(first_round_state.round_id, second_round_state.round_id);
+        assert_eq!(first_round_state.required_contributions, 2);
+        assert_eq!(second_round_state.required_contributions, 2);
+        assert_eq!(first_round_state.own_contribution.identifier, 1);
+        assert_eq!(second_round_state.own_contribution.identifier, 2);
+        assert_ne!(
+            first_round_state.own_contribution.signature_share_hex,
+            second_round_state.own_contribution.signature_share_hex
+        );
+
+        let (dkg_public_key_package, sign_message_bytes) = {
+            let guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get(&start_request.session_id)
+                .expect("session state");
+
+            (
+                session
+                    .dkg_public_key_package
+                    .clone()
+                    .expect("dkg public key package"),
+                session
+                    .sign_message_bytes
+                    .clone()
+                    .expect("sign message bytes"),
+            )
+        };
+
+        let finalize_request = FinalizeSignRoundRequest {
+            session_id: start_request.session_id,
+            taproot_merkle_root_hex: None,
+            attempt_context: None,
+            round_contributions: vec![
+                first_round_state.own_contribution,
+                second_round_state.own_contribution,
+            ],
+        };
+
+        let result = finalize_sign_round(finalize_request, false).expect("finalize");
+
+        assert_eq!(result.round_id, first_round_state.round_id);
+        let signature_bytes = hex::decode(&result.signature_hex).expect("signature decode");
+        let signature = frost::Signature::deserialize(&signature_bytes).expect("signature parse");
+        dkg_public_key_package
+            .verifying_key()
+            .verify(&sign_message_bytes, &signature)
+            .expect("signature verification");
+    }
+
+    #[test]
+    fn start_sign_round_allows_taproot_threshold_subset_members_for_same_active_round() {
+        use frost::keys::Tweak;
+
+        let _guard = lock_test_state();
+        reset_for_tests();
+
+        let participants = (1_u16..=100)
+            .map(|identifier| crate::api::DkgParticipant {
+                identifier,
+                public_key_hex: format!("02{identifier:02x}"),
+            })
+            .collect::<Vec<_>>();
+        let signing_participants = vec![
+            2, 3, 4, 8, 11, 13, 14, 17, 19, 21, 22, 25, 27, 29, 30, 31, 32, 33, 35, 37, 38, 39, 42,
+            44, 45, 48, 50, 51, 52, 53, 57, 58, 60, 61, 63, 64, 65, 67, 68, 73, 76, 77, 80, 81, 84,
+            86, 87, 88, 90, 94, 96,
+        ];
+        let taproot_merkle_root_hex =
+            "37a57b86de2819d2b72a173df46238a7ad295ea1485d3b40e9415daa82b4fdcb";
+
+        let dkg_result = run_dkg(RunDkgRequest {
+            session_id: "session-real-taproot-multi-member-process".to_string(),
+            participants,
+            threshold: 51,
+            dkg_seed_hex: None,
+        })
+        .expect("run dkg");
+
+        let first_request = StartSignRoundRequest {
+            session_id: "session-real-taproot-multi-member-process".to_string(),
+            member_identifier: 86,
+            message_hex: "ac692bb7fddf3f7e1e050a83cf3ffb6e8e69888ce980281aa39da169525750ef"
+                .to_string(),
+            key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: Some(taproot_merkle_root_hex.to_string()),
+            signing_participants: Some(signing_participants.clone()),
+            attempt_context: None,
+            attempt_transition_evidence: None,
+        };
+
+        let first_round_state =
+            start_sign_round(first_request.clone()).expect("first member start sign round");
+        assert_eq!(first_round_state.required_contributions, 51);
+        assert_eq!(
+            first_round_state.signing_participants.as_deref(),
+            Some(signing_participants.as_slice())
+        );
+
+        let mut contributions = vec![first_round_state.own_contribution.clone()];
+        for member_identifier in [76_u16, 39, 53, 3] {
+            let round_state = start_sign_round(StartSignRoundRequest {
+                member_identifier,
+                ..first_request.clone()
+            })
+            .expect("next member start sign round");
+
+            assert_eq!(round_state.session_id, first_round_state.session_id);
+            assert_eq!(round_state.round_id, first_round_state.round_id);
+            assert_eq!(round_state.required_contributions, 51);
+            assert_eq!(round_state.own_contribution.identifier, member_identifier);
+            contributions.push(round_state.own_contribution);
+        }
+
+        let (dkg_key_packages, dkg_public_key_package, sign_message_bytes) = {
+            let guard = state().expect("engine state").lock().expect("engine lock");
+            let session = guard
+                .sessions
+                .get(&first_request.session_id)
+                .expect("session state");
+
+            (
+                session.dkg_key_packages.clone().expect("dkg key packages"),
+                session
+                    .dkg_public_key_package
+                    .clone()
+                    .expect("dkg public key package"),
+                session
+                    .sign_message_bytes
+                    .clone()
+                    .expect("sign message bytes"),
+            )
+        };
+        let taproot_merkle_root_bytes =
+            hex::decode(taproot_merkle_root_hex).expect("taproot merkle root");
+        let mut taproot_merkle_root = [0_u8; 32];
+        taproot_merkle_root.copy_from_slice(&taproot_merkle_root_bytes);
+
+        for member_identifier in signing_participants
+            .iter()
+            .copied()
+            .filter(|identifier| ![86_u16, 76, 39, 53, 3].contains(identifier))
+            .take(46)
+        {
+            let member_request = StartSignRoundRequest {
+                member_identifier,
+                ..first_request.clone()
+            };
+            contributions.push(
+                build_real_signature_share_contribution(
+                    &dkg_key_packages,
+                    signing_participants.as_slice(),
+                    &member_request,
+                    &first_round_state.round_id,
+                    &sign_message_bytes,
+                    Some(&taproot_merkle_root),
+                )
+                .expect("additional contribution"),
+            );
+        }
+        assert_eq!(contributions.len(), 51);
+
+        let result = finalize_sign_round(
+            FinalizeSignRoundRequest {
+                session_id: first_request.session_id,
+                taproot_merkle_root_hex: Some(taproot_merkle_root_hex.to_string()),
+                attempt_context: None,
+                round_contributions: contributions,
+            },
+            false,
+        )
+        .expect("finalize");
+
+        assert_eq!(result.round_id, first_round_state.round_id);
+        let signature_bytes = hex::decode(&result.signature_hex).expect("signature decode");
+        let signature = frost::Signature::deserialize(&signature_bytes).expect("signature parse");
+        let tweaked_public_key_package = dkg_public_key_package
+            .clone()
+            .tweak(Some(taproot_merkle_root.as_slice()));
+        tweaked_public_key_package
+            .verifying_key()
+            .verify(&sign_message_bytes, &signature)
+            .expect("tweaked signature verification");
     }
 
     #[test]

--- a/pkg/tbtc/signer/src/engine.rs
+++ b/pkg/tbtc/signer/src/engine.rs
@@ -24,6 +24,7 @@ use std::str::FromStr;
 use std::sync::{mpsc, Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use frost::keys::Tweak;
 use frost_secp256k1_tr as frost;
 use rand_chacha::rand_core::{CryptoRng, Error as RandCoreError, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -5194,8 +5195,7 @@ pub fn run_dkg(request: RunDkgRequest) -> Result<DkgResult, EngineError> {
         .map(|identifier| participant_identifier_to_frost_identifier(*identifier))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut keygen_rng_seed =
-        development_dealer_dkg_seed(request.dkg_seed_hex.as_deref(), &request_fingerprint)?;
+    let mut keygen_rng_seed = development_dealer_dkg_seed(request.dkg_seed_hex.as_deref())?;
     let keygen_rng = ZeroizingChaCha20Rng::from_seed(keygen_rng_seed);
     keygen_rng_seed.zeroize();
 
@@ -5305,20 +5305,18 @@ fn enforce_bootstrap_dealer_dkg_disabled_in_production(
     Ok(())
 }
 
-fn development_dealer_dkg_seed(
-    dkg_seed_hex: Option<&str>,
-    request_fingerprint: &str,
-) -> Result<[u8; 32], EngineError> {
-    let (seed_source, seed_hex) = match dkg_seed_hex {
-        Some(seed) => ("DKG seed", seed),
-        None => ("DKG request fingerprint", request_fingerprint),
+fn development_dealer_dkg_seed(dkg_seed_hex: Option<&str>) -> Result<[u8; 32], EngineError> {
+    let Some(seed_hex) = dkg_seed_hex else {
+        let mut seed = [0_u8; 32];
+        OsRng.fill_bytes(&mut seed);
+        return Ok(seed);
     };
 
     let seed = hex::decode(seed_hex)
-        .map_err(|e| EngineError::Internal(format!("failed to decode {seed_source}: {e}")))?;
+        .map_err(|e| EngineError::Internal(format!("failed to decode DKG seed: {e}")))?;
     if seed.len() != 32 {
         return Err(EngineError::Internal(format!(
-            "{seed_source} decoded to [{}] bytes, expected 32",
+            "DKG seed decoded to [{}] bytes, expected 32",
             seed.len()
         )));
     }
@@ -6101,6 +6099,24 @@ pub fn finalize_sign_round(
         .map_err(|e| {
             EngineError::Validation(format!("failed to aggregate signature shares: {e}"))
         })?;
+
+        let verification_key_package =
+            if let Some(taproot_merkle_root) = finalize_taproot_merkle_root.as_ref() {
+                dkg_public_key_package
+                    .clone()
+                    .tweak(Some(taproot_merkle_root.as_slice()))
+            } else {
+                dkg_public_key_package.clone()
+            };
+        verification_key_package
+            .verifying_key()
+            .verify(sign_message_bytes, &signature)
+            .map_err(|e| {
+                EngineError::Validation(format!(
+                    "aggregate signature failed self-verification: {e}"
+                ))
+            })?;
+
         let signature_bytes = signature.serialize().map_err(|e| {
             EngineError::Internal(format!("failed to serialize aggregate signature: {e}"))
         })?;
@@ -11828,8 +11844,6 @@ mod tests {
 
     #[test]
     fn finalize_aggregates_real_taproot_tweaked_contributions() {
-        use frost::keys::Tweak;
-
         let _guard = lock_test_state();
         reset_for_tests();
 
@@ -11960,6 +11974,34 @@ mod tests {
                 .verify(&sign_message_bytes, &signature)
                 .is_err(),
             "tweaked signature must not verify under the untweaked key"
+        );
+    }
+
+    #[test]
+    fn taproot_tweak_matches_cross_repo_deposit_fixture() {
+        let internal_key =
+            hex::decode("022336f65004d8f122f1fe947ebd009a8b4add3a0d937356d568e30f7fcc2e4008")
+                .expect("decode compressed internal key");
+        let verifying_key =
+            frost::VerifyingKey::deserialize(&internal_key).expect("deserialize verifying key");
+        let public_key_package = frost::keys::PublicKeyPackage::new(
+            BTreeMap::<frost::Identifier, frost::keys::VerifyingShare>::new(),
+            verifying_key,
+            Some(1),
+        );
+
+        let merkle_root =
+            hex::decode("3d6f9a2fea1de0a6c260d1fbc0343c9b2ed84307e6a7231139b78438448ee8c0")
+                .expect("decode taproot merkle root");
+        let tweaked_public_key = public_key_package
+            .tweak(Some(merkle_root.as_slice()))
+            .verifying_key()
+            .serialize()
+            .expect("serialize tweaked verifying key");
+
+        assert_eq!(
+            hex::encode(&tweaked_public_key[1..]),
+            "90e7ce2b6cd476b7a1c2c7f6585c3fd0eae4379a508e981ed422b3e28b9ae8c2"
         );
     }
 
@@ -12158,8 +12200,6 @@ mod tests {
 
     #[test]
     fn start_sign_round_allows_taproot_threshold_subset_members_for_same_active_round() {
-        use frost::keys::Tweak;
-
         let _guard = lock_test_state();
         reset_for_tests();
 

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -438,6 +438,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let (status_first, first_payload) = call_ffi(&request, frost_tbtc_run_dkg);
@@ -446,6 +447,91 @@ mod tests {
         assert_eq!(status_first, 0);
         assert_eq!(status_second, 0);
         assert_eq!(first_payload, second_payload);
+    }
+
+    #[test]
+    fn run_dkg_is_deterministic_for_identical_request_after_engine_reset() {
+        let _guard = crate::engine::lock_test_state();
+        crate::engine::reset_for_tests();
+
+        let request = RunDkgRequest {
+            session_id: "session-deterministic".to_string(),
+            participants: vec![
+                DkgParticipant {
+                    identifier: 1,
+                    public_key_hex: "02aa".to_string(),
+                },
+                DkgParticipant {
+                    identifier: 2,
+                    public_key_hex: "02bb".to_string(),
+                },
+                DkgParticipant {
+                    identifier: 3,
+                    public_key_hex: "02cc".to_string(),
+                },
+            ],
+            threshold: 2,
+            dkg_seed_hex: None,
+        };
+
+        let (status_first, first_payload) = call_ffi(&request, frost_tbtc_run_dkg);
+        crate::engine::reset_for_tests();
+        let (status_second, second_payload) = call_ffi(&request, frost_tbtc_run_dkg);
+
+        assert_eq!(status_first, 0);
+        assert_eq!(status_second, 0);
+        assert_eq!(first_payload, second_payload);
+    }
+
+    #[test]
+    fn run_dkg_uses_explicit_seed_across_distinct_sessions() {
+        let _guard = crate::engine::lock_test_state();
+        crate::engine::reset_for_tests();
+
+        let participants = vec![
+            DkgParticipant {
+                identifier: 1,
+                public_key_hex: "02aa".to_string(),
+            },
+            DkgParticipant {
+                identifier: 2,
+                public_key_hex: "02bb".to_string(),
+            },
+            DkgParticipant {
+                identifier: 3,
+                public_key_hex: "02cc".to_string(),
+            },
+        ];
+        let dkg_seed_hex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+
+        let request_a = RunDkgRequest {
+            session_id: "session-seeded-a".to_string(),
+            participants: participants.clone(),
+            threshold: 2,
+            dkg_seed_hex: Some(dkg_seed_hex.to_string()),
+        };
+        let (status_a, payload_a) = call_ffi(&request_a, frost_tbtc_run_dkg);
+
+        crate::engine::reset_for_tests();
+
+        let request_b = RunDkgRequest {
+            session_id: "session-seeded-b".to_string(),
+            participants,
+            threshold: 2,
+            dkg_seed_hex: Some(dkg_seed_hex.to_string()),
+        };
+        let (status_b, payload_b) = call_ffi(&request_b, frost_tbtc_run_dkg);
+
+        assert_eq!(status_a, 0);
+        assert_eq!(status_b, 0);
+
+        let result_a: crate::api::DkgResult =
+            serde_json::from_slice(&payload_a).expect("decode first DKG result");
+        let result_b: crate::api::DkgResult =
+            serde_json::from_slice(&payload_b).expect("decode second DKG result");
+
+        assert_ne!(result_a.session_id, result_b.session_id);
+        assert_eq!(result_a.key_group, result_b.key_group);
     }
 
     #[test]
@@ -466,6 +552,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let mut request_b = request_a.clone();
@@ -537,6 +624,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let (dkg_status, _) = call_ffi(&dkg_request, frost_tbtc_run_dkg);
         assert_eq!(dkg_status, 0);
@@ -707,6 +795,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let (dkg_status, dkg_payload) = call_ffi(&dkg_request, frost_tbtc_run_dkg);
         assert_eq!(dkg_status, 0);
@@ -774,6 +863,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let (dkg_status, dkg_payload) = call_ffi(&dkg, frost_tbtc_run_dkg);
@@ -852,6 +942,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
 
         let (dkg_status, dkg_payload) = call_ffi(&dkg, frost_tbtc_run_dkg);
@@ -921,6 +1012,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let (dkg_status, dkg_payload) = call_ffi(&dkg, frost_tbtc_run_dkg);
         assert_eq!(dkg_status, 0);
@@ -979,6 +1071,7 @@ mod tests {
                 },
             ],
             threshold: 2,
+            dkg_seed_hex: None,
         };
         let (dkg_status, dkg_payload) = call_ffi(&dkg, frost_tbtc_run_dkg);
         assert_eq!(dkg_status, 0);

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -450,12 +450,12 @@ mod tests {
     }
 
     #[test]
-    fn run_dkg_is_deterministic_for_identical_request_after_engine_reset() {
+    fn run_dkg_uses_fresh_entropy_for_unseeded_request_after_engine_reset() {
         let _guard = crate::engine::lock_test_state();
         crate::engine::reset_for_tests();
 
         let request = RunDkgRequest {
-            session_id: "session-deterministic".to_string(),
+            session_id: "session-unseeded-entropy".to_string(),
             participants: vec![
                 DkgParticipant {
                     identifier: 1,
@@ -480,7 +480,14 @@ mod tests {
 
         assert_eq!(status_first, 0);
         assert_eq!(status_second, 0);
-        assert_eq!(first_payload, second_payload);
+
+        let result_first: crate::api::DkgResult =
+            serde_json::from_slice(&first_payload).expect("decode first DKG result");
+        let result_second: crate::api::DkgResult =
+            serde_json::from_slice(&second_payload).expect("decode second DKG result");
+
+        assert_eq!(result_first.session_id, result_second.session_id);
+        assert_ne!(result_first.key_group, result_second.key_group);
     }
 
     #[test]

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -542,6 +542,44 @@ mod tests {
     }
 
     #[test]
+    fn run_dkg_reports_malformed_seed_as_recoverable_validation_error() {
+        let _guard = crate::engine::lock_test_state();
+        crate::engine::reset_for_tests();
+        let _profile = EnvVarGuard::set("TBTC_SIGNER_PROFILE", "development");
+        let _provenance_gate = EnvVarGuard::unset("TBTC_SIGNER_ENFORCE_PROVENANCE_GATE");
+        let _admission_policy = EnvVarGuard::unset("TBTC_SIGNER_ENFORCE_ADMISSION_POLICY");
+
+        let request = RunDkgRequest {
+            session_id: "session-bad-seed".to_string(),
+            participants: vec![
+                DkgParticipant {
+                    identifier: 1,
+                    public_key_hex: "02aa".to_string(),
+                },
+                DkgParticipant {
+                    identifier: 2,
+                    public_key_hex: "02bb".to_string(),
+                },
+            ],
+            threshold: 2,
+            dkg_seed_hex: Some("not-hex".to_string()),
+        };
+
+        let (status, payload) = call_ffi(&request, frost_tbtc_run_dkg);
+
+        assert_eq!(status, 1);
+        let response: ErrorResponse =
+            serde_json::from_slice(&payload).expect("decode error response");
+        assert_eq!(response.code, "validation_error");
+        assert_eq!(response.recovery_class, "recoverable");
+        assert!(
+            response.message.contains("dkg_seed_hex must be valid hex"),
+            "unexpected error message: {}",
+            response.message
+        );
+    }
+
+    #[test]
     fn run_dkg_rejects_conflicting_repeat_request_for_same_session() {
         let _guard = crate::engine::lock_test_state();
         crate::engine::reset_for_tests();

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -729,6 +729,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -786,6 +787,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -799,6 +801,7 @@ mod tests {
 
         let finalize = FinalizeSignRoundRequest {
             session_id: "session-sign".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -862,6 +865,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -875,6 +879,7 @@ mod tests {
 
         let finalize = FinalizeSignRoundRequest {
             session_id: "session-sign-bootstrap-disabled".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -927,6 +932,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group.clone(),
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![1, 2]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -939,6 +945,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "cafebabe".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: Some(vec![2, 1]),
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -983,6 +990,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: dkg_result.key_group,
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,
@@ -994,6 +1002,7 @@ mod tests {
 
         let finalize = FinalizeSignRoundRequest {
             session_id: "session-sign-finalized".to_string(),
+            taproot_merkle_root_hex: None,
             attempt_context: None,
             round_contributions: vec![
                 RoundContribution {
@@ -1027,6 +1036,7 @@ mod tests {
             member_identifier: 1,
             message_hex: "deadbeef".to_string(),
             key_group: "missing".to_string(),
+            taproot_merkle_root_hex: None,
             signing_participants: None,
             attempt_context: None,
             attempt_transition_evidence: None,


### PR DESCRIPTION
Stacked on extraction/frost-signer-mirror-2026-05-26 / PR #4005. Adds optional taproot_merkle_root_hex to start/finalize signing rounds, binds it into request fingerprints and round IDs, signs and aggregates with frost-secp256k1-tr Taproot tweaks, and verifies tweaked aggregates in tests. Verification: cargo test in pkg/tbtc/signer.