### PR TITLE
feat(frost/signing): terminate on unmet init-config demand

### DIFF
--- a/pkg/frost/signing/backend.go
+++ b/pkg/frost/signing/backend.go
@@ -198,9 +198,18 @@ func UnregisterNativeExecutionAdapter() {
 //
 // On default builds, this is a no-op.
 // On `frost_native` builds, this registers the tagged native adapter.
+//
+// When TBTC_SIGNER_INIT_CONFIG_PATH is set, the operator demands config-mode
+// FROST operation and this function does not return on failure: any state in
+// which the FROST-native engine did not come up (either registration leg
+// failed, or the build cannot register one at all) terminates the process.
+// See enforceNativeInitConfigDemand for the decision record. With the path
+// unset, registration failures keep the safe-by-default posture and the
+// legacy bridge remains available.
 func RegisterNativeExecutionAdapterForBuild() {
 	registerNativeExecutionAdapterForBuild()
 	RegisterNativeExecutionFFISigningPrimitiveForBuild()
+	enforceNativeInitConfigDemand()
 }
 
 func currentNativeExecutionBackend() (ExecutionBackend, error) {

--- a/pkg/frost/signing/native_ffi_primitive_registration.go
+++ b/pkg/frost/signing/native_ffi_primitive_registration.go
@@ -26,7 +26,11 @@ func setLastRegistrationError(err error) {
 // or when no registration has been attempted yet. Callers that want to fail
 // startup on a registration error should check this after invoking
 // `RegisterNativeExecutionAdapterForBuild` rather than relying on the
-// previously panicking registration helpers themselves.
+// previously panicking registration helpers themselves. Note that when
+// TBTC_SIGNER_INIT_CONFIG_PATH is set, registration enforces this itself:
+// an unmet config-mode demand is process-fatal (see
+// enforceNativeInitConfigDemand), so callers only need this check for
+// env-fallback-mode policies of their own.
 func LastNativeRegistrationError() error {
 	registrationErrorMu.RLock()
 	defer registrationErrorMu.RUnlock()

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -44,14 +44,14 @@ func defaultNativeExecutionFFISigningPrimitiveProviderForBuild() (
 // file. The operator setting the path is an explicit demand for config-mode
 // operation, so every failure - unreadable file, validation rejection, or a
 // loaded signer library that predates frost_tbtc_init_signer_config - fails
-// the FROST-native engine registration. Precisely: the process keeps
-// running on the legacy bridge with FROST operations reporting unavailable
-// (the registration layer's deliberate safe-by-default posture - it never
-// crashes the binary), a misconfigured signer can therefore never execute
-// FROST operations, and the failure is logged at error level here with the
-// config-mode context in addition to the registration layer's generic
-// warning. With the path unset this is a no-op and the signer reads
-// TBTC_SIGNER_* from the process environment (the transitional path).
+// the FROST-native engine registration, and the demand enforcement at the
+// end of registration (enforceNativeInitConfigDemand) then terminates the
+// process: a node that cannot honor its demanded config must not run
+// half-alive on the legacy bridge. The failure is logged at error level
+// here with the config-mode context before the fatal exit so the cause is
+// on record. With the path unset this is a no-op and the signer reads
+// TBTC_SIGNER_* from the process environment (the transitional path), where
+// registration failures keep the safe-by-default degrade posture.
 func installConfiguredTBTCSignerInitConfig() error {
 	configPath := strings.TrimSpace(os.Getenv(TBTCSignerInitConfigPathEnv))
 	if configPath == "" {
@@ -66,8 +66,9 @@ func installConfiguredTBTCSignerInitConfig() error {
 		)
 		registrationLogger.Errorf(
 			"tbtc-signer init config installation failed; FROST-native "+
-				"engine registration fails closed and the process continues "+
-				"on the legacy bridge: [%v]",
+				"engine registration fails closed and the process will "+
+				"terminate at the end of registration (config-mode demand "+
+				"unmet): [%v]",
 			err,
 		)
 		return err
@@ -81,8 +82,9 @@ func installConfiguredTBTCSignerInitConfig() error {
 		)
 		registrationLogger.Errorf(
 			"tbtc-signer init config installation failed; FROST-native "+
-				"engine registration fails closed and the process continues "+
-				"on the legacy bridge: [%v]",
+				"engine registration fails closed and the process will "+
+				"terminate at the end of registration (config-mode demand "+
+				"unmet): [%v]",
 			err,
 		)
 		return err

--- a/pkg/frost/signing/native_init_config_demand.go
+++ b/pkg/frost/signing/native_init_config_demand.go
@@ -83,11 +83,15 @@ func enforceNativeInitConfigDemand() {
 		return
 	}
 
+	// No recorded error here can mean an earlier leg's failure was
+	// overwritten by a later leg's success, so point at the warnings
+	// emitted at failure time instead of claiming a cause.
 	fatalNativeRegistrationExit(
 		"%s is set [%s]: config-mode FROST operation is demanded but "+
 			"native registration did not complete (native adapter "+
 			"registered [%v], native FFI executor registered [%v]); "+
-			"terminating instead of continuing on the legacy bridge",
+			"terminating instead of continuing on the legacy bridge - "+
+			"check the registration warnings logged above for the cause",
 		TBTCSignerInitConfigPathEnv,
 		configPath,
 		adapterRegistered,

--- a/pkg/frost/signing/native_init_config_demand.go
+++ b/pkg/frost/signing/native_init_config_demand.go
@@ -1,0 +1,96 @@
+package signing
+
+import (
+	"os"
+	"strings"
+)
+
+// fatalNativeRegistrationExit terminates the process after logging the
+// formatted message at fatal level. It is a package-level variable only so
+// the demand-enforcement tests can observe the abort instead of dying with
+// the test binary; production code must never override it.
+var fatalNativeRegistrationExit = func(format string, args ...interface{}) {
+	registrationLogger.Fatalf(format, args...)
+}
+
+// enforceNativeInitConfigDemand terminates the process when the operator
+// demanded config-mode FROST operation (TBTC_SIGNER_INIT_CONFIG_PATH set)
+// and this binary did not bring up the FROST-native engine. With the path
+// unset this is a no-op and the registration layer keeps its safe-by-default
+// posture: failures degrade to the legacy bridge with a warning.
+//
+// Decision (2026-06-12, recorded in the Phase 5 gates-doc Decision Log):
+// setting the path is an explicit demand, so ANY state in which the demand
+// is unmet is process-fatal, in every profile and environment, covering the
+// whole failure family:
+//
+//   - the config-install leg failed (unreadable file, parse/validation
+//     rejection, init-time policy or attestation-gate failure, or a loaded
+//     signer library that predates frost_tbtc_init_signer_config),
+//   - the engine-registration leg failed after a successful install,
+//   - the binary cannot honor the demand at all (built without the
+//     frost_native build tag, so no native registration ever runs).
+//
+// Fatality is deliberately NOT conditional on the configured profile: an
+// unreadable config file cannot reveal its profile, and the signer treats a
+// missing profile as production (production-by-omission), so the only
+// non-circular rule is to enforce whenever the path is set. Uniform
+// semantics also mean testnet rehearses exactly the behavior production
+// will have.
+//
+// The checks are positive (registered state), not merely error-presence:
+// LastNativeRegistrationError is reset by later registration legs, so the
+// absence of a recorded error does not prove the engine came up.
+func enforceNativeInitConfigDemand() {
+	configPath := strings.TrimSpace(os.Getenv(TBTCSignerInitConfigPathEnv))
+	if configPath == "" {
+		return
+	}
+
+	if err := LastNativeRegistrationError(); err != nil {
+		fatalNativeRegistrationExit(
+			"%s is set [%s]: config-mode FROST operation is demanded but "+
+				"native registration failed: [%v]; terminating instead of "+
+				"continuing on the legacy bridge (unset %s to run in the "+
+				"transitional env-fallback mode)",
+			TBTCSignerInitConfigPathEnv,
+			configPath,
+			err,
+			TBTCSignerInitConfigPathEnv,
+		)
+		return
+	}
+
+	executionBackendMutex.RLock()
+	adapterRegistered := nativeExecutionAdapter != nil
+	executorRegistered := nativeExecutionFFIExecutor != nil
+	executionBackendMutex.RUnlock()
+
+	if adapterRegistered && executorRegistered {
+		return
+	}
+
+	if !buildHasNativeFROSTRegistration {
+		fatalNativeRegistrationExit(
+			"%s is set [%s]: config-mode FROST operation is demanded but "+
+				"this binary was built without the frost_native build tag "+
+				"and cannot honor it; terminating (deploy a frost_native "+
+				"binary, or unset %s to run this one)",
+			TBTCSignerInitConfigPathEnv,
+			configPath,
+			TBTCSignerInitConfigPathEnv,
+		)
+		return
+	}
+
+	fatalNativeRegistrationExit(
+		"%s is set [%s]: config-mode FROST operation is demanded but "+
+			"native registration did not complete (native adapter "+
+			"registered [%v], native FFI executor registered [%v]); "+
+			"terminating instead of continuing on the legacy bridge",
+		TBTCSignerInitConfigPathEnv,
+		configPath,
+		adapterRegistered,
+		executorRegistered,
+	)
+}

--- a/pkg/frost/signing/native_init_config_demand_flavor_default.go
+++ b/pkg/frost/signing/native_init_config_demand_flavor_default.go
@@ -1,0 +1,8 @@
+//go:build !frost_native
+
+package signing
+
+// buildHasNativeFROSTRegistration reports whether this build flavor runs
+// native FROST registration at init time. Used only to pick the precise
+// fatal message when an init-config demand cannot be honored.
+const buildHasNativeFROSTRegistration = false

--- a/pkg/frost/signing/native_init_config_demand_flavor_frost_native.go
+++ b/pkg/frost/signing/native_init_config_demand_flavor_frost_native.go
@@ -1,0 +1,8 @@
+//go:build frost_native
+
+package signing
+
+// buildHasNativeFROSTRegistration reports whether this build flavor runs
+// native FROST registration at init time. Used only to pick the precise
+// fatal message when an init-config demand cannot be honored.
+const buildHasNativeFROSTRegistration = true

--- a/pkg/frost/signing/native_init_config_demand_test.go
+++ b/pkg/frost/signing/native_init_config_demand_test.go
@@ -1,0 +1,266 @@
+package signing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/net"
+)
+
+// Tests in this file mutate process-global registration state and the fatal
+// seam; per the package convention they must not use t.Parallel.
+
+type capturedFatalCalls struct {
+	messages []string
+}
+
+// captureFatalNativeRegistrationExit swaps the fatal seam for a recorder so
+// the demand enforcement can be observed without killing the test binary.
+func captureFatalNativeRegistrationExit(t *testing.T) *capturedFatalCalls {
+	t.Helper()
+
+	capture := &capturedFatalCalls{}
+	previous := fatalNativeRegistrationExit
+	fatalNativeRegistrationExit = func(format string, args ...interface{}) {
+		capture.messages = append(capture.messages, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		fatalNativeRegistrationExit = previous
+	})
+
+	return capture
+}
+
+// resetNativeRegistrationStateForDemandTest snapshots the process-global
+// registration state, clears it for the test, and restores it on cleanup.
+func resetNativeRegistrationStateForDemandTest(t *testing.T) {
+	t.Helper()
+
+	executionBackendMutex.Lock()
+	previousAdapter := nativeExecutionAdapter
+	previousExecutor := nativeExecutionFFIExecutor
+	nativeExecutionAdapter = nil
+	nativeExecutionFFIExecutor = nil
+	executionBackendMutex.Unlock()
+
+	registrationErrorMu.Lock()
+	previousError := lastRegistrationError
+	lastRegistrationError = nil
+	registrationErrorMu.Unlock()
+
+	t.Cleanup(func() {
+		executionBackendMutex.Lock()
+		nativeExecutionAdapter = previousAdapter
+		nativeExecutionFFIExecutor = previousExecutor
+		executionBackendMutex.Unlock()
+
+		setLastRegistrationError(previousError)
+	})
+}
+
+type demandTestExecutionStub struct{}
+
+func (dtes *demandTestExecutionStub) Execute(
+	_ context.Context,
+	_ log.StandardLogger,
+	_ *Request,
+) (*Result, error) {
+	return nil, errors.New("demand test stub is not executable")
+}
+
+func (dtes *demandTestExecutionStub) RegisterUnmarshallers(
+	_ net.BroadcastChannel,
+) {
+}
+
+func registerDemandTestNativeState(t *testing.T) {
+	t.Helper()
+
+	if err := RegisterNativeExecutionAdapter(&demandTestExecutionStub{}); err != nil {
+		t.Fatalf("failed to register stub native adapter: [%v]", err)
+	}
+	if err := RegisterNativeExecutionFFIExecutor(&demandTestExecutionStub{}); err != nil {
+		t.Fatalf("failed to register stub FFI executor: [%v]", err)
+	}
+}
+
+func TestEnforceNativeInitConfigDemand_PathUnset_KeepsDegradePosture(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+	t.Setenv(TBTCSignerInitConfigPathEnv, "")
+
+	// Even with a recorded registration failure and nothing registered, an
+	// unset path means env-fallback mode: registration failures degrade to
+	// the legacy bridge and never abort the process.
+	setLastRegistrationError(errors.New("simulated registration failure"))
+
+	enforceNativeInitConfigDemand()
+
+	if len(capture.messages) != 0 {
+		t.Fatalf(
+			"expected no fatal exit with the path unset, got: %q",
+			capture.messages,
+		)
+	}
+}
+
+func TestEnforceNativeInitConfigDemand_PathWhitespace_KeepsDegradePosture(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+	t.Setenv(TBTCSignerInitConfigPathEnv, "   ")
+
+	setLastRegistrationError(errors.New("simulated registration failure"))
+
+	enforceNativeInitConfigDemand()
+
+	if len(capture.messages) != 0 {
+		t.Fatalf(
+			"expected no fatal exit with a whitespace-only path, got: %q",
+			capture.messages,
+		)
+	}
+}
+
+func TestEnforceNativeInitConfigDemand_RegistrationError_IsFatal(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+	t.Setenv(TBTCSignerInitConfigPathEnv, "/etc/keep/tbtc-signer-config.json")
+
+	setLastRegistrationError(errors.New("simulated install rejection"))
+
+	enforceNativeInitConfigDemand()
+
+	if len(capture.messages) != 1 {
+		t.Fatalf(
+			"expected exactly one fatal exit, got %d: %q",
+			len(capture.messages), capture.messages,
+		)
+	}
+
+	message := capture.messages[0]
+	for _, want := range []string{
+		TBTCSignerInitConfigPathEnv,
+		"/etc/keep/tbtc-signer-config.json",
+		"simulated install rejection",
+	} {
+		if !strings.Contains(message, want) {
+			t.Errorf("fatal message missing %q: %q", want, message)
+		}
+	}
+}
+
+func TestEnforceNativeInitConfigDemand_NothingRegistered_IsFatal(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+	t.Setenv(TBTCSignerInitConfigPathEnv, "/etc/keep/tbtc-signer-config.json")
+
+	enforceNativeInitConfigDemand()
+
+	if len(capture.messages) != 1 {
+		t.Fatalf(
+			"expected exactly one fatal exit, got %d: %q",
+			len(capture.messages), capture.messages,
+		)
+	}
+
+	message := capture.messages[0]
+	if !strings.Contains(message, TBTCSignerInitConfigPathEnv) {
+		t.Errorf(
+			"fatal message missing %q: %q",
+			TBTCSignerInitConfigPathEnv, message,
+		)
+	}
+
+	// The message names the precise cause per build flavor: a binary without
+	// frost_native can never honor the demand; a frost_native binary reports
+	// which registration leg is missing.
+	if buildHasNativeFROSTRegistration {
+		if !strings.Contains(message, "did not complete") {
+			t.Errorf(
+				"fatal message missing registration-incomplete cause: %q",
+				message,
+			)
+		}
+	} else {
+		if !strings.Contains(message, "without the frost_native build tag") {
+			t.Errorf(
+				"fatal message missing wrong-binary cause: %q",
+				message,
+			)
+		}
+	}
+}
+
+func TestEnforceNativeInitConfigDemand_PartialRegistration_IsFatal(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+	t.Setenv(TBTCSignerInitConfigPathEnv, "/etc/keep/tbtc-signer-config.json")
+
+	// Only the FFI executor comes up; the native adapter leg is missing.
+	// The demand requires the complete bring-up, so this is still fatal.
+	if err := RegisterNativeExecutionFFIExecutor(&demandTestExecutionStub{}); err != nil {
+		t.Fatalf("failed to register stub FFI executor: [%v]", err)
+	}
+
+	enforceNativeInitConfigDemand()
+
+	if len(capture.messages) != 1 {
+		t.Fatalf(
+			"expected exactly one fatal exit, got %d: %q",
+			len(capture.messages), capture.messages,
+		)
+	}
+}
+
+func TestEnforceNativeInitConfigDemand_FullyRegistered_NoFatal(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+	t.Setenv(TBTCSignerInitConfigPathEnv, "/etc/keep/tbtc-signer-config.json")
+
+	registerDemandTestNativeState(t)
+
+	enforceNativeInitConfigDemand()
+
+	if len(capture.messages) != 0 {
+		t.Fatalf(
+			"expected no fatal exit with the native engine fully registered, "+
+				"got: %q",
+			capture.messages,
+		)
+	}
+}
+
+func TestRegisterNativeExecutionAdapterForBuild_EnforcesInitConfigDemand(t *testing.T) {
+	resetNativeRegistrationStateForDemandTest(t)
+	capture := captureFatalNativeRegistrationExit(t)
+
+	// A nonexistent config file: on frost_native builds the install leg
+	// fails and records a registration error; on default builds no native
+	// registration runs at all. Both states must be fatal under a set path,
+	// pinning that the enforcement is wired into the registration entry
+	// point for every build flavor.
+	t.Setenv(
+		TBTCSignerInitConfigPathEnv,
+		t.TempDir()+"/nonexistent-tbtc-signer-config.json",
+	)
+
+	RegisterNativeExecutionAdapterForBuild()
+
+	if len(capture.messages) != 1 {
+		t.Fatalf(
+			"expected exactly one fatal exit, got %d: %q",
+			len(capture.messages), capture.messages,
+		)
+	}
+
+	if !strings.Contains(capture.messages[0], TBTCSignerInitConfigPathEnv) {
+		t.Errorf(
+			"fatal message missing %q: %q",
+			TBTCSignerInitConfigPathEnv, capture.messages[0],
+		)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_init_config.go
+++ b/pkg/frost/signing/native_tbtc_signer_init_config.go
@@ -4,9 +4,12 @@ package signing
 // tbtc-signer init-time operational configuration. When set, the
 // configuration is installed via frost_tbtc_init_signer_config during native
 // FROST engine registration, BEFORE any other signer call; a read, parse,
-// validation, or symbol-availability failure fails the registration closed.
-// When unset, the signer falls back to reading TBTC_SIGNER_* from the
-// process environment (the transitional path).
+// validation, or symbol-availability failure fails the registration closed
+// and TERMINATES THE PROCESS at the end of registration, in every profile
+// and build flavor (see enforceNativeInitConfigDemand for the decision
+// record and the full failure family). When unset, the signer falls back to
+// reading TBTC_SIGNER_* from the process environment (the transitional
+// path), where registration failures degrade to the legacy bridge instead.
 //
 // The JSON schema is owned by the Rust signer (InitSignerConfigRequest in
 // pkg/tbtc/signer/src/api.rs): field names are the lowercased TBTC_SIGNER_*


### PR DESCRIPTION
## Decision being implemented

Team decision (2026-06-12, recorded in the Phase 5 gates-doc Decision Log on the mirror branch): setting `TBTC_SIGNER_INIT_CONFIG_PATH` demands config-mode FROST operation, so **any state in which the FROST-native engine did not come up under a set path is process-fatal**, in every profile and build flavor. This replaces #4041's continue-on-the-legacy-bridge degradation and resolves the open team question posted there.

Why fatal, in one paragraph: this code ships to production only when FROST is a production duty, so "running but FROST-dead" is the dangerous silent state — a half-alive node erodes FROST wallet fault budgets invisibly, while threshold redundancy is designed to absorb loud, full, bounded outages. Fatality is not profile-conditional because an unreadable config file cannot reveal its profile and a missing profile means production (production-by-omission); path-set is the only non-circular trigger. Uniform semantics also mean testnet rehearses exactly what production will do.

## What this covers (the whole failure family)

`enforceNativeInitConfigDemand` runs at the end of `RegisterNativeExecutionAdapterForBuild` and terminates on:
- config-install failure (unreadable file, parse/validation rejection, init-time policy or attestation-gate failure, library predating the init symbol),
- engine-registration failure after a successful install,
- a binary built without `frost_native` (can never honor the demand).

The checks are **positive** (native adapter + FFI executor actually registered under the mutex), not merely error-presence: later registration legs reset `LastNativeRegistrationError`, so a nil error does not prove bring-up. Env-fallback mode (path unset) keeps the safe-by-default degrade posture, byte-for-byte.

## Verification

- 7 new tests (untagged, run in default CI) pin: no fatal with path unset/whitespace even under registration errors; fatal with cause context on recorded errors; flavor-aware wrong-binary vs incomplete-bringup messages; partial registration (executor without adapter) still fatal; fully-registered no-fatal; the registration entry point fires enforcement in every build flavor.
- `gofmt` clean; `go vet` under all three tag shapes (default, `frost_native`, `frost_native,frost_tbtc_signer`); full `./pkg/frost/...` suite green.
- The fatal seam (`fatalNativeRegistrationExit`) exists only so tests can observe the abort; production never overrides it.

## Notes for reviewers

- A non-node binary (tooling, other packages' test binaries) that imports `pkg/frost/signing` with the env var exported and unsatisfiable will now die at init. That is the decided semantics: the variable demands FROST; a binary that cannot honor it says so loudly. CI does not set the variable.
- Mirror-side docs PR records the decision in the gates-doc Decision Log and adds runbook prerequisite 7 (canary config pushes node-by-node; attestation-rotation cadence becomes enforced-by-restart-failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)