### PR TITLE
Phase 7.3: Go cgo bridge for DeriveInteractiveAttemptContext

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -3416,9 +3416,26 @@ func decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(
 	}
 
 	frostIdentifiers := make([]NativeFROSTParticipantIdentifier, 0, len(response.FrostIdentifiers))
-	for _, entry := range response.FrostIdentifiers {
+	for i, entry := range response.FrostIdentifiers {
 		if entry.FrostIdentifier == "" {
 			return nil, buildTaggedTBTCSignerOperationError(operation, "response frost identifier is empty")
+		}
+		// The engine returns identifiers in canonical participant order, one per
+		// included participant. Bind each entry to the participant at its position:
+		// a matching count alone still lets a duplicate, zero, reordered, or
+		// foreign participant_identifier through, yielding a mapping that diverges
+		// from included_participants - which the runner keys commitments and shares
+		// by. (Index is in bounds: the count-match check above pins the lengths.)
+		if entry.ParticipantIdentifier != attemptContext.IncludedParticipants[i] {
+			return nil, buildTaggedTBTCSignerOperationError(
+				operation,
+				fmt.Sprintf(
+					"response frost identifier [%d] is for participant [%d], expected [%d]",
+					i,
+					entry.ParticipantIdentifier,
+					attemptContext.IncludedParticipants[i],
+				),
+			)
 		}
 		frostIdentifiers = append(frostIdentifiers, NativeFROSTParticipantIdentifier{
 			ParticipantIdentifier: entry.ParticipantIdentifier,

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -3400,6 +3400,20 @@ func decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(
 	if len(attemptContext.IncludedParticipants) == 0 {
 		return nil, buildTaggedTBTCSignerOperationError(operation, "response attempt context included participants are empty")
 	}
+	// The engine returns exactly one FROST identifier per included participant
+	// (canonical order); a mismatch is a malformed response the host must not
+	// silently consume - downstream signing-package/aggregate keying depends on
+	// the 1:1 correspondence.
+	if len(response.FrostIdentifiers) != len(attemptContext.IncludedParticipants) {
+		return nil, buildTaggedTBTCSignerOperationError(
+			operation,
+			fmt.Sprintf(
+				"response has [%d] frost identifiers for [%d] included participants",
+				len(response.FrostIdentifiers),
+				len(attemptContext.IncludedParticipants),
+			),
+		)
+	}
 
 	frostIdentifiers := make([]NativeFROSTParticipantIdentifier, 0, len(response.FrostIdentifiers))
 	for _, entry := range response.FrostIdentifiers {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -58,6 +58,10 @@ typedef TbtcSignerResult (*tbtc_verify_signature_share_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_derive_interactive_attempt_context_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef TbtcSignerResult (*tbtc_interactive_session_open_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -223,6 +227,18 @@ static TbtcSignerResult tbtc_signer_verify_signature_share(const uint8_t* reques
   }
 
   return verify_signature_share(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_derive_interactive_attempt_context(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_derive_interactive_attempt_context_fn derive_interactive_attempt_context = (tbtc_derive_interactive_attempt_context_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_derive_interactive_attempt_context"
+  );
+  if (derive_interactive_attempt_context == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return derive_interactive_attempt_context(request_ptr, request_len);
 }
 
 static TbtcSignerResult tbtc_signer_interactive_session_open(const uint8_t* request_ptr, size_t request_len) {
@@ -3245,6 +3261,177 @@ func callBuildTaggedTBTCSignerInteractiveAggregate(requestPayload []byte) ([]byt
 		requestPayload,
 		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
 			return C.tbtc_signer_interactive_aggregate(requestPtr, requestLen)
+		},
+	)
+}
+
+// ----------------------------------------------------------------------------
+// Phase 7.3 interactive attempt-context derivation bridge.
+//
+// Derives the canonical attempt context (coordinator, included-participants
+// fingerprint, attempt id) + per-participant FROST identifiers from an attempt's
+// public inputs, so the Go host never re-implements the engine's
+// domain-separated derivations. Stateless and secret-free; the engine
+// re-validates the derived context against the same strict check
+// InteractiveSessionOpen runs, so the host can pass the result straight back in.
+// Additive: no Go caller yet (the runner wiring is the next increment).
+// ----------------------------------------------------------------------------
+
+type buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequest struct {
+	SessionID            string   `json:"session_id"`
+	MessageHex           string   `json:"message_hex"`
+	KeyGroup             string   `json:"key_group"`
+	Threshold            uint16   `json:"threshold"`
+	AttemptNumber        uint32   `json:"attempt_number"`
+	IncludedParticipants []uint16 `json:"included_participants"`
+}
+
+type buildTaggedTBTCSignerParticipantFrostIdentifier struct {
+	ParticipantIdentifier uint16 `json:"participant_identifier"`
+	FrostIdentifier       string `json:"frost_identifier"`
+}
+
+type buildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse struct {
+	AttemptContext   buildTaggedTBTCSignerInteractiveAttemptContext    `json:"attempt_context"`
+	FrostIdentifiers []buildTaggedTBTCSignerParticipantFrostIdentifier `json:"frost_identifiers"`
+}
+
+func (bttse *buildTaggedTBTCSignerEngine) DeriveInteractiveAttemptContext(
+	sessionID string,
+	message []byte,
+	keyGroup string,
+	threshold uint16,
+	attemptNumber uint32,
+	includedParticipants []uint16,
+) (*NativeDeriveInteractiveAttemptContextResult, error) {
+	requestPayload, err := buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequestPayload(
+		sessionID,
+		message,
+		keyGroup,
+		threshold,
+		attemptNumber,
+		includedParticipants,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerDeriveInteractiveAttemptContext(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(responsePayload)
+}
+
+func buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequestPayload(
+	sessionID string,
+	message []byte,
+	keyGroup string,
+	threshold uint16,
+	attemptNumber uint32,
+	includedParticipants []uint16,
+) ([]byte, error) {
+	const operation = "DeriveInteractiveAttemptContext"
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "session ID is empty")
+	}
+	if len(message) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "message is empty")
+	}
+	if keyGroup == "" {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "key group is empty")
+	}
+	if threshold == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "threshold is zero")
+	}
+	if len(includedParticipants) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "included participants are empty")
+	}
+
+	// attempt.AttemptContext numbers attempts 0-based; the engine's wire
+	// attempt_number is 1-based and rejects 0. Convert here so the first attempt
+	// (RFC 0) is sent as wire 1, matching InteractiveSessionOpen.
+	wireAttemptNumber := attemptNumber + 1
+	if wireAttemptNumber == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			operation,
+			"attempt number overflows the 1-based wire encoding",
+		)
+	}
+
+	return buildTaggedTBTCSignerMarshalRequest(
+		operation,
+		buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequest{
+			SessionID:            sessionID,
+			MessageHex:           hex.EncodeToString(message),
+			KeyGroup:             keyGroup,
+			Threshold:            threshold,
+			AttemptNumber:        wireAttemptNumber,
+			IncludedParticipants: append([]uint16(nil), includedParticipants...),
+		},
+	)
+}
+
+func decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(
+	responsePayload []byte,
+) (*NativeDeriveInteractiveAttemptContextResult, error) {
+	const operation = "DeriveInteractiveAttemptContext"
+	var response buildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			operation,
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+
+	attemptContext := response.AttemptContext
+	if attemptContext.AttemptID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "response attempt context attempt ID is empty")
+	}
+	if attemptContext.CoordinatorIdentifier == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "response attempt context coordinator identifier is zero")
+	}
+	// The engine's wire attempt_number is 1-based; 0 is impossible and would
+	// underflow the conversion below.
+	if attemptContext.AttemptNumber == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "response attempt context attempt number is zero")
+	}
+	if len(attemptContext.IncludedParticipants) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(operation, "response attempt context included participants are empty")
+	}
+
+	frostIdentifiers := make([]NativeFROSTParticipantIdentifier, 0, len(response.FrostIdentifiers))
+	for _, entry := range response.FrostIdentifiers {
+		if entry.FrostIdentifier == "" {
+			return nil, buildTaggedTBTCSignerOperationError(operation, "response frost identifier is empty")
+		}
+		frostIdentifiers = append(frostIdentifiers, NativeFROSTParticipantIdentifier{
+			ParticipantIdentifier: entry.ParticipantIdentifier,
+			FrostIdentifier:       entry.FrostIdentifier,
+		})
+	}
+
+	return &NativeDeriveInteractiveAttemptContextResult{
+		AttemptContext: NativeInteractiveAttemptContext{
+			// Wire 1-based -> RFC-21 0-based, the inverse of the request encoding,
+			// so the host receives the natural attempt.AttemptContext value.
+			AttemptNumber:                   attemptContext.AttemptNumber - 1,
+			CoordinatorIdentifier:           attemptContext.CoordinatorIdentifier,
+			IncludedParticipants:            append([]uint16(nil), attemptContext.IncludedParticipants...),
+			IncludedParticipantsFingerprint: attemptContext.IncludedParticipantsFingerprint,
+			AttemptID:                       attemptContext.AttemptID,
+		},
+		FrostIdentifiers: frostIdentifiers,
+	}, nil
+}
+
+func callBuildTaggedTBTCSignerDeriveInteractiveAttemptContext(requestPayload []byte) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"DeriveInteractiveAttemptContext",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_derive_interactive_attempt_context(requestPtr, requestLen)
 		},
 	)
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1936,3 +1936,121 @@ func TestBuildTaggedTBTCSignerErrorPayload_CandidateCulprits(t *testing.T) {
 		t.Fatalf("expected no culprits for a non-culprit error, got: [%v]", plain.CandidateCulprits)
 	}
 }
+
+func TestBuildTaggedTBTCSignerDeriveInteractiveAttemptContextRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequestPayload(
+		"session-1",
+		[]byte{0xab, 0xcd},
+		"key-group-1",
+		2,
+		3, // RFC-21 0-based attempt
+		[]uint16{1, 2, 3},
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.SessionID != "session-1" {
+		t.Fatalf("unexpected session id: [%s]", request.SessionID)
+	}
+	if request.MessageHex != "abcd" {
+		t.Fatalf("unexpected message hex: [%s]", request.MessageHex)
+	}
+	if request.KeyGroup != "key-group-1" {
+		t.Fatalf("unexpected key group: [%s]", request.KeyGroup)
+	}
+	if request.Threshold != 2 {
+		t.Fatalf("unexpected threshold: [%d]", request.Threshold)
+	}
+	// Wire attempt_number is 1-based: the RFC-21 0-based 3 serializes as 4.
+	if request.AttemptNumber != 4 {
+		t.Fatalf("unexpected wire attempt number: [%d]", request.AttemptNumber)
+	}
+	if len(request.IncludedParticipants) != 3 ||
+		request.IncludedParticipants[0] != 1 ||
+		request.IncludedParticipants[2] != 3 {
+		t.Fatalf("unexpected included participants: [%v]", request.IncludedParticipants)
+	}
+}
+
+func TestBuildTaggedTBTCSignerDeriveInteractiveAttemptContextRequestPayload_RejectsInvalidInput(t *testing.T) {
+	tests := map[string]struct {
+		sessionID    string
+		message      []byte
+		keyGroup     string
+		threshold    uint16
+		participants []uint16
+	}{
+		"empty session":      {"", []byte{0x01}, "kg", 2, []uint16{1, 2}},
+		"empty message":      {"s", nil, "kg", 2, []uint16{1, 2}},
+		"empty key group":    {"s", []byte{0x01}, "", 2, []uint16{1, 2}},
+		"zero threshold":     {"s", []byte{0x01}, "kg", 0, []uint16{1, 2}},
+		"empty participants": {"s", []byte{0x01}, "kg", 2, nil},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := buildTaggedTBTCSignerDeriveInteractiveAttemptContextRequestPayload(
+				tc.sessionID, tc.message, tc.keyGroup, tc.threshold, 0, tc.participants,
+			); err == nil {
+				t.Fatal("expected invalid input to be rejected")
+			}
+		})
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(t *testing.T) {
+	result, err := decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse([]byte(`{
+		"attempt_context": {
+			"attempt_number": 4,
+			"coordinator_identifier": 2,
+			"included_participants": [1, 2, 3],
+			"included_participants_fingerprint": "deadbeef",
+			"attempt_id": "attempt-xyz"
+		},
+		"frost_identifiers": [
+			{"participant_identifier": 1, "frost_identifier": "id-1"},
+			{"participant_identifier": 2, "frost_identifier": "id-2"},
+			{"participant_identifier": 3, "frost_identifier": "id-3"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("unexpected decode error: [%v]", err)
+	}
+	// Wire 1-based attempt_number 4 decodes to the RFC-21 0-based 3.
+	if result.AttemptContext.AttemptNumber != 3 {
+		t.Fatalf("unexpected attempt number: [%d]", result.AttemptContext.AttemptNumber)
+	}
+	if result.AttemptContext.CoordinatorIdentifier != 2 {
+		t.Fatalf("unexpected coordinator: [%d]", result.AttemptContext.CoordinatorIdentifier)
+	}
+	if result.AttemptContext.IncludedParticipantsFingerprint != "deadbeef" {
+		t.Fatalf("unexpected fingerprint: [%s]", result.AttemptContext.IncludedParticipantsFingerprint)
+	}
+	if result.AttemptContext.AttemptID != "attempt-xyz" {
+		t.Fatalf("unexpected attempt id: [%s]", result.AttemptContext.AttemptID)
+	}
+	if len(result.AttemptContext.IncludedParticipants) != 3 ||
+		result.AttemptContext.IncludedParticipants[2] != 3 {
+		t.Fatalf("unexpected included participants: [%v]", result.AttemptContext.IncludedParticipants)
+	}
+	if len(result.FrostIdentifiers) != 3 ||
+		result.FrostIdentifiers[0].ParticipantIdentifier != 1 ||
+		result.FrostIdentifiers[0].FrostIdentifier != "id-1" ||
+		result.FrostIdentifiers[2].FrostIdentifier != "id-3" {
+		t.Fatalf("unexpected frost identifiers: [%+v]", result.FrostIdentifiers)
+	}
+
+	// Malformed JSON and a zero (impossible 1-based) wire attempt number reject.
+	if _, err := decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse([]byte(`{`)); err == nil {
+		t.Fatal("expected malformed payload to be rejected")
+	}
+	if _, err := decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(
+		[]byte(`{"attempt_context":{"attempt_number":0,"coordinator_identifier":2,"included_participants":[1,2],"included_participants_fingerprint":"ab","attempt_id":"a"}}`),
+	); err == nil {
+		t.Fatal("expected zero wire attempt number to be rejected")
+	}
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -2053,4 +2053,10 @@ func TestDecodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(t *t
 	); err == nil {
 		t.Fatal("expected zero wire attempt number to be rejected")
 	}
+	// One identifier per participant is required: 3 participants, 2 identifiers.
+	if _, err := decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(
+		[]byte(`{"attempt_context":{"attempt_number":4,"coordinator_identifier":2,"included_participants":[1,2,3],"included_participants_fingerprint":"ab","attempt_id":"a"},"frost_identifiers":[{"participant_identifier":1,"frost_identifier":"id-1"},{"participant_identifier":2,"frost_identifier":"id-2"}]}`),
+	); err == nil {
+		t.Fatal("expected frost-identifier/participant count mismatch to be rejected")
+	}
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -2059,4 +2059,11 @@ func TestDecodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(t *t
 	); err == nil {
 		t.Fatal("expected frost-identifier/participant count mismatch to be rejected")
 	}
+	// A matching count but mismatched participant correspondence is rejected
+	// (participant 3 appears at the position participant 2 is expected).
+	if _, err := decodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(
+		[]byte(`{"attempt_context":{"attempt_number":4,"coordinator_identifier":2,"included_participants":[1,2,3],"included_participants_fingerprint":"ab","attempt_id":"a"},"frost_identifiers":[{"participant_identifier":1,"frost_identifier":"id-1"},{"participant_identifier":3,"frost_identifier":"id-3"},{"participant_identifier":2,"frost_identifier":"id-2"}]}`),
+	); err == nil {
+		t.Fatal("expected mismatched participant correspondence to be rejected")
+	}
 }

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -108,6 +108,25 @@ type NativeInteractiveSessionAbortResult struct {
 	Aborted   bool
 }
 
+// NativeDeriveInteractiveAttemptContextResult is the result of
+// DeriveInteractiveAttemptContext: the canonical attempt context the host passes
+// to InteractiveSessionOpen (AttemptNumber is the RFC-21 ZERO-based ordinal,
+// converted back from the engine's 1-based wire value), plus one FROST
+// identifier per included participant in canonical (ascending) order.
+type NativeDeriveInteractiveAttemptContextResult struct {
+	AttemptContext   NativeInteractiveAttemptContext
+	FrostIdentifiers []NativeFROSTParticipantIdentifier
+}
+
+// NativeFROSTParticipantIdentifier pairs a Go member identifier with the
+// engine's canonical FROST identifier string (the key-package encoding the
+// signing-package and aggregate paths require), so the host never re-implements
+// that serialization.
+type NativeFROSTParticipantIdentifier struct {
+	ParticipantIdentifier uint16
+	FrostIdentifier       string
+}
+
 // NativeTBTCSignerEngine executes coarse, session-keyed tbtc-signer
 // operations.
 type NativeTBTCSignerEngine interface {


### PR DESCRIPTION
## Phase 7.3 — Go cgo bridge for DeriveInteractiveAttemptContext (Option B)

Wires the Go host to the engine's `frost_tbtc_derive_interactive_attempt_context` export (engine PR merged), so the host obtains the canonical attempt context + FROST identifiers from the single-source-of-truth engine rather than re-deriving the domain-separated hashing in Go.

### What
- C `dlsym` shim `tbtc_signer_derive_interactive_attempt_context` (+ typedef), mirroring the other interactive shims.
- `buildTaggedTBTCSignerEngine.DeriveInteractiveAttemptContext(sessionID, message, keyGroup, threshold, attemptNumber[0-based], includedParticipants)` → request payload builder (0→1-based wire conversion, overflow-guarded) → cgo call → response decoder (1→0-based back; identifier mapping) → `NativeDeriveInteractiveAttemptContextResult{AttemptContext, FrostIdentifiers}`.

### Scope
- **Additive** — no Go caller yet. The concrete engine gets the method now so widening the `interactiveSigningEngine` interface in the next PR (runner integration: coordinator cross-check + placeholder replacement + identifier threading) keeps the cgo build green.
- Production real-engine signing remains gated on the `frost-secp256k1-tr =3.0.0` external audit; this is parse/serialization plumbing only.

### Tests
- Structural (no `.so` needed; the real-FFI round-trip skips when unlinked, like the sibling bridges): request-payload builder (fields + 0→1-based), input rejection, response decode (1→0-based + identifiers + malformed/zero-attempt rejection).
- `gofmt` + cgo `build`/`vet`/`suite` + `frost_native` build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)