### PR TITLE
feat(frost/roast): Phase 7.2b-2 round-2 share collection (RecordShareSubmission)

### DIFF
--- a/pkg/frost/roast/round2_collector.go
+++ b/pkg/frost/roast/round2_collector.go
@@ -18,6 +18,12 @@ import (
 // bytes are self-incriminating proof of coordinator equivocation.
 const EquivocationKindSigningPackageConflict = "signing_package_conflict"
 
+// EquivocationKindShareConflict: a submitter returned two DIFFERENT signed share
+// bodies for the same attempt (different signature share, signing-package hash,
+// or coordinator id). Two operator-signed share bodies from one submitter for
+// one attempt are self-incriminating proof of member equivocation.
+const EquivocationKindShareConflict = "share_conflict"
+
 // ErrRound2UnknownAttempt is returned by Round2Collector when no binding exists
 // for an attempt (BeginAttempt was not called, or the attempt was pruned).
 var ErrRound2UnknownAttempt = errors.New(
@@ -36,6 +42,27 @@ var ErrRound2AttemptBindingConflict = errors.New(
 // (first-write-wins) and EquivocationEvidence is emitted.
 var ErrSigningPackageConflict = errors.New(
 	"roast: a different signing package was already recorded for this attempt (coordinator equivocation)",
+)
+
+// ErrRound2NoSigningPackage is returned by RecordShareSubmission when no signing
+// package has been recorded for the attempt yet - a share cannot be bound or
+// authenticated without the package it answers.
+var ErrRound2NoSigningPackage = errors.New(
+	"roast: no signing package recorded for this attempt yet",
+)
+
+// ErrRound2SubmitterNotIncluded is returned by RecordShareSubmission when the
+// submitter is not in the attempt's included set.
+var ErrRound2SubmitterNotIncluded = errors.New(
+	"roast: share submitter is not in the attempt's included set",
+)
+
+// ErrShareConflict is returned by RecordShareSubmission when a submitter records
+// a second share with a DIFFERENT signed body for an attempt - member
+// equivocation. The first share is retained (first-write-wins) and
+// EquivocationEvidence is emitted.
+var ErrShareConflict = errors.New(
+	"roast: a different share was already recorded by this submitter for this attempt (member equivocation)",
 )
 
 // Round2Collector is the Go-side blame-input layer (RFC-21 Phase 7.2b). It
@@ -75,9 +102,17 @@ type round2Record struct {
 	// re-encoding of the same (body, signature) is not equivocation.
 	signingPackageEnvelope []byte
 	signingPackageBodyHash [sha256.Size]byte
-	// shares retains each submitter's authenticated share (populated by the
-	// next increment).
-	shares map[group.MemberIndex]*ShareSubmission
+	// shares retains each submitter's authenticated share: its BodyHash (the
+	// member-equivocation identity) plus an owned copy of its envelope (evidence).
+	shares map[group.MemberIndex]*round2ShareRecord
+}
+
+// round2ShareRecord is a collector-owned record of one submitter's retained
+// share: the body hash (identity, stable across envelope re-encoding) and an
+// owned copy of the on-wire envelope (for equivocation evidence and blame).
+type round2ShareRecord struct {
+	bodyHash [sha256.Size]byte
+	envelope []byte
 }
 
 // NewRound2Collector returns a collector that authenticates retained bytes with
@@ -132,7 +167,7 @@ func (c *Round2Collector) BeginAttempt(
 		attemptContextHash: append([]byte(nil), attemptContextHash...),
 		electedCoordinator: electedCoordinator,
 		includedSet:        included,
-		shares:             map[group.MemberIndex]*ShareSubmission{},
+		shares:             map[group.MemberIndex]*round2ShareRecord{},
 	}
 	return nil
 }
@@ -219,6 +254,101 @@ func (c *Round2Collector) RecordSigningPackage(pkg *SigningPackage) error {
 	if evidence != nil {
 		emitEquivocationEvidence(*evidence)
 		return ErrSigningPackageConflict
+	}
+	return nil
+}
+
+// RecordShareSubmission authenticates a member's signed share submission against
+// the attempt's binding and its retained signing package, then retains it. The
+// attempt must already have a recorded signing package (ErrRound2NoSigningPackage
+// otherwise) - the share is authenticated against that package's BodyHash. The
+// submitter must be in the attempt's included set (ErrRound2SubmitterNotIncluded
+// otherwise). Re-recording the same signed share body is idempotent (including
+// an envelope re-encoding); a second share with a DIFFERENT signed body from the
+// same submitter is member equivocation: the first is retained (first-write-wins),
+// both envelopes are emitted as EquivocationEvidence, and ErrShareConflict is
+// returned. A share that fails authentication is rejected without retention.
+func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
+	if sub == nil {
+		return errors.New("round2: nil share submission")
+	}
+	key := round2AttemptKey(sub.AttemptContextHash)
+
+	c.mu.Lock()
+	record, ok := c.attempts[key]
+	if !ok {
+		c.mu.Unlock()
+		return ErrRound2UnknownAttempt
+	}
+	if record.signingPackageEnvelope == nil {
+		c.mu.Unlock()
+		return ErrRound2NoSigningPackage
+	}
+	elected := record.electedCoordinator
+	attemptHash := append([]byte(nil), record.attemptContextHash...)
+	pkgBodyHash := record.signingPackageBodyHash
+	c.mu.Unlock()
+
+	// Authenticate outside the lock (Validate + verify). Validate bounds the
+	// submitter id (uint32 -> MemberIndex), so SubmitterID() is safe below.
+	if err := AuthenticateShareSubmission(
+		c.verifier, sub, elected, attemptHash, pkgBodyHash[:],
+	); err != nil {
+		return err
+	}
+	// Identity is the share BODY hash, not the envelope - an unsigned re-encoding
+	// of the same signed body must NOT count as a conflicting share.
+	bodyHash, err := sub.BodyHash()
+	if err != nil {
+		return err
+	}
+	envelope, err := sub.Marshal()
+	if err != nil {
+		return err
+	}
+	ownedEnvelope := append([]byte(nil), envelope...)
+	submitter := sub.SubmitterID()
+
+	var evidence *EquivocationEvidence
+	c.mu.Lock()
+	record, ok = c.attempts[key]
+	if !ok {
+		c.mu.Unlock()
+		return ErrRound2UnknownAttempt
+	}
+	if record.electedCoordinator != elected || record.signingPackageBodyHash != pkgBodyHash {
+		// Binding or authoritative package changed under us (prune + re-begin).
+		c.mu.Unlock()
+		return ErrRound2UnknownAttempt
+	}
+	if _, included := record.includedSet[submitter]; !included {
+		c.mu.Unlock()
+		return ErrRound2SubmitterNotIncluded
+	}
+	switch existing, present := record.shares[submitter]; {
+	case !present:
+		record.shares[submitter] = &round2ShareRecord{
+			bodyHash: bodyHash,
+			envelope: ownedEnvelope,
+		}
+	case existing.bodyHash == bodyHash:
+		// Idempotent: the same signed share body re-recorded (possibly re-encoded).
+	default:
+		// A different signed share body from the same submitter: member
+		// equivocation. Keep the first; emit both.
+		evidence = &EquivocationEvidence{
+			Kind:                EquivocationKindShareConflict,
+			AttemptContextHash:  append([]byte(nil), record.attemptContextHash...),
+			Sender:              submitter,
+			ExistingEnvelope:    append([]byte(nil), existing.envelope...),
+			ConflictingEnvelope: ownedEnvelope,
+		}
+	}
+	c.mu.Unlock()
+
+	if evidence != nil {
+		emitEquivocationEvidence(*evidence)
+		return ErrShareConflict
 	}
 	return nil
 }

--- a/pkg/frost/roast/round2_collector.go
+++ b/pkg/frost/roast/round2_collector.go
@@ -18,10 +18,14 @@ import (
 // bytes are self-incriminating proof of coordinator equivocation.
 const EquivocationKindSigningPackageConflict = "signing_package_conflict"
 
-// EquivocationKindShareConflict: a submitter returned two DIFFERENT signed share
-// bodies for the same attempt (different signature share, signing-package hash,
-// or coordinator id). Two operator-signed share bodies from one submitter for
-// one attempt are self-incriminating proof of member equivocation.
+// EquivocationKindShareConflict: a submitter returned two DIFFERENT signed shares
+// for the SAME authenticated instruction. Authentication pins coordinator_id,
+// attempt, and the signing-package hash, so the differing field is the FROST
+// signature_share itself - self-incriminating member double-signing. (A
+// submission referencing a DIFFERENT package or coordinator is rejected at
+// authentication, not flagged here; detecting that as targeted coordinator
+// equivocation needs cross-package retention plus the f+1 quorum compare and is
+// deferred to Phase 7.2b-4.)
 const EquivocationKindShareConflict = "share_conflict"
 
 // ErrRound2UnknownAttempt is returned by Round2Collector when no binding exists
@@ -272,7 +276,17 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 	if sub == nil {
 		return errors.New("round2: nil share submission")
 	}
+	// Validate up front so SubmitterID() is bounded (uint32 -> MemberIndex) for
+	// the membership pre-gate below. Membership is a cheap gate before the
+	// expensive signature verify: it rejects validly-signed-but-not-included
+	// junk without burning CPU. It is safe to gate here because the attempt
+	// context hash cryptographically commits to the included set, so the set for
+	// a given attempt key cannot change under us.
+	if err := sub.Validate(); err != nil {
+		return fmt.Errorf("share submission failed structural validation: %w", err)
+	}
 	key := round2AttemptKey(sub.AttemptContextHash)
+	submitter := sub.SubmitterID()
 
 	c.mu.Lock()
 	record, ok := c.attempts[key]
@@ -284,13 +298,16 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 		c.mu.Unlock()
 		return ErrRound2NoSigningPackage
 	}
+	if _, included := record.includedSet[submitter]; !included {
+		c.mu.Unlock()
+		return ErrRound2SubmitterNotIncluded
+	}
 	elected := record.electedCoordinator
 	attemptHash := append([]byte(nil), record.attemptContextHash...)
 	pkgBodyHash := record.signingPackageBodyHash
 	c.mu.Unlock()
 
-	// Authenticate outside the lock (Validate + verify). Validate bounds the
-	// submitter id (uint32 -> MemberIndex), so SubmitterID() is safe below.
+	// Authenticate outside the lock (signature verify is the expensive step).
 	if err := AuthenticateShareSubmission(
 		c.verifier, sub, elected, attemptHash, pkgBodyHash[:],
 	); err != nil {
@@ -307,7 +324,6 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 		return err
 	}
 	ownedEnvelope := append([]byte(nil), envelope...)
-	submitter := sub.SubmitterID()
 
 	var evidence *EquivocationEvidence
 	c.mu.Lock()
@@ -320,10 +336,6 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 		// Binding or authoritative package changed under us (prune + re-begin).
 		c.mu.Unlock()
 		return ErrRound2UnknownAttempt
-	}
-	if _, included := record.includedSet[submitter]; !included {
-		c.mu.Unlock()
-		return ErrRound2SubmitterNotIncluded
 	}
 	switch existing, present := record.shares[submitter]; {
 	case !present:

--- a/pkg/frost/roast/round2_collector.go
+++ b/pkg/frost/roast/round2_collector.go
@@ -1,11 +1,11 @@
 package roast
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
-
 	"sync"
 
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
@@ -27,6 +27,16 @@ const EquivocationKindSigningPackageConflict = "signing_package_conflict"
 // equivocation needs cross-package retention plus the f+1 quorum compare and is
 // deferred to Phase 7.2b-4.)
 const EquivocationKindShareConflict = "share_conflict"
+
+// EquivocationKindDivergentShare: an included member submitted a validly-signed,
+// attempt-bound share that does NOT bind the attempt's authoritative package
+// (different signing-package hash or coordinator). It is retained as evidence of
+// possible TARGETED coordinator equivocation (a package distributed to only some
+// members) - the collector preserves the bytes but does NOT attribute fault
+// locally; coordinator-vs-member classification is the f+1 quorum's job
+// (Phase 7.2b-4). The evidence carries the divergent share (ConflictingEnvelope)
+// and the attempt's authoritative signing-package envelope (ExistingEnvelope).
+const EquivocationKindDivergentShare = "divergent_share"
 
 // ErrRound2UnknownAttempt is returned by Round2Collector when no binding exists
 // for an attempt (BeginAttempt was not called, or the attempt was pruned).
@@ -69,6 +79,15 @@ var ErrShareConflict = errors.New(
 	"roast: a different share was already recorded by this submitter for this attempt (member equivocation)",
 )
 
+// ErrShareRetainedNotAccepted is returned by RecordShareSubmission when a share
+// is genuinely submitter-signed for the attempt but does NOT bind the
+// authoritative package/coordinator. It is RETAINED as divergent evidence (for
+// Phase 7.2b-4) but is NOT an accepted aggregation share - the caller must not
+// count it toward the signing threshold.
+var ErrShareRetainedNotAccepted = errors.New(
+	"roast: share retained as divergent evidence but not accepted (does not bind the authoritative package)",
+)
+
 // Round2Collector is the Go-side blame-input layer (RFC-21 Phase 7.2b). It
 // retains the exact round-2 bytes seen for an attempt - the elected
 // coordinator's signed signing package and (a later increment) members' signed
@@ -106,9 +125,14 @@ type round2Record struct {
 	// re-encoding of the same (body, signature) is not equivocation.
 	signingPackageEnvelope []byte
 	signingPackageBodyHash [sha256.Size]byte
-	// shares retains each submitter's authenticated share: its BodyHash (the
-	// member-equivocation identity) plus an owned copy of its envelope (evidence).
+	// shares retains each submitter's ACCEPTED share (binds the authoritative
+	// package + elected coordinator): its BodyHash (the member-equivocation
+	// identity) plus an owned copy of its envelope (evidence).
 	shares map[group.MemberIndex]*round2ShareRecord
+	// divergentShares retains each submitter's first validly-signed but
+	// NON-authoritative-package-bound share - blame evidence of possible targeted
+	// coordinator equivocation, not an aggregation input.
+	divergentShares map[group.MemberIndex]*round2ShareRecord
 }
 
 // round2ShareRecord is a collector-owned record of one submitter's retained
@@ -172,6 +196,7 @@ func (c *Round2Collector) BeginAttempt(
 		electedCoordinator: electedCoordinator,
 		includedSet:        included,
 		shares:             map[group.MemberIndex]*round2ShareRecord{},
+		divergentShares:    map[group.MemberIndex]*round2ShareRecord{},
 	}
 	return nil
 }
@@ -262,16 +287,26 @@ func (c *Round2Collector) RecordSigningPackage(pkg *SigningPackage) error {
 	return nil
 }
 
-// RecordShareSubmission authenticates a member's signed share submission against
-// the attempt's binding and its retained signing package, then retains it. The
-// attempt must already have a recorded signing package (ErrRound2NoSigningPackage
-// otherwise) - the share is authenticated against that package's BodyHash. The
-// submitter must be in the attempt's included set (ErrRound2SubmitterNotIncluded
-// otherwise). Re-recording the same signed share body is idempotent (including
-// an envelope re-encoding); a second share with a DIFFERENT signed body from the
-// same submitter is member equivocation: the first is retained (first-write-wins),
-// both envelopes are emitted as EquivocationEvidence, and ErrShareConflict is
-// returned. A share that fails authentication is rejected without retention.
+// RecordShareSubmission verifies and retains a member's signed share submission.
+// The attempt must already have a recorded signing package
+// (ErrRound2NoSigningPackage) and the submitter must be in the included set
+// (ErrRound2SubmitterNotIncluded, checked cheaply before signature verification).
+// The submitter signature is verified over the attempt-bound body; a share not
+// genuinely submitter-signed for this attempt is rejected without retention.
+//
+// A verified share is classified:
+//   - ACCEPTED if it binds the elected coordinator AND the authoritative signing
+//     package (its BodyHash): retained as an aggregation share, first-write-wins.
+//     A second ACCEPTED share with a different body from the same submitter is
+//     member double-signing -> EquivocationKindShareConflict, ErrShareConflict.
+//   - DIVERGENT otherwise (validly signed for the attempt but bound to a
+//     different package/coordinator): retained SEPARATELY as evidence of possible
+//     targeted coordinator equivocation -> EquivocationKindDivergentShare,
+//     ErrShareRetainedNotAccepted (retained, NOT counted toward the threshold).
+//     Fault is not attributed here; the f+1 quorum decides in Phase 7.2b-4.
+//
+// Re-recording the same body (accepted or divergent) is idempotent, including an
+// unsigned envelope re-encoding.
 func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 	if sub == nil {
 		return errors.New("round2: nil share submission")
@@ -307,10 +342,12 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 	pkgBodyHash := record.signingPackageBodyHash
 	c.mu.Unlock()
 
-	// Authenticate outside the lock (signature verify is the expensive step).
-	if err := AuthenticateShareSubmission(
-		c.verifier, sub, elected, attemptHash, pkgBodyHash[:],
-	); err != nil {
+	// Verify the submitter signature OUTSIDE the lock (the expensive step). This
+	// is the WEAKER check: it does not require the share to bind the authoritative
+	// package or elected coordinator, because a submitter-signed share that
+	// diverges from the authoritative package is retained as evidence (see
+	// EquivocationKindDivergentShare), never dropped.
+	if err := verifyShareSubmissionForAttempt(c.verifier, sub, attemptHash); err != nil {
 		return err
 	}
 	// Identity is the share BODY hash, not the envelope - an unsigned re-encoding
@@ -324,8 +361,16 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 		return err
 	}
 	ownedEnvelope := append([]byte(nil), envelope...)
+	// Accepted = binds the elected coordinator AND the authoritative package
+	// (eligible for aggregation). Otherwise the share is divergent: retained as
+	// targeted-equivocation evidence, not an aggregation input.
+	accepted := sub.CoordinatorID() == elected &&
+		bytes.Equal(sub.SigningPackageHash, pkgBodyHash[:])
 
-	var evidence *EquivocationEvidence
+	var (
+		evidence *EquivocationEvidence
+		result   error
+	)
 	c.mu.Lock()
 	record, ok = c.attempts[key]
 	if !ok {
@@ -337,32 +382,71 @@ func (c *Round2Collector) RecordShareSubmission(sub *ShareSubmission) error {
 		c.mu.Unlock()
 		return ErrRound2UnknownAttempt
 	}
-	switch existing, present := record.shares[submitter]; {
-	case !present:
-		record.shares[submitter] = &round2ShareRecord{
-			bodyHash: bodyHash,
-			envelope: ownedEnvelope,
+	if accepted {
+		switch existing, present := record.shares[submitter]; {
+		case !present:
+			record.shares[submitter] = &round2ShareRecord{
+				bodyHash: bodyHash,
+				envelope: ownedEnvelope,
+			}
+		case existing.bodyHash == bodyHash:
+			// Idempotent: the same accepted share re-recorded (possibly re-encoded).
+		default:
+			// A different accepted share body from the same submitter: member
+			// double-signing the same instruction. Keep the first; emit both.
+			evidence = &EquivocationEvidence{
+				Kind:                EquivocationKindShareConflict,
+				AttemptContextHash:  append([]byte(nil), record.attemptContextHash...),
+				Sender:              submitter,
+				ExistingEnvelope:    append([]byte(nil), existing.envelope...),
+				ConflictingEnvelope: ownedEnvelope,
+			}
+			result = ErrShareConflict
 		}
-	case existing.bodyHash == bodyHash:
-		// Idempotent: the same signed share body re-recorded (possibly re-encoded).
-	default:
-		// A different signed share body from the same submitter: member
-		// equivocation. Keep the first; emit both.
-		evidence = &EquivocationEvidence{
-			Kind:                EquivocationKindShareConflict,
-			AttemptContextHash:  append([]byte(nil), record.attemptContextHash...),
-			Sender:              submitter,
-			ExistingEnvelope:    append([]byte(nil), existing.envelope...),
-			ConflictingEnvelope: ownedEnvelope,
+	} else {
+		// Divergent: retain as evidence (first per submitter) and flag it WITHOUT
+		// attributing fault - the f+1 quorum (7.2b-4) decides coordinator vs
+		// member. Always reported as retained-not-accepted so the caller does not
+		// count it toward the threshold.
+		result = ErrShareRetainedNotAccepted
+		switch existing, present := record.divergentShares[submitter]; {
+		case !present:
+			record.divergentShares[submitter] = &round2ShareRecord{
+				bodyHash: bodyHash,
+				envelope: ownedEnvelope,
+			}
+			evidence = divergentShareEvidence(record, submitter, ownedEnvelope)
+		case existing.bodyHash == bodyHash:
+			// Idempotent: the same divergent share re-recorded.
+		default:
+			// A second, different divergent share from the same submitter: re-flag
+			// (keep the first retained).
+			evidence = divergentShareEvidence(record, submitter, ownedEnvelope)
 		}
 	}
 	c.mu.Unlock()
 
 	if evidence != nil {
 		emitEquivocationEvidence(*evidence)
-		return ErrShareConflict
 	}
-	return nil
+	return result
+}
+
+// divergentShareEvidence builds EquivocationKindDivergentShare evidence: the
+// divergent share envelope plus the attempt's authoritative signing-package
+// envelope for context. The caller holds the lock.
+func divergentShareEvidence(
+	record *round2Record,
+	submitter group.MemberIndex,
+	divergentEnvelope []byte,
+) *EquivocationEvidence {
+	return &EquivocationEvidence{
+		Kind:                EquivocationKindDivergentShare,
+		AttemptContextHash:  append([]byte(nil), record.attemptContextHash...),
+		Sender:              submitter,
+		ExistingEnvelope:    append([]byte(nil), record.signingPackageEnvelope...),
+		ConflictingEnvelope: append([]byte(nil), divergentEnvelope...),
+	}
 }
 
 // PruneAttempt drops all retained round-2 state for an attempt. Callers invoke

--- a/pkg/frost/roast/round2_collector_test.go
+++ b/pkg/frost/roast/round2_collector_test.go
@@ -229,3 +229,148 @@ func TestRound2_NilInputsAreRejectedNotPanicked(t *testing.T) {
 		t.Fatal("ShareSubmission.Unmarshal into a nil receiver must return an error")
 	}
 }
+
+// recordTestPackage begins an attempt, records a coordinator-signed package, and
+// returns the package's BodyHash (the value shares must bind to).
+func recordTestPackage(t *testing.T, c *Round2Collector, elected group.MemberIndex) []byte {
+	t.Helper()
+	if err := c.BeginAttempt(pinnedContextHash[:], elected, testIncludedSet()); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	pkg := signedTestSigningPackage(t, elected, nil)
+	if err := c.RecordSigningPackage(pkg); err != nil {
+		t.Fatalf("record package: %v", err)
+	}
+	h, err := pkg.BodyHash()
+	if err != nil {
+		t.Fatalf("body hash: %v", err)
+	}
+	return h[:]
+}
+
+func TestRound2Collector_RecordShareSubmission_RetainsAuthenticated(t *testing.T) {
+	c := NewRound2Collector(fakeVerifier{})
+	elected := group.MemberIndex(testShareCoordinatorID)
+	pkgHash := recordTestPackage(t, c, elected)
+
+	if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, pkgHash)); err != nil {
+		t.Fatalf("record share: %v", err)
+	}
+	// An identical share (deterministic fakeSigner) re-records idempotently.
+	if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, pkgHash)); err != nil {
+		t.Fatalf("re-record identical share must be idempotent: %v", err)
+	}
+}
+
+func TestRound2Collector_RecordShareSubmission_Rejections(t *testing.T) {
+	elected := group.MemberIndex(testShareCoordinatorID)
+
+	t.Run("nil is rejected", func(t *testing.T) {
+		if err := NewRound2Collector(fakeVerifier{}).RecordShareSubmission(nil); err == nil {
+			t.Fatal("nil share must be rejected, not panic")
+		}
+	})
+	t.Run("unknown attempt", func(t *testing.T) {
+		c := NewRound2Collector(fakeVerifier{})
+		if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, testSigningPackageHash())); !errors.Is(err, ErrRound2UnknownAttempt) {
+			t.Fatalf("want ErrRound2UnknownAttempt, got %v", err)
+		}
+	})
+	t.Run("no signing package recorded yet", func(t *testing.T) {
+		c := NewRound2Collector(fakeVerifier{})
+		if err := c.BeginAttempt(pinnedContextHash[:], elected, testIncludedSet()); err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, testSigningPackageHash())); !errors.Is(err, ErrRound2NoSigningPackage) {
+			t.Fatalf("want ErrRound2NoSigningPackage, got %v", err)
+		}
+	})
+	t.Run("submitter not in included set", func(t *testing.T) {
+		c := NewRound2Collector(fakeVerifier{})
+		if err := c.BeginAttempt(pinnedContextHash[:], elected, []group.MemberIndex{5, 7}); err != nil { // excludes 3
+			t.Fatalf("begin: %v", err)
+		}
+		pkg := signedTestSigningPackage(t, elected, nil)
+		if err := c.RecordSigningPackage(pkg); err != nil {
+			t.Fatalf("record package: %v", err)
+		}
+		pkgHash, _ := pkg.BodyHash()
+		if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, pkgHash[:])); !errors.Is(err, ErrRound2SubmitterNotIncluded) {
+			t.Fatalf("want ErrRound2SubmitterNotIncluded, got %v", err)
+		}
+	})
+	t.Run("share bound to a different package is rejected by auth", func(t *testing.T) {
+		c := NewRound2Collector(fakeVerifier{})
+		_ = recordTestPackage(t, c, elected)
+		wrong := bytes.Repeat([]byte{0x11}, SigningPackageHashLength)
+		if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, wrong)); !errors.Is(err, ErrShareSubmissionWrongPackage) {
+			t.Fatalf("want ErrShareSubmissionWrongPackage, got %v", err)
+		}
+	})
+}
+
+func TestRound2Collector_RecordShareSubmission_DetectsMemberEquivocation(t *testing.T) {
+	captured := captureEquivocationEvidence(t)
+	c := NewRound2Collector(fakeVerifier{})
+	elected := group.MemberIndex(testShareCoordinatorID)
+	pkgHash := recordTestPackage(t, c, elected)
+
+	if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, pkgHash)); err != nil {
+		t.Fatalf("record first share: %v", err)
+	}
+	// Same submitter, DIFFERENT signed share body (different signature share).
+	conflicting := &ShareSubmission{
+		AttemptContextHash: append([]byte(nil), pinnedContextHash[:]...),
+		SubmitterIDValue:   3,
+		CoordinatorIDValue: testShareCoordinatorID,
+		SigningPackageHash: pkgHash,
+		SignatureShare:     []byte("a-different-round2-share"),
+	}
+	if err := SignShareSubmission(&fakeSigner{id: 3}, conflicting); err != nil {
+		t.Fatalf("sign conflicting: %v", err)
+	}
+	if err := c.RecordShareSubmission(conflicting); !errors.Is(err, ErrShareConflict) {
+		t.Fatalf("want ErrShareConflict, got %v", err)
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 equivocation event, got %d", len(*captured))
+	}
+	ev := (*captured)[0]
+	if ev.Kind != EquivocationKindShareConflict || ev.Sender != 3 {
+		t.Fatalf("want share_conflict from sender 3, got kind %q sender %d", ev.Kind, ev.Sender)
+	}
+	if len(ev.ExistingEnvelope) == 0 || len(ev.ConflictingEnvelope) == 0 ||
+		bytes.Equal(ev.ExistingEnvelope, ev.ConflictingEnvelope) {
+		t.Fatal("both distinct share envelopes must be retained as evidence")
+	}
+}
+
+func TestRound2Collector_RecordShareSubmission_EnvelopeReEncodingIsNotEquivocation(t *testing.T) {
+	captured := captureEquivocationEvidence(t)
+	c := NewRound2Collector(fakeVerifier{})
+	elected := group.MemberIndex(testShareCoordinatorID)
+	pkgHash := recordTestPackage(t, c, elected)
+
+	share := signedTestShareSubmission(t, 3, pkgHash)
+	if err := c.RecordShareSubmission(share); err != nil {
+		t.Fatalf("record share: %v", err)
+	}
+	// Re-wrap the SAME (body, signature) in a reversed-field-order envelope.
+	body, _ := share.bodyBytes()
+	var reEncoded []byte
+	reEncoded = append(reEncoded, 0x12, byte(len(share.SubmitterSignature)))
+	reEncoded = append(reEncoded, share.SubmitterSignature...)
+	reEncoded = append(reEncoded, 0x0a, byte(len(body)))
+	reEncoded = append(reEncoded, body...)
+	var reDecoded ShareSubmission
+	if err := reDecoded.Unmarshal(reEncoded); err != nil {
+		t.Fatalf("unmarshal re-encoded: %v", err)
+	}
+
+	if err := c.RecordShareSubmission(&reDecoded); err != nil {
+		t.Fatalf("a re-encoded same-body share must be idempotent, got %v", err)
+	}
+	if len(*captured) != 0 {
+		t.Fatalf("share envelope re-encoding must NOT emit equivocation, got %d", len(*captured))
+	}
+}

--- a/pkg/frost/roast/round2_collector_test.go
+++ b/pkg/frost/roast/round2_collector_test.go
@@ -299,14 +299,45 @@ func TestRound2Collector_RecordShareSubmission_Rejections(t *testing.T) {
 			t.Fatalf("want ErrRound2SubmitterNotIncluded, got %v", err)
 		}
 	})
-	t.Run("share bound to a different package is rejected by auth", func(t *testing.T) {
+	t.Run("share with a bad submitter signature is rejected without retention", func(t *testing.T) {
 		c := NewRound2Collector(fakeVerifier{})
-		_ = recordTestPackage(t, c, elected)
-		wrong := bytes.Repeat([]byte{0x11}, SigningPackageHashLength)
-		if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, wrong)); !errors.Is(err, ErrShareSubmissionWrongPackage) {
-			t.Fatalf("want ErrShareSubmissionWrongPackage, got %v", err)
+		pkgHash := recordTestPackage(t, c, elected)
+		sub := signedTestShareSubmission(t, 3, pkgHash)
+		sub.SubmitterSignature[0] ^= 0xff // tamper
+		if err := c.RecordShareSubmission(sub); !errors.Is(err, ErrSignatureInvalid) {
+			t.Fatalf("want ErrSignatureInvalid, got %v", err)
 		}
 	})
+}
+
+func TestRound2Collector_RecordShareSubmission_RetainsDivergentShare(t *testing.T) {
+	// A validly-signed, attempt-bound, included-member share that does NOT bind
+	// the authoritative package is RETAINED as divergent evidence (possible
+	// targeted coordinator equivocation), not dropped: it returns
+	// ErrShareRetainedNotAccepted and emits EquivocationKindDivergentShare.
+	captured := captureEquivocationEvidence(t)
+	c := NewRound2Collector(fakeVerifier{})
+	elected := group.MemberIndex(testShareCoordinatorID)
+	_ = recordTestPackage(t, c, elected)
+
+	wrong := bytes.Repeat([]byte{0x11}, SigningPackageHashLength)
+	if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, wrong)); !errors.Is(err, ErrShareRetainedNotAccepted) {
+		t.Fatalf("want ErrShareRetainedNotAccepted, got %v", err)
+	}
+	if len(*captured) != 1 || (*captured)[0].Kind != EquivocationKindDivergentShare {
+		t.Fatalf("expected 1 divergent_share event, got %d %+v", len(*captured), *captured)
+	}
+	if (*captured)[0].Sender != 3 || len((*captured)[0].ConflictingEnvelope) == 0 {
+		t.Fatal("divergent evidence must name the submitter and carry the share envelope")
+	}
+	// Re-recording the same divergent share is idempotent: still not accepted, no
+	// new evidence.
+	if err := c.RecordShareSubmission(signedTestShareSubmission(t, 3, wrong)); !errors.Is(err, ErrShareRetainedNotAccepted) {
+		t.Fatalf("re-record: want ErrShareRetainedNotAccepted, got %v", err)
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("idempotent divergent re-record must not emit again, got %d", len(*captured))
+	}
 }
 
 func TestRound2Collector_RecordShareSubmission_DetectsMemberEquivocation(t *testing.T) {

--- a/pkg/frost/roast/share_submission.go
+++ b/pkg/frost/roast/share_submission.go
@@ -1,6 +1,7 @@
 package roast
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 
@@ -158,6 +159,19 @@ func (p *ShareSubmission) SignableBytes() ([]byte, error) {
 	payload = append(payload, body...)
 	p.signaturePayloadCache = payload
 	return payload, nil
+}
+
+// BodyHash returns the SHA-256 of the submission's signed body bytes - the
+// identity used to detect member equivocation (two different signed share bodies
+// from one submitter for one attempt). It hashes the BODY (the signed content:
+// attempt, coordinator, signing-package hash, and share), not the on-wire
+// envelope, so it is stable across an unsigned envelope re-encoding.
+func (p *ShareSubmission) BodyHash() ([sha256.Size]byte, error) {
+	body, err := p.bodyBytes()
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(body), nil
 }
 
 // Type implements net.TaggedUnmarshaler.

--- a/pkg/frost/roast/share_submission_auth.go
+++ b/pkg/frost/roast/share_submission_auth.go
@@ -119,3 +119,49 @@ func AuthenticateShareSubmission(
 	}
 	return nil
 }
+
+// verifyShareSubmissionForAttempt verifies the submitter signature on an
+// already-validated share for the live attempt WITHOUT the strict package /
+// coordinator binding that AuthenticateShareSubmission requires. It confirms only
+// that sub is a genuine, attempt-bound share from its declared submitter.
+//
+// The Round2Collector uses this to RETAIN a submitter-signed share that diverges
+// from the attempt's authoritative package (a different signing-package hash or
+// coordinator) as blame evidence, rather than dropping it: the collector's
+// contract is to preserve the exact bytes adjudication needs, and a dropped
+// divergent share is targeted coordinator equivocation that 7.2b-4 could never
+// recover. Classification (coordinator vs member fault) is deferred to the f+1
+// quorum compare. sub.Validate() must have already passed (so SubmitterID() is
+// bounded).
+func verifyShareSubmissionForAttempt(
+	verifier SignatureVerifier,
+	sub *ShareSubmission,
+	liveAttemptContextHash []byte,
+) error {
+	if len(sub.SubmitterSignature) == 0 {
+		return fmt.Errorf(
+			"%w: share submission has no submitter signature",
+			ErrSignatureMissing,
+		)
+	}
+	if !bytes.Equal(sub.AttemptContextHash, liveAttemptContextHash) {
+		return ErrShareSubmissionWrongAttempt
+	}
+	payload, err := sub.SignableBytes()
+	if err != nil {
+		return fmt.Errorf("share submission signable bytes: %w", err)
+	}
+	if err := verifier.Verify(
+		payload,
+		sub.SubmitterSignature,
+		sub.SubmitterID(),
+	); err != nil {
+		return fmt.Errorf(
+			"%w: submitter %d: %s",
+			ErrSignatureInvalid,
+			sub.SubmitterID(),
+			err.Error(),
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Completes the `Round2Collector` blame-input layer (#4060 added the package side): collects and retains members' Round2 **share submissions**, and detects **member equivocation**. This is the share-retention piece of task #27.

## How

- **`RecordShareSubmission(sub)`**:
  - requires the attempt to already have a recorded signing package (`ErrRound2NoSigningPackage`);
  - **authenticates the share outside the lock** against the binding (elected coordinator + attempt) and the **retained package's `BodyHash`** (so the share is bound to the exact instruction the collector holds);
  - enforces **submitter membership** in the included set (`ErrRound2SubmitterNotIncluded`) — `AuthenticateShareSubmission` deliberately defers membership to the caller;
  - retains per `(attempt, submitter)` **first-write-wins**; a second share with a **different signed body** from the same submitter is member equivocation (`EquivocationKindShareConflict`, `ErrShareConflict`, evidence emitted after unlock with defensive copies).
- **Identity is the share `BodyHash`** (`sha256` of the signed body), not the envelope — so an unsigned envelope re-encoding records idempotently rather than falsely flagging a conflict (the same body-hash lesson applied on the package side). The 3 equivocation dimensions (different share bytes / package hash / coordinator) all live in the body, so the body hash captures them.
- Retains a **collector-owned copy** of the envelope; nil-guarded; re-checks the binding after re-acquiring the lock (matching `RecordSigningPackage`).
- Adds `ShareSubmission.BodyHash()`.

## Testing

`gofmt`/`vet`/`build` clean; full `pkg/frost/roast` suite passes under `go test -race`. Tests: authenticated retain + idempotent re-record; rejections (nil, unknown attempt, no package recorded, non-member submitter, share bound to a different package); member-equivocation evidence (kind/sender/both envelopes); and a re-encoded same-body share recorded idempotently (not equivocation).

## Status

With this, the Phase 7.2b-2 round-2 **sign / distribute / authenticate / retain** surface is complete (the actual `pkg/net` transport wiring is a later, separate step). Next: **7.2b-3** (mirror — FFI candidate culprits) and **7.2b-4** (the cross-member f+1-quorum blame *adjudication* on top of this retained evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)