### PR TITLE
feat(tbtc/signer): Phase 7.2b-1 InteractiveAggregate completion marker

### DIFF
--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -697,12 +697,8 @@ pub fn interactive_aggregate(
     // so a repeat InteractiveAggregate returns the same signature (idempotent)
     // rather than recomputing (Phase 7.2b design section 6). The engine lock was
     // dropped for the aggregation crypto above; re-acquire it to record and
-    // persist. The aggregate is deterministic over public data, so a concurrent
-    // duplicate that raced past the pre-check recomputed the identical
-    // signature: if the record already exists we return ours without storing
-    // twice. Persist before reporting success; on persist failure roll the
-    // record back and fail closed, leaving no half-recorded completion. Count a
-    // success only for a freshly recorded aggregation, not a re-emission.
+    // persist. Persist before reporting success; on persist failure roll the
+    // record back and fail closed, leaving no half-recorded completion.
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
@@ -711,39 +707,49 @@ pub fn interactive_aggregate(
             session_id: request.session_id.clone(),
         }
     })?;
-    let recorded_new = !session
+    // A concurrent aggregate that raced past the pre-check may already have
+    // recorded this attempt. Different responsive subsets can each produce a
+    // VALID but distinct signature for the same attempt, so return the
+    // canonical PERSISTED signature, not the one this call just recomputed -
+    // otherwise the value a caller receives could diverge from what restarts
+    // and later re-emissions return. No re-store and no success count here: the
+    // call that recorded the attempt already counted it.
+    if let Some(existing) = session
         .aggregated_interactive_attempt_signatures
-        .contains_key(&attempt_id);
-    if recorded_new {
-        ensure_consumed_registry_capacity_for_insert(
-            session.aggregated_interactive_attempt_signatures.len(),
-            false,
-            "aggregated_interactive_attempt_signatures",
-            &request.session_id,
-        )?;
+        .get(&attempt_id)
+    {
+        return Ok(InteractiveAggregateResult {
+            session_id: request.session_id.clone(),
+            attempt_id: attempt_id.clone(),
+            signature_hex: existing.clone(),
+        });
+    }
+    ensure_consumed_registry_capacity_for_insert(
+        session.aggregated_interactive_attempt_signatures.len(),
+        false,
+        "aggregated_interactive_attempt_signatures",
+        &request.session_id,
+    )?;
+    session
+        .aggregated_interactive_attempt_signatures
+        .insert(attempt_id.clone(), signature_hex.clone());
+    if let Err(persist_error) = persist_engine_state_to_storage(&guard) {
+        let session = guard
+            .sessions
+            .get_mut(&request.session_id)
+            .expect("session existed under the held engine lock");
         session
             .aggregated_interactive_attempt_signatures
-            .insert(attempt_id.clone(), signature_hex.clone());
-        if let Err(persist_error) = persist_engine_state_to_storage(&guard) {
-            let session = guard
-                .sessions
-                .get_mut(&request.session_id)
-                .expect("session existed under the held engine lock");
-            session
-                .aggregated_interactive_attempt_signatures
-                .remove(&attempt_id);
-            return Err(persist_error);
-        }
+            .remove(&attempt_id);
+        return Err(persist_error);
     }
     drop(guard);
 
-    if recorded_new {
-        record_hardening_telemetry(|telemetry| {
-            telemetry.interactive_aggregate_success_total = telemetry
-                .interactive_aggregate_success_total
-                .saturating_add(1);
-        });
-    }
+    record_hardening_telemetry(|telemetry| {
+        telemetry.interactive_aggregate_success_total = telemetry
+            .interactive_aggregate_success_total
+            .saturating_add(1);
+    });
 
     Ok(InteractiveAggregateResult {
         session_id: request.session_id,

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -561,34 +561,6 @@ pub fn interactive_round2(
     })
 }
 
-// Does a recorded aggregate signature verify under THIS request's tweaked
-// group key and message? The completion record (section 6) is keyed by
-// attempt_id, which does NOT bind the taproot root, and the coordinator may be
-// adversarial - so the stored signature is re-emitted only when it is actually
-// valid for the caller's package/root, never a signature that would fail to
-// verify for these inputs.
-fn recorded_aggregate_matches_request(
-    public_key_package: &frost::keys::PublicKeyPackage,
-    taproot_merkle_root: Option<&[u8; 32]>,
-    signing_package: &frost::SigningPackage,
-    recorded_signature_hex: &str,
-) -> bool {
-    let Ok(signature_bytes) = hex::decode(recorded_signature_hex) else {
-        return false;
-    };
-    let Ok(signature) = frost::Signature::deserialize(&signature_bytes) else {
-        return false;
-    };
-    let verification_key_package = match taproot_merkle_root {
-        Some(root) => public_key_package.clone().tweak(Some(root.as_slice())),
-        None => public_key_package.clone(),
-    };
-    verification_key_package
-        .verifying_key()
-        .verify(signing_package.message().as_slice(), &signature)
-        .is_ok()
-}
-
 pub fn interactive_aggregate(
     request: InteractiveAggregateRequest,
 ) -> Result<InteractiveAggregateResult, EngineError> {
@@ -602,10 +574,10 @@ pub fn interactive_aggregate(
     enforce_provenance_gate()?;
     validate_session_id(&request.session_id)?;
     let attempt_id = canonical_attempt_id(&request.attempt_id);
-    // A completed aggregate persists a completion record keyed by attempt_id,
-    // and the reload path rejects an empty key; reject an empty attempt_id here
-    // too so a malformed (or malicious) request cannot write durable state that
-    // fails to reload after a restart.
+    // The completion marker persists attempt_id, and the reload path rejects an
+    // empty key; reject an empty attempt_id here too so a malformed (or
+    // malicious) request cannot write durable state that fails to reload after
+    // a restart.
     if attempt_id.is_empty() {
         return Err(EngineError::Validation(
             "InteractiveAggregate: attempt_id must not be empty".to_string(),
@@ -649,50 +621,30 @@ pub fn interactive_aggregate(
                 session_id: request.session_id.clone(),
             }
         })?;
+        // Reject a completed attempt: re-aggregation is not a recovery path (a
+        // lost signature is recovered with a fresh attempt), and the marker is
+        // durable so a completed attempt stays rejected across a restart.
+        if session
+            .aggregated_interactive_attempt_markers
+            .contains(&attempt_id)
+        {
+            return Err(EngineError::InteractiveAttemptAlreadyAggregated {
+                session_id: request.session_id.clone(),
+                attempt_id,
+            });
+        }
         if session.dkg_result.is_none() {
             return Err(EngineError::DkgNotReady {
                 session_id: request.session_id.clone(),
             });
         }
-        let public_key_package = session
+        session
             .dkg_public_key_package
             .as_ref()
             .ok_or_else(|| {
                 EngineError::Internal("missing DKG public key package cache".to_string())
             })?
-            .clone();
-        // Idempotent re-emission (Phase 7.2b design section 6): a completed
-        // attempt returns its recorded signature without recomputing, so the
-        // signature stays recoverable from the engine across restart - a host
-        // that lost the FFI response need not spend a fresh signing attempt.
-        // The record is keyed by attempt_id, which does NOT bind the taproot
-        // root, and the coordinator may be adversarial, so re-emit ONLY when the
-        // stored signature actually verifies under THIS request's tweaked group
-        // key and message; a reused attempt_id carrying different aggregate
-        // inputs is rejected rather than handed a signature that fails for them.
-        if let Some(existing) = session
-            .aggregated_interactive_attempt_signatures
-            .get(&attempt_id)
-        {
-            if recorded_aggregate_matches_request(
-                &public_key_package,
-                taproot_merkle_root.as_ref(),
-                &signing_package,
-                existing,
-            ) {
-                return Ok(InteractiveAggregateResult {
-                    session_id: request.session_id.clone(),
-                    attempt_id: attempt_id.clone(),
-                    signature_hex: existing.clone(),
-                });
-            }
-            return Err(EngineError::Validation(format!(
-                "InteractiveAggregate: attempt [{attempt_id}] already aggregated under a \
-                 different package/root; reuse of an attempt_id for different aggregate \
-                 inputs is rejected"
-            )));
-        }
-        public_key_package
+            .clone()
     };
     drop(guard);
 
@@ -746,12 +698,12 @@ pub fn interactive_aggregate(
         .map_err(|e| EngineError::Internal(format!("failed to serialize aggregate: {e}")))?;
     let signature_hex = hex::encode(signature_bytes);
 
-    // Record the aggregate signature for this attempt before reporting success,
-    // so a repeat InteractiveAggregate returns the same signature (idempotent)
-    // rather than recomputing (Phase 7.2b design section 6). The engine lock was
-    // dropped for the aggregation crypto above; re-acquire it to record and
-    // persist. Persist before reporting success; on persist failure roll the
-    // record back and fail closed, leaving no half-recorded completion.
+    // Mark the attempt complete before reporting success, so a repeat
+    // InteractiveAggregate is rejected rather than recomputed (Phase 7.2b design
+    // section 6). The engine lock was dropped for the aggregation crypto above;
+    // re-acquire it, re-check the marker (a concurrent aggregate may have
+    // completed first), insert it, and persist before reporting success; on
+    // persist failure roll the marker back and fail closed.
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
@@ -760,54 +712,34 @@ pub fn interactive_aggregate(
             session_id: request.session_id.clone(),
         }
     })?;
-    // A concurrent aggregate that raced past the pre-check may already have
-    // recorded this attempt. Different responsive subsets can each produce a
-    // VALID but distinct signature for the same attempt, so return the
-    // canonical PERSISTED signature when it verifies under this request's
-    // tweaked key and message (not the one this call just recomputed) -
-    // otherwise the value a caller receives could diverge from what restarts
-    // and later re-emissions return. A record that does NOT verify for these
-    // inputs means the attempt_id was reused for a different package/root:
-    // reject it. No re-store and no success count on re-emission: the call that
-    // recorded the attempt already counted it.
-    if let Some(existing) = session
-        .aggregated_interactive_attempt_signatures
-        .get(&attempt_id)
+    // A concurrent aggregate that raced past the pre-check may have completed
+    // this attempt first; if the marker is now present, reject this call's
+    // re-aggregation - the winner already produced the attempt's signature.
+    if session
+        .aggregated_interactive_attempt_markers
+        .contains(&attempt_id)
     {
-        if recorded_aggregate_matches_request(
-            &public_key_package,
-            taproot_merkle_root.as_ref(),
-            &signing_package,
-            existing,
-        ) {
-            return Ok(InteractiveAggregateResult {
-                session_id: request.session_id.clone(),
-                attempt_id: attempt_id.clone(),
-                signature_hex: existing.clone(),
-            });
-        }
-        return Err(EngineError::Validation(format!(
-            "InteractiveAggregate: attempt [{attempt_id}] already aggregated under a \
-             different package/root; reuse of an attempt_id for different aggregate \
-             inputs is rejected"
-        )));
+        return Err(EngineError::InteractiveAttemptAlreadyAggregated {
+            session_id: request.session_id.clone(),
+            attempt_id,
+        });
     }
-    ensure_consumed_registry_capacity_for_insert(
-        session.aggregated_interactive_attempt_signatures.len(),
-        false,
-        "aggregated_interactive_attempt_signatures",
+    ensure_consumed_registry_insert_capacity(
+        &session.aggregated_interactive_attempt_markers,
+        &attempt_id,
+        "aggregated_interactive_attempt_markers",
         &request.session_id,
     )?;
     session
-        .aggregated_interactive_attempt_signatures
-        .insert(attempt_id.clone(), signature_hex.clone());
+        .aggregated_interactive_attempt_markers
+        .insert(attempt_id.clone());
     if let Err(persist_error) = persist_engine_state_to_storage(&guard) {
         let session = guard
             .sessions
             .get_mut(&request.session_id)
             .expect("session existed under the held engine lock");
         session
-            .aggregated_interactive_attempt_signatures
+            .aggregated_interactive_attempt_markers
             .remove(&attempt_id);
         return Err(persist_error);
     }

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -612,6 +612,18 @@ pub fn interactive_aggregate(
                 session_id: request.session_id.clone(),
             }
         })?;
+        // Reject a repeat aggregate of an already-completed attempt before
+        // recomputing (Phase 7.2b design section 6). The marker is durable,
+        // so a completed attempt stays completed across restart.
+        if session
+            .aggregated_interactive_attempt_markers
+            .contains(&attempt_id)
+        {
+            return Err(EngineError::InteractiveAttemptAlreadyAggregated {
+                session_id: request.session_id.clone(),
+                attempt_id,
+            });
+        }
         if session.dkg_result.is_none() {
             return Err(EngineError::DkgNotReady {
                 session_id: request.session_id.clone(),
@@ -675,6 +687,54 @@ pub fn interactive_aggregate(
     let signature_bytes = signature
         .serialize()
         .map_err(|e| EngineError::Internal(format!("failed to serialize aggregate: {e}")))?;
+
+    // Record the durable completion marker before reporting success, so a
+    // repeat InteractiveAggregate for this attempt is rejected rather than
+    // recomputed (Phase 7.2b design section 6). The engine lock was dropped
+    // for the aggregation crypto above; re-acquire it to mark and persist.
+    // This is a completion marker, not a security gate (the aggregate is
+    // deterministic over public data): a concurrent duplicate that raced past
+    // the pre-check recomputed the identical signature, so re-check the marker
+    // here and let the loser report the attempt already complete instead of
+    // persisting twice. Persist before success; on persist failure roll the
+    // marker back and fail closed, leaving no half-recorded completion.
+    let mut guard = state()?
+        .lock()
+        .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
+    let session = guard.sessions.get_mut(&request.session_id).ok_or_else(|| {
+        EngineError::SessionNotFound {
+            session_id: request.session_id.clone(),
+        }
+    })?;
+    if session
+        .aggregated_interactive_attempt_markers
+        .contains(&attempt_id)
+    {
+        return Err(EngineError::InteractiveAttemptAlreadyAggregated {
+            session_id: request.session_id.clone(),
+            attempt_id,
+        });
+    }
+    ensure_consumed_registry_insert_capacity(
+        &session.aggregated_interactive_attempt_markers,
+        &attempt_id,
+        "aggregated_interactive_attempt_markers",
+        &request.session_id,
+    )?;
+    session
+        .aggregated_interactive_attempt_markers
+        .insert(attempt_id.clone());
+    if let Err(persist_error) = persist_engine_state_to_storage(&guard) {
+        let session = guard
+            .sessions
+            .get_mut(&request.session_id)
+            .expect("session existed under the held engine lock");
+        session
+            .aggregated_interactive_attempt_markers
+            .remove(&attempt_id);
+        return Err(persist_error);
+    }
+    drop(guard);
 
     record_hardening_telemetry(|telemetry| {
         telemetry.interactive_aggregate_success_total = telemetry

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -612,16 +612,20 @@ pub fn interactive_aggregate(
                 session_id: request.session_id.clone(),
             }
         })?;
-        // Reject a repeat aggregate of an already-completed attempt before
-        // recomputing (Phase 7.2b design section 6). The marker is durable,
-        // so a completed attempt stays completed across restart.
-        if session
-            .aggregated_interactive_attempt_markers
-            .contains(&attempt_id)
+        // Idempotent re-emission (Phase 7.2b design section 6): if this attempt
+        // already aggregated, return the stored signature without recomputing.
+        // The record is durable, so the signature stays recoverable from the
+        // engine across restart - a host that lost the FFI response need not
+        // spend a fresh signing attempt to reproduce a signature the engine
+        // already holds.
+        if let Some(signature_hex) = session
+            .aggregated_interactive_attempt_signatures
+            .get(&attempt_id)
         {
-            return Err(EngineError::InteractiveAttemptAlreadyAggregated {
+            return Ok(InteractiveAggregateResult {
                 session_id: request.session_id.clone(),
-                attempt_id,
+                attempt_id: attempt_id.clone(),
+                signature_hex: signature_hex.clone(),
             });
         }
         if session.dkg_result.is_none() {
@@ -687,17 +691,18 @@ pub fn interactive_aggregate(
     let signature_bytes = signature
         .serialize()
         .map_err(|e| EngineError::Internal(format!("failed to serialize aggregate: {e}")))?;
+    let signature_hex = hex::encode(signature_bytes);
 
-    // Record the durable completion marker before reporting success, so a
-    // repeat InteractiveAggregate for this attempt is rejected rather than
-    // recomputed (Phase 7.2b design section 6). The engine lock was dropped
-    // for the aggregation crypto above; re-acquire it to mark and persist.
-    // This is a completion marker, not a security gate (the aggregate is
-    // deterministic over public data): a concurrent duplicate that raced past
-    // the pre-check recomputed the identical signature, so re-check the marker
-    // here and let the loser report the attempt already complete instead of
-    // persisting twice. Persist before success; on persist failure roll the
-    // marker back and fail closed, leaving no half-recorded completion.
+    // Record the aggregate signature for this attempt before reporting success,
+    // so a repeat InteractiveAggregate returns the same signature (idempotent)
+    // rather than recomputing (Phase 7.2b design section 6). The engine lock was
+    // dropped for the aggregation crypto above; re-acquire it to record and
+    // persist. The aggregate is deterministic over public data, so a concurrent
+    // duplicate that raced past the pre-check recomputed the identical
+    // signature: if the record already exists we return ours without storing
+    // twice. Persist before reporting success; on persist failure roll the
+    // record back and fail closed, leaving no half-recorded completion. Count a
+    // success only for a freshly recorded aggregation, not a re-emission.
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
@@ -706,46 +711,44 @@ pub fn interactive_aggregate(
             session_id: request.session_id.clone(),
         }
     })?;
-    if session
-        .aggregated_interactive_attempt_markers
-        .contains(&attempt_id)
-    {
-        return Err(EngineError::InteractiveAttemptAlreadyAggregated {
-            session_id: request.session_id.clone(),
-            attempt_id,
-        });
-    }
-    ensure_consumed_registry_insert_capacity(
-        &session.aggregated_interactive_attempt_markers,
-        &attempt_id,
-        "aggregated_interactive_attempt_markers",
-        &request.session_id,
-    )?;
-    session
-        .aggregated_interactive_attempt_markers
-        .insert(attempt_id.clone());
-    if let Err(persist_error) = persist_engine_state_to_storage(&guard) {
-        let session = guard
-            .sessions
-            .get_mut(&request.session_id)
-            .expect("session existed under the held engine lock");
+    let recorded_new = !session
+        .aggregated_interactive_attempt_signatures
+        .contains_key(&attempt_id);
+    if recorded_new {
+        ensure_consumed_registry_capacity_for_insert(
+            session.aggregated_interactive_attempt_signatures.len(),
+            false,
+            "aggregated_interactive_attempt_signatures",
+            &request.session_id,
+        )?;
         session
-            .aggregated_interactive_attempt_markers
-            .remove(&attempt_id);
-        return Err(persist_error);
+            .aggregated_interactive_attempt_signatures
+            .insert(attempt_id.clone(), signature_hex.clone());
+        if let Err(persist_error) = persist_engine_state_to_storage(&guard) {
+            let session = guard
+                .sessions
+                .get_mut(&request.session_id)
+                .expect("session existed under the held engine lock");
+            session
+                .aggregated_interactive_attempt_signatures
+                .remove(&attempt_id);
+            return Err(persist_error);
+        }
     }
     drop(guard);
 
-    record_hardening_telemetry(|telemetry| {
-        telemetry.interactive_aggregate_success_total = telemetry
-            .interactive_aggregate_success_total
-            .saturating_add(1);
-    });
+    if recorded_new {
+        record_hardening_telemetry(|telemetry| {
+            telemetry.interactive_aggregate_success_total = telemetry
+                .interactive_aggregate_success_total
+                .saturating_add(1);
+        });
+    }
 
     Ok(InteractiveAggregateResult {
         session_id: request.session_id,
         attempt_id,
-        signature_hex: hex::encode(signature_bytes),
+        signature_hex,
     })
 }
 

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -602,6 +602,15 @@ pub fn interactive_aggregate(
     enforce_provenance_gate()?;
     validate_session_id(&request.session_id)?;
     let attempt_id = canonical_attempt_id(&request.attempt_id);
+    // A completed aggregate persists a completion record keyed by attempt_id,
+    // and the reload path rejects an empty key; reject an empty attempt_id here
+    // too so a malformed (or malicious) request cannot write durable state that
+    // fails to reload after a restart.
+    if attempt_id.is_empty() {
+        return Err(EngineError::Validation(
+            "InteractiveAggregate: attempt_id must not be empty".to_string(),
+        ));
+    }
 
     let mut signing_package_bytes = decode_hex_field(
         "InteractiveAggregate",

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -561,6 +561,34 @@ pub fn interactive_round2(
     })
 }
 
+// Does a recorded aggregate signature verify under THIS request's tweaked
+// group key and message? The completion record (section 6) is keyed by
+// attempt_id, which does NOT bind the taproot root, and the coordinator may be
+// adversarial - so the stored signature is re-emitted only when it is actually
+// valid for the caller's package/root, never a signature that would fail to
+// verify for these inputs.
+fn recorded_aggregate_matches_request(
+    public_key_package: &frost::keys::PublicKeyPackage,
+    taproot_merkle_root: Option<&[u8; 32]>,
+    signing_package: &frost::SigningPackage,
+    recorded_signature_hex: &str,
+) -> bool {
+    let Ok(signature_bytes) = hex::decode(recorded_signature_hex) else {
+        return false;
+    };
+    let Ok(signature) = frost::Signature::deserialize(&signature_bytes) else {
+        return false;
+    };
+    let verification_key_package = match taproot_merkle_root {
+        Some(root) => public_key_package.clone().tweak(Some(root.as_slice())),
+        None => public_key_package.clone(),
+    };
+    verification_key_package
+        .verifying_key()
+        .verify(signing_package.message().as_slice(), &signature)
+        .is_ok()
+}
+
 pub fn interactive_aggregate(
     request: InteractiveAggregateRequest,
 ) -> Result<InteractiveAggregateResult, EngineError> {
@@ -612,34 +640,50 @@ pub fn interactive_aggregate(
                 session_id: request.session_id.clone(),
             }
         })?;
-        // Idempotent re-emission (Phase 7.2b design section 6): if this attempt
-        // already aggregated, return the stored signature without recomputing.
-        // The record is durable, so the signature stays recoverable from the
-        // engine across restart - a host that lost the FFI response need not
-        // spend a fresh signing attempt to reproduce a signature the engine
-        // already holds.
-        if let Some(signature_hex) = session
-            .aggregated_interactive_attempt_signatures
-            .get(&attempt_id)
-        {
-            return Ok(InteractiveAggregateResult {
-                session_id: request.session_id.clone(),
-                attempt_id: attempt_id.clone(),
-                signature_hex: signature_hex.clone(),
-            });
-        }
         if session.dkg_result.is_none() {
             return Err(EngineError::DkgNotReady {
                 session_id: request.session_id.clone(),
             });
         }
-        session
+        let public_key_package = session
             .dkg_public_key_package
             .as_ref()
             .ok_or_else(|| {
                 EngineError::Internal("missing DKG public key package cache".to_string())
             })?
-            .clone()
+            .clone();
+        // Idempotent re-emission (Phase 7.2b design section 6): a completed
+        // attempt returns its recorded signature without recomputing, so the
+        // signature stays recoverable from the engine across restart - a host
+        // that lost the FFI response need not spend a fresh signing attempt.
+        // The record is keyed by attempt_id, which does NOT bind the taproot
+        // root, and the coordinator may be adversarial, so re-emit ONLY when the
+        // stored signature actually verifies under THIS request's tweaked group
+        // key and message; a reused attempt_id carrying different aggregate
+        // inputs is rejected rather than handed a signature that fails for them.
+        if let Some(existing) = session
+            .aggregated_interactive_attempt_signatures
+            .get(&attempt_id)
+        {
+            if recorded_aggregate_matches_request(
+                &public_key_package,
+                taproot_merkle_root.as_ref(),
+                &signing_package,
+                existing,
+            ) {
+                return Ok(InteractiveAggregateResult {
+                    session_id: request.session_id.clone(),
+                    attempt_id: attempt_id.clone(),
+                    signature_hex: existing.clone(),
+                });
+            }
+            return Err(EngineError::Validation(format!(
+                "InteractiveAggregate: attempt [{attempt_id}] already aggregated under a \
+                 different package/root; reuse of an attempt_id for different aggregate \
+                 inputs is rejected"
+            )));
+        }
+        public_key_package
     };
     drop(guard);
 
@@ -710,19 +754,34 @@ pub fn interactive_aggregate(
     // A concurrent aggregate that raced past the pre-check may already have
     // recorded this attempt. Different responsive subsets can each produce a
     // VALID but distinct signature for the same attempt, so return the
-    // canonical PERSISTED signature, not the one this call just recomputed -
+    // canonical PERSISTED signature when it verifies under this request's
+    // tweaked key and message (not the one this call just recomputed) -
     // otherwise the value a caller receives could diverge from what restarts
-    // and later re-emissions return. No re-store and no success count here: the
-    // call that recorded the attempt already counted it.
+    // and later re-emissions return. A record that does NOT verify for these
+    // inputs means the attempt_id was reused for a different package/root:
+    // reject it. No re-store and no success count on re-emission: the call that
+    // recorded the attempt already counted it.
     if let Some(existing) = session
         .aggregated_interactive_attempt_signatures
         .get(&attempt_id)
     {
-        return Ok(InteractiveAggregateResult {
-            session_id: request.session_id.clone(),
-            attempt_id: attempt_id.clone(),
-            signature_hex: existing.clone(),
-        });
+        if recorded_aggregate_matches_request(
+            &public_key_package,
+            taproot_merkle_root.as_ref(),
+            &signing_package,
+            existing,
+        ) {
+            return Ok(InteractiveAggregateResult {
+                session_id: request.session_id.clone(),
+                attempt_id: attempt_id.clone(),
+                signature_hex: existing.clone(),
+            });
+        }
+        return Err(EngineError::Validation(format!(
+            "InteractiveAggregate: attempt [{attempt_id}] already aggregated under a \
+             different package/root; reuse of an attempt_id for different aggregate \
+             inputs is rejected"
+        )));
     }
     ensure_consumed_registry_capacity_for_insert(
         session.aggregated_interactive_attempt_signatures.len(),

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -44,11 +44,11 @@ pub(crate) struct PersistedSessionState {
     // interactive state, including nonces, never persists).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) consumed_interactive_attempt_markers: Vec<String>,
-    // Phase 7.2b InteractiveAggregate completion markers (see SessionState).
-    // serde(default) keeps state written before 7.2b loadable: an absent
-    // field deserializes to an empty set.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) aggregated_interactive_attempt_markers: Vec<String>,
+    // Phase 7.2b InteractiveAggregate completion record (see SessionState):
+    // attempt_id -> aggregate signature hex. serde(default) keeps state written
+    // before 7.2b loadable: an absent field deserializes to an empty map.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) aggregated_interactive_attempt_signatures: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1292,24 +1292,23 @@ impl TryFrom<PersistedSessionState> for SessionState {
             "consumed_interactive_attempt_markers",
         )?;
 
-        let mut aggregated_interactive_attempt_markers = HashSet::new();
-        for attempt_marker in persisted.aggregated_interactive_attempt_markers {
-            if attempt_marker.is_empty() {
+        let mut aggregated_interactive_attempt_signatures = BTreeMap::new();
+        for (attempt_id, signature_hex) in persisted.aggregated_interactive_attempt_signatures {
+            if attempt_id.is_empty() {
                 return Err(EngineError::Internal(
-                    "persisted aggregated interactive attempt marker must be non-empty".to_string(),
+                    "persisted aggregated interactive attempt id must be non-empty".to_string(),
                 ));
             }
-
-            if !aggregated_interactive_attempt_markers.insert(attempt_marker.clone()) {
+            if signature_hex.is_empty() {
                 return Err(EngineError::Internal(format!(
-                    "duplicate persisted aggregated interactive attempt marker [{}]",
-                    attempt_marker
+                    "persisted aggregated interactive attempt [{attempt_id}] signature must be non-empty"
                 )));
             }
+            aggregated_interactive_attempt_signatures.insert(attempt_id, signature_hex);
         }
         ensure_consumed_registry_persisted_bound(
-            aggregated_interactive_attempt_markers.len(),
-            "aggregated_interactive_attempt_markers",
+            aggregated_interactive_attempt_signatures.len(),
+            "aggregated_interactive_attempt_signatures",
         )?;
         if persisted.attempt_transition_records.len()
             > TBTC_SIGNER_MAX_ATTEMPT_TRANSITION_RECORDS_PER_SESSION
@@ -1370,7 +1369,7 @@ impl TryFrom<PersistedSessionState> for SessionState {
             // only the consumption markers survive.
             interactive_signing: None,
             consumed_interactive_attempt_markers,
-            aggregated_interactive_attempt_markers,
+            aggregated_interactive_attempt_signatures,
         })
     }
 }
@@ -1481,12 +1480,9 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             .cloned()
             .collect::<Vec<_>>();
         consumed_interactive_attempt_markers.sort_unstable();
-        let mut aggregated_interactive_attempt_markers = session_state
-            .aggregated_interactive_attempt_markers
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        aggregated_interactive_attempt_markers.sort_unstable();
+        let aggregated_interactive_attempt_signatures = session_state
+            .aggregated_interactive_attempt_signatures
+            .clone();
 
         Ok(PersistedSessionState {
             dkg_request_fingerprint: session_state.dkg_request_fingerprint.clone(),
@@ -1511,7 +1507,7 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             refresh_history: session_state.refresh_history.clone(),
             emergency_rekey_event: session_state.emergency_rekey_event.clone(),
             consumed_interactive_attempt_markers,
-            aggregated_interactive_attempt_markers,
+            aggregated_interactive_attempt_signatures,
         })
     }
 }

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -44,6 +44,11 @@ pub(crate) struct PersistedSessionState {
     // interactive state, including nonces, never persists).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) consumed_interactive_attempt_markers: Vec<String>,
+    // Phase 7.2b InteractiveAggregate completion markers (see SessionState).
+    // serde(default) keeps state written before 7.2b loadable: an absent
+    // field deserializes to an empty set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) aggregated_interactive_attempt_markers: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1286,6 +1291,26 @@ impl TryFrom<PersistedSessionState> for SessionState {
             consumed_interactive_attempt_markers.len(),
             "consumed_interactive_attempt_markers",
         )?;
+
+        let mut aggregated_interactive_attempt_markers = HashSet::new();
+        for attempt_marker in persisted.aggregated_interactive_attempt_markers {
+            if attempt_marker.is_empty() {
+                return Err(EngineError::Internal(
+                    "persisted aggregated interactive attempt marker must be non-empty".to_string(),
+                ));
+            }
+
+            if !aggregated_interactive_attempt_markers.insert(attempt_marker.clone()) {
+                return Err(EngineError::Internal(format!(
+                    "duplicate persisted aggregated interactive attempt marker [{}]",
+                    attempt_marker
+                )));
+            }
+        }
+        ensure_consumed_registry_persisted_bound(
+            aggregated_interactive_attempt_markers.len(),
+            "aggregated_interactive_attempt_markers",
+        )?;
         if persisted.attempt_transition_records.len()
             > TBTC_SIGNER_MAX_ATTEMPT_TRANSITION_RECORDS_PER_SESSION
         {
@@ -1345,6 +1370,7 @@ impl TryFrom<PersistedSessionState> for SessionState {
             // only the consumption markers survive.
             interactive_signing: None,
             consumed_interactive_attempt_markers,
+            aggregated_interactive_attempt_markers,
         })
     }
 }
@@ -1455,6 +1481,12 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             .cloned()
             .collect::<Vec<_>>();
         consumed_interactive_attempt_markers.sort_unstable();
+        let mut aggregated_interactive_attempt_markers = session_state
+            .aggregated_interactive_attempt_markers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        aggregated_interactive_attempt_markers.sort_unstable();
 
         Ok(PersistedSessionState {
             dkg_request_fingerprint: session_state.dkg_request_fingerprint.clone(),
@@ -1479,6 +1511,7 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             refresh_history: session_state.refresh_history.clone(),
             emergency_rekey_event: session_state.emergency_rekey_event.clone(),
             consumed_interactive_attempt_markers,
+            aggregated_interactive_attempt_markers,
         })
     }
 }

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -44,11 +44,11 @@ pub(crate) struct PersistedSessionState {
     // interactive state, including nonces, never persists).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) consumed_interactive_attempt_markers: Vec<String>,
-    // Phase 7.2b InteractiveAggregate completion record (see SessionState):
-    // attempt_id -> aggregate signature hex. serde(default) keeps state written
-    // before 7.2b loadable: an absent field deserializes to an empty map.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub(crate) aggregated_interactive_attempt_signatures: BTreeMap<String, String>,
+    // Phase 7.2b InteractiveAggregate completion markers (see SessionState).
+    // serde(default) keeps state written before 7.2b loadable: an absent field
+    // deserializes to an empty set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) aggregated_interactive_attempt_markers: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1292,23 +1292,24 @@ impl TryFrom<PersistedSessionState> for SessionState {
             "consumed_interactive_attempt_markers",
         )?;
 
-        let mut aggregated_interactive_attempt_signatures = BTreeMap::new();
-        for (attempt_id, signature_hex) in persisted.aggregated_interactive_attempt_signatures {
-            if attempt_id.is_empty() {
+        let mut aggregated_interactive_attempt_markers = HashSet::new();
+        for attempt_marker in persisted.aggregated_interactive_attempt_markers {
+            if attempt_marker.is_empty() {
                 return Err(EngineError::Internal(
-                    "persisted aggregated interactive attempt id must be non-empty".to_string(),
+                    "persisted aggregated interactive attempt marker must be non-empty".to_string(),
                 ));
             }
-            if signature_hex.is_empty() {
+
+            if !aggregated_interactive_attempt_markers.insert(attempt_marker.clone()) {
                 return Err(EngineError::Internal(format!(
-                    "persisted aggregated interactive attempt [{attempt_id}] signature must be non-empty"
+                    "duplicate persisted aggregated interactive attempt marker [{}]",
+                    attempt_marker
                 )));
             }
-            aggregated_interactive_attempt_signatures.insert(attempt_id, signature_hex);
         }
         ensure_consumed_registry_persisted_bound(
-            aggregated_interactive_attempt_signatures.len(),
-            "aggregated_interactive_attempt_signatures",
+            aggregated_interactive_attempt_markers.len(),
+            "aggregated_interactive_attempt_markers",
         )?;
         if persisted.attempt_transition_records.len()
             > TBTC_SIGNER_MAX_ATTEMPT_TRANSITION_RECORDS_PER_SESSION
@@ -1369,7 +1370,7 @@ impl TryFrom<PersistedSessionState> for SessionState {
             // only the consumption markers survive.
             interactive_signing: None,
             consumed_interactive_attempt_markers,
-            aggregated_interactive_attempt_signatures,
+            aggregated_interactive_attempt_markers,
         })
     }
 }
@@ -1480,9 +1481,12 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             .cloned()
             .collect::<Vec<_>>();
         consumed_interactive_attempt_markers.sort_unstable();
-        let aggregated_interactive_attempt_signatures = session_state
-            .aggregated_interactive_attempt_signatures
-            .clone();
+        let mut aggregated_interactive_attempt_markers = session_state
+            .aggregated_interactive_attempt_markers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        aggregated_interactive_attempt_markers.sort_unstable();
 
         Ok(PersistedSessionState {
             dkg_request_fingerprint: session_state.dkg_request_fingerprint.clone(),
@@ -1507,7 +1511,7 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             refresh_history: session_state.refresh_history.clone(),
             emergency_rekey_event: session_state.emergency_rekey_event.clone(),
             consumed_interactive_attempt_markers,
-            aggregated_interactive_attempt_signatures,
+            aggregated_interactive_attempt_markers,
         })
     }
 }

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -111,6 +111,13 @@ pub(crate) struct SessionState {
     pub(crate) emergency_rekey_event: Option<EmergencyRekeyEvent>,
     pub(crate) interactive_signing: Option<InteractiveSigningState>,
     pub(crate) consumed_interactive_attempt_markers: HashSet<String>,
+    // Phase 7.2b InteractiveAggregate completion markers: an attempt whose
+    // aggregate signature has been produced is recorded here so a repeat
+    // InteractiveAggregate is rejected rather than recomputed. Durable like
+    // the consumed markers (markers-only durability) and bounded the same
+    // way. Not security-load-bearing - aggregate is deterministic over public
+    // data - but the frozen Phase 7 spec marks the session complete.
+    pub(crate) aggregated_interactive_attempt_markers: HashSet<String>,
 }
 
 #[derive(Default)]

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -111,15 +111,14 @@ pub(crate) struct SessionState {
     pub(crate) emergency_rekey_event: Option<EmergencyRekeyEvent>,
     pub(crate) interactive_signing: Option<InteractiveSigningState>,
     pub(crate) consumed_interactive_attempt_markers: HashSet<String>,
-    // Phase 7.2b InteractiveAggregate completion record: maps a completed
-    // attempt to the aggregate signature hex it produced, so a repeat
-    // InteractiveAggregate returns the same signature (idempotent) rather than
-    // recomputing. Durable like the consumed markers (markers-only durability)
-    // and bounded the same way. Not security-load-bearing - the aggregate is
-    // deterministic over public data and the signature is public - but the
-    // engine stays the source of truth for a completed attempt's signature, so
-    // a host that loses the FFI response recovers it without a new attempt.
-    pub(crate) aggregated_interactive_attempt_signatures: BTreeMap<String, String>,
+    // Phase 7.2b InteractiveAggregate completion markers: an attempt whose
+    // aggregate signature has been produced is recorded here so a repeat
+    // InteractiveAggregate is rejected (re-aggregation is not a recovery path;
+    // a lost signature is recovered with a fresh attempt). Durable like the
+    // consumed markers (markers-only durability) and bounded the same way; not
+    // security-load-bearing (the aggregate is deterministic over public data),
+    // but the frozen Phase 7 spec marks the session complete.
+    pub(crate) aggregated_interactive_attempt_markers: HashSet<String>,
 }
 
 #[derive(Default)]
@@ -444,28 +443,12 @@ pub(crate) fn ensure_consumed_registry_insert_capacity(
     registry_name: &str,
     session_id: &str,
 ) -> Result<(), EngineError> {
-    ensure_consumed_registry_capacity_for_insert(
-        registry.len(),
-        registry.contains(entry),
-        registry_name,
-        session_id,
-    )
-}
-
-// Length-based core shared by the set-keyed consumed registries and the
-// map-keyed Phase 7.2b aggregated-signature record, so both enforce one bound.
-pub(crate) fn ensure_consumed_registry_capacity_for_insert(
-    registry_len: usize,
-    entry_already_present: bool,
-    registry_name: &str,
-    session_id: &str,
-) -> Result<(), EngineError> {
-    if !entry_already_present
-        && registry_len >= TBTC_SIGNER_MAX_CONSUMED_REGISTRY_ENTRIES_PER_SESSION
+    if !registry.contains(entry)
+        && registry.len() >= TBTC_SIGNER_MAX_CONSUMED_REGISTRY_ENTRIES_PER_SESSION
     {
         return Err(EngineError::Internal(format!(
             "{registry_name} registry size [{}] reached max [{}] for session [{}]; use a new session_id",
-            registry_len,
+            registry.len(),
             TBTC_SIGNER_MAX_CONSUMED_REGISTRY_ENTRIES_PER_SESSION,
             session_id
         )));

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -111,13 +111,15 @@ pub(crate) struct SessionState {
     pub(crate) emergency_rekey_event: Option<EmergencyRekeyEvent>,
     pub(crate) interactive_signing: Option<InteractiveSigningState>,
     pub(crate) consumed_interactive_attempt_markers: HashSet<String>,
-    // Phase 7.2b InteractiveAggregate completion markers: an attempt whose
-    // aggregate signature has been produced is recorded here so a repeat
-    // InteractiveAggregate is rejected rather than recomputed. Durable like
-    // the consumed markers (markers-only durability) and bounded the same
-    // way. Not security-load-bearing - aggregate is deterministic over public
-    // data - but the frozen Phase 7 spec marks the session complete.
-    pub(crate) aggregated_interactive_attempt_markers: HashSet<String>,
+    // Phase 7.2b InteractiveAggregate completion record: maps a completed
+    // attempt to the aggregate signature hex it produced, so a repeat
+    // InteractiveAggregate returns the same signature (idempotent) rather than
+    // recomputing. Durable like the consumed markers (markers-only durability)
+    // and bounded the same way. Not security-load-bearing - the aggregate is
+    // deterministic over public data and the signature is public - but the
+    // engine stays the source of truth for a completed attempt's signature, so
+    // a host that loses the FFI response recovers it without a new attempt.
+    pub(crate) aggregated_interactive_attempt_signatures: BTreeMap<String, String>,
 }
 
 #[derive(Default)]
@@ -442,12 +444,28 @@ pub(crate) fn ensure_consumed_registry_insert_capacity(
     registry_name: &str,
     session_id: &str,
 ) -> Result<(), EngineError> {
-    if !registry.contains(entry)
-        && registry.len() >= TBTC_SIGNER_MAX_CONSUMED_REGISTRY_ENTRIES_PER_SESSION
+    ensure_consumed_registry_capacity_for_insert(
+        registry.len(),
+        registry.contains(entry),
+        registry_name,
+        session_id,
+    )
+}
+
+// Length-based core shared by the set-keyed consumed registries and the
+// map-keyed Phase 7.2b aggregated-signature record, so both enforce one bound.
+pub(crate) fn ensure_consumed_registry_capacity_for_insert(
+    registry_len: usize,
+    entry_already_present: bool,
+    registry_name: &str,
+    session_id: &str,
+) -> Result<(), EngineError> {
+    if !entry_already_present
+        && registry_len >= TBTC_SIGNER_MAX_CONSUMED_REGISTRY_ENTRIES_PER_SESSION
     {
         return Err(EngineError::Internal(format!(
             "{registry_name} registry size [{}] reached max [{}] for session [{}]; use a new session_id",
-            registry.len(),
+            registry_len,
             TBTC_SIGNER_MAX_CONSUMED_REGISTRY_ENTRIES_PER_SESSION,
             session_id
         )));

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -12933,6 +12933,30 @@ fn interactive_aggregate_is_idempotent_for_completed_attempt() {
 }
 
 #[test]
+fn interactive_aggregate_rejects_empty_attempt_id() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    // An empty attempt_id must be rejected before anything is persisted: the
+    // completion record is keyed by attempt_id and the reload path rejects an
+    // empty key, so persisting one would brick restart. The guard runs before
+    // the signing-package/share decode, so the placeholder inputs are never
+    // reached.
+    let err = interactive_aggregate(InteractiveAggregateRequest {
+        session_id: "interactive-aggregate-empty-attempt".to_string(),
+        attempt_id: String::new(),
+        signing_package_hex: String::new(),
+        signature_shares: vec![],
+        taproot_merkle_root_hex: None,
+    })
+    .expect_err("an empty attempt_id must be rejected");
+    assert!(
+        matches!(err, EngineError::Validation(ref m) if m.contains("attempt_id must not be empty")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
 fn interactive_aggregate_signature_recoverable_across_restart() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("interactive_aggregate_marker_restart");

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -702,7 +702,7 @@ fn persisted_session_state_fixture() -> PersistedSessionState {
         refresh_history: vec![],
         emergency_rekey_event: None,
         consumed_interactive_attempt_markers: vec![],
-        aggregated_interactive_attempt_markers: vec![],
+        aggregated_interactive_attempt_signatures: Default::default(),
     }
 }
 
@@ -12842,7 +12842,7 @@ fn interactive_aggregate_produces_and_self_verifies_bip340() {
 }
 
 #[test]
-fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
+fn interactive_aggregate_is_idempotent_for_completed_attempt() {
     let _guard = lock_test_state();
     reset_for_tests();
 
@@ -12905,26 +12905,20 @@ fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
     };
 
     // First aggregate completes the attempt.
-    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+    let first =
+        interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
 
-    // A second aggregate for the same attempt is rejected by the durable
-    // completion marker rather than recomputed (Phase 7.2b design section 6).
-    let err = interactive_aggregate(aggregate_request)
-        .expect_err("re-aggregating a completed attempt must be rejected");
-    assert!(
-        matches!(
-            err,
-            EngineError::InteractiveAttemptAlreadyAggregated { ref attempt_id, .. }
-                if *attempt_id == opened.attempt_id
-        ),
-        "unexpected error: {err:?}"
-    );
-    assert_eq!(err.code(), "interactive_attempt_already_aggregated");
-    assert_eq!(err.recovery_class(), "recoverable");
+    // A second aggregate for the same attempt returns the SAME signature
+    // (idempotent re-emission) rather than recomputing or erroring (Phase 7.2b
+    // design section 6).
+    let second = interactive_aggregate(aggregate_request)
+        .expect("re-aggregating a completed attempt returns the stored signature");
+    assert_eq!(second.attempt_id, opened.attempt_id);
+    assert_eq!(second.signature_hex, first.signature_hex);
 }
 
 #[test]
-fn interactive_aggregate_completion_marker_survives_process_restart() {
+fn interactive_aggregate_signature_recoverable_across_restart() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("interactive_aggregate_marker_restart");
     reset_for_tests();
@@ -12986,22 +12980,21 @@ fn interactive_aggregate_completion_marker_survives_process_restart() {
         ],
         taproot_merkle_root_hex: None,
     };
-    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+    let first =
+        interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
 
-    // The completion marker is the only durable interactive artifact (live
-    // nonce state is gone after restart by construction). It must survive a
-    // reload so a replayed aggregate is still rejected - this also exercises
-    // the marker's persistence round-trip (serialize + reload validation).
+    // The completion record (the aggregate signature) is the only durable
+    // interactive artifact (live nonce state is gone after restart by
+    // construction). It must survive a reload so the engine re-emits the
+    // identical signature instead of forcing a brand-new signing attempt -
+    // this also exercises the record's persistence round-trip (serialize +
+    // reload validation).
     simulate_process_restart_for_tests();
     reload_state_from_storage_for_tests();
 
-    let err = interactive_aggregate(aggregate_request)
-        .expect_err("a completed attempt must stay completed across restart");
-    assert!(
-        matches!(err, EngineError::InteractiveAttemptAlreadyAggregated { .. }),
-        "unexpected error: {err:?}"
-    );
-    assert_eq!(err.code(), "interactive_attempt_already_aggregated");
+    let after_restart = interactive_aggregate(aggregate_request)
+        .expect("a completed attempt's signature is recoverable across restart");
+    assert_eq!(after_restart.signature_hex, first.signature_hex);
 
     reset_for_tests();
     cleanup_test_state_artifacts(&state_path);

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -702,6 +702,7 @@ fn persisted_session_state_fixture() -> PersistedSessionState {
         refresh_history: vec![],
         emergency_rekey_event: None,
         consumed_interactive_attempt_markers: vec![],
+        aggregated_interactive_attempt_markers: vec![],
     }
 }
 
@@ -12838,6 +12839,173 @@ fn interactive_aggregate_produces_and_self_verifies_bip340() {
     Secp256k1::verification_only()
         .verify_schnorr(&signature, &SecpMessage::from_digest(message), &public_key)
         .expect("interactive aggregate yields a valid BIP-340 signature");
+}
+
+#[test]
+fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let session_id = "interactive-aggregate-repeat";
+    let key_group = "interactive-test-key-group";
+    let message = [0x4eu8; 32];
+    let included = [1u16, 2];
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+
+    let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
+        .expect("opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment.clone(),
+        ],
+    );
+    let round2 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("round 2 share");
+    let member2_share = sign_share(SignShareRequest {
+        signing_package_hex: signing_package_hex.clone(),
+        nonces_hex: member2.nonces_hex,
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 share");
+
+    let aggregate_request = InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        signing_package_hex,
+        signature_shares: vec![
+            crate::api::NativeFrostSignatureShare {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round2.signature_share_hex,
+            },
+            member2_share.signature_share,
+        ],
+        taproot_merkle_root_hex: None,
+    };
+
+    // First aggregate completes the attempt.
+    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+
+    // A second aggregate for the same attempt is rejected by the durable
+    // completion marker rather than recomputed (Phase 7.2b design section 6).
+    let err = interactive_aggregate(aggregate_request)
+        .expect_err("re-aggregating a completed attempt must be rejected");
+    assert!(
+        matches!(
+            err,
+            EngineError::InteractiveAttemptAlreadyAggregated { ref attempt_id, .. }
+                if *attempt_id == opened.attempt_id
+        ),
+        "unexpected error: {err:?}"
+    );
+    assert_eq!(err.code(), "interactive_attempt_already_aggregated");
+    assert_eq!(err.recovery_class(), "recoverable");
+}
+
+#[test]
+fn interactive_aggregate_completion_marker_survives_process_restart() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_aggregate_marker_restart");
+    reset_for_tests();
+
+    let session_id = "interactive-aggregate-marker-restart";
+    let key_group = "interactive-test-key-group";
+    let message = [0x4fu8; 32];
+    let included = [1u16, 2];
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+
+    let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
+        .expect("opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment.clone(),
+        ],
+    );
+    let round2 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("round 2 share");
+    let member2_share = sign_share(SignShareRequest {
+        signing_package_hex: signing_package_hex.clone(),
+        nonces_hex: member2.nonces_hex,
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 share");
+
+    let aggregate_request = InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        signing_package_hex,
+        signature_shares: vec![
+            crate::api::NativeFrostSignatureShare {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round2.signature_share_hex,
+            },
+            member2_share.signature_share,
+        ],
+        taproot_merkle_root_hex: None,
+    };
+    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+
+    // The completion marker is the only durable interactive artifact (live
+    // nonce state is gone after restart by construction). It must survive a
+    // reload so a replayed aggregate is still rejected - this also exercises
+    // the marker's persistence round-trip (serialize + reload validation).
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+
+    let err = interactive_aggregate(aggregate_request)
+        .expect_err("a completed attempt must stay completed across restart");
+    assert!(
+        matches!(err, EngineError::InteractiveAttemptAlreadyAggregated { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert_eq!(err.code(), "interactive_attempt_already_aggregated");
+
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
 }
 
 #[test]

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -12908,25 +12908,28 @@ fn interactive_aggregate_is_idempotent_for_completed_attempt() {
     let first =
         interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
 
-    // A repeat aggregate returns the PERSISTED signature, not a recompute
-    // (Phase 7.2b design section 6). A plain equality check would pass even on
-    // a recompute (aggregate is deterministic), so overwrite the stored record
-    // with a sentinel and confirm the repeat returns exactly that - the same
-    // return-the-recorded-value property the post-race path relies on.
-    {
-        let mut guard = state().expect("engine state").lock().expect("engine lock");
-        guard
-            .sessions
-            .get_mut(session_id)
-            .expect("session")
-            .aggregated_interactive_attempt_signatures
-            .insert(opened.attempt_id.clone(), "00sentinel".to_string());
-    }
-    let second = interactive_aggregate(aggregate_request)
-        .expect("re-aggregating a completed attempt returns the stored signature");
+    // Re-aggregating the SAME attempt with the SAME inputs returns the recorded
+    // signature (idempotent re-emission, Phase 7.2b design section 6).
+    let second = interactive_aggregate(aggregate_request.clone())
+        .expect("re-aggregating with the same inputs returns the recorded signature");
     assert_eq!(second.attempt_id, opened.attempt_id);
-    assert_eq!(second.signature_hex, "00sentinel");
-    assert_ne!(second.signature_hex, first.signature_hex);
+    assert_eq!(second.signature_hex, first.signature_hex);
+
+    // Reusing the attempt_id with a DIFFERENT taproot root is rejected, not
+    // handed the recorded key-path signature (which would not verify under the
+    // tweaked key). The completion record is keyed by attempt_id, which does
+    // not bind the root, so re-emission is validated against the request's
+    // package/root before returning.
+    let mismatched_root_request = InteractiveAggregateRequest {
+        taproot_merkle_root_hex: Some("11".repeat(32)),
+        ..aggregate_request
+    };
+    let err = interactive_aggregate(mismatched_root_request)
+        .expect_err("reusing an attempt_id with a different root must be rejected");
+    assert!(
+        matches!(err, EngineError::Validation(ref m) if m.contains("different package/root")),
+        "unexpected error: {err:?}"
+    );
 }
 
 #[test]

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -702,7 +702,7 @@ fn persisted_session_state_fixture() -> PersistedSessionState {
         refresh_history: vec![],
         emergency_rekey_event: None,
         consumed_interactive_attempt_markers: vec![],
-        aggregated_interactive_attempt_signatures: Default::default(),
+        aggregated_interactive_attempt_markers: vec![],
     }
 }
 
@@ -12842,7 +12842,7 @@ fn interactive_aggregate_produces_and_self_verifies_bip340() {
 }
 
 #[test]
-fn interactive_aggregate_is_idempotent_for_completed_attempt() {
+fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
     let _guard = lock_test_state();
     reset_for_tests();
 
@@ -12904,32 +12904,25 @@ fn interactive_aggregate_is_idempotent_for_completed_attempt() {
         taproot_merkle_root_hex: None,
     };
 
-    // First aggregate completes the attempt and records its signature.
-    let first =
-        interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+    // First aggregate completes the attempt.
+    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
 
-    // Re-aggregating the SAME attempt with the SAME inputs returns the recorded
-    // signature (idempotent re-emission, Phase 7.2b design section 6).
-    let second = interactive_aggregate(aggregate_request.clone())
-        .expect("re-aggregating with the same inputs returns the recorded signature");
-    assert_eq!(second.attempt_id, opened.attempt_id);
-    assert_eq!(second.signature_hex, first.signature_hex);
-
-    // Reusing the attempt_id with a DIFFERENT taproot root is rejected, not
-    // handed the recorded key-path signature (which would not verify under the
-    // tweaked key). The completion record is keyed by attempt_id, which does
-    // not bind the root, so re-emission is validated against the request's
-    // package/root before returning.
-    let mismatched_root_request = InteractiveAggregateRequest {
-        taproot_merkle_root_hex: Some("11".repeat(32)),
-        ..aggregate_request
-    };
-    let err = interactive_aggregate(mismatched_root_request)
-        .expect_err("reusing an attempt_id with a different root must be rejected");
+    // Re-aggregating a completed attempt is rejected by the durable completion
+    // marker rather than recomputed (re-aggregation is not a recovery path; a
+    // lost signature is recovered with a fresh attempt). Phase 7.2b design
+    // section 6.
+    let err = interactive_aggregate(aggregate_request)
+        .expect_err("re-aggregating a completed attempt must be rejected");
     assert!(
-        matches!(err, EngineError::Validation(ref m) if m.contains("different package/root")),
+        matches!(
+            err,
+            EngineError::InteractiveAttemptAlreadyAggregated { ref attempt_id, .. }
+                if *attempt_id == opened.attempt_id
+        ),
         "unexpected error: {err:?}"
     );
+    assert_eq!(err.code(), "interactive_attempt_already_aggregated");
+    assert_eq!(err.recovery_class(), "recoverable");
 }
 
 #[test]
@@ -12957,7 +12950,7 @@ fn interactive_aggregate_rejects_empty_attempt_id() {
 }
 
 #[test]
-fn interactive_aggregate_signature_recoverable_across_restart() {
+fn interactive_aggregate_completion_marker_survives_process_restart() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("interactive_aggregate_marker_restart");
     reset_for_tests();
@@ -13019,21 +13012,22 @@ fn interactive_aggregate_signature_recoverable_across_restart() {
         ],
         taproot_merkle_root_hex: None,
     };
-    let first =
-        interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
 
-    // The completion record (the aggregate signature) is the only durable
-    // interactive artifact (live nonce state is gone after restart by
-    // construction). It must survive a reload so the engine re-emits the
-    // identical signature instead of forcing a brand-new signing attempt -
-    // this also exercises the record's persistence round-trip (serialize +
-    // reload validation).
+    // The completion marker is the only durable interactive artifact (live
+    // nonce state is gone after restart by construction). It must survive a
+    // reload so a replayed aggregate is still rejected - this also exercises
+    // the marker's persistence round-trip (serialize + reload validation).
     simulate_process_restart_for_tests();
     reload_state_from_storage_for_tests();
 
-    let after_restart = interactive_aggregate(aggregate_request)
-        .expect("a completed attempt's signature is recoverable across restart");
-    assert_eq!(after_restart.signature_hex, first.signature_hex);
+    let err = interactive_aggregate(aggregate_request)
+        .expect_err("a completed attempt must stay completed across restart");
+    assert!(
+        matches!(err, EngineError::InteractiveAttemptAlreadyAggregated { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert_eq!(err.code(), "interactive_attempt_already_aggregated");
 
     reset_for_tests();
     cleanup_test_state_artifacts(&state_path);

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -12904,17 +12904,29 @@ fn interactive_aggregate_is_idempotent_for_completed_attempt() {
         taproot_merkle_root_hex: None,
     };
 
-    // First aggregate completes the attempt.
+    // First aggregate completes the attempt and records its signature.
     let first =
         interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
 
-    // A second aggregate for the same attempt returns the SAME signature
-    // (idempotent re-emission) rather than recomputing or erroring (Phase 7.2b
-    // design section 6).
+    // A repeat aggregate returns the PERSISTED signature, not a recompute
+    // (Phase 7.2b design section 6). A plain equality check would pass even on
+    // a recompute (aggregate is deterministic), so overwrite the stored record
+    // with a sentinel and confirm the repeat returns exactly that - the same
+    // return-the-recorded-value property the post-race path relies on.
+    {
+        let mut guard = state().expect("engine state").lock().expect("engine lock");
+        guard
+            .sessions
+            .get_mut(session_id)
+            .expect("session")
+            .aggregated_interactive_attempt_signatures
+            .insert(opened.attempt_id.clone(), "00sentinel".to_string());
+    }
     let second = interactive_aggregate(aggregate_request)
         .expect("re-aggregating a completed attempt returns the stored signature");
     assert_eq!(second.attempt_id, opened.attempt_id);
-    assert_eq!(second.signature_hex, first.signature_hex);
+    assert_eq!(second.signature_hex, "00sentinel");
+    assert_ne!(second.signature_hex, first.signature_hex);
 }
 
 #[test]

--- a/pkg/tbtc/signer/src/errors.rs
+++ b/pkg/tbtc/signer/src/errors.rs
@@ -82,17 +82,6 @@ pub enum EngineError {
         session_id: String,
         attempt_id: String,
     },
-    /// Returned when InteractiveAggregate is invoked again for an attempt that
-    /// already produced an aggregate signature in this session. The per-attempt
-    /// "aggregated" marker is durable, so a completed attempt stays completed
-    /// across restart; re-aggregation is rejected rather than recomputed.
-    /// Distinct code so callers match on
-    /// `interactive_attempt_already_aggregated` rather than the message.
-    #[error("interactive attempt [{attempt_id}] already aggregated in session [{session_id}]")]
-    InteractiveAttemptAlreadyAggregated {
-        session_id: String,
-        attempt_id: String,
-    },
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -115,9 +104,6 @@ impl EngineError {
             Self::ConsumedAttemptReplay { .. } => "consumed_attempt_replay",
             Self::ConsumedRoundReplay { .. } => "consumed_round_replay",
             Self::ConsumedNonceReplay { .. } => "consumed_nonce_replay",
-            Self::InteractiveAttemptAlreadyAggregated { .. } => {
-                "interactive_attempt_already_aggregated"
-            }
             Self::Internal(_) => "internal_error",
         }
     }
@@ -142,10 +128,6 @@ impl EngineError {
             Self::ConsumedAttemptReplay { .. } => "recoverable",
             Self::ConsumedRoundReplay { .. } => "recoverable",
             Self::ConsumedNonceReplay { .. } => "recoverable",
-            // The aggregate is deterministic over public data and the attempt
-            // is durably marked complete; a re-aggregation request is a benign
-            // duplicate the caller should not retry, not an engine fault.
-            Self::InteractiveAttemptAlreadyAggregated { .. } => "recoverable",
             Self::SessionFinalized { .. } => "terminal",
             Self::SessionNotFound { .. } => "terminal",
             Self::Internal(_) => "terminal",
@@ -185,20 +167,6 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "round_id [round-1] already consumed for sign contribution in session [session-a]",
-        );
-    }
-
-    #[test]
-    fn interactive_attempt_already_aggregated_has_stable_code_and_message_format() {
-        let err = EngineError::InteractiveAttemptAlreadyAggregated {
-            session_id: "session-a".to_string(),
-            attempt_id: "attempt-1".to_string(),
-        };
-        assert_eq!(err.code(), "interactive_attempt_already_aggregated");
-        assert_eq!(err.recovery_class(), "recoverable");
-        assert_eq!(
-            err.to_string(),
-            "interactive attempt [attempt-1] already aggregated in session [session-a]",
         );
     }
 

--- a/pkg/tbtc/signer/src/errors.rs
+++ b/pkg/tbtc/signer/src/errors.rs
@@ -82,6 +82,18 @@ pub enum EngineError {
         session_id: String,
         attempt_id: String,
     },
+    /// Returned when InteractiveAggregate is invoked again for an attempt that
+    /// already produced an aggregate signature in this session. The per-attempt
+    /// "aggregated" marker is durable, so a completed attempt stays completed
+    /// across restart; re-aggregation is rejected rather than recomputed
+    /// (a lost signature is recovered with a fresh attempt, not by replay).
+    /// Distinct code so callers match on
+    /// `interactive_attempt_already_aggregated` rather than the message.
+    #[error("interactive attempt [{attempt_id}] already aggregated in session [{session_id}]")]
+    InteractiveAttemptAlreadyAggregated {
+        session_id: String,
+        attempt_id: String,
+    },
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -104,6 +116,9 @@ impl EngineError {
             Self::ConsumedAttemptReplay { .. } => "consumed_attempt_replay",
             Self::ConsumedRoundReplay { .. } => "consumed_round_replay",
             Self::ConsumedNonceReplay { .. } => "consumed_nonce_replay",
+            Self::InteractiveAttemptAlreadyAggregated { .. } => {
+                "interactive_attempt_already_aggregated"
+            }
             Self::Internal(_) => "internal_error",
         }
     }
@@ -128,6 +143,10 @@ impl EngineError {
             Self::ConsumedAttemptReplay { .. } => "recoverable",
             Self::ConsumedRoundReplay { .. } => "recoverable",
             Self::ConsumedNonceReplay { .. } => "recoverable",
+            // The aggregate is deterministic over public data and the attempt
+            // is durably marked complete; a re-aggregation request is a benign
+            // duplicate the caller should not retry, not an engine fault.
+            Self::InteractiveAttemptAlreadyAggregated { .. } => "recoverable",
             Self::SessionFinalized { .. } => "terminal",
             Self::SessionNotFound { .. } => "terminal",
             Self::Internal(_) => "terminal",
@@ -167,6 +186,20 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "round_id [round-1] already consumed for sign contribution in session [session-a]",
+        );
+    }
+
+    #[test]
+    fn interactive_attempt_already_aggregated_has_stable_code_and_message_format() {
+        let err = EngineError::InteractiveAttemptAlreadyAggregated {
+            session_id: "session-a".to_string(),
+            attempt_id: "attempt-1".to_string(),
+        };
+        assert_eq!(err.code(), "interactive_attempt_already_aggregated");
+        assert_eq!(err.recovery_class(), "recoverable");
+        assert_eq!(
+            err.to_string(),
+            "interactive attempt [attempt-1] already aggregated in session [session-a]",
         );
     }
 

--- a/pkg/tbtc/signer/src/errors.rs
+++ b/pkg/tbtc/signer/src/errors.rs
@@ -82,6 +82,17 @@ pub enum EngineError {
         session_id: String,
         attempt_id: String,
     },
+    /// Returned when InteractiveAggregate is invoked again for an attempt that
+    /// already produced an aggregate signature in this session. The per-attempt
+    /// "aggregated" marker is durable, so a completed attempt stays completed
+    /// across restart; re-aggregation is rejected rather than recomputed.
+    /// Distinct code so callers match on
+    /// `interactive_attempt_already_aggregated` rather than the message.
+    #[error("interactive attempt [{attempt_id}] already aggregated in session [{session_id}]")]
+    InteractiveAttemptAlreadyAggregated {
+        session_id: String,
+        attempt_id: String,
+    },
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -104,6 +115,9 @@ impl EngineError {
             Self::ConsumedAttemptReplay { .. } => "consumed_attempt_replay",
             Self::ConsumedRoundReplay { .. } => "consumed_round_replay",
             Self::ConsumedNonceReplay { .. } => "consumed_nonce_replay",
+            Self::InteractiveAttemptAlreadyAggregated { .. } => {
+                "interactive_attempt_already_aggregated"
+            }
             Self::Internal(_) => "internal_error",
         }
     }
@@ -128,6 +142,10 @@ impl EngineError {
             Self::ConsumedAttemptReplay { .. } => "recoverable",
             Self::ConsumedRoundReplay { .. } => "recoverable",
             Self::ConsumedNonceReplay { .. } => "recoverable",
+            // The aggregate is deterministic over public data and the attempt
+            // is durably marked complete; a re-aggregation request is a benign
+            // duplicate the caller should not retry, not an engine fault.
+            Self::InteractiveAttemptAlreadyAggregated { .. } => "recoverable",
             Self::SessionFinalized { .. } => "terminal",
             Self::SessionNotFound { .. } => "terminal",
             Self::Internal(_) => "terminal",
@@ -167,6 +185,20 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "round_id [round-1] already consumed for sign contribution in session [session-a]",
+        );
+    }
+
+    #[test]
+    fn interactive_attempt_already_aggregated_has_stable_code_and_message_format() {
+        let err = EngineError::InteractiveAttemptAlreadyAggregated {
+            session_id: "session-a".to_string(),
+            attempt_id: "attempt-1".to_string(),
+        };
+        assert_eq!(err.code(), "interactive_attempt_already_aggregated");
+        assert_eq!(err.recovery_class(), "recoverable");
+        assert_eq!(
+            err.to_string(),
+            "interactive attempt [attempt-1] already aggregated in session [session-a]",
         );
     }
 


### PR DESCRIPTION
## Phase 7.2b-1: InteractiveAggregate completion marker

First implementation PR of Phase 7.2b (design signed off in #4054 — gates-doc Decision Log entry 9). **Engine-side only — no blame, no envelopes** — preserving the crypto-only engine boundary (the Q1 correction): all envelope verification and authoritative blame remain Go-side. Targets the mirror branch directly and is independent of #4054 (the code touches no docs; #4054 touches no source).

### What it does
Adds a durable per-attempt "aggregated" marker so re-aggregating a completed interactive attempt is rejected (`InteractiveAttemptAlreadyAggregated`) rather than recomputed (frozen Phase 7 spec; design §6). This is the only engine-side state 7.2b adds.

### Changes
- **`errors.rs`**: new `EngineError::InteractiveAttemptAlreadyAggregated { session_id, attempt_id }` — code `interactive_attempt_already_aggregated`, recovery class `recoverable` (benign duplicate; the engine is healthy).
- **`engine/state.rs`**: `aggregated_interactive_attempt_markers: HashSet<String>` on `SessionState`.
- **`engine/persistence.rs`**: mirrored `Vec<String>` on `PersistedSessionState` with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` (loads pre-7.2b state; writes nothing when empty), bounded via the existing consumed-registry helpers, wired through both `TryFrom` conversions.
- **`engine/interactive.rs`**: `interactive_aggregate` pre-checks the marker before recomputing; keeps the aggregation lock-free; then re-acquires the lock, **re-checks** (a concurrent-duplicate race guard), inserts the marker, and persists with rollback-on-failure — mirroring the Round2 consume-before-release pattern — before reporting success.

### Durable-retention confirmation (design §9)
The §9 question — is the group public key package durably retained beyond the signing-session TTL (needed by the later 7.2b-3 verify-share FFI)? — is **already satisfied**: `dkg_public_key_package` lives on the persisted session and `sweep_expired_interactive_state` clears only the live attempt's nonces. No new persistence is added here.

### Tests
- Re-aggregating a completed attempt is rejected with the correct code.
- The completion marker survives `simulate_process_restart_for_tests()` + reload (persistence round-trip).
- Error code / recovery class / message format pinned.

### Verification
`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean, full suite **274 lib pass / 0 fail / 1 ignored**, Phase-5 chaos suite all scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
