### PR TITLE
Phase 7.2b-4: engine verify_signature_share FFI (backs Go Round2ShareVerifier)

### DIFF
--- a/pkg/tbtc/signer/include/frost_tbtc.h
+++ b/pkg/tbtc/signer/include/frost_tbtc.h
@@ -84,6 +84,20 @@ TbtcSignerResult frost_tbtc_interactive_session_abort(const uint8_t* request_ptr
  * would be forgeable by a coordinator using a mismatched package/root.
  */
 TbtcSignerResult frost_tbtc_interactive_aggregate(const uint8_t* request_ptr, size_t request_len);
+/*
+ * Phase 7.2b-4 single round-2 signature-share verification: backs the Go
+ * host's Round2ShareVerifier (member-blame classifier). Verifies ONE retained
+ * share against the attempt's signing package using the group's own
+ * (taproot-tweaked) verifying material - public material only, no secret and
+ * no operator-signed-envelope inspection (the latter is the Go layer's job).
+ * Returns an explicit tri-state verdict (valid/invalid/indeterminate) so the
+ * caller never infers member-fault from an FFI error code. Like aggregate's
+ * culprit list, an `invalid` verdict is framable by a coordinator that
+ * supplies a mismatched package/root, so it is an INPUT to the Go host's f+1
+ * envelope-bound adjudication (Phase 7.2b spec, section 6), NOT authoritative
+ * blame on its own.
+ */
+TbtcSignerResult frost_tbtc_verify_signature_share(const uint8_t* request_ptr, size_t request_len);
 
 #ifdef __cplusplus
 }

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -281,6 +281,11 @@ pub enum ShareVerificationVerdict {
     Valid,
     /// MEMBER-attributable: the share is mathematically invalid, OR the member's
     /// own operator-signed share bytes are undecodable (self-incriminating).
+    /// NOTE: like InteractiveAggregate's candidate-culprit list, this verdict is
+    /// framable by a coordinator that verifies an honest share against a
+    /// mismatched package/root, so it is an INPUT to the Go host's f+1
+    /// envelope-bound adjudication (Phase 7.2b spec, section 6), NOT authoritative
+    /// blame on its own.
     Invalid,
     /// Not the member's fault: undecodable signing package (coordinator input),
     /// missing/unknown verifying share, session not ready, ambiguous context.

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -268,6 +268,46 @@ pub struct AggregateResult {
     pub signature_hex: String,
 }
 
+/// The verdict of a single-share verification (VerifySignatureShare). It is a
+/// deliberate THREE-way value, not pass/fail: the boundary between a
+/// member-attributable failure (blame) and a not-the-member's-fault failure
+/// (don't blame) is security-critical, and the engine - the only layer that can
+/// tell "the member's signed scalar is malformed" from "the coordinator's
+/// package/context is malformed" - decides it here so the Go host never has to.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShareVerificationVerdict {
+    /// The share is a valid FROST signature share under the (tweaked) package.
+    Valid,
+    /// MEMBER-attributable: the share is mathematically invalid, OR the member's
+    /// own operator-signed share bytes are undecodable (self-incriminating).
+    Invalid,
+    /// Not the member's fault: undecodable signing package (coordinator input),
+    /// missing/unknown verifying share, session not ready, ambiguous context.
+    /// Fail closed against blame.
+    Indeterminate,
+}
+
+/// Request to verify ONE retained round-2 signature share against an attempt's
+/// authoritative signing package, using FROST share verification. The verifying
+/// material is resolved from the session's own DKG state (never the request),
+/// and the taproot root is canonicalized + applied exactly as InteractiveAggregate
+/// does, so the verdict matches what aggregation would conclude for that share.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct VerifySignatureShareRequest {
+    pub session_id: String,
+    pub signing_package_hex: String,
+    pub signature_share_hex: String,
+    pub member_identifier: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub taproot_merkle_root_hex: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct VerifySignatureShareResult {
+    pub verdict: ShareVerificationVerdict,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct StartSignRoundRequest {
     pub session_id: String,

--- a/pkg/tbtc/signer/src/engine/mod.rs
+++ b/pkg/tbtc/signer/src/engine/mod.rs
@@ -107,6 +107,7 @@ mod tests;
 #[cfg(test)]
 mod testsupport;
 mod transaction;
+mod verify_share;
 
 pub(crate) use audit::*;
 pub(crate) use codec::*;
@@ -127,3 +128,4 @@ pub(crate) use telemetry::*;
 #[cfg(test)]
 pub(crate) use testsupport::*;
 pub(crate) use transaction::*;
+pub(crate) use verify_share::*;

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -13700,6 +13700,18 @@ fn verify_signature_share_verdicts_match_aggregate_and_handle_edges() {
         verdict("ee".to_string(), 9),
         ShareVerificationVerdict::Indeterminate
     );
+    // Package-membership contract: member 3 is in the GROUP (threshold 2 of {1,2,3})
+    // but OMITTED from this attempt's package (commitments {1,2}). The package
+    // omission is coordinator/context input, so neither a decodable share NOR
+    // undecodable bytes may blame member 3 - both are Indeterminate, never Invalid.
+    assert_eq!(
+        verdict(round2.signature_share_hex.clone(), 3),
+        ShareVerificationVerdict::Indeterminate
+    );
+    assert_eq!(
+        verdict("ee".to_string(), 3),
+        ShareVerificationVerdict::Indeterminate
+    );
     // Undecodable signing package (coordinator input) -> Indeterminate.
     assert_eq!(
         verify_signature_share(crate::api::VerifySignatureShareRequest {

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -13682,7 +13682,8 @@ fn verify_signature_share_verdicts_match_aggregate_and_handle_edges() {
         ShareVerificationVerdict::Invalid
     );
 
-    // Undecodable member share bytes -> Invalid (self-incriminating member fault).
+    // Undecodable member share bytes, WITH established context (member 2 is in
+    // this group, session ready) -> Invalid (self-incriminating member fault).
     assert_eq!(
         verdict("ee".to_string(), 2),
         ShareVerificationVerdict::Invalid
@@ -13690,6 +13691,13 @@ fn verify_signature_share_verdicts_match_aggregate_and_handle_edges() {
     // A member with no verifying share in the group -> Indeterminate.
     assert_eq!(
         verdict(round2.signature_share_hex.clone(), 9),
+        ShareVerificationVerdict::Indeterminate
+    );
+    // Ordering contract: undecodable share bytes for a member NOT in the group
+    // are Indeterminate, NOT Invalid - the share is only judged once session /
+    // DKG / membership are established, so blame never precedes that context.
+    assert_eq!(
+        verdict("ee".to_string(), 9),
         ShareVerificationVerdict::Indeterminate
     );
     // Undecodable signing package (coordinator input) -> Indeterminate.
@@ -13711,6 +13719,20 @@ fn verify_signature_share_verdicts_match_aggregate_and_handle_edges() {
             session_id: "no-such-session".to_string(),
             signing_package_hex: signing_package_hex.clone(),
             signature_share_hex: round2.signature_share_hex.clone(),
+            member_identifier: 1,
+            taproot_merkle_root_hex: None,
+        })
+        .expect("verify")
+        .verdict,
+        ShareVerificationVerdict::Indeterminate
+    );
+    // Ordering contract: even undecodable share bytes for an unknown session are
+    // Indeterminate (session context is resolved before the share is judged).
+    assert_eq!(
+        verify_signature_share(crate::api::VerifySignatureShareRequest {
+            session_id: "no-such-session".to_string(),
+            signing_package_hex: signing_package_hex.clone(),
+            signature_share_hex: "ee".to_string(),
             member_identifier: 1,
             taproot_merkle_root_hex: None,
         })

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -13718,6 +13718,20 @@ fn verify_signature_share_verdicts_match_aggregate_and_handle_edges() {
         .verdict,
         ShareVerificationVerdict::Indeterminate
     );
+    // Malformed taproot root (coordinator/wallet context) -> Indeterminate,
+    // returned in-band, NOT escaped to the error channel (verdict contract).
+    assert_eq!(
+        verify_signature_share(crate::api::VerifySignatureShareRequest {
+            session_id: session_id.to_string(),
+            signing_package_hex: signing_package_hex.clone(),
+            signature_share_hex: round2.signature_share_hex.clone(),
+            member_identifier: 1,
+            taproot_merkle_root_hex: Some("not-hex".to_string()),
+        })
+        .expect("malformed taproot root must not error out-of-band")
+        .verdict,
+        ShareVerificationVerdict::Indeterminate
+    );
 
     // Equivalence guard: aggregate's AllCheaters verdict over [member 1 valid,
     // member 2 bogus] must name exactly the share verify_signature_share calls

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -13574,3 +13574,177 @@ fn build_taproot_tx_request_omits_absent_script_tree_hex() {
             .expect("a payload omitting script_tree_hex must deserialize");
     assert!(round_trip.script_tree_hex.is_none());
 }
+
+#[test]
+fn verify_signature_share_verdicts_match_aggregate_and_handle_edges() {
+    use crate::api::ShareVerificationVerdict;
+
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let session_id = "verify-share-session";
+    let key_group = "interactive-test-key-group";
+    let message = [0x77u8; 32];
+    let included = [1u16, 2];
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+
+    let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
+        .expect("opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let member2_nonces = member2.nonces_hex.clone();
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment,
+        ],
+    );
+    // Member 1's valid share (engine round2); member 2's valid share (stateless).
+    let round2 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("round 2 share");
+    let member2_valid = sign_share(SignShareRequest {
+        signing_package_hex: signing_package_hex.clone(),
+        nonces_hex: member2_nonces,
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 valid share");
+
+    // Member 2's INVALID share: validly signed over a DIFFERENT package.
+    let bogus_member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("bogus member 2 nonces");
+    let other_message = [0x88u8; 32];
+    let other_package = interactive_package_for_test(
+        &other_message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&2].identifier.clone(),
+                data_hex: bogus_member2.commitment.data_hex.clone(),
+            },
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: bogus_member2.commitment.data_hex,
+            },
+        ],
+    );
+    let bogus_share = sign_share(SignShareRequest {
+        signing_package_hex: other_package,
+        nonces_hex: bogus_member2.nonces_hex,
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("bogus member 2 share");
+
+    let verdict = |share_hex: String, member: u16| {
+        verify_signature_share(crate::api::VerifySignatureShareRequest {
+            session_id: session_id.to_string(),
+            signing_package_hex: signing_package_hex.clone(),
+            signature_share_hex: share_hex,
+            member_identifier: member,
+            taproot_merkle_root_hex: None,
+        })
+        .expect("verify")
+        .verdict
+    };
+
+    // Valid shares verify Valid; the wrong-package share is Invalid.
+    assert_eq!(
+        verdict(round2.signature_share_hex.clone(), 1),
+        ShareVerificationVerdict::Valid
+    );
+    assert_eq!(
+        verdict(member2_valid.signature_share.data_hex.clone(), 2),
+        ShareVerificationVerdict::Valid
+    );
+    assert_eq!(
+        verdict(bogus_share.signature_share.data_hex.clone(), 2),
+        ShareVerificationVerdict::Invalid
+    );
+
+    // Undecodable member share bytes -> Invalid (self-incriminating member fault).
+    assert_eq!(
+        verdict("ee".to_string(), 2),
+        ShareVerificationVerdict::Invalid
+    );
+    // A member with no verifying share in the group -> Indeterminate.
+    assert_eq!(
+        verdict(round2.signature_share_hex.clone(), 9),
+        ShareVerificationVerdict::Indeterminate
+    );
+    // Undecodable signing package (coordinator input) -> Indeterminate.
+    assert_eq!(
+        verify_signature_share(crate::api::VerifySignatureShareRequest {
+            session_id: session_id.to_string(),
+            signing_package_hex: "ee".to_string(),
+            signature_share_hex: round2.signature_share_hex.clone(),
+            member_identifier: 1,
+            taproot_merkle_root_hex: None,
+        })
+        .expect("verify")
+        .verdict,
+        ShareVerificationVerdict::Indeterminate
+    );
+    // Unknown session -> Indeterminate.
+    assert_eq!(
+        verify_signature_share(crate::api::VerifySignatureShareRequest {
+            session_id: "no-such-session".to_string(),
+            signing_package_hex: signing_package_hex.clone(),
+            signature_share_hex: round2.signature_share_hex.clone(),
+            member_identifier: 1,
+            taproot_merkle_root_hex: None,
+        })
+        .expect("verify")
+        .verdict,
+        ShareVerificationVerdict::Indeterminate
+    );
+
+    // Equivalence guard: aggregate's AllCheaters verdict over [member 1 valid,
+    // member 2 bogus] must name exactly the share verify_signature_share calls
+    // Invalid (member 2), and not the one it calls Valid (member 1).
+    let err = interactive_aggregate(InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        signing_package_hex: signing_package_hex.clone(),
+        signature_shares: vec![
+            crate::api::NativeFrostSignatureShare {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round2.signature_share_hex.clone(),
+            },
+            bogus_share.signature_share,
+        ],
+        taproot_merkle_root_hex: None,
+    })
+    .expect_err("an invalid share must fail aggregation closed");
+    let candidate_culprits = match err {
+        EngineError::AggregateShareVerificationFailed {
+            candidate_culprits, ..
+        } => candidate_culprits,
+        other => panic!("expected AggregateShareVerificationFailed, got {other:?}"),
+    };
+    assert_eq!(
+        candidate_culprits,
+        vec![2],
+        "aggregate's culprit verdict must match verify_signature_share: {candidate_culprits:?}"
+    );
+}

--- a/pkg/tbtc/signer/src/engine/verify_share.rs
+++ b/pkg/tbtc/signer/src/engine/verify_share.rs
@@ -77,22 +77,6 @@ pub fn verify_signature_share(
             Err(_) => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
         };
 
-    // The member operator-signed these share bytes: if they are undecodable, that
-    // is self-incriminating member fault -> invalid (the Go layer already
-    // authenticated the envelope; the inner FROST scalar is the member's).
-    let signature_share_bytes = match decode_hex_field(
-        "VerifySignatureShare",
-        "signature_share_hex",
-        &request.signature_share_hex,
-    ) {
-        Ok(bytes) => bytes,
-        Err(_) => return Ok(verdict(ShareVerificationVerdict::Invalid)),
-    };
-    let signature_share = match frost::round2::SignatureShare::deserialize(&signature_share_bytes) {
-        Ok(share) => share,
-        Err(_) => return Ok(verdict(ShareVerificationVerdict::Invalid)),
-    };
-
     // Resolve the group's public key package from the session's own DKG state -
     // never the request - mirroring InteractiveAggregate. A missing session or
     // incomplete DKG is not the member's fault -> indeterminate.
@@ -133,6 +117,26 @@ pub fn verify_signature_share(
         // The member has no verifying share for this group / is not in the
         // package's set - a coordinator/package matter, not member-share fault.
         None => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+    };
+
+    // Only now that the session, completed DKG, and the member's membership in
+    // THIS group are all established do we judge the member's signed share bytes:
+    // if they are undecodable here, that is self-incriminating member fault ->
+    // invalid (the Go layer already authenticated the envelope; the inner FROST
+    // scalar is the member's). Decoding any earlier would let a malformed share
+    // for an unknown / not-ready session or a non-member id return Invalid
+    // (blame) before the member context exists - it must be Indeterminate then.
+    let signature_share_bytes = match decode_hex_field(
+        "VerifySignatureShare",
+        "signature_share_hex",
+        &request.signature_share_hex,
+    ) {
+        Ok(bytes) => bytes,
+        Err(_) => return Ok(verdict(ShareVerificationVerdict::Invalid)),
+    };
+    let signature_share = match frost::round2::SignatureShare::deserialize(&signature_share_bytes) {
+        Ok(share) => share,
+        Err(_) => return Ok(verdict(ShareVerificationVerdict::Invalid)),
     };
 
     match frost_core::verify_signature_share(

--- a/pkg/tbtc/signer/src/engine/verify_share.rs
+++ b/pkg/tbtc/signer/src/engine/verify_share.rs
@@ -114,17 +114,34 @@ pub fn verify_signature_share(
         .get(&member_identifier)
     {
         Some(verifying_share) => verifying_share,
-        // The member has no verifying share for this group / is not in the
-        // package's set - a coordinator/package matter, not member-share fault.
+        // No verifying share in this GROUP (the member never received a DKG
+        // share) - a coordinator/caller matter, not member-share fault.
         None => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
     };
 
-    // Only now that the session, completed DKG, and the member's membership in
-    // THIS group are all established do we judge the member's signed share bytes:
-    // if they are undecodable here, that is self-incriminating member fault ->
-    // invalid (the Go layer already authenticated the envelope; the inner FROST
-    // scalar is the member's). Decoding any earlier would let a malformed share
-    // for an unknown / not-ready session or a non-member id return Invalid
+    // The member must ALSO be a participant in THIS attempt's signing package
+    // (its commitment set), not merely a group member. A package that omits the
+    // member is coordinator/context input - the member never signed a share for
+    // a package they are not in - so undecodable share bytes paired with such a
+    // package must NOT read as self-incriminating. Without this guard the
+    // omitted-member + undecodable-share case would hit the Invalid decode-
+    // failure branch below before frost_core's own UnknownIdentifier check (which
+    // already maps a DECODABLE omitted-member share to Indeterminate) is reached.
+    // Fail closed against blame: Indeterminate.
+    if !signing_package
+        .signing_commitments()
+        .contains_key(&member_identifier)
+    {
+        return Ok(verdict(ShareVerificationVerdict::Indeterminate));
+    }
+
+    // Only now that the session, completed DKG, the member's group membership,
+    // AND the member's inclusion in this attempt's package are all established do
+    // we judge the member's signed share bytes: if they are undecodable here that
+    // is self-incriminating member fault -> invalid (the Go layer already
+    // authenticated the envelope; the inner FROST scalar is the member's).
+    // Decoding any earlier would let a malformed share for an unknown / not-ready
+    // session, a non-member id, or a package that omits the member return Invalid
     // (blame) before the member context exists - it must be Indeterminate then.
     let signature_share_bytes = match decode_hex_field(
         "VerifySignatureShare",

--- a/pkg/tbtc/signer/src/engine/verify_share.rs
+++ b/pkg/tbtc/signer/src/engine/verify_share.rs
@@ -6,6 +6,14 @@
 // pure FROST share verification, no envelope/operator-signature inspection
 // (that is the Go layer's job; frozen Q1 boundary).
 //
+// As with InteractiveAggregate's candidate culprits, an `Invalid` verdict is
+// framable: this endpoint verifies the share against WHATEVER package/root the
+// caller supplies, so a coordinator that verifies an honest share against a
+// mismatched package/root would get `Invalid`. The engine cannot bind these
+// public inputs to what the member signed at Round2; authoritative,
+// envelope-bound blame is the Go host's job at an f+1 accuser quorum (frozen
+// Phase 7.2b spec, section 6). This verdict is that adjudication's INPUT.
+//
 // It returns an explicit tri-state verdict (Valid / Invalid / Indeterminate),
 // not a pass/fail + error: only the engine can distinguish a member's malformed
 // signed scalar (blame) from a malformed package/context (don't blame), so it
@@ -48,9 +56,18 @@ pub fn verify_signature_share(
     };
 
     // Canonicalize + apply the taproot root EXACTLY as InteractiveAggregate (the
-    // tweak path must not drift; None vs Some([]) must resolve identically).
+    // tweak path must not drift; None vs Some([]) must resolve identically). A
+    // malformed root (non-hex / not 32 bytes) is COORDINATOR/wallet-context
+    // input, never the member's signed-share fault, so it returns an in-band
+    // Indeterminate verdict rather than escaping to the FFI error channel: the
+    // contract is "a tri-state verdict for every input", so the Go host never
+    // has to infer "don't blame" from an error code.
     let mut taproot_merkle_root_hex = request.taproot_merkle_root_hex.clone();
-    let taproot_merkle_root = canonicalize_taproot_merkle_root_hex(&mut taproot_merkle_root_hex)?;
+    let taproot_merkle_root =
+        match canonicalize_taproot_merkle_root_hex(&mut taproot_merkle_root_hex) {
+            Ok(root) => root,
+            Err(_) => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+        };
 
     let member_identifier =
         match participant_identifier_to_frost_identifier(request.member_identifier) {

--- a/pkg/tbtc/signer/src/engine/verify_share.rs
+++ b/pkg/tbtc/signer/src/engine/verify_share.rs
@@ -97,9 +97,15 @@ pub fn verify_signature_share(
     // never the request - mirroring InteractiveAggregate. A missing session or
     // incomplete DKG is not the member's fault -> indeterminate.
     let public_key_package = {
-        let guard = state()?
+        let mut guard = state()?
             .lock()
             .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
+        // Verify-share takes the engine lock like every other interactive entry
+        // point, so it sweeps expired interactive state too: the nonce-TTL
+        // guarantee (an abandoned interactive nonce handle gone within the TTL of
+        // inactivity) must hold even when the only post-expiry traffic is
+        // verify-share blame rechecks. Mirrors InteractiveAggregate.
+        sweep_expired_interactive_state(&mut guard);
         let session = match guard.sessions.get(&request.session_id) {
             Some(session) => session,
             None => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),

--- a/pkg/tbtc/signer/src/engine/verify_share.rs
+++ b/pkg/tbtc/signer/src/engine/verify_share.rs
@@ -1,0 +1,131 @@
+// Phase 7.2b-4: single round-2 signature-share verification.
+//
+// Backs the Go host's Round2ShareVerifier (member-blame classifier, 4a). Given
+// one retained share + the attempt's signing package, it answers whether the
+// share verifies against the group's own (taproot-tweaked) verifying material -
+// pure FROST share verification, no envelope/operator-signature inspection
+// (that is the Go layer's job; frozen Q1 boundary).
+//
+// It returns an explicit tri-state verdict (Valid / Invalid / Indeterminate),
+// not a pass/fail + error: only the engine can distinguish a member's malformed
+// signed scalar (blame) from a malformed package/context (don't blame), so it
+// makes that call here rather than forcing the Go host to infer it from an error
+// string. The verifying material + taproot tweak are resolved EXACTLY as
+// InteractiveAggregate does (same session DKG package, same
+// canonicalize_taproot_merkle_root_hex, same `.tweak()`), so the verdict matches
+// what aggregation would conclude for the same share - pinned by the
+// standalone-vs-aggregate equivalence tests.
+
+use super::*;
+
+use crate::api::{
+    ShareVerificationVerdict, VerifySignatureShareRequest, VerifySignatureShareResult,
+};
+
+fn verdict(v: ShareVerificationVerdict) -> VerifySignatureShareResult {
+    VerifySignatureShareResult { verdict: v }
+}
+
+pub fn verify_signature_share(
+    request: VerifySignatureShareRequest,
+) -> Result<VerifySignatureShareResult, EngineError> {
+    enforce_provenance_gate()?;
+    validate_session_id(&request.session_id)?;
+
+    // An undecodable signing package is COORDINATOR-authored input, not the
+    // member's fault -> indeterminate (never blame the member for it).
+    let signing_package_bytes = match decode_hex_field(
+        "VerifySignatureShare",
+        "signing_package_hex",
+        &request.signing_package_hex,
+    ) {
+        Ok(bytes) => bytes,
+        Err(_) => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+    };
+    let signing_package = match frost::SigningPackage::deserialize(&signing_package_bytes) {
+        Ok(package) => package,
+        Err(_) => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+    };
+
+    // Canonicalize + apply the taproot root EXACTLY as InteractiveAggregate (the
+    // tweak path must not drift; None vs Some([]) must resolve identically).
+    let mut taproot_merkle_root_hex = request.taproot_merkle_root_hex.clone();
+    let taproot_merkle_root = canonicalize_taproot_merkle_root_hex(&mut taproot_merkle_root_hex)?;
+
+    let member_identifier =
+        match participant_identifier_to_frost_identifier(request.member_identifier) {
+            Ok(identifier) => identifier,
+            // An out-of-range member id is a caller/package issue, not the
+            // member's signed-share fault.
+            Err(_) => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+        };
+
+    // The member operator-signed these share bytes: if they are undecodable, that
+    // is self-incriminating member fault -> invalid (the Go layer already
+    // authenticated the envelope; the inner FROST scalar is the member's).
+    let signature_share_bytes = match decode_hex_field(
+        "VerifySignatureShare",
+        "signature_share_hex",
+        &request.signature_share_hex,
+    ) {
+        Ok(bytes) => bytes,
+        Err(_) => return Ok(verdict(ShareVerificationVerdict::Invalid)),
+    };
+    let signature_share = match frost::round2::SignatureShare::deserialize(&signature_share_bytes) {
+        Ok(share) => share,
+        Err(_) => return Ok(verdict(ShareVerificationVerdict::Invalid)),
+    };
+
+    // Resolve the group's public key package from the session's own DKG state -
+    // never the request - mirroring InteractiveAggregate. A missing session or
+    // incomplete DKG is not the member's fault -> indeterminate.
+    let public_key_package = {
+        let guard = state()?
+            .lock()
+            .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
+        let session = match guard.sessions.get(&request.session_id) {
+            Some(session) => session,
+            None => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+        };
+        if session.dkg_result.is_none() {
+            return Ok(verdict(ShareVerificationVerdict::Indeterminate));
+        }
+        match session.dkg_public_key_package.as_ref() {
+            Some(package) => package.clone(),
+            None => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+        }
+    };
+
+    // Same tweak expression as InteractiveAggregate (strict input parity).
+    let verification_key_package = match taproot_merkle_root.as_ref() {
+        Some(root) => public_key_package.clone().tweak(Some(root.as_slice())),
+        None => public_key_package.clone(),
+    };
+
+    let verifying_share = match verification_key_package
+        .verifying_shares()
+        .get(&member_identifier)
+    {
+        Some(verifying_share) => verifying_share,
+        // The member has no verifying share for this group / is not in the
+        // package's set - a coordinator/package matter, not member-share fault.
+        None => return Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+    };
+
+    match frost_core::verify_signature_share(
+        member_identifier,
+        verifying_share,
+        &signature_share,
+        &signing_package,
+        verification_key_package.verifying_key(),
+    ) {
+        Ok(()) => Ok(verdict(ShareVerificationVerdict::Valid)),
+        // The member's signed share fails the FROST verification equation.
+        Err(frost_core::Error::InvalidSignatureShare { .. }) => {
+            Ok(verdict(ShareVerificationVerdict::Invalid))
+        }
+        // UnknownIdentifier / commitment / other: a package or context issue, not
+        // attributable member-share fault.
+        Err(_) => Ok(verdict(ShareVerificationVerdict::Indeterminate)),
+    }
+}

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -301,6 +301,19 @@ pub extern "C" fn frost_tbtc_aggregate(
     })
 }
 
+#[no_mangle]
+pub extern "C" fn frost_tbtc_verify_signature_share(
+    request_ptr: *const u8,
+    request_len: usize,
+) -> TbtcSignerResult {
+    ffi_entry(|| {
+        let request: crate::api::VerifySignatureShareRequest =
+            parse_request(request_ptr, request_len)?;
+        let response = engine::verify_signature_share(request)?;
+        serialize_response(&response)
+    })
+}
+
 // Phase 7.1 hardened interactive signing session (frozen spec
 // docs/phase-7-interactive-session-spec-freeze.md). Additive ABI: the
 // Go host adopts these in Phase 7.3; nothing breaks until it calls


### PR DESCRIPTION
## What

Phase 7.2b-4: an engine **single-share FROST verification** the Go host's `Round2ShareVerifier` (the 4a member-blame classifier) calls to re-verify a retained share against the attempt's authoritative package — the **last seam in the blame stack**, and the one piece that needs FROST crypto (Go has none).

## How
- **`engine::verify_signature_share`** resolves the group's `PublicKeyPackage` from the session's own DKG state (never the request), applies the taproot tweak **exactly as `InteractiveAggregate`** (same `canonicalize_taproot_merkle_root_hex` + `.tweak()`), and calls `frost_core::verify_signature_share` against the tweaked verifying share + group key. By construction this matches what `aggregate_custom(AllCheaters)` concludes for the same share.
- **Explicit tri-state `ShareVerificationVerdict`** (`valid`/`invalid`/`indeterminate`) — per the Codex+Gemini design consult, only the engine can distinguish a member's malformed signed scalar (`invalid` → blame) from a malformed package/context (`indeterminate` → don't blame): undecodable **member** share bytes / `InvalidSignatureShare` → `invalid`; undecodable signing **package** / missing-or-`UnknownIdentifier` verifying share / session-not-ready → `indeterminate`; `Ok` → `valid`.
- FFI export `frost_tbtc_verify_signature_share` + `api.rs` request/result. (Go maps the verdict to `ShareVerificationResult`, and any FFI-transport error → `ShareIndeterminate`.)

## Why standalone + tweak-aware is sound (consult)
`frost_core::verify_signature_share` reuses `pre_aggregate` and computes the same binding factors / group commitment / BIP-340 challenge / `verify_share` relation as `aggregate_custom`; the even-Y/R negation is encapsulated in `PublicKeyPackage::tweak()`. **frost-core `=3.0.0`** is required (its `verify_signature_share` was fixed to call `pre_commitment_aggregate()`; older rc's diverged) — pinned, and guarded by the equivalence test.

## Tests
`verify_signature_share_verdicts_match_aggregate_and_handle_edges`: valid shares → `Valid`, wrong-package share → `Invalid`, the **equivalence guard** (aggregate's `AllCheaters` culprit verdict matches verify's per-share verdicts), and edges (undecodable share → `Invalid`; missing member / undecodable package / unknown session → `Indeterminate`). Full lib suite (285) + fmt + clippy green.

## Follow-ups
- The Go-side `Round2ShareVerifier` impl (scaffold) that calls this FFI + registers it in the cgo bridge.
- A script-path (tweaked-root) equivalence-test variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
