### PR TITLE
Phase 7.3: Coordinator.MarkSucceeded (success transition; no spurious transition bundle)

### DIFF
--- a/pkg/frost/roast/coordinator_state.go
+++ b/pkg/frost/roast/coordinator_state.go
@@ -13,10 +13,14 @@ import (
 )
 
 // AttemptState is the phase an attempt is in within the Coordinator
-// state machine. The lifecycle is monotonic:
+// state machine. The lifecycle is monotonic; from AttemptStateCollecting
+// it branches by outcome:
 //
-//	AttemptStatePending -> AttemptStateCollecting -> AttemptStateAggregating
-//	    -> {AttemptStateSucceeded, AttemptStateTransitioned}
+//	AttemptStatePending -> AttemptStateCollecting, then either
+//	  - AttemptStateAggregating -> AttemptStateTransitioned  (failure:
+//	    the coordinator emitted a TransitionMessage; AggregateBundle), or
+//	  - AttemptStateSucceeded  (success: a final signature was aggregated;
+//	    no transition message is needed; MarkSucceeded).
 //
 // AttemptStateSucceeded means the attempt produced a final signature.
 // AttemptStateTransitioned means the attempt timed out or hit an
@@ -130,6 +134,16 @@ type Coordinator interface {
 	// coordinator for the attempt (the Coordinator's selfMember
 	// must equal SelectedCoordinator(handle)).
 	AggregateBundle(handle AttemptHandle) (*TransitionMessage, error)
+	// MarkSucceeded transitions a live (Collecting) attempt to
+	// AttemptStateSucceeded after this node has aggregated a final
+	// signature for it. It is the success counterpart to AggregateBundle's
+	// failure transition: without it a successful attempt would remain
+	// Collecting and the cleanup path would emit a spurious
+	// TransitionMessage for an attempt that actually completed. Any node
+	// may mark its OWN attempt succeeded (unlike AggregateBundle, success
+	// is not coordinator-only). Returns ErrUnknownAttempt for an untracked
+	// handle and ErrAttemptStateInvalid if the attempt is not Collecting.
+	MarkSucceeded(handle AttemptHandle) error
 	// VerifyBundle is called by every receiver of a
 	// TransitionMessage. It validates the structural invariants of
 	// the bundle, verifies the coordinator-level signature against
@@ -458,6 +472,29 @@ func (c *inMemoryCoordinator) markTransitionedLocked(id uint64) {
 	if record, ok := c.attempts[id]; ok {
 		record.state = AttemptStateTransitioned
 	}
+}
+
+func (c *inMemoryCoordinator) MarkSucceeded(handle AttemptHandle) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record, ok := c.attempts[handle.id]
+	if !ok {
+		return ErrUnknownAttempt
+	}
+	// Only a live attempt can succeed. A non-Collecting attempt has already
+	// concluded (aggregating/transitioned to failure, or already succeeded);
+	// re-marking it would mask a caller bug, so fail closed as the other
+	// state-changing methods do.
+	if record.state != AttemptStateCollecting {
+		return fmt.Errorf(
+			"%w: state is %v, want %v",
+			ErrAttemptStateInvalid,
+			record.state,
+			AttemptStateCollecting,
+		)
+	}
+	record.state = AttemptStateSucceeded
+	return nil
 }
 
 func (c *inMemoryCoordinator) VerifyBundle(

--- a/pkg/frost/roast/coordinator_state_test.go
+++ b/pkg/frost/roast/coordinator_state_test.go
@@ -261,3 +261,50 @@ func TestAttemptState_String(t *testing.T) {
 		}
 	}
 }
+
+func TestMarkSucceeded_TransitionsCollectingToSucceeded(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	handle, err := coord.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+
+	if err := coord.MarkSucceeded(handle); err != nil {
+		t.Fatalf("mark succeeded: %v", err)
+	}
+
+	// State is now Succeeded, not Collecting - so the cleanup path's
+	// state == Collecting guard skips it and no spurious TransitionMessage is
+	// produced for an attempt that actually completed.
+	state, err := coord.State(handle)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if state != AttemptStateSucceeded {
+		t.Fatalf("expected Succeeded, got %v", state)
+	}
+}
+
+func TestMarkSucceeded_UnknownHandleReturnsSentinel(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	if err := coord.MarkSucceeded(AttemptHandle{id: 999}); !errors.Is(err, ErrUnknownAttempt) {
+		t.Fatalf("expected ErrUnknownAttempt, got %v", err)
+	}
+}
+
+func TestMarkSucceeded_RejectsNonCollectingAttempt(t *testing.T) {
+	coord := NewInMemoryCoordinator()
+	handle, err := coord.BeginAttempt(newTestContext(t))
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := coord.MarkSucceeded(handle); err != nil {
+		t.Fatalf("first mark succeeded: %v", err)
+	}
+
+	// A second mark on an already-succeeded (non-Collecting) attempt fails
+	// closed rather than masking a caller bug.
+	if err := coord.MarkSucceeded(handle); !errors.Is(err, ErrAttemptStateInvalid) {
+		t.Fatalf("expected ErrAttemptStateInvalid, got %v", err)
+	}
+}

--- a/pkg/frost/signing/roast_retry_executor_entry_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_executor_entry_frost_roast_retry_test.go
@@ -171,6 +171,9 @@ func (e *erroringEntryCoordinator) RecordEvidence(_ roast.AttemptHandle, _ *roas
 func (e *erroringEntryCoordinator) AggregateBundle(_ roast.AttemptHandle) (*roast.TransitionMessage, error) {
 	return nil, nil
 }
+func (e *erroringEntryCoordinator) MarkSucceeded(_ roast.AttemptHandle) error {
+	return nil
+}
 func (e *erroringEntryCoordinator) VerifyBundle(_ roast.AttemptHandle, _ *roast.TransitionMessage) error {
 	return nil
 }

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -295,6 +295,9 @@ func (e *erroringCoordinator) RecordEvidence(_ roast.AttemptHandle, _ *roast.Loc
 func (e *erroringCoordinator) AggregateBundle(_ roast.AttemptHandle) (*roast.TransitionMessage, error) {
 	return nil, nil
 }
+func (e *erroringCoordinator) MarkSucceeded(_ roast.AttemptHandle) error {
+	return nil
+}
 func (e *erroringCoordinator) VerifyBundle(_ roast.AttemptHandle, _ *roast.TransitionMessage) error {
 	return nil
 }

--- a/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
@@ -49,6 +49,9 @@ func (c *captureCoordinator) RecordEvidence(h roast.AttemptHandle, s *roast.Loca
 func (c *captureCoordinator) AggregateBundle(h roast.AttemptHandle) (*roast.TransitionMessage, error) {
 	return c.inner.AggregateBundle(h)
 }
+func (c *captureCoordinator) MarkSucceeded(h roast.AttemptHandle) error {
+	return c.inner.MarkSucceeded(h)
+}
 func (c *captureCoordinator) VerifyBundle(h roast.AttemptHandle, m *roast.TransitionMessage) error {
 	return c.inner.VerifyBundle(h, m)
 }


### PR DESCRIPTION
## What

The `Coordinator` state machine had `AttemptStateSucceeded` in the enum but **no method to reach it** — so a successful interactive aggregate would leave the attempt in `Collecting`, and the cleanup path (`maybeProduceTransitionBundle`, which fires when the *elected coordinator's* attempt is still `Collecting`) would emit a **spurious `TransitionMessage` for an attempt that actually succeeded**. Codex flagged this in the Phase 7.3 design consult.

## How
Adds **`MarkSucceeded(handle)`** to the `Coordinator` interface + `inMemoryCoordinator`:
- transitions a live (`Collecting`) attempt → `Succeeded`;
- returns `ErrUnknownAttempt` for an untracked handle and `ErrAttemptStateInvalid` for a non-`Collecting` attempt (fails closed like `RecordEvidence`/`AggregateBundle`, rather than masking a caller bug);
- **any node may mark its own attempt succeeded** — success, unlike `AggregateBundle`, is not coordinator-only.

The runner (next PR) calls it on a successful aggregate; the cleanup's existing `state == Collecting` guard then skips, closing the bug. Also updated the state-machine doc (`Collecting` branches to `Succeeded` directly on success, or `Aggregating → Transitioned` on failure) and the 3 `Coordinator` test fakes (`frost_roast_retry` tag).

## Blast radius
Interface widening — validated **repo-wide** via `go vet -tags "frost_native frost_tbtc_signer cgo frost_roast_retry" ./...` (the #4070 lesson): the concrete `inMemoryCoordinator` + the 3 fakes are the only implementers, all updated.

## Tests
`Collecting → Succeeded` (State reflects it); unknown handle → `ErrUnknownAttempt`; non-`Collecting` (double-mark) → `ErrAttemptStateInvalid`.

This is **Go-native** (the `roast` Coordinator), so unlike the cgo bridge PRs the standard CI builds and tests it. Default build + repo-wide vet + gofmt + `roast` suite green locally.

## Next (Phase 7.3)
The **in-process runner** (happy + sad/blame path on a fake bus) — which drives `open → round1 → round2 → aggregate`, calls `MarkSucceeded` on success, and on failure runs `ClassifyCandidateCulprits` → `RecordEvidence` → `AggregateBundle` → `NextAttempt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)