### PR TITLE
Phase 7.2b-4: engine-backed Round2ShareVerifier (concrete blame seam)

### DIFF
--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -187,6 +187,16 @@ func (mbttse *mockBuildTaggedTBTCSignerEngine) BuildTaprootTx(
 	return nil, errors.New("not implemented")
 }
 
+func (mbttse *mockBuildTaggedTBTCSignerEngine) VerifySignatureShare(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) (NativeShareVerificationVerdict, error) {
+	return NativeShareVerdictIndeterminate, errors.New("not implemented")
+}
+
 func cloneTestTaprootMerkleRoot(taprootMerkleRoot *[32]byte) *[32]byte {
 	if taprootMerkleRoot == nil {
 		return nil
@@ -286,6 +296,16 @@ func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) BuildTap
 	scriptTreeHex *string,
 ) (*NativeTBTCSignerTxResult, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) VerifySignatureShare(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) (NativeShareVerificationVerdict, error) {
+	return NativeShareVerdictIndeterminate, errors.New("not implemented")
 }
 
 func (dbttsbre *deterministicBuildTaggedTBTCSignerBootstrapRoundEngine) finalizeInputs() []NativeTBTCSignerRoundContribution {

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -103,6 +103,13 @@ type NativeTBTCSignerEngine interface {
 		outputs []NativeTBTCSignerTxOutput,
 		scriptTreeHex *string,
 	) (*NativeTBTCSignerTxResult, error)
+	VerifySignatureShare(
+		sessionID string,
+		signingPackage []byte,
+		signatureShare []byte,
+		memberIdentifier uint16,
+		taprootMerkleRoot *[32]byte,
+	) (NativeShareVerificationVerdict, error)
 }
 
 // NativeTBTCSignerSeededDKGEngine is implemented by tbtc-signer engines that

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native_test.go
@@ -49,6 +49,16 @@ func (mntse *mockNativeTBTCSignerEngine) BuildTaprootTx(
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (mntse *mockNativeTBTCSignerEngine) VerifySignatureShare(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) (NativeShareVerificationVerdict, error) {
+	return NativeShareVerdictIndeterminate, fmt.Errorf("not implemented")
+}
+
 func TestRegisterNativeTBTCSignerEngineRejectsNil(t *testing.T) {
 	UnregisterNativeTBTCSignerEngine()
 	t.Cleanup(UnregisterNativeTBTCSignerEngine)

--- a/pkg/frost/signing/round2_share_verifier_frost_native.go
+++ b/pkg/frost/signing/round2_share_verifier_frost_native.go
@@ -1,0 +1,229 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ipfs/go-log/v2"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+var round2ShareVerifierLogger = log.Logger("keep-frost-signing-blame")
+
+// Round2ShareVerifyingEngine is the slice of the native tbtc-signer engine the
+// EngineRound2ShareVerifier needs: a single round-2 FROST share re-verification.
+//
+// It is defined at the consumer (interface segregation) so the verifier can be
+// unit-tested with a one-method fake - no cgo and no full NativeTBTCSignerEngine.
+// The registered NativeTBTCSignerEngine is a superset and satisfies it.
+type Round2ShareVerifyingEngine interface {
+	VerifySignatureShare(
+		sessionID string,
+		signingPackage []byte,
+		signatureShare []byte,
+		memberIdentifier uint16,
+		taprootMerkleRoot *[32]byte,
+	) (NativeShareVerificationVerdict, error)
+}
+
+// Round2ShareVerificationBinding pins an EngineRound2ShareVerifier to ONE
+// attempt.
+//
+// The engine resolves the group key from SessionID and tweaks the verification
+// by TaprootMerkleRoot; it cannot tell a valid-but-WRONG session/root from the
+// right one, so a mis-bound verifier would make an HONEST share verify invalid
+// and produce FALSE blame. The verifier therefore checks the retained package's
+// own AttemptContextHash and TaprootMerkleRoot against this binding before it
+// calls the engine, refusing (Indeterminate) on any mismatch.
+//
+// SessionID itself cannot be self-checked by the verifier (it cannot re-derive
+// the attempt-context hash here), so the construction site MUST supply a
+// SessionID consistent with AttemptContextHash - the RFC-21 attempt-context
+// derivation includes the session, so an orchestrator that holds both can assert
+// it. That is a hard construction-time contract.
+type Round2ShareVerificationBinding struct {
+	// SessionID names the engine DKG session whose group key the share is
+	// verified against. Must be non-empty and consistent with AttemptContextHash.
+	SessionID string
+	// AttemptContextHash is the attempt this verifier adjudicates (32 bytes).
+	AttemptContextHash [32]byte
+	// TaprootMerkleRoot is the taproot script-tree root the signature is tweaked
+	// by, or nil for a key-path spend. Copied at construction.
+	TaprootMerkleRoot *[32]byte
+}
+
+// EngineRound2ShareVerifier is the engine-backed roast.Round2ShareVerifier: it
+// re-verifies a retained round-2 signature share against an attempt's signing
+// package using the Rust engine's pure FROST share verification (the frozen Q1
+// crypto-only boundary - it never inspects operator-signed envelopes for blame;
+// that is Round2Collector's job). Immutable after construction and safe for
+// concurrent use.
+type EngineRound2ShareVerifier struct {
+	engine             Round2ShareVerifyingEngine
+	sessionID          string
+	attemptContextHash [32]byte
+	taprootMerkleRoot  *[32]byte
+}
+
+var _ roast.Round2ShareVerifier = (*EngineRound2ShareVerifier)(nil)
+
+// NewEngineRound2ShareVerifier binds an engine-backed verifier to one attempt.
+// It errors on a nil engine or an empty SessionID, and copies the binding's
+// taproot root so the verifier is immutable and cannot be mutated through the
+// caller's pointer.
+func NewEngineRound2ShareVerifier(
+	engine Round2ShareVerifyingEngine,
+	binding Round2ShareVerificationBinding,
+) (*EngineRound2ShareVerifier, error) {
+	if engine == nil {
+		return nil, fmt.Errorf(
+			"roast: EngineRound2ShareVerifier requires a non-nil engine",
+		)
+	}
+	if binding.SessionID == "" {
+		return nil, fmt.Errorf(
+			"roast: EngineRound2ShareVerifier requires a non-empty session id",
+		)
+	}
+
+	var taprootMerkleRoot *[32]byte
+	if binding.TaprootMerkleRoot != nil {
+		root := *binding.TaprootMerkleRoot
+		taprootMerkleRoot = &root
+	}
+
+	return &EngineRound2ShareVerifier{
+		engine:             engine,
+		sessionID:          binding.SessionID,
+		attemptContextHash: binding.AttemptContextHash,
+		taprootMerkleRoot:  taprootMerkleRoot,
+	}, nil
+}
+
+// VerifyRetainedShare implements roast.Round2ShareVerifier. It unwraps the
+// retained, collector-authenticated envelopes, confirms the package belongs to
+// THIS verifier's bound attempt and root, then asks the engine to re-verify the
+// member's inner FROST share. It fails closed against blame
+// (ShareIndeterminate) on every not-the-member's-fault condition; only the
+// engine's `invalid` verdict - the member's own share is mathematically invalid
+// or undecodable, judged after the engine establishes session/DKG/group/package
+// context - yields ShareInvalid.
+func (v *EngineRound2ShareVerifier) VerifyRetainedShare(
+	signingPackageEnvelope []byte,
+	shareEnvelope []byte,
+	submitter group.MemberIndex,
+) roast.ShareVerificationResult {
+	// A zero member index is never a valid FROST participant; do not blame.
+	if submitter == 0 {
+		v.logIndeterminate("submitter member index is zero", submitter, nil)
+		return roast.ShareIndeterminate
+	}
+
+	// The retained package/share envelopes are collector-produced (authenticated,
+	// then re-marshaled): the member controls only the inner FROST bytes, not the
+	// envelope framing, so an unmarshal failure here is an internal inconsistency,
+	// not member fault -> Indeterminate, and the engine is NOT called.
+	var signingPackage roast.SigningPackage
+	if err := signingPackage.Unmarshal(signingPackageEnvelope); err != nil {
+		v.logIndeterminate("retained signing-package envelope did not unmarshal", submitter, err)
+		return roast.ShareIndeterminate
+	}
+
+	// Refuse to adjudicate a package that is not THIS attempt's, or whose taproot
+	// root differs from the bound root: a mis-bound or cross-attempt verifier must
+	// never turn an honest share into false blame. Fail closed (Indeterminate).
+	if !bytes.Equal(signingPackage.AttemptContextHash, v.attemptContextHash[:]) {
+		v.logIndeterminate("retained package attempt-context hash does not match the bound attempt", submitter, nil)
+		return roast.ShareIndeterminate
+	}
+	if !v.taprootMerkleRootMatches(signingPackage.TaprootMerkleRoot) {
+		v.logIndeterminate("retained package taproot root does not match the bound root", submitter, nil)
+		return roast.ShareIndeterminate
+	}
+
+	var shareSubmission roast.ShareSubmission
+	if err := shareSubmission.Unmarshal(shareEnvelope); err != nil {
+		v.logIndeterminate("retained share-submission envelope did not unmarshal", submitter, err)
+		return roast.ShareIndeterminate
+	}
+
+	// The retained share envelope must actually belong to the member being
+	// adjudicated: if its own SubmitterID disagrees with submitter, that is a
+	// caller inconsistency, not member fault. Never verify one member's identity
+	// against another member's share bytes (that would manufacture false blame).
+	if shareSubmission.SubmitterID() != submitter {
+		v.logIndeterminate("retained share submitter id does not match the adjudicated member", submitter, nil)
+		return roast.ShareIndeterminate
+	}
+
+	// submitter (group.MemberIndex == uint8) widens to the engine's uint16
+	// losslessly. The engine classifies the inner FROST bytes: undecodable or
+	// mathematically invalid member bytes become `invalid` only AFTER it
+	// establishes session/DKG/group/package context, so passing the raw inner
+	// bytes through is what makes a garbage-share submitter blamable.
+	verdict, err := v.engine.VerifySignatureShare(
+		v.sessionID,
+		signingPackage.SigningPackageBytes,
+		shareSubmission.SignatureShare,
+		uint16(submitter),
+		v.taprootMerkleRoot,
+	)
+	if err != nil {
+		// FFI transport / engine-unavailable / decode failure: not member fault.
+		v.logIndeterminate("engine verify_signature_share failed", submitter, err)
+		return roast.ShareIndeterminate
+	}
+
+	switch verdict {
+	case NativeShareVerdictValid:
+		return roast.ShareValid
+	case NativeShareVerdictInvalid:
+		return roast.ShareInvalid
+	case NativeShareVerdictIndeterminate:
+		// Not the member's fault (per the engine's own tri-state); stay silent -
+		// this is an expected, benign outcome, not a system failure.
+		return roast.ShareIndeterminate
+	default:
+		// An unrecognized verdict must never read as blame.
+		v.logIndeterminate("engine returned an unrecognized verdict", submitter, nil)
+		return roast.ShareIndeterminate
+	}
+}
+
+// taprootMerkleRootMatches reports whether the retained package's taproot root
+// equals the bound root, honoring key-path (nil bound root <-> empty package
+// root) semantics.
+func (v *EngineRound2ShareVerifier) taprootMerkleRootMatches(packageRoot []byte) bool {
+	if v.taprootMerkleRoot == nil {
+		// Bound to a key-path spend: the package must also carry no root.
+		return len(packageRoot) == 0
+	}
+	return bytes.Equal(packageRoot, v.taprootMerkleRoot[:])
+}
+
+// logIndeterminate records a fail-closed Indeterminate for diagnostics so a
+// system failure (FFI/transport, mis-binding, malformed retained bytes) is
+// distinguishable from a benign engine `indeterminate`. It logs the member,
+// session, and reason (and the error, when any), but NEVER the raw package or
+// share bytes.
+func (v *EngineRound2ShareVerifier) logIndeterminate(
+	reason string,
+	submitter group.MemberIndex,
+	err error,
+) {
+	if err != nil {
+		round2ShareVerifierLogger.Warnf(
+			"round-2 share verification indeterminate for member [%d] on session [%s]: %s: [%v]",
+			submitter, v.sessionID, reason, err,
+		)
+		return
+	}
+	round2ShareVerifierLogger.Warnf(
+		"round-2 share verification indeterminate for member [%d] on session [%s]: %s",
+		submitter, v.sessionID, reason,
+	)
+}

--- a/pkg/frost/signing/round2_share_verifier_frost_native.go
+++ b/pkg/frost/signing/round2_share_verifier_frost_native.go
@@ -160,6 +160,23 @@ func (v *EngineRound2ShareVerifier) VerifyRetainedShare(
 		return roast.ShareIndeterminate
 	}
 
+	// The retained share must answer THIS package: SigningPackageHash is the
+	// member's commitment to the package body its share signs over. If it does
+	// not equal the bound package's body hash, the share is not evidence against
+	// this package, and verifying it against a package the member never committed
+	// to would manufacture false blame -> Indeterminate. The collector only
+	// accepts shares matching the authoritative package, so this is a defensive
+	// cross-check that keeps the verifier sound for any caller.
+	packageBodyHash, err := signingPackage.BodyHash()
+	if err != nil {
+		v.logIndeterminate("could not hash the retained signing-package body", submitter, err)
+		return roast.ShareIndeterminate
+	}
+	if !bytes.Equal(shareSubmission.SigningPackageHash, packageBodyHash[:]) {
+		v.logIndeterminate("retained share does not commit to the bound signing package", submitter, nil)
+		return roast.ShareIndeterminate
+	}
+
 	// submitter (group.MemberIndex == uint8) widens to the engine's uint16
 	// losslessly. The engine classifies the inner FROST bytes: undecodable or
 	// mathematically invalid member bytes become `invalid` only AFTER it

--- a/pkg/frost/signing/round2_share_verifier_frost_native_test.go
+++ b/pkg/frost/signing/round2_share_verifier_frost_native_test.go
@@ -1,0 +1,336 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+var errTestEngine = errors.New("engine boom")
+
+// fakeShareVerifyingEngine is a one-method Round2ShareVerifyingEngine: it
+// records the call (to assert the engine is/ isn't invoked and with what
+// arguments) and returns a programmed verdict/error.
+type fakeShareVerifyingEngine struct {
+	verdict NativeShareVerificationVerdict
+	err     error
+
+	called              bool
+	gotSessionID        string
+	gotSigningPackage   []byte
+	gotSignatureShare   []byte
+	gotMemberIdentifier uint16
+	gotTaprootRoot      *[32]byte
+}
+
+func (f *fakeShareVerifyingEngine) VerifySignatureShare(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) (NativeShareVerificationVerdict, error) {
+	f.called = true
+	f.gotSessionID = sessionID
+	f.gotSigningPackage = signingPackage
+	f.gotSignatureShare = signatureShare
+	f.gotMemberIdentifier = memberIdentifier
+	f.gotTaprootRoot = taprootMerkleRoot
+	return f.verdict, f.err
+}
+
+func testSigningPackageEnvelope(
+	t *testing.T,
+	attemptContextHash [32]byte,
+	taprootMerkleRoot []byte,
+	frostSigningPackage []byte,
+) []byte {
+	t.Helper()
+	pkg := &roast.SigningPackage{
+		AttemptContextHash:   append([]byte(nil), attemptContextHash[:]...),
+		CoordinatorIDValue:   1,
+		SigningPackageBytes:  frostSigningPackage,
+		TaprootMerkleRoot:    taprootMerkleRoot,
+		CoordinatorSignature: []byte{0x01}, // dummy; the verifier never authenticates
+	}
+	envelope, err := pkg.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal test signing package: [%v]", err)
+	}
+	return envelope
+}
+
+func testShareSubmissionEnvelope(
+	t *testing.T,
+	attemptContextHash [32]byte,
+	submitter uint32,
+	frostSignatureShare []byte,
+) []byte {
+	t.Helper()
+	sub := &roast.ShareSubmission{
+		AttemptContextHash: append([]byte(nil), attemptContextHash[:]...),
+		SubmitterIDValue:   submitter,
+		CoordinatorIDValue: 1,
+		SigningPackageHash: make([]byte, 32), // 32-byte dummy
+		SignatureShare:     frostSignatureShare,
+		SubmitterSignature: []byte{0x01}, // dummy
+	}
+	envelope, err := sub.Marshal()
+	if err != nil {
+		t.Fatalf("cannot marshal test share submission: [%v]", err)
+	}
+	return envelope
+}
+
+func TestNewEngineRound2ShareVerifier_RejectsNilEngine(t *testing.T) {
+	_, err := NewEngineRound2ShareVerifier(nil, Round2ShareVerificationBinding{
+		SessionID: "session-1",
+	})
+	if err == nil {
+		t.Fatal("expected a nil engine to be rejected")
+	}
+}
+
+func TestNewEngineRound2ShareVerifier_RejectsEmptySessionID(t *testing.T) {
+	_, err := NewEngineRound2ShareVerifier(&fakeShareVerifyingEngine{}, Round2ShareVerificationBinding{
+		SessionID: "",
+	})
+	if err == nil {
+		t.Fatal("expected an empty session id to be rejected")
+	}
+}
+
+// The happy path for each native verdict, with a bound taproot root, asserting
+// both the mapping and that the engine receives the unwrapped inner bytes, the
+// widened member id, the bound session id, and the bound root.
+func TestEngineRound2ShareVerifier_VerdictMappingWithRoot(t *testing.T) {
+	attempt := [32]byte{0xaa}
+	root := [32]byte{0xbb}
+	frostPackage := []byte{0xde, 0xad}
+	frostShare := []byte{0xbe, 0xef}
+
+	tests := map[string]struct {
+		verdict  NativeShareVerificationVerdict
+		expected roast.ShareVerificationResult
+	}{
+		"valid":         {NativeShareVerdictValid, roast.ShareValid},
+		"invalid":       {NativeShareVerdictInvalid, roast.ShareInvalid},
+		"indeterminate": {NativeShareVerdictIndeterminate, roast.ShareIndeterminate},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			engine := &fakeShareVerifyingEngine{verdict: test.verdict}
+			verifier, err := NewEngineRound2ShareVerifier(engine, Round2ShareVerificationBinding{
+				SessionID:          "session-1",
+				AttemptContextHash: attempt,
+				TaprootMerkleRoot:  &root,
+			})
+			if err != nil {
+				t.Fatalf("unexpected constructor error: [%v]", err)
+			}
+
+			pkgEnv := testSigningPackageEnvelope(t, attempt, root[:], frostPackage)
+			shareEnv := testShareSubmissionEnvelope(t, attempt, 2, frostShare)
+
+			result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2)
+			if result != test.expected {
+				t.Fatalf("unexpected result\nexpected: [%v]\nactual:   [%v]", test.expected, result)
+			}
+			if !engine.called {
+				t.Fatal("expected the engine to be called")
+			}
+			if engine.gotSessionID != "session-1" {
+				t.Fatalf("engine got wrong session id: [%s]", engine.gotSessionID)
+			}
+			if !bytes.Equal(engine.gotSigningPackage, frostPackage) {
+				t.Fatalf("engine got wrong inner signing package: [%x]", engine.gotSigningPackage)
+			}
+			if !bytes.Equal(engine.gotSignatureShare, frostShare) {
+				t.Fatalf("engine got wrong inner signature share: [%x]", engine.gotSignatureShare)
+			}
+			if engine.gotMemberIdentifier != 2 {
+				t.Fatalf("engine got wrong member id: [%d]", engine.gotMemberIdentifier)
+			}
+			if engine.gotTaprootRoot == nil || *engine.gotTaprootRoot != root {
+				t.Fatalf("engine got wrong taproot root: [%v]", engine.gotTaprootRoot)
+			}
+		})
+	}
+}
+
+// A key-path (nil root) verifier accepts a package carrying no root and passes a
+// nil root to the engine.
+func TestEngineRound2ShareVerifier_KeyPathNilRoot(t *testing.T) {
+	attempt := [32]byte{0xaa}
+	engine := &fakeShareVerifyingEngine{verdict: NativeShareVerdictValid}
+	verifier, err := NewEngineRound2ShareVerifier(engine, Round2ShareVerificationBinding{
+		SessionID:          "session-1",
+		AttemptContextHash: attempt,
+		TaprootMerkleRoot:  nil,
+	})
+	if err != nil {
+		t.Fatalf("unexpected constructor error: [%v]", err)
+	}
+
+	pkgEnv := testSigningPackageEnvelope(t, attempt, nil, []byte{0xde, 0xad})
+	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, []byte{0xbe, 0xef})
+
+	if result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2); result != roast.ShareValid {
+		t.Fatalf("expected ShareValid, got [%v]", result)
+	}
+	if engine.gotTaprootRoot != nil {
+		t.Fatalf("expected a nil taproot root passed to the engine, got [%v]", engine.gotTaprootRoot)
+	}
+}
+
+func TestEngineRound2ShareVerifier_EngineErrorIsIndeterminate(t *testing.T) {
+	attempt := [32]byte{0xaa}
+	engine := &fakeShareVerifyingEngine{
+		verdict: NativeShareVerdictInvalid, // even a blame verdict must be ignored on error
+		err:     errTestEngine,
+	}
+	verifier := mustVerifier(t, engine, "session-1", attempt, nil)
+
+	pkgEnv := testSigningPackageEnvelope(t, attempt, nil, []byte{0xde, 0xad})
+	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, []byte{0xbe, 0xef})
+
+	if result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2); result != roast.ShareIndeterminate {
+		t.Fatalf("expected ShareIndeterminate on engine error, got [%v]", result)
+	}
+}
+
+func TestEngineRound2ShareVerifier_FailClosedWithoutCallingEngine(t *testing.T) {
+	attempt := [32]byte{0xaa}
+	root := [32]byte{0xbb}
+	otherAttempt := [32]byte{0xcc}
+	otherRoot := [32]byte{0xdd}
+	frostPackage := []byte{0xde, 0xad}
+	frostShare := []byte{0xbe, 0xef}
+
+	validPkgEnv := testSigningPackageEnvelope(t, attempt, root[:], frostPackage)
+
+	tests := map[string]struct {
+		bindRoot  *[32]byte
+		pkgEnv    []byte
+		shareEnv  []byte
+		submitter group.MemberIndex
+	}{
+		"submitter zero": {
+			bindRoot:  &root,
+			pkgEnv:    validPkgEnv,
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			submitter: 0,
+		},
+		"unparseable signing-package envelope": {
+			bindRoot:  &root,
+			pkgEnv:    []byte("not a signing package envelope"),
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			submitter: 2,
+		},
+		"attempt-context mismatch": {
+			bindRoot:  &root,
+			pkgEnv:    testSigningPackageEnvelope(t, otherAttempt, root[:], frostPackage),
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			submitter: 2,
+		},
+		"taproot root mismatch": {
+			bindRoot:  &root,
+			pkgEnv:    testSigningPackageEnvelope(t, attempt, otherRoot[:], frostPackage),
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			submitter: 2,
+		},
+		"key-path verifier rejects a rooted package": {
+			bindRoot:  nil,
+			pkgEnv:    testSigningPackageEnvelope(t, attempt, root[:], frostPackage),
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			submitter: 2,
+		},
+		"unparseable share envelope": {
+			bindRoot:  &root,
+			pkgEnv:    validPkgEnv,
+			shareEnv:  []byte("not a share submission envelope"),
+			submitter: 2,
+		},
+		"share submitter id mismatch": {
+			bindRoot:  &root,
+			pkgEnv:    validPkgEnv,
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 3, frostShare), // envelope says member 3
+			submitter: 2,                                                      // adjudicating member 2
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// A valid verdict would map to ShareValid IF the engine were called -
+			// so a ShareIndeterminate result also proves the engine was bypassed.
+			engine := &fakeShareVerifyingEngine{verdict: NativeShareVerdictValid}
+			verifier := mustVerifier(t, engine, "session-1", attempt, test.bindRoot)
+
+			result := verifier.VerifyRetainedShare(test.pkgEnv, test.shareEnv, test.submitter)
+			if result != roast.ShareIndeterminate {
+				t.Fatalf("expected ShareIndeterminate, got [%v]", result)
+			}
+			if engine.called {
+				t.Fatal("engine must not be called when context fails closed before verification")
+			}
+		})
+	}
+}
+
+// The constructor must copy the bound taproot root so a later mutation of the
+// caller's array cannot change the verifier's root binding.
+func TestEngineRound2ShareVerifier_ConstructorCopiesTaprootRoot(t *testing.T) {
+	attempt := [32]byte{0xaa}
+	root := [32]byte{0xbb}
+	originalRoot := root // value copy of the original bytes
+
+	engine := &fakeShareVerifyingEngine{verdict: NativeShareVerdictValid}
+	verifier, err := NewEngineRound2ShareVerifier(engine, Round2ShareVerificationBinding{
+		SessionID:          "session-1",
+		AttemptContextHash: attempt,
+		TaprootMerkleRoot:  &root,
+	})
+	if err != nil {
+		t.Fatalf("unexpected constructor error: [%v]", err)
+	}
+
+	// Mutate the caller's array AFTER construction. If the verifier retained the
+	// caller's pointer instead of copying, its root would now differ from
+	// originalRoot and the original-root package below would (wrongly) mismatch.
+	root[0] = 0xff
+
+	pkgEnv := testSigningPackageEnvelope(t, attempt, originalRoot[:], []byte{0xde, 0xad})
+	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, []byte{0xbe, 0xef})
+
+	if result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2); result != roast.ShareValid {
+		t.Fatalf("expected ShareValid (verifier root unaffected by caller mutation), got [%v]", result)
+	}
+	if !engine.called {
+		t.Fatal("expected the engine to be called against the copied root")
+	}
+}
+
+func mustVerifier(
+	t *testing.T,
+	engine Round2ShareVerifyingEngine,
+	sessionID string,
+	attemptContextHash [32]byte,
+	taprootMerkleRoot *[32]byte,
+) *EngineRound2ShareVerifier {
+	t.Helper()
+	verifier, err := NewEngineRound2ShareVerifier(engine, Round2ShareVerificationBinding{
+		SessionID:          sessionID,
+		AttemptContextHash: attemptContextHash,
+		TaprootMerkleRoot:  taprootMerkleRoot,
+	})
+	if err != nil {
+		t.Fatalf("unexpected constructor error: [%v]", err)
+	}
+	return verifier
+}

--- a/pkg/frost/signing/round2_share_verifier_frost_native_test.go
+++ b/pkg/frost/signing/round2_share_verifier_frost_native_test.go
@@ -44,12 +44,15 @@ func (f *fakeShareVerifyingEngine) VerifySignatureShare(
 	return f.verdict, f.err
 }
 
-func testSigningPackageEnvelope(
+// testSigningPackage builds a signing package and returns both its on-wire
+// envelope and its body hash, so a share can commit to the SAME package the
+// verifier is bound to (SigningPackageHash == BodyHash).
+func testSigningPackage(
 	t *testing.T,
 	attemptContextHash [32]byte,
 	taprootMerkleRoot []byte,
 	frostSigningPackage []byte,
-) []byte {
+) (envelope []byte, bodyHash []byte) {
 	t.Helper()
 	pkg := &roast.SigningPackage{
 		AttemptContextHash:   append([]byte(nil), attemptContextHash[:]...),
@@ -62,13 +65,18 @@ func testSigningPackageEnvelope(
 	if err != nil {
 		t.Fatalf("cannot marshal test signing package: [%v]", err)
 	}
-	return envelope
+	hash, err := pkg.BodyHash()
+	if err != nil {
+		t.Fatalf("cannot hash test signing package body: [%v]", err)
+	}
+	return envelope, hash[:]
 }
 
 func testShareSubmissionEnvelope(
 	t *testing.T,
 	attemptContextHash [32]byte,
 	submitter uint32,
+	signingPackageHash []byte,
 	frostSignatureShare []byte,
 ) []byte {
 	t.Helper()
@@ -76,7 +84,7 @@ func testShareSubmissionEnvelope(
 		AttemptContextHash: append([]byte(nil), attemptContextHash[:]...),
 		SubmitterIDValue:   submitter,
 		CoordinatorIDValue: 1,
-		SigningPackageHash: make([]byte, 32), // 32-byte dummy
+		SigningPackageHash: signingPackageHash,
 		SignatureShare:     frostSignatureShare,
 		SubmitterSignature: []byte{0x01}, // dummy
 	}
@@ -135,8 +143,8 @@ func TestEngineRound2ShareVerifier_VerdictMappingWithRoot(t *testing.T) {
 				t.Fatalf("unexpected constructor error: [%v]", err)
 			}
 
-			pkgEnv := testSigningPackageEnvelope(t, attempt, root[:], frostPackage)
-			shareEnv := testShareSubmissionEnvelope(t, attempt, 2, frostShare)
+			pkgEnv, pkgHash := testSigningPackage(t, attempt, root[:], frostPackage)
+			shareEnv := testShareSubmissionEnvelope(t, attempt, 2, pkgHash, frostShare)
 
 			result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2)
 			if result != test.expected {
@@ -178,8 +186,8 @@ func TestEngineRound2ShareVerifier_KeyPathNilRoot(t *testing.T) {
 		t.Fatalf("unexpected constructor error: [%v]", err)
 	}
 
-	pkgEnv := testSigningPackageEnvelope(t, attempt, nil, []byte{0xde, 0xad})
-	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, []byte{0xbe, 0xef})
+	pkgEnv, pkgHash := testSigningPackage(t, attempt, nil, []byte{0xde, 0xad})
+	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, pkgHash, []byte{0xbe, 0xef})
 
 	if result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2); result != roast.ShareValid {
 		t.Fatalf("expected ShareValid, got [%v]", result)
@@ -197,8 +205,8 @@ func TestEngineRound2ShareVerifier_EngineErrorIsIndeterminate(t *testing.T) {
 	}
 	verifier := mustVerifier(t, engine, "session-1", attempt, nil)
 
-	pkgEnv := testSigningPackageEnvelope(t, attempt, nil, []byte{0xde, 0xad})
-	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, []byte{0xbe, 0xef})
+	pkgEnv, pkgHash := testSigningPackage(t, attempt, nil, []byte{0xde, 0xad})
+	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, pkgHash, []byte{0xbe, 0xef})
 
 	if result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2); result != roast.ShareIndeterminate {
 		t.Fatalf("expected ShareIndeterminate on engine error, got [%v]", result)
@@ -213,7 +221,13 @@ func TestEngineRound2ShareVerifier_FailClosedWithoutCallingEngine(t *testing.T) 
 	frostPackage := []byte{0xde, 0xad}
 	frostShare := []byte{0xbe, 0xef}
 
-	validPkgEnv := testSigningPackageEnvelope(t, attempt, root[:], frostPackage)
+	validPkgEnv, _ := testSigningPackage(t, attempt, root[:], frostPackage)
+	otherAttemptPkgEnv, _ := testSigningPackage(t, otherAttempt, root[:], frostPackage)
+	otherRootPkgEnv, _ := testSigningPackage(t, attempt, otherRoot[:], frostPackage)
+
+	// A dummy package hash for the share in cases that fail closed BEFORE the
+	// share-commits-to-package check is reached.
+	dummyHash := make([]byte, 32)
 
 	tests := map[string]struct {
 		bindRoot  *[32]byte
@@ -224,31 +238,31 @@ func TestEngineRound2ShareVerifier_FailClosedWithoutCallingEngine(t *testing.T) 
 		"submitter zero": {
 			bindRoot:  &root,
 			pkgEnv:    validPkgEnv,
-			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, dummyHash, frostShare),
 			submitter: 0,
 		},
 		"unparseable signing-package envelope": {
 			bindRoot:  &root,
 			pkgEnv:    []byte("not a signing package envelope"),
-			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, dummyHash, frostShare),
 			submitter: 2,
 		},
 		"attempt-context mismatch": {
 			bindRoot:  &root,
-			pkgEnv:    testSigningPackageEnvelope(t, otherAttempt, root[:], frostPackage),
-			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			pkgEnv:    otherAttemptPkgEnv,
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, dummyHash, frostShare),
 			submitter: 2,
 		},
 		"taproot root mismatch": {
 			bindRoot:  &root,
-			pkgEnv:    testSigningPackageEnvelope(t, attempt, otherRoot[:], frostPackage),
-			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			pkgEnv:    otherRootPkgEnv,
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, dummyHash, frostShare),
 			submitter: 2,
 		},
 		"key-path verifier rejects a rooted package": {
 			bindRoot:  nil,
-			pkgEnv:    testSigningPackageEnvelope(t, attempt, root[:], frostPackage),
-			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, frostShare),
+			pkgEnv:    validPkgEnv,
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, dummyHash, frostShare),
 			submitter: 2,
 		},
 		"unparseable share envelope": {
@@ -260,8 +274,14 @@ func TestEngineRound2ShareVerifier_FailClosedWithoutCallingEngine(t *testing.T) 
 		"share submitter id mismatch": {
 			bindRoot:  &root,
 			pkgEnv:    validPkgEnv,
-			shareEnv:  testShareSubmissionEnvelope(t, attempt, 3, frostShare), // envelope says member 3
-			submitter: 2,                                                      // adjudicating member 2
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 3, dummyHash, frostShare), // envelope says member 3
+			submitter: 2,                                                                 // adjudicating member 2
+		},
+		"share commits to a different package": {
+			bindRoot:  &root,
+			pkgEnv:    validPkgEnv,
+			shareEnv:  testShareSubmissionEnvelope(t, attempt, 2, bytes.Repeat([]byte{0xee}, 32), frostShare),
+			submitter: 2,
 		},
 	}
 
@@ -305,8 +325,8 @@ func TestEngineRound2ShareVerifier_ConstructorCopiesTaprootRoot(t *testing.T) {
 	// originalRoot and the original-root package below would (wrongly) mismatch.
 	root[0] = 0xff
 
-	pkgEnv := testSigningPackageEnvelope(t, attempt, originalRoot[:], []byte{0xde, 0xad})
-	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, []byte{0xbe, 0xef})
+	pkgEnv, pkgHash := testSigningPackage(t, attempt, originalRoot[:], []byte{0xde, 0xad})
+	shareEnv := testShareSubmissionEnvelope(t, attempt, 2, pkgHash, []byte{0xbe, 0xef})
 
 	if result := verifier.VerifyRetainedShare(pkgEnv, shareEnv, 2); result != roast.ShareValid {
 		t.Fatalf("expected ShareValid (verifier root unaffected by caller mutation), got [%v]", result)

--- a/pkg/tbtc/frost_dkg_execution_frost_native_test.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native_test.go
@@ -324,6 +324,17 @@ func (tntsde *testNativeTBTCSignerSeededDKGEngine) BuildTaprootTx(
 	return nil, fmt.Errorf("BuildTaprootTx should not be used")
 }
 
+func (tntsde *testNativeTBTCSignerSeededDKGEngine) VerifySignatureShare(
+	string,
+	[]byte,
+	[]byte,
+	uint16,
+	*[32]byte,
+) (frostsigning.NativeShareVerificationVerdict, error) {
+	return frostsigning.NativeShareVerdictIndeterminate,
+		fmt.Errorf("VerifySignatureShare should not be used")
+}
+
 func assertTBTCSignerDKGParticipantIdentifiers(
 	t *testing.T,
 	participants []frostsigning.NativeTBTCSignerDKGParticipant,

--- a/pkg/tbtc/signing_native_backend_frost_native_test.go
+++ b/pkg/tbtc/signing_native_backend_frost_native_test.go
@@ -292,6 +292,16 @@ func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) BuildTaprootTx(
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) VerifySignatureShare(
+	sessionID string,
+	signingPackage []byte,
+	signatureShare []byte,
+	memberIdentifier uint16,
+	taprootMerkleRoot *[32]byte,
+) (frostsigning.NativeShareVerificationVerdict, error) {
+	return frostsigning.NativeShareVerdictIndeterminate, fmt.Errorf("not implemented")
+}
+
 func (atntsfe *attemptTrackingNativeTBTCSignerEngineForTBTC) uniqueStartCohortsByAttempt() map[uint][][]uint16 {
 	atntsfe.mutex.Lock()
 	defer atntsfe.mutex.Unlock()


### PR DESCRIPTION
## What

Implements the concrete **`roast.Round2ShareVerifier`** using the engine `VerifySignatureShare` bridge (#4069) — completing the 4a member-blame classifier's injected seam. The classifier calls this to re-verify a candidate culprit's retained round-2 share against the attempt's authoritative signing package with real FROST crypto (the Go host has none).

Design came from a **Codex + Gemini consult** (strong convergence; Codex contributed the explicit attempt-binding strengthening below).

## How
- **`EngineRound2ShareVerifier`** in `pkg/frost/signing` (`frost_native`), depending on a narrow **`Round2ShareVerifyingEngine`** interface (interface segregation) so it's unit-tested with a one-method fake — **no cgo**. `NativeTBTCSignerEngine` gains `VerifySignatureShare` (so the registered engine satisfies it); the 3 existing fakes are updated.
- **Bound to ONE attempt** via `Round2ShareVerificationBinding{SessionID, AttemptContextHash, TaprootMerkleRoot}`. `VerifyRetainedShare` unwraps the retained envelopes (`SigningPackage.SigningPackageBytes` + `ShareSubmission.SignatureShare`) and, **before calling the engine**, checks the retained package's own `AttemptContextHash` and `TaprootMerkleRoot` against the binding.

## Why the binding check (the false-blame risk this closes)
The engine resolves the group key from `sessionID` and tweaks by the root; it **cannot tell a valid-but-WRONG session/root from the right one**, so a mis-bound or cross-attempt verifier would make an *honest* share verify `invalid` → **false `ShareInvalid`**. So the verifier self-defends: attempt/root mismatch → `ShareIndeterminate`, and it does **not** rely on the f+1 quorum to paper over mis-binding (both bots). `sessionID` itself can't be self-checked here (can't re-derive the attempt hash), so the construction site must supply one consistent with the attempt — a hard contract, enforced later by orchestration.

## Fail-closed matrix (→ `ShareIndeterminate`, never blame)
`submitter == 0`, unparseable package/share envelope, attempt-context mismatch, taproot-root mismatch, share-submitter-id mismatch, engine error, unrecognized verdict — all `Indeterminate`, and the pre-engine cases **don't call the engine**. Only the engine's `invalid` verdict → `ShareInvalid`. Envelope-unmarshal failures are `Indeterminate` because retained envelopes are collector-authenticated re-marshals — the member controls only the inner FROST bytes, which **do** pass through and become `ShareInvalid` when garbage (the engine judges them after establishing context). **Added beyond the consult:** a share-submitter-id guard (never verify one member's identity against another's share bytes).

## Hygiene
Constructor errors on nil engine / empty `sessionID` and **copies** the root; immutable + concurrency-safe; warns on anomalous `Indeterminate` but **never logs raw package/share bytes**; no operator-signature authentication here (collector's job — frozen Q1 boundary). Compile-time `var _ roast.Round2ShareVerifier = (*EngineRound2ShareVerifier)(nil)`.

## Scope / deferral
The **live construction site** (supplying `sessionID`/`taproot` during a real signing session) is deferred to the not-yet-built interactive orchestration; the compiler prevents dead-code drift since `Round2ShareVerifier` is already consumed by `Round2Collector.ClassifyCandidateCulprits`.

## Tests
Fake engine: verdict mapping (valid/invalid/indeterminate), key-path nil root, engine-error → `Indeterminate`, every fail-closed-without-calling-engine case, constructor copies the root, nil-engine / empty-sessionID rejection, and argument capture (engine receives the unwrapped inner bytes, widened member id, bound session + root).

## Validation
⚠️ As with #4069, the standard `client-*` CI does not build these `frost_native`-tagged files. Validated **locally**: `default` + `frost_native` + `frost_native+frost_tbtc_signer+cgo` builds, full `pkg/frost/signing` suite, `go vet`, `gofmt` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)