### PR TITLE
Phase 7.3 PR3a-i: runner harness foundation (ActiveRoastAttempt + in-process bus)

### DIFF
--- a/pkg/frost/signing/roast_active_attempt_frost_native.go
+++ b/pkg/frost/signing/roast_active_attempt_frost_native.go
@@ -80,6 +80,17 @@ func NewActiveRoastAttempt(
 	if len(dkgGroupPublicKey) == 0 {
 		return nil, fmt.Errorf("roast runner: dkg group public key is empty")
 	}
+	// The DKG group public key must be the one ctx was built from, not merely
+	// non-empty: ctx.AttemptSeed = SHA256(dkgGroupPublicKey || sessionID ||
+	// messageDigest), and this same key later feeds NextAttempt's retry-seed
+	// derivation. Binding ctx's hash (key A) to retry material from a different
+	// key B would make subsequent attempts diverge, so re-derive the seed and
+	// reject a mismatch (sessionID is already asserted == ctx.SessionID above).
+	if attempt.DeriveAttemptSeed(dkgGroupPublicKey, sessionID, ctx.MessageDigest) != ctx.AttemptSeed {
+		return nil, fmt.Errorf(
+			"roast runner: dkg group public key does not match the attempt context (seed mismatch)",
+		)
+	}
 
 	var rootCopy *[32]byte
 	if taprootMerkleRoot != nil {
@@ -89,7 +100,7 @@ func NewActiveRoastAttempt(
 
 	return &ActiveRoastAttempt{
 		sessionID:          sessionID,
-		context:            ctx,
+		context:            cloneAttemptContext(ctx),
 		contextHash:        ctx.Hash(),
 		handle:             handle,
 		electedCoordinator: elected,
@@ -101,8 +112,22 @@ func NewActiveRoastAttempt(
 // SessionID is the engine DKG session this attempt signs under.
 func (a *ActiveRoastAttempt) SessionID() string { return a.sessionID }
 
-// Context is the RFC-21 attempt context.
-func (a *ActiveRoastAttempt) Context() attempt.AttemptContext { return a.context }
+// Context is the RFC-21 attempt context. It returns a clone (its slice fields
+// copied) so a caller cannot mutate the binding's participant sets and make
+// Context().Hash() drift from the pinned ContextHash().
+func (a *ActiveRoastAttempt) Context() attempt.AttemptContext {
+	return cloneAttemptContext(a.context)
+}
+
+// cloneAttemptContext returns a copy of ctx with its slice fields
+// (IncludedSet, ExcludedSet, TransientlyParked) deep-copied, so the result
+// shares no backing arrays with the input. Scalar/array fields copy by value.
+func cloneAttemptContext(ctx attempt.AttemptContext) attempt.AttemptContext {
+	ctx.IncludedSet = append([]group.MemberIndex(nil), ctx.IncludedSet...)
+	ctx.ExcludedSet = append([]group.MemberIndex(nil), ctx.ExcludedSet...)
+	ctx.TransientlyParked = append([]group.MemberIndex(nil), ctx.TransientlyParked...)
+	return ctx
+}
 
 // ContextHash is the attempt-context hash (== Handle().ContextHash()).
 func (a *ActiveRoastAttempt) ContextHash() [attempt.MessageDigestLength]byte {

--- a/pkg/frost/signing/roast_active_attempt_frost_native.go
+++ b/pkg/frost/signing/roast_active_attempt_frost_native.go
@@ -1,0 +1,135 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// ActiveRoastAttempt is the immutable, single-source-of-truth binding for one
+// interactive signing attempt. The runner constructs it once - from the
+// session/signer-material registry plus the Coordinator handle - and derives
+// every engine, collector, and verifier call from it.
+//
+// Why a dedicated, validated, immutable binding: the engine resolves the group
+// key from the sessionID and tweaks by the taproot root, and it cannot tell a
+// valid-but-WRONG session/root from the right one. A mis-bound sessionID,
+// attempt-context hash, or root would make the engine verify honest shares
+// against the wrong material and produce FALSE blame. So the binding is
+// validated once here and then held immutable; the runner never re-derives or
+// re-extracts these values from peer messages.
+type ActiveRoastAttempt struct {
+	sessionID          string
+	context            attempt.AttemptContext
+	contextHash        [attempt.MessageDigestLength]byte
+	handle             roast.AttemptHandle
+	electedCoordinator group.MemberIndex
+	taprootMerkleRoot  *[32]byte
+	dkgGroupPublicKey  []byte
+}
+
+// NewActiveRoastAttempt binds an attempt after enforcing the consistency
+// assertions that keep blame sound:
+//
+//   - sessionID is non-empty and equals ctx.SessionID - the engine resolves the
+//     group key from this sessionID, so it must be the session that produced
+//     ctx (the RFC-21 attempt-context hash folds in the session);
+//   - the handle was minted for ctx (ctx.Hash() == handle.ContextHash());
+//   - the elected coordinator is taken AUTHORITATIVELY from the handle via
+//     coordinator.SelectedCoordinator, never a caller-supplied value;
+//   - dkgGroupPublicKey is non-empty.
+//
+// The taproot root and DKG group public key are copied so the binding cannot be
+// mutated through the caller's pointer/slice: NextAttempt must derive every
+// attempt's seed from the SAME dkgGroupPublicKey bytes, and the verifier must
+// tweak by the SAME root, for the whole signing session.
+func NewActiveRoastAttempt(
+	coordinator roast.Coordinator,
+	handle roast.AttemptHandle,
+	ctx attempt.AttemptContext,
+	sessionID string,
+	taprootMerkleRoot *[32]byte,
+	dkgGroupPublicKey []byte,
+) (*ActiveRoastAttempt, error) {
+	if coordinator == nil {
+		return nil, fmt.Errorf("roast runner: coordinator is nil")
+	}
+	if sessionID == "" {
+		return nil, fmt.Errorf("roast runner: session id is empty")
+	}
+	if sessionID != ctx.SessionID {
+		return nil, fmt.Errorf(
+			"roast runner: session id %q does not match attempt context session id %q",
+			sessionID,
+			ctx.SessionID,
+		)
+	}
+	if ctx.Hash() != handle.ContextHash() {
+		return nil, fmt.Errorf(
+			"roast runner: attempt context hash does not match the handle's bound context",
+		)
+	}
+	elected, err := coordinator.SelectedCoordinator(handle)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: resolve elected coordinator: %w", err)
+	}
+	if len(dkgGroupPublicKey) == 0 {
+		return nil, fmt.Errorf("roast runner: dkg group public key is empty")
+	}
+
+	var rootCopy *[32]byte
+	if taprootMerkleRoot != nil {
+		root := *taprootMerkleRoot
+		rootCopy = &root
+	}
+
+	return &ActiveRoastAttempt{
+		sessionID:          sessionID,
+		context:            ctx,
+		contextHash:        ctx.Hash(),
+		handle:             handle,
+		electedCoordinator: elected,
+		taprootMerkleRoot:  rootCopy,
+		dkgGroupPublicKey:  append([]byte(nil), dkgGroupPublicKey...),
+	}, nil
+}
+
+// SessionID is the engine DKG session this attempt signs under.
+func (a *ActiveRoastAttempt) SessionID() string { return a.sessionID }
+
+// Context is the RFC-21 attempt context.
+func (a *ActiveRoastAttempt) Context() attempt.AttemptContext { return a.context }
+
+// ContextHash is the attempt-context hash (== Handle().ContextHash()).
+func (a *ActiveRoastAttempt) ContextHash() [attempt.MessageDigestLength]byte {
+	return a.contextHash
+}
+
+// Handle is the Coordinator handle for this attempt.
+func (a *ActiveRoastAttempt) Handle() roast.AttemptHandle { return a.handle }
+
+// ElectedCoordinator is the attempt's elected coordinator, resolved
+// authoritatively from the handle at construction.
+func (a *ActiveRoastAttempt) ElectedCoordinator() group.MemberIndex {
+	return a.electedCoordinator
+}
+
+// TaprootMerkleRoot returns a COPY of the bound root (nil for a key-path
+// spend), so a caller cannot mutate the immutable binding.
+func (a *ActiveRoastAttempt) TaprootMerkleRoot() *[32]byte {
+	if a.taprootMerkleRoot == nil {
+		return nil
+	}
+	root := *a.taprootMerkleRoot
+	return &root
+}
+
+// DkgGroupPublicKey returns a COPY of the bound DKG group public key. The same
+// bytes feed every NextAttempt seed derivation for this session.
+func (a *ActiveRoastAttempt) DkgGroupPublicKey() []byte {
+	return append([]byte(nil), a.dkgGroupPublicKey...)
+}

--- a/pkg/frost/signing/roast_active_attempt_frost_native_test.go
+++ b/pkg/frost/signing/roast_active_attempt_frost_native_test.go
@@ -11,12 +11,17 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
+// testDkgGroupPublicKey is the DKG group public key the test attempt contexts
+// are built from; NewActiveRoastAttempt now binds the passed key to ctx via the
+// derived seed, so callers must pass this same key.
+var testDkgGroupPublicKey = []byte{0x01, 0x02}
+
 func testActiveAttemptContext(t *testing.T, sessionID string, digest byte) attempt.AttemptContext {
 	t.Helper()
 	ctx, err := attempt.NewAttemptContext(
 		sessionID,
 		"key-group-test",
-		[]byte{0x01, 0x02},
+		testDkgGroupPublicKey,
 		[attempt.MessageDigestLength]byte{digest},
 		0,
 		[]group.MemberIndex{1, 2, 3, 4, 5},
@@ -36,7 +41,7 @@ func TestNewActiveRoastAttempt_BindsAndValidates(t *testing.T) {
 		t.Fatalf("begin attempt: %v", err)
 	}
 	root := [32]byte{0xaa, 0xbb}
-	dkgKey := []byte{0x09, 0x08, 0x07}
+	dkgKey := append([]byte(nil), testDkgGroupPublicKey...)
 
 	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", &root, dkgKey)
 	if err != nil {
@@ -82,8 +87,6 @@ func TestNewActiveRoastAttempt_RejectsInconsistentBinding(t *testing.T) {
 	// so the session-id check passes but the handle/context-hash check fires.
 	otherCtx := testActiveAttemptContext(t, "session-1", 0x77)
 
-	dkgKey := []byte{0x01}
-
 	tests := map[string]struct {
 		coord     roast.Coordinator
 		handle    roast.AttemptHandle
@@ -91,11 +94,13 @@ func TestNewActiveRoastAttempt_RejectsInconsistentBinding(t *testing.T) {
 		sessionID string
 		dkgKey    []byte
 	}{
-		"nil coordinator":           {nil, handle, ctx, "session-1", dkgKey},
-		"empty session id":          {coord, handle, ctx, "", dkgKey},
-		"session id mismatch":       {coord, handle, ctx, "other-session", dkgKey},
-		"handle / context mismatch": {coord, handle, otherCtx, "session-1", dkgKey},
+		"nil coordinator":           {nil, handle, ctx, "session-1", testDkgGroupPublicKey},
+		"empty session id":          {coord, handle, ctx, "", testDkgGroupPublicKey},
+		"session id mismatch":       {coord, handle, ctx, "other-session", testDkgGroupPublicKey},
+		"handle / context mismatch": {coord, handle, otherCtx, "session-1", testDkgGroupPublicKey},
 		"empty dkg group key":       {coord, handle, ctx, "session-1", nil},
+		// Non-empty but NOT the key ctx was built from: rejected via the seed check.
+		"dkg key mismatch": {coord, handle, ctx, "session-1", []byte{0xff, 0xfe}},
 	}
 
 	for name, test := range tests {
@@ -120,7 +125,9 @@ func TestActiveRoastAttempt_ImmutableAfterConstruction(t *testing.T) {
 		t.Fatalf("begin attempt: %v", err)
 	}
 	root := [32]byte{0xaa}
-	dkgKey := []byte{0x01, 0x02, 0x03}
+	// A copy of the bound key (so mutating it below is safe and it still matches
+	// ctx for the seed check).
+	dkgKey := append([]byte(nil), testDkgGroupPublicKey...)
 
 	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", &root, dkgKey)
 	if err != nil {
@@ -133,7 +140,7 @@ func TestActiveRoastAttempt_ImmutableAfterConstruction(t *testing.T) {
 	if got := ara.TaprootMerkleRoot(); got[0] != 0xaa {
 		t.Fatalf("taproot root not copied from caller: %x", got)
 	}
-	if got := ara.DkgGroupPublicKey(); got[0] != 0x01 {
+	if got := ara.DkgGroupPublicKey(); got[0] != testDkgGroupPublicKey[0] {
 		t.Fatalf("dkg group key not copied from caller: %x", got)
 	}
 

--- a/pkg/frost/signing/roast_active_attempt_frost_native_test.go
+++ b/pkg/frost/signing/roast_active_attempt_frost_native_test.go
@@ -1,0 +1,149 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func testActiveAttemptContext(t *testing.T, sessionID string, digest byte) attempt.AttemptContext {
+	t.Helper()
+	ctx, err := attempt.NewAttemptContext(
+		sessionID,
+		"key-group-test",
+		[]byte{0x01, 0x02},
+		[attempt.MessageDigestLength]byte{digest},
+		0,
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("new attempt context: %v", err)
+	}
+	return ctx
+}
+
+func TestNewActiveRoastAttempt_BindsAndValidates(t *testing.T) {
+	coord := roast.NewInMemoryCoordinator()
+	ctx := testActiveAttemptContext(t, "session-1", 0x42)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	root := [32]byte{0xaa, 0xbb}
+	dkgKey := []byte{0x09, 0x08, 0x07}
+
+	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", &root, dkgKey)
+	if err != nil {
+		t.Fatalf("unexpected construction error: %v", err)
+	}
+
+	if ara.SessionID() != "session-1" {
+		t.Fatalf("unexpected session id: %q", ara.SessionID())
+	}
+	if ara.ContextHash() != ctx.Hash() {
+		t.Fatal("context hash does not match ctx.Hash()")
+	}
+	if ara.Handle() != handle {
+		t.Fatal("handle not bound")
+	}
+	// Elected coordinator is taken authoritatively from the handle.
+	elected, err := coord.SelectedCoordinator(handle)
+	if err != nil {
+		t.Fatalf("selected coordinator: %v", err)
+	}
+	if ara.ElectedCoordinator() != elected {
+		t.Fatalf(
+			"elected coordinator mismatch: got %d, want %d",
+			ara.ElectedCoordinator(), elected,
+		)
+	}
+	if got := ara.TaprootMerkleRoot(); got == nil || *got != root {
+		t.Fatalf("unexpected taproot root: %v", got)
+	}
+	if !bytes.Equal(ara.DkgGroupPublicKey(), dkgKey) {
+		t.Fatalf("unexpected dkg group public key: %x", ara.DkgGroupPublicKey())
+	}
+}
+
+func TestNewActiveRoastAttempt_RejectsInconsistentBinding(t *testing.T) {
+	coord := roast.NewInMemoryCoordinator()
+	ctx := testActiveAttemptContext(t, "session-1", 0x42)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	// A handle minted for a DIFFERENT context (same session id, different digest)
+	// so the session-id check passes but the handle/context-hash check fires.
+	otherCtx := testActiveAttemptContext(t, "session-1", 0x77)
+
+	dkgKey := []byte{0x01}
+
+	tests := map[string]struct {
+		coord     roast.Coordinator
+		handle    roast.AttemptHandle
+		ctx       attempt.AttemptContext
+		sessionID string
+		dkgKey    []byte
+	}{
+		"nil coordinator":           {nil, handle, ctx, "session-1", dkgKey},
+		"empty session id":          {coord, handle, ctx, "", dkgKey},
+		"session id mismatch":       {coord, handle, ctx, "other-session", dkgKey},
+		"handle / context mismatch": {coord, handle, otherCtx, "session-1", dkgKey},
+		"empty dkg group key":       {coord, handle, ctx, "session-1", nil},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewActiveRoastAttempt(
+				test.coord, test.handle, test.ctx, test.sessionID, nil, test.dkgKey,
+			); err == nil {
+				t.Fatal("expected an inconsistent binding to be rejected")
+			}
+		})
+	}
+}
+
+// The binding copies the taproot root and DKG group public key, so mutating the
+// caller's inputs (or the accessors' returns) cannot change it - NextAttempt
+// must derive every attempt's seed from the SAME dkg group public key bytes.
+func TestActiveRoastAttempt_ImmutableAfterConstruction(t *testing.T) {
+	coord := roast.NewInMemoryCoordinator()
+	ctx := testActiveAttemptContext(t, "session-1", 0x42)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	root := [32]byte{0xaa}
+	dkgKey := []byte{0x01, 0x02, 0x03}
+
+	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", &root, dkgKey)
+	if err != nil {
+		t.Fatalf("construction: %v", err)
+	}
+
+	// Mutate the caller's inputs after construction.
+	root[0] = 0xff
+	dkgKey[0] = 0xff
+	if got := ara.TaprootMerkleRoot(); got[0] != 0xaa {
+		t.Fatalf("taproot root not copied from caller: %x", got)
+	}
+	if got := ara.DkgGroupPublicKey(); got[0] != 0x01 {
+		t.Fatalf("dkg group key not copied from caller: %x", got)
+	}
+
+	// Mutate the accessors' returns: the binding must be unaffected.
+	ara.TaprootMerkleRoot()[0] = 0xee
+	ara.DkgGroupPublicKey()[0] = 0xee
+	if got := ara.TaprootMerkleRoot(); got[0] != 0xaa {
+		t.Fatalf("taproot root accessor must return a fresh copy: %x", got)
+	}
+	if got := ara.DkgGroupPublicKey(); got[0] != 0x01 {
+		t.Fatalf("dkg group key accessor must return a fresh copy: %x", got)
+	}
+}

--- a/pkg/frost/signing/roast_runner_bus_frost_native.go
+++ b/pkg/frost/signing/roast_runner_bus_frost_native.go
@@ -125,7 +125,17 @@ func (s *RunnerBusSubscriber) deliver(hash [sha256.Size]byte, msg RunnerMessage)
 	s.mu.Unlock()
 
 	if stream := s.streamFor(msg.Type); stream != nil {
-		stream <- msg
+		// Own the payload bytes per delivery: RunnerMessage.Payload is a slice,
+		// so without this every queued message would alias one backing array.
+		// The broadcaster mutating/reusing it after Broadcast returns, or one
+		// receiver mutating what it read, would then change another subscriber's
+		// view - and the body the bus hashed for dedup could differ from the body
+		// delivered, silently destroying the equivocation evidence this bus
+		// exists to preserve. The dedup hash was computed from these same bytes,
+		// so the copy is byte-identical and consistent with it.
+		delivered := msg
+		delivered.Payload = append([]byte(nil), msg.Payload...)
+		stream <- delivered
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_bus_frost_native.go
+++ b/pkg/frost/signing/roast_runner_bus_frost_native.go
@@ -1,0 +1,176 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"crypto/sha256"
+	"sync"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// RunnerMessageType tags a broadcast interactive-signing message so subscribers
+// can route it to the right typed receive stream.
+type RunnerMessageType int
+
+const (
+	// RunnerMsgCommitments carries a member's round-1 commitments.
+	RunnerMsgCommitments RunnerMessageType = iota
+	// RunnerMsgSigningPackage carries the coordinator's signed SigningPackage.
+	RunnerMsgSigningPackage
+	// RunnerMsgShareSubmission carries a member's signed ShareSubmission.
+	RunnerMsgShareSubmission
+	// RunnerMsgEvidenceSnapshot carries a member's signed LocalEvidenceSnapshot.
+	RunnerMsgEvidenceSnapshot
+	// RunnerMsgTransitionBundle carries the coordinator's TransitionMessage.
+	RunnerMsgTransitionBundle
+)
+
+// RunnerMessage is one broadcast message on the interactive-signing bus. Payload
+// is the serialized content (commitments bytes, SigningPackage/ShareSubmission/
+// LocalEvidenceSnapshot/TransitionMessage envelope bytes); the bus treats it as
+// opaque and never interprets it.
+type RunnerMessage struct {
+	Type    RunnerMessageType
+	Sender  group.MemberIndex
+	Attempt [attempt.MessageDigestLength]byte
+	Payload []byte
+}
+
+// contentHash is the full-message identity used for retransmission dedup. It
+// covers EVERY field including the payload, so two messages from the same sender
+// with different bodies hash differently and are both delivered - critical
+// because for signing packages and shares a body-different duplicate IS
+// equivocation evidence the collector must see. Only byte-identical
+// retransmissions collide and are suppressed.
+func (m RunnerMessage) contentHash() [sha256.Size]byte {
+	h := sha256.New()
+	h.Write([]byte{byte(m.Type), byte(m.Sender)})
+	h.Write(m.Attempt[:])
+	h.Write(m.Payload)
+	var out [sha256.Size]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// RunnerBus is the interactive-signing broadcast mesh. Production wraps pkg/net;
+// the in-process implementation here drives the runner's deterministic unit
+// tests without real networking.
+type RunnerBus interface {
+	// Broadcast delivers msg to every subscriber. Byte-identical retransmissions
+	// are deduplicated per subscriber; body-different messages from the same
+	// sender are NEVER suppressed (they are equivocation evidence). The caller
+	// records its OWN produced messages into its collector/coordinator directly
+	// and must not rely on receiving its own broadcast back.
+	Broadcast(msg RunnerMessage)
+	// Subscribe registers a receiver and returns its typed streams. The harness
+	// wires every node up front (a subscriber does not receive messages
+	// broadcast before it subscribed).
+	Subscribe() *RunnerBusSubscriber
+}
+
+// RunnerBusSubscriber exposes one node's typed receive streams plus a
+// per-subscriber dedup set keyed by full message content.
+type RunnerBusSubscriber struct {
+	commitments       chan RunnerMessage
+	signingPackages   chan RunnerMessage
+	shares            chan RunnerMessage
+	evidenceSnapshots chan RunnerMessage
+	transitionBundles chan RunnerMessage
+
+	mu   sync.Mutex
+	seen map[[sha256.Size]byte]struct{}
+}
+
+// Commitments returns the round-1 commitments stream.
+func (s *RunnerBusSubscriber) Commitments() <-chan RunnerMessage { return s.commitments }
+
+// SigningPackages returns the coordinator signing-package stream.
+func (s *RunnerBusSubscriber) SigningPackages() <-chan RunnerMessage { return s.signingPackages }
+
+// Shares returns the share-submission stream.
+func (s *RunnerBusSubscriber) Shares() <-chan RunnerMessage { return s.shares }
+
+// EvidenceSnapshots returns the evidence-snapshot stream.
+func (s *RunnerBusSubscriber) EvidenceSnapshots() <-chan RunnerMessage { return s.evidenceSnapshots }
+
+// TransitionBundles returns the transition-bundle stream.
+func (s *RunnerBusSubscriber) TransitionBundles() <-chan RunnerMessage { return s.transitionBundles }
+
+func (s *RunnerBusSubscriber) streamFor(t RunnerMessageType) chan RunnerMessage {
+	switch t {
+	case RunnerMsgCommitments:
+		return s.commitments
+	case RunnerMsgSigningPackage:
+		return s.signingPackages
+	case RunnerMsgShareSubmission:
+		return s.shares
+	case RunnerMsgEvidenceSnapshot:
+		return s.evidenceSnapshots
+	case RunnerMsgTransitionBundle:
+		return s.transitionBundles
+	default:
+		return nil
+	}
+}
+
+func (s *RunnerBusSubscriber) deliver(hash [sha256.Size]byte, msg RunnerMessage) {
+	s.mu.Lock()
+	if _, dup := s.seen[hash]; dup {
+		s.mu.Unlock()
+		return
+	}
+	s.seen[hash] = struct{}{}
+	s.mu.Unlock()
+
+	if stream := s.streamFor(msg.Type); stream != nil {
+		stream <- msg
+	}
+}
+
+// inProcessRunnerBus is the deterministic in-process RunnerBus for runner unit
+// tests. Streams are buffered (bufferSize per type per subscriber); a Broadcast
+// blocks only if a subscriber's buffer for that type is full, so the harness
+// sizes the buffer to the expected message volume.
+type inProcessRunnerBus struct {
+	mu          sync.Mutex
+	subscribers []*RunnerBusSubscriber
+	bufferSize  int
+}
+
+// NewInProcessRunnerBus returns an in-process bus with per-stream buffers of the
+// given size.
+func NewInProcessRunnerBus(bufferSize int) RunnerBus {
+	if bufferSize < 1 {
+		bufferSize = 1
+	}
+	return &inProcessRunnerBus{bufferSize: bufferSize}
+}
+
+func (b *inProcessRunnerBus) Subscribe() *RunnerBusSubscriber {
+	s := &RunnerBusSubscriber{
+		commitments:       make(chan RunnerMessage, b.bufferSize),
+		signingPackages:   make(chan RunnerMessage, b.bufferSize),
+		shares:            make(chan RunnerMessage, b.bufferSize),
+		evidenceSnapshots: make(chan RunnerMessage, b.bufferSize),
+		transitionBundles: make(chan RunnerMessage, b.bufferSize),
+		seen:              map[[sha256.Size]byte]struct{}{},
+	}
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, s)
+	b.mu.Unlock()
+	return s
+}
+
+func (b *inProcessRunnerBus) Broadcast(msg RunnerMessage) {
+	hash := msg.contentHash()
+	b.mu.Lock()
+	subscribers := append([]*RunnerBusSubscriber(nil), b.subscribers...)
+	b.mu.Unlock()
+	// Deliver outside the bus lock so a slow/full subscriber stream cannot block
+	// other subscribers' registration; each subscriber guards its own dedup set.
+	for _, s := range subscribers {
+		s.deliver(hash, msg)
+	}
+}

--- a/pkg/frost/signing/roast_runner_bus_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_frost_native_test.go
@@ -99,3 +99,30 @@ func TestInProcessRunnerBus_LateSubscriberMissesPastMessages(t *testing.T) {
 	default:
 	}
 }
+
+// Each delivered message must own its payload bytes: mutating the broadcaster's
+// slice after Broadcast, or one subscriber's received slice, must not change
+// another subscriber's view - otherwise the body the bus hashed for dedup could
+// differ from the body delivered, destroying equivocation evidence.
+func TestInProcessRunnerBus_OwnsDeliveredPayload(t *testing.T) {
+	bus := NewInProcessRunnerBus(8)
+	a := bus.Subscribe()
+	b := bus.Subscribe()
+
+	payload := []byte{0xaa, 0xbb}
+	bus.Broadcast(testRunnerMessage(RunnerMsgSigningPackage, 1, payload))
+
+	// Mutate the broadcaster's original slice after Broadcast returns.
+	payload[0] = 0xff
+	msgA := recvOrFail(t, a.SigningPackages(), "package (a)")
+	if msgA.Payload[0] != 0xaa {
+		t.Fatalf("subscriber a saw the broadcaster's post-broadcast mutation: %x", msgA.Payload)
+	}
+
+	// Mutating a's received payload must not corrupt b's.
+	msgA.Payload[0] = 0xee
+	msgB := recvOrFail(t, b.SigningPackages(), "package (b)")
+	if msgB.Payload[0] != 0xaa {
+		t.Fatalf("subscriber b's payload was corrupted by a's mutation: %x", msgB.Payload)
+	}
+}

--- a/pkg/frost/signing/roast_runner_bus_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_frost_native_test.go
@@ -1,0 +1,101 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func testRunnerMessage(t RunnerMessageType, sender group.MemberIndex, payload []byte) RunnerMessage {
+	return RunnerMessage{
+		Type:    t,
+		Sender:  sender,
+		Attempt: [attempt.MessageDigestLength]byte{0x42},
+		Payload: payload,
+	}
+}
+
+// recvOrFail reads one message from a stream without blocking the test forever.
+func recvOrFail(t *testing.T, stream <-chan RunnerMessage, what string) RunnerMessage {
+	t.Helper()
+	select {
+	case msg := <-stream:
+		return msg
+	default:
+		t.Fatalf("expected a %s message, stream was empty", what)
+		return RunnerMessage{}
+	}
+}
+
+func TestInProcessRunnerBus_BroadcastsToAllSubscribersOnTypedStream(t *testing.T) {
+	bus := NewInProcessRunnerBus(8)
+	a := bus.Subscribe()
+	b := bus.Subscribe()
+
+	bus.Broadcast(testRunnerMessage(RunnerMsgSigningPackage, 1, []byte{0xde, 0xad}))
+
+	for name, sub := range map[string]*RunnerBusSubscriber{"a": a, "b": b} {
+		msg := recvOrFail(t, sub.SigningPackages(), "signing package")
+		if msg.Sender != 1 || string(msg.Payload) != string([]byte{0xde, 0xad}) {
+			t.Fatalf("subscriber %s got wrong message: %+v", name, msg)
+		}
+		// It must NOT also appear on another typed stream.
+		select {
+		case other := <-sub.Commitments():
+			t.Fatalf("subscriber %s leaked a package onto the commitments stream: %+v", name, other)
+		default:
+		}
+	}
+}
+
+func TestInProcessRunnerBus_DedupsExactRetransmission(t *testing.T) {
+	bus := NewInProcessRunnerBus(8)
+	sub := bus.Subscribe()
+
+	msg := testRunnerMessage(RunnerMsgShareSubmission, 2, []byte{0x01, 0x02})
+	bus.Broadcast(msg)
+	bus.Broadcast(msg) // byte-identical retransmission
+
+	recvOrFail(t, sub.Shares(), "share")
+	select {
+	case dup := <-sub.Shares():
+		t.Fatalf("exact retransmission must be deduped, got a second delivery: %+v", dup)
+	default:
+	}
+}
+
+// The critical property: a body-DIFFERENT message from the same sender must NOT
+// be suppressed - for packages and shares it is equivocation evidence the
+// collector has to see. Deduping by (attempt, sender) would silently drop it.
+func TestInProcessRunnerBus_DeliversBodyDifferentDuplicateFromSameSender(t *testing.T) {
+	bus := NewInProcessRunnerBus(8)
+	sub := bus.Subscribe()
+
+	bus.Broadcast(testRunnerMessage(RunnerMsgSigningPackage, 1, []byte{0xaa}))
+	bus.Broadcast(testRunnerMessage(RunnerMsgSigningPackage, 1, []byte{0xbb})) // same sender, different body
+
+	first := recvOrFail(t, sub.SigningPackages(), "first package")
+	second := recvOrFail(t, sub.SigningPackages(), "second (equivocating) package")
+	if string(first.Payload) == string(second.Payload) {
+		t.Fatal("expected two distinct package bodies to be delivered")
+	}
+	got := map[string]bool{string(first.Payload): true, string(second.Payload): true}
+	if !got[string([]byte{0xaa})] || !got[string([]byte{0xbb})] {
+		t.Fatalf("expected both 0xaa and 0xbb bodies delivered, got: %v", got)
+	}
+}
+
+func TestInProcessRunnerBus_LateSubscriberMissesPastMessages(t *testing.T) {
+	bus := NewInProcessRunnerBus(8)
+	bus.Broadcast(testRunnerMessage(RunnerMsgCommitments, 1, []byte{0x01}))
+
+	late := bus.Subscribe()
+	select {
+	case msg := <-late.Commitments():
+		t.Fatalf("a late subscriber must not receive past messages, got: %+v", msg)
+	default:
+	}
+}


### PR DESCRIPTION
## What

First slice of the in-process interactive-signing **runner** (design locked via the Codex+Gemini consult). `frost_native` (**no cgo**), so it's deterministic and fake-testable. **No runner orchestration logic yet** — this is the harness foundation Codex suggested splitting out first; the happy-path runner lands next (PR3a-ii).

## `ActiveRoastAttempt` — the immutable binding
The single-source-of-truth for one attempt `{sessionID, context, contextHash, handle, electedCoordinator, taprootMerkleRoot, dkgGroupPublicKey}`. `NewActiveRoastAttempt` enforces the assertions that keep blame **sound**:
- `sessionID != "" && == ctx.SessionID` (the engine resolves the group key from this session);
- `ctx.Hash() == handle.ContextHash()` (the handle is for this context);
- elected coordinator taken **authoritatively** from `coordinator.SelectedCoordinator(handle)`, never a caller value;
- non-empty DKG group key.

It **copies** the root + DKG key so the binding is immutable — `NextAttempt` must derive every attempt's seed from the *same* DKG group public key bytes. A mis-bound session/root would make the engine verify honest shares against the wrong material → **false blame**, so it's validated once and frozen.

## `RunnerBus` — typed broadcast mesh + 🔑 critical dedup
`Broadcast(msg)` + per-type receive streams (commitments / package / share / snapshot / bundle), with an in-process impl for tests. **The dedup semantics are the point of the consult:** dedup **only byte-identical retransmissions** (per-subscriber seen-set keyed by *full message content* hash). Body-different messages from the same sender are **never** suppressed — for signing packages and shares a body-different duplicate *is* equivocation evidence the collector must see; deduping by `(attempt, sender)` would silently drop it and **defeat the 4b proof-carrying mechanism**. The runner records its *own* produced messages directly and never relies on bus self-echo.

## Tests
`ActiveRoastAttempt`: happy construction + each hard-assertion rejection + immutability of the copied root/dkg-key. Bus: typed routing, exact-retransmit dedup, **body-different-duplicate delivery** (the equivocation case), late-subscriber isolation. **Passes under `-race`.**

## Validation
`frost_native` suite + `gofmt` + repo-wide `frost_native` vet green. ⚠️ `client-*` CI builds default tags, not `frost_native`; validated locally.

## Next
**PR3a-ii — happy path:** the runner driving `open → round1 → (coordinator) package → round2 → aggregate → MarkSucceeded` over this bus, with a multi-node fake-engine harness producing a valid aggregate signature. Then PR3b — the sad/blame path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)