### PR TITLE
test(frost/roast): pin cross-language coordinator selection vectors

### DIFF
--- a/pkg/frost/roast/coordinator_test.go
+++ b/pkg/frost/roast/coordinator_test.go
@@ -109,3 +109,64 @@ func TestSelectCoordinator_AffectedBySeed(t *testing.T) {
 		t.Fatal("coordinator did not change for any seed")
 	}
 }
+
+// TestSelectCoordinator_CrossLanguagePinnedVectors pins concrete
+// SelectCoordinator outputs so cross-language agreement with the Rust
+// engine is enforced by tests on both sides. The Rust port of Go's
+// math/rand (pkg/tbtc/signer/src/go_math_rand.rs,
+// select_coordinator_matches_known_keep_core_vectors) asserts these
+// exact values; the FROST/ROAST liveness path depends on every honest
+// node electing the same coordinator for the same attempt.
+//
+// If this test breaks, the Go selection semantics changed (for
+// example a move to math/rand/v2, a different shuffle, or a different
+// seed composition). That is a network-fracturing change: it must be
+// coordinated with the Rust engine and rolled out as a new versioned
+// selection rule, never shipped silently.
+func TestSelectCoordinator_CrossLanguagePinnedVectors(t *testing.T) {
+	const seed = int64(6879463052285329321)
+
+	vectors := []struct {
+		members     []group.MemberIndex
+		seed        int64
+		attempt     uint
+		coordinator group.MemberIndex
+	}{
+		{[]group.MemberIndex{1, 2}, seed, 1, 2},
+		{[]group.MemberIndex{1, 2}, seed, 2, 1},
+		{[]group.MemberIndex{1, 2}, seed, 3, 2},
+		{[]group.MemberIndex{1, 2, 3}, seed, 1, 3},
+		{[]group.MemberIndex{1, 2, 3}, seed, 2, 2},
+		{[]group.MemberIndex{1, 2, 3}, seed, 4, 1},
+		{[]group.MemberIndex{1, 2, 3, 4, 5, 6}, 333, 4, 4},
+	}
+
+	for _, vector := range vectors {
+		actual, err := SelectCoordinator(
+			vector.members,
+			vector.seed,
+			vector.attempt,
+		)
+		if err != nil {
+			t.Fatalf(
+				"selection failed for members [%v] seed [%d] attempt [%d]: [%v]",
+				vector.members,
+				vector.seed,
+				vector.attempt,
+				err,
+			)
+		}
+
+		if actual != vector.coordinator {
+			t.Fatalf(
+				"pinned vector drift for members [%v] seed [%d] attempt [%d]\n"+
+					"expected: [%v]\nactual:   [%v]",
+				vector.members,
+				vector.seed,
+				vector.attempt,
+				vector.coordinator,
+				actual,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #3866 (base: `feat/frost-schnorr-migration-scaffold`).

## What

Adds `TestSelectCoordinator_CrossLanguagePinnedVectors` to `pkg/frost/roast/coordinator_test.go`, pinning concrete `SelectCoordinator` outputs for fixed `(members, seed, attempt)` tuples.

## Why

The Rust signer (PR #4005) ports Go's `math/rand` shuffle semantics in `pkg/tbtc/signer/src/go_math_rand.rs` and pins exact expected coordinators in `select_coordinator_matches_known_keep_core_vectors` (seed `6879463052285329321`). The Go suite, however, only asserted *properties* (determinism, input-order independence, seed/attempt sensitivity) — never concrete outputs.

That asymmetry means a Go-side semantic change (e.g. migrating to `math/rand/v2`, changing the shuffle, or altering the `attemptSeed + attemptNumber` composition) would pass the entire Go suite while silently breaking coordinator agreement with the Rust engine — a network-fracturing liveness failure that would only surface in mixed-version soak testing.

This PR pins the exact same vectors as the Rust test (verified locally that current Go code produces them), plus pins the previously value-free `(seed=333, attempt=4)` case to its concrete result. Either side drifting now fails its own unit suite.

## Review note (no code change)

While verifying parity I noticed the two layers derive the legacy `int64` shuffle seed differently today:

- Go RFC-21 layer: `foldAttemptSeed(SHA256(DkgGroupPublicKey || SessionID || MessageDigest))` (first 8 bytes, BE), 0-based `AttemptNumber`.
- Rust engine strict-mode validation (`roast_attempt_seed_from_message_digest_hex`): first 8 bytes of the **raw message digest**, with a 1-based `attempt_number`.

Not a live bug — keep-core does not yet send `attempt_context` over the FFI, and Rust strict mode is opt-in — but when a later phase wires RFC-21 attempt contexts into the Rust engine's `validate_attempt_context`, the two expected-coordinator computations will disagree unless one side is aligned first. Flagging so it lands on the integration checklist rather than in a testnet incident.