### PR TITLE
Phase 7.3: pkg/net transport adapter for the interactive signing runner

### DIFF
--- a/pkg/frost/signing/roast_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native.go
@@ -1,0 +1,296 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This file implements the production RunnerBus over keep-core's pkg/net
+// BroadcastChannel, per the 2026-06-17 Codex+Gemini transport consult. It is a
+// THIN adapter: it does NOT create or own the channel (the wallet signing
+// channel is created and membership-filtered by pkg/tbtc) - it is constructed
+// from the channel + the group MembershipValidator the existing signing.Request
+// already carries.
+//
+// It honors the runner's two transport-contract assumptions:
+//
+//  1. RunnerMessage.Sender is the AUTHENTICATED seat. The wire body carries a
+//     CLAIMED sender_id; the adapter accepts it only after IsValidMembership
+//     confirms the claimed seat belongs to the message's authenticated operator
+//     public key, then sets Sender from it. It NEVER trusts a sender field
+//     inside Payload. (An operator can hold multiple seats - MembershipValidator
+//     maps an address to a SET of positions - so a public key does not resolve
+//     to a single member index; the claimed-and-validated seat is the only sound
+//     binding.)
+//  2. Delivery never blocks an honest broadcaster. The single Recv handler
+//     demuxes into bounded per-subscriber streams with non-blocking sends
+//     (dropping the newest on overflow); late/excess traffic is the blame path's
+//     concern, and pkg/net retransmits a genuinely-needed message anyway.
+
+// runnerTransportType maps each RunnerMessageType to the distinct pkg/net
+// message Type() string the BroadcastChannel dispatches on.
+var runnerTransportType = map[RunnerMessageType]string{
+	RunnerMsgCommitments:      "frost/roast_runner/commitments",
+	RunnerMsgSigningPackage:   "frost/roast_runner/signing_package",
+	RunnerMsgShareSubmission:  "frost/roast_runner/share_submission",
+	RunnerMsgEvidenceSnapshot: "frost/roast_runner/evidence_snapshot",
+	RunnerMsgTransitionBundle: "frost/roast_runner/transition_bundle",
+}
+
+// runnerTransportMessage is the wire envelope for one RunnerMessage. The five
+// runner stream types share this body and are distinguished by the Type()
+// string (set per registered unmarshaler), matching the RegisterUnmarshallers
+// convention. The body carries the CLAIMED sender seat, the attempt context
+// hash, and the opaque runner payload.
+type runnerTransportMessage struct {
+	messageType RunnerMessageType
+	sender      group.MemberIndex
+	attempt     [attemptContextHashLength]byte
+	payload     []byte
+}
+
+// attemptContextHashLength is the fixed wire length of the attempt context hash
+// (a SHA-256 digest). It equals attempt.MessageDigestLength; redeclared as a
+// constant here to keep the fixed-size prefix framing self-documenting.
+const attemptContextHashLength = sha256.Size
+
+// Type returns the pkg/net dispatch tag for this message's runner type.
+func (m *runnerTransportMessage) Type() string {
+	return runnerTransportType[m.messageType]
+}
+
+// Marshal encodes the body as: sender_id (uint32 big-endian) || attempt_context
+// _hash (32 bytes) || payload (remaining bytes). The fixed-size prefix makes the
+// boundary unambiguous, so the variable-length payload needs no length prefix.
+func (m *runnerTransportMessage) Marshal() ([]byte, error) {
+	if m.sender == 0 {
+		return nil, fmt.Errorf("runner transport: sender is zero")
+	}
+	out := make([]byte, 4+attemptContextHashLength+len(m.payload))
+	binary.BigEndian.PutUint32(out[0:4], uint32(m.sender))
+	copy(out[4:4+attemptContextHashLength], m.attempt[:])
+	copy(out[4+attemptContextHashLength:], m.payload)
+	return out, nil
+}
+
+// Unmarshal decodes a body produced by Marshal. messageType is preset by the
+// registered unmarshaler (one per Type() string), so it is not carried on the
+// wire.
+func (m *runnerTransportMessage) Unmarshal(data []byte) error {
+	const prefix = 4 + attemptContextHashLength
+	if len(data) < prefix {
+		return fmt.Errorf(
+			"runner transport: message length [%d] shorter than the %d-byte header",
+			len(data), prefix,
+		)
+	}
+	m.sender = group.MemberIndex(binary.BigEndian.Uint32(data[0:4]))
+	if m.sender == 0 {
+		return fmt.Errorf("runner transport: sender is zero")
+	}
+	copy(m.attempt[:], data[4:prefix])
+	m.payload = append([]byte(nil), data[prefix:]...)
+	return nil
+}
+
+// registerRunnerTransportUnmarshalers registers one unmarshaler per runner
+// stream type, each presetting messageType so Type() and the demux know the
+// stream without a wire type tag.
+func registerRunnerTransportUnmarshalers(channel net.BroadcastChannel) {
+	for messageType := range runnerTransportType {
+		mt := messageType
+		channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+			return &runnerTransportMessage{messageType: mt}
+		})
+	}
+}
+
+const (
+	// defaultRunnerBusStreamBuffer bounds each per-subscriber stream. Sized to
+	// comfortably hold one attempt's worth of one type from every member, with
+	// headroom; overflow drops the newest (late/excess is the blame path's
+	// concern).
+	defaultRunnerBusStreamBuffer = 256
+	// defaultRunnerBusSeenBound caps the per-subscriber dedup set so a peer
+	// flooding body-different messages cannot grow it without bound. On overflow
+	// the set resets (coarse but bounded); a re-delivered byte-identical message
+	// is harmless because pkg/net already dedups retransmissions and the
+	// collector is idempotent.
+	defaultRunnerBusSeenBound = 4096
+)
+
+// broadcastChannelRunnerBus is the production RunnerBus over a net.BroadcastChannel.
+type broadcastChannelRunnerBus struct {
+	ctx                 context.Context
+	logger              log.StandardLogger
+	channel             net.BroadcastChannel
+	membershipValidator *group.MembershipValidator
+	streamBuffer        int
+	seenBound           int
+
+	mu          sync.Mutex
+	subscribers []*RunnerBusSubscriber
+}
+
+// NewBroadcastChannelRunnerBus returns a RunnerBus over the given wallet signing
+// broadcast channel. It registers the runner message unmarshalers and installs
+// a receive handler for the lifetime of ctx; cancel ctx (e.g. at session end)
+// to stop receiving. The channel and membershipValidator are the ones the
+// existing signing.Request already carries; this adapter does not create them.
+func NewBroadcastChannelRunnerBus(
+	ctx context.Context,
+	logger log.StandardLogger,
+	channel net.BroadcastChannel,
+	membershipValidator *group.MembershipValidator,
+) (RunnerBus, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("runner bus: context is nil")
+	}
+	if channel == nil {
+		return nil, fmt.Errorf("runner bus: broadcast channel is nil")
+	}
+	if membershipValidator == nil {
+		return nil, fmt.Errorf("runner bus: membership validator is nil")
+	}
+	if logger == nil {
+		logger = log.Logger("frost-roast-runner-bus")
+	}
+
+	b := &broadcastChannelRunnerBus{
+		ctx:                 ctx,
+		logger:              logger,
+		channel:             channel,
+		membershipValidator: membershipValidator,
+		streamBuffer:        defaultRunnerBusStreamBuffer,
+		seenBound:           defaultRunnerBusSeenBound,
+	}
+
+	registerRunnerTransportUnmarshalers(channel)
+	channel.Recv(ctx, b.handleMessage)
+
+	return b, nil
+}
+
+// Subscribe registers a receiver and returns its typed streams. Subscribing
+// before any Broadcast is the caller's responsibility (the runner subscribes in
+// its constructor).
+func (b *broadcastChannelRunnerBus) Subscribe() *RunnerBusSubscriber {
+	s := &RunnerBusSubscriber{
+		commitments:       make(chan RunnerMessage, b.streamBuffer),
+		signingPackages:   make(chan RunnerMessage, b.streamBuffer),
+		shares:            make(chan RunnerMessage, b.streamBuffer),
+		evidenceSnapshots: make(chan RunnerMessage, b.streamBuffer),
+		transitionBundles: make(chan RunnerMessage, b.streamBuffer),
+		seen:              make(map[[sha256.Size]byte]struct{}),
+	}
+
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, s)
+	b.mu.Unlock()
+
+	return s
+}
+
+// Broadcast publishes msg to the channel. It is fire-and-forget: pkg/net handles
+// retransmission, so a Send error is logged (not surfaced) and the runner
+// records its OWN produced messages directly rather than relying on self-echo.
+func (b *broadcastChannelRunnerBus) Broadcast(msg RunnerMessage) {
+	wire := &runnerTransportMessage{
+		messageType: msg.Type,
+		sender:      msg.Sender,
+		attempt:     msg.Attempt,
+		payload:     msg.Payload,
+	}
+	if err := b.channel.Send(b.ctx, wire); err != nil {
+		b.logger.Warnf("runner bus: failed to broadcast [%s] message: [%v]", wire.Type(), err)
+	}
+}
+
+// handleMessage is the single Recv handler. It authenticates the claimed sender
+// seat against the message's authenticated operator public key, then demuxes the
+// message into every subscriber's typed stream (non-blocking, deduped).
+func (b *broadcastChannelRunnerBus) handleMessage(m net.Message) {
+	wire, ok := m.Payload().(*runnerTransportMessage)
+	if !ok {
+		// A message of an unregistered/foreign type, or a decode failure.
+		return
+	}
+
+	// Bind the CLAIMED seat to the AUTHENTICATED operator public key. An operator
+	// may hold several seats, so this validates membership of the specific
+	// claimed seat rather than resolving the key to one index. A spoofed seat (a
+	// seat the sender's key was not selected to) is dropped here, before the
+	// runner ever sees it.
+	if !b.membershipValidator.IsValidMembership(wire.sender, m.SenderPublicKey()) {
+		b.logger.Warnf(
+			"runner bus: dropping [%s] message claiming unauthenticated seat [%d]",
+			wire.Type(), wire.sender,
+		)
+		return
+	}
+
+	msg := RunnerMessage{
+		Type:    wire.messageType,
+		Sender:  wire.sender,
+		Attempt: wire.attempt,
+		Payload: wire.payload,
+	}
+	hash := msg.contentHash()
+
+	b.mu.Lock()
+	subscribers := append([]*RunnerBusSubscriber(nil), b.subscribers...)
+	b.mu.Unlock()
+
+	for _, s := range subscribers {
+		s.deliverNonBlocking(hash, msg, b.seenBound)
+	}
+}
+
+// deliverNonBlocking routes msg into the matching typed stream WITHOUT blocking:
+// on a full stream it drops the newest message (earlier, useful ones stay
+// queued). It dedups by full content hash per subscriber - byte-identical
+// retransmissions are suppressed, while body-different messages (equivocation
+// evidence) are delivered while the buffer permits. seenBound caps the dedup
+// set; on overflow it resets (bounded - a rare re-delivery is harmless given
+// pkg/net's own retransmission dedup and the collector's idempotent recording).
+func (s *RunnerBusSubscriber) deliverNonBlocking(
+	hash [sha256.Size]byte,
+	msg RunnerMessage,
+	seenBound int,
+) {
+	s.mu.Lock()
+	if _, dup := s.seen[hash]; dup {
+		s.mu.Unlock()
+		return
+	}
+	if seenBound > 0 && len(s.seen) >= seenBound {
+		s.seen = make(map[[sha256.Size]byte]struct{})
+	}
+	s.seen[hash] = struct{}{}
+	s.mu.Unlock()
+
+	stream := s.streamFor(msg.Type)
+	if stream == nil {
+		return
+	}
+	// Own the payload bytes per delivery (matches the in-process bus): the
+	// receive path may reuse the backing array, and a receiver must not be able
+	// to mutate another subscriber's view.
+	delivered := msg
+	delivered.Payload = append([]byte(nil), msg.Payload...)
+	select {
+	case stream <- delivered:
+	default:
+		// Stream full: drop the newest. Late/excess delivery is the blame path's
+		// concern, and pkg/net retransmits a genuinely-needed message.
+	}
+}

--- a/pkg/frost/signing/roast_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native.go
@@ -33,8 +33,15 @@ import (
 //     binding.)
 //  2. Delivery never blocks an honest broadcaster. The single Recv handler
 //     demuxes into bounded per-subscriber streams with non-blocking sends
-//     (dropping the newest on overflow); late/excess traffic is the blame path's
-//     concern, and pkg/net retransmits a genuinely-needed message anyway.
+//     (dropping the newest on overflow). A dropped message is PERMANENT: pkg/net
+//     filters retransmissions before this handler (BroadcastChannel.Recv wraps it
+//     with retransmission support), so a retransmit never re-reaches the bus. The
+//     streams are therefore sized to hold a whole attempt's honest message volume
+//     so honest operation never overflows; overflow only arises when a peer floods
+//     distinct messages faster than the runner drains, which degrades the attempt
+//     to a ROAST retry (pkg/net per-peer limits backstop the flood). Blocking
+//     instead is unsafe: the runner drains the streams in phases, so blocking on a
+//     stream it has finished with would stall delivery of the ones it still needs.
 
 // runnerTransportType maps each RunnerMessageType to the distinct pkg/net
 // message Type() string the BroadcastChannel dispatches on.
@@ -124,11 +131,15 @@ func registerRunnerTransportUnmarshalers(channel net.BroadcastChannel) {
 }
 
 const (
-	// defaultRunnerBusStreamBuffer bounds each per-subscriber stream. Sized to
-	// comfortably hold one attempt's worth of one type from every member, with
-	// headroom; overflow drops the newest (late/excess is the blame path's
-	// concern).
-	defaultRunnerBusStreamBuffer = 256
+	// defaultRunnerBusStreamBuffer bounds each per-subscriber stream. Because a
+	// drop here is permanent (pkg/net filters retransmissions before the handler),
+	// it is sized well above a single attempt's honest message volume - at most
+	// one message per included member per type, plus a small equivocation
+	// allowance the collector caps anyway - for the expected group sizes (tBTC
+	// wallets are ~100 seats). Honest operation thus never overflows; only a peer
+	// flooding distinct messages faster than the runner drains can, and that
+	// degrades the attempt to a retry rather than silently losing an honest one.
+	defaultRunnerBusStreamBuffer = 1024
 	// defaultRunnerBusSeenBound caps the per-subscriber dedup set so a peer
 	// flooding body-different messages cannot grow it without bound. On overflow
 	// the set resets (coarse but bounded); a re-delivered byte-identical message
@@ -295,15 +306,20 @@ func (s *RunnerBusSubscriber) deliverNonBlocking(
 	}
 	select {
 	case stream <- delivered:
-		// Record as seen ONLY after a successful enqueue. A message dropped on
-		// overflow is left un-seen so the pkg/net retransmission of it can still be
-		// delivered once the stream drains - marking it here would permanently
-		// suppress a message the runner never actually received.
+		// Record as seen ONLY after a successful enqueue, so a drop never poisons
+		// the dedup set against a later re-delivery of the same content. (Standard
+		// pkg/net retransmissions are filtered upstream and do NOT re-reach this
+		// handler, so this guards only a non-retransmit re-delivery; it is not a
+		// recovery path for an overflow drop - the buffer sizing is what keeps
+		// honest messages from being dropped in the first place.)
 		if seenBound > 0 && len(s.seen) >= seenBound {
 			s.seen = make(map[[sha256.Size]byte]struct{})
 		}
 		s.seen[hash] = struct{}{}
 	default:
-		// Stream full: drop the newest, leave it un-seen for a future retransmit.
+		// Stream full: drop the newest. This is permanent (retransmissions are
+		// filtered upstream), so the buffer is sized above honest volume and this
+		// only occurs under a flood (-> ROAST retry). Left un-seen so a
+		// non-retransmit re-delivery, if any, is still accepted.
 	}
 }

--- a/pkg/frost/signing/roast_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native.go
@@ -93,10 +93,19 @@ func (m *runnerTransportMessage) Unmarshal(data []byte) error {
 			len(data), prefix,
 		)
 	}
-	m.sender = group.MemberIndex(binary.BigEndian.Uint32(data[0:4]))
-	if m.sender == 0 {
-		return fmt.Errorf("runner transport: sender is zero")
+	// Validate the raw 4-byte seat BEFORE narrowing to group.MemberIndex (uint8).
+	// A truncating cast would wrap an out-of-range claim (e.g. 259 -> 3) and let
+	// it pass IsValidMembership for whoever holds the wrapped seat - and round-1
+	// commitments carry no inner signature to reject it later. Reject any
+	// non-canonical seat at the decode boundary.
+	rawSender := binary.BigEndian.Uint32(data[0:4])
+	if rawSender == 0 || rawSender > uint32(group.MaxMemberIndex) {
+		return fmt.Errorf(
+			"runner transport: sender id [%d] out of range [1, %d]",
+			rawSender, group.MaxMemberIndex,
+		)
 	}
+	m.sender = group.MemberIndex(rawSender)
 	copy(m.attempt[:], data[4:prefix])
 	m.payload = append([]byte(nil), data[prefix:]...)
 	return nil
@@ -267,17 +276,6 @@ func (s *RunnerBusSubscriber) deliverNonBlocking(
 	msg RunnerMessage,
 	seenBound int,
 ) {
-	s.mu.Lock()
-	if _, dup := s.seen[hash]; dup {
-		s.mu.Unlock()
-		return
-	}
-	if seenBound > 0 && len(s.seen) >= seenBound {
-		s.seen = make(map[[sha256.Size]byte]struct{})
-	}
-	s.seen[hash] = struct{}{}
-	s.mu.Unlock()
-
 	stream := s.streamFor(msg.Type)
 	if stream == nil {
 		return
@@ -287,10 +285,25 @@ func (s *RunnerBusSubscriber) deliverNonBlocking(
 	// to mutate another subscriber's view.
 	delivered := msg
 	delivered.Payload = append([]byte(nil), msg.Payload...)
+
+	// Dedup-check, enqueue, and record-seen under one lock. The non-blocking
+	// send never blocks (select/default), so holding the lock across it is safe.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, dup := s.seen[hash]; dup {
+		return
+	}
 	select {
 	case stream <- delivered:
+		// Record as seen ONLY after a successful enqueue. A message dropped on
+		// overflow is left un-seen so the pkg/net retransmission of it can still be
+		// delivered once the stream drains - marking it here would permanently
+		// suppress a message the runner never actually received.
+		if seenBound > 0 && len(s.seen) >= seenBound {
+			s.seen = make(map[[sha256.Size]byte]struct{})
+		}
+		s.seen[hash] = struct{}{}
 	default:
-		// Stream full: drop the newest. Late/excess delivery is the blame path's
-		// concern, and pkg/net retransmits a genuinely-needed message.
+		// Stream full: drop the newest, leave it un-seen for a future retransmit.
 	}
 }

--- a/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
@@ -197,10 +197,13 @@ func TestRunnerTransportMessage_RejectsOutOfRangeSender(t *testing.T) {
 	}
 }
 
-// A message dropped because a stream was full must NOT be recorded as seen, so a
-// pkg/net retransmission of it is still delivered once the stream drains -
-// otherwise the runner could permanently miss a required message.
-func TestBroadcastChannelRunnerBus_DoesNotSuppressDroppedMessages(t *testing.T) {
+// A message dropped because a stream was full must NOT be recorded as seen: a
+// drop must not poison the dedup set against a later re-delivery of the same
+// content. (Standard pkg/net retransmissions are filtered upstream and would not
+// re-reach the handler, so the real protection against losing an honest message
+// is the buffer sizing; this guards only the dedup bookkeeping for any
+// non-retransmit re-delivery.)
+func TestBroadcastChannelRunnerBus_DropDoesNotPoisonDedup(t *testing.T) {
 	f := newRunnerBusAuthFixture(t, 1) // buffer of one
 	sub := f.bus.Subscribe()
 
@@ -214,15 +217,16 @@ func TestBroadcastChannelRunnerBus_DoesNotSuppressDroppedMessages(t *testing.T) 
 		t.Fatalf("expected 'first' drained, got %q", got.Payload)
 	}
 
-	// Retransmission of the dropped message, now that the buffer has room.
+	// A re-delivery of the dropped content, now that the buffer has room, is
+	// accepted (not suppressed as a duplicate).
 	f.bus.handleMessage(second)
 	select {
 	case got := <-sub.Shares():
 		if string(got.Payload) != "second" {
-			t.Fatalf("expected 'second' on retransmit, got %q", got.Payload)
+			t.Fatalf("expected 'second' on re-delivery, got %q", got.Payload)
 		}
 	default:
-		t.Fatal("a message dropped on overflow must be deliverable on retransmit after drain")
+		t.Fatal("a message dropped on overflow must not be suppressed on a later re-delivery")
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
@@ -5,6 +5,7 @@ package signing
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/keep-network/keep-core/internal/testutils"
@@ -179,6 +180,49 @@ func TestBroadcastChannelRunnerBus_DedupsByteIdentical(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected one delivery for byte-identical messages, got [%d]", count)
+	}
+}
+
+func TestRunnerTransportMessage_RejectsOutOfRangeSender(t *testing.T) {
+	frame := make([]byte, 4+attemptContextHashLength+2)
+	// A seat beyond the valid range must be rejected at decode, BEFORE the uint8
+	// narrowing - else it would wrap (e.g. 256+3 -> 3) and pass authentication.
+	binary.BigEndian.PutUint32(frame[0:4], uint32(group.MaxMemberIndex)+1)
+	if err := (&runnerTransportMessage{}).Unmarshal(frame); err == nil {
+		t.Fatal("expected an out-of-range sender id to be rejected")
+	}
+	binary.BigEndian.PutUint32(frame[0:4], 256+3) // wraps to seat 3 if truncated
+	if err := (&runnerTransportMessage{}).Unmarshal(frame); err == nil {
+		t.Fatal("expected a wrapping sender id to be rejected before truncation")
+	}
+}
+
+// A message dropped because a stream was full must NOT be recorded as seen, so a
+// pkg/net retransmission of it is still delivered once the stream drains -
+// otherwise the runner could permanently miss a required message.
+func TestBroadcastChannelRunnerBus_DoesNotSuppressDroppedMessages(t *testing.T) {
+	f := newRunnerBusAuthFixture(t, 1) // buffer of one
+	sub := f.bus.Subscribe()
+
+	first := shareMessage(1, f.operatorA, "first")
+	second := shareMessage(1, f.operatorA, "second") // distinct body, distinct hash
+
+	f.bus.handleMessage(first)  // fills the single-slot buffer
+	f.bus.handleMessage(second) // buffer full -> dropped (must stay un-seen)
+
+	if got := <-sub.Shares(); string(got.Payload) != "first" {
+		t.Fatalf("expected 'first' drained, got %q", got.Payload)
+	}
+
+	// Retransmission of the dropped message, now that the buffer has room.
+	f.bus.handleMessage(second)
+	select {
+	case got := <-sub.Shares():
+		if string(got.Payload) != "second" {
+			t.Fatalf("expected 'second' on retransmit, got %q", got.Payload)
+		}
+	default:
+		t.Fatal("a message dropped on overflow must be deliverable on retransmit after drain")
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
@@ -1,0 +1,106 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestRunnerTransportMessage_RoundTrip(t *testing.T) {
+	original := &runnerTransportMessage{
+		messageType: RunnerMsgSigningPackage,
+		sender:      3,
+		attempt:     [attemptContextHashLength]byte{0x42, 0x99, 0xff},
+		payload:     []byte("signed-signing-package-envelope"),
+	}
+
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// The registered unmarshaler presets messageType (it is not on the wire).
+	decoded := &runnerTransportMessage{messageType: RunnerMsgSigningPackage}
+	if err := decoded.Unmarshal(data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.sender != original.sender {
+		t.Fatalf("sender: got [%d], want [%d]", decoded.sender, original.sender)
+	}
+	if decoded.attempt != original.attempt {
+		t.Fatalf("attempt mismatch: got [%x], want [%x]", decoded.attempt, original.attempt)
+	}
+	if !bytes.Equal(decoded.payload, original.payload) {
+		t.Fatalf("payload mismatch: got [%q], want [%q]", decoded.payload, original.payload)
+	}
+	if decoded.Type() != "frost/roast_runner/signing_package" {
+		t.Fatalf("unexpected wire type: [%s]", decoded.Type())
+	}
+}
+
+func TestRunnerTransportMessage_EmptyPayloadRoundTrips(t *testing.T) {
+	original := &runnerTransportMessage{messageType: RunnerMsgCommitments, sender: 1}
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	decoded := &runnerTransportMessage{messageType: RunnerMsgCommitments}
+	if err := decoded.Unmarshal(data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.sender != 1 || len(decoded.payload) != 0 {
+		t.Fatalf("unexpected decode: sender [%d], payload len [%d]", decoded.sender, len(decoded.payload))
+	}
+}
+
+func TestRunnerTransportMessage_RejectsInvalid(t *testing.T) {
+	// Zero sender on marshal.
+	if _, err := (&runnerTransportMessage{messageType: RunnerMsgCommitments, sender: 0}).Marshal(); err == nil {
+		t.Fatal("expected marshal to reject a zero sender")
+	}
+	// Shorter than the fixed header.
+	if err := (&runnerTransportMessage{}).Unmarshal([]byte{0x00, 0x01}); err == nil {
+		t.Fatal("expected unmarshal to reject a short message")
+	}
+	// Exactly the header but a zero sender (all-zero prefix).
+	if err := (&runnerTransportMessage{}).Unmarshal(make([]byte, 4+attemptContextHashLength)); err == nil {
+		t.Fatal("expected unmarshal to reject a zero sender")
+	}
+}
+
+func TestRunnerTransportType_CoversEveryStream(t *testing.T) {
+	// Every type the subscriber demuxes must have a distinct wire type string,
+	// else BroadcastChannel cannot dispatch it.
+	types := []RunnerMessageType{
+		RunnerMsgCommitments,
+		RunnerMsgSigningPackage,
+		RunnerMsgShareSubmission,
+		RunnerMsgEvidenceSnapshot,
+		RunnerMsgTransitionBundle,
+	}
+	seen := map[string]struct{}{}
+	for _, mt := range types {
+		s := runnerTransportType[mt]
+		if s == "" {
+			t.Fatalf("runner message type [%v] has no wire type string", mt)
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("wire type string [%s] is not distinct", s)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+func TestNewBroadcastChannelRunnerBus_RejectsNilDependencies(t *testing.T) {
+	ctx := context.Background()
+	// nil context
+	if _, err := NewBroadcastChannelRunnerBus(nil, nil, nil, nil); err == nil { //nolint:staticcheck
+		t.Fatal("expected nil context to be rejected")
+	}
+	// nil channel (other deps non-nil-checked after)
+	if _, err := NewBroadcastChannelRunnerBus(ctx, nil, nil, nil); err == nil {
+		t.Fatal("expected nil channel to be rejected")
+	}
+}

--- a/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_net_frost_native_test.go
@@ -6,7 +6,206 @@ import (
 	"bytes"
 	"context"
 	"testing"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
+
+// fakeNetMessage is a minimal net.Message for exercising the adapter's receive
+// path (sender authentication + demux) without standing up a full network. The
+// authenticated author key is SenderPublicKey(); Payload() is the unmarshaled
+// runner transport message the channel would hand the handler.
+type fakeNetMessage struct {
+	senderPublicKey []byte
+	payload         interface{}
+}
+
+func (m fakeNetMessage) TransportSenderID() net.TransportIdentifier { return nil }
+func (m fakeNetMessage) SenderPublicKey() []byte                    { return m.senderPublicKey }
+func (m fakeNetMessage) Payload() interface{}                       { return m.payload }
+func (m fakeNetMessage) Seqno() uint64                              { return 0 }
+func (m fakeNetMessage) Type() string {
+	if w, ok := m.payload.(*runnerTransportMessage); ok {
+		return w.Type()
+	}
+	return ""
+}
+
+// runnerBusAuthFixture builds a three-seat group with a MULTI-SEAT operator
+// (operator A holds seats 1 and 3; operator B holds seat 2) and a bus wired to
+// the resulting MembershipValidator. It returns the bus plus each operator's
+// authenticated public-key bytes and an outsider's key (not in the group).
+type runnerBusAuthFixture struct {
+	bus        *broadcastChannelRunnerBus
+	operatorA  []byte // seats 1 and 3
+	operatorB  []byte // seat 2
+	outsider   []byte // not selected
+	streamSize int
+}
+
+func newRunnerBusAuthFixture(t *testing.T, streamSize int) runnerBusAuthFixture {
+	t.Helper()
+	signing := local_v1.Connect(3, 3).Signing()
+
+	key := func() []byte {
+		_, publicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("generate operator key: %v", err)
+		}
+		return operator.MarshalUncompressed(publicKey)
+	}
+	operatorA, operatorB, outsider := key(), key(), key()
+
+	addrA := signing.PublicKeyBytesToAddress(operatorA)
+	addrB := signing.PublicKeyBytesToAddress(operatorB)
+	// Ordered seats: 1 -> A, 2 -> B, 3 -> A (operator A is multi-seat).
+	validator := group.NewMembershipValidator(
+		&testutils.MockLogger{},
+		[]chain.Address{addrA, addrB, addrA},
+		signing,
+	)
+
+	bus := &broadcastChannelRunnerBus{
+		logger:              &testutils.MockLogger{},
+		membershipValidator: validator,
+		streamBuffer:        streamSize,
+		seenBound:           defaultRunnerBusSeenBound,
+	}
+	return runnerBusAuthFixture{
+		bus:        bus,
+		operatorA:  operatorA,
+		operatorB:  operatorB,
+		outsider:   outsider,
+		streamSize: streamSize,
+	}
+}
+
+func shareMessage(sender group.MemberIndex, authorPublicKey []byte, payload string) fakeNetMessage {
+	return fakeNetMessage{
+		senderPublicKey: authorPublicKey,
+		payload: &runnerTransportMessage{
+			messageType: RunnerMsgShareSubmission,
+			sender:      sender,
+			attempt:     [attemptContextHashLength]byte{0x42},
+			payload:     []byte(payload),
+		},
+	}
+}
+
+func TestBroadcastChannelRunnerBus_AuthenticatedMessageDemuxed(t *testing.T) {
+	f := newRunnerBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	// Operator A authentically sends as seat 1 (a seat it holds).
+	f.bus.handleMessage(shareMessage(1, f.operatorA, "share-from-1"))
+
+	select {
+	case msg := <-sub.Shares():
+		if msg.Sender != 1 {
+			t.Fatalf("unexpected sender: [%d]", msg.Sender)
+		}
+		if string(msg.Payload) != "share-from-1" {
+			t.Fatalf("unexpected payload: [%q]", msg.Payload)
+		}
+		if msg.Type != RunnerMsgShareSubmission {
+			t.Fatalf("unexpected type: [%v]", msg.Type)
+		}
+	default:
+		t.Fatal("expected an authenticated message to be delivered")
+	}
+}
+
+func TestBroadcastChannelRunnerBus_RejectsSpoofedSeat(t *testing.T) {
+	f := newRunnerBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	// Operator B (seat 2) claims seat 1 - a seat its key was NOT selected to.
+	f.bus.handleMessage(shareMessage(1, f.operatorB, "spoofed"))
+	// An outsider (no seat) claims seat 1.
+	f.bus.handleMessage(shareMessage(1, f.outsider, "outsider"))
+
+	select {
+	case msg := <-sub.Shares():
+		t.Fatalf("expected spoofed-seat messages to be dropped, got sender [%d]", msg.Sender)
+	default:
+	}
+}
+
+func TestBroadcastChannelRunnerBus_MultiSeatOperator(t *testing.T) {
+	f := newRunnerBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	// Operator A holds seats 1 AND 3: it may authentically send as either, but
+	// NOT as seat 2 (operator B's).
+	f.bus.handleMessage(shareMessage(3, f.operatorA, "share-from-3"))
+	f.bus.handleMessage(shareMessage(2, f.operatorA, "claiming-Bs-seat"))
+
+	got := map[group.MemberIndex]string{}
+	for {
+		select {
+		case msg := <-sub.Shares():
+			got[msg.Sender] = string(msg.Payload)
+			continue
+		default:
+		}
+		break
+	}
+	if len(got) != 1 || got[3] != "share-from-3" {
+		t.Fatalf("expected only seat 3 delivered, got %v", got)
+	}
+}
+
+func TestBroadcastChannelRunnerBus_DedupsByteIdentical(t *testing.T) {
+	f := newRunnerBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	msg := shareMessage(1, f.operatorA, "same-body")
+	f.bus.handleMessage(msg)
+	f.bus.handleMessage(msg) // a retransmission of the identical content
+
+	count := 0
+	for {
+		select {
+		case <-sub.Shares():
+			count++
+			continue
+		default:
+		}
+		break
+	}
+	if count != 1 {
+		t.Fatalf("expected one delivery for byte-identical messages, got [%d]", count)
+	}
+}
+
+func TestBroadcastChannelRunnerBus_DropsWhenStreamFullWithoutBlocking(t *testing.T) {
+	f := newRunnerBusAuthFixture(t, 2) // tiny stream buffer
+	sub := f.bus.Subscribe()
+
+	// Deliver more distinct (body-different) shares than the buffer holds. Each
+	// must not block; the excess is dropped (newest).
+	for i := 0; i < 5; i++ {
+		f.bus.handleMessage(shareMessage(1, f.operatorA, string(rune('a'+i))))
+	}
+
+	count := 0
+	for {
+		select {
+		case <-sub.Shares():
+			count++
+			continue
+		default:
+		}
+		break
+	}
+	if count != 2 {
+		t.Fatalf("expected the stream bounded to 2, got [%d] (and Broadcast must not have blocked)", count)
+	}
+}
 
 func TestRunnerTransportMessage_RoundTrip(t *testing.T) {
 	original := &runnerTransportMessage{


### PR DESCRIPTION
## Phase 7.3 — pkg/net transport adapter for the interactive signing runner (Option B)

Implements the production `RunnerBus` over keep-core's `pkg/net.BroadcastChannel`, per the Codex+Gemini transport consult — the runner can now run over real networking instead of the in-process test bus.

### What
- **Thin adapter** — `broadcastChannelRunnerBus`, constructed from the existing `signing.Request{Channel, MembershipValidator}`; it does **not** create/own channels (`pkg/tbtc` creates `tbtc-<walletPubKey>` + sets the membership filter).
- **Wire envelope** — `runnerTransportMessage{sender_id, attempt_context_hash, payload}`, one body shared by five distinct `TaggedMarshaler`/`Unmarshaler` types (`frost/roast_runner/{commitments,signing_package,share_submission,evidence_snapshot,transition_bundle}`), registered via `SetUnmarshaler`.
- **Sender authentication (assumption #1)** — the single `Recv` handler validates the *claimed* seat against the message's *authenticated* operator key via `membershipValidator.IsValidMembership(senderID, m.SenderPublicKey())` before setting `RunnerMessage.Sender`; never trusts a payload-internal sender. Operators hold multiple seats, so the claimed-and-validated seat is the sound binding (a public key does not resolve to one index).
- **Non-blocking demux (assumption #2)** — bounded per-subscriber streams, drop-newest on overflow, content-hash dedup with a bounded cache.

### Tests
- Unit: wire round-trip (incl. empty payload), marshal/unmarshal rejections, distinct-wire-type coverage, constructor nil guards.
- Integration (real `MembershipValidator`, multi-seat group, fake `net.Message`): authenticated demux, **spoofed-seat rejection**, multi-seat operator, byte-identical dedup, drop-not-block.
- `frost_native` build/vet/suite (`-race`) + cgo vet all clean.

### Scope
- **Additive** — no caller yet. Wiring `attemptRoastRetryOrchestrationFromRequest` to construct this bus + drive the runner is the **next PR**.
- Production real-engine signing stays gated on the `frost-secp256k1-tr =3.0.0` external audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)