### PR TITLE
Phase 7.3: wire the runner to engine-derived attempt context (retire placeholders)

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -370,6 +370,13 @@ import (
 
 type buildTaggedTBTCSignerEngine struct{}
 
+// The cgo-backed engine must satisfy the runner's interactiveSigningEngine
+// boundary (defined under the frost_native tag, which this file also carries).
+// This assertion lives in the cgo wiring layer so widening the interface there
+// is compile-checked against the real engine, even before a production path
+// constructs one.
+var _ interactiveSigningEngine = (*buildTaggedTBTCSignerEngine)(nil)
+
 type buildTaggedTBTCSignerRunDKGRequest struct {
 	SessionID    string                                `json:"session_id"`
 	Participants []buildTaggedTBTCSignerDKGParticipant `json:"participants"`

--- a/pkg/frost/signing/roast_runner_engine_frost_native.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native.go
@@ -15,6 +15,21 @@ package signing
 // the public commitments, the coordinator's signing package, and the signature
 // shares returned here.
 type interactiveSigningEngine interface {
+	// DeriveInteractiveAttemptContext derives the canonical attempt context
+	// (coordinator, included-participants fingerprint, attempt id) and the
+	// per-participant FROST identifiers from the attempt's public inputs, so the
+	// runner never re-implements the engine's domain-separated derivations. The
+	// runner cross-checks the returned coordinator/included set against the
+	// binding's own RFC-21 election before opening.
+	DeriveInteractiveAttemptContext(
+		sessionID string,
+		message []byte,
+		keyGroup string,
+		threshold uint16,
+		attemptNumber uint32,
+		includedParticipants []uint16,
+	) (*NativeDeriveInteractiveAttemptContextResult, error)
+
 	// InteractiveSessionOpen opens (or idempotently re-opens) the attempt and
 	// returns the engine's canonical attempt id.
 	InteractiveSessionOpen(

--- a/pkg/frost/signing/roast_runner_engine_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native_test.go
@@ -24,6 +24,11 @@ type fakeInteractiveSigningEngine struct {
 	signingPackage []byte
 	signature      []byte
 	aggregateErr   error
+	// coordinatorIdentifier is what DeriveInteractiveAttemptContext returns; the
+	// harness sets it to the binding's elected coordinator so the runner's
+	// cross-check passes (a real engine derives the same value the binding did).
+	coordinatorIdentifier uint16
+	deriveErr             error
 
 	commitmentsByMember map[uint16][]byte
 	shareByMember       map[uint16][]byte
@@ -35,7 +40,41 @@ type fakeInteractiveSigningEngine struct {
 	round2Calls         int
 	aggregateCalls      int
 	abortCalls          int
+	deriveCalls         int
 	lastAggregateShares []nativeFROSTSignatureShare
+}
+
+func (f *fakeInteractiveSigningEngine) DeriveInteractiveAttemptContext(
+	sessionID string,
+	message []byte,
+	keyGroup string,
+	threshold uint16,
+	attemptNumber uint32,
+	includedParticipants []uint16,
+) (*NativeDeriveInteractiveAttemptContextResult, error) {
+	f.mu.Lock()
+	f.deriveCalls++
+	f.mu.Unlock()
+	if f.deriveErr != nil {
+		return nil, f.deriveErr
+	}
+	identifiers := make([]NativeFROSTParticipantIdentifier, 0, len(includedParticipants))
+	for _, participant := range includedParticipants {
+		identifiers = append(identifiers, NativeFROSTParticipantIdentifier{
+			ParticipantIdentifier: participant,
+			FrostIdentifier:       fmt.Sprintf("frost-id-%d", participant),
+		})
+	}
+	return &NativeDeriveInteractiveAttemptContextResult{
+		AttemptContext: NativeInteractiveAttemptContext{
+			AttemptNumber:                   attemptNumber,
+			CoordinatorIdentifier:           f.coordinatorIdentifier,
+			IncludedParticipants:            append([]uint16(nil), includedParticipants...),
+			IncludedParticipantsFingerprint: "fake-fingerprint",
+			AttemptID:                       "fake-attempt-id",
+		},
+		FrostIdentifiers: identifiers,
+	}, nil
 }
 
 func (f *fakeInteractiveSigningEngine) InteractiveSessionAbort(

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -5,8 +5,6 @@ package signing
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/frost/roast"
@@ -120,8 +118,39 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	contextHash := binding.ContextHash()
 	elected := binding.ElectedCoordinator()
 
-	// 1. Open the interactive session; the engine returns the attempt id used
-	// for every subsequent round.
+	// 1. Derive the canonical attempt context + per-participant FROST identifiers
+	// from the engine (single source of truth - the runner never re-implements the
+	// engine's domain-separated derivations). Cross-check the engine-derived
+	// coordinator and included set against the binding's own RFC-21 election so a
+	// divergence fails closed HERE rather than producing a signature bound to the
+	// wrong coordinator/set; the two independent derivations must agree.
+	derived, err := r.engine.DeriveInteractiveAttemptContext(
+		binding.SessionID(),
+		r.messageDigest,
+		attemptCtx.KeyGroupID,
+		r.threshold,
+		attemptCtx.AttemptNumber,
+		includedSetToUint16(includedSet),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: derive attempt context: %w", err)
+	}
+	if group.MemberIndex(derived.AttemptContext.CoordinatorIdentifier) != elected {
+		return nil, fmt.Errorf(
+			"roast runner: engine-derived coordinator [%d] does not match the bound elected coordinator [%d]",
+			derived.AttemptContext.CoordinatorIdentifier, elected,
+		)
+	}
+	if !sameMemberSet(derived.AttemptContext.IncludedParticipants, includedSet) {
+		return nil, fmt.Errorf("roast runner: engine-derived included set diverges from the bound attempt")
+	}
+	frostIdentifiers, err := frostIdentifierMap(derived.FrostIdentifiers, includedSet)
+	if err != nil {
+		return nil, fmt.Errorf("roast runner: %w", err)
+	}
+
+	// 2. Open the interactive session with the engine-derived context; the engine
+	// returns the attempt id used for every subsequent round.
 	open, err := r.engine.InteractiveSessionOpen(
 		binding.SessionID(),
 		uint16(r.member),
@@ -129,7 +158,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 		attemptCtx.KeyGroupID,
 		r.threshold,
 		binding.TaprootMerkleRoot(),
-		nativeAttemptContext(binding),
+		derived.AttemptContext,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("roast runner: open session: %w", err)
@@ -178,7 +207,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 
 	// 5. The elected coordinator builds, signs, and broadcasts the signing
 	// package; everyone else awaits it.
-	signingPackageEnvelope, err := r.obtainSigningPackage(ctx, r.sub.SigningPackages(), elected, contextHash, commitments, includedSet)
+	signingPackageEnvelope, err := r.obtainSigningPackage(ctx, r.sub.SigningPackages(), elected, contextHash, commitments, includedSet, frostIdentifiers)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +266,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 		binding.SessionID(),
 		attemptID,
 		pkg.SigningPackageBytes,
-		toFrostSignatureShares(shares),
+		toFrostSignatureShares(shares, frostIdentifiers),
 		binding.TaprootMerkleRoot(),
 	)
 	if err != nil {
@@ -269,6 +298,7 @@ func (r *interactiveSigningRunner) obtainSigningPackage(
 	contextHash [attempt.MessageDigestLength]byte,
 	commitments map[group.MemberIndex][]byte,
 	includedSet []group.MemberIndex,
+	frostIdentifiers map[group.MemberIndex]string,
 ) ([]byte, error) {
 	if r.member != elected {
 		// Accept ONLY the elected coordinator's package for THIS attempt. Without
@@ -301,7 +331,7 @@ func (r *interactiveSigningRunner) obtainSigningPackage(
 		}
 	}
 
-	frostPackage, err := r.engine.NewSigningPackage(r.messageDigest, toFrostCommitments(commitments, includedSet))
+	frostPackage, err := r.engine.NewSigningPackage(r.messageDigest, toFrostCommitments(commitments, includedSet, frostIdentifiers))
 	if err != nil {
 		return nil, fmt.Errorf("roast runner: new signing package: %w", err)
 	}
@@ -532,49 +562,63 @@ func (r *interactiveSigningRunner) recordBufferedCoordinatorPackages(
 	}
 }
 
-// nativeAttemptContext maps the binding's RFC-21 attempt context to the engine's
-// wire shape. AttemptNumber stays 0-based (the bridge converts to the 1-based
-// wire value).
-//
-// IncludedParticipantsFingerprint and AttemptID are PLACEHOLDERS, inert here:
-// the only engine #4076 wires is the fake, which ignores them, and no production
-// path constructs the real cgo engine yet. They are NOT engine-valid. Strict-mode
-// validate_attempt_context (engine roast.rs) recomputes both from canonical
-// inputs and rejects a mismatch before round 1:
-//   - fingerprint := roast_included_participants_fingerprint_hex(participants)
-//     (domain-separated hash of the framed u16 set), and
-//   - attempt_id   := roast_attempt_id_hex(session_id, message_digest_hex,
-//     attempt_number, coordinator_id, fingerprint_hex).
-//
-// Producing these byte-for-byte is a cross-impl derivation (the seed-divergence
-// class of bug); deriving-in-Go vs exposing-from-engine is the open design fork
-// for the real-engine attempt-context wiring increment. The runner already drives
-// subsequent rounds with the attempt id the engine RETURNS, not this field.
-func nativeAttemptContext(binding *ActiveRoastAttempt) NativeInteractiveAttemptContext {
-	ctx := binding.Context()
-	included := make([]uint16, 0, len(ctx.IncludedSet))
-	for _, m := range ctx.IncludedSet {
-		included = append(included, uint16(m))
-	}
-	hash := binding.ContextHash()
-	return NativeInteractiveAttemptContext{
-		AttemptNumber:                   ctx.AttemptNumber,
-		CoordinatorIdentifier:           uint16(binding.ElectedCoordinator()),
-		IncludedParticipants:            included,
-		IncludedParticipantsFingerprint: hex.EncodeToString(includedSetFingerprint(ctx.IncludedSet)),
-		AttemptID:                       hex.EncodeToString(hash[:]),
-	}
-}
-
-func includedSetFingerprint(includedSet []group.MemberIndex) []byte {
-	h := sha256.New()
+// includedSetToUint16 converts the binding's member-index set to the u16 list the
+// engine's DeriveInteractiveAttemptContext expects.
+func includedSetToUint16(includedSet []group.MemberIndex) []uint16 {
+	out := make([]uint16, 0, len(includedSet))
 	for _, m := range includedSet {
-		h.Write([]byte{byte(m)})
+		out = append(out, uint16(m))
 	}
-	return h.Sum(nil)
+	return out
 }
 
-func toFrostCommitments(commitments map[group.MemberIndex][]byte, includedSet []group.MemberIndex) []nativeFROSTCommitment {
+// sameMemberSet reports whether the engine-derived participant list is the same
+// SET as the binding's included members - the cross-check that the engine's
+// canonicalization agrees with the bound attempt, independent of order.
+func sameMemberSet(derived []uint16, included []group.MemberIndex) bool {
+	if len(derived) != len(included) {
+		return false
+	}
+	want := make(map[uint16]struct{}, len(included))
+	for _, m := range included {
+		want[uint16(m)] = struct{}{}
+	}
+	for _, d := range derived {
+		if _, ok := want[d]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// frostIdentifierMap indexes the engine-derived FROST identifiers by Go member
+// index, requiring exactly one per included member. The engine returns one per
+// participant and the bridge already verified the 1:1 correspondence, so a gap
+// here is defensive against a future engine/bridge change.
+func frostIdentifierMap(
+	entries []NativeFROSTParticipantIdentifier,
+	includedSet []group.MemberIndex,
+) (map[group.MemberIndex]string, error) {
+	out := make(map[group.MemberIndex]string, len(entries))
+	for _, entry := range entries {
+		out[group.MemberIndex(entry.ParticipantIdentifier)] = entry.FrostIdentifier
+	}
+	for _, m := range includedSet {
+		if out[m] == "" {
+			return nil, fmt.Errorf("missing FROST identifier for included member [%d]", m)
+		}
+	}
+	return out, nil
+}
+
+// toFrostCommitments keys each collected commitment by the engine-derived FROST
+// identifier for that member (frostIdentifiers), so NewSigningPackage builds the
+// FROST BTreeMap<Identifier, _> the member's key share expects.
+func toFrostCommitments(
+	commitments map[group.MemberIndex][]byte,
+	includedSet []group.MemberIndex,
+	frostIdentifiers map[group.MemberIndex]string,
+) []nativeFROSTCommitment {
 	out := make([]nativeFROSTCommitment, 0, len(includedSet))
 	for _, m := range includedSet {
 		data, ok := commitments[m]
@@ -582,37 +626,28 @@ func toFrostCommitments(commitments map[group.MemberIndex][]byte, includedSet []
 			continue
 		}
 		out = append(out, nativeFROSTCommitment{
-			Identifier: memberFrostIdentifier(m),
+			Identifier: frostIdentifiers[m],
 			Data:       append([]byte(nil), data...),
 		})
 	}
 	return out
 }
 
-func toFrostSignatureShares(shares map[group.MemberIndex][]byte) []nativeFROSTSignatureShare {
+// toFrostSignatureShares keys each collected share by the engine-derived FROST
+// identifier for that member, so InteractiveAggregate matches each share to the
+// member's verifying share.
+func toFrostSignatureShares(
+	shares map[group.MemberIndex][]byte,
+	frostIdentifiers map[group.MemberIndex]string,
+) []nativeFROSTSignatureShare {
 	out := make([]nativeFROSTSignatureShare, 0, len(shares))
 	for m, data := range shares {
 		out = append(out, nativeFROSTSignatureShare{
-			Identifier: memberFrostIdentifier(m),
+			Identifier: frostIdentifiers[m],
 			Data:       append([]byte(nil), data...),
 		})
 	}
 	return out
-}
-
-// memberFrostIdentifier maps a Go member index to the FROST identifier the
-// engine keys signing-package commitments and signature shares by.
-//
-// This decimal form is a PLACEHOLDER, inert against the fake (which ignores it)
-// and never reaching the real engine in #4076. The engine's canonical encoding
-// (codec.rs participant_identifier_to_frost_identifier + frost_identifier_to_go_string)
-// is the u16 serialized as the secp256k1 scalar - 32-byte big-endian - hex
-// encoded; the real engine deserializes exactly that to build the
-// BTreeMap<Identifier, _> in the FROST signing package, so "1" would not match
-// the member's key share. Replaced with the canonical encoding in the
-// real-engine wiring increment.
-func memberFrostIdentifier(member group.MemberIndex) string {
-	return fmt.Sprintf("%d", member)
 }
 
 // taprootRootMatches reports whether a received package's taproot root equals

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -135,7 +135,10 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("roast runner: derive attempt context: %w", err)
 	}
-	if group.MemberIndex(derived.AttemptContext.CoordinatorIdentifier) != elected {
+	// Compare in uint16 space (widening the uint8 elected is lossless): a
+	// truncating group.MemberIndex(...) cast would let a malformed engine
+	// coordinator > 255 alias an honest member (e.g. 257 -> 1) and falsely match.
+	if derived.AttemptContext.CoordinatorIdentifier != uint16(elected) {
 		return nil, fmt.Errorf(
 			"roast runner: engine-derived coordinator [%d] does not match the bound elected coordinator [%d]",
 			derived.AttemptContext.CoordinatorIdentifier, elected,

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -577,21 +577,25 @@ func includedSetToUint16(includedSet []group.MemberIndex) []uint16 {
 
 // sameMemberSet reports whether the engine-derived participant list is the same
 // SET as the binding's included members - the cross-check that the engine's
-// canonicalization agrees with the bound attempt, independent of order.
+// canonicalization agrees with the bound attempt, independent of order. It
+// rejects duplicates in `derived` (consuming each expected member at most once),
+// so a malformed list like [1,1] for included [1,2] does NOT falsely match
+// despite the equal length.
 func sameMemberSet(derived []uint16, included []group.MemberIndex) bool {
 	if len(derived) != len(included) {
 		return false
 	}
-	want := make(map[uint16]struct{}, len(included))
+	remaining := make(map[uint16]struct{}, len(included))
 	for _, m := range included {
-		want[uint16(m)] = struct{}{}
+		remaining[uint16(m)] = struct{}{}
 	}
 	for _, d := range derived {
-		if _, ok := want[d]; !ok {
+		if _, ok := remaining[d]; !ok {
 			return false
 		}
+		delete(remaining, d)
 	}
-	return true
+	return len(remaining) == 0
 }
 
 // frostIdentifierMap indexes the engine-derived FROST identifiers by Go member

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -68,6 +68,10 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 		}
 		collector := roast.NewRound2Collector(verifier)
 		engine := newFakeInteractiveSigningEngine()
+		// The engine derivation must agree with the binding's RFC-21 election, or
+		// the runner's cross-check fails closed (a real engine derives the same
+		// coordinator the binding did).
+		engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator())
 		runner, err := newInteractiveSigningRunner(
 			ara, member, threshold,
 			engine,
@@ -255,6 +259,7 @@ func TestInteractiveSigningRunner_AbortsNativeAttemptOnEarlyExit(t *testing.T) {
 		t.Fatalf("active attempt: %v", err)
 	}
 	engine := newFakeInteractiveSigningEngine()
+	engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator())
 	runner, err := newInteractiveSigningRunner(
 		ara, 1, 2, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
 	)
@@ -271,6 +276,69 @@ func TestInteractiveSigningRunner_AbortsNativeAttemptOnEarlyExit(t *testing.T) {
 	}
 	if got := engine.abortCallCount(); got != 1 {
 		t.Fatalf("expected exactly one native abort on early exit, got %d", got)
+	}
+}
+
+// The runner cross-checks the engine-derived coordinator against the binding's
+// own RFC-21 election and fails closed on divergence - BEFORE opening a session -
+// so it can never sign an attempt bound to the wrong coordinator.
+func TestInteractiveSigningRunner_RejectsEngineCoordinatorMismatch(t *testing.T) {
+	included := []group.MemberIndex{1, 2}
+	dkgKey := []byte{0x01, 0x02}
+	ctx, err := attempt.NewAttemptContext(
+		"session-1", "key-group-1", dkgKey,
+		[attempt.MessageDigestLength]byte{0x42}, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt context: %v", err)
+	}
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	bus := NewInProcessRunnerBus(8)
+	coord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	ara, err := NewActiveRoastAttempt(coord, handle, ctx, "session-1", nil, dkgKey)
+	if err != nil {
+		t.Fatalf("active attempt: %v", err)
+	}
+	engine := newFakeInteractiveSigningEngine()
+	// Engine derives a coordinator the binding did NOT elect.
+	engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator()) + 100
+	runner, err := newInteractiveSigningRunner(
+		ara, 1, 2, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
+	)
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := runner.Run(runCtx); err == nil {
+		t.Fatal("expected the engine/binding coordinator mismatch to be rejected")
+	}
+	// The mismatch is caught at the derive cross-check, before the session opens.
+	if engine.openCalls != 0 {
+		t.Fatalf("expected no session open on coordinator mismatch, got %d", engine.openCalls)
+	}
+}
+
+// The happy path must key signing-package commitments and aggregate shares by the
+// engine-derived FROST identifiers, not a Go-fabricated placeholder.
+func TestInteractiveSigningRunner_UsesEngineDerivedFrostIdentifiers(t *testing.T) {
+	h := buildInteractiveSigningHarness(t, 3, 2)
+	h.runAndAssertAllSucceed(t)
+
+	got := map[string]struct{}{}
+	for _, share := range h.engines[0].lastAggregateShares {
+		got[share.Identifier] = struct{}{}
+	}
+	for _, want := range []string{"frost-id-1", "frost-id-2", "frost-id-3"} {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("aggregate missing engine-derived identifier %q; got %v", want, got)
+		}
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -342,6 +342,27 @@ func TestInteractiveSigningRunner_UsesEngineDerivedFrostIdentifiers(t *testing.T
 	}
 }
 
+func TestSameMemberSet(t *testing.T) {
+	cases := map[string]struct {
+		derived  []uint16
+		included []group.MemberIndex
+		want     bool
+	}{
+		"equal, reordered":        {[]uint16{3, 1, 2}, []group.MemberIndex{1, 2, 3}, true},
+		"different length":        {[]uint16{1, 2}, []group.MemberIndex{1, 2, 3}, false},
+		"foreign member":          {[]uint16{1, 9}, []group.MemberIndex{1, 2}, false},
+		"duplicate masks missing": {[]uint16{1, 1}, []group.MemberIndex{1, 2}, false},
+		"empty equal":             {[]uint16{}, []group.MemberIndex{}, true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := sameMemberSet(tc.derived, tc.included); got != tc.want {
+				t.Fatalf("sameMemberSet(%v, %v) = %v, want %v", tc.derived, tc.included, got, tc.want)
+			}
+		})
+	}
+}
+
 // captureEquivocationEvidence registers a process-wide observer recording every
 // emitted equivocation event for the test's duration, returning a snapshot
 // accessor. Only one observer may be registered process-wide, so tests using it


### PR DESCRIPTION
## Phase 7.3 — runner integration: engine-derived attempt context (Option B, final piece)

The runner now obtains the canonical attempt context + FROST identifiers from the engine (via the merged bridge) instead of fabricating them, **retiring the three placeholders** the earlier runner PR documented as inert.

### What
- **Interface:** widen `interactiveSigningEngine` with `DeriveInteractiveAttemptContext`; add a compile-time assertion in the cgo layer (`var _ interactiveSigningEngine = (*buildTaggedTBTCSignerEngine)(nil)`) so the widening is checked against the real engine even before a production path constructs one.
- **Run:** derive → **cross-check** the engine-derived coordinator + included set against the binding's own RFC-21 election (fail closed on divergence, before `InteractiveSessionOpen`) → open with the derived context → key commitments/shares by the engine-derived identifiers.
- **Remove** `nativeAttemptContext` (fingerprint/attempt_id placeholders), `includedSetFingerprint`, `memberFrostIdentifier`, and the now-unused `crypto/sha256` + `encoding/hex` imports.

### Why cross-check (not just trust the engine)
The Go host keeps its own RFC-21 coordinator derivation for routing; verifying it equals the engine's at the boundary turns a potential silent divergence into a loud, fail-closed assertion (per the design consult).

### Tests (`frost_native`, fake engine)
- `UsesEngineDerivedFrostIdentifiers` — the happy path keys aggregate shares by the engine-derived identifiers.
- `RejectsEngineCoordinatorMismatch` — a divergent engine coordinator fails closed before any session opens.
- All existing runner / equivocation / cross-attempt / abort / prune tests pass under `-race`; the harness sets the fake's derived coordinator to the binding's elected.
- gofmt + `frost_native` vet/suite + cgo build/vet/derive-tests + repo-wide frost vet all clean.

### Scope
- Completes the derivation increment; the runner is real-engine-ready (no placeholders). Nothing constructs the real cgo engine yet; production real-engine signing stays gated on the `frost-secp256k1-tr =3.0.0` external audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)