### PR TITLE
Phase 7.2b-4b: surface coordinator-signed package proofs (collector)

### DIFF
--- a/pkg/frost/roast/round2_classifier.go
+++ b/pkg/frost/roast/round2_classifier.go
@@ -204,3 +204,36 @@ func (c *Round2Collector) snapshotCandidatesForClassification(
 	}
 	return signingPackageEnvelope, snapshot, nil
 }
+
+// CoordinatorConflicts surfaces this observer's locally-detected coordinator
+// equivocation for an attempt as a ConflictEntry accusation against the elected
+// coordinator, for the observer's LocalEvidenceSnapshot.Conflicts ->
+// NextAttempt's f+1 establishment gate (symmetric with ClassifyCandidateCulprits;
+// it never excludes by itself). An established coordinator conflict excludes the
+// coordinator, which auto-rotates it out of the next attempt's included set.
+//
+// The collector flags equivocation when the coordinator distributes two
+// body-different signing packages for one attempt; both were individually
+// authenticated as coordinator-signed before the conflict was recorded, so the
+// accusation rests on unforgeable, self-incriminating proof (no re-verification
+// needed, unlike candidate culprits). At most one entry - a single coordinator
+// per attempt - with Count 1; empty when no conflict was observed.
+//
+// This catches only equivocation THIS observer directly received (the rare
+// broadcast case). Targeted/split equivocation - different packages to disjoint
+// members, so no single observer sees two - needs the cross-observer comparison
+// (Phase 7.2b-4b-ii). Returns ErrRound2UnknownAttempt if the attempt was never
+// begun.
+func (c *Round2Collector) CoordinatorConflicts(attemptContextHash []byte) ([]ConflictEntry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	record, ok := c.attempts[round2AttemptKey(attemptContextHash)]
+	if !ok {
+		return nil, ErrRound2UnknownAttempt
+	}
+	if record.conflictingSigningPackageEnvelope == nil {
+		return nil, nil
+	}
+	return []ConflictEntry{{Sender: record.electedCoordinator, Count: 1}}, nil
+}

--- a/pkg/frost/roast/round2_classifier.go
+++ b/pkg/frost/roast/round2_classifier.go
@@ -205,26 +205,27 @@ func (c *Round2Collector) snapshotCandidatesForClassification(
 	return signingPackageEnvelope, snapshot, nil
 }
 
-// CoordinatorConflicts surfaces this observer's locally-detected coordinator
-// equivocation for an attempt as a ConflictEntry accusation against the elected
-// coordinator, for the observer's LocalEvidenceSnapshot.Conflicts ->
-// NextAttempt's f+1 establishment gate (symmetric with ClassifyCandidateCulprits;
-// it never excludes by itself). An established coordinator conflict excludes the
-// coordinator, which auto-rotates it out of the next attempt's included set.
+// CoordinatorPackageProofs returns the coordinator-signed signing-package
+// envelope(s) this observer retained for an attempt, to publish in its
+// LocalEvidenceSnapshot so NextAttempt can detect coordinator equivocation
+// across observers (Phase 7.2b-4b). It returns the authoritative package the
+// observer accepted and, when the coordinator equivocated TO THIS observer (a
+// second body-different package arrived), that conflicting package too - at most
+// two envelopes (authoritative first, then the first conflicting one).
 //
-// The collector flags equivocation when the coordinator distributes two
-// body-different signing packages for one attempt; both were individually
-// authenticated as coordinator-signed before the conflict was recorded, so the
-// accusation rests on unforgeable, self-incriminating proof (no re-verification
-// needed, unlike candidate culprits). At most one entry - a single coordinator
-// per attempt - with Count 1; empty when no conflict was observed.
+// These are the raw, unforgeable proof material: each envelope carries the
+// coordinator's operator signature over its body and the attempt context.
+// Adjudication is NextAttempt's job, NOT the collector's - NextAttempt verifies
+// the coordinator signature + attempt binding, dedupes by body hash, and
+// instant-excludes a coordinator that signed >= 2 distinct bodies for one
+// attempt. Because that proof is unforgeable, a single honest observer suffices
+// and it does NOT pass through the f+1 counted gate (which exists to bound
+// fabricated bare-counter claims). The collector only surfaces retained signed
+// bytes (owned copies); it never decides blame.
 //
-// This catches only equivocation THIS observer directly received (the rare
-// broadcast case). Targeted/split equivocation - different packages to disjoint
-// members, so no single observer sees two - needs the cross-observer comparison
-// (Phase 7.2b-4b-ii). Returns ErrRound2UnknownAttempt if the attempt was never
-// begun.
-func (c *Round2Collector) CoordinatorConflicts(attemptContextHash []byte) ([]ConflictEntry, error) {
+// Returns ErrRound2UnknownAttempt if the attempt was never begun, and an empty
+// slice (nil error) if no authoritative package has been recorded yet.
+func (c *Round2Collector) CoordinatorPackageProofs(attemptContextHash []byte) ([][]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -232,8 +233,12 @@ func (c *Round2Collector) CoordinatorConflicts(attemptContextHash []byte) ([]Con
 	if !ok {
 		return nil, ErrRound2UnknownAttempt
 	}
-	if record.conflictingSigningPackageEnvelope == nil {
+	if record.signingPackageEnvelope == nil {
 		return nil, nil
 	}
-	return []ConflictEntry{{Sender: record.electedCoordinator, Count: 1}}, nil
+	proofs := [][]byte{append([]byte(nil), record.signingPackageEnvelope...)}
+	if record.conflictingSigningPackageEnvelope != nil {
+		proofs = append(proofs, append([]byte(nil), record.conflictingSigningPackageEnvelope...))
+	}
+	return proofs, nil
 }

--- a/pkg/frost/roast/round2_classifier_test.go
+++ b/pkg/frost/roast/round2_classifier_test.go
@@ -223,3 +223,58 @@ func TestClassifyCandidateCulprits_Errors(t *testing.T) {
 		}
 	})
 }
+
+func TestCoordinatorConflicts_SurfacesEquivocationAsConflictEntry(t *testing.T) {
+	_ = captureEquivocationEvidence(t)
+	c := NewRound2Collector(fakeVerifier{})
+	const elected = group.MemberIndex(3)
+	if err := c.BeginAttempt(pinnedContextHash[:], elected, testIncludedSet()); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, nil)); err != nil {
+		t.Fatalf("record first package: %v", err)
+	}
+
+	// No second package yet -> no coordinator equivocation -> no accusation.
+	conflicts, err := c.CoordinatorConflicts(pinnedContextHash[:])
+	if err != nil {
+		t.Fatalf("coordinator conflicts (pre-conflict): %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("no equivocation yet, want no conflicts, got %+v", conflicts)
+	}
+
+	// A second, body-different authenticated package for the same attempt is
+	// coordinator equivocation.
+	scriptRoot := bytes.Repeat([]byte{0xab}, TaprootMerkleRootLength)
+	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, scriptRoot)); !errors.Is(err, ErrSigningPackageConflict) {
+		t.Fatalf("want ErrSigningPackageConflict, got %v", err)
+	}
+
+	conflicts, err = c.CoordinatorConflicts(pinnedContextHash[:])
+	if err != nil {
+		t.Fatalf("coordinator conflicts: %v", err)
+	}
+	want := []ConflictEntry{{Sender: elected, Count: 1}}
+	if !reflect.DeepEqual(conflicts, want) {
+		t.Fatalf("want %+v, got %+v", want, conflicts)
+	}
+
+	// A third body-different package keeps it idempotent: still one accusation
+	// against the coordinator (Count is the f+1 tally's concern, not ours).
+	otherRoot := bytes.Repeat([]byte{0xcd}, TaprootMerkleRootLength)
+	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, otherRoot)); !errors.Is(err, ErrSigningPackageConflict) {
+		t.Fatalf("third package: want ErrSigningPackageConflict, got %v", err)
+	}
+	conflicts, _ = c.CoordinatorConflicts(pinnedContextHash[:])
+	if !reflect.DeepEqual(conflicts, want) {
+		t.Fatalf("idempotent: want %+v, got %+v", want, conflicts)
+	}
+}
+
+func TestCoordinatorConflicts_UnknownAttempt(t *testing.T) {
+	c := NewRound2Collector(fakeVerifier{})
+	if _, err := c.CoordinatorConflicts(pinnedContextHash[:]); !errors.Is(err, ErrRound2UnknownAttempt) {
+		t.Fatalf("want ErrRound2UnknownAttempt, got %v", err)
+	}
+}

--- a/pkg/frost/roast/round2_classifier_test.go
+++ b/pkg/frost/roast/round2_classifier_test.go
@@ -224,57 +224,74 @@ func TestClassifyCandidateCulprits_Errors(t *testing.T) {
 	})
 }
 
-func TestCoordinatorConflicts_SurfacesEquivocationAsConflictEntry(t *testing.T) {
+func TestCoordinatorPackageProofs_SurfacesAuthoritativeAndConflicting(t *testing.T) {
 	_ = captureEquivocationEvidence(t)
 	c := NewRound2Collector(fakeVerifier{})
 	const elected = group.MemberIndex(3)
 	if err := c.BeginAttempt(pinnedContextHash[:], elected, testIncludedSet()); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
-	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, nil)); err != nil {
-		t.Fatalf("record first package: %v", err)
-	}
 
-	// No second package yet -> no coordinator equivocation -> no accusation.
-	conflicts, err := c.CoordinatorConflicts(pinnedContextHash[:])
+	// No package recorded yet -> no proofs.
+	proofs, err := c.CoordinatorPackageProofs(pinnedContextHash[:])
 	if err != nil {
-		t.Fatalf("coordinator conflicts (pre-conflict): %v", err)
+		t.Fatalf("proofs (pre-package): %v", err)
 	}
-	if len(conflicts) != 0 {
-		t.Fatalf("no equivocation yet, want no conflicts, got %+v", conflicts)
+	if len(proofs) != 0 {
+		t.Fatalf("no package yet, want no proofs, got %d", len(proofs))
 	}
 
-	// A second, body-different authenticated package for the same attempt is
-	// coordinator equivocation.
+	// One authoritative package -> exactly one proof (the accepted package the
+	// observer publishes for cross-observer comparison).
+	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, nil)); err != nil {
+		t.Fatalf("record authoritative package: %v", err)
+	}
+	proofs, err = c.CoordinatorPackageProofs(pinnedContextHash[:])
+	if err != nil {
+		t.Fatalf("proofs (one package): %v", err)
+	}
+	if len(proofs) != 1 || len(proofs[0]) == 0 {
+		t.Fatalf("want exactly one non-empty authoritative proof, got %d", len(proofs))
+	}
+	authoritative := append([]byte(nil), proofs[0]...)
+
+	// A second body-different authenticated package = coordinator equivocation
+	// -> two proofs (authoritative first, then the conflicting one), the
+	// unforgeable pair NextAttempt instant-excludes on.
 	scriptRoot := bytes.Repeat([]byte{0xab}, TaprootMerkleRootLength)
 	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, scriptRoot)); !errors.Is(err, ErrSigningPackageConflict) {
 		t.Fatalf("want ErrSigningPackageConflict, got %v", err)
 	}
-
-	conflicts, err = c.CoordinatorConflicts(pinnedContextHash[:])
+	proofs, err = c.CoordinatorPackageProofs(pinnedContextHash[:])
 	if err != nil {
-		t.Fatalf("coordinator conflicts: %v", err)
+		t.Fatalf("proofs (conflict): %v", err)
 	}
-	want := []ConflictEntry{{Sender: elected, Count: 1}}
-	if !reflect.DeepEqual(conflicts, want) {
-		t.Fatalf("want %+v, got %+v", want, conflicts)
+	if len(proofs) != 2 {
+		t.Fatalf("want two proofs (authoritative + conflicting), got %d", len(proofs))
 	}
+	if !bytes.Equal(proofs[0], authoritative) {
+		t.Fatal("the authoritative proof must stay first and unchanged")
+	}
+	if bytes.Equal(proofs[1], authoritative) || len(proofs[1]) == 0 {
+		t.Fatal("the conflicting proof must be a distinct, non-empty envelope")
+	}
+	conflicting := append([]byte(nil), proofs[1]...)
 
-	// A third body-different package keeps it idempotent: still one accusation
-	// against the coordinator (Count is the f+1 tally's concern, not ours).
+	// A third body-different package stays capped at two, keeping the FIRST
+	// conflicting envelope (idempotent retention).
 	otherRoot := bytes.Repeat([]byte{0xcd}, TaprootMerkleRootLength)
 	if err := c.RecordSigningPackage(signedTestSigningPackage(t, elected, otherRoot)); !errors.Is(err, ErrSigningPackageConflict) {
 		t.Fatalf("third package: want ErrSigningPackageConflict, got %v", err)
 	}
-	conflicts, _ = c.CoordinatorConflicts(pinnedContextHash[:])
-	if !reflect.DeepEqual(conflicts, want) {
-		t.Fatalf("idempotent: want %+v, got %+v", want, conflicts)
+	proofs, _ = c.CoordinatorPackageProofs(pinnedContextHash[:])
+	if len(proofs) != 2 || !bytes.Equal(proofs[0], authoritative) || !bytes.Equal(proofs[1], conflicting) {
+		t.Fatalf("must stay capped at two with the first (authoritative, conflicting) pair, got %d", len(proofs))
 	}
 }
 
-func TestCoordinatorConflicts_UnknownAttempt(t *testing.T) {
+func TestCoordinatorPackageProofs_UnknownAttempt(t *testing.T) {
 	c := NewRound2Collector(fakeVerifier{})
-	if _, err := c.CoordinatorConflicts(pinnedContextHash[:]); !errors.Is(err, ErrRound2UnknownAttempt) {
+	if _, err := c.CoordinatorPackageProofs(pinnedContextHash[:]); !errors.Is(err, ErrRound2UnknownAttempt) {
 		t.Fatalf("want ErrRound2UnknownAttempt, got %v", err)
 	}
 }

--- a/pkg/frost/roast/round2_collector.go
+++ b/pkg/frost/roast/round2_collector.go
@@ -138,7 +138,9 @@ type round2Record struct {
 	// authoritative one is signingPackageEnvelope). Non-nil = the coordinator
 	// equivocated: the observer holds two distinct, individually authenticated
 	// coordinator-signed packages - unforgeable, self-incriminating proof.
-	// Surfaced as a ConflictEntry against the coordinator by CoordinatorConflicts.
+	// Surfaced (with the authoritative package) as raw proof material by
+	// CoordinatorPackageProofs for NextAttempt's proof-carrying coordinator
+	// exclusion - never as a bare f+1 ConflictEntry.
 	conflictingSigningPackageEnvelope []byte
 }
 

--- a/pkg/frost/roast/round2_collector.go
+++ b/pkg/frost/roast/round2_collector.go
@@ -133,6 +133,13 @@ type round2Record struct {
 	// NON-authoritative-package-bound share - blame evidence of possible targeted
 	// coordinator equivocation, not an aggregation input.
 	divergentShares map[group.MemberIndex]*round2ShareRecord
+	// conflictingSigningPackageEnvelope retains the FIRST body-different signing
+	// package the elected coordinator distributed for this attempt (the
+	// authoritative one is signingPackageEnvelope). Non-nil = the coordinator
+	// equivocated: the observer holds two distinct, individually authenticated
+	// coordinator-signed packages - unforgeable, self-incriminating proof.
+	// Surfaced as a ConflictEntry against the coordinator by CoordinatorConflicts.
+	conflictingSigningPackageEnvelope []byte
 }
 
 // round2ShareRecord is a collector-owned record of one submitter's retained
@@ -269,7 +276,11 @@ func (c *Round2Collector) RecordSigningPackage(pkg *SigningPackage) error {
 		// Idempotent: the same signed body re-recorded (possibly re-encoded).
 	default:
 		// A different signed body for the same attempt: coordinator equivocation.
-		// Keep the first; emit both.
+		// Keep the first authoritative package; retain the first conflicting one
+		// (idempotent) as self-incriminating proof, and emit both.
+		if record.conflictingSigningPackageEnvelope == nil {
+			record.conflictingSigningPackageEnvelope = ownedEnvelope
+		}
 		evidence = &EquivocationEvidence{
 			Kind:                EquivocationKindSigningPackageConflict,
 			AttemptContextHash:  append([]byte(nil), record.attemptContextHash...),


### PR DESCRIPTION
## What (revised per the 4b design consultation)

**This PR was pivoted.** The Codex+Gemini 4b consultation converged on **proof-carrying** coordinator-equivocation blame with **instant establishment**, superseding the original bare-`ConflictEntry`/f+1 approach. This PR is now the **collector proof-surface** (layer 1 of the unified proof-carrying 4b).

`Round2Collector.CoordinatorPackageProofs(attemptContextHash) ([][]byte, error)` surfaces the coordinator-signed signing-package envelope(s) the observer retained: the authoritative package it accepted, plus the conflicting one if the coordinator equivocated *to this observer* — capped at two, authoritative first. These are the raw, unforgeable proof material a member publishes in its `LocalEvidenceSnapshot`. (The retention — `round2Record.conflictingSigningPackageEnvelope`, set idempotently when a body-different authenticated package arrives — is unchanged and reused.)

## Why proof-carrying (consultation conclusions)
- **Instant establishment, bypass f+1:** two distinct *valid coordinator-signed bodies* for one attempt are unforgeable, so a single honest observer presenting them must exclude the coordinator immediately. Forcing that proof through the f+1 counted gate (the original `ConflictEntry`) lets a coordinator equivocate to ≤ f members and escape. The f+1 gate stays for *fabricated* bare-counter claims.
- **Full envelopes, not hash+sig:** the coordinator signs `domain ‖ body`, so a verifier needs the body to check both the signature and the embedded `attempt_context_hash` — a `hash+sig` pair is replayable to frame an honest coordinator. (Both reviewers flagged this; it corrected the initial leaning.)

## Scope — layer 1 of 3
- **This PR:** collector surfaces the proof envelope(s); adjudicates nothing.
- **PR 2:** `LocalEvidenceSnapshot` carries the proof(s) (≤2, failure-path only — bounded).
- **PR 3:** `NextAttempt` verifies coordinator sig + attempt binding, dedupes by body hash, **instant-excludes** a coordinator with ≥2 distinct valid bodies (→ auto-rotation). Unifies the old "4b-i" (local two) and "4b-ii" (split).
- **Divergent_share** stays a neutral "put up or shut up" hint; the package proof carries blame, never the bare divergent share.

## Tests
`TestCoordinatorPackageProofs_*`: no package → none; one → `[authoritative]`; conflict → `[authoritative, conflicting]` (distinct); third body-different package → capped at two, first pair retained; unknown attempt → error. Full `roast` package + gofmt + vet green.

**Re-review needed:** prior approvals were for the superseded `ConflictEntry` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
