### PR TITLE
Prevent UniFFI FROST wallet material generation

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -428,23 +428,12 @@ const buildTaggedTBTCSignerUnavailableStatusCode = -1
 func registerBuildTaggedNativeFROSTSigningEngine() error {
 	engine := &buildTaggedTBTCSignerEngine{}
 
-	if err := RegisterNativeTBTCSignerEngine(engine); err != nil {
-		return err
-	}
-
-	dkgEngine, err := newUniFFINativeFROSTDKGEngine(engine)
-	if err != nil {
-		return err
-	}
-	if err := RegisterNativeFROSTDKGEngine(dkgEngine); err != nil {
-		return err
-	}
-
-	signingEngine, err := newUniFFINativeFROSTSigningEngine(engine)
-	if err != nil {
-		return err
-	}
-	return RegisterNativeFROSTSigningEngine(signingEngine)
+	// Do not register the tbtc-signer bridge as the generic UniFFI-shaped
+	// FROST DKG/signing engine. That path persists `frost-uniffi-v2` wallet
+	// material, which cannot produce Taproot-tweaked signatures required for
+	// Taproot deposit sweeps. New FROST wallets in this build must use the
+	// coarse `frost-tbtc-signer-v1` material path exclusively.
+	return RegisterNativeTBTCSignerEngine(engine)
 }
 
 func (bttse *buildTaggedTBTCSignerEngine) Version() (string, error) {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -58,48 +58,13 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 	}
 
 	dkgEngine := currentNativeFROSTDKGEngine()
-	if dkgEngine == nil {
-		t.Fatal("expected native FROST DKG engine registration")
-	}
-
-	_, err = dkgEngine.Part1(
-		"\"0100000000000000000000000000000000000000000000000000000000000000\"",
-		3,
-		2,
-	)
-	if err == nil {
-		t.Fatal("expected unavailable native FROST DKG bridge error")
-	}
-
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
-		t.Fatalf(
-			"expected native cryptography unavailable error: [%v], got [%v]",
-			ErrNativeCryptographyUnavailable,
-			err,
-		)
+	if dkgEngine != nil {
+		t.Fatal("did not expect UniFFI native FROST DKG engine registration")
 	}
 
 	signingEngine := currentNativeFROSTSigningEngine()
-	if signingEngine == nil {
-		t.Fatal("expected native FROST signing engine registration")
-	}
-
-	_, _, err = signingEngine.GenerateNoncesAndCommitments(
-		&NativeFROSTKeyPackage{
-			Identifier: "\"0100000000000000000000000000000000000000000000000000000000000000\"",
-			Data:       []byte{0x01},
-		},
-	)
-	if err == nil {
-		t.Fatal("expected unavailable native FROST signing bridge error")
-	}
-
-	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
-		t.Fatalf(
-			"expected native cryptography unavailable error: [%v], got [%v]",
-			ErrNativeCryptographyUnavailable,
-			err,
-		)
+	if signingEngine != nil {
+		t.Fatal("did not expect UniFFI native FROST signing engine registration")
 	}
 
 	_, err = engine.BuildTaprootTx(

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -246,6 +246,16 @@ func executeFrostDKG(
 	channel net.BroadcastChannel,
 	membershipValidator *group.MembershipValidator,
 ) (*frostDKGExecutionResult, error) {
+	if nativeTBTCSignerEngine != nil {
+		return executeTBTCSignerFROSTDKG(
+			nativeTBTCSignerEngine,
+			event,
+			activeMemberIndexes,
+			signatureThreshold,
+			sessionID,
+		)
+	}
+
 	if nativeFROSTDKGEngine != nil {
 		nativeResult, err := frostsigning.ExecuteNativeFROSTDKG(
 			ctx,
@@ -281,13 +291,7 @@ func executeFrostDKG(
 		}, nil
 	}
 
-	return executeTBTCSignerFROSTDKG(
-		nativeTBTCSignerEngine,
-		event,
-		activeMemberIndexes,
-		signatureThreshold,
-		sessionID,
-	)
+	return nil, fmt.Errorf("native FROST DKG engine is unavailable")
 }
 
 func executeTBTCSignerFROSTDKG(

--- a/pkg/tbtc/frost_dkg_execution_frost_native_test.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native_test.go
@@ -4,7 +4,10 @@ package tbtc
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/frost/registry"
@@ -98,4 +101,145 @@ func TestOutputKeyFromTBTCSignerDKGResult_AcceptsCompressedKeyGroup(
 			outputKey[:],
 		)
 	}
+}
+
+func TestExecuteFrostDKG_PrefersTBTCSignerMaterial(t *testing.T) {
+	tbtcSignerEngine := &testNativeTBTCSignerSeededDKGEngine{}
+	uniffiEngine := &testNativeFROSTDKGEngine{}
+
+	result, err := executeFrostDKG(
+		context.Background(),
+		nil,
+		uniffiEngine,
+		tbtcSignerEngine,
+		&FrostDKGStartedEvent{Seed: big.NewInt(0x1234)},
+		1,
+		[]group.MemberIndex{1, 2, 3},
+		&GroupSelectionResult{},
+		2,
+		"test-session",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected DKG error: [%v]", err)
+	}
+
+	if !tbtcSignerEngine.runDKGWithSeedCalled {
+		t.Fatal("expected tbtc-signer DKG engine to be used")
+	}
+	if uniffiEngine.called {
+		t.Fatal("did not expect UniFFI native FROST DKG engine to be used")
+	}
+	if result.signerMaterial == nil {
+		t.Fatal("expected signer material")
+	}
+	if result.signerMaterial.Format !=
+		frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1 {
+		t.Fatalf(
+			"unexpected signer material format\nexpected: [%s]\nactual:   [%s]",
+			frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
+			result.signerMaterial.Format,
+		)
+	}
+}
+
+type testNativeTBTCSignerSeededDKGEngine struct {
+	runDKGWithSeedCalled bool
+}
+
+func (tntsde *testNativeTBTCSignerSeededDKGEngine) RunDKG(
+	string,
+	[]frostsigning.NativeTBTCSignerDKGParticipant,
+	uint16,
+) (*frostsigning.NativeTBTCSignerDKGResult, error) {
+	return nil, fmt.Errorf("unseeded RunDKG should not be used")
+}
+
+func (tntsde *testNativeTBTCSignerSeededDKGEngine) RunDKGWithSeed(
+	sessionID string,
+	participants []frostsigning.NativeTBTCSignerDKGParticipant,
+	threshold uint16,
+	dkgSeedHex string,
+) (*frostsigning.NativeTBTCSignerDKGResult, error) {
+	tntsde.runDKGWithSeedCalled = true
+
+	if sessionID != "test-session" {
+		return nil, fmt.Errorf("unexpected session ID: [%s]", sessionID)
+	}
+	if len(participants) != 3 {
+		return nil, fmt.Errorf("unexpected participant count: [%d]", len(participants))
+	}
+	if threshold != 2 {
+		return nil, fmt.Errorf("unexpected threshold: [%d]", threshold)
+	}
+	if dkgSeedHex == "" {
+		return nil, fmt.Errorf("expected DKG seed")
+	}
+
+	return &frostsigning.NativeTBTCSignerDKGResult{
+		SessionID:        sessionID,
+		KeyGroup:         "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		ParticipantCount: uint16(len(participants)),
+		Threshold:        threshold,
+		CreatedAtUnix:    1,
+	}, nil
+}
+
+func (tntsde *testNativeTBTCSignerSeededDKGEngine) StartSignRound(
+	string,
+	uint16,
+	[]byte,
+	string,
+	[]uint16,
+	*[32]byte,
+) (*frostsigning.NativeTBTCSignerRoundState, error) {
+	return nil, fmt.Errorf("StartSignRound should not be used")
+}
+
+func (tntsde *testNativeTBTCSignerSeededDKGEngine) FinalizeSignRound(
+	string,
+	[]frostsigning.NativeTBTCSignerRoundContribution,
+	*[32]byte,
+) ([]byte, error) {
+	return nil, fmt.Errorf("FinalizeSignRound should not be used")
+}
+
+func (tntsde *testNativeTBTCSignerSeededDKGEngine) BuildTaprootTx(
+	string,
+	[]frostsigning.NativeTBTCSignerTxInput,
+	[]frostsigning.NativeTBTCSignerTxOutput,
+	*string,
+) (*frostsigning.NativeTBTCSignerTxResult, error) {
+	return nil, fmt.Errorf("BuildTaprootTx should not be used")
+}
+
+type testNativeFROSTDKGEngine struct {
+	called bool
+}
+
+func (tnfdkg *testNativeFROSTDKGEngine) Part1(
+	string,
+	uint16,
+	uint16,
+) (*frostsigning.NativeFROSTDKGPart1Result, error) {
+	tnfdkg.called = true
+	return nil, fmt.Errorf("UniFFI DKG Part1 should not be used")
+}
+
+func (tnfdkg *testNativeFROSTDKGEngine) Part2(
+	*frostsigning.NativeFROSTDKGRound1SecretPackage,
+	[]*frostsigning.NativeFROSTDKGRound1Package,
+) (*frostsigning.NativeFROSTDKGPart2Result, error) {
+	tnfdkg.called = true
+	return nil, fmt.Errorf("UniFFI DKG Part2 should not be used")
+}
+
+func (tnfdkg *testNativeFROSTDKGEngine) Part3(
+	*frostsigning.NativeFROSTDKGRound2SecretPackage,
+	[]*frostsigning.NativeFROSTDKGRound1Package,
+	[]*frostsigning.NativeFROSTDKGRound2Package,
+) (*frostsigning.NativeFROSTDKGResult, error) {
+	tnfdkg.called = true
+	return nil, fmt.Errorf("UniFFI DKG Part3 should not be used")
 }


### PR DESCRIPTION
## Summary
- stop the frost_tbtc_signer build from registering the tbtc-signer bridge as the generic UniFFI FROST DKG/signing engine
- ensure new FROST DKG prefers coarse frost-tbtc-signer-v1 material if a tbtc-signer engine is available
- add regression coverage so fresh FROST DKG cannot emit frost-uniffi-v2 material in the tbtc-signer stack

## Why
The private testnet E2E reached Taproot deposit sweep signing with a wallet generated as frost-uniffi-v2. That material cannot produce Taproot-tweaked signatures, so real Taproot deposits would be stuck at sweep signing. The production FROST rollout should only generate tbtc-signer-backed FROST wallet material.

## Tests
- go test -tags 'frost_native frost_tbtc_signer cgo' ./pkg/frost/signing -run 'TestRegisterBuildTaggedTBTCSignerEngine|TestBuildTaggedTBTCSignerInteractiveFROSTBridge_WithLinkedSigner'
- go test -tags 'frost_native frost_tbtc_signer cgo' ./pkg/tbtc -run 'TestExecuteFrostDKG_PrefersTBTCSignerMaterial|TestOutputKeyFromTBTCSignerDKGResult'
- go test -tags 'frost_native frost_tbtc_signer cgo' ./pkg/frost/signing
- KEEP_CORE_FROST_TBTC_SIGNER_ACCEPT_SCAFFOLD_KEY_GROUP=true go test -tags 'frost_native frost_tbtc_signer cgo' ./pkg/tbtc