### PR TITLE
test(tbtc/signer): pin concrete coordinator vector in order-independence test

### DIFF
--- a/pkg/tbtc/signer/src/go_math_rand.rs
+++ b/pkg/tbtc/signer/src/go_math_rand.rs
@@ -817,5 +817,11 @@ mod tests {
         let right = select_coordinator_identifier(&[6, 1, 5, 2, 4, 3], 333, 4);
 
         assert_eq!(left, right);
+        // Pin the concrete result, not just the equality: the Go side
+        // (keep-core pkg/frost/roast,
+        // TestSelectCoordinator_CrossLanguagePinnedVectors) asserts the
+        // same value, so either implementation drifting fails its own
+        // suite instead of fracturing coordinator agreement at runtime.
+        assert_eq!(left, Some(4));
     }
 }


### PR DESCRIPTION
Stacked on #4005 (base: `extraction/frost-signer-mirror-2026-05-26`). Companion to #4026 on the Go branch.

## What

`select_coordinator_is_input_order_independent` in `pkg/tbtc/signer/src/go_math_rand.rs` asserted only that two input orderings of the member set agree — not what they agree on. This pins the concrete result (`Some(4)` for `(members=[1..6], seed=333, attempt=4)`), matching the value now pinned on the Go side in `TestSelectCoordinator_CrossLanguagePinnedVectors` (#4026).

## Why

Coordinator selection must agree byte-for-byte between Go's `SelectCoordinator` and this Rust port of Go's `math/rand` shuffle, or honest nodes elect different coordinators and the ROAST liveness path fractures. With the vector sets symmetric across both test suites, either implementation drifting fails its own unit tests instead of surfacing in mixed-version soak testing.

Verified locally: `cargo test --lib go_math_rand` passes, `cargo fmt --check` clean.