### PR TITLE
Support FROST moving funds outputs

### DIFF
--- a/pkg/chain/ethereum/frost_dkg.go
+++ b/pkg/chain/ethereum/frost_dkg.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
@@ -26,6 +27,22 @@ var _ tbtc.FrostDKGChain = (*TbtcChain)(nil)
 // with a FROST wallet registry address.
 func (tc *TbtcChain) FrostWalletRegistryAvailable() bool {
 	return tc.frostWalletRegistry != nil
+}
+
+// GetFrostOperatorID returns the FROST sortition pool ID number of the given
+// operator address. An ID number of 0 means the operator has not been allocated
+// an ID number yet.
+func (tc *TbtcChain) GetFrostOperatorID(
+	operatorAddress chain.Address,
+) (chain.OperatorID, error) {
+	if tc.frostSortitionPool == nil {
+		return 0, fmt.Errorf("FROST sortition pool is not configured")
+	}
+
+	return getOperatorID(
+		tc.frostSortitionPool,
+		common.HexToAddress(operatorAddress.String()),
+	)
 }
 
 // OnBridgeNewWalletRequested registers a callback for Bridge.NewWalletRequested.

--- a/pkg/maintainer/spv/moved_funds_sweep.go
+++ b/pkg/maintainer/spv/moved_funds_sweep.go
@@ -1,7 +1,6 @@
 package spv
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -116,6 +115,16 @@ func parseMovedFundsSweepTransactionInputs(
 		)
 	}
 
+	if input.Outpoint.OutputIndex >= uint32(len(inputTx.Outputs)) {
+		return bitcoin.UnspentTransactionOutput{}, fmt.Errorf(
+			"output index [%d] out of range for transaction [%s] "+
+				"with [%d] outputs",
+			input.Outpoint.OutputIndex,
+			input.Outpoint.TransactionHash.Hex(bitcoin.InternalByteOrder),
+			len(inputTx.Outputs),
+		)
+	}
+
 	// Get the specific output spent by the moved funds sweep transaction.
 	spentOutput := inputTx.Outputs[input.Outpoint.OutputIndex]
 
@@ -210,10 +219,12 @@ func getUnprovenMovedFundsSweepTransactions(
 
 		// When wallet makes a moved funds sweep transaction, it transfers
 		// funds to itself. Therefore we can search all the transactions that
-		// pay to the wallet's public key hash.
-		walletTransactions, err := btcChain.GetTransactionsForPublicKeyHash(
+		// pay to one of the wallet's scripts.
+		walletTransactions, err := getWalletTransactions(
 			walletPublicKeyHash,
+			wallet,
 			transactionLimit,
+			btcChain,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -327,21 +338,17 @@ func isUnprovenMovedFundsSweepTransaction(
 	// transfer funds to the wallet itself.
 	output := transaction.Outputs[0]
 
-	p2pkh, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
+	isWalletOutput, err := isWalletOutputScript(
+		walletPublicKeyHash,
+		output.PublicKeyScript,
+		spvChain,
+	)
 	if err != nil {
 		return false, fmt.Errorf(
-			"failed to compute p2pkh script for transaction output: [%v]",
-			err,
-		)
-	}
-	p2wpkh, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
-	if err != nil {
-		return false, fmt.Errorf(
-			"failed to compute p2wpkh script for transaction output: [%v]",
+			"failed to check if output is a wallet output: [%v]",
 			err,
 		)
 	}
 
-	return bytes.Equal(output.PublicKeyScript, p2pkh) ||
-		bytes.Equal(output.PublicKeyScript, p2wpkh), nil
+	return isWalletOutput, nil
 }

--- a/pkg/maintainer/spv/moved_funds_sweep_test.go
+++ b/pkg/maintainer/spv/moved_funds_sweep_test.go
@@ -383,3 +383,126 @@ func TestGetUnprovenMovedFundsSweepTransactions(t *testing.T) {
 		t.Errorf("invalid unproven transaction hashes: %v", diff)
 	}
 }
+
+func TestGetUnprovenMovedFundsSweepTransactions_FindsTaprootWalletOutput(
+	t *testing.T,
+) {
+	historyDepth := uint64(5)
+	transactionLimit := 10
+
+	btcChain := newLocalBitcoinChain()
+	spvChain := newLocalChain()
+
+	currentBlock := uint64(1000)
+	blockCounter := newMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	spvChain.setBlockCounter(blockCounter)
+
+	walletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	walletID := [32]byte{
+		0x23, 0x36, 0xf6, 0x50, 0x04, 0xd8, 0xf1, 0x22,
+		0xf1, 0xfe, 0x94, 0x7e, 0xbd, 0x00, 0x9a, 0x8b,
+		0x4a, 0xdd, 0x3a, 0x0d, 0x93, 0x73, 0x56, 0xd5,
+		0x68, 0xe3, 0x0f, 0x7f, 0xcc, 0x2e, 0x40, 0x08,
+	}
+	walletScript, err := bitcoin.PayToTaproot(walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var previousTxHash bitcoin.Hash
+	previousTxHash[0] = 0x04
+	movingFundsTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: previousTxHash,
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           100000,
+				PublicKeyScript: walletScript,
+			},
+		},
+	}
+	if err := btcChain.BroadcastTransaction(movingFundsTx); err != nil {
+		t.Fatal(err)
+	}
+
+	movedFundsSweepTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: movingFundsTx.Hash(),
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           99000,
+				PublicKeyScript: walletScript,
+			},
+		},
+	}
+	if err := btcChain.BroadcastTransaction(movedFundsSweepTx); err != nil {
+		t.Fatal(err)
+	}
+
+	spvChain.setWallet(walletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID:                            walletID,
+		State:                               tbtc.StateLive,
+		PendingMovedFundsSweepRequestsCount: 1,
+	})
+	spvChain.setMovedFundsSweepRequest(
+		movingFundsTx.Hash(),
+		0,
+		&tbtc.MovedFundsSweepRequest{
+			State: tbtc.MovedFundsStatePending,
+		},
+	)
+
+	err = spvChain.addPastMovingFundsCommitmentSubmittedEvent(
+		&tbtc.MovingFundsCommitmentSubmittedEventFilter{
+			StartBlock: currentBlock - historyDepth,
+		},
+		&tbtc.MovingFundsCommitmentSubmittedEvent{
+			WalletPublicKeyHash: bytes20FromHex(
+				t,
+				"8db50eb52063ea9d98b3eac91489a90f738986f6",
+			),
+			TargetWallets: [][20]byte{
+				walletPublicKeyHash,
+			},
+			BlockNumber: currentBlock - 1,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unprovenTransactions, err := getUnprovenMovedFundsSweepTransactions(
+		historyDepth,
+		transactionLimit,
+		btcChain,
+		spvChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.AssertIntsEqual(t, "transactions count", 1, len(unprovenTransactions))
+	expectedHash := movedFundsSweepTx.Hash()
+	actualHash := unprovenTransactions[0].Hash()
+	testutils.AssertBytesEqual(t, expectedHash[:], actualHash[:])
+}

--- a/pkg/maintainer/spv/moving_funds.go
+++ b/pkg/maintainer/spv/moving_funds.go
@@ -1,7 +1,6 @@
 package spv
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -53,6 +52,7 @@ func submitMovingFundsProof(
 
 	mainUTXO, walletPublicKeyHash, err := parseMovingFundsTransactionInput(
 		btcChain,
+		spvChain,
 		transaction,
 	)
 	if err != nil {
@@ -81,6 +81,7 @@ func submitMovingFundsProof(
 // returns the main UTXO and the wallet public key hash.
 func parseMovingFundsTransactionInput(
 	btcChain bitcoin.Chain,
+	spvChain Chain,
 	transaction *bitcoin.Transaction,
 ) (bitcoin.UnspentTransactionOutput, [20]byte, error) {
 	// Perform a sanity check: a moving funds transaction must have exactly one
@@ -103,6 +104,16 @@ func parseMovingFundsTransactionInput(
 		)
 	}
 
+	if input.Outpoint.OutputIndex >= uint32(len(inputTx.Outputs)) {
+		return bitcoin.UnspentTransactionOutput{}, [20]byte{}, fmt.Errorf(
+			"output index [%d] out of range for transaction [%s] "+
+				"with [%d] outputs",
+			input.Outpoint.OutputIndex,
+			input.Outpoint.TransactionHash.Hex(bitcoin.InternalByteOrder),
+			len(inputTx.Outputs),
+		)
+	}
+
 	// Get the specific output spent by the moving funds transaction.
 	spentOutput := inputTx.Outputs[input.Outpoint.OutputIndex]
 
@@ -112,8 +123,11 @@ func parseMovingFundsTransactionInput(
 		Value:    spentOutput.Value,
 	}
 
-	// Extract the wallet public key hash from script
-	walletPublicKeyHash, err := bitcoin.ExtractPublicKeyHash(spentOutput.PublicKeyScript)
+	// Extract the wallet public key hash from script.
+	walletPublicKeyHash, err := walletPublicKeyHashFromScript(
+		spvChain,
+		spentOutput.PublicKeyScript,
+	)
 	if err != nil {
 		return bitcoin.UnspentTransactionOutput{}, [20]byte{}, fmt.Errorf(
 			"cannot extract wallet public key hash: [%v]",
@@ -197,10 +211,21 @@ func getUnprovenMovingFundsTransactions(
 		// source wallet.
 		targetWalletPublicKeyHash := targetWallets[0]
 
-		walletTransactions, err := btcChain.GetTransactionsForPublicKeyHash(
-			targetWalletPublicKeyHash,
-			transactionLimit,
-		)
+		targetWallet, err := spvChain.GetWallet(targetWalletPublicKeyHash)
+		var walletTransactions []*bitcoin.Transaction
+		if err != nil {
+			walletTransactions, err = btcChain.GetTransactionsForPublicKeyHash(
+				targetWalletPublicKeyHash,
+				transactionLimit,
+			)
+		} else {
+			walletTransactions, err = getWalletTransactions(
+				targetWalletPublicKeyHash,
+				targetWallet,
+				transactionLimit,
+				btcChain,
+			)
+		}
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to get transactions for wallet: [%v]",
@@ -289,23 +314,18 @@ func isUnprovenMovingFundsTransaction(
 		// in the same order as target wallets on the list.
 		targetWalletPublicKeyHash := targetWalletsPublicKeyHashes[outputIndex]
 
-		p2pkh, err := bitcoin.PayToPublicKeyHash(targetWalletPublicKeyHash)
+		isWalletOutput, err := isWalletOutputScript(
+			targetWalletPublicKeyHash,
+			output.PublicKeyScript,
+			spvChain,
+		)
 		if err != nil {
 			return false, fmt.Errorf(
-				"failed to compute p2pkh script for transaction output: [%v]",
+				"failed to check if output is a target wallet output: [%v]",
 				err,
 			)
 		}
-		p2wpkh, err := bitcoin.PayToWitnessPublicKeyHash(targetWalletPublicKeyHash)
-		if err != nil {
-			return false, fmt.Errorf(
-				"failed to compute p2wpkh script for transaction output: [%v]",
-				err,
-			)
-		}
-
-		if !bytes.Equal(output.PublicKeyScript, p2pkh) &&
-			!bytes.Equal(output.PublicKeyScript, p2wpkh) {
+		if !isWalletOutput {
 			return false, nil
 		}
 	}

--- a/pkg/maintainer/spv/moving_funds_test.go
+++ b/pkg/maintainer/spv/moving_funds_test.go
@@ -332,6 +332,13 @@ func TestGetUnprovenMovingFundsTransactions(t *testing.T) {
 		},
 	}
 
+	targetWallets := [][20]byte{
+		bytes20FromHex("3091d288521caec06ea912eacfd733edc5a36d6e"),
+		bytes20FromHex("92a6ec889a8fa34f731e639edede4c75e184307c"),
+		bytes20FromHex("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
+		bytes20FromHex("2cd680318747b720d67bf4246eb7403b476adb34"),
+	}
+
 	// Record wallet data on both chains.
 	for _, wallet := range wallets {
 		spvChain.setWallet(wallet.walletPublicKeyHash, wallet.data)
@@ -343,25 +350,24 @@ func TestGetUnprovenMovingFundsTransactions(t *testing.T) {
 			}
 		}
 	}
+	for _, targetWallet := range targetWallets {
+		spvChain.setWallet(targetWallet, &tbtc.WalletChainData{
+			WalletID: tbtc.DeriveLegacyWalletID(targetWallet),
+		})
+	}
 
 	// Add moving funds commitment submitted events for the wallets.
 	// The block number field is just to make them distinguishable while reading.
 	events := []*tbtc.MovingFundsCommitmentSubmittedEvent{
 		{
 			WalletPublicKeyHash: wallets[0].walletPublicKeyHash,
-			TargetWallets: [][20]byte{
-				bytes20FromHex("3091d288521caec06ea912eacfd733edc5a36d6e"),
-				bytes20FromHex("92a6ec889a8fa34f731e639edede4c75e184307c"),
-				bytes20FromHex("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
-			},
-			BlockNumber: 100,
+			TargetWallets:       targetWallets[:3],
+			BlockNumber:         100,
 		},
 		{
 			WalletPublicKeyHash: wallets[1].walletPublicKeyHash,
-			TargetWallets: [][20]byte{
-				bytes20FromHex("2cd680318747b720d67bf4246eb7403b476adb34"),
-			},
-			BlockNumber: 200,
+			TargetWallets:       targetWallets[3:],
+			BlockNumber:         200,
 		},
 	}
 

--- a/pkg/maintainer/spv/moving_funds_test.go
+++ b/pkg/maintainer/spv/moving_funds_test.go
@@ -109,6 +109,118 @@ func TestSubmitMovingFundsProof(t *testing.T) {
 	testutils.AssertBytesEqual(t, bytesFromHex("7ac2d9378a1c47e589dfb8095ca95ed2140d2726"), submittedProof.walletPublicKeyHash[:])
 }
 
+func TestSubmitMovingFundsProof_TaprootWalletInput(t *testing.T) {
+	requiredConfirmations := uint(6)
+
+	btcChain := newLocalBitcoinChain()
+	spvChain := newLocalChain()
+
+	walletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	walletID := [32]byte{
+		0x23, 0x36, 0xf6, 0x50, 0x04, 0xd8, 0xf1, 0x22,
+		0xf1, 0xfe, 0x94, 0x7e, 0xbd, 0x00, 0x9a, 0x8b,
+		0x4a, 0xdd, 0x3a, 0x0d, 0x93, 0x73, 0x56, 0xd5,
+		0x68, 0xe3, 0x0f, 0x7f, 0xcc, 0x2e, 0x40, 0x08,
+	}
+	spvChain.setWallet(walletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: walletID,
+	})
+
+	walletOutputScript, err := bitcoin.PayToTaproot(walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var previousTxHash bitcoin.Hash
+	previousTxHash[0] = 0x01
+	inputTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: previousTxHash,
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           100000,
+				PublicKeyScript: walletOutputScript,
+			},
+		},
+	}
+	if err := btcChain.BroadcastTransaction(inputTx); err != nil {
+		t.Fatal(err)
+	}
+
+	targetOutputScript, err := bitcoin.PayToWitnessPublicKeyHash(
+		bytes20FromHex(t, "3091d288521caec06ea912eacfd733edc5a36d6e"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	movingFundsTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: inputTx.Hash(),
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           99000,
+				PublicKeyScript: targetOutputScript,
+			},
+		},
+	}
+
+	proof := &bitcoin.SpvProof{
+		MerkleProof:    []byte{0x01},
+		TxIndexInBlock: 2,
+		BitcoinHeaders: []byte{0x03},
+	}
+	mockSpvProofAssembler := func(
+		hash bitcoin.Hash,
+		confirmations uint,
+		btcChain bitcoin.Chain,
+	) (*bitcoin.Transaction, *bitcoin.SpvProof, error) {
+		if hash == movingFundsTx.Hash() && confirmations == requiredConfirmations {
+			return movingFundsTx, proof, nil
+		}
+
+		return nil, nil, fmt.Errorf("error while assembling spv proof")
+	}
+
+	err = submitMovingFundsProof(
+		movingFundsTx.Hash(),
+		requiredConfirmations,
+		btcChain,
+		spvChain,
+		mockSpvProofAssembler,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submittedProofs := spvChain.getSubmittedMovingFundsProofs()
+	testutils.AssertIntsEqual(t, "proofs count", 1, len(submittedProofs))
+	testutils.AssertBytesEqual(
+		t,
+		walletPublicKeyHash[:],
+		submittedProofs[0].walletPublicKeyHash[:],
+	)
+}
+
 func TestGetUnprovenMovingFundsTransactions(t *testing.T) {
 	bytesFromHex := func(str string) []byte {
 		value, err := hex.DecodeString(str)
@@ -288,4 +400,148 @@ func TestGetUnprovenMovingFundsTransactions(t *testing.T) {
 	if diff := deep.Equal(expectedTransactionsHashes, transactionsHashes); diff != nil {
 		t.Errorf("invalid unproven transaction hashes: %v", diff)
 	}
+}
+
+func TestGetUnprovenMovingFundsTransactions_FindsTaprootTargetOutput(
+	t *testing.T,
+) {
+	historyDepth := uint64(5)
+	transactionLimit := 10
+
+	btcChain := newLocalBitcoinChain()
+	spvChain := newLocalChain()
+
+	currentBlock := uint64(1000)
+	blockCounter := newMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	spvChain.setBlockCounter(blockCounter)
+
+	sourceWalletPublicKeyHash := bytes20FromHex(
+		t,
+		"8db50eb52063ea9d98b3eac91489a90f738986f6",
+	)
+	sourceWalletID := [32]byte{
+		0x23, 0x36, 0xf6, 0x50, 0x04, 0xd8, 0xf1, 0x22,
+		0xf1, 0xfe, 0x94, 0x7e, 0xbd, 0x00, 0x9a, 0x8b,
+		0x4a, 0xdd, 0x3a, 0x0d, 0x93, 0x73, 0x56, 0xd5,
+		0x68, 0xe3, 0x0f, 0x7f, 0xcc, 0x2e, 0x40, 0x08,
+	}
+	targetWalletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	targetWalletID := [32]byte{
+		0x90, 0xe7, 0xce, 0x2b, 0x70, 0xe4, 0x23, 0x3a,
+		0xbe, 0x6f, 0xd4, 0x9d, 0x45, 0x72, 0x45, 0xe3,
+		0x5a, 0x3b, 0xa1, 0x4f, 0x12, 0x1d, 0x16, 0x0c,
+		0xeb, 0x61, 0x26, 0xed, 0x1e, 0xdf, 0x14, 0x5a,
+	}
+
+	sourceScript, err := bitcoin.PayToTaproot(sourceWalletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetScript, err := bitcoin.PayToTaproot(targetWalletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var previousTxHash bitcoin.Hash
+	previousTxHash[0] = 0x02
+	inputTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: previousTxHash,
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           100000,
+				PublicKeyScript: sourceScript,
+			},
+		},
+	}
+	if err := btcChain.BroadcastTransaction(inputTx); err != nil {
+		t.Fatal(err)
+	}
+
+	movingFundsTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: inputTx.Hash(),
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           99000,
+				PublicKeyScript: targetScript,
+			},
+		},
+	}
+	if err := btcChain.BroadcastTransaction(movingFundsTx); err != nil {
+		t.Fatal(err)
+	}
+
+	spvChain.setWallet(sourceWalletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: sourceWalletID,
+		MainUtxoHash: spvChain.ComputeMainUtxoHash(
+			&bitcoin.UnspentTransactionOutput{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: inputTx.Hash(),
+					OutputIndex:     0,
+				},
+				Value: 100000,
+			},
+		),
+		State: tbtc.StateMovingFunds,
+	})
+	spvChain.setWallet(targetWalletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: targetWalletID,
+		State:    tbtc.StateLive,
+	})
+
+	err = spvChain.addPastMovingFundsCommitmentSubmittedEvent(
+		&tbtc.MovingFundsCommitmentSubmittedEventFilter{
+			StartBlock: currentBlock - historyDepth,
+		},
+		&tbtc.MovingFundsCommitmentSubmittedEvent{
+			WalletPublicKeyHash: sourceWalletPublicKeyHash,
+			TargetWallets: [][20]byte{
+				targetWalletPublicKeyHash,
+			},
+			BlockNumber: currentBlock - 1,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unprovenTransactions, err := getUnprovenMovingFundsTransactions(
+		historyDepth,
+		transactionLimit,
+		btcChain,
+		spvChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.AssertIntsEqual(t, "transactions count", 1, len(unprovenTransactions))
+	expectedHash := movingFundsTx.Hash()
+	actualHash := unprovenTransactions[0].Hash()
+	testutils.AssertBytesEqual(
+		t,
+		expectedHash[:],
+		actualHash[:],
+	)
 }

--- a/pkg/maintainer/spv/redemptions.go
+++ b/pkg/maintainer/spv/redemptions.go
@@ -263,7 +263,7 @@ func walletPublicKeyScripts(
 	if bitcoin.GetScriptType(walletOutputScript) == bitcoin.P2TRScript {
 		// FROST Taproot wallets use the canonical wallet ID as the x-only
 		// Taproot output key.
-		publicKeyScripts = append(publicKeyScripts, walletOutputScript)
+		return []bitcoin.Script{walletOutputScript}, nil
 	}
 
 	return publicKeyScripts, nil

--- a/pkg/maintainer/spv/redemptions.go
+++ b/pkg/maintainer/spv/redemptions.go
@@ -1,7 +1,6 @@
 package spv
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -253,17 +252,18 @@ func walletPublicKeyScripts(
 
 	publicKeyScripts := []bitcoin.Script{p2pkh, p2wpkh}
 
-	if wallet.WalletID != [32]byte{} {
-		// FROST Taproot wallets use the canonical wallet ID as the x-only
-		// Taproot output key. Legacy wallets will not normally have history
-		// under this script, but querying it is harmless and keeps discovery
-		// independent of wallet generation.
-		p2tr, err := bitcoin.PayToTaproot(wallet.WalletID)
-		if err != nil {
-			return nil, fmt.Errorf("cannot construct P2TR for wallet: [%v]", err)
-		}
+	walletOutputScript, err := tbtc.WalletOutputScript(
+		walletPublicKeyHash,
+		wallet.WalletID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot construct wallet output script: [%v]", err)
+	}
 
-		publicKeyScripts = append(publicKeyScripts, p2tr)
+	if bitcoin.GetScriptType(walletOutputScript) == bitcoin.P2TRScript {
+		// FROST Taproot wallets use the canonical wallet ID as the x-only
+		// Taproot output key.
+		publicKeyScripts = append(publicKeyScripts, walletOutputScript)
 	}
 
 	return publicKeyScripts, nil
@@ -471,36 +471,9 @@ func isWalletChangeOutput(
 	spvChain Chain,
 	output *bitcoin.TransactionOutput,
 ) (bool, error) {
-	walletP2PKH, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
-	if err != nil {
-		return false, fmt.Errorf("cannot construct P2PKH for wallet: [%v]", err)
-	}
-	walletP2WPKH, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
-	if err != nil {
-		return false, fmt.Errorf("cannot construct P2WPKH for wallet: [%v]", err)
-	}
-
-	script := output.PublicKeyScript
-	if bytes.Equal(script, walletP2PKH) || bytes.Equal(script, walletP2WPKH) {
-		return true, nil
-	}
-
-	if bitcoin.GetScriptType(script) != bitcoin.P2TRScript {
-		return false, nil
-	}
-
-	wallet, err := spvChain.GetWallet(walletPublicKeyHash)
-	if err != nil {
-		return false, fmt.Errorf("cannot get wallet: [%v]", err)
-	}
-	if wallet.WalletID == [32]byte{} {
-		return false, nil
-	}
-
-	walletP2TR, err := bitcoin.PayToTaproot(wallet.WalletID)
-	if err != nil {
-		return false, fmt.Errorf("cannot construct P2TR for wallet: [%v]", err)
-	}
-
-	return bytes.Equal(script, walletP2TR), nil
+	return isWalletOutputScript(
+		walletPublicKeyHash,
+		output.PublicKeyScript,
+		spvChain,
+	)
 }

--- a/pkg/maintainer/spv/redemptions_test.go
+++ b/pkg/maintainer/spv/redemptions_test.go
@@ -592,3 +592,165 @@ func TestGetUnprovenRedemptionTransactions_TaprootWallet(t *testing.T) {
 		)
 	}
 }
+
+func TestGetUnprovenRedemptionTransactions_TaprootWalletIgnoresLegacyAliases(
+	t *testing.T,
+) {
+	bytesFromHex := func(str string) []byte {
+		value, err := hex.DecodeString(str)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return value
+	}
+
+	bytes20FromHex := func(str string) [20]byte {
+		var value [20]byte
+		copy(value[:], bytesFromHex(str))
+		return value
+	}
+
+	bytes32FromHex := func(str string) [32]byte {
+		var value [32]byte
+		copy(value[:], bytesFromHex(str))
+		return value
+	}
+
+	historyDepth := uint64(5)
+	transactionLimit := 1
+
+	btcChain := newLocalBitcoinChain()
+	spvChain := newLocalChain()
+
+	currentBlock := uint64(1000)
+	blockCounter := newMockBlockCounter()
+	blockCounter.SetCurrentBlock(currentBlock)
+	spvChain.setBlockCounter(blockCounter)
+
+	walletPublicKeyHash := bytes20FromHex(
+		"2a621226d6f9916a929c0ab8cc7d3252c1485708",
+	)
+	walletID := bytes32FromHex(
+		"93fd799256287638b1589bc4c8db1b11fcf873796aabeac9edf4cf238f38e596",
+	)
+	walletP2TR, err := bitcoin.PayToTaproot(walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	walletP2PKH, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redeemerScript, err := bitcoin.PayToWitnessPublicKeyHash(
+		bytes20FromHex("e3395778bb7f567e5a527ced184320018e59b4de"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mainUtxoTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1000000,
+				PublicKeyScript: walletP2TR,
+			},
+		},
+	}
+	redemptionTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: mainUtxoTransaction.Hash(),
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           10000,
+				PublicKeyScript: walletP2TR,
+			},
+			{
+				Value:           900000,
+				PublicKeyScript: redeemerScript,
+			},
+		},
+	}
+	aliasDustTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           1,
+				PublicKeyScript: walletP2PKH,
+			},
+		},
+	}
+
+	for _, transaction := range []*bitcoin.Transaction{
+		mainUtxoTransaction,
+		redemptionTransaction,
+		aliasDustTransaction,
+	} {
+		if err := btcChain.BroadcastTransaction(transaction); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mainUtxo := &bitcoin.UnspentTransactionOutput{
+		Outpoint: &bitcoin.TransactionOutpoint{
+			TransactionHash: mainUtxoTransaction.Hash(),
+			OutputIndex:     0,
+		},
+		Value: 1000000,
+	}
+	spvChain.setWallet(
+		walletPublicKeyHash,
+		&tbtc.WalletChainData{
+			WalletID:     walletID,
+			MainUtxoHash: spvChain.ComputeMainUtxoHash(mainUtxo),
+			State:        tbtc.StateLive,
+		},
+	)
+	spvChain.setPendingRedemptionRequest(
+		walletPublicKeyHash,
+		&tbtc.RedemptionRequest{
+			RedeemerOutputScript: redeemerScript,
+		},
+	)
+
+	err = spvChain.addPastRedemptionRequestedEvent(
+		&tbtc.RedemptionRequestedEventFilter{
+			StartBlock: currentBlock - historyDepth,
+		},
+		&tbtc.RedemptionRequestedEvent{
+			WalletPublicKeyHash: walletPublicKeyHash,
+			BlockNumber:         100,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transactions, err := getUnprovenRedemptionTransactions(
+		historyDepth,
+		transactionLimit,
+		btcChain,
+		spvChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.AssertIntsEqual(t, "transactions count", 1, len(transactions))
+	if transactions[0].Hash() != redemptionTransaction.Hash() {
+		t.Errorf(
+			"invalid transaction hash\nexpected: %v\nactual:   %v",
+			redemptionTransaction.Hash(),
+			transactions[0].Hash(),
+		)
+	}
+}

--- a/pkg/maintainer/spv/wallet_output.go
+++ b/pkg/maintainer/spv/wallet_output.go
@@ -1,0 +1,48 @@
+package spv
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+func isWalletOutputScript(
+	walletPublicKeyHash [20]byte,
+	outputScript bitcoin.Script,
+	spvChain Chain,
+) (bool, error) {
+	walletP2PKH, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		return false, fmt.Errorf("cannot construct P2PKH for wallet: [%v]", err)
+	}
+	walletP2WPKH, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		return false, fmt.Errorf("cannot construct P2WPKH for wallet: [%v]", err)
+	}
+
+	if bytes.Equal(outputScript, walletP2PKH) ||
+		bytes.Equal(outputScript, walletP2WPKH) {
+		return true, nil
+	}
+
+	if bitcoin.GetScriptType(outputScript) != bitcoin.P2TRScript {
+		return false, nil
+	}
+
+	wallet, err := spvChain.GetWallet(walletPublicKeyHash)
+	if err != nil {
+		return false, fmt.Errorf("cannot get wallet: [%v]", err)
+	}
+
+	walletScript, err := tbtc.WalletOutputScript(
+		walletPublicKeyHash,
+		wallet.WalletID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cannot construct wallet output script: [%v]", err)
+	}
+
+	return bytes.Equal(outputScript, walletScript), nil
+}

--- a/pkg/maintainer/spv/wallet_output.go
+++ b/pkg/maintainer/spv/wallet_output.go
@@ -13,36 +13,42 @@ func isWalletOutputScript(
 	outputScript bitcoin.Script,
 	spvChain Chain,
 ) (bool, error) {
-	walletP2PKH, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
-	if err != nil {
-		return false, fmt.Errorf("cannot construct P2PKH for wallet: [%v]", err)
-	}
-	walletP2WPKH, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
-	if err != nil {
-		return false, fmt.Errorf("cannot construct P2WPKH for wallet: [%v]", err)
-	}
-
-	if bytes.Equal(outputScript, walletP2PKH) ||
-		bytes.Equal(outputScript, walletP2WPKH) {
-		return true, nil
-	}
-
-	if bitcoin.GetScriptType(outputScript) != bitcoin.P2TRScript {
-		return false, nil
-	}
-
 	wallet, err := spvChain.GetWallet(walletPublicKeyHash)
 	if err != nil {
 		return false, fmt.Errorf("cannot get wallet: [%v]", err)
 	}
 
+	walletID := wallet.WalletID
+	if walletID == [32]byte{} {
+		walletID = tbtc.DeriveLegacyWalletID(walletPublicKeyHash)
+	}
+
 	walletScript, err := tbtc.WalletOutputScript(
 		walletPublicKeyHash,
-		wallet.WalletID,
+		walletID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("cannot construct wallet output script: [%v]", err)
 	}
 
-	return bytes.Equal(outputScript, walletScript), nil
+	if bytes.Equal(outputScript, walletScript) {
+		return true, nil
+	}
+
+	if bitcoin.GetScriptType(outputScript) != bitcoin.P2PKHScript {
+		return false, nil
+	}
+
+	legacyWalletPublicKeyHash, ok :=
+		tbtc.WalletPublicKeyHashFromLegacyWalletID(walletID)
+	if !ok || !bytes.Equal(legacyWalletPublicKeyHash[:], walletPublicKeyHash[:]) {
+		return false, nil
+	}
+
+	walletP2PKH, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		return false, fmt.Errorf("cannot construct P2PKH for wallet: [%v]", err)
+	}
+
+	return bytes.Equal(outputScript, walletP2PKH), nil
 }

--- a/pkg/maintainer/spv/wallet_output_test.go
+++ b/pkg/maintainer/spv/wallet_output_test.go
@@ -8,6 +8,50 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
+func TestIsWalletOutputScript_AcceptsLegacyOutputs(t *testing.T) {
+	walletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	walletID := tbtc.DeriveLegacyWalletID(walletPublicKeyHash)
+
+	spvChain := newLocalChain()
+	spvChain.setWallet(walletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: walletID,
+	})
+
+	outputScripts := map[string]bitcoin.Script{}
+
+	p2pkh, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputScripts["P2PKH"] = p2pkh
+
+	p2wpkh, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputScripts["P2WPKH"] = p2wpkh
+
+	for scriptType, outputScript := range outputScripts {
+		t.Run(scriptType, func(t *testing.T) {
+			isWalletOutput, err := isWalletOutputScript(
+				walletPublicKeyHash,
+				outputScript,
+				spvChain,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !isWalletOutput {
+				t.Fatalf("expected legacy %s output to be recognized", scriptType)
+			}
+		})
+	}
+}
+
 func TestIsWalletOutputScript_AcceptsFrostP2TR(t *testing.T) {
 	walletPublicKeyHash := bytes20FromHex(
 		t,
@@ -41,6 +85,55 @@ func TestIsWalletOutputScript_AcceptsFrostP2TR(t *testing.T) {
 
 	if !isWalletOutput {
 		t.Fatal("expected FROST P2TR output to be recognized")
+	}
+}
+
+func TestIsWalletOutputScript_RejectsFrostLegacyOutputs(t *testing.T) {
+	walletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	walletID := [32]byte{
+		0x23, 0x36, 0xf6, 0x50, 0x04, 0xd8, 0xf1, 0x22,
+		0xf1, 0xfe, 0x94, 0x7e, 0xbd, 0x00, 0x9a, 0x8b,
+		0x4a, 0xdd, 0x3a, 0x0d, 0x93, 0x73, 0x56, 0xd5,
+		0x68, 0xe3, 0x0f, 0x7f, 0xcc, 0x2e, 0x40, 0x08,
+	}
+
+	spvChain := newLocalChain()
+	spvChain.setWallet(walletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: walletID,
+	})
+
+	outputScripts := map[string]bitcoin.Script{}
+
+	p2pkh, err := bitcoin.PayToPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputScripts["P2PKH"] = p2pkh
+
+	p2wpkh, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputScripts["P2WPKH"] = p2wpkh
+
+	for scriptType, outputScript := range outputScripts {
+		t.Run(scriptType, func(t *testing.T) {
+			isWalletOutput, err := isWalletOutputScript(
+				walletPublicKeyHash,
+				outputScript,
+				spvChain,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if isWalletOutput {
+				t.Fatalf("expected FROST %s alias output to be rejected", scriptType)
+			}
+		})
 	}
 }
 

--- a/pkg/maintainer/spv/wallet_output_test.go
+++ b/pkg/maintainer/spv/wallet_output_test.go
@@ -1,0 +1,90 @@
+package spv
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+func TestIsWalletOutputScript_AcceptsFrostP2TR(t *testing.T) {
+	walletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	walletID := [32]byte{
+		0x23, 0x36, 0xf6, 0x50, 0x04, 0xd8, 0xf1, 0x22,
+		0xf1, 0xfe, 0x94, 0x7e, 0xbd, 0x00, 0x9a, 0x8b,
+		0x4a, 0xdd, 0x3a, 0x0d, 0x93, 0x73, 0x56, 0xd5,
+		0x68, 0xe3, 0x0f, 0x7f, 0xcc, 0x2e, 0x40, 0x08,
+	}
+
+	spvChain := newLocalChain()
+	spvChain.setWallet(walletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: walletID,
+	})
+
+	outputScript, err := bitcoin.PayToTaproot(walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isWalletOutput, err := isWalletOutputScript(
+		walletPublicKeyHash,
+		outputScript,
+		spvChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isWalletOutput {
+		t.Fatal("expected FROST P2TR output to be recognized")
+	}
+}
+
+func TestIsWalletOutputScript_DoesNotAcceptLegacyIDAsP2TR(t *testing.T) {
+	walletPublicKeyHash := bytes20FromHex(
+		t,
+		"c7302d75072d78be94eb8d36c4b77583c7abb06e",
+	)
+	walletID := tbtc.DeriveLegacyWalletID(walletPublicKeyHash)
+
+	spvChain := newLocalChain()
+	spvChain.setWallet(walletPublicKeyHash, &tbtc.WalletChainData{
+		WalletID: walletID,
+	})
+
+	outputScript, err := bitcoin.PayToTaproot(walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isWalletOutput, err := isWalletOutputScript(
+		walletPublicKeyHash,
+		outputScript,
+		spvChain,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isWalletOutput {
+		t.Fatal("expected legacy wallet ID P2TR output to be rejected")
+	}
+}
+
+func bytes20FromHex(t *testing.T, hexString string) [20]byte {
+	t.Helper()
+
+	decoded, err := hex.DecodeString(hexString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result [20]byte
+	copy(result[:], decoded)
+
+	return result
+}

--- a/pkg/protocol/announcer/announcer.go
+++ b/pkg/protocol/announcer/announcer.go
@@ -108,24 +108,46 @@ func (a *Announcer) Announce(
 	[]group.MemberIndex,
 	error,
 ) {
+	return a.AnnounceMany(ctx, []group.MemberIndex{memberIndex}, sessionID)
+}
+
+// AnnounceMany sends readiness announcements for all given local member
+// indexes and listens for announcements from other group members. It returns a
+// list of unique members indexes that are ready for the given attempt,
+// including the local member indexes. The list is sorted in ascending order.
+// This function blocks until the ctx passed as argument is done.
+func (a *Announcer) AnnounceMany(
+	ctx context.Context,
+	memberIndexes []group.MemberIndex,
+	sessionID string,
+) (
+	[]group.MemberIndex,
+	error,
+) {
 	messagesChan := make(chan net.Message, announceReceiveBuffer)
 
 	a.broadcastChannel.Recv(ctx, func(message net.Message) {
 		messagesChan <- message
 	})
 
-	err := a.broadcastChannel.Send(ctx, &announcementMessage{
-		senderID:   memberIndex,
-		protocolID: a.protocolID,
-		sessionID:  sessionID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot send announcement message: [%w]", err)
-	}
-
 	readyMembersIndexesSet := make(map[group.MemberIndex]bool)
-	// Mark itself as ready.
-	readyMembersIndexesSet[memberIndex] = true
+	for _, memberIndex := range memberIndexes {
+		if readyMembersIndexesSet[memberIndex] {
+			continue
+		}
+
+		err := a.broadcastChannel.Send(ctx, &announcementMessage{
+			senderID:   memberIndex,
+			protocolID: a.protocolID,
+			sessionID:  sessionID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cannot send announcement message: [%w]", err)
+		}
+
+		// Mark itself as ready.
+		readyMembersIndexesSet[memberIndex] = true
+	}
 
 loop:
 	for {
@@ -136,7 +158,7 @@ loop:
 				continue
 			}
 
-			if announcement.senderID == memberIndex {
+			if readyMembersIndexesSet[announcement.senderID] {
 				continue
 			}
 

--- a/pkg/protocol/announcer/announcer_test.go
+++ b/pkg/protocol/announcer/announcer_test.go
@@ -228,6 +228,83 @@ func TestAnnouncer(t *testing.T) {
 	}
 }
 
+func TestAnnouncerAnnounceMany(t *testing.T) {
+	protocolID := "protocol-test"
+	groupSize := 4
+	honestThreshold := 3
+
+	operatorPrivateKey, operatorPublicKey, err := operator.GenerateKeyPair(
+		local_v1.DefaultCurve,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localChain := local_v1.ConnectWithKey(
+		groupSize,
+		honestThreshold,
+		operatorPrivateKey,
+	)
+
+	operatorAddress, err := localChain.Signing().PublicKeyToAddress(
+		operatorPublicKey,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var operators []chain.Address
+	for i := 0; i < groupSize; i++ {
+		operators = append(operators, operatorAddress)
+	}
+
+	localProvider := local.ConnectWithKey(operatorPublicKey)
+	broadcastChannel, err := localProvider.BroadcastChannelFor("announce-many")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	membershipValidator := group.NewMembershipValidator(
+		&testutils.MockLogger{},
+		operators,
+		localChain.Signing(),
+	)
+
+	RegisterUnmarshaller(broadcastChannel)
+
+	announcer := New(
+		protocolID,
+		broadcastChannel,
+		membershipValidator,
+	)
+
+	ctx, cancelCtx := context.WithTimeout(
+		context.Background(),
+		4*local.RetransmissionTick,
+	)
+	defer cancelCtx()
+
+	readyMembersIndexes, err := announcer.AnnounceMany(
+		ctx,
+		[]group.MemberIndex{3, 1, 3},
+		"session-test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []group.MemberIndex{1, 3}
+	if !reflect.DeepEqual(expected, readyMembersIndexes) {
+		t.Errorf(
+			"unexpected ready members\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expected,
+			readyMembersIndexes,
+		)
+	}
+}
+
 func TestUnreadyMembers(t *testing.T) {
 	tests := map[string]struct {
 		readyMembers []group.MemberIndex

--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -209,6 +210,7 @@ func (cf *coordinationFault) String() string {
 // CoordinationProposalRequest represents a request for a coordination proposal.
 type CoordinationProposalRequest struct {
 	WalletPublicKeyHash [20]byte
+	WalletPublicKey     *ecdsa.PublicKey
 	WalletOperators     []chain.Address
 	ExecutingOperator   chain.Address
 	ActionsChecklist    []WalletActionType
@@ -655,6 +657,7 @@ func (ce *coordinationExecutor) executeLeaderRoutine(
 	proposal, err := ce.generateProposal(
 		&CoordinationProposalRequest{
 			WalletPublicKeyHash: walletPublicKeyHash,
+			WalletPublicKey:     ce.coordinatedWallet.publicKey,
 			WalletOperators:     ce.coordinatedWallet.signingGroupOperators,
 			ExecutingOperator:   ce.operatorAddress,
 			ActionsChecklist:    actionsChecklist,

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -79,152 +79,145 @@ func executeFrostDKGIfPossible(
 	fullMembers := frostFullMembers(groupSelectionResult)
 	dkgTimeoutBlock := event.BlockNumber + params.SubmissionTimeoutBlocks
 
-	for _, currentMemberIndex := range memberIndexes {
-		memberIndex := currentMemberIndex
+	go func() {
+		dkgLogger := logger.With(
+			zap.String("seed", fmt.Sprintf("0x%x", event.Seed)),
+			zap.String("memberIndexes", fmt.Sprintf("%v", memberIndexes)),
+		)
 
-		go func() {
-			dkgLogger := logger.With(
-				zap.String("seed", fmt.Sprintf("0x%x", event.Seed)),
-				zap.Uint8("memberIndex", uint8(memberIndex)),
-			)
+		node.protocolLatch.Lock()
+		defer node.protocolLatch.Unlock()
 
-			node.protocolLatch.Lock()
-			defer node.protocolLatch.Unlock()
+		dkgCtx, cancelDkgCtx := withCancelOnBlock(
+			ctx,
+			dkgTimeoutBlock,
+			node.waitForBlockHeight,
+		)
+		defer cancelDkgCtx()
 
-			dkgCtx, cancelDkgCtx := withCancelOnBlock(
-				ctx,
-				dkgTimeoutBlock,
-				node.waitForBlockHeight,
-			)
-			defer cancelDkgCtx()
-
-			sessionID := fmt.Sprintf("%s-%s", channelName, "attempt-1")
-			activeMemberIndexes, misbehavedMembersIndices, err :=
-				announceFrostDKGReadiness(
-					dkgCtx,
-					node,
-					channel,
-					membershipValidator,
-					fmt.Sprintf("%v-%v", ProtocolName, "frost-dkg"),
-					sessionID,
-					memberIndex,
-					len(groupSelectionResult.OperatorsIDs),
-				)
-			if err != nil {
-				dkgLogger.Errorf("FROST DKG readiness announcement failed: [%v]", err)
-				return
-			}
-
-			submitterMemberIndex := lowestLocalActiveMemberIndex(
-				memberIndexes,
-				activeMemberIndexes,
-			)
-			if submitterMemberIndex == 0 {
-				dkgLogger.Infof(
-					"skipping FROST DKG result assembly; no local member "+
-						"index is active in [%v]",
-					activeMemberIndexes,
-				)
-				return
-			}
-
-			tbtcSignerMemberIndexes, err := finalFrostDKGMemberIndexes(
-				activeMemberIndexes,
-				groupSelectionResult,
-				node.groupParameters,
-			)
-			if err != nil {
-				dkgLogger.Errorf("failed to resolve final FROST DKG member indexes: [%v]", err)
-				return
-			}
-
-			executionResult, err := executeFrostDKG(
-				nativeTBTCSignerEngine,
-				event,
-				tbtcSignerMemberIndexes,
-				signatureThreshold,
+		sessionID := fmt.Sprintf("%s-%s", channelName, "attempt-1")
+		activeMemberIndexes, misbehavedMembersIndices, err :=
+			announceFrostDKGReadiness(
+				dkgCtx,
+				node,
+				channel,
+				membershipValidator,
+				fmt.Sprintf("%v-%v", ProtocolName, "frost-dkg"),
 				sessionID,
+				memberIndexes,
+				len(groupSelectionResult.OperatorsIDs),
 			)
-			if err != nil {
-				dkgLogger.Errorf("FROST DKG execution failed: [%v]", err)
-				return
-			}
+		if err != nil {
+			dkgLogger.Errorf("FROST DKG readiness announcement failed: [%v]", err)
+			return
+		}
 
+		localActiveMemberIndexes := localActiveFrostMemberIndexes(
+			memberIndexes,
+			activeMemberIndexes,
+		)
+		submitterMemberIndex := lowestLocalActiveMemberIndex(
+			localActiveMemberIndexes,
+			activeMemberIndexes,
+		)
+		if submitterMemberIndex == 0 {
+			dkgLogger.Infof(
+				"skipping FROST DKG result assembly; no local member "+
+					"index is active in [%v]",
+				activeMemberIndexes,
+			)
+			return
+		}
+
+		tbtcSignerMemberIndexes, err := finalFrostDKGMemberIndexes(
+			activeMemberIndexes,
+			groupSelectionResult,
+			node.groupParameters,
+		)
+		if err != nil {
+			dkgLogger.Errorf("failed to resolve final FROST DKG member indexes: [%v]", err)
+			return
+		}
+
+		executionResult, err := executeFrostDKG(
+			nativeTBTCSignerEngine,
+			event,
+			tbtcSignerMemberIndexes,
+			signatureThreshold,
+			sessionID,
+		)
+		if err != nil {
+			dkgLogger.Errorf("FROST DKG execution failed: [%v]", err)
+			return
+		}
+
+		for _, localMemberIndex := range localActiveMemberIndexes {
 			if err := registerFrostSignerWithMaterial(
 				node,
 				executionResult.outputKey,
 				executionResult.signerMaterial,
-				memberIndex,
+				localMemberIndex,
 				activeMemberIndexes,
 				groupSelectionResult,
 			); err != nil {
 				dkgLogger.Errorf("failed to register FROST signer: [%v]", err)
 				return
 			}
+		}
 
-			unsignedResult, err := registry.AssembleResult(
-				uint64(submitterMemberIndex),
-				executionResult.outputKey,
-				fullMembers,
-				misbehavedMembersIndices,
-				nil,
-				nil,
-			)
-			if err != nil {
-				dkgLogger.Errorf("failed to assemble unsigned FROST DKG result: [%v]", err)
-				return
-			}
+		unsignedResult, err := registry.AssembleResult(
+			uint64(submitterMemberIndex),
+			executionResult.outputKey,
+			fullMembers,
+			misbehavedMembersIndices,
+			nil,
+			nil,
+		)
+		if err != nil {
+			dkgLogger.Errorf("failed to assemble unsigned FROST DKG result: [%v]", err)
+			return
+		}
 
-			signedResult, err := signAndCollectFrostDKGResultSignatures(
-				dkgCtx,
-				node,
-				frostChain,
-				channel,
-				membershipValidator,
-				sessionID,
-				event.Seed,
-				memberIndex,
-				activeMemberIndexes,
-				groupSelectionResult,
-				unsignedResult,
-			)
-			if err != nil {
-				dkgLogger.Errorf("failed to collect FROST DKG result signatures: [%v]", err)
-				return
-			}
+		signedResult, err := signAndCollectFrostDKGResultSignatures(
+			dkgCtx,
+			node,
+			frostChain,
+			channel,
+			membershipValidator,
+			sessionID,
+			event.Seed,
+			localActiveMemberIndexes,
+			activeMemberIndexes,
+			groupSelectionResult,
+			unsignedResult,
+		)
+		if err != nil {
+			dkgLogger.Errorf("failed to collect FROST DKG result signatures: [%v]", err)
+			return
+		}
 
-			valid, reason, err := frostChain.IsFrostDKGResultValid(signedResult)
-			if err != nil {
-				dkgLogger.Errorf("failed to pre-validate FROST DKG result: [%v]", err)
-				return
-			}
-			if !valid {
-				dkgLogger.Errorf("assembled FROST DKG result is invalid: [%s]", reason)
-				return
-			}
+		valid, reason, err := frostChain.IsFrostDKGResultValid(signedResult)
+		if err != nil {
+			dkgLogger.Errorf("failed to pre-validate FROST DKG result: [%v]", err)
+			return
+		}
+		if !valid {
+			dkgLogger.Errorf("assembled FROST DKG result is invalid: [%s]", reason)
+			return
+		}
 
-			if memberIndex != submitterMemberIndex {
-				dkgLogger.Infof(
-					"skipping FROST DKG result submission; member [%d] is "+
-						"the designated local submitter",
-					submitterMemberIndex,
-				)
-				return
-			}
-
-			if err := submitFrostDKGResultWithDelay(
-				dkgCtx,
-				node,
-				frostChain,
-				submitterMemberIndex,
-				activeMemberIndexes,
-				signedResult,
-			); err != nil {
-				dkgLogger.Errorf("failed to submit FROST DKG result: [%v]", err)
-				return
-			}
-		}()
-	}
+		if err := submitFrostDKGResultWithDelay(
+			dkgCtx,
+			node,
+			frostChain,
+			submitterMemberIndex,
+			activeMemberIndexes,
+			signedResult,
+		); err != nil {
+			dkgLogger.Errorf("failed to submit FROST DKG result: [%v]", err)
+			return
+		}
+	}()
 }
 
 type frostDKGExecutionResult struct {
@@ -448,7 +441,7 @@ func announceFrostDKGReadiness(
 	membershipValidator *group.MembershipValidator,
 	protocolID string,
 	sessionID string,
-	memberIndex group.MemberIndex,
+	memberIndexes []group.MemberIndex,
 	groupSize int,
 ) (
 	[]group.MemberIndex,
@@ -474,9 +467,9 @@ func announceFrostDKGReadiness(
 	defer cancelAnnounceCtx()
 
 	announcer := protocolannouncer.New(protocolID, channel, membershipValidator)
-	activeMemberIndexes, err := announcer.Announce(
+	activeMemberIndexes, err := announcer.AnnounceMany(
 		announceCtx,
-		memberIndex,
+		memberIndexes,
 		sessionID,
 	)
 	if err != nil {
@@ -497,6 +490,35 @@ func announceFrostDKGReadiness(
 	return activeMemberIndexes,
 		frostMisbehavedMemberIndices(groupSize, activeMemberIndexes),
 		nil
+}
+
+func localActiveFrostMemberIndexes(
+	localMemberIndexes []group.MemberIndex,
+	activeMemberIndexes []group.MemberIndex,
+) []group.MemberIndex {
+	activeMembersSet := make(
+		map[group.MemberIndex]struct{},
+		len(activeMemberIndexes),
+	)
+	for _, activeMemberIndex := range activeMemberIndexes {
+		activeMembersSet[activeMemberIndex] = struct{}{}
+	}
+
+	localActiveMemberIndexes := make(
+		[]group.MemberIndex,
+		0,
+		len(localMemberIndexes),
+	)
+	for _, localMemberIndex := range localMemberIndexes {
+		if _, ok := activeMembersSet[localMemberIndex]; ok {
+			localActiveMemberIndexes = append(
+				localActiveMemberIndexes,
+				localMemberIndex,
+			)
+		}
+	}
+
+	return localActiveMemberIndexes
 }
 
 func registerFrostSignerWithMaterial(

--- a/pkg/tbtc/frost_dkg_execution_frost_native_test.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native_test.go
@@ -54,6 +54,32 @@ func TestLowestLocalActiveMemberIndex(t *testing.T) {
 	}
 }
 
+func TestLocalActiveFrostMemberIndexes(t *testing.T) {
+	actual := localActiveFrostMemberIndexes(
+		[]group.MemberIndex{5, 2, 4, 9},
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+	)
+
+	expected := []group.MemberIndex{5, 2, 4}
+	if len(actual) != len(expected) {
+		t.Fatalf(
+			"unexpected local active member indexes length\nexpected: [%d]\nactual:   [%d]",
+			len(expected),
+			len(actual),
+		)
+	}
+	for i := range expected {
+		if actual[i] != expected[i] {
+			t.Fatalf(
+				"unexpected local active member index at [%d]\nexpected: [%d]\nactual:   [%d]",
+				i,
+				expected[i],
+				actual[i],
+			)
+		}
+	}
+}
+
 func TestFrostMisbehavedMemberIndices(t *testing.T) {
 	actual := frostMisbehavedMemberIndices(
 		7,

--- a/pkg/tbtc/frost_dkg_result_signing.go
+++ b/pkg/tbtc/frost_dkg_result_signing.go
@@ -73,7 +73,7 @@ func signAndCollectFrostDKGResultSignatures(
 	membershipValidator *group.MembershipValidator,
 	sessionID string,
 	seed *big.Int,
-	memberIndex group.MemberIndex,
+	localMemberIndexes []group.MemberIndex,
 	includedMembersIndexes []group.MemberIndex,
 	groupSelectionResult *GroupSelectionResult,
 	unsignedResult *registry.Result,
@@ -98,23 +98,33 @@ func signAndCollectFrostDKGResultSignatures(
 		return nil, fmt.Errorf("cannot sign FROST DKG result digest: [%w]", err)
 	}
 
-	ownMessage := &frostDKGResultSignatureMessage{
-		SenderIDValue: uint32(memberIndex),
-		SessionID:     sessionID,
-		Digest:        append([]byte{}, digest[:]...),
-		PublicKey:     append([]byte{}, signing.PublicKey()...),
-		Signature:     append([]byte{}, ownSignature...),
-	}
-	if err := channel.Send(
-		ctx,
-		ownMessage,
-		net.BackoffRetransmissionStrategy,
-	); err != nil {
-		return nil, fmt.Errorf("cannot broadcast FROST DKG result signature: [%w]", err)
-	}
+	localMemberIndexesSet := make(map[group.MemberIndex]struct{})
+	signatures := make(map[group.MemberIndex][]byte)
+	for _, localMemberIndex := range localMemberIndexes {
+		if _, included := includedMembersSet[localMemberIndex]; !included {
+			continue
+		}
+		if _, seen := localMemberIndexesSet[localMemberIndex]; seen {
+			continue
+		}
 
-	signatures := map[group.MemberIndex][]byte{
-		memberIndex: ownSignature,
+		localMemberIndexesSet[localMemberIndex] = struct{}{}
+		signatures[localMemberIndex] = append([]byte{}, ownSignature...)
+
+		ownMessage := &frostDKGResultSignatureMessage{
+			SenderIDValue: uint32(localMemberIndex),
+			SessionID:     sessionID,
+			Digest:        append([]byte{}, digest[:]...),
+			PublicKey:     append([]byte{}, signing.PublicKey()...),
+			Signature:     append([]byte{}, ownSignature...),
+		}
+		if err := channel.Send(
+			ctx,
+			ownMessage,
+			net.BackoffRetransmissionStrategy,
+		); err != nil {
+			return nil, fmt.Errorf("cannot broadcast FROST DKG result signature: [%w]", err)
+		}
 	}
 
 	expectedSignaturesCount, err := frostDKGSignatureThreshold(node.groupParameters)
@@ -148,7 +158,7 @@ func signAndCollectFrostDKGResultSignatures(
 			payload,
 			message.SenderPublicKey(),
 			sessionID,
-			memberIndex,
+			localMemberIndexesSet,
 			includedMembersSet,
 			membershipValidator,
 		) {
@@ -253,7 +263,7 @@ func shouldAcceptFrostDKGResultSignatureMessage(
 	message *frostDKGResultSignatureMessage,
 	senderPublicKey []byte,
 	sessionID string,
-	selfMemberIndex group.MemberIndex,
+	selfMemberIndexesSet map[group.MemberIndex]struct{},
 	includedMembersSet map[group.MemberIndex]struct{},
 	membershipValidator *group.MembershipValidator,
 ) bool {
@@ -262,7 +272,10 @@ func shouldAcceptFrostDKGResultSignatureMessage(
 	}
 
 	senderID := message.SenderID()
-	if senderID == 0 || senderID == selfMemberIndex {
+	if senderID == 0 {
+		return false
+	}
+	if _, isSelf := selfMemberIndexesSet[senderID]; isSelf {
 		return false
 	}
 	if message.SessionID != sessionID {

--- a/pkg/tbtc/frost_dkg_result_signing_test.go
+++ b/pkg/tbtc/frost_dkg_result_signing_test.go
@@ -1,0 +1,49 @@
+package tbtc
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func TestShouldAcceptFrostDKGResultSignatureMessageRejectsLocalSeats(
+	t *testing.T,
+) {
+	includedMembersSet := map[group.MemberIndex]struct{}{
+		1: {},
+		2: {},
+		3: {},
+	}
+	localMembersSet := map[group.MemberIndex]struct{}{
+		1: {},
+		3: {},
+	}
+
+	if shouldAcceptFrostDKGResultSignatureMessage(
+		&frostDKGResultSignatureMessage{
+			SenderIDValue: 3,
+			SessionID:     "session",
+		},
+		nil,
+		"session",
+		localMembersSet,
+		includedMembersSet,
+		nil,
+	) {
+		t.Fatal("expected local member signature message to be rejected")
+	}
+
+	if !shouldAcceptFrostDKGResultSignatureMessage(
+		&frostDKGResultSignatureMessage{
+			SenderIDValue: 2,
+			SessionID:     "session",
+		},
+		nil,
+		"session",
+		localMembersSet,
+		includedMembersSet,
+		nil,
+	) {
+		t.Fatal("expected remote included member signature message to be accepted")
+	}
+}

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -1,7 +1,6 @@
 package tbtc
 
 import (
-	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 	"time"
@@ -137,7 +136,18 @@ func (mfsa *movedFundsSweepAction) execute() error {
 
 	walletPublicKeyHash := bitcoin.PublicKeyHash(mfsa.wallet().publicKey)
 
-	err := ValidateMovedFundsSweepProposal(
+	walletOutputScript, err := walletOutputScriptForPublicKeyHash(
+		mfsa.chain,
+		walletPublicKeyHash,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"error while resolving moved funds sweep wallet output: [%v]",
+			err,
+		)
+	}
+
+	err = ValidateMovedFundsSweepProposal(
 		validateProposalLogger,
 		walletPublicKeyHash,
 		mfsa.proposal,
@@ -189,9 +199,9 @@ func (mfsa *movedFundsSweepAction) execute() error {
 
 	unsignedMovedFundsSweepTx, err := assembleMovedFundsSweepTransaction(
 		mfsa.btcChain,
-		mfsa.wallet().publicKey,
 		movedFundsUtxo,
 		walletMainUtxo,
+		walletOutputScript,
 		mfsa.proposal.SweepTxFee.Int64(),
 	)
 	if err != nil {
@@ -256,6 +266,16 @@ func assembleMovedFundsSweepUtxo(
 		)
 	}
 
+	if movingFundsTxOutputIdx >= uint32(len(movingFundsTx.Outputs)) {
+		movingFundsTxHashForDisplay := bitcoin.Hash(movingFundsTxHash)
+		return nil, fmt.Errorf(
+			"output index [%d] out of range for transaction [%s] "+
+				"with [%d] outputs",
+			movingFundsTxOutputIdx,
+			movingFundsTxHashForDisplay.Hex(bitcoin.InternalByteOrder),
+			len(movingFundsTx.Outputs),
+		)
+	}
 	movingFundsTxValue := movingFundsTx.Outputs[movingFundsTxOutputIdx].Value
 
 	return &bitcoin.UnspentTransactionOutput{
@@ -309,40 +329,23 @@ func ValidateMovedFundsSweepProposal(
 
 func assembleMovedFundsSweepTransaction(
 	bitcoinChain bitcoin.Chain,
-	walletPublicKey *ecdsa.PublicKey,
 	movedFundsUtxo *bitcoin.UnspentTransactionOutput,
 	walletMainUtxo *bitcoin.UnspentTransactionOutput,
+	walletOutputScript bitcoin.Script,
 	fee int64,
 ) (*bitcoin.TransactionBuilder, error) {
 	if movedFundsUtxo == nil {
 		return nil, fmt.Errorf("moved funds UTXO is required")
 	}
 
-	if walletMainUtxo != nil {
-		scriptType, err := walletMainUtxoScriptType(
-			bitcoinChain,
-			walletMainUtxo,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"cannot inspect wallet main UTXO script: [%v]",
-				err,
-			)
-		}
-
-		if scriptType == bitcoin.P2TRScript {
-			return nil, fmt.Errorf(
-				"Taproot moved-funds sweep main UTXOs are not supported " +
-					"until moved-funds sweep transactions support P2TR " +
-					"wallet outputs",
-			)
-		}
+	if walletOutputScript == nil {
+		return nil, fmt.Errorf("wallet output script is required")
 	}
 
 	builder := bitcoin.NewTransactionBuilder(bitcoinChain)
 
 	// The moved funds UTXO is always the first input.
-	err := builder.AddPublicKeyHashInput(movedFundsUtxo)
+	err := addWalletUtxoInput(builder, bitcoinChain, movedFundsUtxo)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"cannot add input pointing to moved funds UTXO: [%v]",
@@ -352,7 +355,7 @@ func assembleMovedFundsSweepTransaction(
 
 	// If the wallet has the main UTXO it becomes the second input.
 	if walletMainUtxo != nil {
-		err := builder.AddPublicKeyHashInput(walletMainUtxo)
+		err := addWalletUtxoInput(builder, bitcoinChain, walletMainUtxo)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"cannot add input pointing to main wallet UTXO: [%v]",
@@ -364,16 +367,9 @@ func assembleMovedFundsSweepTransaction(
 	// Add a single output transferring funds to the wallet itself.
 	outputValue := builder.TotalInputsValue() - fee
 
-	outputScript, err := bitcoin.PayToWitnessPublicKeyHash(
-		bitcoin.PublicKeyHash(walletPublicKey),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("cannot compute output script: [%v]", err)
-	}
-
 	builder.AddOutput(&bitcoin.TransactionOutput{
 		Value:           outputValue,
-		PublicKeyScript: outputScript,
+		PublicKeyScript: walletOutputScript,
 	})
 
 	return builder, nil

--- a/pkg/tbtc/moved_funds_sweep_test.go
+++ b/pkg/tbtc/moved_funds_sweep_test.go
@@ -159,11 +159,18 @@ func TestAssembleMovedFundsSweepTransaction(t *testing.T) {
 				}
 			}
 
+			walletOutputScript, err := bitcoin.PayToWitnessPublicKeyHash(
+				bitcoin.PublicKeyHash(scenario.WalletPublicKey),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			builder, err := assembleMovedFundsSweepTransaction(
 				bitcoinChain,
-				scenario.WalletPublicKey,
 				scenario.MovedFundsUtxo,
 				scenario.WalletMainUtxo,
+				walletOutputScript,
 				scenario.Fee,
 			)
 
@@ -211,7 +218,7 @@ func TestAssembleMovedFundsSweepTransaction(t *testing.T) {
 	}
 }
 
-func TestAssembleMovedFundsSweepTransaction_RejectsTaprootWalletMainUtxo(
+func TestAssembleMovedFundsSweepTransaction_SupportsTaprootUtxos(
 	t *testing.T,
 ) {
 	bitcoinChain := newLocalBitcoinChain()
@@ -225,26 +232,106 @@ func TestAssembleMovedFundsSweepTransaction_RejectsTaprootWalletMainUtxo(
 		walletPublicKey,
 	)
 
-	var movedFundsTxHash bitcoin.Hash
-	movedFundsTxHash[0] = 0x02
+	walletXOnlyPublicKey, err := walletXOnlyPublicKey(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := assembleMovedFundsSweepTransaction(
+	walletOutputScript, err := bitcoin.PayToTaproot(walletXOnlyPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var previousTxHash bitcoin.Hash
+	previousTxHash[0] = 0x02
+	movingFundsTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: previousTxHash,
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           100000,
+				PublicKeyScript: walletOutputScript,
+			},
+		},
+	}
+	if err := bitcoinChain.BroadcastTransaction(movingFundsTx); err != nil {
+		t.Fatal(err)
+	}
+
+	builder, err := assembleMovedFundsSweepTransaction(
 		bitcoinChain,
-		walletPublicKey,
 		&bitcoin.UnspentTransactionOutput{
 			Outpoint: &bitcoin.TransactionOutpoint{
-				TransactionHash: movedFundsTxHash,
+				TransactionHash: movingFundsTx.Hash(),
 				OutputIndex:     0,
 			},
 			Value: 100000,
 		},
 		walletMainUtxo,
+		walletOutputScript,
 		1000,
 	)
-	if err == nil {
-		t.Fatal("expected Taproot moved-funds sweep main UTXO rejection")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "Taproot moved-funds sweep main UTXOs") {
+
+	if !builder.HasOnlyTaprootKeyPathInputs() {
+		t.Fatal("expected moved funds sweep builder to use Taproot key-path inputs")
+	}
+}
+
+func TestAssembleMovedFundsSweepUtxo_RejectsOutOfRangeOutputIndex(t *testing.T) {
+	bitcoinChain := newLocalBitcoinChain()
+
+	var previousTxHash bitcoin.Hash
+	previousTxHash[0] = 0x03
+
+	outputScript, err := bitcoin.PayToWitnessPublicKeyHash(
+		hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	movingFundsTx := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: previousTxHash,
+					OutputIndex:     0,
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{
+				Value:           100000,
+				PublicKeyScript: outputScript,
+			},
+		},
+	}
+	if err := bitcoinChain.BroadcastTransaction(movingFundsTx); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = assembleMovedFundsSweepUtxo(
+		bitcoinChain,
+		movingFundsTx.Hash(),
+		1,
+	)
+	if err == nil {
+		t.Fatal("expected out-of-range output index error")
+	}
+	if !strings.Contains(err.Error(), "output index [1] out of range") {
 		t.Fatalf("unexpected error: [%v]", err)
 	}
 }

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -151,14 +151,6 @@ func (mfa *movingFundsAction) execute() error {
 		return fmt.Errorf("moving funds wallet has no main UTXO")
 	}
 
-	err = ensureMovingFundsMainUtxoSupportsLegacyTargets(
-		mfa.btcChain,
-		walletMainUtxo,
-	)
-	if err != nil {
-		return fmt.Errorf("unsupported moving funds wallet main UTXO: [%v]", err)
-	}
-
 	// Perform initial validation of the moving funds proposal.
 	err = ValidateMovingFundsProposal(
 		validateProposalLogger,
@@ -210,10 +202,21 @@ func (mfa *movingFundsAction) execute() error {
 		)
 	}
 
+	targetWalletOutputScripts, err := walletOutputScriptsForPublicKeyHashes(
+		mfa.chain,
+		mfa.proposal.TargetWallets,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"error while resolving moving funds target wallet outputs: [%v]",
+			err,
+		)
+	}
+
 	unsignedMovingFundsTx, err := assembleMovingFundsTransaction(
 		mfa.btcChain,
 		walletMainUtxo,
-		mfa.proposal.TargetWallets,
+		targetWalletOutputScripts,
 		mfa.proposal.MovingFundsTxFee.Int64(),
 	)
 	if err != nil {
@@ -571,10 +574,10 @@ func isWalletPendingMovingFundsTarget(
 func assembleMovingFundsTransaction(
 	bitcoinChain bitcoin.Chain,
 	walletMainUtxo *bitcoin.UnspentTransactionOutput,
-	targetWallets [][20]byte,
+	targetWalletOutputScripts []bitcoin.Script,
 	fee int64,
 ) (*bitcoin.TransactionBuilder, error) {
-	if len(targetWallets) < 1 {
+	if len(targetWalletOutputScripts) < 1 {
 		return nil, fmt.Errorf("at least one target wallet is required")
 	}
 
@@ -582,16 +585,8 @@ func assembleMovingFundsTransaction(
 		return nil, fmt.Errorf("wallet main UTXO is required")
 	}
 
-	err := ensureMovingFundsMainUtxoSupportsLegacyTargets(
-		bitcoinChain,
-		walletMainUtxo,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	builder := bitcoin.NewTransactionBuilder(bitcoinChain)
-	err = builder.AddPublicKeyHashInput(walletMainUtxo)
+	err := addWalletUtxoInput(builder, bitcoinChain, walletMainUtxo)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"cannot add input pointing to wallet main UTXO: [%v]",
@@ -600,7 +595,7 @@ func assembleMovingFundsTransaction(
 	}
 
 	// The number of target wallets. It determines the number of outputs.
-	targetWalletsCount := int64(len(targetWallets))
+	targetWalletsCount := int64(len(targetWalletOutputScripts))
 
 	// The sum of all the outputs equal to the input value minus fee.
 	totalOutputValue := walletMainUtxo.Value - fee
@@ -619,16 +614,9 @@ func assembleMovingFundsTransaction(
 	// should be the same as during the commitment. We don't to check it,
 	// as the order of target wallets has already been validated by the on-chain
 	// contract.
-	for i, targetWalletPublicKeyHash := range targetWallets {
-		outputScript, err := bitcoin.PayToWitnessPublicKeyHash(
-			targetWalletPublicKeyHash,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("cannot compute output script: [%v]", err)
-		}
-
+	for i, targetWalletOutputScript := range targetWalletOutputScripts {
 		outputValue := singleOutputValue
-		if i == len(targetWallets)-1 {
+		if i == len(targetWalletOutputScripts)-1 {
 			// If we are at the last output, increase its value by the remaining
 			// satoshis. If the total output amount is divisible by the number
 			// of target wallets, the increase will be `0`.
@@ -637,28 +625,9 @@ func assembleMovingFundsTransaction(
 
 		builder.AddOutput(&bitcoin.TransactionOutput{
 			Value:           outputValue,
-			PublicKeyScript: outputScript,
+			PublicKeyScript: targetWalletOutputScript,
 		})
 	}
 
 	return builder, nil
-}
-
-func ensureMovingFundsMainUtxoSupportsLegacyTargets(
-	bitcoinChain bitcoin.Chain,
-	walletMainUtxo *bitcoin.UnspentTransactionOutput,
-) error {
-	scriptType, err := walletMainUtxoScriptType(bitcoinChain, walletMainUtxo)
-	if err != nil {
-		return err
-	}
-
-	if scriptType == bitcoin.P2TRScript {
-		return fmt.Errorf(
-			"Taproot moving-funds main UTXOs are not supported until " +
-				"moving-funds transactions support P2TR target wallet outputs",
-		)
-	}
-
-	return nil
 }

--- a/pkg/tbtc/moving_funds_test.go
+++ b/pkg/tbtc/moving_funds_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +88,9 @@ func TestMovingFundsAction_Execute(t *testing.T) {
 				MainUtxoHash:                           walletMainUtxoHash,
 				MovingFundsTargetWalletsCommitmentHash: movingFundsCommitmentHash,
 			})
+			for _, targetWallet := range scenario.TargetWallets {
+				hostChain.setWallet(targetWallet, &WalletChainData{})
+			}
 
 			// Create a signing executor mock instance.
 			signingExecutor := newMockWalletSigningExecutor()
@@ -169,10 +171,17 @@ func TestAssembleMovingFundsTransaction(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			targetWalletOutputScripts, err := testLegacyWalletOutputScripts(
+				scenario.TargetWallets,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			builder, err := assembleMovingFundsTransaction(
 				bitcoinChain,
 				scenario.WalletMainUtxo,
-				scenario.TargetWallets,
+				targetWalletOutputScripts,
 				scenario.Fee,
 			)
 
@@ -227,60 +236,41 @@ func TestAssembleMovingFundsTransaction(t *testing.T) {
 	}
 }
 
-func TestAssembleMovingFundsTransaction_RejectsTaprootWalletMainUtxo(
+func TestAssembleMovingFundsTransaction_SupportsTaprootWalletMainUtxo(
 	t *testing.T,
 ) {
-	var taprootOutputKey [32]byte
-	taprootOutputKey[31] = 1
+	bitcoinChain := newLocalBitcoinChain()
+	walletPublicKey := testWalletPublicKeyFromXOnly(
+		t,
+		"2336f65004d8f122f1fe947ebd009a8b4add3a0d937356d568e30f7fcc2e4008",
+	)
+	walletMainUtxo := testTaprootWalletMainUtxo(
+		t,
+		bitcoinChain,
+		walletPublicKey,
+	)
 
-	taprootScript, err := bitcoin.PayToTaproot(taprootOutputKey)
+	var targetWalletID [32]byte
+	targetWalletID[31] = 1
+	targetWalletOutputScript, err := bitcoin.PayToTaproot(targetWalletID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fundingTx := &bitcoin.Transaction{
-		Version: 1,
-		Inputs: []*bitcoin.TransactionInput{
-			{
-				Outpoint: &bitcoin.TransactionOutpoint{
-					TransactionHash: bitcoin.Hash{},
-					OutputIndex:     0,
-				},
-				Sequence: 0xffffffff,
-			},
-		},
-		Outputs: []*bitcoin.TransactionOutput{
-			{
-				Value:           100000,
-				PublicKeyScript: taprootScript,
-			},
-		},
-	}
-
-	bitcoinChain := newLocalBitcoinChain()
-	if err := bitcoinChain.BroadcastTransaction(fundingTx); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = assembleMovingFundsTransaction(
+	builder, err := assembleMovingFundsTransaction(
 		bitcoinChain,
-		&bitcoin.UnspentTransactionOutput{
-			Outpoint: &bitcoin.TransactionOutpoint{
-				TransactionHash: fundingTx.Hash(),
-				OutputIndex:     0,
-			},
-			Value: 100000,
-		},
-		[][20]byte{
-			hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e"),
+		walletMainUtxo,
+		[]bitcoin.Script{
+			targetWalletOutputScript,
 		},
 		1000,
 	)
-	if err == nil {
-		t.Fatal("expected Taproot moving-funds main UTXO rejection")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "Taproot moving-funds main UTXOs") {
-		t.Fatalf("unexpected error: [%v]", err)
+
+	if !builder.HasOnlyTaprootKeyPathInputs() {
+		t.Fatal("expected moving funds builder to use Taproot key-path inputs")
 	}
 }
 
@@ -489,4 +479,23 @@ func hexToByte20(hexStr string) [20]byte {
 	var result [20]byte
 	copy(result[:], decoded)
 	return result
+}
+
+func testLegacyWalletOutputScripts(
+	walletPublicKeyHashes [][20]byte,
+) ([]bitcoin.Script, error) {
+	outputScripts := make([]bitcoin.Script, len(walletPublicKeyHashes))
+
+	for i, walletPublicKeyHash := range walletPublicKeyHashes {
+		outputScript, err := bitcoin.PayToWitnessPublicKeyHash(
+			walletPublicKeyHash,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		outputScripts[i] = outputScript
+	}
+
+	return outputScripts, nil
 }

--- a/pkg/tbtc/wallet_output_script.go
+++ b/pkg/tbtc/wallet_output_script.go
@@ -1,0 +1,78 @@
+package tbtc
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
+
+// WalletOutputScript constructs the Bitcoin locking script for the canonical
+// wallet identity. Legacy ECDSA wallets keep using P2WPKH outputs. Native FROST
+// wallets use their canonical wallet ID as the P2TR output key.
+func WalletOutputScript(
+	walletPublicKeyHash [20]byte,
+	walletID [32]byte,
+) (bitcoin.Script, error) {
+	if walletID == [32]byte{} {
+		walletID = DeriveLegacyWalletID(walletPublicKeyHash)
+	}
+
+	if legacyWalletPublicKeyHash, ok := WalletPublicKeyHashFromLegacyWalletID(
+		walletID,
+	); ok {
+		if !bytes.Equal(
+			legacyWalletPublicKeyHash[:],
+			walletPublicKeyHash[:],
+		) {
+			return nil, fmt.Errorf(
+				"legacy wallet ID does not match wallet public key hash",
+			)
+		}
+
+		return bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
+	}
+
+	return bitcoin.PayToTaproot(walletID)
+}
+
+type walletDataResolver interface {
+	GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)
+}
+
+func walletOutputScriptForPublicKeyHash(
+	chain walletDataResolver,
+	walletPublicKeyHash [20]byte,
+) (bitcoin.Script, error) {
+	walletChainData, err := chain.GetWallet(walletPublicKeyHash)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get wallet's chain data: [%w]", err)
+	}
+
+	return WalletOutputScript(walletPublicKeyHash, walletChainData.WalletID)
+}
+
+func walletOutputScriptsForPublicKeyHashes(
+	chain walletDataResolver,
+	walletPublicKeyHashes [][20]byte,
+) ([]bitcoin.Script, error) {
+	outputScripts := make([]bitcoin.Script, len(walletPublicKeyHashes))
+
+	for i, walletPublicKeyHash := range walletPublicKeyHashes {
+		outputScript, err := walletOutputScriptForPublicKeyHash(
+			chain,
+			walletPublicKeyHash,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"cannot compute output script for wallet [%d]: [%w]",
+				i,
+				err,
+			)
+		}
+
+		outputScripts[i] = outputScript
+	}
+
+	return outputScripts, nil
+}

--- a/pkg/tbtc/wallet_output_script_test.go
+++ b/pkg/tbtc/wallet_output_script_test.go
@@ -1,0 +1,81 @@
+package tbtc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
+
+func TestWalletOutputScript_LegacyWalletID(t *testing.T) {
+	walletPublicKeyHash := hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e")
+	walletID := DeriveLegacyWalletID(walletPublicKeyHash)
+
+	actualScript, err := WalletOutputScript(walletPublicKeyHash, walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedScript, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(actualScript, expectedScript) {
+		t.Fatalf("unexpected legacy wallet script: [%x]", actualScript)
+	}
+}
+
+func TestWalletOutputScript_ZeroWalletIDFallsBackToLegacy(t *testing.T) {
+	walletPublicKeyHash := hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e")
+
+	actualScript, err := WalletOutputScript(walletPublicKeyHash, [32]byte{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedScript, err := bitcoin.PayToWitnessPublicKeyHash(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(actualScript, expectedScript) {
+		t.Fatalf("unexpected zero-ID wallet script: [%x]", actualScript)
+	}
+}
+
+func TestWalletOutputScript_FrostWalletID(t *testing.T) {
+	walletPublicKeyHash := hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e")
+	walletID := [32]byte{
+		0x23, 0x36, 0xf6, 0x50, 0x04, 0xd8, 0xf1, 0x22,
+		0xf1, 0xfe, 0x94, 0x7e, 0xbd, 0x00, 0x9a, 0x8b,
+		0x4a, 0xdd, 0x3a, 0x0d, 0x93, 0x73, 0x56, 0xd5,
+		0x68, 0xe3, 0x0f, 0x7f, 0xcc, 0x2e, 0x40, 0x08,
+	}
+
+	actualScript, err := WalletOutputScript(walletPublicKeyHash, walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedScript, err := bitcoin.PayToTaproot(walletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(actualScript, expectedScript) {
+		t.Fatalf("unexpected FROST wallet script: [%x]", actualScript)
+	}
+}
+
+func TestWalletOutputScript_LegacyWalletIDMismatch(t *testing.T) {
+	walletPublicKeyHash := hexToByte20("c7302d75072d78be94eb8d36c4b77583c7abb06e")
+	walletID := DeriveLegacyWalletID(
+		hexToByte20("3091d288521caec06ea912eacfd733edc5a36d6e"),
+	)
+
+	_, err := WalletOutputScript(walletPublicKeyHash, walletID)
+	if err == nil {
+		t.Fatal("expected legacy wallet ID mismatch error")
+	}
+}

--- a/pkg/tbtc/wallet_utxo_script.go
+++ b/pkg/tbtc/wallet_utxo_script.go
@@ -10,6 +10,13 @@ func walletMainUtxoScriptType(
 	bitcoinChain bitcoin.Chain,
 	walletMainUtxo *bitcoin.UnspentTransactionOutput,
 ) (bitcoin.ScriptType, error) {
+	return walletUtxoScriptType(bitcoinChain, walletMainUtxo)
+}
+
+func walletUtxoScriptType(
+	bitcoinChain bitcoin.Chain,
+	walletMainUtxo *bitcoin.UnspentTransactionOutput,
+) (bitcoin.ScriptType, error) {
 	if walletMainUtxo == nil {
 		return bitcoin.NonStandardScript, fmt.Errorf("wallet main UTXO is required")
 	}
@@ -45,4 +52,21 @@ func walletMainUtxoScriptType(
 	return bitcoin.GetScriptType(
 		transaction.Outputs[outputIndex].PublicKeyScript,
 	), nil
+}
+
+func addWalletUtxoInput(
+	builder *bitcoin.TransactionBuilder,
+	bitcoinChain bitcoin.Chain,
+	utxo *bitcoin.UnspentTransactionOutput,
+) error {
+	scriptType, err := walletUtxoScriptType(bitcoinChain, utxo)
+	if err != nil {
+		return err
+	}
+
+	if scriptType == bitcoin.P2TRScript {
+		return builder.AddTaprootKeyPathInput(utxo)
+	}
+
+	return builder.AddPublicKeyHashInput(utxo)
 }

--- a/pkg/tbtcpg/chain.go
+++ b/pkg/tbtcpg/chain.go
@@ -141,6 +141,10 @@ type Chain interface {
 	// GetOperatorID returns the operator ID for the given operator address.
 	GetOperatorID(operatorAddress chain.Address) (chain.OperatorID, error)
 
+	// GetFrostOperatorID returns the FROST sortition pool operator ID for the
+	// given operator address.
+	GetFrostOperatorID(operatorAddress chain.Address) (chain.OperatorID, error)
+
 	// ValidateHeartbeatProposal validates the given heartbeat proposal
 	// against the chain. Returns an error if the proposal is not valid or
 	// nil otherwise.

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -97,6 +97,7 @@ type LocalChain struct {
 	movedFundsSweepRequests                  map[[32]byte]*tbtc.MovedFundsSweepRequest
 	movedFundsSweepProposalValidations       map[[32]byte]bool
 	operatorIDs                              map[chain.Address]uint32
+	frostOperatorIDs                         map[chain.Address]uint32
 	redemptionDelays                         map[[32]byte]time.Duration
 	depositMinAge                            uint32
 	currentBlockTimestamp                    time.Time
@@ -121,6 +122,7 @@ func NewLocalChain() *LocalChain {
 		movedFundsSweepRequests:                  make(map[[32]byte]*tbtc.MovedFundsSweepRequest),
 		movedFundsSweepProposalValidations:       make(map[[32]byte]bool),
 		operatorIDs:                              make(map[chain.Address]uint32),
+		frostOperatorIDs:                         make(map[chain.Address]uint32),
 		redemptionDelays:                         make(map[[32]byte]time.Duration),
 		currentBlockTimestamp:                    time.Now(),
 	}
@@ -1081,6 +1083,35 @@ func (lc *LocalChain) GetOperatorID(
 	operatorID, ok := lc.operatorIDs[operatorAddress]
 	if !ok {
 		return 0, fmt.Errorf("operator not found")
+	}
+
+	return operatorID, nil
+}
+
+func (lc *LocalChain) SetFrostOperatorID(
+	operatorAddress chain.Address,
+	operatorID chain.OperatorID,
+) error {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	_, ok := lc.frostOperatorIDs[operatorAddress]
+	if !ok {
+		lc.frostOperatorIDs[operatorAddress] = operatorID
+	}
+
+	return nil
+}
+
+func (lc *LocalChain) GetFrostOperatorID(
+	operatorAddress chain.Address,
+) (chain.OperatorID, error) {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	operatorID, ok := lc.frostOperatorIDs[operatorAddress]
+	if !ok {
+		return 0, fmt.Errorf("FROST operator not found")
 	}
 
 	return operatorID, nil

--- a/pkg/tbtcpg/moving_funds.go
+++ b/pkg/tbtcpg/moving_funds.go
@@ -134,8 +134,12 @@ func (mft *MovingFundsTask) Run(request *tbtc.CoordinationProposalRequest) (
 		return nil, false, nil
 	}
 
-	walletMainUtxo, err := tbtc.DetermineWalletMainUtxo(
-		walletPublicKeyHash,
+	if request.WalletPublicKey == nil {
+		return nil, false, fmt.Errorf("wallet public key is required")
+	}
+
+	walletMainUtxo, err := tbtc.DetermineWalletMainUtxoForPublicKey(
+		request.WalletPublicKey,
 		mft.chain,
 		mft.btcChain,
 	)
@@ -189,6 +193,7 @@ func (mft *MovingFundsTask) Run(request *tbtc.CoordinationProposalRequest) (
 		walletMemberIDs, walletMemberIndex, err := mft.GetWalletMembersInfo(
 			request.WalletOperators,
 			request.ExecutingOperator,
+			walletChainData.EcdsaWalletID == [32]byte{},
 		)
 		if err != nil {
 			return nil, false, fmt.Errorf(
@@ -439,6 +444,7 @@ func (mft *MovingFundsTask) retrieveCommittedTargetWallets(
 func (mft *MovingFundsTask) GetWalletMembersInfo(
 	walletOperators []chain.Address,
 	executingOperator chain.Address,
+	useFrostOperatorIDs bool,
 ) ([]uint32, uint32, error) {
 	// Cache mapping operator addresses to their wallet member IDs. It helps to
 	// limit the number of calls to the ETH client if some operator addresses
@@ -465,7 +471,10 @@ func (mft *MovingFundsTask) GetWalletMembersInfo(
 		// Search for the operator address in the cache. Store the operator
 		// address in the cache if it's not there.
 		if operatorID, found := operatorIDCache[operatorAddress]; !found {
-			fetchedOperatorID, err := mft.chain.GetOperatorID(operatorAddress)
+			fetchedOperatorID, err := mft.getOperatorID(
+				operatorAddress,
+				useFrostOperatorIDs,
+			)
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to get operator ID: [%w]", err)
 			}
@@ -482,6 +491,17 @@ func (mft *MovingFundsTask) GetWalletMembersInfo(
 	}
 
 	return walletMemberIDs, uint32(walletMemberIndex), nil
+}
+
+func (mft *MovingFundsTask) getOperatorID(
+	operatorAddress chain.Address,
+	useFrostOperatorID bool,
+) (chain.OperatorID, error) {
+	if useFrostOperatorID {
+		return mft.chain.GetFrostOperatorID(operatorAddress)
+	}
+
+	return mft.chain.GetOperatorID(operatorAddress)
 }
 
 // SubmitMovingFundsCommitment submits the moving funds commitment and waits

--- a/pkg/tbtcpg/moving_funds_test.go
+++ b/pkg/tbtcpg/moving_funds_test.go
@@ -331,7 +331,9 @@ func TestMovingFundsAction_FindTargetWallets_CommitmentAlreadySubmitted(t *testi
 func TestMovingFundsAction_GetWalletMembersInfo(t *testing.T) {
 	var tests = map[string]struct {
 		walletOperators          []operatorInfo
+		frostOperatorIDs         []operatorInfo
 		executingOperator        chain.Address
+		useFrostOperatorIDs      bool
 		expectedMemberIDs        []uint32
 		expectedOperatorPosition uint32
 		expectedError            error
@@ -346,6 +348,28 @@ func TestMovingFundsAction_GetWalletMembersInfo(t *testing.T) {
 				{"28759deda2ea33bd72f68ea2e8f60cd670c2549f", 2},
 			},
 			executingOperator:        "28759deda2ea33bd72f68ea2e8f60cd670c2549f",
+			expectedMemberIDs:        []uint32{3, 1, 2, 4, 2},
+			expectedOperatorPosition: 3,
+			expectedError:            nil,
+		},
+		"success case with FROST operator IDs": {
+			walletOperators: []operatorInfo{
+				// Legacy IDs are intentionally different to prove the FROST
+				// sortition pool is used.
+				{"5df232b0348928793658dd05dfc6b05a59d11ae8", 30},
+				{"dcc895d32b74b34cef2baa6546884fcda65da1e9", 10},
+				{"28759deda2ea33bd72f68ea2e8f60cd670c2549f", 20},
+				{"f7891d42f3c61a49e0aed1e31b151877c0905cf7", 40},
+				{"28759deda2ea33bd72f68ea2e8f60cd670c2549f", 20},
+			},
+			frostOperatorIDs: []operatorInfo{
+				{"5df232b0348928793658dd05dfc6b05a59d11ae8", 3},
+				{"dcc895d32b74b34cef2baa6546884fcda65da1e9", 1},
+				{"28759deda2ea33bd72f68ea2e8f60cd670c2549f", 2},
+				{"f7891d42f3c61a49e0aed1e31b151877c0905cf7", 4},
+			},
+			executingOperator:        "28759deda2ea33bd72f68ea2e8f60cd670c2549f",
+			useFrostOperatorIDs:      true,
 			expectedMemberIDs:        []uint32{3, 1, 2, 4, 2},
 			expectedOperatorPosition: 3,
 			expectedError:            nil,
@@ -379,10 +403,20 @@ func TestMovingFundsAction_GetWalletMembersInfo(t *testing.T) {
 				}
 				walletOperators = append(walletOperators, operatorInfo.Address)
 			}
+			for _, operatorInfo := range test.frostOperatorIDs {
+				err := tbtcChain.SetFrostOperatorID(
+					operatorInfo.Address,
+					operatorInfo.OperatorID,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
 			memberIDs, operatorPosition, err := task.GetWalletMembersInfo(
 				walletOperators,
 				test.executingOperator,
+				test.useFrostOperatorIDs,
 			)
 
 			if diff := deep.Equal(test.expectedMemberIDs, memberIDs); diff != nil {


### PR DESCRIPTION
## Summary
- support P2TR wallet inputs and target wallet outputs for moving-funds transactions
- support P2TR moved-funds sweep inputs/outputs and SPV discovery by actual wallet output script
- add shared wallet-output helpers for legacy aliases vs native FROST wallet IDs
- support multi-seat FROST DKG readiness/result signatures so one operator can announce/sign for all selected local seats

## Testnet state safety
- created checkpoint at /private/tmp/frost-e2e-state-backup-20260607-before-frost-moving-funds-impl before implementation
- checkpoint includes node storage/logs, deployment addresses, current node binary, roundtrip state, secret env copy, and Anvil dump
- did not wipe or replace node storage while preparing this PR

## Tests
- go test ./pkg/protocol/announcer
- go test -tags frost_native ./pkg/tbtc -run 'TestFrostDKG|TestSignAndCollectFrostDKG|TestShouldAcceptFrostDKG|TestExecuteFrostDKG|TestFinalFrostDKG|TestLocalActiveFrost|TestLowestLocalActiveMemberIndex'
- go test -tags frost_native ./pkg/tbtc -run 'TestAssembleMovingFundsTransaction|TestAssembleMovedFundsSweepTransaction|TestAssembleMovedFundsSweepUtxo|TestWalletOutputScript|TestFrostDKG|TestShouldAcceptFrostDKG|TestLocalActiveFrost|TestLowestLocalActiveMemberIndex'
- go test -tags frost_native ./pkg/maintainer/spv -run 'TestIsWalletOutputScript|TestGetUnprovenMovingFundsTransactions|TestGetUnprovenMovedFundsSweepTransactions|TestSubmitMovingFundsProof|TestSubmitMovedFundsSweepProof'
- go test ./pkg/tbtc ./pkg/maintainer/spv ./pkg/bitcoin