### PR TITLE
Phase 7.2b-4: engine VerifySignatureShare FFI bridge (cgo)

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -54,6 +54,10 @@ typedef TbtcSignerResult (*tbtc_aggregate_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_verify_signature_share_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef TbtcSignerResult (*tbtc_start_sign_round_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -187,6 +191,18 @@ static TbtcSignerResult tbtc_signer_aggregate(const uint8_t* request_ptr, size_t
   }
 
   return aggregate(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_verify_signature_share(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_verify_signature_share_fn verify_signature_share = (tbtc_verify_signature_share_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_verify_signature_share"
+  );
+  if (verify_signature_share == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return verify_signature_share(request_ptr, request_len);
 }
 
 static TbtcSignerResult tbtc_signer_start_sign_round(const uint8_t* request_ptr, size_t request_len) {
@@ -379,6 +395,18 @@ type buildTaggedTBTCSignerAggregateRequest struct {
 
 type buildTaggedTBTCSignerAggregateResponse struct {
 	SignatureHex string `json:"signature_hex"`
+}
+
+type buildTaggedTBTCSignerVerifySignatureShareRequest struct {
+	SessionID            string  `json:"session_id"`
+	SigningPackageHex    string  `json:"signing_package_hex"`
+	SignatureShareHex    string  `json:"signature_share_hex"`
+	MemberIdentifier     uint16  `json:"member_identifier"`
+	TaprootMerkleRootHex *string `json:"taproot_merkle_root_hex,omitempty"`
+}
+
+type buildTaggedTBTCSignerVerifySignatureShareResponse struct {
+	Verdict string `json:"verdict"`
 }
 
 type buildTaggedTBTCSignerStartSignRoundRequest struct {
@@ -671,6 +699,37 @@ func (bttse *buildTaggedTBTCSignerEngine) Aggregate(
 	}
 
 	return decodeBuildTaggedTBTCSignerAggregateResponse(responsePayload)
+}
+
+// VerifySignatureShare re-verifies ONE retained round-2 signature share against
+// an attempt's signing package, returning the engine's tri-state verdict. It
+// backs the Go host's Round2ShareVerifier (member-blame classifier). On any
+// FFI-transport error it returns (NativeShareVerdictIndeterminate, err); the
+// caller fails closed to don't-blame.
+func (bttse *buildTaggedTBTCSignerEngine) VerifySignatureShare(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) (NativeShareVerificationVerdict, error) {
+	requestPayload, err := buildTaggedTBTCSignerVerifySignatureShareRequestPayload(
+		sessionID,
+		signingPackage,
+		signatureShare,
+		memberIdentifier,
+		taprootMerkleRoot,
+	)
+	if err != nil {
+		return NativeShareVerdictIndeterminate, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerVerifySignatureShare(requestPayload)
+	if err != nil {
+		return NativeShareVerdictIndeterminate, err
+	}
+
+	return decodeBuildTaggedTBTCSignerVerifySignatureShareResponse(responsePayload)
 }
 
 func (bttse *buildTaggedTBTCSignerEngine) StartSignRound(
@@ -1469,6 +1528,83 @@ func decodeBuildTaggedTBTCSignerAggregateResponse(
 		"response signature",
 		response.SignatureHex,
 	)
+}
+
+// buildTaggedTBTCSignerVerifySignatureShareRequestPayload builds the
+// VerifySignatureShare request.
+//
+// Unlike every other bridge operation, it deliberately does NOT reject empty or
+// short signing-package / signature-share bytes. For THIS operation those bytes
+// are the SUBJECT of the engine's tri-state verdict: a member's retained share
+// envelope can carry empty or malformed inner FROST bytes (the collector
+// authenticates the operator signature over the envelope, not the FROST share
+// equation), and the engine classifies such bytes as an `invalid` (blamable)
+// verdict. If the bridge instead rejected them with an error here, the Go host
+// would map that FFI error to ShareIndeterminate and a cheater who submitted
+// garbage would dodge blame. So only the sessionID routing key is validated;
+// the package, share, and member identifier are passed through for the engine
+// to classify (a malformed package or out-of-range id yields `indeterminate`,
+// never false blame).
+func buildTaggedTBTCSignerVerifySignatureShareRequestPayload(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"VerifySignatureShare",
+			"session ID is empty",
+		)
+	}
+
+	var taprootMerkleRootHex *string
+	if taprootMerkleRoot != nil {
+		encoded := hex.EncodeToString(taprootMerkleRoot[:])
+		taprootMerkleRootHex = &encoded
+	}
+
+	return buildTaggedTBTCSignerMarshalRequest(
+		"VerifySignatureShare",
+		buildTaggedTBTCSignerVerifySignatureShareRequest{
+			SessionID:            sessionID,
+			SigningPackageHex:    hex.EncodeToString(signingPackage),
+			SignatureShareHex:    hex.EncodeToString(signatureShare),
+			MemberIdentifier:     memberIdentifier,
+			TaprootMerkleRootHex: taprootMerkleRootHex,
+		},
+	)
+}
+
+// decodeBuildTaggedTBTCSignerVerifySignatureShareResponse maps the engine's
+// snake_case verdict string to the typed tri-state. An unrecognized verdict is
+// an error (never silently defaulted); the zero value of the verdict type is the
+// safe Indeterminate, so an unchecked error never reads as blame.
+func decodeBuildTaggedTBTCSignerVerifySignatureShareResponse(
+	responsePayload []byte,
+) (NativeShareVerificationVerdict, error) {
+	var response buildTaggedTBTCSignerVerifySignatureShareResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return NativeShareVerdictIndeterminate, buildTaggedTBTCSignerOperationError(
+			"VerifySignatureShare",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	switch response.Verdict {
+	case "valid":
+		return NativeShareVerdictValid, nil
+	case "invalid":
+		return NativeShareVerdictInvalid, nil
+	case "indeterminate":
+		return NativeShareVerdictIndeterminate, nil
+	default:
+		return NativeShareVerdictIndeterminate, buildTaggedTBTCSignerOperationError(
+			"VerifySignatureShare",
+			fmt.Sprintf("response verdict is unrecognized: %q", response.Verdict),
+		)
+	}
 }
 
 func buildTaggedTBTCSignerMarshalRequest(
@@ -2276,6 +2412,18 @@ func callBuildTaggedTBTCSignerAggregate(
 		requestPayload,
 		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
 			return C.tbtc_signer_aggregate(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerVerifySignatureShare(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"VerifySignatureShare",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_verify_signature_share(requestPtr, requestLen)
 		},
 	)
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1482,3 +1482,26 @@ func TestDecodeBuildTaggedTBTCSignerVerifySignatureShareResponse_UnrecognizedVer
 		)
 	}
 }
+
+func TestDecodeBuildTaggedTBTCSignerVerifySignatureShareResponse_MalformedJSON(
+	t *testing.T,
+) {
+	verdict, err := decodeBuildTaggedTBTCSignerVerifySignatureShareResponse(
+		[]byte("not json"),
+	)
+	if err == nil {
+		t.Fatal("expected malformed JSON to be rejected")
+	}
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf("expected ErrNativeBridgeOperationFailed, got: [%v]", err)
+	}
+	// The other decoder error path (a json.Unmarshal failure) must also fail
+	// closed to the safe Indeterminate, never to a blame verdict.
+	if verdict != NativeShareVerdictIndeterminate {
+		t.Fatalf(
+			"expected Indeterminate on error\nexpected: [%v]\nactual:   [%v]",
+			NativeShareVerdictIndeterminate,
+			verdict,
+		)
+	}
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1292,3 +1292,193 @@ func TestDecodeBuildTaggedTBTCSignerBuildTaprootTxResponse(t *testing.T) {
 		)
 	}
 }
+
+func TestBuildTaggedTBTCSignerVerifySignatureShareRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerVerifySignatureShareRequestPayload(
+		"session-1",
+		[]byte{0xde, 0xad},
+		[]byte{0xbe, 0xef},
+		2,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerVerifySignatureShareRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.SessionID != "session-1" {
+		t.Fatalf(
+			"unexpected session id\nexpected: [%v]\nactual:   [%v]",
+			"session-1",
+			request.SessionID,
+		)
+	}
+	if request.SigningPackageHex != "dead" {
+		t.Fatalf(
+			"unexpected signing package hex\nexpected: [%v]\nactual:   [%v]",
+			"dead",
+			request.SigningPackageHex,
+		)
+	}
+	if request.SignatureShareHex != "beef" {
+		t.Fatalf(
+			"unexpected signature share hex\nexpected: [%v]\nactual:   [%v]",
+			"beef",
+			request.SignatureShareHex,
+		)
+	}
+	if request.MemberIdentifier != 2 {
+		t.Fatalf(
+			"unexpected member identifier\nexpected: [%v]\nactual:   [%v]",
+			2,
+			request.MemberIdentifier,
+		)
+	}
+	if request.TaprootMerkleRootHex != nil {
+		t.Fatalf(
+			"expected omitted taproot merkle root, got: [%v]",
+			*request.TaprootMerkleRootHex,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerVerifySignatureShareRequestPayload_TaprootMerkleRoot(
+	t *testing.T,
+) {
+	var taprootMerkleRoot [32]byte
+	taprootMerkleRoot[0] = 0xab
+	taprootMerkleRoot[31] = 0xcd
+
+	payload, err := buildTaggedTBTCSignerVerifySignatureShareRequestPayload(
+		"session-1",
+		[]byte{0xde, 0xad},
+		[]byte{0xbe, 0xef},
+		2,
+		&taprootMerkleRoot,
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerVerifySignatureShareRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.TaprootMerkleRootHex == nil {
+		t.Fatal("expected taproot merkle root")
+	}
+	expectedTaprootMerkleRootHex := hex.EncodeToString(taprootMerkleRoot[:])
+	if *request.TaprootMerkleRootHex != expectedTaprootMerkleRootHex {
+		t.Fatalf(
+			"unexpected taproot merkle root hex\nexpected: [%v]\nactual:   [%v]",
+			expectedTaprootMerkleRootHex,
+			*request.TaprootMerkleRootHex,
+		)
+	}
+}
+
+func TestBuildTaggedTBTCSignerVerifySignatureShareRequestPayload_EmptySessionID(
+	t *testing.T,
+) {
+	_, err := buildTaggedTBTCSignerVerifySignatureShareRequestPayload(
+		"",
+		[]byte{0xde, 0xad},
+		[]byte{0xbe, 0xef},
+		2,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected an empty session id to be rejected")
+	}
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf("expected ErrNativeBridgeOperationFailed, got: [%v]", err)
+	}
+}
+
+// The verify-share request builder must NOT reject empty/short package or share
+// bytes: those are the SUBJECT of the engine's verdict. A member who submits
+// empty/garbage inner FROST bytes must reach the engine (which returns
+// `invalid` -> blame); a bridge-side rejection would surface as an FFI error the
+// Go host maps to ShareIndeterminate, letting the cheater dodge blame. This test
+// pins that the builder passes such bytes through as empty/short hex.
+func TestBuildTaggedTBTCSignerVerifySignatureShareRequestPayload_PassesThroughEmptyBlameSubjectBytes(
+	t *testing.T,
+) {
+	payload, err := buildTaggedTBTCSignerVerifySignatureShareRequestPayload(
+		"session-1",
+		nil,
+		nil,
+		2,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("empty package/share bytes must pass through, got error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerVerifySignatureShareRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.SigningPackageHex != "" {
+		t.Fatalf("expected empty signing package hex, got: [%q]", request.SigningPackageHex)
+	}
+	if request.SignatureShareHex != "" {
+		t.Fatalf("expected empty signature share hex, got: [%q]", request.SignatureShareHex)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerVerifySignatureShareResponse(t *testing.T) {
+	tests := map[string]struct {
+		verdict  string
+		expected NativeShareVerificationVerdict
+	}{
+		"valid":         {verdict: "valid", expected: NativeShareVerdictValid},
+		"invalid":       {verdict: "invalid", expected: NativeShareVerdictInvalid},
+		"indeterminate": {verdict: "indeterminate", expected: NativeShareVerdictIndeterminate},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload := []byte(fmt.Sprintf(`{"verdict":%q}`, test.verdict))
+			verdict, err := decodeBuildTaggedTBTCSignerVerifySignatureShareResponse(payload)
+			if err != nil {
+				t.Fatalf("unexpected decode error: [%v]", err)
+			}
+			if verdict != test.expected {
+				t.Fatalf(
+					"unexpected verdict\nexpected: [%v]\nactual:   [%v]",
+					test.expected,
+					verdict,
+				)
+			}
+		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerVerifySignatureShareResponse_UnrecognizedVerdict(
+	t *testing.T,
+) {
+	verdict, err := decodeBuildTaggedTBTCSignerVerifySignatureShareResponse(
+		[]byte(`{"verdict":"maybe"}`),
+	)
+	if err == nil {
+		t.Fatal("expected an unrecognized verdict to be rejected")
+	}
+	if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+		t.Fatalf("expected ErrNativeBridgeOperationFailed, got: [%v]", err)
+	}
+	// An unrecognized verdict must fail closed to the safe Indeterminate, never
+	// to a blame verdict, even though the caller is expected to check the error.
+	if verdict != NativeShareVerdictIndeterminate {
+		t.Fatalf(
+			"expected Indeterminate on error\nexpected: [%v]\nactual:   [%v]",
+			NativeShareVerdictIndeterminate,
+			verdict,
+		)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -53,6 +53,29 @@ type NativeTBTCSignerRoundState struct {
 	OwnContribution       *NativeTBTCSignerRoundContribution `json:"ownContribution"`
 }
 
+// NativeShareVerificationVerdict is the typed result of a single-share FROST
+// re-verification (frost_tbtc_verify_signature_share). It mirrors the engine's
+// tri-state verdict.
+//
+// Indeterminate is deliberately the ZERO value: the boundary between blame
+// (Invalid) and don't-blame is security-critical, so an unset value, a decode
+// failure, or an FFI-transport error all fail closed against false blame. A
+// verdict is only meaningful when the accompanying error is nil.
+type NativeShareVerificationVerdict int
+
+const (
+	// NativeShareVerdictIndeterminate: verification could not be completed for a
+	// reason that is not the member's fault (or could not be obtained at all).
+	// Fail closed against blame. Zero value.
+	NativeShareVerdictIndeterminate NativeShareVerificationVerdict = iota
+	// NativeShareVerdictValid: the share is a valid FROST signature share for the
+	// (tweaked) package. Not blamable.
+	NativeShareVerdictValid
+	// NativeShareVerdictInvalid: the share is member-attributable garbage -
+	// mathematically invalid, or undecodable member-signed bytes. Blamable.
+	NativeShareVerdictInvalid
+)
+
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer
 // operations.
 type NativeTBTCSignerEngine interface {


### PR DESCRIPTION
## What

Wires the Go host to the Rust engine's `frost_tbtc_verify_signature_share` (merged in keep-core #4068) via the existing `frost_native && frost_tbtc_signer && cgo` bridge, so the upcoming **`Round2ShareVerifier`** (the 4a member-blame classifier's injected seam) can re-verify a retained round-2 share against an attempt's signing package with real FROST crypto.

**Additive — nothing calls it yet** (mirrors how the engine export #4068 landed before its Go caller). This is PR 2a of 2; PR 2b is the concrete verifier + wiring.

## How
- **cgo**: `tbtc_verify_signature_share` typedef + `dlsym` wrapper + `callBuildTaggedTBTCSignerVerifySignatureShare`, mirroring `tbtc_signer_aggregate`.
- **`buildTaggedTBTCSignerEngine.VerifySignatureShare(sessionID, signingPackage, signatureShare, memberIdentifier, taprootMerkleRoot)`** → tri-state verdict, plus request/response marshalling + decoding helpers.
- **`NativeShareVerificationVerdict`** tri-state with **`Indeterminate` as the ZERO value** — an unset value, a decode failure, or an FFI-transport error all fail closed against false blame.

## Blame-soundness (the one non-mechanical decision)
The request builder **deliberately does NOT reject empty/short signing-package or signature-share bytes.** For this operation those bytes are the *subject* of the engine's verdict: a member's retained share envelope can carry empty/garbage inner FROST bytes (the collector authenticates the operator signature over the envelope, not the FROST equation), and the engine maps such bytes to `invalid` (blame). A bridge-side rejection would surface as an FFI error the Go host maps to `ShareIndeterminate` — letting a cheater who submitted garbage dodge blame. So only the `sessionID` routing key is validated; package/share/member-id pass through for the engine to classify (malformed → `indeterminate`, never false blame). Pinned by a dedicated test.

## Tests
Payload builder (fields, taproot variant, empty-session rejection, pass-through of empty blame-subject bytes) and verdict decoder (valid/invalid/indeterminate; both error paths — unrecognized verdict and malformed JSON — → error + `Indeterminate`).

## Validation
⚠️ **The standard `client-*` CI checks do not build this code** — they compile the default build tags, while this bridge lives behind `frost_native && frost_tbtc_signer && cgo` (which needs the linked Rust signer lib). It was validated **locally**: builds clean under **default**, **frost_native**, and **frost_native+frost_tbtc_signer+cgo**; full `pkg/frost/signing` suite + `go vet` + `gofmt` green. The bridge compiles without the Rust lib present (the `dlsym` resolves at runtime), so the marshal/decode helpers run as ordinary unit tests; the live-FFI method body is exercised by `_WithLinkedSigner`-style integration alongside 2b's real-session wiring.

## Follow-up (PR 2b)
The concrete `Round2ShareVerifier` that unwraps the retained envelopes (`SigningPackage.SigningPackageBytes` + the share submission body), binds session/taproot, calls this method, and maps the verdict → `roast.ShareVerificationResult`; plus adding `VerifySignatureShare` to the `NativeTBTCSignerEngine` interface and updating the test fakes. (Carry-forward: 2b must range-check the `group.MemberIndex → uint16` conversion → out-of-range maps to `ShareIndeterminate`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)