### PR TITLE
feat(frost): member-level participant selection (7.3 PR2b-1a)

### DIFF
--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -6,8 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
-	"math/rand"
-	"sort"
 
 	"github.com/keep-network/keep-core/pkg/protocol/announcer"
 
@@ -353,7 +351,7 @@ func (srl *signingRetryLoop) start(
 			continue
 		}
 
-		excludedMembersIndexes, err := srl.performMembersSelection(
+		includedMembersIndexes, excludedMembersIndexes, err := srl.performMembersSelection(
 			readyMembersIndexes,
 		)
 		if err != nil {
@@ -362,14 +360,6 @@ func (srl *signingRetryLoop) start(
 				srl.attemptCounter,
 				err,
 			)
-		}
-
-		includedMembersIndexes := make([]group.MemberIndex, 0)
-		for i := range srl.signingGroupOperators {
-			memberIndex := group.MemberIndex(i + 1)
-			if !slices.Contains(excludedMembersIndexes, memberIndex) {
-				includedMembersIndexes = append(includedMembersIndexes, memberIndex)
-			}
 		}
 
 		attemptSkipped := slices.Contains(
@@ -484,70 +474,31 @@ func (srl *signingRetryLoop) start(
 	}
 }
 
-// performMembersSelection runs the member selection process whose result
-// is a list of members' indexes that should be excluded by the client
-// for the given signing attempt.
+// performMembersSelection runs the member selection process for the given
+// signing attempt, returning BOTH the included member indices (the members
+// that participate) and the excluded ones (everyone else), each sorted
+// ascending.
 //
-// The member selection process is done based on the list of ready members
-// provided as the readyMembersIndexes argument. This list is used twice:
-//
-// First, the algorithm determining the qualified operators set uses the
-// ready members list to build an input consisting of only active operators.
-// This way we guarantee that the qualified operators set contains only
-// ready and active operators that will actually take part in the signing
-// attempt.
-//
-// Second, the ready members list is used to determine a list of excluded
-// members. The excluded members list is built using the qualified operators
-// set. The algorithm that determines the qualified operators set does not
-// care about an exact mapping between operators and controlled members but
-// relies on the members count solely. That means the information about
-// readiness of specific members controlled by the given operators is not
-// included in the resulting qualified operators set. In order to properly
-// decide about inclusion or exclusion of specific members of a given
-// qualified operator, we must take the ready members list into account.
+// Selection is dispatched through participantSelector (RFC-21 Phase 6.4) so a
+// ROAST-driven implementation can be installed behind the frost_roast_retry
+// build tag without touching this call site. As of RFC-21 Phase 7.3 PR2b-1a
+// the selector is MEMBER-LEVEL: it returns the exact included member indices.
+// The legacy implementation computes them from the qualified-operator set, the
+// ready members, and the surplus trim; the ROAST implementation (PR2b-1b) will
+// return the transition's IncludedSet directly. The excluded set is the
+// complement of the included set over the whole signing group, so the two
+// partition [1, groupSize] -- which is why the downstream AttemptInfo can
+// reconstruct the exact included set from the excluded one losslessly.
 func (srl *signingRetryLoop) performMembersSelection(
 	readyMembersIndexes []group.MemberIndex,
-) ([]group.MemberIndex, error) {
-	qualifiedOperatorsSet, err := srl.qualifiedOperatorsSet(readyMembersIndexes)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get qualified operators: [%w]", err)
-	}
-
-	// Exclude all members controlled by the operators that were not
-	// qualified for the current attempt.
-	return srl.excludedMembersIndexes(
-		qualifiedOperatorsSet,
-		readyMembersIndexes,
-	), nil
-}
-
-// qualifiedOperatorsSet returns a set of operators qualified to participate
-// in the given signing attempt. The set of qualified operators is taken
-// from the set of active operators who announced readiness through
-// their controlled signing group members.
-func (srl *signingRetryLoop) qualifiedOperatorsSet(
-	readyMembersIndexes []group.MemberIndex,
-) (map[chain.Address]bool, error) {
-	// The retry algorithm expects that we count retries from 0. Since
-	// the first invocation of the algorithm will be for `attemptCounter == 1`
-	// we need to subtract one while determining the number of the given retry.
+) ([]group.MemberIndex, []group.MemberIndex, error) {
+	// The retry algorithm counts retries from 0. The first invocation is for
+	// attemptCounter == 1, so the retry count is attemptCounter - 1.
 	retryCount := srl.attemptCounter - 1
 
-	var readySigningGroupOperators []chain.Address
-	for _, memberIndex := range readyMembersIndexes {
-		readySigningGroupOperators = append(
-			readySigningGroupOperators,
-			srl.signingGroupOperators[memberIndex-1],
-		)
-	}
-
-	// RFC-21 Phase 6.4: dispatch through participantSelector so a
-	// future ROAST-driven implementation can be installed behind
-	// the frost_roast_retry build tag without touching this call
-	// site. Default and current behaviour: legacy retry shuffle.
-	qualifiedOperators, err := srl.participantSelector.Select(
-		readySigningGroupOperators,
+	includedMembersIndexes, err := srl.participantSelector.Select(
+		readyMembersIndexes,
+		srl.signingGroupOperators,
 		srl.attemptSeed,
 		retryCount,
 		uint(srl.groupParameters.HonestThreshold),
@@ -555,68 +506,38 @@ func (srl *signingRetryLoop) qualifiedOperatorsSet(
 		srl.signingGroupMemberIndex,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"random operator selection failed: [%w]",
+		return nil, nil, fmt.Errorf(
+			"participant selection failed: [%w]",
 			err,
 		)
 	}
 
-	return chain.Addresses(qualifiedOperators).Set(), nil
+	excludedMembersIndexes := membersComplement(
+		includedMembersIndexes,
+		len(srl.signingGroupOperators),
+	)
+
+	return includedMembersIndexes, excludedMembersIndexes, nil
 }
 
-// excludedMembersIndexes returns a list of excluded members' indexes for
-// the given qualified operators set.
-func (srl *signingRetryLoop) excludedMembersIndexes(
-	qualifiedOperatorsSet map[chain.Address]bool,
-	readyMembersIndexes []group.MemberIndex,
+// membersComplement returns the member indices in [1, groupSize] that are NOT
+// in the included set, sorted ascending. Together with the included set it
+// partitions the whole signing group.
+func membersComplement(
+	includedMembersIndexes []group.MemberIndex,
+	groupSize int,
 ) []group.MemberIndex {
-	includedMembersIndexes := make([]group.MemberIndex, 0)
-	excludedMembersIndexes := make([]group.MemberIndex, 0)
-	for i, operator := range srl.signingGroupOperators {
-		memberIndex := group.MemberIndex(i + 1)
-
-		if qualifiedOperatorsSet[operator] &&
-			slices.Contains(readyMembersIndexes, memberIndex) {
-			includedMembersIndexes = append(
-				includedMembersIndexes,
-				memberIndex,
-			)
-		} else {
-			excludedMembersIndexes = append(
-				excludedMembersIndexes,
-				memberIndex,
-			)
-		}
+	includedSet := make(map[group.MemberIndex]bool, len(includedMembersIndexes))
+	for _, memberIndex := range includedMembersIndexes {
+		includedSet[memberIndex] = true
 	}
 
-	// Make sure we always use just the smallest required count of
-	// signing members for performance reasons
-	if len(includedMembersIndexes) > srl.groupParameters.HonestThreshold {
-		// #nosec G404 (insecure random number source (rand))
-		// Shuffling does not require secure randomness.
-		rng := rand.New(rand.NewSource(
-			srl.attemptSeed + int64(srl.attemptCounter),
-		))
-		// Sort in ascending order just in case.
-		sort.Slice(includedMembersIndexes, func(i, j int) bool {
-			return includedMembersIndexes[i] < includedMembersIndexes[j]
-		})
-		// Shuffle the included members slice to randomize the
-		// selection of additionally excluded members.
-		rng.Shuffle(len(includedMembersIndexes), func(i, j int) {
-			includedMembersIndexes[i], includedMembersIndexes[j] =
-				includedMembersIndexes[j], includedMembersIndexes[i]
-		})
-		// Get the surplus of included members and add them to
-		// the excluded members list.
-		excludedMembersIndexes = append(
-			excludedMembersIndexes,
-			includedMembersIndexes[srl.groupParameters.HonestThreshold:]...,
-		)
-		// Sort the resulting excluded members list in ascending order.
-		sort.Slice(excludedMembersIndexes, func(i, j int) bool {
-			return excludedMembersIndexes[i] < excludedMembersIndexes[j]
-		})
+	excludedMembersIndexes := make([]group.MemberIndex, 0, groupSize)
+	for i := 0; i < groupSize; i++ {
+		memberIndex := group.MemberIndex(i + 1)
+		if !includedSet[memberIndex] {
+			excludedMembersIndexes = append(excludedMembersIndexes, memberIndex)
+		}
 	}
 
 	return excludedMembersIndexes

--- a/pkg/tbtc/signing_loop_legacy_selector.go
+++ b/pkg/tbtc/signing_loop_legacy_selector.go
@@ -2,6 +2,8 @@ package tbtc
 
 import (
 	"fmt"
+	"math/rand"
+	"sort"
 
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/frost/retry"
@@ -9,7 +11,10 @@ import (
 )
 
 // legacySigningParticipantSelector is the pre-RFC-21 implementation:
-// it calls the pseudo-random retry shuffle in pkg/frost/retry.
+// it calls the pseudo-random retry shuffle in pkg/frost/retry and maps
+// the resulting qualified operators back to the included member
+// indices.
+//
 // Kept as the canonical fallback through Phase 6; Phase 7 may
 // remove it once the ROAST-driven retry path is fully wired and
 // the readiness manifest flips.
@@ -18,18 +23,39 @@ import (
 // preserve the operational rollback path: if a deployment toggles
 // the readiness env var off, this implementation is what the
 // dispatcher falls back to.
+//
+// RFC-21 Phase 7.3 PR2b-1a moved the member-index mapping and the
+// surplus trim from the signing-loop INTO this selector so selection
+// is member-level (see signingParticipantSelector). The computation is
+// byte-identical to the pre-RFC-21 signing_loop.excludedMembersIndexes:
+// the same operator selection, the same per-member inclusion rule, and
+// the same seeded surplus shuffle (seed offset by the attempt counter,
+// which is retryCount+1), just producing the included set directly
+// instead of the excluded complement.
 type legacySigningParticipantSelector struct{}
 
 func (legacySigningParticipantSelector) Select(
-	members []chain.Address,
+	readyMembersIndexes []group.MemberIndex,
+	signingGroupOperators chain.Addresses,
 	seed int64,
 	retryCount uint,
 	honestThreshold uint,
 	_ string,
 	_ group.MemberIndex,
-) ([]chain.Address, error) {
+) ([]group.MemberIndex, error) {
+	// Build the input the retry shuffle expects: one operator address
+	// per ready member (an operator controlling k ready members appears
+	// k times, matching the pre-RFC-21 input to the algorithm).
+	readyOperators := make([]chain.Address, 0, len(readyMembersIndexes))
+	for _, memberIndex := range readyMembersIndexes {
+		readyOperators = append(
+			readyOperators,
+			signingGroupOperators[memberIndex-1],
+		)
+	}
+
 	qualifiedOperators, err := retry.EvaluateRetryParticipantsForSigning(
-		members,
+		readyOperators,
 		seed,
 		retryCount,
 		honestThreshold,
@@ -40,5 +66,52 @@ func (legacySigningParticipantSelector) Select(
 			err,
 		)
 	}
-	return qualifiedOperators, nil
+	qualifiedOperatorsSet := chain.Addresses(qualifiedOperators).Set()
+
+	readyMembersSet := make(map[group.MemberIndex]bool, len(readyMembersIndexes))
+	for _, memberIndex := range readyMembersIndexes {
+		readyMembersSet[memberIndex] = true
+	}
+
+	// Include a member iff its operator is qualified and the member
+	// itself announced readiness. This is the per-member inclusion rule
+	// the old signing_loop.excludedMembersIndexes applied; doing it here
+	// keeps the ROAST-excluded seat of a multi-seat qualified operator
+	// from being pulled back in (the precision the address-based path
+	// lost).
+	includedMembersIndexes := make([]group.MemberIndex, 0, len(signingGroupOperators))
+	for i, operator := range signingGroupOperators {
+		memberIndex := group.MemberIndex(i + 1)
+		if qualifiedOperatorsSet[operator] && readyMembersSet[memberIndex] {
+			includedMembersIndexes = append(includedMembersIndexes, memberIndex)
+		}
+	}
+
+	// Trim to the smallest required count of signing members for
+	// performance, dropping the surplus by a seeded shuffle. The shuffle
+	// seed matches the pre-RFC-21 loop: seed + attemptCounter, and
+	// attemptCounter == retryCount + 1.
+	if len(includedMembersIndexes) > int(honestThreshold) {
+		// #nosec G404 (insecure random number source (rand))
+		// Shuffling does not require secure randomness.
+		rng := rand.New(rand.NewSource(seed + int64(retryCount) + 1))
+		// Sort in ascending order first so the shuffle (and thus the
+		// retained set) is independent of the iteration order above.
+		sort.Slice(includedMembersIndexes, func(i, j int) bool {
+			return includedMembersIndexes[i] < includedMembersIndexes[j]
+		})
+		rng.Shuffle(len(includedMembersIndexes), func(i, j int) {
+			includedMembersIndexes[i], includedMembersIndexes[j] =
+				includedMembersIndexes[j], includedMembersIndexes[i]
+		})
+		includedMembersIndexes = includedMembersIndexes[:honestThreshold]
+	}
+
+	// Return the included set in canonical ascending order (matches the
+	// pre-RFC-21 AttemptInfo.IncludedMembersIndexes, which was the
+	// ascending complement of the sorted excluded set).
+	sort.Slice(includedMembersIndexes, func(i, j int) bool {
+		return includedMembersIndexes[i] < includedMembersIndexes[j]
+	})
+	return includedMembersIndexes, nil
 }

--- a/pkg/tbtc/signing_loop_roast_dispatcher.go
+++ b/pkg/tbtc/signing_loop_roast_dispatcher.go
@@ -5,8 +5,8 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
-// signingParticipantSelector picks the set of operators qualified for
-// a signing attempt. The legacy implementation is the pseudo-random
+// signingParticipantSelector picks the set of members included in a
+// signing attempt. The legacy implementation is the pseudo-random
 // retry shuffle in pkg/frost/retry; the RFC-21 Phase-6 migration
 // introduces this interface so an alternate ROAST-driven
 // implementation can be installed behind the frost_roast_retry build
@@ -15,27 +15,40 @@ import (
 // PR 6.4 ships the dispatcher with only the legacy implementation
 // installed; Phase 7 wires the ROAST-driven implementation along
 // with the supporting AggregateBundle production at the executor-
-// adapter layer. Until Phase 7, behaviour is byte-identical to
+// adapter layer. Until the ROAST selector consumes its transition
+// record (RFC-21 Phase 7.3 PR2b), behaviour is byte-identical to
 // pre-RFC-21 retry semantics.
+//
+// RFC-21 Phase 7.3 PR2b-1a made selection MEMBER-LEVEL: Select returns
+// the exact included member indices, not a qualified-operator address
+// set the caller re-maps. The legacy path computes the indices
+// internally (operator selection + member mapping + surplus trim);
+// the ROAST path (PR2b) returns the transition's IncludedSet directly.
+// This removes the multi-seat precision loss of the old address-based
+// path, where one ready seat qualified ALL of an operator's seats --
+// including ones ROAST means to park or exclude.
 type signingParticipantSelector interface {
-	// Select returns the set of operators qualified to participate
-	// in the given signing attempt. members is the set of operators
-	// whose ready signal was received for this attempt. seed is the
-	// per-message retry seed; retryCount is 0-based (i.e. 0 for the
-	// first retry). honestThreshold is the group's signing
-	// threshold. sessionID is the STABLE ROAST session id and
-	// memberIndex is the local signer's member; together they key the
-	// per-(session, member) transition record the ROAST selector
-	// consumes (a multi-seat operator runs one signer per seat, each
-	// with its own record).
+	// Select returns the member indices included in the given signing
+	// attempt, sorted ascending. readyMembersIndexes is the set of
+	// members whose ready signal was received this attempt;
+	// signingGroupOperators is the full member->operator roster
+	// (index i is member i+1), used by the legacy path to map
+	// qualified operators back to members. seed is the per-message
+	// retry seed; retryCount is 0-based (0 for the first attempt).
+	// honestThreshold is the group's signing threshold. sessionID is
+	// the STABLE ROAST session id and memberIndex is the local
+	// signer's member; together they key the per-(session, member)
+	// transition record the ROAST selector consumes (a multi-seat
+	// operator runs one signer per seat, each with its own record).
 	Select(
-		members []chain.Address,
+		readyMembersIndexes []group.MemberIndex,
+		signingGroupOperators chain.Addresses,
 		seed int64,
 		retryCount uint,
 		honestThreshold uint,
 		sessionID string,
 		memberIndex group.MemberIndex,
-	) ([]chain.Address, error)
+	) ([]group.MemberIndex, error)
 }
 
 // defaultSigningParticipantSelector returns the build-default

--- a/pkg/tbtc/signing_loop_roast_dispatcher_test.go
+++ b/pkg/tbtc/signing_loop_roast_dispatcher_test.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -19,18 +20,19 @@ import (
 // than the legacy path.
 type recordingSelector struct {
 	calls  int
-	result []chain.Address
+	result []group.MemberIndex
 	err    error
 }
 
 func (r *recordingSelector) Select(
-	members []chain.Address,
+	readyMembersIndexes []group.MemberIndex,
+	_ chain.Addresses,
 	_ int64,
 	_ uint,
 	_ uint,
 	_ string,
 	_ group.MemberIndex,
-) ([]chain.Address, error) {
+) ([]group.MemberIndex, error) {
 	r.calls++
 	if r.err != nil {
 		return nil, r.err
@@ -38,31 +40,41 @@ func (r *recordingSelector) Select(
 	if r.result != nil {
 		return r.result, nil
 	}
-	return members, nil
+	return readyMembersIndexes, nil
 }
 
 func TestLegacySigningParticipantSelector_DelegatesToRetryShuffle(t *testing.T) {
-	members := []chain.Address{
+	operators := chain.Addresses{
 		chain.Address("op-1"),
 		chain.Address("op-2"),
 		chain.Address("op-3"),
 		chain.Address("op-4"),
 		chain.Address("op-5"),
 	}
+	readyMembers := []group.MemberIndex{1, 2, 3, 4, 5}
 	sel := legacySigningParticipantSelector{}
-	got, err := sel.Select(members, 42, 0, 3, "session-x", 1)
+	got, err := sel.Select(readyMembers, operators, 42, 0, 3, "session-x", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got) < 3 {
-		t.Fatalf("expected at least 3 qualified operators, got %d", len(got))
+	// Five members are ready and the honest threshold is 3, so the
+	// surplus trim leaves exactly the threshold count included.
+	if len(got) != 3 {
+		t.Fatalf("expected 3 included members (the honest threshold), got %d", len(got))
+	}
+	// The result must be sorted ascending and contain only ready members.
+	for i := 1; i < len(got); i++ {
+		if got[i] <= got[i-1] {
+			t.Fatalf("expected included members sorted ascending, got %v", got)
+		}
 	}
 }
 
 func TestLegacySigningParticipantSelector_PropagatesErrors(t *testing.T) {
 	sel := legacySigningParticipantSelector{}
 	_, err := sel.Select(
-		[]chain.Address{chain.Address("op-1")},
+		[]group.MemberIndex{1},
+		chain.Addresses{chain.Address("op-1")},
 		0, 0,
 		99, // honest threshold higher than member count
 		"session-x",
@@ -74,11 +86,7 @@ func TestLegacySigningParticipantSelector_PropagatesErrors(t *testing.T) {
 }
 
 func TestSigningRetryLoopUsesDispatcher(t *testing.T) {
-	sentinel := []chain.Address{
-		chain.Address("op-1"),
-		chain.Address("op-2"),
-		chain.Address("op-3"),
-	}
+	sentinel := []group.MemberIndex{1, 2, 3}
 	recorder := &recordingSelector{result: sentinel}
 
 	srl := &signingRetryLoop{
@@ -97,18 +105,25 @@ func TestSigningRetryLoopUsesDispatcher(t *testing.T) {
 		participantSelector: recorder,
 	}
 
-	set, err := srl.qualifiedOperatorsSet([]group.MemberIndex{1, 2, 3, 4, 5})
+	included, excluded, err := srl.performMembersSelection(
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if recorder.calls != 1 {
 		t.Fatalf("expected dispatcher to be called once; got %d", recorder.calls)
 	}
-	if len(set) != len(sentinel) {
+	if !reflect.DeepEqual(included, sentinel) {
 		t.Fatalf(
-			"expected %d qualified operators (the sentinel), got %d",
-			len(sentinel), len(set),
+			"expected the dispatcher's included set (the sentinel %v), got %v",
+			sentinel, included,
 		)
+	}
+	// Excluded is the complement of the sentinel over the 5-member group.
+	wantExcluded := []group.MemberIndex{4, 5}
+	if !reflect.DeepEqual(excluded, wantExcluded) {
+		t.Fatalf("expected excluded %v, got %v", wantExcluded, excluded)
 	}
 }
 
@@ -124,7 +139,7 @@ func TestSigningRetryLoopPropagatesSelectorError(t *testing.T) {
 		attemptSeed:         0,
 		participantSelector: &recordingSelector{err: wantErr},
 	}
-	_, err := srl.qualifiedOperatorsSet([]group.MemberIndex{1, 2})
+	_, _, err := srl.performMembersSelection([]group.MemberIndex{1, 2})
 	if err == nil {
 		t.Fatal("expected selector error to propagate")
 	}

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
@@ -31,19 +31,27 @@ func defaultSigningParticipantSelector() signingParticipantSelector {
 	return roastSigningParticipantSelector{}
 }
 
-// Select delegates to the legacy retry shuffle in PR2a. The sessionID +
-// memberIndex parameters are threaded through the interface now so PR2b can wire
-// distributed, member-level consumption of the transition record without
-// touching the call site again.
+// Select delegates to the legacy retry shuffle in PR2a/PR2b-1a. The
+// readyMembersIndexes + signingGroupOperators + sessionID + memberIndex
+// parameters are threaded through the interface now so PR2b-1b can wire
+// distributed, member-level consumption of the transition record (it returns
+// the transition's IncludedSet directly) without touching the call site again.
 func (s roastSigningParticipantSelector) Select(
-	members []chain.Address,
+	readyMembersIndexes []group.MemberIndex,
+	signingGroupOperators chain.Addresses,
 	seed int64,
 	retryCount uint,
 	honestThreshold uint,
 	sessionID string,
 	memberIndex group.MemberIndex,
-) ([]chain.Address, error) {
+) ([]group.MemberIndex, error) {
 	return s.legacy.Select(
-		members, seed, retryCount, honestThreshold, sessionID, memberIndex,
+		readyMembersIndexes,
+		signingGroupOperators,
+		seed,
+		retryCount,
+		honestThreshold,
+		sessionID,
+		memberIndex,
 	)
 }

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/frost/roast"
 	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 func selectorTestMembers() []chain.Address {
@@ -45,12 +46,16 @@ func TestROASTSelector_DelegatesToLegacyAndDoesNotConsumeRecord(t *testing.T) {
 	})
 
 	sel := roastSigningParticipantSelector{}
-	got, err := sel.Select(selectorTestMembers(), 42, 0, 3, "session", 1)
+	got, err := sel.Select(
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		selectorTestMembers(),
+		42, 0, 3, "session", 1,
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(got) < 3 {
-		t.Fatalf("expected a legacy-shaped qualified set; got %d", len(got))
+		t.Fatalf("expected a legacy-shaped included set; got %d", len(got))
 	}
 
 	// The record must be untouched: PR2a's selector does not consume it.


### PR DESCRIPTION
## RFC-21 Phase 7.3 PR2b-1a — member-level participant selection

The first, behaviour-preserving slice of PR2b-1. It changes the
participant-selection seam to be **member-level** so PR2b-1b's ROAST
selector can return its transition `IncludedSet` directly.

### What changes
- `signingParticipantSelector.Select` now returns the **included member
  indices** (`[]group.MemberIndex`), sorted ascending, instead of a
  qualified-operator **address** set the signing loop re-mapped.
- The **legacy** selector computes the indices internally: operator
  selection (`retry.EvaluateRetryParticipantsForSigning`) → per-member
  inclusion (`qualified[op] && ready[member]`) → surplus trim. The
  surplus shuffle seed is identical to the old loop
  (`seed + retryCount + 1 == attemptSeed + attemptCounter`).
- `signingRetryLoop.performMembersSelection` returns `(included,
  excluded)`; the excluded set is the complement of the included set
  over the group, so the two partition `[1, groupSize]`. The old
  `qualifiedOperatorsSet` / `excludedMembersIndexes` methods and the
  loop's manual complement pass are removed.
- The ROAST selector (`frost_roast_retry`) still delegates to legacy —
  **consumption stays deferred to PR2b-1b** (no cross-node behaviour
  change here).

### Why
The address-based path lost per-member precision for multi-seat
operators: one ready seat qualified **all** of an operator's seats,
including ones ROAST means to park or exclude. Member-level selection
removes that, and gives PR2b-1b a seam that threads the exact set.

### Behaviour preservation
Byte-identical for the legacy path: the kept included set is
`shuffle(sorted(qualified∩ready))[:t]` with the same RNG, and the
excluded complement equals the old `excludedMembersIndexes` output in
both the surplus and non-surplus cases. The full `pkg/tbtc` suite's
`excludedMembersIndexes` assertions are unchanged.

### Tests
gofmt clean; build/vet green on default / `frost_native` /
`frost_native frost_tbtc_signer cgo` / `frost_roast_retry`; loop +
selector tests pass (incl. `-race`); full default `pkg/tbtc` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)