### PR TITLE
feat(tbtc/clientinfo): RFC-21 Annex B implied-f liveness alerting

### DIFF
--- a/docs/development/frost-roast-retry-rollout.adoc
+++ b/docs/development/frost-roast-retry-rollout.adoc
@@ -118,6 +118,47 @@ RFC-21 design and is enforced in
   paths are retained through Phase 6 and 7 deliberately to make
   this rollback bit-for-bit safe.
 
+== Interim liveness alerting (RFC-21 Annex B)
+
+Until Phase-7 t-of-included finalize removes the per-attempt veto,
+the serial retry loop's liveness envelope assumes `f <= 2` byzantine
+members (see RFC-21 Annex B for the sampling arithmetic). The node
+exports three gauges via the `/metrics` endpoint implementing the
+annex's required alerting:
+
+[cols="2,3"]
+|===
+| Gauge | Meaning
+
+| `signing_attempt_rolling_success_rate`
+| Per-attempt success rate over the last 50 terminal attempt
+  outcomes observed by this node (all wallets aggregated; one
+  observation per network-wide attempt).
+
+| `signing_attempt_rolling_sample_count`
+| Number of outcomes currently in the rolling window (caps at 50).
+
+| `signing_attempt_implied_f_alert`
+| `1` when the window is full and the success rate is below `0.14` -
+  observed failure rates imply `f >= 3` behaviour under the Annex B
+  model. Alert on this value being sustained, not on a single
+  scrape: the window slides per attempt, so consecutive scrapes are
+  correlated.
+|===
+
+For independent full windows the default threshold false-alarms on
+roughly 4% of windows at a true `f = 2` and detects roughly 64% of
+windows at `f = 3` (97% at `f >= 4`; the staggered-silence profile
+that fails attempts deterministically is detected with certainty).
+Benign attempt failures (network flakes, restarts) depress the rate
+below the model's prediction, so once the Phase 5 baseline
+calibration worksheet records the benign failure rate, revisit the
+threshold (`SigningLivenessAlertSuccessRateThreshold` in
+`pkg/clientinfo/signing_liveness.go`). The alert is advisory: its
+operational response is the Annex B escalation path (investigate
+member inactivity, operator-inactivity claims, wallet retirement),
+not an automatic rollback.
+
 == FROST DKG digest format coupling
 
 The FROST DKG result digest is a cross-repo wire-format contract

--- a/docs/development/frost-roast-retry-rollout.adoc
+++ b/docs/development/frost-roast-retry-rollout.adoc
@@ -124,21 +124,24 @@ Until Phase-7 t-of-included finalize removes the per-attempt veto,
 the serial retry loop's liveness envelope assumes `f <= 2` byzantine
 members (see RFC-21 Annex B for the sampling arithmetic). The node
 exports three gauges via the `/metrics` endpoint implementing the
-annex's required alerting:
+annex's required alerting. The names below are the exported series
+names: the metrics registry prepends the `performance_` application
+prefix to every gauge it registers, so alert queries must use the
+prefixed form.
 
 [cols="2,3"]
 |===
-| Gauge | Meaning
+| Exported gauge | Meaning
 
-| `signing_attempt_rolling_success_rate`
+| `performance_signing_attempt_rolling_success_rate`
 | Per-attempt success rate over the last 50 terminal attempt
   outcomes observed by this node (all wallets aggregated; one
   observation per network-wide attempt).
 
-| `signing_attempt_rolling_sample_count`
+| `performance_signing_attempt_rolling_sample_count`
 | Number of outcomes currently in the rolling window (caps at 50).
 
-| `signing_attempt_implied_f_alert`
+| `performance_signing_attempt_implied_f_alert`
 | `1` when the window is full and the success rate is below `0.14` -
   observed failure rates imply `f >= 3` behaviour under the Annex B
   model. Alert on this value being sustained, not on a single

--- a/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
+++ b/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
@@ -1017,10 +1017,10 @@ Recommendation codified by this annex:
 . Until then, the `signingAttemptsLimit = 5` / `f ≤ 2` assumption and
   this annex's tables are the documented envelope; alerting should
   fire when observed attempt failure rates imply `f ≥ 3` behaviour.
-  (Implemented: the `signing_attempt_rolling_success_rate` /
-  `signing_attempt_implied_f_alert` gauges fed by the retry loop's
-  attempt-outcome reporter; thresholds and operator guidance in
-  `docs/development/frost-roast-retry-rollout.adoc` and
+  (Implemented: the `performance_signing_attempt_rolling_success_rate`
+  / `performance_signing_attempt_implied_f_alert` gauges fed by the
+  retry loop's attempt-outcome reporter; thresholds and operator
+  guidance in `docs/development/frost-roast-retry-rollout.adoc` and
   `pkg/clientinfo/signing_liveness.go`.)
 
 == References

--- a/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
+++ b/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
@@ -1017,6 +1017,11 @@ Recommendation codified by this annex:
 . Until then, the `signingAttemptsLimit = 5` / `f ≤ 2` assumption and
   this annex's tables are the documented envelope; alerting should
   fire when observed attempt failure rates imply `f ≥ 3` behaviour.
+  (Implemented: the `signing_attempt_rolling_success_rate` /
+  `signing_attempt_implied_f_alert` gauges fed by the retry loop's
+  attempt-outcome reporter; thresholds and operator guidance in
+  `docs/development/frost-roast-retry-rollout.adoc` and
+  `pkg/clientinfo/signing_liveness.go`.)
 
 == References
 

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -48,6 +48,12 @@ type PerformanceMetrics struct {
 	// Gauges track current values (like queue sizes)
 	gaugesMutex sync.RWMutex
 	gauges      map[string]*gauge
+
+	// signingLiveness is the process-wide signing-attempt liveness tracker
+	// (RFC-21 Annex B implied-f alerting), shared by all wallet signing
+	// executors so their attempts feed one rolling window.
+	signingLivenessOnce sync.Once
+	signingLiveness     *SigningAttemptLivenessTracker
 }
 
 // Ensure PerformanceMetrics implements PerformanceMetricsRecorder
@@ -312,6 +318,9 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricIncomingMessageQueueSize,
 		MetricMessageHandlerQueueSize,
 		MetricSigningAttemptsPerOperation,
+		MetricSigningAttemptRollingSuccessRate,
+		MetricSigningAttemptRollingSampleCount,
+		MetricSigningAttemptImpliedFAlert,
 		MetricCPUUtilization,
 		MetricMemoryUsageMB,
 		MetricGoroutineCount,
@@ -565,6 +574,18 @@ func (pm *PerformanceMetrics) updateMachineStats() {
 			pm.SetGauge(MetricSwapUtilizationPercent, 0)
 		}
 	}
+}
+
+// SigningAttemptLivenessTracker returns the process-wide signing-attempt
+// liveness tracker bound to this metrics instance, creating it on first
+// use. Signing executors of every wallet share the returned tracker so all
+// attempt outcomes feed one rolling window.
+func (pm *PerformanceMetrics) SigningAttemptLivenessTracker() *SigningAttemptLivenessTracker {
+	pm.signingLivenessOnce.Do(func() {
+		pm.signingLiveness = NewSigningAttemptLivenessTracker(pm)
+	})
+
+	return pm.signingLiveness
 }
 
 // NoOpPerformanceMetrics is a no-op implementation of PerformanceMetricsRecorder

--- a/pkg/clientinfo/signing_liveness.go
+++ b/pkg/clientinfo/signing_liveness.go
@@ -91,8 +91,16 @@ func NewSigningAttemptLivenessTracker(
 
 // RecordAttemptOutcome records the terminal outcome of one network-wide
 // signing attempt and refreshes the exported gauges.
+//
+// The gauges are published while holding the tracker mutex so concurrent
+// recordings (executors of different wallets share one tracker) cannot
+// publish out of order and leave a stale rate or alert value standing
+// until the next attempt. The nesting tracker.mutex -> recorder gauge
+// lock is the only acquisition order between the two; the recorder never
+// calls back into the tracker.
 func (salt *SigningAttemptLivenessTracker) RecordAttemptOutcome(success bool) {
 	salt.mutex.Lock()
+	defer salt.mutex.Unlock()
 
 	if salt.filled == len(salt.window) {
 		if salt.window[salt.next] {
@@ -112,8 +120,6 @@ func (salt *SigningAttemptLivenessTracker) RecordAttemptOutcome(success bool) {
 	successRate := float64(salt.successCount) / float64(samples)
 	alert := samples >= salt.minimumSamples &&
 		successRate < salt.alertThreshold
-
-	salt.mutex.Unlock()
 
 	salt.recorder.SetGauge(MetricSigningAttemptRollingSuccessRate, successRate)
 	salt.recorder.SetGauge(

--- a/pkg/clientinfo/signing_liveness.go
+++ b/pkg/clientinfo/signing_liveness.go
@@ -44,6 +44,12 @@ const (
 // the raw rolling window so operators can apply their own thresholds; the
 // alert gauge encodes the documented Annex B default (1 = observed attempt
 // failure rates imply f >= 3 under the sampling model).
+//
+// These constants are the registry source keys, NOT the exported series
+// names: ObserveApplicationSource prepends the "performance_" application
+// prefix, so the series operators query are
+// performance_signing_attempt_rolling_success_rate and friends. Operator
+// docs must use the prefixed form.
 const (
 	MetricSigningAttemptRollingSuccessRate = "signing_attempt_rolling_success_rate"
 	MetricSigningAttemptRollingSampleCount = "signing_attempt_rolling_sample_count"
@@ -81,10 +87,18 @@ type SigningAttemptLivenessTracker struct {
 func NewSigningAttemptLivenessTracker(
 	recorder SigningLivenessGaugeSetter,
 ) *SigningAttemptLivenessTracker {
+	// The sample count can never exceed the window size, so a minimum
+	// above it would make the alert silently unreachable; clamp to keep
+	// the alert attainable if the constants ever diverge.
+	minimumSamples := SigningLivenessMinimumSamples
+	if minimumSamples > SigningLivenessWindowSize {
+		minimumSamples = SigningLivenessWindowSize
+	}
+
 	return &SigningAttemptLivenessTracker{
 		recorder:       recorder,
 		window:         make([]bool, SigningLivenessWindowSize),
-		minimumSamples: SigningLivenessMinimumSamples,
+		minimumSamples: minimumSamples,
 		alertThreshold: SigningLivenessAlertSuccessRateThreshold,
 	}
 }

--- a/pkg/clientinfo/signing_liveness.go
+++ b/pkg/clientinfo/signing_liveness.go
@@ -1,0 +1,129 @@
+package clientinfo
+
+import "sync"
+
+// RFC-21 Annex B codifies the liveness envelope of the serial signing
+// retry loop for the production wallet shape (n = 100, t = 51): an attempt
+// succeeds only when the drawn t-subset contains no byzantine member, so
+// the per-attempt success probability against f byzantine-but-announcing
+// members is
+//
+//	f=1: 0.490    f=2: 0.238    f=3: 0.114    f=5: 0.025
+//
+// and the deployed signingAttemptsLimit = 5 rationale assumes f <= 2. The
+// annex requires alerting "when observed attempt failure rates imply f >= 3
+// behaviour" as the interim measure until Phase-7 t-of-included finalize
+// removes the per-attempt veto. The defaults below implement that rule.
+const (
+	// SigningLivenessWindowSize is the number of most recent attempt
+	// outcomes the rolling window holds.
+	SigningLivenessWindowSize = 50
+
+	// SigningLivenessMinimumSamples is the minimum number of recorded
+	// outcomes before the implied-f alert may fire. Below this the rate
+	// gauge is still exported but the alert stays at 0.
+	SigningLivenessMinimumSamples = 50
+
+	// SigningLivenessAlertSuccessRateThreshold is the rolling per-attempt
+	// success rate below which the implied-f alert fires. 0.14 sits between
+	// the f=2 (0.238) and f=3 (0.114) expectations. For independent
+	// 50-attempt windows (normal approximation of the Annex B i.i.d.
+	// model): a true f=2 fleet false-alarms on ~4% of windows, a true f=3
+	// fleet alerts on ~64%, f>=4 on ~97%, and the staggered-silence
+	// adversary profile (deterministic attempt failure) alerts with
+	// certainty. Two caveats for tuning against the Phase 5 baseline
+	// calibration worksheet: benign failures (network flakes, restarts)
+	// depress the observed rate below the model, so a measured benign
+	// failure rate may justify raising the threshold; and the window
+	// slides per attempt, so consecutive evaluations are correlated -
+	// operators should alert on a sustained value, not a single scrape.
+	SigningLivenessAlertSuccessRateThreshold = 0.14
+)
+
+// Signing-attempt liveness gauges. The rate and sample-count gauges expose
+// the raw rolling window so operators can apply their own thresholds; the
+// alert gauge encodes the documented Annex B default (1 = observed attempt
+// failure rates imply f >= 3 under the sampling model).
+const (
+	MetricSigningAttemptRollingSuccessRate = "signing_attempt_rolling_success_rate"
+	MetricSigningAttemptRollingSampleCount = "signing_attempt_rolling_sample_count"
+	MetricSigningAttemptImpliedFAlert      = "signing_attempt_implied_f_alert"
+)
+
+// SigningLivenessGaugeSetter is the minimal recorder surface the tracker
+// needs.
+type SigningLivenessGaugeSetter interface {
+	SetGauge(name string, value float64)
+}
+
+// SigningAttemptLivenessTracker keeps a rolling window of signing-attempt
+// outcomes and exports the Annex B implied-f liveness gauges. Outcomes are
+// node-level aggregates: a node serving several wallets interleaves their
+// attempts in one window, which keeps gauge cardinality flat at the cost of
+// diluting a single compromised wallet's signal among healthy ones - if any
+// served wallet's group exhibits f >= 3 behaviour, its operations still
+// drag the aggregate rate toward the alert threshold.
+type SigningAttemptLivenessTracker struct {
+	mutex    sync.Mutex
+	recorder SigningLivenessGaugeSetter
+
+	window       []bool
+	next         int
+	filled       int
+	successCount int
+
+	minimumSamples int
+	alertThreshold float64
+}
+
+// NewSigningAttemptLivenessTracker creates a tracker with the documented
+// Annex B defaults, exporting through the given recorder.
+func NewSigningAttemptLivenessTracker(
+	recorder SigningLivenessGaugeSetter,
+) *SigningAttemptLivenessTracker {
+	return &SigningAttemptLivenessTracker{
+		recorder:       recorder,
+		window:         make([]bool, SigningLivenessWindowSize),
+		minimumSamples: SigningLivenessMinimumSamples,
+		alertThreshold: SigningLivenessAlertSuccessRateThreshold,
+	}
+}
+
+// RecordAttemptOutcome records the terminal outcome of one network-wide
+// signing attempt and refreshes the exported gauges.
+func (salt *SigningAttemptLivenessTracker) RecordAttemptOutcome(success bool) {
+	salt.mutex.Lock()
+
+	if salt.filled == len(salt.window) {
+		if salt.window[salt.next] {
+			salt.successCount--
+		}
+	} else {
+		salt.filled++
+	}
+
+	salt.window[salt.next] = success
+	if success {
+		salt.successCount++
+	}
+	salt.next = (salt.next + 1) % len(salt.window)
+
+	samples := salt.filled
+	successRate := float64(salt.successCount) / float64(samples)
+	alert := samples >= salt.minimumSamples &&
+		successRate < salt.alertThreshold
+
+	salt.mutex.Unlock()
+
+	salt.recorder.SetGauge(MetricSigningAttemptRollingSuccessRate, successRate)
+	salt.recorder.SetGauge(
+		MetricSigningAttemptRollingSampleCount,
+		float64(samples),
+	)
+
+	alertValue := 0.0
+	if alert {
+		alertValue = 1.0
+	}
+	salt.recorder.SetGauge(MetricSigningAttemptImpliedFAlert, alertValue)
+}

--- a/pkg/clientinfo/signing_liveness_test.go
+++ b/pkg/clientinfo/signing_liveness_test.go
@@ -1,0 +1,119 @@
+package clientinfo
+
+import "testing"
+
+type gaugeCaptureRecorder struct {
+	values map[string]float64
+}
+
+func newGaugeCaptureRecorder() *gaugeCaptureRecorder {
+	return &gaugeCaptureRecorder{values: make(map[string]float64)}
+}
+
+func (gcr *gaugeCaptureRecorder) SetGauge(name string, value float64) {
+	gcr.values[name] = value
+}
+
+func recordOutcomes(
+	tracker *SigningAttemptLivenessTracker,
+	successes int,
+	failures int,
+) {
+	for i := 0; i < failures; i++ {
+		tracker.RecordAttemptOutcome(false)
+	}
+	for i := 0; i < successes; i++ {
+		tracker.RecordAttemptOutcome(true)
+	}
+}
+
+func assertGauge(
+	t *testing.T,
+	recorder *gaugeCaptureRecorder,
+	name string,
+	expected float64,
+) {
+	t.Helper()
+
+	actual, exists := recorder.values[name]
+	if !exists {
+		t.Errorf("gauge [%v] was never set", name)
+		return
+	}
+	if actual != expected {
+		t.Errorf(
+			"unexpected value of gauge [%v]\nexpected: [%v]\nactual:   [%v]",
+			name,
+			expected,
+			actual,
+		)
+	}
+}
+
+func TestSigningAttemptLivenessTracker_BelowMinimumSamples_NoAlert(t *testing.T) {
+	recorder := newGaugeCaptureRecorder()
+	tracker := NewSigningAttemptLivenessTracker(recorder)
+
+	// One short of the minimum sample count: even a zero success rate must
+	// not fire the alert yet.
+	recordOutcomes(tracker, 0, SigningLivenessMinimumSamples-1)
+
+	assertGauge(t, recorder, MetricSigningAttemptRollingSuccessRate, 0)
+	assertGauge(
+		t,
+		recorder,
+		MetricSigningAttemptRollingSampleCount,
+		float64(SigningLivenessMinimumSamples-1),
+	)
+	assertGauge(t, recorder, MetricSigningAttemptImpliedFAlert, 0)
+}
+
+func TestSigningAttemptLivenessTracker_AlertFiresBelowThreshold(t *testing.T) {
+	recorder := newGaugeCaptureRecorder()
+	tracker := NewSigningAttemptLivenessTracker(recorder)
+
+	// 6 successes of 50 = 0.12, below the 0.14 threshold with a full
+	// window: the implied-f alert fires.
+	recordOutcomes(tracker, 6, 44)
+
+	assertGauge(t, recorder, MetricSigningAttemptRollingSuccessRate, 0.12)
+	assertGauge(t, recorder, MetricSigningAttemptRollingSampleCount, 50)
+	assertGauge(t, recorder, MetricSigningAttemptImpliedFAlert, 1)
+}
+
+func TestSigningAttemptLivenessTracker_ThresholdBoundary_NoAlert(t *testing.T) {
+	recorder := newGaugeCaptureRecorder()
+	tracker := NewSigningAttemptLivenessTracker(recorder)
+
+	// 7 successes of 50 = 0.14 exactly: the alert requires the rate to be
+	// strictly below the threshold, so it must not fire. (IEEE 754
+	// division is correctly rounded, so 7.0/50.0 and the 0.14 literal are
+	// the same float64.)
+	recordOutcomes(tracker, 7, 43)
+
+	assertGauge(t, recorder, MetricSigningAttemptRollingSuccessRate, 0.14)
+	assertGauge(t, recorder, MetricSigningAttemptRollingSampleCount, 50)
+	assertGauge(t, recorder, MetricSigningAttemptImpliedFAlert, 0)
+}
+
+func TestSigningAttemptLivenessTracker_WindowRollover(t *testing.T) {
+	recorder := newGaugeCaptureRecorder()
+	tracker := NewSigningAttemptLivenessTracker(recorder)
+
+	// A full window of failures fires the alert...
+	recordOutcomes(tracker, 0, SigningLivenessWindowSize)
+	assertGauge(t, recorder, MetricSigningAttemptImpliedFAlert, 1)
+
+	// ...and a subsequent full window of successes evicts every failure:
+	// the rate recovers to 1, the sample count stays capped at the window
+	// size, and the alert clears.
+	recordOutcomes(tracker, SigningLivenessWindowSize, 0)
+	assertGauge(t, recorder, MetricSigningAttemptRollingSuccessRate, 1)
+	assertGauge(
+		t,
+		recorder,
+		MetricSigningAttemptRollingSampleCount,
+		float64(SigningLivenessWindowSize),
+	)
+	assertGauge(t, recorder, MetricSigningAttemptImpliedFAlert, 0)
+}

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -93,6 +93,17 @@ type signingExecutor struct {
 		SetGauge(name string, value float64)
 		RecordDuration(name string, duration time.Duration)
 	}
+
+	// livenessTracker is optional and feeds the RFC-21 Annex B implied-f
+	// signing-attempt liveness gauges. It is shared across all wallets'
+	// executors of this node (acquired from the metrics recorder).
+	livenessTracker *clientinfo.SigningAttemptLivenessTracker
+}
+
+// signingLivenessTrackerProvider is implemented by metrics recorders that
+// own the process-wide signing-attempt liveness tracker.
+type signingLivenessTrackerProvider interface {
+	SigningAttemptLivenessTracker() *clientinfo.SigningAttemptLivenessTracker
 }
 
 var _ schnorrWalletSigningExecutor = (*signingExecutor)(nil)
@@ -336,6 +347,16 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 				doneCheck,
 			)
 
+			// Every local signer of this wallet observes the same
+			// network-wide attempts, so exactly one of them reports
+			// outcomes to the liveness tracker to avoid multiplying
+			// observations of a single attempt.
+			if signer == se.signers[0] && se.livenessTracker != nil {
+				retryLoop.setAttemptOutcomeReporter(
+					se.livenessTracker.RecordAttemptOutcome,
+				)
+			}
+
 			// Set up the loop timeout signal. This context is associated with
 			// all attempts and gets canceled in three situations:
 			// - one of the attempts failed with an error,
@@ -569,4 +590,11 @@ func (se *signingExecutor) setMetricsRecorder(recorder interface {
 	RecordDuration(name string, duration time.Duration)
 }) {
 	se.metricsRecorder = recorder
+
+	// Recorders owning the process-wide signing-attempt liveness tracker
+	// (RFC-21 Annex B implied-f alerting) share it with this executor;
+	// no-op recorders simply leave the tracker disabled.
+	if provider, ok := recorder.(signingLivenessTrackerProvider); ok {
+		se.livenessTracker = provider.SigningAttemptLivenessTracker()
+	}
 }

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -112,6 +112,17 @@ type signingRetryLoop struct {
 	// ROAST-driven implementation behind the frost_roast_retry
 	// build tag once AggregateBundle production is wired upstream.
 	participantSelector signingParticipantSelector
+
+	// attemptOutcomeReporter, when non-nil, receives the terminal outcome
+	// of every network-wide signing attempt this loop observes (RFC-21
+	// Annex B implied-f liveness alerting). An outcome is reported when an
+	// attempt reaches a terminal disposition: minority readiness after a
+	// completed announcement, a failed protocol run, a failed done-check
+	// exchange, or success. Mechanical iterations that never sample the
+	// group - block-timing skips, local announcement errors, context
+	// cancellation - are deliberately not reported, so the rate feeding
+	// the Annex B sampling model is not diluted by local noise.
+	attemptOutcomeReporter func(success bool)
 }
 
 func newSigningRetryLoop(
@@ -136,6 +147,20 @@ func newSigningRetryLoop(
 		attemptSeed:             signingAttemptSeed(message),
 		doneCheck:               doneCheck,
 		participantSelector:     defaultSigningParticipantSelector(),
+	}
+}
+
+// setAttemptOutcomeReporter installs the attempt-outcome reporter. See the
+// attemptOutcomeReporter field for the reporting contract.
+func (srl *signingRetryLoop) setAttemptOutcomeReporter(
+	reporter func(success bool),
+) {
+	srl.attemptOutcomeReporter = reporter
+}
+
+func (srl *signingRetryLoop) reportAttemptOutcome(success bool) {
+	if srl.attemptOutcomeReporter != nil {
+		srl.attemptOutcomeReporter(success)
 	}
 }
 
@@ -315,6 +340,7 @@ func (srl *signingRetryLoop) start(
 				len(readyMembersIndexes),
 				unreadyMembersIndexes,
 			)
+			srl.reportAttemptOutcome(false)
 			continue
 		}
 
@@ -378,6 +404,7 @@ func (srl *signingRetryLoop) start(
 					srl.attemptCounter,
 					err,
 				)
+				srl.reportAttemptOutcome(false)
 				continue
 			}
 
@@ -403,6 +430,11 @@ func (srl *signingRetryLoop) start(
 					srl.attemptCounter,
 					err,
 				)
+				// A failed done signal is a local fault, but this loop
+				// abandons the attempt here, so from this node's sampler
+				// the attempt did not complete; the baseline calibration
+				// absorbs this as benign noise.
+				srl.reportAttemptOutcome(false)
 				continue
 			}
 		} else {
@@ -423,6 +455,7 @@ func (srl *signingRetryLoop) start(
 				srl.attemptCounter,
 				err,
 			)
+			srl.reportAttemptOutcome(false)
 			continue
 		}
 
@@ -430,6 +463,8 @@ func (srl *signingRetryLoop) start(
 			activeMembers:   readyMembersIndexes,
 			inactiveMembers: unreadyMembersIndexes,
 		}
+
+		srl.reportAttemptOutcome(true)
 
 		return &signingRetryLoopResult{
 			result:              result,

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -120,8 +120,10 @@ type signingRetryLoop struct {
 	// completed announcement, a failed protocol run, a failed done-check
 	// exchange, or success. Mechanical iterations that never sample the
 	// group - block-timing skips, local announcement errors, context
-	// cancellation - are deliberately not reported, so the rate feeding
-	// the Annex B sampling model is not diluted by local noise.
+	// cancellation, and a members-selection error (which terminates the
+	// whole loop, not the attempt) - are deliberately not reported, so
+	// the rate feeding the Annex B sampling model is not diluted by
+	// local noise.
 	attemptOutcomeReporter func(success bool)
 }
 

--- a/pkg/tbtc/signing_loop_test.go
+++ b/pkg/tbtc/signing_loop_test.go
@@ -984,3 +984,106 @@ func (msdc *mockSigningDoneCheck) signalDone(
 func (msdc *mockSigningDoneCheck) waitUntilAllDone(ctx context.Context) (*signing.Result, uint64, error) {
 	return msdc.waitUntilAllDoneOutcomeFn(msdc.currentAttemptNumber)
 }
+
+func TestSigningRetryLoop_AttemptOutcomeReporting(t *testing.T) {
+	message := big.NewInt(100)
+
+	groupParameters := &GroupParameters{
+		GroupSize:       10,
+		HonestThreshold: 6,
+	}
+
+	signingGroupOperators := chain.Addresses{
+		"address-1", "address-2", "address-8", "address-4", "address-2",
+		"address-6", "address-7", "address-8", "address-9", "address-8",
+	}
+
+	signingGroupMembersIndexes := make([]group.MemberIndex, 0)
+	for i := range signingGroupOperators {
+		signingGroupMembersIndexes = append(
+			signingGroupMembersIndexes,
+			group.MemberIndex(i+1),
+		)
+	}
+
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(
+			sessionID string,
+		) ([]group.MemberIndex, error) {
+			return signingGroupMembersIndexes, nil
+		},
+	}
+
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(
+			attemptNumber uint64,
+		) (*signing.Result, uint64, error) {
+			if attemptNumber == 1 {
+				return nil, 0, fmt.Errorf("done check timeout")
+			}
+			return testResult, 250, nil
+		},
+	}
+
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		message,
+		200,
+		group.MemberIndex(1),
+		signingGroupOperators,
+		groupParameters,
+		announcer,
+		doneCheck,
+	)
+
+	reportedOutcomes := make([]bool, 0)
+	retryLoop.setAttemptOutcomeReporter(func(success bool) {
+		reportedOutcomes = append(reportedOutcomes, success)
+	})
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelCtx()
+
+	result, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error {
+			return nil
+		},
+		func() (uint64, error) {
+			return 200, nil
+		},
+		func(params *signingAttemptParams) (*signing.Result, uint64, error) {
+			// The first attempt's protocol run fails; subsequent ones
+			// succeed. Regardless of whether this member is included in
+			// the second attempt's subset, the attempt outcome must be
+			// reported exactly once per attempt: failure for the first,
+			// success for the second.
+			if params.number == 1 {
+				return nil, 0, fmt.Errorf("protocol failure")
+			}
+			return testResult, 250, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected retry loop error: [%v]", err)
+	}
+	if result == nil {
+		t.Fatal("expected a non-nil retry loop result")
+	}
+
+	expectedOutcomes := []bool{false, true}
+	if !reflect.DeepEqual(expectedOutcomes, reportedOutcomes) {
+		t.Errorf(
+			"unexpected reported attempt outcomes\n"+
+				"expected: [%v]\n"+
+				"actual:   [%v]",
+			expectedOutcomes,
+			reportedOutcomes,
+		)
+	}
+}


### PR DESCRIPTION
## What

Implements the interim liveness measure RFC-21 Annex B requires: "alerting should fire when observed attempt failure rates imply f ≥ 3 behaviour" — the regime where the serial retry loop's 5-attempt budget fails with better-than-even odds and the structural fix (Phase-7 t-of-included finalize, gates-doc decision 5) does not exist yet. Scheduled as the pre-canary alerting item in the decision memo / gates doc.

## How

- **Reporter in the retry loop** (`pkg/tbtc/signing_loop.go`): every terminal attempt outcome is reported — minority readiness after a completed announcement, failed protocol run, failed done-check exchange, or success. Mechanical iterations that never sample the group (block-timing skips, local announcement errors, context cancellation, loop-terminal members-selection errors) are deliberately excluded so the rate feeding the Annex B sampling model is not diluted by local noise.
- **One observation per network attempt**: only the first local signer per wallet reports (all local signers of a wallet observe the same attempts).
- **Process-wide rolling window** (`pkg/clientinfo/signing_liveness.go`): 50 outcomes, shared across wallets via the `PerformanceMetrics` instance; three gauges registered at boot. The metrics registry prepends the `performance_` application prefix, so the **exported series operators must query** are:
  - `performance_signing_attempt_rolling_success_rate`
  - `performance_signing_attempt_rolling_sample_count`
  - `performance_signing_attempt_implied_f_alert` — 1 when the full window's rate < 0.14, between the f=2 expectation (0.238) and f=3 expectation (0.114) of the Annex B table (n=100, t=51). Per independent window: ~4% false-alarm at true f=2, ~64% detection at f=3, ~97% at f≥4; the staggered-silence profile (deterministic attempt failure) is detected with certainty.

## Operator guidance

New rollout-doc section documents the exported gauge names, the alert-on-sustained-value caveat (the window slides per attempt, consecutive scrapes are correlated), and the threshold-tuning instruction once the Phase 5 baseline calibration worksheet records the benign failure rate. Annex B now points at the implementation.

## Review follow-ups applied

- `d119fbd7a`: gauges published under the tracker mutex — concurrent recordings could publish out of order and leave a stale rate/alert standing until the next attempt.
- `93b37d3e8`: docs use the exported `performance_`-prefixed series names (Codex/Gemini finding — the bare source keys would have made documented alert queries silently match nothing); const block documents the source-key-vs-exported-name distinction; constructor clamps `minimumSamples` to the window size so the alert cannot become silently unreachable.

## Verification

- Tracker unit tests: below-minimum-samples no-alert, alert below threshold, exact-threshold boundary (7/50 = 0.14 does not fire; IEEE 754 correctly-rounded division makes this deterministic), window rollover/eviction.
- Retry-loop test pins the reported outcome sequence `[false, true]` for a failed-then-successful attempt using the existing mock harness.
- `gofmt`/`go vet` clean (default + `frost_roast_retry` shapes); full `pkg/tbtc` (146s) + `pkg/clientinfo` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)