### PR TITLE
docs(tbtc/signer): record the init-config fatality decision

### DIFF
--- a/pkg/tbtc/signer/docs/roast-phase-5-rollout-runbook.md
+++ b/pkg/tbtc/signer/docs/roast-phase-5-rollout-runbook.md
@@ -55,7 +55,12 @@ Before Stage 1 canary:
    yesterday can be rejected after an upgrade, so upgrade + config
    changes are canaried together. Note this also enforces prerequisite
    6's attestation cadence: a node restarted with expired attestation
-   material will not start until re-attested.
+   material will not start until re-attested. Scope the variable to
+   the signer service unit (e.g. the systemd unit's `Environment=`),
+   never the host-global environment: every binary importing the
+   signing package honors the same demand, so a host-global export
+   plus a broken config would also kill maintenance tooling and test
+   binaries run on that host.
 
 ## 3. Rollout Stages
 

--- a/pkg/tbtc/signer/docs/roast-phase-5-rollout-runbook.md
+++ b/pkg/tbtc/signer/docs/roast-phase-5-rollout-runbook.md
@@ -44,6 +44,18 @@ Before Stage 1 canary:
    is deliberately unsupported: it would require a dedicated,
    narrowly-scoped FFI, never general config mutation, which would
    reopen the split-brain risk the immutable install design closed.
+7. Config-file pushes are canaried node-by-node: an unmet init-config
+   demand (`TBTC_SIGNER_INIT_CONFIG_PATH` set but the FROST-native
+   engine did not come up) terminates the process in every profile
+   (gates-doc Decision Log, decision 7). A bad config template pushed
+   fleet-wide therefore produces a visible, correlated outage instead
+   of silent capability loss - push to a single node, confirm a clean
+   start, then roll out. The same applies to signer-library upgrades
+   that tighten init-time validation: a config that installed
+   yesterday can be rejected after an upgrade, so upgrade + config
+   changes are canaried together. Note this also enforces prerequisite
+   6's attestation cadence: a node restarted with expired attestation
+   material will not start until re-attested.
 
 ## 3. Rollout Stages
 

--- a/pkg/tbtc/signer/docs/roast-phase-5-security-rollout-gates.md
+++ b/pkg/tbtc/signer/docs/roast-phase-5-security-rollout-gates.md
@@ -141,6 +141,30 @@ architecture questions:
    interactive session flow is designed t-of-included-native from the
    start; no first-t-responsive retrofit of the transitional finalize
    contract is needed or wanted.
+7. **Init-config demand is process-fatal.** Setting
+   `TBTC_SIGNER_INIT_CONFIG_PATH` demands config-mode FROST operation;
+   any state in which the FROST-native engine does not come up under a
+   set path - config-install failure, engine-registration failure
+   after a successful install, or a binary built without
+   `frost_native` - terminates the process, in every profile and
+   environment. This replaces the earlier
+   continue-on-the-legacy-bridge degradation adopted in keep-core
+   PR #4041. Rationale: this code ships to production only when FROST
+   is a production duty, so "running but FROST-dead" is the dangerous
+   state - a silently half-alive node erodes FROST wallet fault
+   budgets invisibly, while threshold redundancy is designed to absorb
+   loud, full, bounded outages; and fatality cannot be
+   profile-conditional because an unreadable config file cannot reveal
+   its profile and a missing profile means production
+   (production-by-omission), so path-set is the only non-circular
+   trigger. Uniform semantics also mean testnet rehearses exactly the
+   behavior production will have. Env-fallback mode (path unset) keeps
+   the safe-by-default degrade posture. Operational consequence:
+   config-file pushes to config-mode fleets must be canaried
+   node-by-node (runbook prerequisite 7) because a bad push now
+   produces visible downtime instead of silent capability loss.
+   Implemented on the scaffold branch as the follow-up to PR #4041's
+   Go-host adoption.
 
 ## Provisional Rollback Thresholds (Draft)
 

--- a/pkg/tbtc/signer/docs/roast-phase-5-security-rollout-gates.md
+++ b/pkg/tbtc/signer/docs/roast-phase-5-security-rollout-gates.md
@@ -163,8 +163,8 @@ architecture questions:
    config-file pushes to config-mode fleets must be canaried
    node-by-node (runbook prerequisite 7) because a bad push now
    produces visible downtime instead of silent capability loss.
-   Implemented on the scaffold branch as the follow-up to PR #4041's
-   Go-host adoption.
+   Implemented in keep-core PR #4045 (scaffold), the follow-up to
+   PR #4041's Go-host adoption.
 
 ## Provisional Rollback Thresholds (Draft)
 


### PR DESCRIPTION
## What

Records 2026-06-12 decision 7 in the gates-doc Decision Log: an unmet init-config demand (`TBTC_SIGNER_INIT_CONFIG_PATH` set but the FROST-native engine did not come up) is **process-fatal in every profile**, replacing the continue-on-legacy-bridge degradation from keep-core #4041. Implementation: keep-core #4045 (scaffold).

Adds runbook prerequisite 7 with the operational consequences: config pushes and validation-tightening library upgrades are canaried node-by-node (a bad fleet push now produces a visible, correlated outage instead of silent capability loss), and prerequisite 6's attestation-rotation cadence becomes enforced rather than advisory — a node restarted with expired attestation material will not start until re-attested.

## Rationale recorded in the entry

The scaffold ships to production only when FROST is a production duty, so "running but FROST-dead" is the dangerous state: a silently half-alive node erodes FROST wallet fault budgets invisibly, while threshold redundancy is designed for loud, full, bounded outages. Fatality cannot be profile-conditional (unreadable file cannot reveal its profile; production-by-omission), so path-set is the only non-circular trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)