### PR TITLE
Phase 7.2b-4b PR3: instant coordinator-equivocation exclusion in NextAttempt

### DIFF
--- a/pkg/frost/roast/next_attempt.go
+++ b/pkg/frost/roast/next_attempt.go
@@ -160,19 +160,22 @@ func (c *inMemoryCoordinator) NextAttempt(
 	prev := record.context
 	c.mu.Unlock()
 
-	return computeNextAttempt(prev, bundle, threshold, dkgGroupPublicKey)
+	return computeNextAttempt(prev, bundle, threshold, dkgGroupPublicKey, c.verifier)
 }
 
-// computeNextAttempt is the pure-function policy core: it takes the
-// previous AttemptContext, a verified bundle, and the signing
-// threshold, and returns the next AttemptContext. Factored out from
-// NextAttempt so the policy is independently unit-testable without a
-// Coordinator instance.
+// computeNextAttempt is the policy core: it takes the previous AttemptContext, a
+// verified bundle, the signing threshold, and the operator-signature verifier,
+// and returns the next AttemptContext. Factored out from NextAttempt so the
+// policy is independently unit-testable without a Coordinator instance (tests
+// inject a fake verifier). The verifier is used ONLY to authenticate the
+// coordinator-signed package proofs carried in the snapshots (proof-carrying
+// coordinator-equivocation exclusion); the f+1 accusation tally needs no crypto.
 func computeNextAttempt(
 	prev attempt.AttemptContext,
 	bundle *TransitionMessage,
 	threshold uint,
 	dkgGroupPublicKey []byte,
+	verifier SignatureVerifier,
 ) (attempt.AttemptContext, error) {
 	// Original signer set persists across transitions as
 	// IncludedSet ∪ ExcludedSet ∪ TransientlyParked. Its size (not
@@ -201,11 +204,20 @@ func computeNextAttempt(
 		bundle, credibleObservers, original, quorum, snapshotOverflowAccusations,
 	)
 
+	// Proof-carrying coordinator equivocation: if the bundle's snapshots carry
+	// two distinct VALID coordinator-signed packages for this attempt, the
+	// coordinator equivocated. That is unforgeable (the coordinator's own two
+	// signatures over different bodies), so it is established INSTANTLY - it does
+	// NOT pass through the f+1 accuser gate, which exists only to bound
+	// fabricated bare-counter claims (frozen Phase 7.2b spec, section 6).
+	coordinatorEquivocators := verifiedCoordinatorEquivocations(bundle, verifier)
+
 	// Merge into permanent exclusion.
 	exclSet := newMemberSet()
 	exclSet.addAll(prev.ExcludedSet)
 	exclSet.addAll(rejectBlamed)
 	exclSet.addAll(conflictBlamed)
+	exclSet.addAll(coordinatorEquivocators)
 
 	// (3)+(4) Parking: established overflow accusations plus senders
 	// in prev.IncludedSet missing from the bundle -- in both cases
@@ -324,6 +336,46 @@ func snapshotConflictAccusations(
 		out = append(out, entry.Sender)
 	}
 	return out
+}
+
+// verifiedCoordinatorEquivocations returns the elected coordinator if the bundle
+// proves it equivocated: two distinct VALID coordinator-signed signing packages
+// for this attempt, surfaced (possibly by different members) in the snapshots'
+// CoordinatorPackageProofs. Each proof is authenticated as a genuine
+// SignedSigningPackage from the elected coordinator binding this attempt - Go
+// operator-signature verification, not FROST crypto - so unparseable or
+// unauthenticated proofs are ignored, never blamed. Two distinct authentic body
+// hashes are unforgeable proof (the coordinator's own two signatures over
+// different bodies), so a SINGLE honest observer's bundle entry suffices: no f+1
+// gate. Returns nil when no such proof is present.
+func verifiedCoordinatorEquivocations(
+	bundle *TransitionMessage,
+	verifier SignatureVerifier,
+) []group.MemberIndex {
+	electedCoordinator := bundle.CoordinatorID()
+	bodies := make(map[[32]byte]struct{}, 2)
+	for i := range bundle.Bundle {
+		for _, proof := range bundle.Bundle[i].CoordinatorPackageProofs {
+			pkg := &SigningPackage{}
+			if err := pkg.Unmarshal(proof); err != nil {
+				continue
+			}
+			if err := AuthenticateSigningPackage(
+				verifier, pkg, electedCoordinator, bundle.AttemptContextHash,
+			); err != nil {
+				continue
+			}
+			bodyHash, err := pkg.BodyHash()
+			if err != nil {
+				continue
+			}
+			bodies[bodyHash] = struct{}{}
+			if len(bodies) >= 2 {
+				return []group.MemberIndex{electedCoordinator}
+			}
+		}
+	}
+	return nil
 }
 
 // establishedAccused tallies one evidence category across the bundle

--- a/pkg/frost/roast/next_attempt_categories_test.go
+++ b/pkg/frost/roast/next_attempt_categories_test.go
@@ -110,7 +110,7 @@ func TestNextAttempt_EstablishedRejectExcludesPermanently(t *testing.T) {
 		nil,
 	)
 
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestNextAttempt_EstablishedConflictExcludesPermanently(t *testing.T) {
 		[]group.MemberIndex{3},
 	)
 
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestNextAttempt_SubQuorumRejectAndConflictDoNotExclude(t *testing.T) {
 		[]group.MemberIndex{3},
 	)
 
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestNextAttempt_MultipleRejectReasonsAreOneAccuser(t *testing.T) {
 		nil,
 	)
 
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestNextAttempt_RejectAndConflictBothExclude(t *testing.T) {
 		[]group.MemberIndex{4},
 	)
 
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestNextAttempt_EmptyRejectsAndConflicts_DoNotExclude(t *testing.T) {
 	f := newNextAttemptFixture()
 	prev := f.prev(t)
 	bundle := buildBundleWithCategories(t, prev, nil, nil)
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestNextAttempt_ExactQuorumOfHonestObserversExcludes(t *testing.T) {
 		nil,
 	)
 
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}

--- a/pkg/frost/roast/next_attempt_coordinator_equivocation_test.go
+++ b/pkg/frost/roast/next_attempt_coordinator_equivocation_test.go
@@ -1,0 +1,118 @@
+package roast
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func mustMarshalProof(t *testing.T, pkg *SigningPackage) []byte {
+	t.Helper()
+	b, err := pkg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal signing package proof: %v", err)
+	}
+	return b
+}
+
+// equivocationBundle builds a bundle over the full fixture signer set {1..5}
+// (so no member is silence-parked and excluding the coordinator stays feasible),
+// bound to pinnedContextHash, with the given per-sender coordinator package
+// proofs.
+func equivocationBundle(coordinator group.MemberIndex, proofsBySender map[uint32][][]byte) *TransitionMessage {
+	bundle := make([]LocalEvidenceSnapshot, 0, 5)
+	for _, s := range []uint32{1, 2, 3, 4, 5} {
+		bundle = append(bundle, LocalEvidenceSnapshot{
+			SenderIDValue:            s,
+			AttemptContextHash:       append([]byte(nil), pinnedContextHash[:]...),
+			CoordinatorPackageProofs: proofsBySender[s],
+		})
+	}
+	return &TransitionMessage{
+		AttemptContextHash: append([]byte(nil), pinnedContextHash[:]...),
+		CoordinatorIDValue: uint32(coordinator),
+		Bundle:             bundle,
+	}
+}
+
+func TestComputeNextAttempt_ProofCarryingCoordinatorEquivocationExcludesCoordinator(t *testing.T) {
+	f := newNextAttemptFixture()
+	prev := f.prev(t)
+	const coordinator = group.MemberIndex(1) // the fixture's bundle coordinator
+
+	// Coordinator 1 distributed two body-different signing packages for this
+	// attempt; members 2 and 3 each surface ONE (the targeted/split case, where no
+	// single observer sees both). Authenticated + distinct => unforgeable
+	// equivocation => INSTANT exclusion (no f+1 gate).
+	proofA := mustMarshalProof(t, signedTestSigningPackage(t, coordinator, nil))
+	proofB := mustMarshalProof(t, signedTestSigningPackage(
+		t, coordinator, bytes.Repeat([]byte{0xab}, TaprootMerkleRootLength),
+	))
+
+	bundle := equivocationBundle(coordinator, map[uint32][][]byte{
+		2: {proofA},
+		3: {proofB},
+	})
+
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if !memberSliceContains(next.ExcludedSet, coordinator) {
+		t.Fatalf("equivocating coordinator %d must be excluded; excluded=%v", coordinator, next.ExcludedSet)
+	}
+	if memberSliceContains(next.IncludedSet, coordinator) {
+		t.Fatalf("excluded coordinator must drop from the next included set; included=%v", next.IncludedSet)
+	}
+}
+
+func TestComputeNextAttempt_SingleCoordinatorPackageProofDoesNotExclude(t *testing.T) {
+	f := newNextAttemptFixture()
+	prev := f.prev(t)
+	const coordinator = group.MemberIndex(1)
+
+	// Every member publishes the ONE package it accepted: legitimate, not
+	// equivocation. Two members carrying the SAME package is still one distinct
+	// body.
+	proof := mustMarshalProof(t, signedTestSigningPackage(t, coordinator, nil))
+	bundle := equivocationBundle(coordinator, map[uint32][][]byte{
+		2: {proof},
+		3: {proof},
+	})
+
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if memberSliceContains(next.ExcludedSet, coordinator) {
+		t.Fatalf("a single (or repeated identical) proof must not exclude the coordinator; excluded=%v", next.ExcludedSet)
+	}
+}
+
+func TestComputeNextAttempt_UnauthenticatedProofsAreIgnored(t *testing.T) {
+	f := newNextAttemptFixture()
+	prev := f.prev(t)
+	const coordinator = group.MemberIndex(1)
+
+	// Only authentic, this-coordinator, this-attempt proofs count. A garbage
+	// envelope and a package signed by a DIFFERENT member (wrong coordinator) are
+	// ignored - so there are not two distinct VALID bodies, and the coordinator
+	// is not blamed.
+	authentic := mustMarshalProof(t, signedTestSigningPackage(t, coordinator, nil))
+	wrongCoordinator := mustMarshalProof(t, signedTestSigningPackage(
+		t, 4, bytes.Repeat([]byte{0xcd}, TaprootMerkleRootLength),
+	))
+	bundle := equivocationBundle(coordinator, map[uint32][][]byte{
+		2: {authentic, []byte("not-a-signing-package")},
+		3: {wrongCoordinator},
+	})
+
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if memberSliceContains(next.ExcludedSet, coordinator) {
+		t.Fatalf("garbage / wrong-coordinator proofs must be ignored; excluded=%v", next.ExcludedSet)
+	}
+}

--- a/pkg/frost/roast/next_attempt_test.go
+++ b/pkg/frost/roast/next_attempt_test.go
@@ -137,7 +137,7 @@ func TestNextAttempt_NoEvidenceProducesIdenticalIncludedSet(t *testing.T) {
 	f := newNextAttemptFixture()
 	prev := f.prev(t)
 	bundle := f.bundle(t)
-	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestNextAttempt_EstablishedOverflowParksTransiently(t *testing.T) {
 	for observer := group.MemberIndex(2); observer <= 5; observer++ {
 		f.overflows[observer] = map[group.MemberIndex]uint{3: 1}
 	}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestNextAttempt_EstablishedOverflowParkIsTransient(t *testing.T) {
 		f.overflows[observer] = map[group.MemberIndex]uint{3: 1}
 	}
 	attemptN1, err := computeNextAttempt(
-		f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey,
+		f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{},
 	)
 	if err != nil {
 		t.Fatalf("N -> N+1: %v", err)
@@ -220,7 +220,7 @@ func TestNextAttempt_EstablishedOverflowParkIsTransient(t *testing.T) {
 		},
 	}
 	attemptN2, err := computeNextAttempt(
-		attemptN1, bundleN1, f.threshold, f.dkgGroupPublicKey,
+		attemptN1, bundleN1, f.threshold, f.dkgGroupPublicKey, fakeVerifier{},
 	)
 	if err != nil {
 		t.Fatalf("N+1 -> N+2: %v", err)
@@ -240,7 +240,7 @@ func TestNextAttempt_SubQuorumOverflowHasNoEffect(t *testing.T) {
 	// blame: an accusation below the accuser quorum is ignored.
 	f.overflows[2] = map[group.MemberIndex]uint{3: 100}
 	f.overflows[4] = map[group.MemberIndex]uint{3: 100}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestNextAttempt_SilentMemberIsParkedTransiently(t *testing.T) {
 	f := newNextAttemptFixture()
 	// Only members 1, 2, 4, 5 submit; member 3 is silent.
 	f.bundleSenders = []group.MemberIndex{1, 2, 4, 5}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestNextAttempt_PreviouslyParkedAreReinstated(t *testing.T) {
 	// Bundle: only the included set submits (parked cannot).
 	f.bundleSenders = []group.MemberIndex{1, 2, 4, 5}
 
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestNextAttempt_ParkingIsStrictlyTransient_NoEscalation(t *testing.T) {
 	f.bundleSenders = []group.MemberIndex{1, 2, 4, 5}
 	prev := f.prev(t)
 	bundle := f.bundle(t)
-	attemptN1, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey)
+	attemptN1, err := computeNextAttempt(prev, bundle, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("N -> N+1: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestNextAttempt_ParkingIsStrictlyTransient_NoEscalation(t *testing.T) {
 			{SenderIDValue: 5, AttemptContextHash: append([]byte{}, attemptN1Hash[:]...)},
 		},
 	}
-	attemptN2, err := computeNextAttempt(attemptN1, bundleN1, f.threshold, f.dkgGroupPublicKey)
+	attemptN2, err := computeNextAttempt(attemptN1, bundleN1, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("N+1 -> N+2: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestNextAttempt_ParkingIsStrictlyTransient_NoEscalation(t *testing.T) {
 func TestNextAttempt_OriginalSignerSetPreservedAcrossTransitions(t *testing.T) {
 	f := newNextAttemptFixture()
 	f.bundleSenders = []group.MemberIndex{1, 2, 4, 5} // 3 silent
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -374,11 +374,11 @@ func TestNextAttempt_PolicyIsDeterministic(t *testing.T) {
 	f.bundleSenders = []group.MemberIndex{1, 2, 4, 5}
 	f.overflows[2] = map[group.MemberIndex]uint{1: 2}
 	f.overflows[5] = map[group.MemberIndex]uint{1: 2}
-	a, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	a, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("first compute: %v", err)
 	}
-	b, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	b, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("second compute: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestNextAttempt_InfeasibilityWhenBelowThreshold(t *testing.T) {
 	// Silently lose 2 members -> only 3 remain in IncludedSet, below
 	// threshold of 5.
 	f.bundleSenders = []group.MemberIndex{1, 2, 3}
-	_, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	_, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if !errors.Is(err, ErrAttemptInfeasible) {
 		t.Fatalf("expected ErrAttemptInfeasible, got %v", err)
 	}
@@ -415,7 +415,7 @@ func TestNextAttempt_ThresholdZeroDisablesInfeasibilityCheck(t *testing.T) {
 	f.bundleSenders = []group.MemberIndex{1}
 	// IncludedSet would become {1}; for threshold=0 that's still
 	// permitted.
-	_, err := computeNextAttempt(f.prev(t), f.bundle(t), 0, f.dkgGroupPublicKey)
+	_, err := computeNextAttempt(f.prev(t), f.bundle(t), 0, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("expected success with threshold=0, got %v", err)
 	}
@@ -430,7 +430,7 @@ func TestNextAttempt_SingleObserverCountMagnitudeIsNotBlame(t *testing.T) {
 	f.overflows[5] = map[group.MemberIndex]uint{3: 1000}
 	f.rejects[5] = map[group.MemberIndex]uint{3: 1000}
 	f.conflicts[5] = map[group.MemberIndex]uint{3: 1000}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -474,6 +474,7 @@ func TestNextAttempt_QuorumBoundaryForRejectAndConflict(t *testing.T) {
 				fixtureAtF.bundle(t),
 				fixtureAtF.threshold,
 				fixtureAtF.dkgGroupPublicKey,
+				fakeVerifier{},
 			)
 			if err != nil {
 				t.Fatalf("compute at f accusers: %v", err)
@@ -495,6 +496,7 @@ func TestNextAttempt_QuorumBoundaryForRejectAndConflict(t *testing.T) {
 				fixtureAtQuorum.bundle(t),
 				fixtureAtQuorum.threshold,
 				fixtureAtQuorum.dkgGroupPublicKey,
+				fakeVerifier{},
 			)
 			if err != nil {
 				t.Fatalf("compute at quorum: %v", err)
@@ -522,7 +524,7 @@ func TestNextAttempt_CrossCategoryAccusationsDoNotSum(t *testing.T) {
 	f.rejects[2] = map[group.MemberIndex]uint{3: 1}
 	f.conflicts[4] = map[group.MemberIndex]uint{3: 1}
 	f.conflicts[5] = map[group.MemberIndex]uint{3: 1}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -589,7 +591,7 @@ func TestNextAttempt_FabricatedBlameCannotGrindHonestMembers(t *testing.T) {
 			Bundle:             bundle,
 		}
 
-		next, err := computeNextAttempt(prev, msg, f.threshold, f.dkgGroupPublicKey)
+		next, err := computeNextAttempt(prev, msg, f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 		if err != nil {
 			t.Fatalf("attempt %d: %v", attemptIndex, err)
 		}
@@ -622,7 +624,7 @@ func TestNextAttempt_NonCredibleAccusersAreIgnored(t *testing.T) {
 	f.conflicts[2] = map[group.MemberIndex]uint{3: 1}
 	f.conflicts[6] = map[group.MemberIndex]uint{3: 1}
 	f.conflicts[7] = map[group.MemberIndex]uint{3: 1}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -645,7 +647,7 @@ func TestNextAttempt_AccusationsAgainstNonOriginalMembersIgnored(t *testing.T) {
 	f.conflicts[1] = map[group.MemberIndex]uint{9: 1}
 	f.conflicts[2] = map[group.MemberIndex]uint{9: 1}
 	f.conflicts[4] = map[group.MemberIndex]uint{9: 1}
-	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey)
+	next, err := computeNextAttempt(f.prev(t), f.bundle(t), f.threshold, f.dkgGroupPublicKey, fakeVerifier{})
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}


### PR DESCRIPTION
## What

Phase 7.2b-4b **PR 3** — the final proof-carrying layer and the adjudication **heart**. `computeNextAttempt` now verifies the coordinator-signed package proofs carried in the bundle's snapshots (PR 2) and **instant-excludes** a coordinator that signed ≥2 distinct packages for one attempt, auto-rotating it out of the next `IncludedSet`.

## How
- **`verifiedCoordinatorEquivocations(bundle, verifier)`**: for each snapshot's `CoordinatorPackageProofs`, parse the `SignedSigningPackage` and authenticate it via **`AuthenticateSigningPackage`** — Go operator-signature verification of the *coordinator's own* signature (not FROST crypto), bound to the elected coordinator + the attempt context. Collect distinct valid `BodyHash()`es; **≥2 ⇒ the coordinator equivocated.**
- **Instant establishment (no f+1):** two distinct coordinator signatures over different bodies are unforgeable, so a single honest observer's bundle entry suffices. The f+1 gate stays for fabricated bare-counter claims. Unparseable / wrong-coordinator / wrong-attempt proofs are **ignored, never blamed**.
- **Verifier seam:** `computeNextAttempt` + `NextAttempt` gain a `SignatureVerifier` (`NextAttempt` passes `c.verifier`); the policy core stays deterministic + unit-testable with a fake verifier (both consultation bots endorsed verifier-aware `NextAttempt`). The equivocator merges into `exclSet` alongside the f+1 `reject`/`conflict` exclusions.

## Tests
- **Targeted/split case** (the completeness-critical one): members 2 and 3 each surface *one* distinct coordinator-signed proof → coordinator excluded + dropped from `IncludedSet`.
- Single / repeated-identical proof → no exclusion.
- Garbage envelope + wrong-coordinator package → ignored (no false exclusion).
- Full `roast` package + gofmt + vet green.

## Completes proof-carrying 4b
- #4065 — collector surfaces the proofs.
- #4066 — snapshot carries them (signed body, bounded).
- **This** — `NextAttempt` verifies + dedupes + instant-excludes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
