### PR TITLE
docs(rfc-21): record Phase 6 completion; home the readiness manifest in keep-core

### DIFF
--- a/docs/development/frost-readiness-manifest.adoc
+++ b/docs/development/frost-readiness-manifest.adoc
@@ -1,0 +1,55 @@
+= FROST Readiness Manifest
+
+*Status:* Living document - gate states change only with attached
+evidence.
+*Owner:* Threshold Labs
+*Update discipline:* a gate flips from `missing-no-go` to `present`
+only when the supporting evidence is linked in the same change. No
+early flips, no flips on intention (RFC-21, "Phase 7: Readiness
+manifest evidence"). Reviewers should reject a flip whose evidence
+link does not substantiate the stated condition.
+
+This manifest was originally planned for the tBTC monorepo's
+`docs/operations/` directory. The monorepo signer is retired and
+`keep-core` is canonical, so the manifest lives here. Production
+binaries adopt the `frost_roast_retry` build tag once the gates
+below read `present`
+(`docs/development/frost-roast-retry-rollout.adoc`).
+
+== Gates
+
+[cols="2,1,4,3"]
+|===
+| Gate | State | Flip conditions | Evidence
+
+| ROAST retry
+| `missing-no-go`
+| (1) RFC-21 Phase 6 call-site migration shipped - *met*, see the
+  Phase 6 status section of RFC-21 (one live receive loop migrated;
+  the generic two-round exchange was removed as unreachable in
+  commit `1c692bf03`). +
+  (2) The `frost_roast_retry` integration suite has been run against
+  a real testnet deployment - *pending*. +
+  (3) Verified migration off FrostUniFFIV1 signer material across
+  production signers - *pending* (the DKG-pubkey extraction helper
+  rejects V1 material, so ROAST retry silently falls back to legacy
+  on V1-bearing nodes; see the rollout doc).
+| Phase 6 status: RFC-21. Testnet run: none yet. V1 migration: none
+  yet.
+
+| Transition evidence
+| `missing-no-go`
+| Same testnet-run condition as ROAST retry, exercised end to end:
+  coordinator-produced `TransitionMessage` bundles (signed-body
+  envelopes per the evidence wire format) observed driving
+  next-attempt participant selection on testnet, with the
+  byte-preservation contract intact across at least one node
+  restart.
+| None yet.
+|===
+
+== Change log
+
+* 2026-06-12: manifest created in keep-core (moved from the retired
+  monorepo plan); both gates recorded `missing-no-go` with Phase 6
+  completion noted as met.

--- a/docs/development/frost-roast-retry-rollout.adoc
+++ b/docs/development/frost-roast-retry-rollout.adoc
@@ -91,9 +91,12 @@ RFC-21 design and is enforced in
 . *Build the binary with the tag.* Internal builds and CI
   pipelines already exercise the tag via
   `go test -tags 'frost_roast_retry' ./pkg/frost/... ./pkg/tbtc/...`.
-  Production binaries adopt the tag once the readiness manifest
-  in the cross-repo tBTC monorepo's `docs/operations/` directory
-  flips to `present`.
+  Production binaries adopt the tag once the readiness manifest at
+  `docs/development/frost-readiness-manifest.adoc` flips to
+  `present`. (The manifest was originally planned for the tBTC
+  monorepo's `docs/operations/` directory; the monorepo signer is
+  retired and keep-core is canonical, so the manifest lives in this
+  repository.)
 . *Verify FROST/UniFFI V1 migration.* The DKG-pubkey extraction
   helper rejects FrostUniFFIV1 signer material. The Phase 7
   manifest flip is gated on verified migration off V1 across
@@ -135,6 +138,7 @@ cleanup.
 == Cross-references
 
 * RFC-21: `docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc`
+* Readiness manifest: `docs/development/frost-readiness-manifest.adoc`
 * Build-tag scaffolding: `pkg/frost/signing/roast_retry_registration_*.go`
 * Orchestration entry point: `pkg/frost/signing/roast_retry_orchestration.go`
 * Executor-adapter wiring: `pkg/frost/signing/native_ffi_executor_adapter.go`

--- a/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
+++ b/docs/rfc/rfc-21-roast-coordinator-retry-and-transition-evidence.adoc
@@ -483,17 +483,45 @@ risk-management mechanism.
 
 === Phase 6: Migrate all signing call sites
 
-* Migrate *all three* signing call sites onto the adapter in a single
-  coordinated change:
-** `collectNativeFROSTRoundOneMessages`
-** `collectNativeFROSTRoundTwoMessages`
-** `collectBuildTaggedTBTCSignerRoundContributionMessages`
-+
-The three flows share one attempt context per session; migrating
-them together preserves the round-to-round evidence binding within a
-session.
+*Status (2026-06-12): the call-site migration is complete.* The plan
+below originally named three receive loops; the tree evolved under
+it and the honest accounting is:
+
+* `collectBuildTaggedTBTCSignerRoundContributionMessages` - the only
+  receive loop with a production consumer - is migrated: it takes
+  its `EvidenceRecorder` from the roast-retry registry
+  (`roastRetryRecorderForCollect`, NoOp fallback preserving Phase 2
+  semantics when nothing is registered), binds contributions to the
+  session's attempt context via the `attemptContextHash` message
+  field, and submits its end-of-collect snapshot through
+  `submitSnapshotIfActive` into `Coordinator.RecordEvidence`.
+* `collectNativeFROSTRoundOneMessages` and
+  `collectNativeFROSTRoundTwoMessages` were *deleted*, not migrated:
+  commit `1c692bf03` (2026-06-07, "Remove unreachable generic FROST
+  protocol scaffolding") removed the generic two-round exchange they
+  belonged to, because no production flow reached it -
+  `frost-uniffi-v1` payloads execute on the legacy bridge and
+  `frost-tbtc-signer-v1` uses the coarse signing flow. The
+  single-coordinated-change constraint ("the three flows share one
+  attempt context per session") is therefore satisfied by
+  subtraction: exactly one flow exists, and it is fully bound.
+* The surrounding orchestration shipped with the migration: the
+  executor adapter's Phase 6.3 entry
+  (`attemptRoastRetryOrchestrationFromRequest` →
+  `BeginOrchestrationForSession`), the static-vs-runtime error
+  taxonomy, the Phase 7.1 coordinator-side bundle production
+  (`maybeProduceTransitionBundle` in the orchestration cleanup), and
+  the Phase 7.2 bundle-consuming participant selector
+  (`roastSigningParticipantSelector` behind the `frost_roast_retry`
+  tag, legacy-shuffle fallback when no bundle is present).
+
+Two exit items remain deliberately open, gated on Phase 7's manifest
+flip - not on more code:
+
 * Once the legacy `EvaluateRetryParticipantsForSigning` has no
-  callers, delete it. (Key-generation legacy retry stays.)
+  callers, delete it. (Key-generation legacy retry stays.) It still
+  has one caller by design: `legacySigningParticipantSelector` is
+  the retained rollback path through Phases 6-7.
 * Remove the `frost_roast_retry` build tag; the new retry path is
   unconditional once Phase 7's manifest gate flips.
 
@@ -503,6 +531,12 @@ session.
   transition evidence from `missing-no-go` to `present` once Phase 6
   ships and the integration test suite has been run against a real
   testnet.
+* The manifest lives at
+  `docs/development/frost-readiness-manifest.adoc` in this
+  repository. (It was originally planned for the tBTC monorepo's
+  `docs/operations/` directory; the monorepo signer is retired and
+  keep-core is canonical, so the manifest moved here with the same
+  update discipline.)
 * As with every readiness gate in this repo, the manifest is updated
   only when the supporting evidence is attached. The RFC does not
   promise an early flip.
@@ -1029,10 +1063,11 @@ Recommendation codified by this annex:
   https://github.com/threshold-network/keep-core/pull/3866.
 * L5 paired error-code change: `tlabs-xyz/tbtc#425` (Rust producer) +
   `threshold-network/keep-core#3961` (Go consumer).
-* Receive-loop drop sites:
-** `pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go:973`
-** `pkg/frost/signing/native_frost_protocol_frost_native.go:568`
-** `pkg/frost/signing/native_frost_protocol_frost_native.go:650`
+* Receive-loop drop site (the generic two-round exchange's two
+  further sites were removed with the unreachable scaffolding in
+  commit `1c692bf03`; see Phase 6 status):
+** `pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go`
+   (`collectBuildTaggedTBTCSignerRoundContributionMessages`)
 * Byte-identical retry shuffle:
 ** `pkg/frost/retry/retry.go`
 ** `pkg/tecdsa/retry/retry.go`


### PR DESCRIPTION
## What

Two things Phase 6 needed that were not code:

1. **The RFC's Phase 6 section now records reality.** The plan named three receive loops to migrate "in a single coordinated change." The tree evolved under the plan: `collectBuildTaggedTBTCSignerRoundContributionMessages` — the only loop with a production consumer — is fully migrated (registry-sourced `EvidenceRecorder`, `attemptContextHash` binding, end-of-collect snapshot submission into `Coordinator.RecordEvidence`, all verified in code), while `collectNativeFROSTRoundOneMessages`/`RoundTwoMessages` were **deleted** with the unreachable generic two-round exchange (commit `1c692bf03`, 2026-06-07) — uniffi-v1 payloads run on the legacy bridge and tbtc-signer-v1 uses the coarse flow, so nothing reached them. The shared-attempt-context constraint is satisfied by subtraction. The surrounding orchestration (Phase 6.3 executor-adapter entry, static-vs-runtime error taxonomy, Phase 7.1 bundle production, Phase 7.2 bundle-consuming selector) shipped with it. The two open exit items (legacy `EvaluateRetryParticipantsForSigning` deletion; `frost_roast_retry` tag removal) are restated as gated on Phase 7's manifest flip, with the legacy evaluator's surviving caller identified as the deliberate rollback path.

2. **The readiness manifest gets a home in the canonical repo** (`docs/development/frost-readiness-manifest.adoc`). It was planned for the tBTC monorepo's `docs/operations/` directory; the monorepo signer is retired and keep-core is canonical, so Phase 7's flip target now actually exists here. Both gates (ROAST retry, transition evidence) recorded `missing-no-go` with explicit flip conditions: Phase 6 shipped (met), real-testnet integration run (pending), verified FrostUniFFIV1 migration (pending). Update discipline restated: flips only with attached evidence.

Also fixes the RFC's stale receive-loop drop-site references and repoints the rollout doc at the new manifest.

## Why now

Phase 7's only remaining inputs are operational (testnet run, V1-migration verification), not code. Leaving Phase 6 documented as future work is exactly the claims-drift failure mode prior reviews of this stack flagged; this PR closes it with commit-level evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)