### PR TITLE
Phase 7.3 PR1: interactive signing-session cgo bridge (open/round1/round2/abort)

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -2843,6 +2843,19 @@ func buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
 		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "attempt context included participants are empty")
 	}
 
+	// attempt.AttemptContext numbers attempts 0-based; the engine's wire
+	// attempt_number is 1-based and rejects 0 ("must be at least 1"). Convert
+	// here so the first attempt (RFC 0) is sent as wire 1 rather than rejected
+	// before round 1. The engine subtracts 1 internally for its shuffle math.
+	wireAttemptNumber := attemptContext.AttemptNumber + 1
+	if wireAttemptNumber == 0 {
+		// attemptContext.AttemptNumber was the max uint32; +1 wrapped to 0.
+		return nil, buildTaggedTBTCSignerOperationError(
+			"InteractiveSessionOpen",
+			"attempt number overflows the 1-based wire encoding",
+		)
+	}
+
 	var taprootMerkleRootHex *string
 	if taprootMerkleRoot != nil {
 		encoded := hex.EncodeToString(taprootMerkleRoot[:])
@@ -2859,7 +2872,7 @@ func buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
 			Threshold:            threshold,
 			TaprootMerkleRootHex: taprootMerkleRootHex,
 			AttemptContext: buildTaggedTBTCSignerInteractiveAttemptContext{
-				AttemptNumber:                   attemptContext.AttemptNumber,
+				AttemptNumber:                   wireAttemptNumber,
 				CoordinatorIdentifier:           attemptContext.CoordinatorIdentifier,
 				IncludedParticipants:            append([]uint16(nil), attemptContext.IncludedParticipants...),
 				IncludedParticipantsFingerprint: attemptContext.IncludedParticipantsFingerprint,

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -58,6 +58,22 @@ typedef TbtcSignerResult (*tbtc_verify_signature_share_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_interactive_session_open_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
+typedef TbtcSignerResult (*tbtc_interactive_round1_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
+typedef TbtcSignerResult (*tbtc_interactive_round2_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
+typedef TbtcSignerResult (*tbtc_interactive_session_abort_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef TbtcSignerResult (*tbtc_start_sign_round_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -203,6 +219,54 @@ static TbtcSignerResult tbtc_signer_verify_signature_share(const uint8_t* reques
   }
 
   return verify_signature_share(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_interactive_session_open(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_interactive_session_open_fn interactive_session_open = (tbtc_interactive_session_open_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_interactive_session_open"
+  );
+  if (interactive_session_open == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return interactive_session_open(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_interactive_round1(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_interactive_round1_fn interactive_round1 = (tbtc_interactive_round1_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_interactive_round1"
+  );
+  if (interactive_round1 == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return interactive_round1(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_interactive_round2(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_interactive_round2_fn interactive_round2 = (tbtc_interactive_round2_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_interactive_round2"
+  );
+  if (interactive_round2 == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return interactive_round2(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_interactive_session_abort(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_interactive_session_abort_fn interactive_session_abort = (tbtc_interactive_session_abort_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_interactive_session_abort"
+  );
+  if (interactive_session_abort == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return interactive_session_abort(request_ptr, request_len);
 }
 
 static TbtcSignerResult tbtc_signer_start_sign_round(const uint8_t* request_ptr, size_t request_len) {
@@ -2578,4 +2642,433 @@ func InstallNativeTBTCSignerConfig(
 	}
 
 	return result, nil
+}
+
+// ----------------------------------------------------------------------------
+// Phase 7.3 interactive signing session bridge: open / round1 / round2 / abort.
+//
+// The hardened interactive path - unlike the stateless nonce contract, secret
+// nonces NEVER cross this boundary: the engine generates, holds, consumes, and
+// zeroizes them keyed by (session_id, attempt_id). The caller exchanges only
+// public commitments, the coordinator's signing package, and signature shares.
+// Additive: no Go caller yet (the orchestrator adopts these in a later
+// increment). interactive_aggregate, whose failure path surfaces candidate
+// culprits, lands in a separate PR with its own structured error.
+// ----------------------------------------------------------------------------
+
+type buildTaggedTBTCSignerInteractiveAttemptContext struct {
+	AttemptNumber                   uint32   `json:"attempt_number"`
+	CoordinatorIdentifier           uint16   `json:"coordinator_identifier"`
+	IncludedParticipants            []uint16 `json:"included_participants"`
+	IncludedParticipantsFingerprint string   `json:"included_participants_fingerprint"`
+	AttemptID                       string   `json:"attempt_id"`
+}
+
+type buildTaggedTBTCSignerInteractiveSessionOpenRequest struct {
+	SessionID            string                                         `json:"session_id"`
+	MemberIdentifier     uint16                                         `json:"member_identifier"`
+	MessageHex           string                                         `json:"message_hex"`
+	KeyGroup             string                                         `json:"key_group"`
+	Threshold            uint16                                         `json:"threshold"`
+	TaprootMerkleRootHex *string                                        `json:"taproot_merkle_root_hex,omitempty"`
+	AttemptContext       buildTaggedTBTCSignerInteractiveAttemptContext `json:"attempt_context"`
+}
+
+type buildTaggedTBTCSignerInteractiveSessionOpenResponse struct {
+	SessionID  string `json:"session_id"`
+	AttemptID  string `json:"attempt_id"`
+	Idempotent bool   `json:"idempotent"`
+}
+
+type buildTaggedTBTCSignerInteractiveRound1Request struct {
+	SessionID        string `json:"session_id"`
+	AttemptID        string `json:"attempt_id"`
+	MemberIdentifier uint16 `json:"member_identifier"`
+}
+
+type buildTaggedTBTCSignerInteractiveRound1Response struct {
+	CommitmentsHex string `json:"commitments_hex"`
+}
+
+type buildTaggedTBTCSignerInteractiveRound2Request struct {
+	SessionID         string `json:"session_id"`
+	AttemptID         string `json:"attempt_id"`
+	MemberIdentifier  uint16 `json:"member_identifier"`
+	SigningPackageHex string `json:"signing_package_hex"`
+}
+
+type buildTaggedTBTCSignerInteractiveRound2Response struct {
+	SessionID         string `json:"session_id"`
+	AttemptID         string `json:"attempt_id"`
+	SignatureShareHex string `json:"signature_share_hex"`
+}
+
+type buildTaggedTBTCSignerInteractiveSessionAbortRequest struct {
+	SessionID string  `json:"session_id"`
+	AttemptID *string `json:"attempt_id,omitempty"`
+}
+
+type buildTaggedTBTCSignerInteractiveSessionAbortResponse struct {
+	SessionID string `json:"session_id"`
+	Aborted   bool   `json:"aborted"`
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) InteractiveSessionOpen(
+	sessionID string,
+	memberIdentifier uint16,
+	message []byte,
+	keyGroup string,
+	threshold uint16,
+	taprootMerkleRoot *[32]byte,
+	attemptContext NativeInteractiveAttemptContext,
+) (*NativeInteractiveSessionOpenResult, error) {
+	requestPayload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+		sessionID,
+		memberIdentifier,
+		message,
+		keyGroup,
+		threshold,
+		taprootMerkleRoot,
+		attemptContext,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerInteractiveSessionOpen(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerInteractiveSessionOpenResponse(responsePayload)
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) InteractiveRound1(
+	sessionID string,
+	attemptID string,
+	memberIdentifier uint16,
+) (commitments []byte, err error) {
+	requestPayload, err := buildTaggedTBTCSignerInteractiveRound1RequestPayload(
+		sessionID,
+		attemptID,
+		memberIdentifier,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerInteractiveRound1(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerInteractiveRound1Response(responsePayload)
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) InteractiveRound2(
+	sessionID string,
+	attemptID string,
+	memberIdentifier uint16,
+	signingPackage []byte,
+) (signatureShare []byte, err error) {
+	requestPayload, err := buildTaggedTBTCSignerInteractiveRound2RequestPayload(
+		sessionID,
+		attemptID,
+		memberIdentifier,
+		signingPackage,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerInteractiveRound2(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerInteractiveRound2Response(responsePayload)
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) InteractiveSessionAbort(
+	sessionID string,
+	attemptID *string,
+) (*NativeInteractiveSessionAbortResult, error) {
+	requestPayload, err := buildTaggedTBTCSignerInteractiveSessionAbortRequestPayload(
+		sessionID,
+		attemptID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerInteractiveSessionAbort(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerInteractiveSessionAbortResponse(responsePayload)
+}
+
+func buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+	sessionID string,
+	memberIdentifier uint16,
+	message []byte,
+	keyGroup string,
+	threshold uint16,
+	taprootMerkleRoot *[32]byte,
+	attemptContext NativeInteractiveAttemptContext,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "session ID is empty")
+	}
+	if memberIdentifier == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "member identifier is zero")
+	}
+	if len(message) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "message is empty")
+	}
+	if keyGroup == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "key group is empty")
+	}
+	if threshold == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "threshold is zero")
+	}
+	if attemptContext.AttemptID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "attempt context attempt ID is empty")
+	}
+	if attemptContext.CoordinatorIdentifier == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "attempt context coordinator identifier is zero")
+	}
+	if len(attemptContext.IncludedParticipants) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "attempt context included participants are empty")
+	}
+
+	var taprootMerkleRootHex *string
+	if taprootMerkleRoot != nil {
+		encoded := hex.EncodeToString(taprootMerkleRoot[:])
+		taprootMerkleRootHex = &encoded
+	}
+
+	return buildTaggedTBTCSignerMarshalRequest(
+		"InteractiveSessionOpen",
+		buildTaggedTBTCSignerInteractiveSessionOpenRequest{
+			SessionID:            sessionID,
+			MemberIdentifier:     memberIdentifier,
+			MessageHex:           hex.EncodeToString(message),
+			KeyGroup:             keyGroup,
+			Threshold:            threshold,
+			TaprootMerkleRootHex: taprootMerkleRootHex,
+			AttemptContext: buildTaggedTBTCSignerInteractiveAttemptContext{
+				AttemptNumber:                   attemptContext.AttemptNumber,
+				CoordinatorIdentifier:           attemptContext.CoordinatorIdentifier,
+				IncludedParticipants:            append([]uint16(nil), attemptContext.IncludedParticipants...),
+				IncludedParticipantsFingerprint: attemptContext.IncludedParticipantsFingerprint,
+				AttemptID:                       attemptContext.AttemptID,
+			},
+		},
+	)
+}
+
+func decodeBuildTaggedTBTCSignerInteractiveSessionOpenResponse(
+	responsePayload []byte,
+) (*NativeInteractiveSessionOpenResult, error) {
+	var response buildTaggedTBTCSignerInteractiveSessionOpenResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"InteractiveSessionOpen",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+	if response.SessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "response session ID is empty")
+	}
+	if response.AttemptID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionOpen", "response attempt ID is empty")
+	}
+
+	return &NativeInteractiveSessionOpenResult{
+		SessionID:  response.SessionID,
+		AttemptID:  response.AttemptID,
+		Idempotent: response.Idempotent,
+	}, nil
+}
+
+func buildTaggedTBTCSignerInteractiveRound1RequestPayload(
+	sessionID string,
+	attemptID string,
+	memberIdentifier uint16,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound1", "session ID is empty")
+	}
+	if attemptID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound1", "attempt ID is empty")
+	}
+	if memberIdentifier == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound1", "member identifier is zero")
+	}
+
+	return buildTaggedTBTCSignerMarshalRequest(
+		"InteractiveRound1",
+		buildTaggedTBTCSignerInteractiveRound1Request{
+			SessionID:        sessionID,
+			AttemptID:        attemptID,
+			MemberIdentifier: memberIdentifier,
+		},
+	)
+}
+
+func decodeBuildTaggedTBTCSignerInteractiveRound1Response(
+	responsePayload []byte,
+) ([]byte, error) {
+	var response buildTaggedTBTCSignerInteractiveRound1Response
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"InteractiveRound1",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	return buildTaggedTBTCSignerDecodeHexField(
+		"InteractiveRound1",
+		"response commitments",
+		response.CommitmentsHex,
+	)
+}
+
+func buildTaggedTBTCSignerInteractiveRound2RequestPayload(
+	sessionID string,
+	attemptID string,
+	memberIdentifier uint16,
+	signingPackage []byte,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound2", "session ID is empty")
+	}
+	if attemptID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound2", "attempt ID is empty")
+	}
+	if memberIdentifier == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound2", "member identifier is zero")
+	}
+	if len(signingPackage) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveRound2", "signing package is empty")
+	}
+
+	return buildTaggedTBTCSignerMarshalRequest(
+		"InteractiveRound2",
+		buildTaggedTBTCSignerInteractiveRound2Request{
+			SessionID:         sessionID,
+			AttemptID:         attemptID,
+			MemberIdentifier:  memberIdentifier,
+			SigningPackageHex: hex.EncodeToString(signingPackage),
+		},
+	)
+}
+
+func decodeBuildTaggedTBTCSignerInteractiveRound2Response(
+	responsePayload []byte,
+) ([]byte, error) {
+	var response buildTaggedTBTCSignerInteractiveRound2Response
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"InteractiveRound2",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	return buildTaggedTBTCSignerDecodeHexField(
+		"InteractiveRound2",
+		"response signature share",
+		response.SignatureShareHex,
+	)
+}
+
+func buildTaggedTBTCSignerInteractiveSessionAbortRequestPayload(
+	sessionID string,
+	attemptID *string,
+) ([]byte, error) {
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionAbort", "session ID is empty")
+	}
+
+	var requestAttemptID *string
+	if attemptID != nil {
+		if *attemptID == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"InteractiveSessionAbort",
+				"attempt ID is set but empty",
+			)
+		}
+		copied := *attemptID
+		requestAttemptID = &copied
+	}
+
+	return buildTaggedTBTCSignerMarshalRequest(
+		"InteractiveSessionAbort",
+		buildTaggedTBTCSignerInteractiveSessionAbortRequest{
+			SessionID: sessionID,
+			AttemptID: requestAttemptID,
+		},
+	)
+}
+
+func decodeBuildTaggedTBTCSignerInteractiveSessionAbortResponse(
+	responsePayload []byte,
+) (*NativeInteractiveSessionAbortResult, error) {
+	var response buildTaggedTBTCSignerInteractiveSessionAbortResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"InteractiveSessionAbort",
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+	if response.SessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError("InteractiveSessionAbort", "response session ID is empty")
+	}
+
+	return &NativeInteractiveSessionAbortResult{
+		SessionID: response.SessionID,
+		Aborted:   response.Aborted,
+	}, nil
+}
+
+func callBuildTaggedTBTCSignerInteractiveSessionOpen(requestPayload []byte) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"InteractiveSessionOpen",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_interactive_session_open(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerInteractiveRound1(requestPayload []byte) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"InteractiveRound1",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_interactive_round1(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerInteractiveRound2(requestPayload []byte) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"InteractiveRound2",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_interactive_round2(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerInteractiveSessionAbort(requestPayload []byte) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"InteractiveSessionAbort",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_interactive_session_abort(requestPtr, requestLen)
+		},
+	)
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1505,3 +1505,243 @@ func TestDecodeBuildTaggedTBTCSignerVerifySignatureShareResponse_MalformedJSON(
 		)
 	}
 }
+
+func testInteractiveAttemptContext() NativeInteractiveAttemptContext {
+	return NativeInteractiveAttemptContext{
+		AttemptNumber:                   3,
+		CoordinatorIdentifier:           2,
+		IncludedParticipants:            []uint16{1, 2, 3},
+		IncludedParticipantsFingerprint: "fingerprint-abc",
+		AttemptID:                       "attempt-1",
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+		"session-1",
+		2,
+		[]byte{0xab, 0xcd},
+		"key-group-1",
+		2,
+		nil,
+		testInteractiveAttemptContext(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerInteractiveSessionOpenRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+
+	if request.SessionID != "session-1" {
+		t.Fatalf("unexpected session id: [%s]", request.SessionID)
+	}
+	if request.MemberIdentifier != 2 {
+		t.Fatalf("unexpected member id: [%d]", request.MemberIdentifier)
+	}
+	if request.MessageHex != "abcd" {
+		t.Fatalf("unexpected message hex: [%s]", request.MessageHex)
+	}
+	if request.KeyGroup != "key-group-1" {
+		t.Fatalf("unexpected key group: [%s]", request.KeyGroup)
+	}
+	if request.Threshold != 2 {
+		t.Fatalf("unexpected threshold: [%d]", request.Threshold)
+	}
+	if request.TaprootMerkleRootHex != nil {
+		t.Fatalf("expected omitted taproot root, got: [%v]", *request.TaprootMerkleRootHex)
+	}
+	if request.AttemptContext.AttemptNumber != 3 ||
+		request.AttemptContext.CoordinatorIdentifier != 2 ||
+		request.AttemptContext.IncludedParticipantsFingerprint != "fingerprint-abc" ||
+		request.AttemptContext.AttemptID != "attempt-1" {
+		t.Fatalf("unexpected attempt context: [%+v]", request.AttemptContext)
+	}
+	if len(request.AttemptContext.IncludedParticipants) != 3 ||
+		request.AttemptContext.IncludedParticipants[0] != 1 ||
+		request.AttemptContext.IncludedParticipants[2] != 3 {
+		t.Fatalf("unexpected included participants: [%v]", request.AttemptContext.IncludedParticipants)
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_TaprootMerkleRoot(t *testing.T) {
+	var root [32]byte
+	root[0] = 0xab
+	root[31] = 0xcd
+
+	payload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+		"session-1", 2, []byte{0xab}, "key-group-1", 2, &root, testInteractiveAttemptContext(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerInteractiveSessionOpenRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.TaprootMerkleRootHex == nil {
+		t.Fatal("expected taproot merkle root")
+	}
+	if *request.TaprootMerkleRootHex != hex.EncodeToString(root[:]) {
+		t.Fatalf("unexpected taproot root hex: [%s]", *request.TaprootMerkleRootHex)
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_RejectsInvalidInput(t *testing.T) {
+	ctx := testInteractiveAttemptContext()
+	emptyCtx := NativeInteractiveAttemptContext{}
+	noParticipantsCtx := testInteractiveAttemptContext()
+	noParticipantsCtx.IncludedParticipants = nil
+
+	tests := map[string]struct {
+		sessionID string
+		member    uint16
+		message   []byte
+		keyGroup  string
+		threshold uint16
+		ctx       NativeInteractiveAttemptContext
+	}{
+		"empty session":            {"", 2, []byte{0xab}, "kg", 2, ctx},
+		"zero member":              {"s", 0, []byte{0xab}, "kg", 2, ctx},
+		"empty message":            {"s", 2, nil, "kg", 2, ctx},
+		"empty key group":          {"s", 2, []byte{0xab}, "", 2, ctx},
+		"zero threshold":           {"s", 2, []byte{0xab}, "kg", 0, ctx},
+		"empty attempt context":    {"s", 2, []byte{0xab}, "kg", 2, emptyCtx},
+		"no included participants": {"s", 2, []byte{0xab}, "kg", 2, noParticipantsCtx},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+				test.sessionID, test.member, test.message, test.keyGroup, test.threshold, nil, test.ctx,
+			)
+			if err == nil {
+				t.Fatal("expected invalid input to be rejected")
+			}
+			if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+				t.Fatalf("expected ErrNativeBridgeOperationFailed, got: [%v]", err)
+			}
+		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerInteractiveSessionOpenResponse(t *testing.T) {
+	result, err := decodeBuildTaggedTBTCSignerInteractiveSessionOpenResponse(
+		[]byte(`{"session_id":"session-1","attempt_id":"attempt-1","idempotent":true}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+	if result.SessionID != "session-1" || result.AttemptID != "attempt-1" || !result.Idempotent {
+		t.Fatalf("unexpected result: [%+v]", result)
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveRound1RequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerInteractiveRound1RequestPayload("session-1", "attempt-1", 2)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+	var request buildTaggedTBTCSignerInteractiveRound1Request
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.SessionID != "session-1" || request.AttemptID != "attempt-1" || request.MemberIdentifier != 2 {
+		t.Fatalf("unexpected request: [%+v]", request)
+	}
+
+	if _, err := buildTaggedTBTCSignerInteractiveRound1RequestPayload("", "attempt-1", 2); err == nil {
+		t.Fatal("expected empty session id to be rejected")
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerInteractiveRound1Response(t *testing.T) {
+	commitments, err := decodeBuildTaggedTBTCSignerInteractiveRound1Response(
+		[]byte(`{"commitments_hex":"dead"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+	if hex.EncodeToString(commitments) != "dead" {
+		t.Fatalf("unexpected commitments: [%x]", commitments)
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveRound2RequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerInteractiveRound2RequestPayload(
+		"session-1", "attempt-1", 2, []byte{0xbe, 0xef},
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+	var request buildTaggedTBTCSignerInteractiveRound2Request
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.SigningPackageHex != "beef" {
+		t.Fatalf("unexpected signing package hex: [%s]", request.SigningPackageHex)
+	}
+
+	if _, err := buildTaggedTBTCSignerInteractiveRound2RequestPayload("session-1", "attempt-1", 2, nil); err == nil {
+		t.Fatal("expected empty signing package to be rejected")
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerInteractiveRound2Response(t *testing.T) {
+	share, err := decodeBuildTaggedTBTCSignerInteractiveRound2Response(
+		[]byte(`{"session_id":"s","attempt_id":"a","signature_share_hex":"cafe"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+	if hex.EncodeToString(share) != "cafe" {
+		t.Fatalf("unexpected signature share: [%x]", share)
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveSessionAbortRequestPayload(t *testing.T) {
+	attemptID := "attempt-1"
+	payload, err := buildTaggedTBTCSignerInteractiveSessionAbortRequestPayload("session-1", &attemptID)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+	var request buildTaggedTBTCSignerInteractiveSessionAbortRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.AttemptID == nil || *request.AttemptID != "attempt-1" {
+		t.Fatalf("unexpected attempt id: [%v]", request.AttemptID)
+	}
+
+	// A nil attempt id (abort whatever is live) is valid and omitted on the wire.
+	payloadNil, err := buildTaggedTBTCSignerInteractiveSessionAbortRequestPayload("session-1", nil)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+	var requestNil buildTaggedTBTCSignerInteractiveSessionAbortRequest
+	if err := json.Unmarshal(payloadNil, &requestNil); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if requestNil.AttemptID != nil {
+		t.Fatalf("expected omitted attempt id, got: [%v]", *requestNil.AttemptID)
+	}
+
+	if _, err := buildTaggedTBTCSignerInteractiveSessionAbortRequestPayload("", nil); err == nil {
+		t.Fatal("expected empty session id to be rejected")
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerInteractiveSessionAbortResponse(t *testing.T) {
+	result, err := decodeBuildTaggedTBTCSignerInteractiveSessionAbortResponse(
+		[]byte(`{"session_id":"session-1","aborted":true}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+	if result.SessionID != "session-1" || !result.Aborted {
+		t.Fatalf("unexpected result: [%+v]", result)
+	}
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1553,7 +1553,8 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(t *testing.T)
 	if request.TaprootMerkleRootHex != nil {
 		t.Fatalf("expected omitted taproot root, got: [%v]", *request.TaprootMerkleRootHex)
 	}
-	if request.AttemptContext.AttemptNumber != 3 ||
+	// Wire attempt_number is 1-based: the RFC-21 0-based 3 serializes as 4.
+	if request.AttemptContext.AttemptNumber != 4 ||
 		request.AttemptContext.CoordinatorIdentifier != 2 ||
 		request.AttemptContext.IncludedParticipantsFingerprint != "fingerprint-abc" ||
 		request.AttemptContext.AttemptID != "attempt-1" {
@@ -1563,6 +1564,32 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(t *testing.T)
 		request.AttemptContext.IncludedParticipants[0] != 1 ||
 		request.AttemptContext.IncludedParticipants[2] != 3 {
 		t.Fatalf("unexpected included participants: [%v]", request.AttemptContext.IncludedParticipants)
+	}
+}
+
+// The RFC-21 0-based first attempt (AttemptNumber 0) must serialize as the
+// engine's 1-based wire attempt_number 1 - the engine rejects 0, so passing it
+// through unchanged would fail InteractiveSessionOpen before round 1.
+func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_FirstAttemptIsOneBasedOnWire(t *testing.T) {
+	ctx := testInteractiveAttemptContext()
+	ctx.AttemptNumber = 0 // RFC-21 first attempt
+
+	payload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+		"session-1", 2, []byte{0xab}, "key-group-1", 2, nil, ctx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerInteractiveSessionOpenRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.AttemptContext.AttemptNumber != 1 {
+		t.Fatalf(
+			"expected RFC-21 attempt 0 to serialize as wire attempt_number 1, got [%d]",
+			request.AttemptContext.AttemptNumber,
+		)
 	}
 }
 
@@ -1743,5 +1770,29 @@ func TestDecodeBuildTaggedTBTCSignerInteractiveSessionAbortResponse(t *testing.T
 	}
 	if result.SessionID != "session-1" || !result.Aborted {
 		t.Fatalf("unexpected result: [%+v]", result)
+	}
+}
+
+// Every interactive decoder must reject a malformed payload rather than return a
+// zero-valued result, and the open decoder must also reject a structurally
+// valid response missing the session/attempt ids.
+func TestDecodeBuildTaggedTBTCSignerInteractiveResponses_RejectMalformed(t *testing.T) {
+	malformed := []byte("not json")
+
+	if _, err := decodeBuildTaggedTBTCSignerInteractiveSessionOpenResponse(malformed); err == nil {
+		t.Fatal("open: expected malformed JSON to be rejected")
+	}
+	if _, err := decodeBuildTaggedTBTCSignerInteractiveRound1Response(malformed); err == nil {
+		t.Fatal("round1: expected malformed JSON to be rejected")
+	}
+	if _, err := decodeBuildTaggedTBTCSignerInteractiveRound2Response(malformed); err == nil {
+		t.Fatal("round2: expected malformed JSON to be rejected")
+	}
+	if _, err := decodeBuildTaggedTBTCSignerInteractiveSessionAbortResponse(malformed); err == nil {
+		t.Fatal("abort: expected malformed JSON to be rejected")
+	}
+
+	if _, err := decodeBuildTaggedTBTCSignerInteractiveSessionOpenResponse([]byte(`{}`)); err == nil {
+		t.Fatal("open: expected a response missing session/attempt ids to be rejected")
 	}
 }

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -81,6 +81,10 @@ const (
 // orchestrator derives it from the wallet/session state (never from a peer
 // message) and passes it on InteractiveSessionOpen.
 type NativeInteractiveAttemptContext struct {
+	// AttemptNumber is the RFC-21 ZERO-based attempt ordinal (attempt 0 is the
+	// first), matching attempt.AttemptContext. The bridge converts it to the
+	// engine's ONE-based wire attempt_number (which rejects 0) on the way out, so
+	// callers pass the natural attempt.AttemptContext value unchanged.
 	AttemptNumber                   uint32
 	CoordinatorIdentifier           uint16
 	IncludedParticipants            []uint16

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -76,6 +76,34 @@ const (
 	NativeShareVerdictInvalid
 )
 
+// NativeInteractiveAttemptContext is the RFC-21 attempt context an interactive
+// signing session is bound to. It mirrors the engine's AttemptContext: the
+// orchestrator derives it from the wallet/session state (never from a peer
+// message) and passes it on InteractiveSessionOpen.
+type NativeInteractiveAttemptContext struct {
+	AttemptNumber                   uint32
+	CoordinatorIdentifier           uint16
+	IncludedParticipants            []uint16
+	IncludedParticipantsFingerprint string
+	AttemptID                       string
+}
+
+// NativeInteractiveSessionOpenResult is the result of InteractiveSessionOpen:
+// the engine's canonical attempt id for the opened (or idempotently re-opened)
+// attempt.
+type NativeInteractiveSessionOpenResult struct {
+	SessionID  string
+	AttemptID  string
+	Idempotent bool
+}
+
+// NativeInteractiveSessionAbortResult is the result of InteractiveSessionAbort.
+// Aborted is false when there was no live attempt to abort.
+type NativeInteractiveSessionAbortResult struct {
+	SessionID string
+	Aborted   bool
+}
+
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer
 // operations.
 type NativeTBTCSignerEngine interface {


### PR DESCRIPTION
## What

First increment of the **live-orchestration wiring** (Phase 7.3; design locked via Codex+Gemini consult). Bridges the hardened **interactive engine FFI** to Go so a later orchestrator can drive engine-held-nonce signing. Mirrors the #4069 `VerifySignatureShare` bridge pattern exactly (typedef + `dlsym` wrapper + call helper + request/response marshalling).

## How
Adds to `buildTaggedTBTCSignerEngine` (build tag `frost_native && frost_tbtc_signer && cgo`):
- `InteractiveSessionOpen(sessionID, member, message, keyGroup, threshold, taprootMerkleRoot, attemptContext)` → `{sessionID, attemptID, idempotent}`
- `InteractiveRound1(sessionID, attemptID, member)` → commitments bytes
- `InteractiveRound2(sessionID, attemptID, member, signingPackage)` → share bytes
- `InteractiveSessionAbort(sessionID, *attemptID)` → `{sessionID, aborted}`

Plus the request/response structs and a `NativeInteractiveAttemptContext` input type (+ session-open/abort result types) in the `frost_native` engine file so the orchestrator can reference them **without cgo**. Secret nonces never cross this boundary — engine-held, keyed by `(session_id, attempt_id)`; the caller exchanges only public commitments, the coordinator's signing package, and signature shares.

## Scope / blast radius
- **Additive — no Go caller yet** (the orchestrator adopts these in a later increment).
- The `NativeTBTCSignerEngine` **interface is NOT widened** (methods land on the concrete engine only), so **no fakes change** — repo-wide `go vet -tags frost_native ./...` stays clean (I confirmed this explicitly, per the #4070 interface-widening lesson).
- **`interactive_aggregate` is deliberately deferred to the next PR**: its failure path surfaces **candidate culprits**, which needs a structured error type carrying them (the current error envelope is `code`/`message` only). Keeping it separate keeps this PR purely mechanical.

## Tests
Payload builders (fields, attempt-context marshalling, taproot variant, empty-input rejections incl. empty/zero attempt-context fields) + response decoders for all four ops.

## Validation
⚠️ The standard `client-*` CI does not build these cgo-tagged files. Validated **locally**: builds clean under **default** / **frost_native** / **frost_native+frost_tbtc_signer+cgo**; full `pkg/frost/signing` suite + **repo-wide `frost_native` vet** + `gofmt` green.

## Next (Phase 7.3 sequence)
PR1b = `interactive_aggregate` bridge + candidate-culprit structured error → then `Coordinator.MarkSucceeded` + active-attempt object → in-process runner (happy + sad/blame path) → real `pkg/net` transport → executor integration → t-of-included finalize → delete the transitional coarse path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)