### PR TITLE
feat(frost/signing): adopt the tbtc-signer init-time config FFI

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -44,9 +44,14 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // file. The operator setting the path is an explicit demand for config-mode
 // operation, so every failure - unreadable file, validation rejection, or a
 // loaded signer library that predates frost_tbtc_init_signer_config - fails
-// the native engine registration closed. With the path unset this is a
-// no-op and the signer reads TBTC_SIGNER_* from the process environment
-// (the transitional path).
+// the FROST-native engine registration. Precisely: the process keeps
+// running on the legacy bridge with FROST operations reporting unavailable
+// (the registration layer's deliberate safe-by-default posture - it never
+// crashes the binary), a misconfigured signer can therefore never execute
+// FROST operations, and the failure is logged at error level here with the
+// config-mode context in addition to the registration layer's generic
+// warning. With the path unset this is a no-op and the signer reads
+// TBTC_SIGNER_* from the process environment (the transitional path).
 func installConfiguredTBTCSignerInitConfig() error {
 	configPath := strings.TrimSpace(os.Getenv(TBTCSignerInitConfigPathEnv))
 	if configPath == "" {
@@ -55,18 +60,32 @@ func installConfiguredTBTCSignerInitConfig() error {
 
 	configJSON, err := os.ReadFile(configPath)
 	if err != nil {
-		return fmt.Errorf(
+		err = fmt.Errorf(
 			"read tbtc-signer init config [%s]: %w",
 			configPath, err,
 		)
+		registrationLogger.Errorf(
+			"tbtc-signer init config installation failed; FROST-native "+
+				"engine registration fails closed and the process continues "+
+				"on the legacy bridge: [%v]",
+			err,
+		)
+		return err
 	}
 
 	result, err := InstallNativeTBTCSignerConfig(configJSON)
 	if err != nil {
-		return fmt.Errorf(
+		err = fmt.Errorf(
 			"install tbtc-signer init config from [%s]: %w",
 			configPath, err,
 		)
+		registrationLogger.Errorf(
+			"tbtc-signer init config installation failed; FROST-native "+
+				"engine registration fails closed and the process continues "+
+				"on the legacy bridge: [%v]",
+			err,
+		)
+		return err
 	}
 
 	registrationLogger.Infof(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -27,11 +28,56 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 	NativeExecutionFFISigningPrimitive,
 	error,
 ) {
+	if err := installConfiguredTBTCSignerInitConfig(); err != nil {
+		return nil, err
+	}
+
 	if err := registerBuildTaggedNativeFROSTSigningEngine(); err != nil {
 		return nil, err
 	}
 
 	return &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}, nil
+}
+
+// installConfiguredTBTCSignerInitConfig installs the tbtc-signer init-time
+// configuration when TBTC_SIGNER_INIT_CONFIG_PATH points at a JSON config
+// file. The operator setting the path is an explicit demand for config-mode
+// operation, so every failure - unreadable file, validation rejection, or a
+// loaded signer library that predates frost_tbtc_init_signer_config - fails
+// the native engine registration closed. With the path unset this is a
+// no-op and the signer reads TBTC_SIGNER_* from the process environment
+// (the transitional path).
+func installConfiguredTBTCSignerInitConfig() error {
+	configPath := strings.TrimSpace(os.Getenv(TBTCSignerInitConfigPathEnv))
+	if configPath == "" {
+		return nil
+	}
+
+	configJSON, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf(
+			"read tbtc-signer init config [%s]: %w",
+			configPath, err,
+		)
+	}
+
+	result, err := InstallNativeTBTCSignerConfig(configJSON)
+	if err != nil {
+		return fmt.Errorf(
+			"install tbtc-signer init config from [%s]: %w",
+			configPath, err,
+		)
+	}
+
+	registrationLogger.Infof(
+		"installed tbtc-signer init config from [%s]: fingerprint [%s], "+
+			"configured keys [%d], idempotent [%v]",
+		configPath,
+		result.ConfigFingerprint,
+		result.ConfiguredKeyCount,
+		result.Idempotent,
+	)
+	return nil
 }
 
 // buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive is a

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -66,6 +66,10 @@ typedef TbtcSignerResult (*tbtc_build_taproot_tx_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_init_signer_config_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef void (*tbtc_free_buffer_fn)(uint8_t* ptr, size_t len);
 
 static TbtcSignerResult unavailable_tbtc_signer_result(void) {
@@ -219,6 +223,18 @@ static TbtcSignerResult tbtc_signer_build_taproot_tx(const uint8_t* request_ptr,
   }
 
   return build_taproot_tx(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_init_signer_config(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_init_signer_config_fn init_signer_config = (tbtc_init_signer_config_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_init_signer_config"
+  );
+  if (init_signer_config == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return init_signer_config(request_ptr, request_len);
 }
 
 static void tbtc_signer_free_buffer(uint8_t* ptr, size_t len) {
@@ -2374,4 +2390,44 @@ func buildTaggedTBTCSignerResultStatusError(
 	}
 
 	return nil
+}
+
+func callBuildTaggedTBTCSignerInitSignerConfig(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"InitSignerConfig",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_init_signer_config(requestPtr, requestLen)
+		},
+	)
+}
+
+// InstallNativeTBTCSignerConfig installs the tbtc-signer's init-time
+// operational configuration via frost_tbtc_init_signer_config. configJSON is
+// passed through verbatim: the Rust signer owns the schema and validation
+// (unknown fields rejected, enforcement-gated policy combinations validated
+// at install, environment ignored wholesale once installed) and the install
+// is idempotent for an identical payload while a conflicting re-install is
+// rejected. Must be called before the first state-touching signer operation.
+// Returns an ErrNativeCryptographyUnavailable-classed error when the loaded
+// signer library predates the symbol.
+func InstallNativeTBTCSignerConfig(
+	configJSON []byte,
+) (*NativeTBTCSignerInitConfigResult, error) {
+	responsePayload, err := callBuildTaggedTBTCSignerInitSignerConfig(configJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &NativeTBTCSignerInitConfigResult{}
+	if err := json.Unmarshal(responsePayload, result); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"InitSignerConfig",
+			fmt.Sprintf("response decode failed: [%v]", err),
+		)
+	}
+
+	return result, nil
 }

--- a/pkg/frost/signing/native_tbtc_signer_init_config.go
+++ b/pkg/frost/signing/native_tbtc_signer_init_config.go
@@ -1,0 +1,26 @@
+package signing
+
+// TBTCSignerInitConfigPathEnv optionally points at a JSON file holding the
+// tbtc-signer init-time operational configuration. When set, the
+// configuration is installed via frost_tbtc_init_signer_config during native
+// FROST engine registration, BEFORE any other signer call; a read, parse,
+// validation, or symbol-availability failure fails the registration closed.
+// When unset, the signer falls back to reading TBTC_SIGNER_* from the
+// process environment (the transitional path).
+//
+// The JSON schema is owned by the Rust signer (InitSignerConfigRequest in
+// pkg/tbtc/signer/src/api.rs): field names are the lowercased TBTC_SIGNER_*
+// suffixes, unknown fields are rejected, and once installed the process
+// environment is ignored wholesale for covered knobs. Secrets never ride
+// this channel: TBTC_SIGNER_STATE_ENCRYPTION_KEY_HEX stays on the dedicated
+// env/command key-provider path.
+const TBTCSignerInitConfigPathEnv = "TBTC_SIGNER_INIT_CONFIG_PATH"
+
+// NativeTBTCSignerInitConfigResult captures the response of an init-time
+// signer-config installation (frost_tbtc_init_signer_config).
+type NativeTBTCSignerInitConfigResult struct {
+	Installed          bool   `json:"installed"`
+	Idempotent         bool   `json:"idempotent"`
+	ConfigFingerprint  string `json:"config_fingerprint"`
+	ConfiguredKeyCount uint32 `json:"configured_key_count"`
+}

--- a/pkg/frost/signing/native_tbtc_signer_init_config.go
+++ b/pkg/frost/signing/native_tbtc_signer_init_config.go
@@ -13,7 +13,9 @@ package signing
 // suffixes, unknown fields are rejected, and once installed the process
 // environment is ignored wholesale for covered knobs. Secrets never ride
 // this channel: TBTC_SIGNER_STATE_ENCRYPTION_KEY_HEX stays on the dedicated
-// env/command key-provider path.
+// env/command key-provider path. The file may carry the state_key_command
+// execution spec, so restrict its permissions to the operator account
+// (e.g. 0600), as with the signer state path.
 const TBTCSignerInitConfigPathEnv = "TBTC_SIGNER_INIT_CONFIG_PATH"
 
 // NativeTBTCSignerInitConfigResult captures the response of an init-time

--- a/pkg/frost/signing/native_tbtc_signer_init_config_default.go
+++ b/pkg/frost/signing/native_tbtc_signer_init_config_default.go
@@ -1,0 +1,17 @@
+//go:build !(frost_native && frost_tbtc_signer && cgo)
+
+package signing
+
+import "fmt"
+
+// InstallNativeTBTCSignerConfig is unavailable in builds without the
+// tbtc-signer cgo bridge; see the frost_native && frost_tbtc_signer && cgo
+// variant for the real implementation and contract.
+func InstallNativeTBTCSignerConfig(
+	_ []byte,
+) (*NativeTBTCSignerInitConfigResult, error) {
+	return nil, fmt.Errorf(
+		"%w: tbtc-signer bridge operation [InitSignerConfig] is unavailable in this build",
+		ErrNativeCryptographyUnavailable,
+	)
+}

--- a/pkg/frost/signing/native_tbtc_signer_init_config_default_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_init_config_default_test.go
@@ -1,0 +1,18 @@
+//go:build !(frost_native && frost_tbtc_signer && cgo)
+
+package signing
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestInstallNativeTBTCSignerConfig_UnavailableWithoutBridge(t *testing.T) {
+	result, err := InstallNativeTBTCSignerConfig([]byte(`{}`))
+	if result != nil {
+		t.Fatalf("expected nil result, got %+v", result)
+	}
+	if !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf("expected ErrNativeCryptographyUnavailable, got %v", err)
+	}
+}


### PR DESCRIPTION
Go-host adoption of `frost_tbtc_init_signer_config` — the companion to keep-core#4037 (which added the init-time config FFI to the Rust signer on the mirror branch). Hosts can now install the signer's operational configuration once at startup instead of exporting ~40 `TBTC_SIGNER_*` process environment variables.

## What this adds

- **`InstallNativeTBTCSignerConfig(configJSON)`** — passes operator JSON through verbatim; the Rust signer owns the schema and all validation (unknown fields rejected, enforcement-gated policy combinations validated at install with rollback, environment ignored wholesale once installed, idempotent re-install by fingerprint). Go stays a transport: no schema duplication, no drift surface.
- **`TBTC_SIGNER_INIT_CONFIG_PATH`** — when set, the JSON file is installed during native FROST engine registration, *before* any other signer call. Setting the path is an explicit demand for config-mode operation, so every failure — unreadable file, validation rejection, or a loaded signer library that predates the symbol — **fails registration closed**. Unset, registration proceeds on the environment-fallback path exactly as today (zero behavior change for existing deployments). Net ops effect: one pointer variable replaces forty value variables; secrets stay on the dedicated env/command key-provider channel.

## Cross-branch compatibility (why this is safe to land now)

The bridge resolves every symbol per call via `dlsym(RTLD_DEFAULT, …)` with graceful degradation — the established pattern in this file. A signer library **without** the new symbol returns the existing `ErrNativeCryptographyUnavailable` classification rather than failing the link, so:

- path unset + old library → status quo;
- path unset + new library → status quo (env fallback, with the signer's own one-time production warning suggesting the init FFI);
- path set + new library → config installed, logged with fingerprint/key-count/idempotency;
- path set + old library → registration fails closed with a precise error (operator demanded config mode; the deployment is wrong).

## Build-shape verification

Three configurations verified: default tags (stub + unit test asserting the unavailable classification), `frost_native` alone (the registration wiring compiles against the stub), and `frost_native && frost_tbtc_signer && cgo` (real cgo bridge, compile + vet — running bridge tests requires the built signer library, which lives on the mirror branch until promotion). `gofmt`, `go vet`, and the full `pkg/frost` test suite are clean under default tags.

## Out of scope

keep-client TOML config plumbing (a first-class config section feeding this) — deliberately left for the team's config-schema conventions; the file-pointer wiring gives ops a complete adoption path today without touching the client config surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)