### PR TITLE
Phase 7.3 PR3a-ii: happy-path interactive signing runner (multi-node, fake bus)

### DIFF
--- a/pkg/frost/signing/roast_runner_engine_frost_native.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native.go
@@ -60,4 +60,13 @@ type interactiveSigningEngine interface {
 		signatureShares []nativeFROSTSignatureShare,
 		taprootMerkleRoot *[32]byte,
 	) ([]byte, error)
+
+	// InteractiveSessionAbort tells the engine to drop the attempt's held
+	// secret nonces/session state. The runner defers it for early exits so an
+	// attempt abandoned before aggregation does not leave nonce material
+	// resident.
+	InteractiveSessionAbort(
+		sessionID string,
+		attemptID *string,
+	) (*NativeInteractiveSessionAbortResult, error)
 }

--- a/pkg/frost/signing/roast_runner_engine_frost_native.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native.go
@@ -1,0 +1,63 @@
+//go:build frost_native
+
+package signing
+
+// interactiveSigningEngine is the slice of the native tbtc-signer engine the
+// interactive runner drives for one attempt. It is defined at the runner
+// boundary (interface segregation) so the runner is exercised with a
+// programmable fake under frost_native alone - no cgo, deterministic - per the
+// design consult. The cgo-backed buildTaggedTBTCSignerEngine satisfies it; that
+// satisfaction is asserted in the cgo wiring layer, not here, so this file does
+// not pull in frost_tbtc_signer && cgo.
+//
+// Secret nonces never cross this boundary: the engine generates, holds, and
+// zeroizes them keyed by (session_id, attempt_id); the runner exchanges only
+// the public commitments, the coordinator's signing package, and the signature
+// shares returned here.
+type interactiveSigningEngine interface {
+	// InteractiveSessionOpen opens (or idempotently re-opens) the attempt and
+	// returns the engine's canonical attempt id.
+	InteractiveSessionOpen(
+		sessionID string,
+		memberIdentifier uint16,
+		message []byte,
+		keyGroup string,
+		threshold uint16,
+		taprootMerkleRoot *[32]byte,
+		attemptContext NativeInteractiveAttemptContext,
+	) (*NativeInteractiveSessionOpenResult, error)
+
+	// InteractiveRound1 returns this member's public round-1 commitments.
+	InteractiveRound1(
+		sessionID string,
+		attemptID string,
+		memberIdentifier uint16,
+	) ([]byte, error)
+
+	// NewSigningPackage builds the FROST signing package from the responsive
+	// subset's commitments (the elected coordinator calls this).
+	NewSigningPackage(
+		message []byte,
+		commitments []nativeFROSTCommitment,
+	) ([]byte, error)
+
+	// InteractiveRound2 consumes this member's nonces against the coordinator's
+	// signing package and returns its signature share.
+	InteractiveRound2(
+		sessionID string,
+		attemptID string,
+		memberIdentifier uint16,
+		signingPackage []byte,
+	) ([]byte, error)
+
+	// InteractiveAggregate aggregates the collected shares into the BIP-340
+	// signature, or fails (with an InteractiveAggregateShareVerificationError
+	// carrying candidate culprits) when a share does not verify.
+	InteractiveAggregate(
+		sessionID string,
+		attemptID string,
+		signingPackage []byte,
+		signatureShares []nativeFROSTSignatureShare,
+		taprootMerkleRoot *[32]byte,
+	) ([]byte, error)
+}

--- a/pkg/frost/signing/roast_runner_engine_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native_test.go
@@ -34,7 +34,24 @@ type fakeInteractiveSigningEngine struct {
 	newPackageCalls     int
 	round2Calls         int
 	aggregateCalls      int
+	abortCalls          int
 	lastAggregateShares []nativeFROSTSignatureShare
+}
+
+func (f *fakeInteractiveSigningEngine) InteractiveSessionAbort(
+	sessionID string,
+	attemptID *string,
+) (*NativeInteractiveSessionAbortResult, error) {
+	f.mu.Lock()
+	f.abortCalls++
+	f.mu.Unlock()
+	return &NativeInteractiveSessionAbortResult{SessionID: sessionID, Aborted: true}, nil
+}
+
+func (f *fakeInteractiveSigningEngine) abortCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.abortCalls
 }
 
 func newFakeInteractiveSigningEngine() *fakeInteractiveSigningEngine {

--- a/pkg/frost/signing/roast_runner_engine_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native_test.go
@@ -1,0 +1,167 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// Compile-time assertion that the fake satisfies the runner's engine boundary.
+var _ interactiveSigningEngine = (*fakeInteractiveSigningEngine)(nil)
+
+// fakeInteractiveSigningEngine is a programmable interactiveSigningEngine for
+// runner tests. It returns configured (non-crypto) responses and records call
+// counts so the runner's orchestration is exercised deterministically without
+// cgo or real FROST - the real engine's crypto is covered by the engine's own
+// suite. Per-member commitments/shares default to member-derived bytes so each
+// member's contribution is distinct; the aggregate result (or error) is
+// programmable for the happy and, later, the sad path.
+type fakeInteractiveSigningEngine struct {
+	attemptID      string
+	idempotent     bool
+	signingPackage []byte
+	signature      []byte
+	aggregateErr   error
+
+	commitmentsByMember map[uint16][]byte
+	shareByMember       map[uint16][]byte
+
+	mu                  sync.Mutex
+	openCalls           int
+	round1Calls         int
+	newPackageCalls     int
+	round2Calls         int
+	aggregateCalls      int
+	lastAggregateShares []nativeFROSTSignatureShare
+}
+
+func newFakeInteractiveSigningEngine() *fakeInteractiveSigningEngine {
+	return &fakeInteractiveSigningEngine{
+		attemptID:           "attempt-1",
+		signingPackage:      []byte("fake-signing-package"),
+		signature:           []byte("fake-bip340-signature"),
+		commitmentsByMember: map[uint16][]byte{},
+		shareByMember:       map[uint16][]byte{},
+	}
+}
+
+func (f *fakeInteractiveSigningEngine) memberCommitments(member uint16) []byte {
+	if c, ok := f.commitmentsByMember[member]; ok {
+		return c
+	}
+	return []byte(fmt.Sprintf("commitments-%d", member))
+}
+
+func (f *fakeInteractiveSigningEngine) memberShare(member uint16) []byte {
+	if s, ok := f.shareByMember[member]; ok {
+		return s
+	}
+	return []byte(fmt.Sprintf("share-%d", member))
+}
+
+func (f *fakeInteractiveSigningEngine) InteractiveSessionOpen(
+	sessionID string,
+	memberIdentifier uint16,
+	message []byte,
+	keyGroup string,
+	threshold uint16,
+	taprootMerkleRoot *[32]byte,
+	attemptContext NativeInteractiveAttemptContext,
+) (*NativeInteractiveSessionOpenResult, error) {
+	f.mu.Lock()
+	f.openCalls++
+	f.mu.Unlock()
+	return &NativeInteractiveSessionOpenResult{
+		SessionID:  sessionID,
+		AttemptID:  f.attemptID,
+		Idempotent: f.idempotent,
+	}, nil
+}
+
+func (f *fakeInteractiveSigningEngine) InteractiveRound1(
+	sessionID string,
+	attemptID string,
+	memberIdentifier uint16,
+) ([]byte, error) {
+	f.mu.Lock()
+	f.round1Calls++
+	f.mu.Unlock()
+	return f.memberCommitments(memberIdentifier), nil
+}
+
+func (f *fakeInteractiveSigningEngine) NewSigningPackage(
+	message []byte,
+	commitments []nativeFROSTCommitment,
+) ([]byte, error) {
+	f.mu.Lock()
+	f.newPackageCalls++
+	f.mu.Unlock()
+	return f.signingPackage, nil
+}
+
+func (f *fakeInteractiveSigningEngine) InteractiveRound2(
+	sessionID string,
+	attemptID string,
+	memberIdentifier uint16,
+	signingPackage []byte,
+) ([]byte, error) {
+	f.mu.Lock()
+	f.round2Calls++
+	f.mu.Unlock()
+	return f.memberShare(memberIdentifier), nil
+}
+
+func (f *fakeInteractiveSigningEngine) InteractiveAggregate(
+	sessionID string,
+	attemptID string,
+	signingPackage []byte,
+	signatureShares []nativeFROSTSignatureShare,
+	taprootMerkleRoot *[32]byte,
+) ([]byte, error) {
+	f.mu.Lock()
+	f.aggregateCalls++
+	f.lastAggregateShares = signatureShares
+	f.mu.Unlock()
+	if f.aggregateErr != nil {
+		return nil, f.aggregateErr
+	}
+	return f.signature, nil
+}
+
+func TestFakeInteractiveSigningEngine_Programmable(t *testing.T) {
+	engine := newFakeInteractiveSigningEngine()
+
+	open, err := engine.InteractiveSessionOpen("s", 1, []byte("m"), "kg", 2, nil, NativeInteractiveAttemptContext{})
+	if err != nil || open.AttemptID != "attempt-1" {
+		t.Fatalf("unexpected open result: %+v err=%v", open, err)
+	}
+
+	// Per-member round-1/round-2 bytes are distinct by default.
+	c1, _ := engine.InteractiveRound1("s", "a", 1)
+	c2, _ := engine.InteractiveRound1("s", "a", 2)
+	if string(c1) == string(c2) {
+		t.Fatal("expected distinct per-member commitments")
+	}
+
+	pkg, _ := engine.NewSigningPackage([]byte("m"), nil)
+	if string(pkg) != "fake-signing-package" {
+		t.Fatalf("unexpected signing package: %s", pkg)
+	}
+
+	sig, err := engine.InteractiveAggregate("s", "a", pkg, nil, nil)
+	if err != nil || string(sig) != "fake-bip340-signature" {
+		t.Fatalf("unexpected aggregate result: %s err=%v", sig, err)
+	}
+
+	// A programmed aggregate error surfaces (the later sad path uses this).
+	engine.aggregateErr = fmt.Errorf("boom")
+	if _, err := engine.InteractiveAggregate("s", "a", pkg, nil, nil); err == nil {
+		t.Fatal("expected the programmed aggregate error")
+	}
+
+	if engine.openCalls != 1 || engine.round1Calls != 2 || engine.newPackageCalls != 1 || engine.aggregateCalls != 2 {
+		t.Fatalf("unexpected call counts: %+v", engine)
+	}
+}

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -379,10 +379,9 @@ func (r *interactiveSigningRunner) collectCommitments(
 }
 
 // collectShares fills `into` with each included member's inner FROST share
-// bytes (own already seeded), unwrapping each ShareSubmission envelope and
-// counting the first accepted body per sender. Every well-formed share is still
-// passed to the collector for retention, even after a sender's first - that is
-// where member equivocation is detected.
+// bytes (own already seeded), counting the first accepted body per sender, and
+// retains EVERY well-formed share in the collector - including a sender's later,
+// body-different ones - which is where member equivocation is detected.
 func (r *interactiveSigningRunner) collectShares(
 	ctx context.Context,
 	stream <-chan RunnerMessage,
@@ -396,47 +395,63 @@ func (r *interactiveSigningRunner) collectShares(
 		case <-ctx.Done():
 			return ctx.Err()
 		case msg := <-stream:
-			if msg.Attempt != contextHash {
-				continue
-			}
-			if _, want := included[msg.Sender]; !want {
-				continue
-			}
-			var sub roast.ShareSubmission
-			if err := sub.Unmarshal(msg.Payload); err != nil {
-				continue
-			}
-			// Bind the authenticated transport sender to the claimed submitter:
-			// a node embedding another member's id would otherwise fill that
-			// honest member's slot with garbage, drop their real share, and get
-			// them falsely blamed.
-			if sub.SubmitterID() != msg.Sender {
-				continue
-			}
-			// Authenticate + retain via the collector BEFORE the already-collected
-			// short-circuit. A body-different second signed share from a sender is
-			// exactly the member-equivocation evidence the collector is built to
-			// retain and emit (EquivocationKindShareConflict / DivergentShare);
-			// dropping it just because we already hold that sender's first share
-			// would let a double-signer go unrecorded. Retention is bounded (the
-			// collector keeps the first per submitter and only emits on the rest),
-			// and the bus delivers only body-different duplicates.
-			recordErr := r.collector.RecordShareSubmission(&sub)
-			if _, have := into[msg.Sender]; have {
-				continue
-			}
-			// Only an ACCEPTED share (err == nil: operator-sig valid, binds the
-			// elected coordinator AND the authoritative package) counts toward
-			// aggregation; a divergent/conflicting/unauthenticated share is
-			// retained above where applicable but never counted
-			// (ErrShareRetainedNotAccepted / ErrShareConflict / auth failure).
-			if recordErr != nil {
-				continue
-			}
-			into[msg.Sender] = append([]byte(nil), sub.SignatureShare...)
+			r.recordShareMessage(msg, contextHash, included, into)
 		}
 	}
-	return nil
+	// `into` is full, but the slot-filling share may have body-different
+	// duplicates already queued behind it on the stream. Drain and record them
+	// before Run aggregates and prunes the collector, else that queued member-
+	// equivocation evidence is lost (same rationale as the coordinator-package
+	// drain). Non-blocking and buffer-bounded; late arrivals are the blame path's
+	// concern.
+	for {
+		select {
+		case msg := <-stream:
+			r.recordShareMessage(msg, contextHash, included, into)
+		default:
+			return nil
+		}
+	}
+}
+
+// recordShareMessage validates a share-submission bus message, retains it in the
+// collector, and counts it toward `into` when it is the sender's first accepted
+// share. Recording BEFORE the already-collected check is what lets the collector
+// observe member equivocation (a body-different second signed share ->
+// EquivocationKindShareConflict / DivergentShare); a divergent / conflicting /
+// unauthenticated share is retained where applicable but never counted.
+// Retention is bounded (the collector keeps the first per submitter and only
+// emits on the rest), and the bus delivers only body-different duplicates.
+func (r *interactiveSigningRunner) recordShareMessage(
+	msg RunnerMessage,
+	contextHash [attempt.MessageDigestLength]byte,
+	included map[group.MemberIndex]struct{},
+	into map[group.MemberIndex][]byte,
+) {
+	if msg.Attempt != contextHash {
+		return
+	}
+	if _, want := included[msg.Sender]; !want {
+		return
+	}
+	var sub roast.ShareSubmission
+	if err := sub.Unmarshal(msg.Payload); err != nil {
+		return
+	}
+	// Bind the authenticated transport sender to the claimed submitter: a node
+	// embedding another member's id would otherwise fill that honest member's
+	// slot with garbage, drop their real share, and get them falsely blamed.
+	if sub.SubmitterID() != msg.Sender {
+		return
+	}
+	recordErr := r.collector.RecordShareSubmission(&sub)
+	if _, have := into[msg.Sender]; have {
+		return
+	}
+	if recordErr != nil {
+		return
+	}
+	into[msg.Sender] = append([]byte(nil), sub.SignatureShare...)
 }
 
 // recordBufferedCoordinatorPackages drains every signing package the elected

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -3,6 +3,7 @@
 package signing
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -128,7 +129,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 
 	// 4. Collect every included member's commitments.
 	commitments := map[group.MemberIndex][]byte{r.member: ownCommitments}
-	if err := r.collectCommitments(ctx, r.sub.Commitments(), includedSet, commitments); err != nil {
+	if err := r.collectCommitments(ctx, r.sub.Commitments(), contextHash, includedSet, commitments); err != nil {
 		return nil, fmt.Errorf("roast runner: collect commitments: %w", err)
 	}
 
@@ -146,6 +147,12 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	// the collector, not here).
 	if err := r.collector.RecordSigningPackage(pkg); err != nil {
 		return nil, fmt.Errorf("roast runner: record signing package: %w", err)
+	}
+	// Refuse a package whose taproot root diverges from the bound root: signing
+	// Round 2 against it would sign for the WRONG tweak. The package was retained
+	// above as evidence for the blame path; we just must not sign it.
+	if !r.taprootRootMatches(pkg.TaprootMerkleRoot) {
+		return nil, fmt.Errorf("roast runner: signing package taproot root diverges from the bound session root")
 	}
 
 	// 6. Round 2: our signature share, recorded locally and broadcast.
@@ -167,7 +174,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	// included set, so the aggregate needs a share from each of them (silent-
 	// member subsetting is the retry path's concern, not the happy flow).
 	shares := map[group.MemberIndex][]byte{r.member: ownShare}
-	if err := r.collectShares(ctx, r.sub.Shares(), len(includedSet), shares); err != nil {
+	if err := r.collectShares(ctx, r.sub.Shares(), contextHash, includedSet, shares); err != nil {
 		return nil, fmt.Errorf("roast runner: collect shares: %w", err)
 	}
 
@@ -208,11 +215,20 @@ func (r *interactiveSigningRunner) obtainSigningPackage(
 	includedSet []group.MemberIndex,
 ) ([]byte, error) {
 	if r.member != elected {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case msg := <-stream:
-			return msg.Payload, nil
+		// Accept ONLY the elected coordinator's package for THIS attempt. Without
+		// this, any node could broadcast a garbage package; the honest member
+		// would forward it to RecordSigningPackage, fail authentication, and abort
+		// its run before the real package ever arrives.
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case msg := <-stream:
+				if msg.Attempt != contextHash || msg.Sender != elected {
+					continue
+				}
+				return append([]byte(nil), msg.Payload...), nil
+			}
 		}
 	}
 
@@ -295,6 +311,7 @@ func (r *interactiveSigningRunner) signShareSubmission(
 func (r *interactiveSigningRunner) collectCommitments(
 	ctx context.Context,
 	stream <-chan RunnerMessage,
+	contextHash [attempt.MessageDigestLength]byte,
 	includedSet []group.MemberIndex,
 	into map[group.MemberIndex][]byte,
 ) error {
@@ -304,13 +321,21 @@ func (r *interactiveSigningRunner) collectCommitments(
 		case <-ctx.Done():
 			return ctx.Err()
 		case msg := <-stream:
+			// Ignore messages for another attempt (the bus may carry several),
+			// from non-included senders, and a sender already collected. Round-1
+			// commitments are unsigned; a spoofed commitment for a member is
+			// caught engine-side at Round2, which byte-checks the member's own
+			// commitment against the package.
+			if msg.Attempt != contextHash {
+				continue
+			}
 			if _, want := included[msg.Sender]; !want {
 				continue
 			}
 			if _, have := into[msg.Sender]; have {
 				continue
 			}
-			into[msg.Sender] = msg.Payload
+			into[msg.Sender] = append([]byte(nil), msg.Payload...)
 		}
 	}
 	return nil
@@ -322,24 +347,47 @@ func (r *interactiveSigningRunner) collectCommitments(
 func (r *interactiveSigningRunner) collectShares(
 	ctx context.Context,
 	stream <-chan RunnerMessage,
-	need int,
+	contextHash [attempt.MessageDigestLength]byte,
+	includedSet []group.MemberIndex,
 	into map[group.MemberIndex][]byte,
 ) error {
-	for len(into) < need {
+	included := setOf(includedSet)
+	for len(into) < len(included) {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case msg := <-stream:
+			if msg.Attempt != contextHash {
+				continue
+			}
+			if _, want := included[msg.Sender]; !want {
+				continue
+			}
 			if _, have := into[msg.Sender]; have {
 				continue
 			}
 			var sub roast.ShareSubmission
 			if err := sub.Unmarshal(msg.Payload); err != nil {
-				// A malformed peer submission is not fatal to collection; skip it
-				// (blame for it is the sad path's concern, not the happy flow).
 				continue
 			}
-			into[sub.SubmitterID()] = append([]byte(nil), sub.SignatureShare...)
+			// Bind the authenticated transport sender to the claimed submitter:
+			// a node embedding another member's id would otherwise fill that
+			// honest member's slot with garbage, drop their real share, and get
+			// them falsely blamed.
+			if sub.SubmitterID() != msg.Sender {
+				continue
+			}
+			// Authenticate + retain via the collector. Only an ACCEPTED share
+			// (operator-sig valid, binds the elected coordinator AND the
+			// authoritative package) counts toward aggregation; a divergent or
+			// conflicting share is retained for the blame path but not counted
+			// (ErrShareRetainedNotAccepted / ErrShareConflict), and an
+			// unauthenticated one is dropped. Retaining peer shares here is also
+			// what lets the blame path corroborate engine culprits.
+			if err := r.collector.RecordShareSubmission(&sub); err != nil {
+				continue
+			}
+			into[msg.Sender] = append([]byte(nil), sub.SignatureShare...)
 		}
 	}
 	return nil
@@ -406,6 +454,17 @@ func toFrostSignatureShares(shares map[group.MemberIndex][]byte) []nativeFROSTSi
 // engine ignores it); here it is a stable, distinct-per-member placeholder.
 func memberFrostIdentifier(member group.MemberIndex) string {
 	return fmt.Sprintf("%d", member)
+}
+
+// taprootRootMatches reports whether a received package's taproot root equals
+// the bound session root, honoring key-path (nil bound root <-> empty package
+// root) semantics.
+func (r *interactiveSigningRunner) taprootRootMatches(packageRoot []byte) bool {
+	bound := r.attempt.TaprootMerkleRoot()
+	if bound == nil {
+		return len(packageRoot) == 0
+	}
+	return bytes.Equal(packageRoot, bound[:])
 }
 
 func memberInSet(member group.MemberIndex, set []group.MemberIndex) bool {

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -415,10 +415,21 @@ func (r *interactiveSigningRunner) collectShares(
 
 // nativeAttemptContext maps the binding's RFC-21 attempt context to the engine's
 // wire shape. AttemptNumber stays 0-based (the bridge converts to the 1-based
-// wire value). The included-participants fingerprint and attempt id are derived
-// here as stable placeholders; their exact engine-valid derivation is finalized
-// when the real cgo engine is wired (the fake engine ignores them, and the
-// runner drives subsequent rounds with the attempt id the engine RETURNS).
+// wire value).
+//
+// IncludedParticipantsFingerprint and AttemptID are PLACEHOLDERS, inert here:
+// the only engine #4076 wires is the fake, which ignores them, and no production
+// path constructs the real cgo engine yet. They are NOT engine-valid. Strict-mode
+// validate_attempt_context (engine roast.rs) recomputes both from canonical
+// inputs and rejects a mismatch before round 1:
+//   - fingerprint := roast_included_participants_fingerprint_hex(participants)
+//     (domain-separated hash of the framed u16 set), and
+//   - attempt_id   := roast_attempt_id_hex(session_id, message_digest_hex,
+//     attempt_number, coordinator_id, fingerprint_hex).
+// Producing these byte-for-byte is a cross-impl derivation (the seed-divergence
+// class of bug); deriving-in-Go vs exposing-from-engine is the open design fork
+// for the real-engine attempt-context wiring increment. The runner already drives
+// subsequent rounds with the attempt id the engine RETURNS, not this field.
 func nativeAttemptContext(binding *ActiveRoastAttempt) NativeInteractiveAttemptContext {
 	ctx := binding.Context()
 	included := make([]uint16, 0, len(ctx.IncludedSet))
@@ -469,9 +480,17 @@ func toFrostSignatureShares(shares map[group.MemberIndex][]byte) []nativeFROSTSi
 	return out
 }
 
-// memberFrostIdentifier maps a Go member index to the FROST identifier string
-// the engine expects. The exact encoding is finalized at cgo wiring (the fake
-// engine ignores it); here it is a stable, distinct-per-member placeholder.
+// memberFrostIdentifier maps a Go member index to the FROST identifier the
+// engine keys signing-package commitments and signature shares by.
+//
+// This decimal form is a PLACEHOLDER, inert against the fake (which ignores it)
+// and never reaching the real engine in #4076. The engine's canonical encoding
+// (codec.rs participant_identifier_to_frost_identifier + frost_identifier_to_go_string)
+// is the u16 serialized as the secp256k1 scalar - 32-byte big-endian - hex
+// encoded; the real engine deserializes exactly that to build the
+// BTreeMap<Identifier, _> in the FROST signing package, so "1" would not match
+// the member's key share. Replaced with the canonical encoding in the
+// real-engine wiring increment.
 func memberFrostIdentifier(member group.MemberIndex) string {
 	return fmt.Sprintf("%d", member)
 }

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -25,15 +25,18 @@ import (
 // node records its OWN produced share into the collector explicitly rather than
 // relying on bus self-echo.
 type interactiveSigningRunner struct {
-	attempt     *ActiveRoastAttempt
-	member      group.MemberIndex
-	message     []byte
-	threshold   uint16
-	engine      interactiveSigningEngine
-	collector   *roast.Round2Collector
-	coordinator roast.Coordinator
-	signer      roast.Signer
-	bus         RunnerBus
+	attempt *ActiveRoastAttempt
+	member  group.MemberIndex
+	// messageDigest is the message FROST signs: the binding's MessageDigest, NOT
+	// a separate caller parameter, so the runner can never open/aggregate a
+	// message inconsistent with the attempt it is bound to.
+	messageDigest []byte
+	threshold     uint16
+	engine        interactiveSigningEngine
+	collector     *roast.Round2Collector
+	coordinator   roast.Coordinator
+	signer        roast.Signer
+	bus           RunnerBus
 	// sub is established at construction (before any Run broadcasts) so a node
 	// never misses a peer message broadcast before it subscribed.
 	sub *RunnerBusSubscriber
@@ -42,7 +45,6 @@ type interactiveSigningRunner struct {
 func newInteractiveSigningRunner(
 	attempt *ActiveRoastAttempt,
 	member group.MemberIndex,
-	message []byte,
 	threshold uint16,
 	engine interactiveSigningEngine,
 	collector *roast.Round2Collector,
@@ -65,25 +67,28 @@ func newInteractiveSigningRunner(
 		return nil, fmt.Errorf("roast runner: bus is nil")
 	case threshold == 0:
 		return nil, fmt.Errorf("roast runner: threshold is zero")
-	case len(message) == 0:
-		return nil, fmt.Errorf("roast runner: message is empty")
 	}
-	if !memberInSet(member, attempt.Context().IncludedSet) {
+	attemptCtx := attempt.Context()
+	if !memberInSet(member, attemptCtx.IncludedSet) {
 		return nil, fmt.Errorf(
 			"roast runner: member %d is not in the attempt's included set", member,
 		)
 	}
+	// The signed message is the binding's MessageDigest, derived here rather than
+	// accepted as a parameter: a caller-supplied message that diverged from the
+	// digest the attempt (and its package/share envelopes) is bound to could mark
+	// an attempt for digest A succeeded with a signature over digest B.
 	return &interactiveSigningRunner{
-		attempt:     attempt,
-		member:      member,
-		message:     append([]byte(nil), message...),
-		threshold:   threshold,
-		engine:      engine,
-		collector:   collector,
-		coordinator: coordinator,
-		signer:      signer,
-		bus:         bus,
-		sub:         bus.Subscribe(),
+		attempt:       attempt,
+		member:        member,
+		messageDigest: append([]byte(nil), attemptCtx.MessageDigest[:]...),
+		threshold:     threshold,
+		engine:        engine,
+		collector:     collector,
+		coordinator:   coordinator,
+		signer:        signer,
+		bus:           bus,
+		sub:           bus.Subscribe(),
 	}, nil
 }
 
@@ -103,7 +108,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	open, err := r.engine.InteractiveSessionOpen(
 		binding.SessionID(),
 		uint16(r.member),
-		r.message,
+		r.messageDigest,
 		attemptCtx.KeyGroupID,
 		r.threshold,
 		binding.TaprootMerkleRoot(),
@@ -113,6 +118,18 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("roast runner: open session: %w", err)
 	}
 	attemptID := open.AttemptID
+
+	// Once the session is open the engine holds this attempt's secret nonces and
+	// session state. On any early exit (ctx cancel, or an error before round 2
+	// consumes the nonces) abort so the engine drops that material; a clean
+	// success clears the flag first. Best-effort - a failing abort must not mask
+	// the run's real outcome.
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			_, _ = r.engine.InteractiveSessionAbort(binding.SessionID(), &attemptID)
+		}
+	}()
 
 	// 2. Begin collecting evidence for this attempt (elected coordinator from the
 	// binding, not a peer).
@@ -196,6 +213,9 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	if err := r.coordinator.MarkSucceeded(binding.Handle()); err != nil {
 		return nil, fmt.Errorf("roast runner: mark succeeded: %w", err)
 	}
+	// Aggregation consumed the nonces and the attempt is finalized; suppress the
+	// deferred abort.
+	succeeded = true
 	return signature, nil
 }
 
@@ -232,7 +252,7 @@ func (r *interactiveSigningRunner) obtainSigningPackage(
 		}
 	}
 
-	frostPackage, err := r.engine.NewSigningPackage(r.message, toFrostCommitments(commitments, includedSet))
+	frostPackage, err := r.engine.NewSigningPackage(r.messageDigest, toFrostCommitments(commitments, includedSet))
 	if err != nil {
 		return nil, fmt.Errorf("roast runner: new signing package: %w", err)
 	}

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -1,0 +1,426 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// interactiveSigningRunner drives one node's participation in ONE interactive
+// signing attempt over a RunnerBus: round-1 commitments, the coordinator's
+// signing package, round-2 shares, and aggregation - terminating in
+// MarkSucceeded + the BIP-340 signature on the happy path. The blame path (on
+// an aggregate share-verification failure) lands separately.
+//
+// Every value the runner consumes for engine/collector calls is derived from
+// the immutable ActiveRoastAttempt binding, never from peer messages, and the
+// node records its OWN produced share into the collector explicitly rather than
+// relying on bus self-echo.
+type interactiveSigningRunner struct {
+	attempt     *ActiveRoastAttempt
+	member      group.MemberIndex
+	message     []byte
+	threshold   uint16
+	engine      interactiveSigningEngine
+	collector   *roast.Round2Collector
+	coordinator roast.Coordinator
+	signer      roast.Signer
+	bus         RunnerBus
+	// sub is established at construction (before any Run broadcasts) so a node
+	// never misses a peer message broadcast before it subscribed.
+	sub *RunnerBusSubscriber
+}
+
+func newInteractiveSigningRunner(
+	attempt *ActiveRoastAttempt,
+	member group.MemberIndex,
+	message []byte,
+	threshold uint16,
+	engine interactiveSigningEngine,
+	collector *roast.Round2Collector,
+	coordinator roast.Coordinator,
+	signer roast.Signer,
+	bus RunnerBus,
+) (*interactiveSigningRunner, error) {
+	switch {
+	case attempt == nil:
+		return nil, fmt.Errorf("roast runner: active attempt is nil")
+	case engine == nil:
+		return nil, fmt.Errorf("roast runner: engine is nil")
+	case collector == nil:
+		return nil, fmt.Errorf("roast runner: collector is nil")
+	case coordinator == nil:
+		return nil, fmt.Errorf("roast runner: coordinator is nil")
+	case signer == nil:
+		return nil, fmt.Errorf("roast runner: signer is nil")
+	case bus == nil:
+		return nil, fmt.Errorf("roast runner: bus is nil")
+	case threshold == 0:
+		return nil, fmt.Errorf("roast runner: threshold is zero")
+	case len(message) == 0:
+		return nil, fmt.Errorf("roast runner: message is empty")
+	}
+	if !memberInSet(member, attempt.Context().IncludedSet) {
+		return nil, fmt.Errorf(
+			"roast runner: member %d is not in the attempt's included set", member,
+		)
+	}
+	return &interactiveSigningRunner{
+		attempt:     attempt,
+		member:      member,
+		message:     append([]byte(nil), message...),
+		threshold:   threshold,
+		engine:      engine,
+		collector:   collector,
+		coordinator: coordinator,
+		signer:      signer,
+		bus:         bus,
+		sub:         bus.Subscribe(),
+	}, nil
+}
+
+// Run executes the happy-path interactive signing flow for this node and
+// returns the aggregated signature on success. It subscribes to the bus before
+// broadcasting so no peer message is missed, and honors ctx cancellation while
+// collecting commitments and shares.
+func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
+	binding := r.attempt
+	attemptCtx := binding.Context()
+	includedSet := attemptCtx.IncludedSet
+	contextHash := binding.ContextHash()
+	elected := binding.ElectedCoordinator()
+
+	// 1. Open the interactive session; the engine returns the attempt id used
+	// for every subsequent round.
+	open, err := r.engine.InteractiveSessionOpen(
+		binding.SessionID(),
+		uint16(r.member),
+		r.message,
+		attemptCtx.KeyGroupID,
+		r.threshold,
+		binding.TaprootMerkleRoot(),
+		nativeAttemptContext(binding),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: open session: %w", err)
+	}
+	attemptID := open.AttemptID
+
+	// 2. Begin collecting evidence for this attempt (elected coordinator from the
+	// binding, not a peer).
+	if err := r.collector.BeginAttempt(contextHash[:], elected, includedSet); err != nil {
+		return nil, fmt.Errorf("roast runner: collector begin attempt: %w", err)
+	}
+
+	// 3. Round 1: our commitments, broadcast to the group (own kept locally).
+	ownCommitments, err := r.engine.InteractiveRound1(binding.SessionID(), attemptID, uint16(r.member))
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: round 1: %w", err)
+	}
+	r.broadcast(RunnerMsgCommitments, contextHash, ownCommitments)
+
+	// 4. Collect every included member's commitments.
+	commitments := map[group.MemberIndex][]byte{r.member: ownCommitments}
+	if err := r.collectCommitments(ctx, r.sub.Commitments(), includedSet, commitments); err != nil {
+		return nil, fmt.Errorf("roast runner: collect commitments: %w", err)
+	}
+
+	// 5. The elected coordinator builds, signs, and broadcasts the signing
+	// package; everyone else awaits it.
+	signingPackageEnvelope, err := r.obtainSigningPackage(ctx, r.sub.SigningPackages(), elected, contextHash, commitments, includedSet)
+	if err != nil {
+		return nil, err
+	}
+	pkg := &roast.SigningPackage{}
+	if err := pkg.Unmarshal(signingPackageEnvelope); err != nil {
+		return nil, fmt.Errorf("roast runner: unmarshal signing package: %w", err)
+	}
+	// Authenticate + retain the coordinator-signed package (Q1 boundary lives in
+	// the collector, not here).
+	if err := r.collector.RecordSigningPackage(pkg); err != nil {
+		return nil, fmt.Errorf("roast runner: record signing package: %w", err)
+	}
+
+	// 6. Round 2: our signature share, recorded locally and broadcast.
+	ownShare, err := r.engine.InteractiveRound2(binding.SessionID(), attemptID, uint16(r.member), pkg.SigningPackageBytes)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: round 2: %w", err)
+	}
+	ownSubmission, ownSubmissionEnvelope, err := r.signShareSubmission(pkg, contextHash, elected, ownShare)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.collector.RecordShareSubmission(ownSubmission); err != nil {
+		return nil, fmt.Errorf("roast runner: record own share submission: %w", err)
+	}
+	r.broadcast(RunnerMsgShareSubmission, contextHash, ownSubmissionEnvelope)
+
+	// 7. Collect a share from every signer in the package (own already in), as
+	// inner FROST share bytes. The package was built from the whole responsive
+	// included set, so the aggregate needs a share from each of them (silent-
+	// member subsetting is the retry path's concern, not the happy flow).
+	shares := map[group.MemberIndex][]byte{r.member: ownShare}
+	if err := r.collectShares(ctx, r.sub.Shares(), len(includedSet), shares); err != nil {
+		return nil, fmt.Errorf("roast runner: collect shares: %w", err)
+	}
+
+	// 8. Aggregate. A share-verification failure surfaces the typed error with
+	// candidate culprits for the (separate) blame path.
+	signature, err := r.engine.InteractiveAggregate(
+		binding.SessionID(),
+		attemptID,
+		pkg.SigningPackageBytes,
+		toFrostSignatureShares(shares),
+		binding.TaprootMerkleRoot(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: aggregate: %w", err)
+	}
+
+	// 9. Mark the attempt succeeded so the cleanup path produces no transition
+	// bundle for a completed attempt.
+	if err := r.coordinator.MarkSucceeded(binding.Handle()); err != nil {
+		return nil, fmt.Errorf("roast runner: mark succeeded: %w", err)
+	}
+	return signature, nil
+}
+
+func (r *interactiveSigningRunner) broadcast(t RunnerMessageType, attempt [attempt.MessageDigestLength]byte, payload []byte) {
+	r.bus.Broadcast(RunnerMessage{Type: t, Sender: r.member, Attempt: attempt, Payload: payload})
+}
+
+// obtainSigningPackage returns the attempt's signing-package envelope: built and
+// broadcast locally when this node is the elected coordinator, or awaited from
+// the bus otherwise.
+func (r *interactiveSigningRunner) obtainSigningPackage(
+	ctx context.Context,
+	stream <-chan RunnerMessage,
+	elected group.MemberIndex,
+	contextHash [attempt.MessageDigestLength]byte,
+	commitments map[group.MemberIndex][]byte,
+	includedSet []group.MemberIndex,
+) ([]byte, error) {
+	if r.member != elected {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case msg := <-stream:
+			return msg.Payload, nil
+		}
+	}
+
+	frostPackage, err := r.engine.NewSigningPackage(r.message, toFrostCommitments(commitments, includedSet))
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: new signing package: %w", err)
+	}
+	envelope, err := r.signSigningPackage(contextHash, elected, frostPackage)
+	if err != nil {
+		return nil, err
+	}
+	r.broadcast(RunnerMsgSigningPackage, contextHash, envelope)
+	return envelope, nil
+}
+
+func (r *interactiveSigningRunner) signSigningPackage(
+	contextHash [attempt.MessageDigestLength]byte,
+	elected group.MemberIndex,
+	frostPackage []byte,
+) ([]byte, error) {
+	pkg := &roast.SigningPackage{
+		AttemptContextHash:  append([]byte(nil), contextHash[:]...),
+		CoordinatorIDValue:  uint32(elected),
+		SigningPackageBytes: frostPackage,
+	}
+	if root := r.attempt.TaprootMerkleRoot(); root != nil {
+		pkg.TaprootMerkleRoot = append([]byte(nil), root[:]...)
+	}
+	payload, err := pkg.SignableBytes()
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: signing package signable bytes: %w", err)
+	}
+	sig, err := r.signer.Sign(payload)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: sign signing package: %w", err)
+	}
+	pkg.CoordinatorSignature = sig
+	envelope, err := pkg.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: marshal signing package: %w", err)
+	}
+	return envelope, nil
+}
+
+func (r *interactiveSigningRunner) signShareSubmission(
+	pkg *roast.SigningPackage,
+	contextHash [attempt.MessageDigestLength]byte,
+	elected group.MemberIndex,
+	share []byte,
+) (*roast.ShareSubmission, []byte, error) {
+	packageHash, err := pkg.BodyHash()
+	if err != nil {
+		return nil, nil, fmt.Errorf("roast runner: signing package body hash: %w", err)
+	}
+	sub := &roast.ShareSubmission{
+		AttemptContextHash: append([]byte(nil), contextHash[:]...),
+		SubmitterIDValue:   uint32(r.member),
+		CoordinatorIDValue: uint32(elected),
+		SigningPackageHash: append([]byte(nil), packageHash[:]...),
+		SignatureShare:     append([]byte(nil), share...),
+	}
+	payload, err := sub.SignableBytes()
+	if err != nil {
+		return nil, nil, fmt.Errorf("roast runner: share submission signable bytes: %w", err)
+	}
+	sig, err := r.signer.Sign(payload)
+	if err != nil {
+		return nil, nil, fmt.Errorf("roast runner: sign share submission: %w", err)
+	}
+	sub.SubmitterSignature = sig
+	envelope, err := sub.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("roast runner: marshal share submission: %w", err)
+	}
+	return sub, envelope, nil
+}
+
+// collectCommitments fills `into` with every included member's commitments
+// (own already seeded), taking the first body per sender.
+func (r *interactiveSigningRunner) collectCommitments(
+	ctx context.Context,
+	stream <-chan RunnerMessage,
+	includedSet []group.MemberIndex,
+	into map[group.MemberIndex][]byte,
+) error {
+	included := setOf(includedSet)
+	for len(into) < len(included) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg := <-stream:
+			if _, want := included[msg.Sender]; !want {
+				continue
+			}
+			if _, have := into[msg.Sender]; have {
+				continue
+			}
+			into[msg.Sender] = msg.Payload
+		}
+	}
+	return nil
+}
+
+// collectShares fills `into` with at least `need` members' inner FROST share
+// bytes (own already seeded), unwrapping each ShareSubmission envelope and
+// taking the first accepted body per sender.
+func (r *interactiveSigningRunner) collectShares(
+	ctx context.Context,
+	stream <-chan RunnerMessage,
+	need int,
+	into map[group.MemberIndex][]byte,
+) error {
+	for len(into) < need {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg := <-stream:
+			if _, have := into[msg.Sender]; have {
+				continue
+			}
+			var sub roast.ShareSubmission
+			if err := sub.Unmarshal(msg.Payload); err != nil {
+				// A malformed peer submission is not fatal to collection; skip it
+				// (blame for it is the sad path's concern, not the happy flow).
+				continue
+			}
+			into[sub.SubmitterID()] = append([]byte(nil), sub.SignatureShare...)
+		}
+	}
+	return nil
+}
+
+// nativeAttemptContext maps the binding's RFC-21 attempt context to the engine's
+// wire shape. AttemptNumber stays 0-based (the bridge converts to the 1-based
+// wire value). The included-participants fingerprint and attempt id are derived
+// here as stable placeholders; their exact engine-valid derivation is finalized
+// when the real cgo engine is wired (the fake engine ignores them, and the
+// runner drives subsequent rounds with the attempt id the engine RETURNS).
+func nativeAttemptContext(binding *ActiveRoastAttempt) NativeInteractiveAttemptContext {
+	ctx := binding.Context()
+	included := make([]uint16, 0, len(ctx.IncludedSet))
+	for _, m := range ctx.IncludedSet {
+		included = append(included, uint16(m))
+	}
+	hash := binding.ContextHash()
+	return NativeInteractiveAttemptContext{
+		AttemptNumber:                   ctx.AttemptNumber,
+		CoordinatorIdentifier:           uint16(binding.ElectedCoordinator()),
+		IncludedParticipants:            included,
+		IncludedParticipantsFingerprint: hex.EncodeToString(includedSetFingerprint(ctx.IncludedSet)),
+		AttemptID:                       hex.EncodeToString(hash[:]),
+	}
+}
+
+func includedSetFingerprint(includedSet []group.MemberIndex) []byte {
+	h := sha256.New()
+	for _, m := range includedSet {
+		h.Write([]byte{byte(m)})
+	}
+	return h.Sum(nil)
+}
+
+func toFrostCommitments(commitments map[group.MemberIndex][]byte, includedSet []group.MemberIndex) []nativeFROSTCommitment {
+	out := make([]nativeFROSTCommitment, 0, len(includedSet))
+	for _, m := range includedSet {
+		data, ok := commitments[m]
+		if !ok {
+			continue
+		}
+		out = append(out, nativeFROSTCommitment{
+			Identifier: memberFrostIdentifier(m),
+			Data:       append([]byte(nil), data...),
+		})
+	}
+	return out
+}
+
+func toFrostSignatureShares(shares map[group.MemberIndex][]byte) []nativeFROSTSignatureShare {
+	out := make([]nativeFROSTSignatureShare, 0, len(shares))
+	for m, data := range shares {
+		out = append(out, nativeFROSTSignatureShare{
+			Identifier: memberFrostIdentifier(m),
+			Data:       append([]byte(nil), data...),
+		})
+	}
+	return out
+}
+
+// memberFrostIdentifier maps a Go member index to the FROST identifier string
+// the engine expects. The exact encoding is finalized at cgo wiring (the fake
+// engine ignores it); here it is a stable, distinct-per-member placeholder.
+func memberFrostIdentifier(member group.MemberIndex) string {
+	return fmt.Sprintf("%d", member)
+}
+
+func memberInSet(member group.MemberIndex, set []group.MemberIndex) bool {
+	for _, m := range set {
+		if m == member {
+			return true
+		}
+	}
+	return false
+}
+
+func setOf(members []group.MemberIndex) map[group.MemberIndex]struct{} {
+	out := make(map[group.MemberIndex]struct{}, len(members))
+	for _, m := range members {
+		out[m] = struct{}{}
+	}
+	return out
+}

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -264,6 +264,19 @@ func (r *interactiveSigningRunner) obtainSigningPackage(
 				if msg.Attempt != contextHash || msg.Sender != elected {
 					continue
 				}
+				// Trust the SIGNED attempt hash, not just the unsigned outer bus
+				// field. A package the coordinator legitimately signed for ANOTHER
+				// attempt, rewrapped in a current-attempt message, must not drive
+				// this flow - it could be recorded/authenticated under that other
+				// attempt (if live in this shared collector) and we would sign the
+				// wrong package. Keep waiting for the package signed for THIS attempt.
+				pkg := &roast.SigningPackage{}
+				if err := pkg.Unmarshal(msg.Payload); err != nil {
+					continue
+				}
+				if !bytes.Equal(pkg.AttemptContextHash, contextHash[:]) {
+					continue
+				}
 				return append([]byte(nil), msg.Payload...), nil
 			}
 		}
@@ -445,6 +458,14 @@ func (r *interactiveSigningRunner) recordShareMessage(
 	if sub.SubmitterID() != msg.Sender {
 		return
 	}
+	// Trust the SIGNED attempt hash, not just the unsigned outer bus field. The
+	// collector keys RecordShareSubmission by sub.AttemptContextHash, so a share
+	// the submitter signed for ANOTHER attempt - rewrapped in a current-attempt
+	// message - would be recorded under that attempt (accepted, returning nil if
+	// it is live in this shared collector) and counted toward THIS aggregate.
+	if !bytes.Equal(sub.AttemptContextHash, contextHash[:]) {
+		return
+	}
 	recordErr := r.collector.RecordShareSubmission(&sub)
 	if _, have := into[msg.Sender]; have {
 		return
@@ -477,6 +498,12 @@ func (r *interactiveSigningRunner) recordBufferedCoordinatorPackages(
 			}
 			pkg := &roast.SigningPackage{}
 			if err := pkg.Unmarshal(msg.Payload); err != nil {
+				continue
+			}
+			// Signed attempt hash, not the unsigned outer field (see
+			// obtainSigningPackage): never record a package signed for another
+			// attempt under it via this attempt's drain.
+			if !bytes.Equal(pkg.AttemptContextHash, contextHash[:]) {
 				continue
 			}
 			_ = r.collector.RecordSigningPackage(pkg)

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -399,12 +399,12 @@ func (r *interactiveSigningRunner) collectShares(
 		}
 	}
 	// `into` is full, but the slot-filling share may have body-different
-	// duplicates already queued behind it on the stream. Drain and record them
-	// before Run aggregates and prunes the collector, else that queued member-
-	// equivocation evidence is lost (same rationale as the coordinator-package
-	// drain). Non-blocking and buffer-bounded; late arrivals are the blame path's
-	// concern.
-	for {
+	// duplicates already queued behind it on the stream. Record ONLY those
+	// buffered at entry: the bound is the queue length now, so a peer that keeps
+	// the stream non-empty (e.g. flooding body-different shares) cannot starve a
+	// receive-until-empty loop and livelock the drain, stalling aggregation. Late
+	// arrivals are the blame path's concern.
+	for i, n := 0, len(stream); i < n; i++ {
 		select {
 		case msg := <-stream:
 			r.recordShareMessage(msg, contextHash, included, into)
@@ -412,6 +412,7 @@ func (r *interactiveSigningRunner) collectShares(
 			return nil
 		}
 	}
+	return nil
 }
 
 // recordShareMessage validates a share-submission bus message, retains it in the
@@ -454,20 +455,21 @@ func (r *interactiveSigningRunner) recordShareMessage(
 	into[msg.Sender] = append([]byte(nil), sub.SignatureShare...)
 }
 
-// recordBufferedCoordinatorPackages drains every signing package the elected
-// coordinator has already broadcast for this attempt and records each, so the
-// collector can surface coordinator equivocation. The caller MUST have recorded
-// the authoritative package first, so a body-different one here records as the
-// conflicting package (not the authoritative). Non-blocking: it retains the
-// duplicates already buffered; continuous monitoring across a real transport is
-// the blame path's concern. RecordSigningPackage authenticates the coordinator
-// signature, so a forged-sender package is rejected rather than retained.
+// recordBufferedCoordinatorPackages records the signing packages the elected
+// coordinator has already broadcast for this attempt that are buffered at entry,
+// so the collector can surface coordinator equivocation. The caller MUST have
+// recorded the authoritative package first, so a body-different one here records
+// as the conflicting package (not the authoritative). Bounded by the queue
+// length at entry so a flooding peer cannot livelock a receive-until-empty loop;
+// continuous monitoring across a real transport is the blame path's concern.
+// RecordSigningPackage authenticates the coordinator signature, so a
+// forged-sender package is rejected rather than retained.
 func (r *interactiveSigningRunner) recordBufferedCoordinatorPackages(
 	stream <-chan RunnerMessage,
 	elected group.MemberIndex,
 	contextHash [attempt.MessageDigestLength]byte,
 ) {
-	for {
+	for i, n := 0, len(stream); i < n; i++ {
 		select {
 		case msg := <-stream:
 			if msg.Attempt != contextHash || msg.Sender != elected {

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -24,6 +24,23 @@ import (
 // the immutable ActiveRoastAttempt binding, never from peer messages, and the
 // node records its OWN produced share into the collector explicitly rather than
 // relying on bus self-echo.
+//
+// Transport assumptions - the in-process test bus meets the first; the real
+// pkg/net transport MUST meet both:
+//  1. RunnerMessage.Sender is the AUTHENTICATED peer identity. The sender==elected
+//     and SubmitterID==Sender filters, and per-member commitment slotting, are
+//     only as sound as that authentication.
+//  2. Delivery must not let a slow or flooding peer block an honest broadcaster
+//     indefinitely. The runner does not fully drain every stream - it bounds the
+//     equivocation drains, and the coordinator never reads its own package
+//     stream - so the transport must apply backpressure or drop, never block
+//     forever, on an undrained or oversubscribed stream.
+//
+// Round-1 commitments are unsigned: with authenticated senders the worst case is
+// a member's own bad or equivocated commitment, which surfaces as a round-2
+// mismatch and retry, never a cross-member poison or signing breach. Blaming
+// commitment equivocation would need signed commitments - a protocol decision
+// for the design consult.
 type interactiveSigningRunner struct {
 	attempt *ActiveRoastAttempt
 	member  group.MemberIndex

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -172,6 +172,16 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	if err := r.collector.RecordSigningPackage(pkg); err != nil {
 		return nil, fmt.Errorf("roast runner: record signing package: %w", err)
 	}
+	// Retain any FURTHER body-different packages the elected coordinator already
+	// broadcast for this attempt: the authoritative one is recorded above, so
+	// these record as coordinator equivocation (EquivocationKindSigningPackageConflict,
+	// surfaced via CoordinatorPackageProofs). obtainSigningPackage returns on the
+	// first package, so without this the duplicates the bus deliberately preserves
+	// would be lost. Non-coordinators only - the coordinator does not receive its
+	// own broadcast.
+	if r.member != elected {
+		r.recordBufferedCoordinatorPackages(r.sub.SigningPackages(), elected, contextHash)
+	}
 	// Refuse a package whose taproot root diverges from the bound root: signing
 	// Round 2 against it would sign for the WRONG tweak. The package was retained
 	// above as evidence for the blame path; we just must not sign it.
@@ -368,9 +378,11 @@ func (r *interactiveSigningRunner) collectCommitments(
 	return nil
 }
 
-// collectShares fills `into` with at least `need` members' inner FROST share
+// collectShares fills `into` with each included member's inner FROST share
 // bytes (own already seeded), unwrapping each ShareSubmission envelope and
-// taking the first accepted body per sender.
+// counting the first accepted body per sender. Every well-formed share is still
+// passed to the collector for retention, even after a sender's first - that is
+// where member equivocation is detected.
 func (r *interactiveSigningRunner) collectShares(
 	ctx context.Context,
 	stream <-chan RunnerMessage,
@@ -390,9 +402,6 @@ func (r *interactiveSigningRunner) collectShares(
 			if _, want := included[msg.Sender]; !want {
 				continue
 			}
-			if _, have := into[msg.Sender]; have {
-				continue
-			}
 			var sub roast.ShareSubmission
 			if err := sub.Unmarshal(msg.Payload); err != nil {
 				continue
@@ -404,20 +413,60 @@ func (r *interactiveSigningRunner) collectShares(
 			if sub.SubmitterID() != msg.Sender {
 				continue
 			}
-			// Authenticate + retain via the collector. Only an ACCEPTED share
-			// (operator-sig valid, binds the elected coordinator AND the
-			// authoritative package) counts toward aggregation; a divergent or
-			// conflicting share is retained for the blame path but not counted
-			// (ErrShareRetainedNotAccepted / ErrShareConflict), and an
-			// unauthenticated one is dropped. Retaining peer shares here is also
-			// what lets the blame path corroborate engine culprits.
-			if err := r.collector.RecordShareSubmission(&sub); err != nil {
+			// Authenticate + retain via the collector BEFORE the already-collected
+			// short-circuit. A body-different second signed share from a sender is
+			// exactly the member-equivocation evidence the collector is built to
+			// retain and emit (EquivocationKindShareConflict / DivergentShare);
+			// dropping it just because we already hold that sender's first share
+			// would let a double-signer go unrecorded. Retention is bounded (the
+			// collector keeps the first per submitter and only emits on the rest),
+			// and the bus delivers only body-different duplicates.
+			recordErr := r.collector.RecordShareSubmission(&sub)
+			if _, have := into[msg.Sender]; have {
+				continue
+			}
+			// Only an ACCEPTED share (err == nil: operator-sig valid, binds the
+			// elected coordinator AND the authoritative package) counts toward
+			// aggregation; a divergent/conflicting/unauthenticated share is
+			// retained above where applicable but never counted
+			// (ErrShareRetainedNotAccepted / ErrShareConflict / auth failure).
+			if recordErr != nil {
 				continue
 			}
 			into[msg.Sender] = append([]byte(nil), sub.SignatureShare...)
 		}
 	}
 	return nil
+}
+
+// recordBufferedCoordinatorPackages drains every signing package the elected
+// coordinator has already broadcast for this attempt and records each, so the
+// collector can surface coordinator equivocation. The caller MUST have recorded
+// the authoritative package first, so a body-different one here records as the
+// conflicting package (not the authoritative). Non-blocking: it retains the
+// duplicates already buffered; continuous monitoring across a real transport is
+// the blame path's concern. RecordSigningPackage authenticates the coordinator
+// signature, so a forged-sender package is rejected rather than retained.
+func (r *interactiveSigningRunner) recordBufferedCoordinatorPackages(
+	stream <-chan RunnerMessage,
+	elected group.MemberIndex,
+	contextHash [attempt.MessageDigestLength]byte,
+) {
+	for {
+		select {
+		case msg := <-stream:
+			if msg.Attempt != contextHash || msg.Sender != elected {
+				continue
+			}
+			pkg := &roast.SigningPackage{}
+			if err := pkg.Unmarshal(msg.Payload); err != nil {
+				continue
+			}
+			_ = r.collector.RecordSigningPackage(pkg)
+		default:
+			return
+		}
+	}
 }
 
 // nativeAttemptContext maps the binding's RFC-21 attempt context to the engine's

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -119,13 +119,20 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	}
 	attemptID := open.AttemptID
 
-	// Once the session is open the engine holds this attempt's secret nonces and
-	// session state. On any early exit (ctx cancel, or an error before round 2
-	// consumes the nonces) abort so the engine drops that material; a clean
-	// success clears the flag first. Best-effort - a failing abort must not mask
-	// the run's real outcome.
+	// Cleanup on conclusion - the attempt concludes for this runner on any exit:
+	//   - Always prune this attempt's round-2 collector state, per the collector's
+	//     prune-on-conclusion contract. A collector reused across attempts would
+	//     otherwise retain every concluded attempt's package/share envelopes
+	//     indefinitely. A no-op if the attempt was never begun, and (when the
+	//     blame path lands) it extracts its evidence into the transition bundle
+	//     within Run, before this defer fires.
+	//   - On an EARLY exit only (ctx cancel, or an error before round 2 consumed
+	//     the nonces) abort the engine session so it drops this attempt's resident
+	//     secret nonces; a clean success consumed them and clears the flag first.
+	// Both are best-effort: they must not mask the run's real outcome.
 	succeeded := false
 	defer func() {
+		r.collector.PruneAttempt(contextHash[:])
 		if !succeeded {
 			_, _ = r.engine.InteractiveSessionAbort(binding.SessionID(), &attemptID)
 		}
@@ -426,6 +433,7 @@ func (r *interactiveSigningRunner) collectShares(
 //     (domain-separated hash of the framed u16 set), and
 //   - attempt_id   := roast_attempt_id_hex(session_id, message_digest_hex,
 //     attempt_number, coordinator_id, fingerprint_hex).
+//
 // Producing these byte-for-byte is a cross-impl derivation (the seed-divergence
 // class of bug); deriving-in-Go vs exposing-from-engine is the open design fork
 // for the real-engine attempt-context wiring increment. The runner already drives

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -119,23 +119,25 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	}
 	attemptID := open.AttemptID
 
-	// Cleanup on conclusion - the attempt concludes for this runner on any exit:
-	//   - Always prune this attempt's round-2 collector state, per the collector's
-	//     prune-on-conclusion contract. A collector reused across attempts would
-	//     otherwise retain every concluded attempt's package/share envelopes
-	//     indefinitely. A no-op if the attempt was never begun, and (when the
-	//     blame path lands) it extracts its evidence into the transition bundle
-	//     within Run, before this defer fires.
-	//   - On an EARLY exit only (ctx cancel, or an error before round 2 consumed
-	//     the nonces) abort the engine session so it drops this attempt's resident
-	//     secret nonces; a clean success consumed them and clears the flag first.
-	// Both are best-effort: they must not mask the run's real outcome.
+	// Cleanup on conclusion, by outcome:
+	//   - SUCCESS: prune this attempt's round-2 collector state per the
+	//     prune-on-conclusion contract (nothing needs it), so a collector reused
+	//     across attempts does not retain concluded attempts indefinitely.
+	//   - FAILURE / early exit: abort the engine session so it drops this
+	//     attempt's resident secret nonces, but do NOT prune the collector. A
+	//     failure path (the root-divergence return below, or - once it lands - an
+	//     aggregate share-verification failure) retains signed evidence that the
+	//     blame/retry path must still read via CoordinatorPackageProofs /
+	//     ClassifyCandidateCulprits; the caller prunes after snapshotting or
+	//     propagating it.
+	// Best-effort: neither may mask the run's real outcome.
 	succeeded := false
 	defer func() {
-		r.collector.PruneAttempt(contextHash[:])
-		if !succeeded {
-			_, _ = r.engine.InteractiveSessionAbort(binding.SessionID(), &attemptID)
+		if succeeded {
+			r.collector.PruneAttempt(contextHash[:])
+			return
 		}
+		_, _ = r.engine.InteractiveSessionAbort(binding.SessionID(), &attemptID)
 	}()
 
 	// 2. Begin collecting evidence for this attempt (elected coordinator from the

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -537,6 +537,110 @@ func TestInteractiveSigningRunner_DrainDoesNotLivelockUnderShareFlood(t *testing
 	<-floodDone
 }
 
+// beginSyntheticAttempt makes a second attempt live in the SAME collector, keyed
+// by a synthetic context hash with the given elected coordinator, and records an
+// authoritative package for it - so a cross-attempt test can prove a payload
+// signed for THIS attempt would be accepted here absent the signed-hash guard.
+// Returns that attempt's authoritative package body hash.
+func beginSyntheticAttempt(
+	t *testing.T,
+	collector *roast.Round2Collector,
+	hash [attempt.MessageDigestLength]byte,
+	elected group.MemberIndex,
+	included []group.MemberIndex,
+	signer roast.Signer,
+) [32]byte {
+	t.Helper()
+	if err := collector.BeginAttempt(hash[:], elected, included); err != nil {
+		t.Fatalf("begin synthetic attempt: %v", err)
+	}
+	envelope, bodyHash := craftSigningPackage(t, hash, elected, []byte("authoritative-B"), signer)
+	pkg := &roast.SigningPackage{}
+	if err := pkg.Unmarshal(envelope); err != nil {
+		t.Fatalf("unmarshal synthetic authoritative: %v", err)
+	}
+	if err := collector.RecordSigningPackage(pkg); err != nil {
+		t.Fatalf("record synthetic authoritative: %v", err)
+	}
+	return bodyHash
+}
+
+func recordAuthoritativePackage(
+	t *testing.T,
+	collector *roast.Round2Collector,
+	hash [attempt.MessageDigestLength]byte,
+	elected group.MemberIndex,
+	signer roast.Signer,
+) {
+	t.Helper()
+	envelope, _ := craftSigningPackage(t, hash, elected, []byte("authoritative-A"), signer)
+	pkg := &roast.SigningPackage{}
+	if err := pkg.Unmarshal(envelope); err != nil {
+		t.Fatalf("unmarshal authoritative: %v", err)
+	}
+	if err := collector.RecordSigningPackage(pkg); err != nil {
+		t.Fatalf("record authoritative: %v", err)
+	}
+}
+
+// A share carried in a current-attempt (A) bus message but SIGNED for another
+// live attempt (B) must not be counted toward A - the runner must check the
+// signed AttemptContextHash, not the unsigned outer bus field. Without the
+// guard, the collector records it under B (accepted) and returns nil, so this
+// code would count it toward A.
+func TestInteractiveSigningRunner_RejectsCrossAttemptShare(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	runner, collector, hashA, electedA := buildEquivocationRunner(t, included)
+	signer := fixedTestSigner{}
+	if err := collector.BeginAttempt(hashA[:], electedA, included); err != nil {
+		t.Fatalf("collector begin A: %v", err)
+	}
+	recordAuthoritativePackage(t, collector, hashA, electedA, signer)
+
+	// Attempt B live in the same collector (electedB == electedA so an electedA-
+	// bound payload is acceptable there).
+	hashB := [attempt.MessageDigestLength]byte{0x99}
+	pkgBodyHashB := beginSyntheticAttempt(t, collector, hashB, electedA, included, signer)
+
+	shareForB := craftShareSubmission(t, hashB, 1, electedA, pkgBodyHashB, []byte("share-for-B"), signer)
+	msg := RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 1, Attempt: hashA, Payload: shareForB}
+
+	into := map[group.MemberIndex][]byte{}
+	runner.recordShareMessage(msg, hashA, setOf(included), into)
+	if _, counted := into[1]; counted {
+		t.Fatal("share signed for attempt B was counted toward attempt A")
+	}
+}
+
+// A package carried in a current-attempt (A) bus message but SIGNED for another
+// live attempt (B) must not be recorded by A's buffered-package drain. Without
+// the guard the drain records it under B (a body-different conflict there),
+// emitting a B equivocation event A had no business producing.
+func TestInteractiveSigningRunner_RejectsCrossAttemptPackageInDrain(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	runner, collector, hashA, electedA := buildEquivocationRunner(t, included)
+	signer := fixedTestSigner{}
+	if err := collector.BeginAttempt(hashA[:], electedA, included); err != nil {
+		t.Fatalf("collector begin A: %v", err)
+	}
+	recordAuthoritativePackage(t, collector, hashA, electedA, signer)
+
+	hashB := [attempt.MessageDigestLength]byte{0x99}
+	_ = beginSyntheticAttempt(t, collector, hashB, electedA, included, signer)
+
+	// A body-different package signed for B, rewrapped as a current-attempt (A)
+	// message from electedA.
+	crossEnvelope, _ := craftSigningPackage(t, hashB, electedA, []byte("equivocating-B"), signer)
+	stream := make(chan RunnerMessage, 4)
+	stream <- RunnerMessage{Type: RunnerMsgSigningPackage, Sender: electedA, Attempt: hashA, Payload: crossEnvelope}
+
+	evidence := captureEquivocationEvidence(t)
+	runner.recordBufferedCoordinatorPackages(stream, electedA, hashA)
+	if got := evidence(); len(got) != 0 {
+		t.Fatalf("package signed for attempt B was recorded under it via A's drain: %+v", got)
+	}
+}
+
 func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	// A valid baseline to vary one field at a time.
 	included := []group.MemberIndex{1, 2, 3}

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -20,47 +20,39 @@ type fixedTestSigner struct{}
 
 func (fixedTestSigner) Sign(_ []byte) ([]byte, error) { return []byte{0x01}, nil }
 
-// TestInteractiveSigningRunner_HappyPath wires N nodes - each with its own
-// coordinator, collector, and fake engine - to one shared in-process bus and
-// runs them concurrently. Every node must reach a successful aggregate, emit the
-// signature, and transition its attempt to Succeeded.
-func TestInteractiveSigningRunner_HappyPath(t *testing.T) {
-	const n = 3
-	const threshold = uint16(2)
+type harness struct {
+	bus         RunnerBus
+	runners     []*interactiveSigningRunner
+	coords      []roast.Coordinator
+	handles     []roast.AttemptHandle
+	contextHash [attempt.MessageDigestLength]byte
+	includedSet []group.MemberIndex
+}
 
+// buildInteractiveSigningHarness wires n nodes - each with its own coordinator,
+// collector, and fake engine - to one shared in-process bus. Every node
+// subscribes in its constructor, so all are wired before any Run broadcasts.
+func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harness {
+	t.Helper()
 	included := make([]group.MemberIndex, 0, n)
 	for i := 1; i <= n; i++ {
 		included = append(included, group.MemberIndex(i))
 	}
 	dkgKey := []byte{0x01, 0x02}
 	ctx, err := attempt.NewAttemptContext(
-		"session-1",
-		"key-group-1",
-		dkgKey,
-		[attempt.MessageDigestLength]byte{0x42},
-		0,
-		included,
-		nil,
+		"session-1", "key-group-1", dkgKey,
+		[attempt.MessageDigestLength]byte{0x42}, 0, included, nil,
 	)
 	if err != nil {
 		t.Fatalf("attempt context: %v", err)
 	}
 
 	bus := NewInProcessRunnerBus(256)
-	// A fixed non-empty signature: the wire envelopes' Marshal rejects an empty
-	// signature (so NoOpSigner, which signs nil, cannot be used), while the
-	// accept-anything verifier authenticates it - the runner test exercises the
-	// envelope/signing plumbing but not real operator-key crypto.
 	signer := fixedTestSigner{}
 	verifier := roast.NoOpSignatureVerifier()
 	message := []byte("message-to-sign")
 
-	coords := make([]roast.Coordinator, n)
-	handles := make([]roast.AttemptHandle, n)
-	runners := make([]*interactiveSigningRunner, n)
-
-	// Construct every node (each subscribes to the bus in its constructor)
-	// BEFORE any Run broadcasts, so no node misses a peer's first message.
+	h := harness{bus: bus, contextHash: ctx.Hash(), includedSet: included}
 	for i := 0; i < n; i++ {
 		member := group.MemberIndex(i + 1)
 		coord := roast.NewInMemoryCoordinatorWithSigning(member, signer, verifier)
@@ -73,55 +65,157 @@ func TestInteractiveSigningRunner_HappyPath(t *testing.T) {
 			t.Fatalf("active attempt (member %d): %v", member, err)
 		}
 		runner, err := newInteractiveSigningRunner(
-			ara,
-			member,
-			message,
-			threshold,
+			ara, member, message, threshold,
 			newFakeInteractiveSigningEngine(),
 			roast.NewRound2Collector(verifier),
-			coord,
-			signer,
-			bus,
+			coord, signer, bus,
 		)
 		if err != nil {
 			t.Fatalf("runner (member %d): %v", member, err)
 		}
-		coords[i], handles[i], runners[i] = coord, handle, runner
+		h.coords = append(h.coords, coord)
+		h.handles = append(h.handles, handle)
+		h.runners = append(h.runners, runner)
 	}
+	return h
+}
 
+// runAll runs every node concurrently and asserts each reaches a successful
+// aggregate and transitions its attempt to Succeeded.
+func (h harness) runAndAssertAllSucceed(t *testing.T) {
+	t.Helper()
 	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	type result struct {
-		sig []byte
-		err error
-	}
-	results := make([]result, n)
+	sigs := make([][]byte, len(h.runners))
+	errs := make([]error, len(h.runners))
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for i := range h.runners {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			sig, runErr := runners[idx].Run(runCtx)
-			results[idx] = result{sig, runErr}
+			sigs[idx], errs[idx] = h.runners[idx].Run(runCtx)
 		}(i)
 	}
 	wg.Wait()
 
-	for i := 0; i < n; i++ {
+	for i := range h.runners {
 		member := i + 1
-		if results[i].err != nil {
-			t.Fatalf("member %d run failed: %v", member, results[i].err)
+		if errs[i] != nil {
+			t.Fatalf("member %d run failed: %v", member, errs[i])
 		}
-		if string(results[i].sig) != "fake-bip340-signature" {
-			t.Fatalf("member %d unexpected signature: %q", member, results[i].sig)
+		if string(sigs[i]) != "fake-bip340-signature" {
+			t.Fatalf("member %d unexpected signature: %q", member, sigs[i])
 		}
-		state, err := coords[i].State(handles[i])
+		state, err := h.coords[i].State(h.handles[i])
 		if err != nil {
 			t.Fatalf("member %d state: %v", member, err)
 		}
 		if state != roast.AttemptStateSucceeded {
 			t.Fatalf("member %d: expected Succeeded, got %v", member, state)
 		}
+	}
+}
+
+func TestInteractiveSigningRunner_HappyPath(t *testing.T) {
+	buildInteractiveSigningHarness(t, 3, 2).runAndAssertAllSucceed(t)
+}
+
+// Adversarial bus traffic - a garbage signing package from a non-elected sender
+// and a share from a member outside the included set - must be ignored by the
+// runner's sender/membership/attempt filters, leaving the honest run to succeed.
+func TestInteractiveSigningRunner_IgnoresAdversarialBusMessages(t *testing.T) {
+	h := buildInteractiveSigningHarness(t, 3, 2)
+
+	// Determine the elected coordinator, then have a DIFFERENT included member
+	// spam a garbage package (wrong sender) and an outsider (member 99) spam a
+	// share. Injected before Run starts, so they sit first in every buffer.
+	elected := h.runners[0].attempt.ElectedCoordinator()
+	var nonElected group.MemberIndex
+	for _, m := range h.includedSet {
+		if m != elected {
+			nonElected = m
+			break
+		}
+	}
+	h.bus.Broadcast(RunnerMessage{
+		Type: RunnerMsgSigningPackage, Sender: nonElected, Attempt: h.contextHash,
+		Payload: []byte("garbage package from a non-coordinator"),
+	})
+	h.bus.Broadcast(RunnerMessage{
+		Type: RunnerMsgShareSubmission, Sender: group.MemberIndex(99), Attempt: h.contextHash,
+		Payload: []byte("garbage share from an outsider"),
+	})
+
+	h.runAndAssertAllSucceed(t)
+}
+
+func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
+	// A valid baseline to vary one field at a time.
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x01, 0x02}
+	ctx, err := attempt.NewAttemptContext(
+		"session-1", "key-group-1", dkgKey,
+		[attempt.MessageDigestLength]byte{0x42}, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt context: %v", err)
+	}
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	bus := NewInProcessRunnerBus(8)
+	coord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", nil, dkgKey)
+	if err != nil {
+		t.Fatalf("active attempt: %v", err)
+	}
+	engine := newFakeInteractiveSigningEngine()
+	collector := roast.NewRound2Collector(verifier)
+	msg := []byte("m")
+
+	// Sanity: the baseline constructs.
+	if _, err := newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, coord, signer, bus); err != nil {
+		t.Fatalf("baseline construction failed: %v", err)
+	}
+
+	tests := map[string]func() (*interactiveSigningRunner, error){
+		"nil attempt": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(nil, 1, msg, 2, engine, collector, coord, signer, bus)
+		},
+		"nil engine": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, msg, 2, nil, collector, coord, signer, bus)
+		},
+		"nil collector": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, nil, coord, signer, bus)
+		},
+		"nil coordinator": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, nil, signer, bus)
+		},
+		"nil signer": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, coord, nil, bus)
+		},
+		"nil bus": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, coord, signer, nil)
+		},
+		"zero threshold": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, msg, 0, engine, collector, coord, signer, bus)
+		},
+		"empty message": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 1, nil, 2, engine, collector, coord, signer, bus)
+		},
+		"member not included": func() (*interactiveSigningRunner, error) {
+			return newInteractiveSigningRunner(ara, 99, msg, 2, engine, collector, coord, signer, bus)
+		},
+	}
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := build(); err == nil {
+				t.Fatal("expected invalid construction to be rejected")
+			}
+		})
 	}
 }

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -435,6 +435,52 @@ func TestInteractiveSigningRunner_RetainsMemberShareEquivocation(t *testing.T) {
 	}
 }
 
+// A body-different duplicate queued BEHIND the share that fills the final slot
+// must still be retained: collectShares stops counting once `into` is full, so
+// it must drain the remaining buffered shares before Run aggregates and prunes.
+func TestInteractiveSigningRunner_RetainsQueuedShareEquivocationAfterCollection(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	runner, collector, contextHash, elected := buildEquivocationRunner(t, included)
+	signer := fixedTestSigner{}
+
+	if err := collector.BeginAttempt(contextHash[:], elected, included); err != nil {
+		t.Fatalf("collector begin: %v", err)
+	}
+	authEnvelope, pkgBodyHash := craftSigningPackage(t, contextHash, elected, []byte("authoritative-package"), signer)
+	authPkg := &roast.SigningPackage{}
+	if err := authPkg.Unmarshal(authEnvelope); err != nil {
+		t.Fatalf("unmarshal authoritative: %v", err)
+	}
+	if err := collector.RecordSigningPackage(authPkg); err != nil {
+		t.Fatalf("record authoritative: %v", err)
+	}
+
+	// Member 2's first share fills the final slot; its body-different duplicate is
+	// queued right behind it, so the collection loop exits before reading it and
+	// only the post-completion drain can retain it.
+	share1 := craftShareSubmission(t, contextHash, 1, elected, pkgBodyHash, []byte("share-1"), signer)
+	share2a := craftShareSubmission(t, contextHash, 2, elected, pkgBodyHash, []byte("share-2-a"), signer)
+	share2b := craftShareSubmission(t, contextHash, 2, elected, pkgBodyHash, []byte("share-2-b"), signer)
+	stream := make(chan RunnerMessage, 8)
+	stream <- RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 1, Attempt: contextHash, Payload: share1}
+	stream <- RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 2, Attempt: contextHash, Payload: share2a}
+	stream <- RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 2, Attempt: contextHash, Payload: share2b}
+
+	evidence := captureEquivocationEvidence(t)
+	into := map[group.MemberIndex][]byte{}
+	if err := runner.collectShares(context.Background(), stream, contextHash, included, into); err != nil {
+		t.Fatalf("collect shares: %v", err)
+	}
+
+	if string(into[1]) != "share-1" || string(into[2]) != "share-2-a" {
+		t.Fatalf("unexpected counted shares: 1=%q 2=%q", into[1], into[2])
+	}
+	got := evidence()
+	if len(got) != 1 || got[0].Kind != roast.EquivocationKindShareConflict || got[0].Sender != 2 {
+		t.Fatalf("expected one queued share conflict from member 2, got %+v", got)
+	}
+}
+
 func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	// A valid baseline to vary one field at a time.
 	included := []group.MemberIndex{1, 2, 3}

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -24,6 +24,7 @@ type harness struct {
 	bus         RunnerBus
 	runners     []*interactiveSigningRunner
 	coords      []roast.Coordinator
+	collectors  []*roast.Round2Collector
 	handles     []roast.AttemptHandle
 	contextHash [attempt.MessageDigestLength]byte
 	includedSet []group.MemberIndex
@@ -63,16 +64,18 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 		if err != nil {
 			t.Fatalf("active attempt (member %d): %v", member, err)
 		}
+		collector := roast.NewRound2Collector(verifier)
 		runner, err := newInteractiveSigningRunner(
 			ara, member, threshold,
 			newFakeInteractiveSigningEngine(),
-			roast.NewRound2Collector(verifier),
+			collector,
 			coord, signer, bus,
 		)
 		if err != nil {
 			t.Fatalf("runner (member %d): %v", member, err)
 		}
 		h.coords = append(h.coords, coord)
+		h.collectors = append(h.collectors, collector)
 		h.handles = append(h.handles, handle)
 		h.runners = append(h.runners, runner)
 	}
@@ -118,6 +121,31 @@ func (h harness) runAndAssertAllSucceed(t *testing.T) {
 
 func TestInteractiveSigningRunner_HappyPath(t *testing.T) {
 	buildInteractiveSigningHarness(t, 3, 2).runAndAssertAllSucceed(t)
+}
+
+// A concluded attempt must leave no retained round-2 collector state, per the
+// collector's prune-on-conclusion contract (else a long-lived collector reused
+// across attempts accumulates every attempt's envelopes). The collector exposes
+// no presence query, but a SURVIVING record makes a re-begin of the same context
+// hash under a DIFFERENT binding conflict, whereas a pruned collector accepts
+// that fresh begin - so a clean re-begin proves the prune happened.
+func TestInteractiveSigningRunner_PrunesCollectorStateAfterSuccess(t *testing.T) {
+	h := buildInteractiveSigningHarness(t, 3, 2)
+	h.runAndAssertAllSucceed(t)
+
+	elected := h.runners[0].attempt.ElectedCoordinator()
+	var differentElected group.MemberIndex
+	for _, m := range h.includedSet {
+		if m != elected {
+			differentElected = m
+			break
+		}
+	}
+	for i, collector := range h.collectors {
+		if err := collector.BeginAttempt(h.contextHash[:], differentElected, h.includedSet); err != nil {
+			t.Fatalf("member %d: collector retained concluded attempt state (conflicting re-begin: %v)", i+1, err)
+		}
+	}
 }
 
 // Adversarial bus traffic - a garbage signing package from a non-elected sender

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -481,6 +481,62 @@ func TestInteractiveSigningRunner_RetainsQueuedShareEquivocationAfterCollection(
 	}
 }
 
+// The post-completion drain must be bounded: a peer that keeps the share stream
+// non-empty (flooding body-different shares) must not livelock collectShares
+// once enough valid shares are already collected. With `into` pre-filled only
+// the drain runs, and it must return promptly despite the continuous flood.
+func TestInteractiveSigningRunner_DrainDoesNotLivelockUnderShareFlood(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	runner, collector, contextHash, elected := buildEquivocationRunner(t, included)
+	signer := fixedTestSigner{}
+	if err := collector.BeginAttempt(contextHash[:], elected, included); err != nil {
+		t.Fatalf("collector begin: %v", err)
+	}
+	authEnvelope, pkgBodyHash := craftSigningPackage(t, contextHash, elected, []byte("authoritative-package"), signer)
+	authPkg := &roast.SigningPackage{}
+	if err := authPkg.Unmarshal(authEnvelope); err != nil {
+		t.Fatalf("unmarshal authoritative: %v", err)
+	}
+	if err := collector.RecordSigningPackage(authPkg); err != nil {
+		t.Fatalf("record authoritative: %v", err)
+	}
+
+	floodEnvelope := craftShareSubmission(t, contextHash, 2, elected, pkgBodyHash, []byte("flood"), signer)
+	floodMsg := RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 2, Attempt: contextHash, Payload: floodEnvelope}
+	stream := make(chan RunnerMessage, 8)
+	for i := 0; i < cap(stream); i++ {
+		stream <- floodMsg // full at entry, so the bound is actually exercised
+	}
+	stop := make(chan struct{})
+	floodDone := make(chan struct{})
+	go func() {
+		defer close(floodDone)
+		for {
+			select {
+			case <-stop:
+				return
+			case stream <- floodMsg: // keep the stream non-empty as the drain reads
+			}
+		}
+	}()
+
+	// `into` already complete -> the collection loop is skipped; only the drain runs.
+	into := map[group.MemberIndex][]byte{1: []byte("a"), 2: []byte("b")}
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		_ = runner.collectShares(context.Background(), stream, contextHash, included, into)
+	}()
+	select {
+	case <-returned:
+		// Bounded drain returned despite the flood.
+	case <-time.After(2 * time.Second):
+		t.Fatal("collectShares drain livelocked under share flood")
+	}
+	close(stop)
+	<-floodDone
+}
+
 func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	// A valid baseline to vary one field at a time.
 	included := []group.MemberIndex{1, 2, 3}

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -1,0 +1,127 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// fixedTestSigner returns a fixed non-empty signature so the wire envelopes
+// Marshal (they reject empty signatures); paired with NoOpSignatureVerifier it
+// authenticates without real operator-key crypto.
+type fixedTestSigner struct{}
+
+func (fixedTestSigner) Sign(_ []byte) ([]byte, error) { return []byte{0x01}, nil }
+
+// TestInteractiveSigningRunner_HappyPath wires N nodes - each with its own
+// coordinator, collector, and fake engine - to one shared in-process bus and
+// runs them concurrently. Every node must reach a successful aggregate, emit the
+// signature, and transition its attempt to Succeeded.
+func TestInteractiveSigningRunner_HappyPath(t *testing.T) {
+	const n = 3
+	const threshold = uint16(2)
+
+	included := make([]group.MemberIndex, 0, n)
+	for i := 1; i <= n; i++ {
+		included = append(included, group.MemberIndex(i))
+	}
+	dkgKey := []byte{0x01, 0x02}
+	ctx, err := attempt.NewAttemptContext(
+		"session-1",
+		"key-group-1",
+		dkgKey,
+		[attempt.MessageDigestLength]byte{0x42},
+		0,
+		included,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt context: %v", err)
+	}
+
+	bus := NewInProcessRunnerBus(256)
+	// A fixed non-empty signature: the wire envelopes' Marshal rejects an empty
+	// signature (so NoOpSigner, which signs nil, cannot be used), while the
+	// accept-anything verifier authenticates it - the runner test exercises the
+	// envelope/signing plumbing but not real operator-key crypto.
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	message := []byte("message-to-sign")
+
+	coords := make([]roast.Coordinator, n)
+	handles := make([]roast.AttemptHandle, n)
+	runners := make([]*interactiveSigningRunner, n)
+
+	// Construct every node (each subscribes to the bus in its constructor)
+	// BEFORE any Run broadcasts, so no node misses a peer's first message.
+	for i := 0; i < n; i++ {
+		member := group.MemberIndex(i + 1)
+		coord := roast.NewInMemoryCoordinatorWithSigning(member, signer, verifier)
+		handle, err := coord.BeginAttempt(ctx)
+		if err != nil {
+			t.Fatalf("begin attempt (member %d): %v", member, err)
+		}
+		ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", nil, dkgKey)
+		if err != nil {
+			t.Fatalf("active attempt (member %d): %v", member, err)
+		}
+		runner, err := newInteractiveSigningRunner(
+			ara,
+			member,
+			message,
+			threshold,
+			newFakeInteractiveSigningEngine(),
+			roast.NewRound2Collector(verifier),
+			coord,
+			signer,
+			bus,
+		)
+		if err != nil {
+			t.Fatalf("runner (member %d): %v", member, err)
+		}
+		coords[i], handles[i], runners[i] = coord, handle, runner
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type result struct {
+		sig []byte
+		err error
+	}
+	results := make([]result, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sig, runErr := runners[idx].Run(runCtx)
+			results[idx] = result{sig, runErr}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		member := i + 1
+		if results[i].err != nil {
+			t.Fatalf("member %d run failed: %v", member, results[i].err)
+		}
+		if string(results[i].sig) != "fake-bip340-signature" {
+			t.Fatalf("member %d unexpected signature: %q", member, results[i].sig)
+		}
+		state, err := coords[i].State(handles[i])
+		if err != nil {
+			t.Fatalf("member %d state: %v", member, err)
+		}
+		if state != roast.AttemptStateSucceeded {
+			t.Fatalf("member %d: expected Succeeded, got %v", member, state)
+		}
+	}
+}

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -50,7 +50,6 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 	bus := NewInProcessRunnerBus(256)
 	signer := fixedTestSigner{}
 	verifier := roast.NoOpSignatureVerifier()
-	message := []byte("message-to-sign")
 
 	h := harness{bus: bus, contextHash: ctx.Hash(), includedSet: included}
 	for i := 0; i < n; i++ {
@@ -65,7 +64,7 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 			t.Fatalf("active attempt (member %d): %v", member, err)
 		}
 		runner, err := newInteractiveSigningRunner(
-			ara, member, message, threshold,
+			ara, member, threshold,
 			newFakeInteractiveSigningEngine(),
 			roast.NewRound2Collector(verifier),
 			coord, signer, bus,
@@ -150,6 +149,52 @@ func TestInteractiveSigningRunner_IgnoresAdversarialBusMessages(t *testing.T) {
 	h.runAndAssertAllSucceed(t)
 }
 
+// When Run exits early after the engine session is open (here: ctx expires
+// while collecting commitments, before round 2 consumes the nonces), the runner
+// must abort the native attempt so the engine drops the resident secret
+// nonces/session state rather than leaking it.
+func TestInteractiveSigningRunner_AbortsNativeAttemptOnEarlyExit(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	dkgKey := []byte{0x01, 0x02}
+	ctx, err := attempt.NewAttemptContext(
+		"session-1", "key-group-1", dkgKey,
+		[attempt.MessageDigestLength]byte{0x42}, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt context: %v", err)
+	}
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	bus := NewInProcessRunnerBus(8)
+	coord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", nil, dkgKey)
+	if err != nil {
+		t.Fatalf("active attempt: %v", err)
+	}
+	engine := newFakeInteractiveSigningEngine()
+	runner, err := newInteractiveSigningRunner(
+		ara, 1, 2, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
+	)
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	// No second node ever broadcasts, so Run blocks in collectCommitments until
+	// the short deadline fires - an early exit with the session already open.
+	runCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := runner.Run(runCtx); err == nil {
+		t.Fatal("expected Run to fail on the expired context")
+	}
+	if got := engine.abortCallCount(); got != 1 {
+		t.Fatalf("expected exactly one native abort on early exit, got %d", got)
+	}
+}
+
 func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	// A valid baseline to vary one field at a time.
 	included := []group.MemberIndex{1, 2, 3}
@@ -175,40 +220,36 @@ func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	}
 	engine := newFakeInteractiveSigningEngine()
 	collector := roast.NewRound2Collector(verifier)
-	msg := []byte("m")
 
 	// Sanity: the baseline constructs.
-	if _, err := newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, coord, signer, bus); err != nil {
+	if _, err := newInteractiveSigningRunner(ara, 1, 2, engine, collector, coord, signer, bus); err != nil {
 		t.Fatalf("baseline construction failed: %v", err)
 	}
 
 	tests := map[string]func() (*interactiveSigningRunner, error){
 		"nil attempt": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(nil, 1, msg, 2, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(nil, 1, 2, engine, collector, coord, signer, bus)
 		},
 		"nil engine": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, msg, 2, nil, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, nil, collector, coord, signer, bus)
 		},
 		"nil collector": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, nil, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, engine, nil, coord, signer, bus)
 		},
 		"nil coordinator": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, nil, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, engine, collector, nil, signer, bus)
 		},
 		"nil signer": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, coord, nil, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, engine, collector, coord, nil, bus)
 		},
 		"nil bus": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, msg, 2, engine, collector, coord, signer, nil)
+			return newInteractiveSigningRunner(ara, 1, 2, engine, collector, coord, signer, nil)
 		},
 		"zero threshold": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, msg, 0, engine, collector, coord, signer, bus)
-		},
-		"empty message": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, nil, 2, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 0, engine, collector, coord, signer, bus)
 		},
 		"member not included": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 99, msg, 2, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 99, 2, engine, collector, coord, signer, bus)
 		},
 	}
 	for name, build := range tests {

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -223,6 +223,218 @@ func TestInteractiveSigningRunner_AbortsNativeAttemptOnEarlyExit(t *testing.T) {
 	}
 }
 
+// captureEquivocationEvidence registers a process-wide observer recording every
+// emitted equivocation event for the test's duration, returning a snapshot
+// accessor. Only one observer may be registered process-wide, so tests using it
+// must not run in parallel.
+func captureEquivocationEvidence(t *testing.T) func() []roast.EquivocationEvidence {
+	t.Helper()
+	var mu sync.Mutex
+	var captured []roast.EquivocationEvidence
+	if err := roast.RegisterEquivocationEvidenceObserver(func(ev roast.EquivocationEvidence) {
+		mu.Lock()
+		captured = append(captured, ev)
+		mu.Unlock()
+	}); err != nil {
+		t.Fatalf("register equivocation observer: %v", err)
+	}
+	t.Cleanup(roast.UnregisterEquivocationEvidenceObserver)
+	return func() []roast.EquivocationEvidence {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]roast.EquivocationEvidence(nil), captured...)
+	}
+}
+
+// craftSigningPackage builds a coordinator-signed signing-package envelope (and
+// returns its body hash) over the given FROST package body.
+func craftSigningPackage(
+	t *testing.T,
+	contextHash [attempt.MessageDigestLength]byte,
+	elected group.MemberIndex,
+	body []byte,
+	signer roast.Signer,
+) ([]byte, [32]byte) {
+	t.Helper()
+	pkg := &roast.SigningPackage{
+		AttemptContextHash:  append([]byte(nil), contextHash[:]...),
+		CoordinatorIDValue:  uint32(elected),
+		SigningPackageBytes: append([]byte(nil), body...),
+	}
+	payload, err := pkg.SignableBytes()
+	if err != nil {
+		t.Fatalf("signing package signable bytes: %v", err)
+	}
+	sig, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign signing package: %v", err)
+	}
+	pkg.CoordinatorSignature = sig
+	envelope, err := pkg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal signing package: %v", err)
+	}
+	bodyHash, err := pkg.BodyHash()
+	if err != nil {
+		t.Fatalf("signing package body hash: %v", err)
+	}
+	return envelope, bodyHash
+}
+
+// craftShareSubmission builds a submitter-signed accepted-share envelope for a
+// member, binding the elected coordinator and authoritative package body hash so
+// the collector accepts it (a body-different share for the same member is then
+// member equivocation).
+func craftShareSubmission(
+	t *testing.T,
+	contextHash [attempt.MessageDigestLength]byte,
+	member, elected group.MemberIndex,
+	pkgBodyHash [32]byte,
+	share []byte,
+	signer roast.Signer,
+) []byte {
+	t.Helper()
+	sub := &roast.ShareSubmission{
+		AttemptContextHash: append([]byte(nil), contextHash[:]...),
+		SubmitterIDValue:   uint32(member),
+		CoordinatorIDValue: uint32(elected),
+		SigningPackageHash: append([]byte(nil), pkgBodyHash[:]...),
+		SignatureShare:     append([]byte(nil), share...),
+	}
+	payload, err := sub.SignableBytes()
+	if err != nil {
+		t.Fatalf("share submission signable bytes: %v", err)
+	}
+	sig, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign share submission: %v", err)
+	}
+	sub.SubmitterSignature = sig
+	envelope, err := sub.Marshal()
+	if err != nil {
+		t.Fatalf("marshal share submission: %v", err)
+	}
+	return envelope
+}
+
+// buildEquivocationRunner builds a single runner with a fresh collector for the
+// evidence-retention tests, returning the runner, its collector, the attempt
+// context hash, and the elected coordinator.
+func buildEquivocationRunner(t *testing.T, included []group.MemberIndex) (
+	*interactiveSigningRunner, *roast.Round2Collector, [attempt.MessageDigestLength]byte, group.MemberIndex,
+) {
+	t.Helper()
+	dkgKey := []byte{0x01, 0x02}
+	ctx, err := attempt.NewAttemptContext(
+		"session-1", "key-group-1", dkgKey,
+		[attempt.MessageDigestLength]byte{0x42}, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt context: %v", err)
+	}
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	bus := NewInProcessRunnerBus(16)
+	coord := roast.NewInMemoryCoordinatorWithSigning(included[0], signer, verifier)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", nil, dkgKey)
+	if err != nil {
+		t.Fatalf("active attempt: %v", err)
+	}
+	collector := roast.NewRound2Collector(verifier)
+	runner, err := newInteractiveSigningRunner(
+		ara, included[0], 2, newFakeInteractiveSigningEngine(), collector, coord, signer, bus,
+	)
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+	return runner, collector, ctx.Hash(), ara.ElectedCoordinator()
+}
+
+// A second, body-different package from the elected coordinator must be recorded
+// as coordinator equivocation, not dropped because obtainSigningPackage already
+// returned on the first one.
+func TestInteractiveSigningRunner_RetainsCoordinatorPackageEquivocation(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	runner, collector, contextHash, elected := buildEquivocationRunner(t, included)
+	signer := fixedTestSigner{}
+
+	if err := collector.BeginAttempt(contextHash[:], elected, included); err != nil {
+		t.Fatalf("collector begin: %v", err)
+	}
+	// The authoritative package is recorded first (as Run does).
+	authEnvelope, _ := craftSigningPackage(t, contextHash, elected, []byte("authoritative-package"), signer)
+	authPkg := &roast.SigningPackage{}
+	if err := authPkg.Unmarshal(authEnvelope); err != nil {
+		t.Fatalf("unmarshal authoritative: %v", err)
+	}
+	if err := collector.RecordSigningPackage(authPkg); err != nil {
+		t.Fatalf("record authoritative: %v", err)
+	}
+
+	// A body-different package the coordinator also broadcast sits buffered.
+	conflictEnvelope, _ := craftSigningPackage(t, contextHash, elected, []byte("equivocating-package"), signer)
+	stream := make(chan RunnerMessage, 4)
+	stream <- RunnerMessage{Type: RunnerMsgSigningPackage, Sender: elected, Attempt: contextHash, Payload: conflictEnvelope}
+
+	evidence := captureEquivocationEvidence(t)
+	runner.recordBufferedCoordinatorPackages(stream, elected, contextHash)
+
+	got := evidence()
+	if len(got) != 1 || got[0].Kind != roast.EquivocationKindSigningPackageConflict || got[0].Sender != elected {
+		t.Fatalf("expected one signing-package conflict from member %d, got %+v", elected, got)
+	}
+}
+
+// A member that double-signs (a body-different second accepted share) must be
+// recorded as equivocation even after its first share was already counted -
+// collectShares must not drop the later envelope before the collector sees it.
+func TestInteractiveSigningRunner_RetainsMemberShareEquivocation(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	runner, collector, contextHash, elected := buildEquivocationRunner(t, included)
+	signer := fixedTestSigner{}
+
+	if err := collector.BeginAttempt(contextHash[:], elected, included); err != nil {
+		t.Fatalf("collector begin: %v", err)
+	}
+	authEnvelope, pkgBodyHash := craftSigningPackage(t, contextHash, elected, []byte("authoritative-package"), signer)
+	authPkg := &roast.SigningPackage{}
+	if err := authPkg.Unmarshal(authEnvelope); err != nil {
+		t.Fatalf("unmarshal authoritative: %v", err)
+	}
+	if err := collector.RecordSigningPackage(authPkg); err != nil {
+		t.Fatalf("record authoritative: %v", err)
+	}
+
+	// Member 1 double-signs; member 2 sends one share. Ordered so member 1's
+	// first share is counted before its conflicting second arrives.
+	share1a := craftShareSubmission(t, contextHash, 1, elected, pkgBodyHash, []byte("share-1-a"), signer)
+	share1b := craftShareSubmission(t, contextHash, 1, elected, pkgBodyHash, []byte("share-1-b"), signer)
+	share2 := craftShareSubmission(t, contextHash, 2, elected, pkgBodyHash, []byte("share-2"), signer)
+	stream := make(chan RunnerMessage, 8)
+	stream <- RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 1, Attempt: contextHash, Payload: share1a}
+	stream <- RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 1, Attempt: contextHash, Payload: share1b}
+	stream <- RunnerMessage{Type: RunnerMsgShareSubmission, Sender: 2, Attempt: contextHash, Payload: share2}
+
+	evidence := captureEquivocationEvidence(t)
+	into := map[group.MemberIndex][]byte{}
+	if err := runner.collectShares(context.Background(), stream, contextHash, included, into); err != nil {
+		t.Fatalf("collect shares: %v", err)
+	}
+
+	// The first accepted share per member is counted; the double-sign is retained.
+	if string(into[1]) != "share-1-a" || string(into[2]) != "share-2" {
+		t.Fatalf("unexpected counted shares: 1=%q 2=%q", into[1], into[2])
+	}
+	got := evidence()
+	if len(got) != 1 || got[0].Kind != roast.EquivocationKindShareConflict || got[0].Sender != 1 {
+		t.Fatalf("expected one share conflict from member 1, got %+v", got)
+	}
+}
+
 func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	// A valid baseline to vary one field at a time.
 	included := []group.MemberIndex{1, 2, 3}

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -4,6 +4,7 @@ package signing
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,7 @@ type harness struct {
 	runners     []*interactiveSigningRunner
 	coords      []roast.Coordinator
 	collectors  []*roast.Round2Collector
+	engines     []*fakeInteractiveSigningEngine
 	handles     []roast.AttemptHandle
 	contextHash [attempt.MessageDigestLength]byte
 	includedSet []group.MemberIndex
@@ -65,9 +67,10 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 			t.Fatalf("active attempt (member %d): %v", member, err)
 		}
 		collector := roast.NewRound2Collector(verifier)
+		engine := newFakeInteractiveSigningEngine()
 		runner, err := newInteractiveSigningRunner(
 			ara, member, threshold,
-			newFakeInteractiveSigningEngine(),
+			engine,
 			collector,
 			coord, signer, bus,
 		)
@@ -76,6 +79,7 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 		}
 		h.coords = append(h.coords, coord)
 		h.collectors = append(h.collectors, collector)
+		h.engines = append(h.engines, engine)
 		h.handles = append(h.handles, handle)
 		h.runners = append(h.runners, runner)
 	}
@@ -144,6 +148,53 @@ func TestInteractiveSigningRunner_PrunesCollectorStateAfterSuccess(t *testing.T)
 	for i, collector := range h.collectors {
 		if err := collector.BeginAttempt(h.contextHash[:], differentElected, h.includedSet); err != nil {
 			t.Fatalf("member %d: collector retained concluded attempt state (conflicting re-begin: %v)", i+1, err)
+		}
+	}
+}
+
+// A FAILED attempt must NOT be pruned by the runner: the retained signed
+// evidence is what the blame/retry path reads (CoordinatorPackageProofs /
+// ClassifyCandidateCulprits). Force aggregation to fail after every node has
+// recorded its package and shares, then assert each collector still holds the
+// attempt - a conflicting re-begin is rejected, whereas a pruned collector would
+// accept it.
+func TestInteractiveSigningRunner_PreservesEvidenceOnAggregateFailure(t *testing.T) {
+	h := buildInteractiveSigningHarness(t, 3, 2)
+	for _, e := range h.engines {
+		e.aggregateErr = fmt.Errorf("aggregate share verification failed")
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	errs := make([]error, len(h.runners))
+	var wg sync.WaitGroup
+	for i := range h.runners {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = h.runners[idx].Run(runCtx)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err == nil {
+			t.Fatalf("member %d: expected aggregate failure", i+1)
+		}
+	}
+
+	// Retained evidence must survive the failure (not pruned): a surviving record
+	// makes a re-begin under a DIFFERENT binding conflict.
+	elected := h.runners[0].attempt.ElectedCoordinator()
+	var differentElected group.MemberIndex
+	for _, m := range h.includedSet {
+		if m != elected {
+			differentElected = m
+			break
+		}
+	}
+	for i, collector := range h.collectors {
+		if err := collector.BeginAttempt(h.contextHash[:], differentElected, h.includedSet); err == nil {
+			t.Fatalf("member %d: evidence pruned on failure (conflicting re-begin unexpectedly succeeded)", i+1)
 		}
 	}
 }


### PR DESCRIPTION
## What

The **happy-path interactive signing runner** — the orchestrator that finally runs the interactive FROST flow end-to-end. It drives one node's participation over the `RunnerBus` (#4075) and, on success, calls `MarkSucceeded` (#4074) and emits the BIP-340 signature. `frost_native` (**no cgo**), exercised with a programmable fake engine + multi-node fake-bus harness — orchestration correctness without real crypto, per the consult.

Two commits: (1) the narrow `interactiveSigningEngine` boundary + programmable fake engine; (2) the runner orchestration + harness + happy test.

## Flow (`interactiveSigningRunner.Run`)
`InteractiveSessionOpen → collector.BeginAttempt → round1 + broadcast commitments → collect all → (elected coordinator) NewSigningPackage + sign + broadcast → RecordSigningPackage + round2 + sign ShareSubmission + broadcast + record own → collect a share from every signer → InteractiveAggregate → MarkSucceeded + return signature.`

## Design (consult + the #4075 slice-aliasing lesson)
- **Subscribes in the constructor** (before any `Run` broadcasts) so a node never misses a peer's first message; the harness constructs all nodes before starting them.
- **Every engine/collector input derives from the immutable `ActiveRoastAttempt` binding**, never from peer messages; the node records its **own** share explicitly (no bus self-echo); envelope/payload bytes are **copied at the boundary**.
- **Elected coordinator from the binding** — exactly that node builds + signs the package; everyone authenticates + retains it via the collector (the frozen Q1 boundary lives in the collector, not the runner).
- The coordinator builds the package from the **whole responsive included set**, so the aggregate needs a share from each (silent-member subsetting is the retry path's concern, not the happy flow).

## Tests
N=3 nodes run **concurrently** to a successful aggregate; each emits the signature and transitions its attempt to `Succeeded`. **Passes under `-race`.** A fix surfaced while writing it: `NoOpSigner` signs `nil`, which the envelopes' `Marshal` rejects — so the test uses a fixed non-empty signer + the accept-anything verifier (exercises the envelope/signing plumbing, not real crypto).

## Validation
`frost_native` suite + `-race` + `gofmt` + repo-wide `frost_native` vet + default build green. ⚠️ `client-*` CI builds default tags, not `frost_native`; validated locally.

## Deferred (fake-ignored, finalized at cgo wiring)
The FROST member-identifier encoding and the attempt-context fingerprint/id are placeholders here (the fake ignores them, and the runner drives rounds with the attempt id the engine *returns*); their engine-valid derivation is settled when the real cgo engine is wired.

## Next
**PR3b — the sad/blame path:** fault-inject a bad share → `InteractiveAggregate` returns culprits → `ClassifyCandidateCulprits` (engine-backed verifier) → `RecordEvidence` → `AggregateBundle` → `NextAttempt` excludes the culprit and the next attempt re-elects/retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)