### PR TITLE
feat(frost): ROAST transition distribution + member-level selection (7.3 PR2b-1b)

### DIFF
--- a/pkg/frost/signing/attempt.go
+++ b/pkg/frost/signing/attempt.go
@@ -4,7 +4,11 @@ import "github.com/keep-network/keep-core/pkg/protocol/group"
 
 // Attempt describes runtime context for a signing attempt coordinated by ROAST.
 type Attempt struct {
-	// Number is the 1-based signing attempt counter for the same message.
+	// Number is the 1-based attempt number for the same message. Under active
+	// ROAST retry this is the COMMITTED roast attempt number (roastAttemptNumber+1),
+	// which can be strictly less than the wall-clock attempt count after
+	// pre-selection skips; without ROAST it is the block-paced attempt counter.
+	// BuildAttemptContextFromRequest maps it to the 0-based AttemptContext number.
 	Number uint
 	// CoordinatorMemberIndex is the member coordinating this attempt.
 	CoordinatorMemberIndex group.MemberIndex

--- a/pkg/frost/signing/attempt.go
+++ b/pkg/frost/signing/attempt.go
@@ -27,6 +27,16 @@ func cloneAttempt(attempt *Attempt) *Attempt {
 		return nil
 	}
 
+	// Preserve nil-ness for the optional parked set (nil when there is no
+	// parking) so a clone compares equal to an attempt that never set it.
+	var transientlyParked []group.MemberIndex
+	if attempt.TransientlyParkedMembersIndexes != nil {
+		transientlyParked = append(
+			[]group.MemberIndex{},
+			attempt.TransientlyParkedMembersIndexes...,
+		)
+	}
+
 	return &Attempt{
 		Number:                 attempt.Number,
 		CoordinatorMemberIndex: attempt.CoordinatorMemberIndex,
@@ -38,9 +48,6 @@ func cloneAttempt(attempt *Attempt) *Attempt {
 			[]group.MemberIndex{},
 			attempt.ExcludedMembersIndexes...,
 		),
-		TransientlyParkedMembersIndexes: append(
-			[]group.MemberIndex{},
-			attempt.TransientlyParkedMembersIndexes...,
-		),
+		TransientlyParkedMembersIndexes: transientlyParked,
 	}
 }

--- a/pkg/frost/signing/attempt.go
+++ b/pkg/frost/signing/attempt.go
@@ -10,8 +10,16 @@ type Attempt struct {
 	CoordinatorMemberIndex group.MemberIndex
 	// IncludedMembersIndexes are members participating in this attempt.
 	IncludedMembersIndexes []group.MemberIndex
-	// ExcludedMembersIndexes are members excluded from this attempt.
+	// ExcludedMembersIndexes are members NOT participating in this attempt --
+	// the permanently-excluded members together with the transiently-parked
+	// ones (TransientlyParkedMembersIndexes is a subset).
 	ExcludedMembersIndexes []group.MemberIndex
+	// TransientlyParkedMembersIndexes are the members the prior ROAST transition
+	// parked for THIS attempt only (silence/overflow): they do not participate
+	// now but the attempt after this one reinstates them. RFC-21 Phase 7.3
+	// PR2b-1b carries this so a one-attempt park does not become permanent.
+	// Empty for the legacy/attempt-zero shape.
+	TransientlyParkedMembersIndexes []group.MemberIndex
 }
 
 func cloneAttempt(attempt *Attempt) *Attempt {
@@ -29,6 +37,10 @@ func cloneAttempt(attempt *Attempt) *Attempt {
 		ExcludedMembersIndexes: append(
 			[]group.MemberIndex{},
 			attempt.ExcludedMembersIndexes...,
+		),
+		TransientlyParkedMembersIndexes: append(
+			[]group.MemberIndex{},
+			attempt.TransientlyParkedMembersIndexes...,
 		),
 	}
 }

--- a/pkg/frost/signing/attempt_context_from_request.go
+++ b/pkg/frost/signing/attempt_context_from_request.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // ErrAttemptContextConstruction is the sentinel error class returned
@@ -132,6 +133,16 @@ func BuildAttemptContextFromRequest(
 		roastSessionID = request.SessionID
 	}
 
+	// RFC-21 Phase 7.3 PR2b-1b: carry transient parking. Attempt.Excluded is the
+	// full "not participating now" set (permanent-excluded plus transiently-
+	// parked); split it so the AttemptContext distinguishes them, or NextAttempt
+	// would treat a one-attempt park as a permanent exclusion and never reinstate
+	// the member.
+	transientlyParked := request.Attempt.TransientlyParkedMembersIndexes
+	permanentExcluded := membersDifference(
+		request.Attempt.ExcludedMembersIndexes,
+		transientlyParked,
+	)
 	ctx, err := attempt.NewAttemptContextWithParking(
 		roastSessionID,
 		keyGroupID,
@@ -139,8 +150,8 @@ func BuildAttemptContextFromRequest(
 		digest,
 		attemptNumber,
 		request.Attempt.IncludedMembersIndexes,
-		request.Attempt.ExcludedMembersIndexes,
-		nil, // Phase 6 ships attempt-zero shape; parking lands in Phase 7+ orchestration.
+		permanentExcluded,
+		transientlyParked,
 	)
 	if err != nil {
 		return attempt.AttemptContext{}, fmt.Errorf(
@@ -150,6 +161,26 @@ func BuildAttemptContextFromRequest(
 		)
 	}
 	return ctx, nil
+}
+
+// membersDifference returns the members in `all` not present in `remove`,
+// preserving the order of `all`. Used to split an attempt's "not participating"
+// set into permanently-excluded vs transiently-parked.
+func membersDifference(all, remove []group.MemberIndex) []group.MemberIndex {
+	if len(remove) == 0 {
+		return all
+	}
+	removeSet := make(map[group.MemberIndex]bool, len(remove))
+	for _, m := range remove {
+		removeSet[m] = true
+	}
+	out := make([]group.MemberIndex, 0, len(all))
+	for _, m := range all {
+		if !removeSet[m] {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // deriveKeyGroupID computes the AttemptContext KeyGroupID field

--- a/pkg/frost/signing/attempt_context_from_request.go
+++ b/pkg/frost/signing/attempt_context_from_request.go
@@ -168,7 +168,10 @@ func BuildAttemptContextFromRequest(
 // set into permanently-excluded vs transiently-parked.
 func membersDifference(all, remove []group.MemberIndex) []group.MemberIndex {
 	if len(remove) == 0 {
-		return all
+		// Return a fresh slice, never the caller's backing array: the result
+		// becomes permanentExcluded on the context-build path and must not alias
+		// request.Attempt.ExcludedMembersIndexes (shared via the request template).
+		return append([]group.MemberIndex(nil), all...)
 	}
 	removeSet := make(map[group.MemberIndex]bool, len(remove))
 	for _, m := range remove {

--- a/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry.go
@@ -1,0 +1,101 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+import (
+	"fmt"
+)
+
+// ObserveAttemptForTransition begins a LOCAL "observe" attempt for the given
+// signing request against the registered ROAST-retry coordinator and stores the
+// resulting handle/context/dkg-key binding keyed by (roastSessionID, member,
+// attemptContextHash).
+//
+// RFC-21 Phase 7.3 PR2b-1b: every local seat -- including ones excluded from the
+// attempt -- observes each attempt so it holds a coordinator-instance-local
+// handle to later VerifyBundle the attempt's transition bundle and run
+// NextAttempt for participant selection (an AttemptHandle is not portable across
+// coordinator instances, so a receiver cannot use another node's handle). The
+// observe binding is DISTINCT from the active signing path's drive handle: it is
+// produced here for the transition machinery, not for the FROST signing rounds.
+//
+// It is a no-op (returns nil) under the deterministic static conditions every
+// honest node observes identically -- no coordinator registered, material not
+// extractable, or an attempt context that cannot be constructed -- so the caller
+// proceeds without an observe binding. Only a BeginAttempt failure (genuine
+// runtime fault) is returned, so the caller can log it; in PR2b-1b's
+// observe-only wiring a missing binding surfaces later as a fail-closed
+// selection, never a divergent one.
+func ObserveAttemptForTransition(request *Request) error {
+	if request == nil {
+		return fmt.Errorf("observe attempt: request is nil")
+	}
+
+	// Respect the readiness opt-in gate, exactly as BeginOrchestrationForSession
+	// does: when ROAST retry is opted out, observing is pointless (nothing
+	// consumes the binding) and must stay inert. Opt-out is a deterministic
+	// static condition every honest node sees identically.
+	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
+		return nil
+	}
+
+	deps, ok := RegisteredRoastRetryCoordinator()
+	if !ok || deps.Coordinator == nil {
+		// No orchestration registered -- static fallback, every honest node
+		// observes the same empty registry.
+		return nil
+	}
+
+	signerMaterial, err := request.NativeSignerMaterial()
+	if err != nil {
+		// Material not extractable (e.g. a UniFFI v1 deployment) -- deterministic
+		// static fallback.
+		return nil
+	}
+
+	ffiRequest := &NativeExecutionFFISigningRequest{
+		Message:           request.Message,
+		SessionID:         request.SessionID,
+		RoastSessionID:    request.RoastSessionID,
+		MemberIndex:       request.MemberIndex,
+		SignerMaterial:    signerMaterial,
+		TaprootMerkleRoot: request.TaprootMerkleRoot,
+		Attempt:           request.Attempt,
+	}
+
+	attemptCtx, err := BuildAttemptContextFromRequest(ffiRequest)
+	if err != nil {
+		// Deterministic per-input construction failure -- static fallback (matches
+		// attemptRoastRetryOrchestrationFromRequest's handling).
+		return nil
+	}
+
+	dkgGroupPublicKey, err := ExtractDkgGroupPublicKeyFromMaterial(signerMaterial)
+	if err != nil {
+		return nil
+	}
+
+	// Begin a local attempt to mint a coordinator-instance-local handle bound to
+	// this attempt's context. BeginAttempt elects the coordinator deterministically
+	// from the included set, so every honest seat's observe binding agrees on the
+	// elected coordinator without exchanging anything.
+	handle, err := deps.Coordinator.BeginAttempt(attemptCtx)
+	if err != nil {
+		return fmt.Errorf("observe attempt: begin attempt: %w", err)
+	}
+
+	// Key by the STABLE attemptCtx.SessionID (== RoastSessionID), matching the
+	// transition-record registry, plus the attempt context hash so the transition
+	// listener can resolve the binding from the hash an incoming bundle carries.
+	recordObservedAttempt(
+		attemptCtx.SessionID,
+		request.MemberIndex,
+		attemptCtx.Hash(),
+		observedAttemptBinding{
+			handle:            handle,
+			context:           attemptCtx,
+			dkgGroupPublicKey: dkgGroupPublicKey,
+		},
+	)
+	return nil
+}

--- a/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry.go
@@ -4,6 +4,8 @@ package signing
 
 import (
 	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
 )
 
 // ObserveAttemptForTransition begins a LOCAL "observe" attempt for the given
@@ -26,9 +28,12 @@ import (
 // runtime fault) is returned, so the caller can log it; in PR2b-1b's
 // observe-only wiring a missing binding surfaces later as a fail-closed
 // selection, never a divergent one.
-func ObserveAttemptForTransition(request *Request) error {
+func ObserveAttemptForTransition(
+	request *Request,
+) ([attempt.MessageDigestLength]byte, error) {
+	var zeroHash [attempt.MessageDigestLength]byte
 	if request == nil {
-		return fmt.Errorf("observe attempt: request is nil")
+		return zeroHash, fmt.Errorf("observe attempt: request is nil")
 	}
 
 	// Respect the readiness opt-in gate, exactly as BeginOrchestrationForSession
@@ -36,21 +41,21 @@ func ObserveAttemptForTransition(request *Request) error {
 	// consumes the binding) and must stay inert. Opt-out is a deterministic
 	// static condition every honest node sees identically.
 	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
-		return nil
+		return zeroHash, nil
 	}
 
 	deps, ok := RegisteredRoastRetryCoordinator()
 	if !ok || deps.Coordinator == nil {
 		// No orchestration registered -- static fallback, every honest node
 		// observes the same empty registry.
-		return nil
+		return zeroHash, nil
 	}
 
 	signerMaterial, err := request.NativeSignerMaterial()
 	if err != nil {
 		// Material not extractable (e.g. a UniFFI v1 deployment) -- deterministic
 		// static fallback.
-		return nil
+		return zeroHash, nil
 	}
 
 	ffiRequest := &NativeExecutionFFISigningRequest{
@@ -67,12 +72,12 @@ func ObserveAttemptForTransition(request *Request) error {
 	if err != nil {
 		// Deterministic per-input construction failure -- static fallback (matches
 		// attemptRoastRetryOrchestrationFromRequest's handling).
-		return nil
+		return zeroHash, nil
 	}
 
 	dkgGroupPublicKey, err := ExtractDkgGroupPublicKeyFromMaterial(signerMaterial)
 	if err != nil {
-		return nil
+		return zeroHash, nil
 	}
 
 	// Begin a local attempt to mint a coordinator-instance-local handle bound to
@@ -81,7 +86,7 @@ func ObserveAttemptForTransition(request *Request) error {
 	// elected coordinator without exchanging anything.
 	handle, err := deps.Coordinator.BeginAttempt(attemptCtx)
 	if err != nil {
-		return fmt.Errorf("observe attempt: begin attempt: %w", err)
+		return zeroHash, fmt.Errorf("observe attempt: begin attempt: %w", err)
 	}
 
 	// Key by the STABLE attemptCtx.SessionID (== RoastSessionID), matching the
@@ -97,5 +102,5 @@ func ObserveAttemptForTransition(request *Request) error {
 			dkgGroupPublicKey: dkgGroupPublicKey,
 		},
 	)
-	return nil
+	return attemptCtx.Hash(), nil
 }

--- a/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry_test.go
@@ -1,0 +1,101 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func newObserveTestRequest() *Request {
+	payload, _ := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup: "tbtc-signer-observe-group",
+	})
+	return &Request{
+		Message:        new(big.Int).SetBytes([]byte{0xab, 0xcd}),
+		RoastSessionID: "observe-test-session",
+		MemberIndex:    2,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: payload,
+		},
+		Attempt: &Attempt{
+			Number:                 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2, 3, 4, 5},
+			ExcludedMembersIndexes: []group.MemberIndex{},
+		},
+	}
+}
+
+func registerObserveTestCoordinator() {
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  2,
+	})
+}
+
+func TestObserveAttemptForTransition_StoresBinding(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	ResetRoastRetryRegistrationForTest()
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	registerObserveTestCoordinator()
+
+	req := newObserveTestRequest()
+	if err := ObserveAttemptForTransition(req); err != nil {
+		t.Fatalf("observe must not error: %v", err)
+	}
+	if !ObservedAttemptStoredForTest(req.RoastSessionID, req.MemberIndex) {
+		t.Fatal("observe must store a binding for (roastSessionID, member)")
+	}
+}
+
+func TestObserveAttemptForTransition_StaticFallback_NoCoordinator(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	ResetRoastRetryRegistrationForTest()
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	// No coordinator registered -> static fallback, no binding.
+	req := newObserveTestRequest()
+	if err := ObserveAttemptForTransition(req); err != nil {
+		t.Fatalf("static fallback must not error: %v", err)
+	}
+	if ObservedAttemptStoredForTest(req.RoastSessionID, req.MemberIndex) {
+		t.Fatal("no binding must be stored when no coordinator is registered")
+	}
+}
+
+func TestObserveAttemptForTransition_StaticFallback_ReadinessOff(t *testing.T) {
+	// Env var empty -> opted out, even with a coordinator registered.
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "")
+	ResetRoastRetryRegistrationForTest()
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	registerObserveTestCoordinator()
+
+	req := newObserveTestRequest()
+	if err := ObserveAttemptForTransition(req); err != nil {
+		t.Fatalf("readiness-off fallback must not error: %v", err)
+	}
+	if ObservedAttemptStoredForTest(req.RoastSessionID, req.MemberIndex) {
+		t.Fatal("no binding must be stored when readiness opt-in is off")
+	}
+}
+
+func TestObserveAttemptForTransition_NilRequest(t *testing.T) {
+	if err := ObserveAttemptForTransition(nil); err == nil {
+		t.Fatal("nil request must error")
+	}
+}

--- a/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry_test.go
@@ -50,7 +50,7 @@ func TestObserveAttemptForTransition_StoresBinding(t *testing.T) {
 	registerObserveTestCoordinator()
 
 	req := newObserveTestRequest()
-	if err := ObserveAttemptForTransition(req); err != nil {
+	if _, err := ObserveAttemptForTransition(req); err != nil {
 		t.Fatalf("observe must not error: %v", err)
 	}
 	if !ObservedAttemptStoredForTest(req.RoastSessionID, req.MemberIndex) {
@@ -67,7 +67,7 @@ func TestObserveAttemptForTransition_StaticFallback_NoCoordinator(t *testing.T) 
 
 	// No coordinator registered -> static fallback, no binding.
 	req := newObserveTestRequest()
-	if err := ObserveAttemptForTransition(req); err != nil {
+	if _, err := ObserveAttemptForTransition(req); err != nil {
 		t.Fatalf("static fallback must not error: %v", err)
 	}
 	if ObservedAttemptStoredForTest(req.RoastSessionID, req.MemberIndex) {
@@ -86,7 +86,7 @@ func TestObserveAttemptForTransition_StaticFallback_ReadinessOff(t *testing.T) {
 	registerObserveTestCoordinator()
 
 	req := newObserveTestRequest()
-	if err := ObserveAttemptForTransition(req); err != nil {
+	if _, err := ObserveAttemptForTransition(req); err != nil {
 		t.Fatalf("readiness-off fallback must not error: %v", err)
 	}
 	if ObservedAttemptStoredForTest(req.RoastSessionID, req.MemberIndex) {
@@ -95,7 +95,7 @@ func TestObserveAttemptForTransition_StaticFallback_ReadinessOff(t *testing.T) {
 }
 
 func TestObserveAttemptForTransition_NilRequest(t *testing.T) {
-	if err := ObserveAttemptForTransition(nil); err == nil {
+	if _, err := ObserveAttemptForTransition(nil); err == nil {
 		t.Fatal("nil request must error")
 	}
 }

--- a/pkg/frost/signing/roast_observed_attempt_registry_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_observed_attempt_registry_frost_native_roast_retry.go
@@ -1,0 +1,136 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// ObservedAttemptRegistryTTL is how long an observe binding is retained before
+// the background sweeper evicts it. Matches the session-handle TTL: an observe
+// binding is useless once the session it tracks is archived.
+const ObservedAttemptRegistryTTL = SessionHandleBindingTTL
+
+// observedAttemptKey scopes one local seat's observe binding to a specific
+// attempt of a ROAST session. RFC-21 Phase 7.3 PR2b-1b has every local signer --
+// including ones excluded from the attempt -- BeginAttempt locally so it holds a
+// coordinator-instance-local handle to verify a transition bundle and run
+// NextAttempt. The attempt hash discriminates the per-attempt bindings of one
+// (session, member); the transition listener looks a binding up by the hash the
+// incoming bundle carries.
+type observedAttemptKey struct {
+	sessionID   string
+	member      group.MemberIndex
+	attemptHash [attempt.MessageDigestLength]byte
+}
+
+// observedAttemptBinding is the per-attempt observe state a receiver needs to
+// verify the attempt's transition bundle and compute the next attempt: the local
+// handle (its own coordinator instance produced it), the bound attempt context
+// (NextAttempt reads it as the previous context), and the DKG group public key
+// (NextAttempt derives the next seed from it).
+type observedAttemptBinding struct {
+	handle            roast.AttemptHandle
+	context           attempt.AttemptContext
+	dkgGroupPublicKey []byte
+}
+
+type observedAttemptEntry struct {
+	binding   observedAttemptBinding
+	createdAt time.Time
+}
+
+var (
+	observedAttemptRegistryMu sync.RWMutex
+	observedAttemptRegistry   = map[observedAttemptKey]observedAttemptEntry{}
+)
+
+// recordObservedAttempt stores the observe binding for (sessionID, member,
+// attemptHash). A later call for the same key overwrites the earlier binding
+// (a re-observed attempt re-binds against the latest handle).
+func recordObservedAttempt(
+	sessionID string,
+	member group.MemberIndex,
+	attemptHash [attempt.MessageDigestLength]byte,
+	binding observedAttemptBinding,
+) {
+	observedAttemptRegistryMu.Lock()
+	defer observedAttemptRegistryMu.Unlock()
+	observedAttemptRegistry[observedAttemptKey{sessionID, member, attemptHash}] =
+		observedAttemptEntry{binding: binding, createdAt: time.Now()}
+}
+
+// observedAttempt returns the observe binding for (sessionID, member,
+// attemptHash) plus a presence flag.
+func observedAttempt(
+	sessionID string,
+	member group.MemberIndex,
+	attemptHash [attempt.MessageDigestLength]byte,
+) (observedAttemptBinding, bool) {
+	observedAttemptRegistryMu.RLock()
+	defer observedAttemptRegistryMu.RUnlock()
+	entry, ok := observedAttemptRegistry[observedAttemptKey{sessionID, member, attemptHash}]
+	if !ok {
+		return observedAttemptBinding{}, false
+	}
+	return entry.binding, true
+}
+
+// clearObservedAttempt removes the observe binding for (sessionID, member,
+// attemptHash). Called once a verified transition record is stored for the
+// attempt, on success, or at session end.
+func clearObservedAttempt(
+	sessionID string,
+	member group.MemberIndex,
+	attemptHash [attempt.MessageDigestLength]byte,
+) {
+	observedAttemptRegistryMu.Lock()
+	defer observedAttemptRegistryMu.Unlock()
+	delete(observedAttemptRegistry, observedAttemptKey{sessionID, member, attemptHash})
+}
+
+// ObservedAttemptStoredForTest reports whether any observe binding exists for
+// (sessionID, member), regardless of attempt hash. Exported test seam so
+// downstream-package tests can assert the controller stored a binding without
+// reaching into the unexported registry.
+func ObservedAttemptStoredForTest(sessionID string, member group.MemberIndex) bool {
+	observedAttemptRegistryMu.RLock()
+	defer observedAttemptRegistryMu.RUnlock()
+	for key := range observedAttemptRegistry {
+		if key.sessionID == sessionID && key.member == member {
+			return true
+		}
+	}
+	return false
+}
+
+// ResetObservedAttemptRegistryForTest clears every observe binding. Test-only
+// seam.
+func ResetObservedAttemptRegistryForTest() {
+	observedAttemptRegistryMu.Lock()
+	defer observedAttemptRegistryMu.Unlock()
+	observedAttemptRegistry = map[observedAttemptKey]observedAttemptEntry{}
+}
+
+// evictStaleObservedAttempts sweeps the registry and removes bindings older than
+// maxAge. Exposed at the package level so tests can invoke it directly with
+// small maxAge values and so the session-handle sweeper can share one background
+// goroutine.
+func evictStaleObservedAttempts(maxAge time.Duration) int {
+	cutoff := time.Now().Add(-maxAge)
+	observedAttemptRegistryMu.Lock()
+	defer observedAttemptRegistryMu.Unlock()
+	evicted := 0
+	for key, entry := range observedAttemptRegistry {
+		if entry.createdAt.Before(cutoff) {
+			delete(observedAttemptRegistry, key)
+			evicted++
+		}
+	}
+	return evicted
+}

--- a/pkg/frost/signing/roast_observed_attempt_registry_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_observed_attempt_registry_frost_native_roast_retry.go
@@ -94,6 +94,22 @@ func clearObservedAttempt(
 	delete(observedAttemptRegistry, observedAttemptKey{sessionID, member, attemptHash})
 }
 
+// clearObservedAttemptsForSession removes every observe binding for
+// (sessionID, member), regardless of attempt hash. The transition exchange calls
+// it when the session ends (its listener context is done), so a signing whose
+// attempts succeeded -- and therefore never produced a transition record to clear
+// per-attempt via clearObservedAttempt -- does not leave its observe bindings
+// behind.
+func clearObservedAttemptsForSession(sessionID string, member group.MemberIndex) {
+	observedAttemptRegistryMu.Lock()
+	defer observedAttemptRegistryMu.Unlock()
+	for key := range observedAttemptRegistry {
+		if key.sessionID == sessionID && key.member == member {
+			delete(observedAttemptRegistry, key)
+		}
+	}
+}
+
 // ObservedAttemptStoredForTest reports whether any observe binding exists for
 // (sessionID, member), regardless of attempt hash. Exported test seam so
 // downstream-package tests can assert the controller stored a binding without

--- a/pkg/frost/signing/roast_observed_attempt_registry_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_observed_attempt_registry_frost_roast_retry.go
@@ -1,4 +1,4 @@
-//go:build frost_native && frost_roast_retry
+//go:build frost_roast_retry
 
 package signing
 

--- a/pkg/frost/signing/roast_observed_attempt_registry_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_observed_attempt_registry_frost_roast_retry.go
@@ -48,11 +48,20 @@ type observedAttemptEntry struct {
 var (
 	observedAttemptRegistryMu sync.RWMutex
 	observedAttemptRegistry   = map[observedAttemptKey]observedAttemptEntry{}
+	// observedAttemptHistory records that (sessionID, member) observed an attempt
+	// hash, retained even after the per-attempt binding is consumed or cleared so
+	// the transition listener can tell a bundle for an attempt this seat NEVER
+	// observed (it skipped a window peers committed -> lost ROAST sync -> fail
+	// closed) apart from a duplicate bundle for one it already consumed (a benign
+	// retransmit). It shares the binding's lifetime: cleared at session end and
+	// swept by the same TTL.
+	observedAttemptHistory = map[observedAttemptKey]time.Time{}
 )
 
 // recordObservedAttempt stores the observe binding for (sessionID, member,
-// attemptHash). A later call for the same key overwrites the earlier binding
-// (a re-observed attempt re-binds against the latest handle).
+// attemptHash) and marks the attempt as observed in the history. A later call for
+// the same key overwrites the earlier binding (a re-observed attempt re-binds
+// against the latest handle).
 func recordObservedAttempt(
 	sessionID string,
 	member group.MemberIndex,
@@ -61,8 +70,10 @@ func recordObservedAttempt(
 ) {
 	observedAttemptRegistryMu.Lock()
 	defer observedAttemptRegistryMu.Unlock()
-	observedAttemptRegistry[observedAttemptKey{sessionID, member, attemptHash}] =
-		observedAttemptEntry{binding: binding, createdAt: time.Now()}
+	now := time.Now()
+	key := observedAttemptKey{sessionID, member, attemptHash}
+	observedAttemptRegistry[key] = observedAttemptEntry{binding: binding, createdAt: now}
+	observedAttemptHistory[key] = now
 }
 
 // observedAttempt returns the observe binding for (sessionID, member,
@@ -81,6 +92,23 @@ func observedAttempt(
 	return entry.binding, true
 }
 
+// attemptEverObserved reports whether (sessionID, member) observed the given
+// attempt hash at any point this session -- including an attempt whose per-attempt
+// binding has since been consumed or cleared. The transition listener uses it to
+// tell a bundle for a NEVER-observed attempt (this seat skipped a window peers
+// committed -> lost ROAST sync) apart from a duplicate bundle for an
+// already-consumed attempt (a benign retransmit that must NOT trip lost sync).
+func attemptEverObserved(
+	sessionID string,
+	member group.MemberIndex,
+	attemptHash [attempt.MessageDigestLength]byte,
+) bool {
+	observedAttemptRegistryMu.RLock()
+	defer observedAttemptRegistryMu.RUnlock()
+	_, ok := observedAttemptHistory[observedAttemptKey{sessionID, member, attemptHash}]
+	return ok
+}
+
 // clearObservedAttempt removes the observe binding for (sessionID, member,
 // attemptHash). Called once a verified transition record is stored for the
 // attempt, on success, or at session end.
@@ -92,6 +120,25 @@ func clearObservedAttempt(
 	observedAttemptRegistryMu.Lock()
 	defer observedAttemptRegistryMu.Unlock()
 	delete(observedAttemptRegistry, observedAttemptKey{sessionID, member, attemptHash})
+}
+
+// ClearObservedAttemptOnLocalSuccess clears the observe binding for an attempt
+// this seat completed successfully (a valid signature aggregated on its drive
+// handle). The observe handle otherwise stays in a collecting state, so an elected
+// coordinator could still aggregate a failure bundle, and a peer's failure bundle
+// would be stored as a transition record, for an attempt that actually SUCCEEDED.
+// Clearing the binding -- the observed-history marker remains, so a later bundle
+// for it is treated as a benign retransmit, not lost sync -- means no failure
+// transition is synthesized or stored for the succeeded attempt, so a subsequent
+// done-check failure fails closed (no fresh record) instead of consuming a
+// dishonest failure transition (RFC-21 Phase 7.3 PR2b-1b B3). Exported so the
+// pkg/tbtc transition controller can call it on local success.
+func ClearObservedAttemptOnLocalSuccess(
+	sessionID string,
+	member group.MemberIndex,
+	attemptHash [attempt.MessageDigestLength]byte,
+) {
+	clearObservedAttempt(sessionID, member, attemptHash)
 }
 
 // clearObservedAttemptsForSession removes every observe binding for
@@ -106,6 +153,11 @@ func clearObservedAttemptsForSession(sessionID string, member group.MemberIndex)
 	for key := range observedAttemptRegistry {
 		if key.sessionID == sessionID && key.member == member {
 			delete(observedAttemptRegistry, key)
+		}
+	}
+	for key := range observedAttemptHistory {
+		if key.sessionID == sessionID && key.member == member {
+			delete(observedAttemptHistory, key)
 		}
 	}
 }
@@ -131,6 +183,7 @@ func ResetObservedAttemptRegistryForTest() {
 	observedAttemptRegistryMu.Lock()
 	defer observedAttemptRegistryMu.Unlock()
 	observedAttemptRegistry = map[observedAttemptKey]observedAttemptEntry{}
+	observedAttemptHistory = map[observedAttemptKey]time.Time{}
 }
 
 // evictStaleObservedAttempts sweeps the registry and removes bindings older than
@@ -146,6 +199,13 @@ func evictStaleObservedAttempts(maxAge time.Duration) int {
 		if entry.createdAt.Before(cutoff) {
 			delete(observedAttemptRegistry, key)
 			evicted++
+		}
+	}
+	// Sweep stale observed-history markers on the same cutoff so a long-abandoned
+	// session's lost-sync markers do not linger past their backstop TTL.
+	for key, observedAt := range observedAttemptHistory {
+		if observedAt.Before(cutoff) {
+			delete(observedAttemptHistory, key)
 		}
 	}
 	return evicted

--- a/pkg/frost/signing/roast_observed_attempt_registry_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_observed_attempt_registry_frost_roast_retry_test.go
@@ -1,0 +1,101 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// TestClearObservedAttemptOnLocalSuccess asserts that clearing an observe binding
+// on local success removes the active binding (so the observe handle no longer
+// collects, and no failure transition can be synthesized for a succeeded attempt)
+// while RETAINING the observed-history marker, so a later bundle for the attempt
+// is a benign retransmit rather than lost sync (RFC-21 Phase 7.3 PR2b-1b B3).
+func TestClearObservedAttemptOnLocalSuccess(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	sessionID := "registry-success-session"
+	var member group.MemberIndex = 2
+	var hash [attempt.MessageDigestLength]byte
+	hash[0] = 0x5a
+
+	recordObservedAttempt(sessionID, member, hash, observedAttemptBinding{})
+
+	if _, ok := observedAttempt(sessionID, member, hash); !ok {
+		t.Fatal("binding must exist after observing")
+	}
+	if !attemptEverObserved(sessionID, member, hash) {
+		t.Fatal("history marker must exist after observing")
+	}
+
+	ClearObservedAttemptOnLocalSuccess(sessionID, member, hash)
+
+	if _, ok := observedAttempt(sessionID, member, hash); ok {
+		t.Fatal("binding must be cleared on local success")
+	}
+	if !attemptEverObserved(sessionID, member, hash) {
+		t.Fatal("history marker must survive a local-success clear (so a retransmit is not lost sync)")
+	}
+}
+
+// TestAttemptEverObservedUnobserved asserts an attempt this seat never observed is
+// reported as never-observed -- the signal the transition listener uses to trip
+// lost sync.
+func TestAttemptEverObservedUnobserved(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	var hash [attempt.MessageDigestLength]byte
+	hash[0] = 0x77
+	if attemptEverObserved("never-session", 1, hash) {
+		t.Fatal("an unobserved attempt must report not-ever-observed")
+	}
+}
+
+// TestConsumeClearRetainsHistoryMarker asserts the per-attempt consume clear
+// (clearObservedAttempt) drops the binding but keeps the observed-history marker,
+// so a retransmit of a consumed bundle is distinguishable from a never-observed
+// one.
+func TestConsumeClearRetainsHistoryMarker(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	sessionID := "registry-consume-session"
+	var member group.MemberIndex = 1
+	var hash [attempt.MessageDigestLength]byte
+	hash[0] = 0x2b
+	recordObservedAttempt(sessionID, member, hash, observedAttemptBinding{})
+
+	clearObservedAttempt(sessionID, member, hash)
+
+	if _, ok := observedAttempt(sessionID, member, hash); ok {
+		t.Fatal("binding must be cleared after consume")
+	}
+	if !attemptEverObserved(sessionID, member, hash) {
+		t.Fatal("history marker must survive a consume clear")
+	}
+}
+
+// TestClearObservedAttemptsForSessionClearsHistory asserts session-end clearing
+// drops the observed-history markers too, so a stale marker does not suppress a
+// genuine lost-sync signal in a later session that reuses the same id.
+func TestClearObservedAttemptsForSessionClearsHistory(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	sessionID := "registry-session-end"
+	var member group.MemberIndex = 1
+	var hash [attempt.MessageDigestLength]byte
+	hash[0] = 0x3c
+	recordObservedAttempt(sessionID, member, hash, observedAttemptBinding{})
+
+	clearObservedAttemptsForSession(sessionID, member)
+
+	if attemptEverObserved(sessionID, member, hash) {
+		t.Fatal("session-end clear must drop the observed-history marker")
+	}
+}

--- a/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
@@ -128,6 +128,13 @@ func sessionHandleSweepLoop(stop <-chan struct{}) {
 			return
 		case <-ticker.C:
 			evictStaleSessionHandleBindings(SessionHandleBindingTTL)
+			// Defense-in-depth backstop for the cross-attempt registries
+			// (RFC-21 Phase 7.3 PR2b-1b): observe bindings are normally cleared
+			// at session end and transition records are overwritten per attempt,
+			// but a session that ends abnormally could orphan either -- sweep
+			// anything past the TTL.
+			evictStaleObservedAttempts(ObservedAttemptRegistryTTL)
+			evictStaleRoastTransitions(RoastTransitionRegistryTTL)
 		}
 	}
 }

--- a/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
+++ b/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
@@ -88,29 +88,13 @@ func attemptRoastRetryOrchestrationFromRequest(
 		request.SignerMaterial.Format,
 	)
 
-	// Extract the DKG group public key for the transition record: the next
-	// attempt's selector needs it to derive a valid next context via
-	// NextAttempt (a nil key yields a context NewActiveRoastAttempt rejects).
-	// BuildAttemptContextFromRequest already validated the material above, so
-	// this re-extraction is expected to succeed; a failure is the same
-	// deterministic static-fallback class.
-	dkgGroupPublicKey, err := ExtractDkgGroupPublicKeyFromMaterial(request.SignerMaterial)
-	if err != nil {
-		logger.Infof(
-			"ROAST orchestration unavailable for session %q: %v",
-			request.SessionID, err,
-		)
-		return nil, nil, nil
-	}
-
 	// The handle registry stays keyed by the attempt-specific request.SessionID:
 	// the coarse receive-loop binding validation + snapshot submission look the
 	// handle up by that id, so keying it otherwise would silently disable them.
-	// Only the CROSS-ATTEMPT transition record is keyed by the stable
-	// ctx.SessionID (== RoastSessionID), inside BeginOrchestrationForSession's
-	// cleanup, so the next attempt's selector can find it.
+	// The cross-attempt transition record is produced + keyed (by the stable
+	// RoastSessionID) entirely in the transition exchange now, not here.
 	handle, cleanup, err := BeginOrchestrationForSession(
-		request.SessionID, attemptCtx, dkgGroupPublicKey,
+		request.SessionID, attemptCtx,
 	)
 	if err != nil {
 		switch {

--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -55,7 +55,6 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/frost/roast"
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
-	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // ErrNoRoastRetryCoordinatorRegistered is returned by
@@ -89,10 +88,13 @@ var ErrNoRoastRetryCoordinatorRegistered = errors.New(
 // "shape" -- (handle, cleanup, error) -- forces the caller to
 // handle the absence of a coordinator explicitly rather than
 // silently dropping the orchestration.
+//
+// RFC-21 Phase 7.3 PR2b-1b retired the cleanup's transition-record
+// production (the transition exchange is now the sole producer), so
+// this no longer takes the DKG group public key.
 func BeginOrchestrationForSession(
 	sessionID string,
 	ctx attempt.AttemptContext,
-	dkgGroupPublicKey []byte,
 ) (roast.AttemptHandle, func(), error) {
 	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
 		return roast.AttemptHandle{}, nil, fmt.Errorf(
@@ -122,94 +124,16 @@ func BeginOrchestrationForSession(
 	}
 	SetCurrentAttemptHandleForSession(sessionID, handle, ctx)
 	cleanup := func() {
-		// RFC-21 Phase 7.1/7.3: if this node's registered coordinator
-		// member is the elected coordinator and the attempt is still
-		// Collecting at cleanup time (i.e. it did not succeed via
-		// signature aggregation), produce the TransitionMessage and
-		// stash a full RoastTransitionRecord (bundle + this attempt's
-		// handle/context + the DKG group public key) keyed by
-		// (sessionID, deps.SelfMember). The record carries the
-		// handle/context so the selector does not race the
-		// ClearCurrentAttemptHandleForSession below, and the DKG key
-		// so NextAttempt can derive a valid next context.
-		//
-		// Failures are best-effort and silent: a panic in the
-		// deferred cleanup is materially worse than a missing
-		// transition record (the next attempt's selector falls
-		// back to the legacy retry shuffle), so we swallow errors
-		// rather than propagate them.
-		// The transition record is keyed by the STABLE ctx.SessionID
-		// (== RoastSessionID) so the next attempt's selector finds it; the
-		// handle registry above stays keyed by the attempt-specific sessionID.
-		maybeProduceTransitionRecord(ctx.SessionID, handle, ctx, dkgGroupPublicKey, deps)
+		// RFC-21 Phase 7.3 PR2b-1b: the cleanup ONLY clears the per-attempt
+		// handle binding. It no longer produces a transition record -- the
+		// session-scoped transition exchange (the observe binding + forced-
+		// snapshot aggregation + bundle distribution) is now the SOLE producer,
+		// keyed by the observe handle. Producing here too would let this drive
+		// handle's (empty) aggregation write a SECOND, possibly divergent record
+		// for the same (sessionID, member) the exchange owns -- a fracture risk.
 		ClearCurrentAttemptHandleForSession(sessionID)
 	}
 	return handle, cleanup, nil
-}
-
-// maybeProduceTransitionRecord attempts to call AggregateBundle on
-// the registered Coordinator when (a) this node's registered
-// coordinator member (deps.SelfMember) is the elected coordinator
-// for the attempt and (b) the attempt has not already transitioned,
-// then stashes a full RoastTransitionRecord keyed by
-// (sessionID, deps.SelfMember) via RecordRoastTransition (a no-op in
-// the default build). On any error path the function returns
-// silently because cleanup must not break the signing-flow contract.
-//
-// The elected check uses deps.SelfMember -- NOT the per-seat Execute
-// member -- because AggregateBundle is gated on the in-memory
-// coordinator's own bound selfMember being the elected coordinator
-// (deps.Coordinator was constructed with deps.SelfMember). Checking a
-// per-seat member instead would let a multi-seat operator's
-// non-registered elected seat reach AggregateBundle, which then
-// rejects (the bound selfMember != elected) and the swallowed error
-// would leave NO record. Production therefore happens on the node
-// whose registered coordinator is the elected one, keyed by that
-// member; in Phase 7.3 PR2b the snapshot/transition bus exchange
-// distributes the record to every other signer (which store it under
-// their own member).
-//
-// In the default build this still compiles because
-// RecordRoastTransition is a no-op stub; calls to roast.Coordinator
-// methods compile because pkg/frost/roast is not build-tagged.
-func maybeProduceTransitionRecord(
-	roastSessionID string,
-	handle roast.AttemptHandle,
-	ctx attempt.AttemptContext,
-	dkgGroupPublicKey []byte,
-	deps RoastRetryDeps,
-) {
-	if deps.Coordinator == nil || deps.SelfMember == 0 {
-		return
-	}
-	selfMember := group.MemberIndex(deps.SelfMember)
-	elected, err := deps.Coordinator.SelectedCoordinator(handle)
-	if err != nil {
-		return
-	}
-	if elected != selfMember {
-		return
-	}
-	state, err := deps.Coordinator.State(handle)
-	if err != nil {
-		return
-	}
-	if state != roast.AttemptStateCollecting {
-		// Already transitioned or succeeded -- nothing to do.
-		return
-	}
-	bundle, err := deps.Coordinator.AggregateBundle(handle)
-	if err != nil {
-		// Best-effort; the next attempt's selector will fall
-		// back to the legacy retry shuffle.
-		return
-	}
-	RecordRoastTransition(roastSessionID, selfMember, RoastTransitionRecord{
-		Bundle:            bundle,
-		PreviousHandle:    handle,
-		PreviousContext:   ctx,
-		DkgGroupPublicKey: dkgGroupPublicKey,
-	})
 }
 
 // EndOrchestrationForSession is a convenience for callers that

--- a/pkg/frost/signing/roast_retry_orchestration_bundle_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_bundle_test.go
@@ -10,21 +10,12 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
-// bundleTestDkgKey is the DKG group public key signingForBundleContext builds
-// the attempt context from; the orchestration cleanup stores it in the
-// transition record.
-var bundleTestDkgKey = []byte{0x01, 0x02, 0x03}
-
-// signingForBundleContext constructs an attempt context whose
-// SelectCoordinator will deterministically pick a member (for the
-// sake of this test). Real production deployments use the
-// rotating selection; here we pin a stable handle for assertion.
-func signingForBundleContext(t *testing.T, members []group.MemberIndex) attempt.AttemptContext {
+func cleanupTestContext(t *testing.T, members []group.MemberIndex) attempt.AttemptContext {
 	t.Helper()
 	ctx, err := attempt.NewAttemptContext(
-		"orchestration-bundle-test",
+		"orchestration-cleanup-test",
 		"key-group",
-		bundleTestDkgKey,
+		[]byte{0x01, 0x02, 0x03},
 		[attempt.MessageDigestLength]byte{0xab},
 		0,
 		members,
@@ -36,39 +27,31 @@ func signingForBundleContext(t *testing.T, members []group.MemberIndex) attempt.
 	return ctx
 }
 
-// realCoordinatorForBundleTest returns an in-memory coordinator with NoOp
-// signer/verifier so the AggregateBundle path runs end-to-end without crypto
-// setup, plus the elected coordinator computed from the test context. The
-// caller passes `elected` as the member to BeginOrchestrationForSession so
-// maybeProduceTransitionRecord's elected==member check passes and it invokes
-// AggregateBundle.
-func realCoordinatorForBundleTest(
-	t *testing.T,
-	ctx attempt.AttemptContext,
-) (roast.Coordinator, group.MemberIndex) {
-	t.Helper()
+// TestCleanup_ClearsBindingAndProducesNoTransitionRecord pins the RFC-21
+// Phase 7.3 PR2b-1b producer retirement: the orchestration cleanup clears the
+// per-attempt handle binding and, even on the elected coordinator with recorded
+// evidence (the exact case the old producer aggregated), produces NO transition
+// record -- the session-scoped transition exchange is the sole producer now, so
+// a second drive-handle producer here would risk a divergent record.
+func TestCleanup_ClearsBindingAndProducesNoTransitionRecord(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+
+	ctx := cleanupTestContext(t, []group.MemberIndex{1, 2, 3, 4, 5})
+
+	// Determine the elected coordinator and register a coordinator bound to it,
+	// so the retired producer's elected==member precondition WOULD have held.
 	scratch := roast.NewInMemoryCoordinator()
-	hScratch, _ := scratch.BeginAttempt(ctx)
-	elected, _ := scratch.SelectedCoordinator(hScratch)
+	scratchHandle, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(scratchHandle)
 	coord := roast.NewInMemoryCoordinatorWithSigning(
-		elected,
-		roast.NoOpSigner(),
-		roast.NoOpSignatureVerifier(),
+		elected, roast.NoOpSigner(), roast.NoOpSignatureVerifier(),
 	)
-	return coord, elected
-}
-
-func TestCleanup_ProducesRecordWhenElectedCoordinator(t *testing.T) {
-	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
-	ResetRoastRetryRegistrationForTest()
-	ResetSessionHandleRegistryForTest()
-	ResetRoastTransitionRegistryForTest()
-	t.Cleanup(ResetRoastRetryRegistrationForTest)
-	t.Cleanup(ResetSessionHandleRegistryForTest)
-	t.Cleanup(ResetRoastTransitionRegistryForTest)
-
-	ctx := signingForBundleContext(t, []group.MemberIndex{1, 2, 3, 4, 5})
-	coord, elected := realCoordinatorForBundleTest(t, ctx)
 	RegisterRoastRetryCoordinator(RoastRetryDeps{
 		Coordinator: coord,
 		Signer:      roast.NoOpSigner(),
@@ -76,127 +59,25 @@ func TestCleanup_ProducesRecordWhenElectedCoordinator(t *testing.T) {
 		SelfMember:  uint32(elected),
 	})
 
-	const sessionID = "bundle-producer-session"
-	handle, cleanup, err := BeginOrchestrationForSession(sessionID, ctx, bundleTestDkgKey)
+	const sessionID = "cleanup-no-record-session"
+	handle, cleanup, err := BeginOrchestrationForSession(sessionID, ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 
-	// Seed at least one snapshot so AggregateBundle's non-empty-bundle
-	// validation passes. NoOpSigner returns empty bytes but the
-	// signature-verification pre-check rejects zero-length signatures, so
-	// provide a dummy non-empty signature (the NoOp verifier accepts any bytes).
+	// Seed the evidence the old producer would have aggregated.
 	snap := roast.NewLocalEvidenceSnapshot(elected, ctx.Hash(), attempt.Evidence{})
 	snap.OperatorSignature = []byte{0x01}
 	if err := coord.RecordEvidence(handle, snap); err != nil {
 		t.Fatalf("record evidence: %v", err)
 	}
 
-	// Cleanup must produce + record a transition record (we passed the elected
-	// member and the attempt is still Collecting).
 	cleanup()
 
-	record, ok := RoastTransitionForSession(ctx.SessionID, elected)
-	if !ok {
-		t.Fatal("elected coordinator's cleanup must produce a transition record")
+	if _, ok := RoastTransitionForSession(ctx.SessionID, elected); ok {
+		t.Fatal("cleanup must not produce a transition record (the exchange is the sole producer)")
 	}
-	if record.Bundle == nil {
-		t.Fatal("recorded transition must carry a non-nil bundle")
+	if _, _, ok := currentAttemptHandleForCollect(sessionID); ok {
+		t.Fatal("cleanup must clear the per-attempt handle binding")
 	}
-	if record.Bundle.CoordinatorID() != elected {
-		t.Fatalf("bundle coordinator id %d != elected %d", record.Bundle.CoordinatorID(), elected)
-	}
-	// The record must carry the binding the selector needs.
-	if record.PreviousHandle != handle {
-		t.Fatal("record must carry the failed attempt's handle (survives cleanup's handle clear)")
-	}
-	if string(record.DkgGroupPublicKey) != string(bundleTestDkgKey) {
-		t.Fatalf("record dkg key %x != %x", record.DkgGroupPublicKey, bundleTestDkgKey)
-	}
-}
-
-func TestCleanup_DoesNotProduceRecordWhenNotElectedCoordinator(t *testing.T) {
-	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
-	ResetRoastRetryRegistrationForTest()
-	ResetSessionHandleRegistryForTest()
-	ResetRoastTransitionRegistryForTest()
-	t.Cleanup(ResetRoastRetryRegistrationForTest)
-	t.Cleanup(ResetSessionHandleRegistryForTest)
-	t.Cleanup(ResetRoastTransitionRegistryForTest)
-
-	ctx := signingForBundleContext(t, []group.MemberIndex{1, 2, 3, 4, 5})
-	_, elected := realCoordinatorForBundleTest(t, ctx)
-
-	// A member that is NOT the elected coordinator.
-	nonElected := group.MemberIndex(elected + 10)
-	for _, m := range ctx.IncludedSet {
-		if m != elected {
-			nonElected = m
-			break
-		}
-	}
-
-	coord := roast.NewInMemoryCoordinatorWithSigning(
-		nonElected,
-		roast.NoOpSigner(),
-		roast.NoOpSignatureVerifier(),
-	)
-	RegisterRoastRetryCoordinator(RoastRetryDeps{
-		Coordinator: coord,
-		Signer:      roast.NoOpSigner(),
-		Verifier:    roast.NoOpSignatureVerifier(),
-		SelfMember:  uint32(nonElected),
-	})
-
-	const sessionID = "non-elected-session"
-	_, cleanup, err := BeginOrchestrationForSession(sessionID, ctx, bundleTestDkgKey)
-	if err != nil {
-		t.Fatalf("begin: %v", err)
-	}
-	cleanup()
-
-	if _, ok := RoastTransitionForSession(ctx.SessionID, nonElected); ok {
-		t.Fatal("non-elected coordinator must not produce a transition record")
-	}
-}
-
-func TestCleanup_AggregateBundleErrorIsSwallowed(t *testing.T) {
-	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
-	ResetRoastRetryRegistrationForTest()
-	ResetSessionHandleRegistryForTest()
-	ResetRoastTransitionRegistryForTest()
-	t.Cleanup(ResetRoastRetryRegistrationForTest)
-	t.Cleanup(ResetSessionHandleRegistryForTest)
-	t.Cleanup(ResetRoastTransitionRegistryForTest)
-
-	ctx := signingForBundleContext(t, []group.MemberIndex{1, 2, 3, 4, 5})
-	coord, elected := realCoordinatorForBundleTest(t, ctx)
-	RegisterRoastRetryCoordinator(RoastRetryDeps{
-		Coordinator: coord,
-		Signer:      roast.NoOpSigner(),
-		Verifier:    roast.NoOpSignatureVerifier(),
-		SelfMember:  uint32(elected),
-	})
-
-	const sessionID = "double-cleanup-session"
-	handle, cleanup, err := BeginOrchestrationForSession(sessionID, ctx, bundleTestDkgKey)
-	if err != nil {
-		t.Fatalf("begin: %v", err)
-	}
-
-	snap := roast.NewLocalEvidenceSnapshot(elected, ctx.Hash(), attempt.Evidence{})
-	snap.OperatorSignature = []byte{0x01}
-	if err := coord.RecordEvidence(handle, snap); err != nil {
-		t.Fatalf("record evidence: %v", err)
-	}
-
-	// First cleanup -- record produced.
-	cleanup()
-	if _, ok := RoastTransitionForSession(ctx.SessionID, elected); !ok {
-		t.Fatal("first cleanup must record a transition")
-	}
-
-	// Second cleanup -- state is now Transitioned. AggregateBundle returns
-	// ErrAttemptStateInvalid; the helper must swallow it rather than panic.
-	cleanup() // Must not panic.
 }

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -45,7 +45,7 @@ func TestBeginOrchestrationForSession_HappyPath(t *testing.T) {
 	})
 
 	ctx := newOrchestrationTestContext(t)
-	handle, cleanup, err := BeginOrchestrationForSession("session-A", ctx, []byte{0x01, 0x02})
+	handle, cleanup, err := BeginOrchestrationForSession("session-A", ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestBeginOrchestrationForSession_ErrorsWhenRegistryEmpty(t *testing.T) {
 
 	// Readiness env var is set; the registry is empty -- we expect
 	// the registry-empty error, not the env-var error.
-	_, _, err := BeginOrchestrationForSession("session-X", newOrchestrationTestContext(t), []byte{0x01, 0x02})
+	_, _, err := BeginOrchestrationForSession("session-X", newOrchestrationTestContext(t))
 	if err == nil {
 		t.Fatal("expected error when registry is empty")
 	}
@@ -110,7 +110,7 @@ func TestBeginOrchestrationForSession_ErrorsWhenReadinessOptInUnset(t *testing.T
 		SelfMember:  1,
 	})
 
-	_, _, err := BeginOrchestrationForSession("session-no-optin", newOrchestrationTestContext(t), []byte{0x01, 0x02})
+	_, _, err := BeginOrchestrationForSession("session-no-optin", newOrchestrationTestContext(t))
 	if !errors.Is(err, ErrRoastRetryReadinessOptOut) {
 		t.Fatalf("expected ErrRoastRetryReadinessOptOut, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestBeginOrchestrationForSession_ErrorsWhenCoordinatorNil(t *testing.T) {
 		SelfMember:  1,
 	})
 
-	_, _, err := BeginOrchestrationForSession("session-Y", newOrchestrationTestContext(t), []byte{0x01, 0x02})
+	_, _, err := BeginOrchestrationForSession("session-Y", newOrchestrationTestContext(t))
 	if err == nil {
 		t.Fatal("expected error when Coordinator is nil")
 	}
@@ -154,7 +154,7 @@ func TestBeginOrchestrationForSession_PropagatesBeginAttemptError(t *testing.T) 
 		SelfMember:  1,
 	})
 
-	_, _, err := BeginOrchestrationForSession("session-Z", newOrchestrationTestContext(t), []byte{0x01, 0x02})
+	_, _, err := BeginOrchestrationForSession("session-Z", newOrchestrationTestContext(t))
 	if err == nil {
 		t.Fatal("expected error from coordinator")
 	}

--- a/pkg/frost/signing/roast_retry_orchestration_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_test.go
@@ -30,7 +30,7 @@ func TestBeginOrchestrationForSession_DefaultBuildReturnsError(t *testing.T) {
 		t.Fatalf("ctx: %v", err)
 	}
 
-	_, _, err = BeginOrchestrationForSession("session-default-build", ctx, []byte{0x01, 0x02})
+	_, _, err = BeginOrchestrationForSession("session-default-build", ctx)
 	if err == nil {
 		t.Fatal("default build must return error from BeginOrchestrationForSession")
 	}

--- a/pkg/frost/signing/roast_retry_readiness.go
+++ b/pkg/frost/signing/roast_retry_readiness.go
@@ -60,17 +60,26 @@ func RoastRetryReadinessOptInEnabled() bool {
 }
 
 // RoastRetryActive reports whether ROAST retry orchestration is runtime-active:
-// the readiness opt-in is set AND a coordinator is registered. It is the
-// deterministic, process-level gate every honest node evaluates identically
-// (env var + in-process registration), so the signing loop and the signing
-// executor agree on whether to key the active attempt off the COMMITTED ROAST
-// attempt index (roastAttemptNumber) rather than the block-paced attemptCounter
-// -- RFC-21 Phase 7.3 PR2b-1b. It mirrors the gate the ROAST participant
-// selector uses, so selection, observe, and the active signing context stay
-// consistent. Always false in builds without the frost_roast_retry tag, because
-// RegisteredRoastRetryCoordinator's default stub reports not-registered.
+// the readiness opt-in is set, a coordinator is registered, AND this build
+// contains the transition producer (frost_native). It is the deterministic,
+// process-level gate every honest node evaluates identically (env var +
+// in-process registration + build), so the signing loop and the signing executor
+// agree on whether to key the active attempt off the COMMITTED ROAST attempt
+// index (roastAttemptNumber) rather than the block-paced attemptCounter -- RFC-21
+// Phase 7.3 PR2b-1b. The participant selector gates on the same predicate, so
+// selection, observe, and the active signing context stay consistent.
+//
+// The producer requirement matters in a frost_roast_retry && !frost_native build:
+// there the selector and the registry exist but nothing PRODUCES transition
+// records, so without this check a retry would fail-close against a record that
+// can never be created instead of using the uniform legacy shuffle (Codex P2-1).
+// Always false in builds without the frost_roast_retry tag (the registration and
+// producer default stubs both report unavailable).
 func RoastRetryActive() bool {
 	if !RoastRetryReadinessOptInEnabled() {
+		return false
+	}
+	if !roastTransitionProducerAvailable() {
 		return false
 	}
 	_, ok := RegisteredRoastRetryCoordinator()

--- a/pkg/frost/signing/roast_retry_readiness.go
+++ b/pkg/frost/signing/roast_retry_readiness.go
@@ -58,3 +58,21 @@ func RoastRetryReadinessOptInEnabled() bool {
 	value := strings.TrimSpace(os.Getenv(RoastRetryReadinessOptInEnvVar))
 	return strings.EqualFold(value, "true")
 }
+
+// RoastRetryActive reports whether ROAST retry orchestration is runtime-active:
+// the readiness opt-in is set AND a coordinator is registered. It is the
+// deterministic, process-level gate every honest node evaluates identically
+// (env var + in-process registration), so the signing loop and the signing
+// executor agree on whether to key the active attempt off the COMMITTED ROAST
+// attempt index (roastAttemptNumber) rather than the block-paced attemptCounter
+// -- RFC-21 Phase 7.3 PR2b-1b. It mirrors the gate the ROAST participant
+// selector uses, so selection, observe, and the active signing context stay
+// consistent. Always false in builds without the frost_roast_retry tag, because
+// RegisteredRoastRetryCoordinator's default stub reports not-registered.
+func RoastRetryActive() bool {
+	if !RoastRetryReadinessOptInEnabled() {
+		return false
+	}
+	_, ok := RegisteredRoastRetryCoordinator()
+	return ok
+}

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
@@ -38,6 +38,41 @@ func TestRoastRetryRegistration_TaggedBuildRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRoastRetryActive_GatesOnReadinessAndRegistration asserts RoastRetryActive
+// is true only when BOTH the readiness opt-in is set AND a coordinator is
+// registered -- the deterministic group-wide gate the signing loop uses to decide
+// whether to key the active attempt off the committed roast number.
+func TestRoastRetryActive_GatesOnReadinessAndRegistration(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	// Readiness off -> inactive regardless of registration.
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "false")
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		SelfMember:  1,
+	})
+	if RoastRetryActive() {
+		t.Fatal("readiness off must yield inactive even with a coordinator")
+	}
+
+	// Readiness on but no coordinator -> inactive.
+	ResetRoastRetryRegistrationForTest()
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	if RoastRetryActive() {
+		t.Fatal("readiness on without a coordinator must yield inactive")
+	}
+
+	// Readiness on AND a coordinator -> active.
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		SelfMember:  1,
+	})
+	if !RoastRetryActive() {
+		t.Fatal("readiness on with a coordinator must yield active")
+	}
+}
+
 func TestRoastRetryRegistration_LaterRegistrationOverwrites(t *testing.T) {
 	ResetRoastRetryRegistrationForTest()
 	t.Cleanup(ResetRoastRetryRegistrationForTest)

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
@@ -63,13 +63,19 @@ func TestRoastRetryActive_GatesOnReadinessAndRegistration(t *testing.T) {
 		t.Fatal("readiness on without a coordinator must yield inactive")
 	}
 
-	// Readiness on AND a coordinator -> active.
+	// Readiness on AND a coordinator -> active IFF a transition producer is built in
+	// (frost_native). A frost_roast_retry && !frost_native build has no producer, so
+	// ROAST stays inactive (legacy) even with readiness + a coordinator -- the
+	// build-config gate from Codex P2-1.
 	RegisterRoastRetryCoordinator(RoastRetryDeps{
 		Coordinator: roast.NewInMemoryCoordinator(),
 		SelfMember:  1,
 	})
-	if !RoastRetryActive() {
-		t.Fatal("readiness on with a coordinator must yield active")
+	if RoastRetryActive() != roastTransitionProducerAvailable() {
+		t.Fatalf(
+			"readiness + coordinator: RoastRetryActive must equal producer availability (%v); got %v",
+			roastTransitionProducerAvailable(), RoastRetryActive(),
+		)
 	}
 }
 

--- a/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
@@ -26,8 +26,10 @@ func resetSelectionRegistries(t *testing.T) {
 	t.Helper()
 	ResetRoastRetryRegistrationForTest()
 	ResetRoastTransitionRegistryForTest()
+	ResetObservedAttemptRegistryForTest()
 	t.Cleanup(ResetRoastRetryRegistrationForTest)
 	t.Cleanup(ResetRoastTransitionRegistryForTest)
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
 }
 
 func TestConsumeRoastTransitionForSelection_FallbackInitialAttempt(t *testing.T) {

--- a/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
@@ -34,7 +34,7 @@ func TestConsumeRoastTransitionForSelection_FallbackInitialAttempt(t *testing.T)
 	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
 	resetSelectionRegistries(t)
 
-	if _, err := ConsumeRoastTransitionForSelection("session", 1, 0, 3); !errors.Is(
+	if _, _, err := ConsumeRoastTransitionForSelection("session", 1, 0, 3); !errors.Is(
 		err, ErrRoastSelectionFallBackToLegacy,
 	) {
 		t.Fatalf("retry 0 must request the legacy fallback, got %v", err)
@@ -46,7 +46,7 @@ func TestConsumeRoastTransitionForSelection_FallbackInactiveRoast(t *testing.T) 
 	resetSelectionRegistries(t)
 
 	// No coordinator registered -> inactive -> uniform legacy fallback.
-	if _, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3); !errors.Is(
+	if _, _, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3); !errors.Is(
 		err, ErrRoastSelectionFallBackToLegacy,
 	) {
 		t.Fatalf("inactive ROAST must request the legacy fallback, got %v", err)
@@ -65,7 +65,7 @@ func TestConsumeRoastTransitionForSelection_FailsClosedNoRecord(t *testing.T) {
 
 	// Active ROAST, a retry, but no record -> a transition was expected -> fail
 	// closed (NOT the legacy-fallback sentinel).
-	_, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3)
+	_, _, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3)
 	if err == nil || errors.Is(err, ErrRoastSelectionFallBackToLegacy) {
 		t.Fatalf("a missing expected transition must fail closed, got %v", err)
 	}
@@ -88,9 +88,80 @@ func TestConsumeRoastTransitionForSelection_FailsClosedStaleRecord(t *testing.T)
 		PreviousContext: prevCtx,
 	})
 
-	_, err := ConsumeRoastTransitionForSelection("session", 1, 3, 3)
+	_, _, err := ConsumeRoastTransitionForSelection("session", 1, 3, 3)
 	if err == nil || errors.Is(err, ErrRoastSelectionFallBackToLegacy) {
 		t.Fatalf("a stale record must fail closed, got %v", err)
+	}
+}
+
+func TestConsumeRoastTransitionForSelection_CarriesParking(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+
+	roastSessionID := "consume-parking-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x0c}
+	prevCtx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := prevCtx.Hash()
+
+	probe := roast.NewInMemoryCoordinatorWithSigning(0, fixedSigner{}, roast.NoOpSignatureVerifier())
+	probeHandle, _ := probe.BeginAttempt(prevCtx)
+	elected, _ := probe.SelectedCoordinator(probeHandle)
+
+	// Pick a parked member that is NOT the elected coordinator, so the coordinator
+	// is in the bundle and can aggregate; omit its forced snapshot so NextAttempt
+	// silence-parks it (absent-from-bundle -> transient park).
+	var parkedMember group.MemberIndex
+	for _, m := range included {
+		if m != elected {
+			parkedMember = m
+			break
+		}
+	}
+
+	coord := roast.NewInMemoryCoordinatorWithSigning(
+		elected, fixedSigner{}, roast.NoOpSignatureVerifier(),
+	)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: coord,
+		Signer:      fixedSigner{},
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  uint32(elected),
+	})
+	handle, _ := coord.BeginAttempt(prevCtx)
+	for _, m := range included {
+		if m == parkedMember {
+			continue // omit -> silence-parked by NextAttempt
+		}
+		if err := coord.RecordEvidence(handle, signedForcedSnapshot(m, hash)); err != nil {
+			t.Fatalf("record evidence for member %d: %v", m, err)
+		}
+	}
+	bundle, err := coord.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate bundle: %v", err)
+	}
+	RecordRoastTransition(roastSessionID, elected, RoastTransitionRecord{
+		Bundle:            bundle,
+		PreviousHandle:    handle,
+		PreviousContext:   prevCtx,
+		DkgGroupPublicKey: dkgKey,
+	})
+
+	// threshold 2 so the 2-member next set stays feasible.
+	includedSet, parked, err := ConsumeRoastTransitionForSelection(roastSessionID, elected, 1, 2)
+	if err != nil {
+		t.Fatalf("consume must succeed: %v", err)
+	}
+	// The absent member is carried as parked (reinstated next attempt, not
+	// permanently excluded) and is not in the included set.
+	if len(parked) != 1 || parked[0] != parkedMember {
+		t.Fatalf("expected parked [%d], got %v", parkedMember, parked)
+	}
+	for _, m := range includedSet {
+		if m == parkedMember {
+			t.Fatalf("parked member %d must not be in the included set %v", parkedMember, includedSet)
+		}
 	}
 }
 
@@ -145,14 +216,18 @@ func TestConsumeRoastTransitionForSelection_ConsumesFreshRecord(t *testing.T) {
 		DkgGroupPublicKey: dkgKey,
 	})
 
-	// Consume for retry 1 (prevCtx.AttemptNumber 0 + 1 == 1).
-	includedSet, err := ConsumeRoastTransitionForSelection(roastSessionID, elected, 1, 3)
+	// Consume for roast attempt 1 (prevCtx.AttemptNumber 0 + 1 == 1).
+	includedSet, parked, err := ConsumeRoastTransitionForSelection(roastSessionID, elected, 1, 3)
 	if err != nil {
 		t.Fatalf("consume must succeed for a fresh record: %v", err)
 	}
 	// Every included member submitted a proof-of-attendance snapshot, so none is
-	// silence-parked: the next included set equals the prior included set.
+	// silence-parked: the next included set equals the prior included set and the
+	// parked set is empty.
 	if len(includedSet) != len(included) {
 		t.Fatalf("expected the full included set %v, got %v", included, includedSet)
+	}
+	if len(parked) != 0 {
+		t.Fatalf("expected no parked members, got %v", parked)
 	}
 }

--- a/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
@@ -1,0 +1,158 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+func signedForcedSnapshot(
+	member group.MemberIndex,
+	hash [attempt.MessageDigestLength]byte,
+) *roast.LocalEvidenceSnapshot {
+	snap := roast.NewLocalEvidenceSnapshot(member, hash, attempt.Evidence{})
+	payload, _ := snap.SignableBytes()
+	sig, _ := fixedSigner{}.Sign(payload)
+	snap.OperatorSignature = sig
+	return snap
+}
+
+func resetSelectionRegistries(t *testing.T) {
+	t.Helper()
+	ResetRoastRetryRegistrationForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+}
+
+func TestConsumeRoastTransitionForSelection_FallbackInitialAttempt(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+
+	if _, err := ConsumeRoastTransitionForSelection("session", 1, 0, 3); !errors.Is(
+		err, ErrRoastSelectionFallBackToLegacy,
+	) {
+		t.Fatalf("retry 0 must request the legacy fallback, got %v", err)
+	}
+}
+
+func TestConsumeRoastTransitionForSelection_FallbackInactiveRoast(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+
+	// No coordinator registered -> inactive -> uniform legacy fallback.
+	if _, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3); !errors.Is(
+		err, ErrRoastSelectionFallBackToLegacy,
+	) {
+		t.Fatalf("inactive ROAST must request the legacy fallback, got %v", err)
+	}
+}
+
+func TestConsumeRoastTransitionForSelection_FailsClosedNoRecord(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	// Active ROAST, a retry, but no record -> a transition was expected -> fail
+	// closed (NOT the legacy-fallback sentinel).
+	_, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3)
+	if err == nil || errors.Is(err, ErrRoastSelectionFallBackToLegacy) {
+		t.Fatalf("a missing expected transition must fail closed, got %v", err)
+	}
+}
+
+func TestConsumeRoastTransitionForSelection_FailsClosedStaleRecord(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	// A record fresh for retry 1 (prev attempt 0) but we select for retry 3.
+	prevCtx := newExchangeTestContext(t, "session", []group.MemberIndex{1, 2, 3}, []byte{0x01})
+	RecordRoastTransition("session", 1, RoastTransitionRecord{
+		Bundle:          &roast.TransitionMessage{CoordinatorIDValue: 1},
+		PreviousContext: prevCtx,
+	})
+
+	_, err := ConsumeRoastTransitionForSelection("session", 1, 3, 3)
+	if err == nil || errors.Is(err, ErrRoastSelectionFallBackToLegacy) {
+		t.Fatalf("a stale record must fail closed, got %v", err)
+	}
+}
+
+func TestConsumeRoastTransitionForSelection_ConsumesFreshRecord(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+
+	roastSessionID := "consume-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x0a, 0x0b}
+	prevCtx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := prevCtx.Hash()
+
+	// Determine the deterministically elected coordinator for prevCtx.
+	probe := roast.NewInMemoryCoordinatorWithSigning(0, fixedSigner{}, roast.NoOpSignatureVerifier())
+	probeHandle, err := probe.BeginAttempt(prevCtx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	elected, err := probe.SelectedCoordinator(probeHandle)
+	if err != nil {
+		t.Fatalf("selected coordinator: %v", err)
+	}
+
+	// Register a coordinator bound to the elected member and build a real bundle.
+	coord := roast.NewInMemoryCoordinatorWithSigning(
+		elected, fixedSigner{}, roast.NoOpSignatureVerifier(),
+	)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: coord,
+		Signer:      fixedSigner{},
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  uint32(elected),
+	})
+	handle, err := coord.BeginAttempt(prevCtx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	for _, m := range included {
+		if err := coord.RecordEvidence(handle, signedForcedSnapshot(m, hash)); err != nil {
+			t.Fatalf("record evidence for member %d: %v", m, err)
+		}
+	}
+	bundle, err := coord.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate bundle: %v", err)
+	}
+	RecordRoastTransition(roastSessionID, elected, RoastTransitionRecord{
+		Bundle:            bundle,
+		PreviousHandle:    handle,
+		PreviousContext:   prevCtx,
+		DkgGroupPublicKey: dkgKey,
+	})
+
+	// Consume for retry 1 (prevCtx.AttemptNumber 0 + 1 == 1).
+	includedSet, err := ConsumeRoastTransitionForSelection(roastSessionID, elected, 1, 3)
+	if err != nil {
+		t.Fatalf("consume must succeed for a fresh record: %v", err)
+	}
+	// Every included member submitted a proof-of-attendance snapshot, so none is
+	// silence-parked: the next included set equals the prior included set.
+	if len(includedSet) != len(included) {
+		t.Fatalf("expected the full included set %v, got %v", included, includedSet)
+	}
+}

--- a/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
@@ -64,10 +64,13 @@ func ConsumeRoastTransitionForSelection(
 		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
 
-	// ROAST retry inactive (readiness opted out or no coordinator registered):
-	// a uniform legacy fallback. This MUST mirror the observe/exchange gating, so
-	// a node that produced no records also does not expect to consume one.
-	if optInErr := EnsureRoastRetryReadinessOptIn(); optInErr != nil {
+	// ROAST retry inactive (readiness opted out, no coordinator registered, or no
+	// transition producer built in -- frost_roast_retry && !frost_native): a uniform
+	// legacy fallback. This MUST mirror the observe/exchange gating, so a node that
+	// produced no records also does not expect to consume one; in particular,
+	// without a producer (RoastRetryActive false on the build) the selector must NOT
+	// fail-close every retry against records that can never be created (Codex P2-1).
+	if !RoastRetryActive() {
 		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
 	deps, ok := RegisteredRoastRetryCoordinator()

--- a/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
@@ -1,0 +1,116 @@
+//go:build frost_roast_retry
+
+package signing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// ErrRoastSelectionFallBackToLegacy signals that ROAST-driven participant
+// selection does not apply to this attempt and the caller must use the legacy
+// retry selection. It is a UNIFORM, deterministic decision every honest node
+// makes identically -- the initial attempt, or ROAST retry not active -- so a
+// legacy fallback on this sentinel never fractures the group. It is NOT a
+// fail-closed condition.
+var ErrRoastSelectionFallBackToLegacy = errors.New(
+	"roast selection: not applicable; use legacy selection",
+)
+
+// ConsumeRoastTransitionForSelection computes the next attempt's included set
+// from this seat's stored transition record (RFC-21 Phase 7.3 PR2b-1b C3 -- the
+// activation of the cross-attempt ROAST retry path).
+//
+// Returns one of:
+//   - (includedSet, nil): a FRESH transition record drove the next attempt; the
+//     caller uses includedSet verbatim (member-level, no address round-trip).
+//   - (nil, ErrRoastSelectionFallBackToLegacy): the initial attempt, or ROAST
+//     retry is not active -- a UNIFORM legacy fallback (deterministic across
+//     honest nodes, so non-fracturing).
+//   - (nil, any other error): a committed ROAST attempt EXPECTED a transition
+//     but no FRESH record exists, or NextAttempt failed. The caller MUST FAIL
+//     CLOSED (terminate the retry loop), NEVER fall back to legacy: a node that
+//     selected legacy while peers selected from the transition would split the
+//     signing group into divergent included sets -- the fracture class.
+//
+// The "a transition is expected" predicate is deterministic group-wide: every
+// honest node, with the same (uniformly deployed) gating, agrees that retry > 0
+// under active ROAST retry expects a transition. VerifyBundle is NOT called here
+// -- the transition listener already verified the bundle before storing the
+// record, so the selector consumes only verified records.
+//
+// threshold is the FROST signing threshold t for the key group, used by
+// NextAttempt's infeasibility check (the next included set must stay at or above
+// t). For tBTC wallets the group's honest threshold IS that signing threshold,
+// so the caller passes it; if the two ever diverge for a key group, the
+// authoritative value is the persisted DKGThreshold.
+func ConsumeRoastTransitionForSelection(
+	roastSessionID string,
+	member group.MemberIndex,
+	retryCount uint,
+	threshold uint,
+) ([]group.MemberIndex, error) {
+	// The initial attempt has no prior transition: uniform legacy/initial
+	// selection.
+	if retryCount == 0 {
+		return nil, ErrRoastSelectionFallBackToLegacy
+	}
+
+	// ROAST retry inactive (readiness opted out or no coordinator registered):
+	// a uniform legacy fallback. This MUST mirror the observe/exchange gating, so
+	// a node that produced no records also does not expect to consume one.
+	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
+		return nil, ErrRoastSelectionFallBackToLegacy
+	}
+	deps, ok := RegisteredRoastRetryCoordinator()
+	if !ok || deps.Coordinator == nil {
+		return nil, ErrRoastSelectionFallBackToLegacy
+	}
+
+	// From here a transition from the prior attempt IS expected; its absence is
+	// fail-closed, never a legacy fallback.
+	record, ok := RoastTransitionForSession(roastSessionID, member)
+	if !ok {
+		return nil, fmt.Errorf(
+			"roast selection: no transition record for retry %d; fail closed",
+			retryCount,
+		)
+	}
+
+	// Freshness: the record must describe the IMMEDIATELY prior attempt. The
+	// previous attempt's 0-based AttemptNumber plus one must equal this retry
+	// count (also 0-based). A stale record (e.g. a missed intervening
+	// transition) must not drive selection -- fail closed.
+	if uint(record.PreviousContext.AttemptNumber)+1 != retryCount {
+		return nil, fmt.Errorf(
+			"roast selection: stale transition record (prev attempt %d, expected %d); fail closed",
+			record.PreviousContext.AttemptNumber, retryCount-1,
+		)
+	}
+
+	nextContext, err := deps.Coordinator.NextAttempt(
+		record.PreviousHandle,
+		record.Bundle,
+		threshold,
+		record.DkgGroupPublicKey,
+	)
+	if err != nil {
+		// Includes ErrAttemptInfeasible (the next included set would drop below
+		// threshold): the session cannot make progress -- fail closed.
+		return nil, fmt.Errorf("roast selection: next attempt: %w", err)
+	}
+
+	// Defensive: the derived attempt number must match the retry we select for
+	// (NextAttempt derives prev+1, which equals retryCount given the freshness
+	// check above; re-assert so any drift fails closed rather than mis-selects).
+	if uint(nextContext.AttemptNumber) != retryCount {
+		return nil, fmt.Errorf(
+			"roast selection: derived attempt %d does not match retry %d; fail closed",
+			nextContext.AttemptNumber, retryCount,
+		)
+	}
+
+	return nextContext.IncludedSet, nil
+}

--- a/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
@@ -24,93 +24,100 @@ var ErrRoastSelectionFallBackToLegacy = errors.New(
 // activation of the cross-attempt ROAST retry path).
 //
 // Returns one of:
-//   - (includedSet, nil): a FRESH transition record drove the next attempt; the
-//     caller uses includedSet verbatim (member-level, no address round-trip).
-//   - (nil, ErrRoastSelectionFallBackToLegacy): the initial attempt, or ROAST
-//     retry is not active -- a UNIFORM legacy fallback (deterministic across
-//     honest nodes, so non-fracturing).
-//   - (nil, any other error): a committed ROAST attempt EXPECTED a transition
-//     but no FRESH record exists, or NextAttempt failed. The caller MUST FAIL
-//     CLOSED (terminate the retry loop), NEVER fall back to legacy: a node that
-//     selected legacy while peers selected from the transition would split the
-//     signing group into divergent included sets -- the fracture class.
+//   - (includedSet, parked, nil): a FRESH transition record drove the next
+//     attempt; the caller uses includedSet verbatim (member-level) AND carries
+//     parked so the attempt after reinstates the parked members.
+//   - (nil, nil, ErrRoastSelectionFallBackToLegacy): the initial ROAST attempt,
+//     or ROAST retry is not active -- a UNIFORM legacy fallback (deterministic
+//     across honest nodes, so non-fracturing).
+//   - (nil, nil, any other error): a committed ROAST attempt EXPECTED a
+//     transition but no FRESH record exists, or NextAttempt failed. The caller
+//     MUST FAIL CLOSED (terminate the retry loop), NEVER fall back to legacy: a
+//     node that selected legacy while peers selected from the transition would
+//     split the signing group into divergent included sets -- the fracture class.
 //
 // The "a transition is expected" predicate is deterministic group-wide: every
-// honest node, with the same (uniformly deployed) gating, agrees that retry > 0
-// under active ROAST retry expects a transition. VerifyBundle is NOT called here
-// -- the transition listener already verified the bundle before storing the
-// record, so the selector consumes only verified records.
+// honest node, with the same (uniformly deployed) gating, agrees that
+// roastAttemptNumber > 0 under active ROAST retry expects a transition. VerifyBundle
+// is NOT called here -- the transition listener already verified the bundle before
+// storing the record, so the selector consumes only verified records.
 //
 // threshold is the FROST signing threshold t for the key group, used by
 // NextAttempt's infeasibility check (the next included set must stay at or above
 // t). For tBTC wallets the group's honest threshold IS that signing threshold,
 // so the caller passes it; if the two ever diverge for a key group, the
 // authoritative value is the persisted DKGThreshold.
+// roastAttemptNumber is the 0-based COMMITTED ROAST attempt index (advanced only
+// by observed attempts, decoupled from the block-paced loop attempt counter), so
+// skipped loop iterations do not break the consecutive-transition chain. It
+// returns the next attempt's included set AND its transiently-parked set; the
+// caller MUST carry the parking, or a one-attempt park becomes permanent.
 func ConsumeRoastTransitionForSelection(
 	roastSessionID string,
 	member group.MemberIndex,
-	retryCount uint,
+	roastAttemptNumber uint,
 	threshold uint,
-) ([]group.MemberIndex, error) {
-	// The initial attempt has no prior transition: uniform legacy/initial
+) (included []group.MemberIndex, transientlyParked []group.MemberIndex, err error) {
+	// The initial ROAST attempt has no prior transition: uniform legacy/initial
 	// selection.
-	if retryCount == 0 {
-		return nil, ErrRoastSelectionFallBackToLegacy
+	if roastAttemptNumber == 0 {
+		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
 
 	// ROAST retry inactive (readiness opted out or no coordinator registered):
 	// a uniform legacy fallback. This MUST mirror the observe/exchange gating, so
 	// a node that produced no records also does not expect to consume one.
-	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
-		return nil, ErrRoastSelectionFallBackToLegacy
+	if optInErr := EnsureRoastRetryReadinessOptIn(); optInErr != nil {
+		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
 	deps, ok := RegisteredRoastRetryCoordinator()
 	if !ok || deps.Coordinator == nil {
-		return nil, ErrRoastSelectionFallBackToLegacy
+		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
 
-	// From here a transition from the prior attempt IS expected; its absence is
-	// fail-closed, never a legacy fallback.
+	// From here a transition from the prior COMMITTED attempt IS expected; its
+	// absence is fail-closed, never a legacy fallback.
 	record, ok := RoastTransitionForSession(roastSessionID, member)
 	if !ok {
-		return nil, fmt.Errorf(
-			"roast selection: no transition record for retry %d; fail closed",
-			retryCount,
+		return nil, nil, fmt.Errorf(
+			"roast selection: no transition record for roast attempt %d; fail closed",
+			roastAttemptNumber,
 		)
 	}
 
-	// Freshness: the record must describe the IMMEDIATELY prior attempt. The
-	// previous attempt's 0-based AttemptNumber plus one must equal this retry
-	// count (also 0-based). A stale record (e.g. a missed intervening
-	// transition) must not drive selection -- fail closed.
-	if uint(record.PreviousContext.AttemptNumber)+1 != retryCount {
-		return nil, fmt.Errorf(
+	// Freshness: the record must describe the IMMEDIATELY prior committed attempt.
+	// The previous attempt's 0-based AttemptNumber plus one must equal this
+	// roast attempt number. A stale record (e.g. a missed intervening transition)
+	// must not drive selection -- fail closed.
+	if uint(record.PreviousContext.AttemptNumber)+1 != roastAttemptNumber {
+		return nil, nil, fmt.Errorf(
 			"roast selection: stale transition record (prev attempt %d, expected %d); fail closed",
-			record.PreviousContext.AttemptNumber, retryCount-1,
+			record.PreviousContext.AttemptNumber, roastAttemptNumber-1,
 		)
 	}
 
-	nextContext, err := deps.Coordinator.NextAttempt(
+	nextContext, nextErr := deps.Coordinator.NextAttempt(
 		record.PreviousHandle,
 		record.Bundle,
 		threshold,
 		record.DkgGroupPublicKey,
 	)
-	if err != nil {
+	if nextErr != nil {
 		// Includes ErrAttemptInfeasible (the next included set would drop below
 		// threshold): the session cannot make progress -- fail closed.
-		return nil, fmt.Errorf("roast selection: next attempt: %w", err)
+		return nil, nil, fmt.Errorf("roast selection: next attempt: %w", nextErr)
 	}
 
-	// Defensive: the derived attempt number must match the retry we select for
-	// (NextAttempt derives prev+1, which equals retryCount given the freshness
-	// check above; re-assert so any drift fails closed rather than mis-selects).
-	if uint(nextContext.AttemptNumber) != retryCount {
-		return nil, fmt.Errorf(
-			"roast selection: derived attempt %d does not match retry %d; fail closed",
-			nextContext.AttemptNumber, retryCount,
+	// Defensive: the derived attempt number must match the roast attempt we select
+	// for (NextAttempt derives prev+1, which equals roastAttemptNumber given the
+	// freshness check above; re-assert so any drift fails closed rather than
+	// mis-selects).
+	if uint(nextContext.AttemptNumber) != roastAttemptNumber {
+		return nil, nil, fmt.Errorf(
+			"roast selection: derived attempt %d does not match roast attempt %d; fail closed",
+			nextContext.AttemptNumber, roastAttemptNumber,
 		)
 	}
 
-	return nextContext.IncludedSet, nil
+	return nextContext.IncludedSet, nextContext.TransientlyParked, nil
 }

--- a/pkg/frost/signing/roast_selection_consume_no_producer_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_selection_consume_no_producer_frost_roast_retry_test.go
@@ -1,0 +1,41 @@
+//go:build frost_roast_retry && !frost_native
+
+package signing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+)
+
+// TestConsumeRoastTransitionForSelection_FallbackWhenNoProducer asserts that in a
+// frost_roast_retry build WITHOUT frost_native -- where the participant selector
+// and the coordinator registry exist but nothing PRODUCES transition records (the
+// observe step, exchange, and aggregation are frost_native && frost_roast_retry) --
+// a retry falls back to the uniform legacy shuffle instead of fail-closing against
+// a transition record that can never be created (Codex P2-1). Without the producer
+// gate in RoastRetryActive this would fail closed and stall the signing.
+func TestConsumeRoastTransitionForSelection_FallbackWhenNoProducer(t *testing.T) {
+	if roastTransitionProducerAvailable() {
+		t.Fatal("precondition: this build (no frost_native) must have no producer")
+	}
+
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	// roastAttemptNumber 1 (> 0): with a producer this expects a transition and
+	// fail-closes when none exists; without a producer it must fall back to legacy
+	// (the deterministic, group-wide outcome every no-producer node reaches).
+	_, _, err := ConsumeRoastTransitionForSelection("session", 1, 1, 3)
+	if !errors.Is(err, ErrRoastSelectionFallBackToLegacy) {
+		t.Fatalf("a no-producer build must fall back to legacy, not fail closed; got %v", err)
+	}
+}

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
@@ -1,0 +1,247 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// RoastTransitionExchange runs one signer's session-scoped ROAST transition
+// exchange over a RunnerBus (RFC-21 Phase 7.3 PR2b-1b C2). It owns the receive
+// side (a listener goroutine for the session lifetime) and exposes the produce
+// side the block-timed controller drives:
+//
+//   - listen: peers' evidence snapshots are recorded against the elected
+//     coordinator's local observe handle (only the elected seat collects, for
+//     aggregation); peers' transition bundles are verified against this seat's
+//     own observe handle and, when valid, stored as the next-attempt record.
+//   - BroadcastForcedSnapshot: a participating seat publishes a forced (empty)
+//     proof-of-attendance snapshot so it appears in the aggregated bundle and is
+//     not silence-parked by NextAttempt. It records its OWN snapshot before
+//     broadcasting, so VerifyBundle's censorship check is meaningful.
+//   - AggregateAndBroadcast: the elected seat aggregates the collected snapshots
+//     into a coordinator-signed bundle, stores it locally via the same
+//     verify+store path receivers use, and broadcasts it. A no-op on a seat that
+//     is not the elected coordinator (AggregateBundle returns ErrNotAggregator).
+//
+// Every binding lookup resolves the per-attempt observe handle the C1 observe
+// step stored, keyed by (roastSessionID, member, attemptContextHash). The
+// exchange never trusts an unsigned outer bus field over the signed body: it
+// resolves bindings and roles from the snapshot/bundle's own AttemptContextHash.
+type RoastTransitionExchange struct {
+	ctx            context.Context
+	logger         log.StandardLogger
+	bus            RunnerBus
+	deps           RoastRetryDeps
+	roastSessionID string
+	member         group.MemberIndex
+	sub            *RunnerBusSubscriber
+}
+
+// NewRoastTransitionExchange constructs the exchange and starts its listener for
+// the lifetime of ctx (cancel ctx -- e.g. at session end -- to stop it). It
+// subscribes to the bus before returning so no peer message broadcast after
+// construction is missed.
+func NewRoastTransitionExchange(
+	ctx context.Context,
+	logger log.StandardLogger,
+	bus RunnerBus,
+	deps RoastRetryDeps,
+	roastSessionID string,
+	member group.MemberIndex,
+) *RoastTransitionExchange {
+	if logger == nil {
+		logger = log.Logger("keep-frost-roast-transition-exchange")
+	}
+	e := &RoastTransitionExchange{
+		ctx:            ctx,
+		logger:         logger,
+		bus:            bus,
+		deps:           deps,
+		roastSessionID: roastSessionID,
+		member:         member,
+		sub:            bus.Subscribe(),
+	}
+	go e.listen()
+	return e
+}
+
+func (e *RoastTransitionExchange) listen() {
+	for {
+		select {
+		case <-e.ctx.Done():
+			return
+		case msg := <-e.sub.EvidenceSnapshots():
+			e.onSnapshot(msg)
+		case msg := <-e.sub.TransitionBundles():
+			e.onBundle(msg)
+		}
+	}
+}
+
+// onSnapshot records a peer's evidence snapshot against this seat's observe
+// handle for the attempt, but ONLY when this seat is the attempt's elected
+// coordinator -- it is the only seat that aggregates, so other seats need not
+// collect. The snapshot's signed AttemptContextHash (not the unsigned bus field)
+// resolves the binding, and the authenticated bus sender must match the claimed
+// submitter.
+func (e *RoastTransitionExchange) onSnapshot(msg RunnerMessage) {
+	snapshot := &roast.LocalEvidenceSnapshot{}
+	if err := snapshot.Unmarshal(msg.Payload); err != nil {
+		return
+	}
+	if snapshot.SenderID() != msg.Sender {
+		// A seat embedding another member's id: drop, do not let it fill that
+		// member's slot.
+		return
+	}
+	hash := snapshot.AttemptContextHashArray()
+	binding, ok := observedAttempt(e.roastSessionID, e.member, hash)
+	if !ok {
+		return
+	}
+	elected, err := e.deps.Coordinator.SelectedCoordinator(binding.handle)
+	if err != nil || elected != group.MemberIndex(e.deps.SelfMember) {
+		// Only the elected coordinator collects snapshots for aggregation.
+		return
+	}
+	if err := e.deps.Coordinator.RecordEvidence(binding.handle, snapshot); err != nil {
+		e.logger.Warnf(
+			"roast transition: record peer snapshot from [%d] failed: [%v]",
+			msg.Sender, err,
+		)
+	}
+}
+
+// onBundle verifies a received transition bundle against this seat's observe
+// handle and, when valid, stores the next-attempt record. The bundle's claimed
+// coordinator must equal the authenticated bus sender (hygiene; VerifyBundle then
+// authenticates the coordinator signature cryptographically).
+func (e *RoastTransitionExchange) onBundle(msg RunnerMessage) {
+	bundle := &roast.TransitionMessage{}
+	if err := bundle.Unmarshal(msg.Payload); err != nil {
+		return
+	}
+	if bundle.CoordinatorID() != msg.Sender {
+		return
+	}
+	e.verifyAndStore(bundle)
+}
+
+// BroadcastForcedSnapshot publishes this seat's forced (empty) proof-of-attendance
+// snapshot for the attempt, recording it locally BEFORE the broadcast so the
+// censorship check on the returned bundle is meaningful. A no-op when the seat
+// has no observe binding for the attempt or signing fails.
+func (e *RoastTransitionExchange) BroadcastForcedSnapshot(
+	attemptHash [attempt.MessageDigestLength]byte,
+) {
+	binding, ok := observedAttempt(e.roastSessionID, e.member, attemptHash)
+	if !ok {
+		return
+	}
+	snapshot := roast.NewLocalEvidenceSnapshot(e.member, attemptHash, attempt.Evidence{})
+	payload, err := snapshot.SignableBytes()
+	if err != nil {
+		e.logger.Warnf("roast transition: forced snapshot signable bytes: [%v]", err)
+		return
+	}
+	signature, err := e.deps.Signer.Sign(payload)
+	if err != nil {
+		e.logger.Warnf("roast transition: sign forced snapshot: [%v]", err)
+		return
+	}
+	snapshot.OperatorSignature = signature
+
+	// Marshal first so the wire bytes are fixed, then record OWN before
+	// broadcasting: the elected coordinator must have it for aggregation, and
+	// recording-before-broadcast makes VerifyBundle's self-submission censorship
+	// check meaningful -- the recorded snapshot is byte-identical to the
+	// broadcast one and to the copy peers aggregate.
+	envelope, err := snapshot.Marshal()
+	if err != nil {
+		e.logger.Warnf("roast transition: marshal forced snapshot: [%v]", err)
+		return
+	}
+	if err := e.deps.Coordinator.RecordEvidence(binding.handle, snapshot); err != nil {
+		e.logger.Warnf("roast transition: record own snapshot failed: [%v]", err)
+		return
+	}
+	e.bus.Broadcast(RunnerMessage{
+		Type:    RunnerMsgEvidenceSnapshot,
+		Sender:  e.member,
+		Attempt: attemptHash,
+		Payload: envelope,
+	})
+}
+
+// AggregateAndBroadcast aggregates the collected snapshots into a
+// coordinator-signed bundle, stores it locally via the same verify+store path
+// receivers use, and broadcasts it. A no-op on any seat that is not the attempt's
+// elected coordinator (AggregateBundle returns ErrNotAggregator) or that has no
+// observe binding.
+func (e *RoastTransitionExchange) AggregateAndBroadcast(
+	attemptHash [attempt.MessageDigestLength]byte,
+) {
+	binding, ok := observedAttempt(e.roastSessionID, e.member, attemptHash)
+	if !ok {
+		return
+	}
+	bundle, err := e.deps.Coordinator.AggregateBundle(binding.handle)
+	if err != nil {
+		// Not the elected coordinator, already transitioned, or an empty bundle:
+		// nothing to broadcast. Non-elected seats reach here harmlessly.
+		return
+	}
+
+	// Store our own record the same way receivers do, then broadcast (the bus
+	// does not echo our own message back).
+	e.verifyAndStore(bundle)
+
+	envelope, err := bundle.Marshal()
+	if err != nil {
+		e.logger.Warnf("roast transition: marshal bundle: [%v]", err)
+		return
+	}
+	e.bus.Broadcast(RunnerMessage{
+		Type:    RunnerMsgTransitionBundle,
+		Sender:  e.member,
+		Attempt: attemptHash,
+		Payload: envelope,
+	})
+}
+
+// verifyAndStore is the single verify+store path both receivers (onBundle) and
+// the producing coordinator (AggregateAndBroadcast) use, so a stored record is
+// always a verified one. It resolves this seat's observe binding from the
+// bundle's signed AttemptContextHash, verifies the bundle against that handle,
+// stores the next-attempt record, and clears the consumed observe binding.
+func (e *RoastTransitionExchange) verifyAndStore(bundle *roast.TransitionMessage) {
+	hash := bundle.AttemptContextHashArray()
+	binding, ok := observedAttempt(e.roastSessionID, e.member, hash)
+	if !ok {
+		return
+	}
+	if err := e.deps.Coordinator.VerifyBundle(binding.handle, bundle); err != nil {
+		e.logger.Warnf("roast transition: verify bundle failed: [%v]", err)
+		return
+	}
+	// Defensive: the bundle's hash must match the binding's bound context hash
+	// (VerifyBundle binds to the handle, but keep the record self-consistent).
+	boundHash := binding.context.Hash()
+	if !bytes.Equal(hash[:], boundHash[:]) {
+		return
+	}
+	RecordRoastTransition(e.roastSessionID, e.member, RoastTransitionRecord{
+		Bundle:            bundle,
+		PreviousHandle:    binding.handle,
+		PreviousContext:   binding.context,
+		DkgGroupPublicKey: binding.dkgGroupPublicKey,
+	})
+	clearObservedAttempt(e.roastSessionID, e.member, hash)
+}

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
@@ -73,6 +73,11 @@ func NewRoastTransitionExchange(
 }
 
 func (e *RoastTransitionExchange) listen() {
+	// On session end (ctx done), drop any observe bindings this seat did not
+	// consume per-attempt -- e.g. a signing whose attempts all succeeded never
+	// produced a transition record to clear, so its bindings would otherwise
+	// linger until the TTL sweep.
+	defer clearObservedAttemptsForSession(e.roastSessionID, e.member)
 	for {
 		select {
 		case <-e.ctx.Done():

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
@@ -5,6 +5,7 @@ package signing
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/frost/roast"
@@ -42,6 +43,10 @@ type RoastTransitionExchange struct {
 	roastSessionID string
 	member         group.MemberIndex
 	sub            *RunnerBusSubscriber
+	// lostSync is set by the listener when a transition bundle arrives for an
+	// attempt this seat never observed (it skipped a window peers committed). The
+	// retry loop reads it via the controller from its own goroutine, hence atomic.
+	lostSync atomic.Bool
 }
 
 // NewRoastTransitionExchange constructs the exchange and starts its listener for
@@ -136,7 +141,40 @@ func (e *RoastTransitionExchange) onBundle(msg RunnerMessage) {
 	if bundle.CoordinatorID() != msg.Sender {
 		return
 	}
+	hash := bundle.AttemptContextHashArray()
+	if !attemptEverObserved(e.roastSessionID, e.member, hash) {
+		// A bundle for an attempt this seat NEVER observed: peers committed an
+		// attempt this seat skipped (its local block schedule moved past the
+		// announcement window while peers stayed in it), so this seat is behind the
+		// group's committed ROAST attempt chain. Flag lost sync; the retry loop
+		// fails closed before its next selection rather than select a divergent
+		// included set (the fracture class).
+		//
+		// The bundle is authenticated (the bus binds msg.Sender to an operator seat
+		// and the claimed coordinator must equal it) but UNVERIFIABLE here:
+		// VerifyBundle needs the local observe handle this seat never created. An
+		// authenticated member could thus broadcast a bundle for a bogus hash to
+		// force a peer's fail-closed -- an insider-liveness surface that the blame
+		// bridge addresses (PR2b-2) and that stays within 1b's accepted
+		// fail-closed-terminate liveness regression (a single bad actor can already
+		// kill a round by withholding a bundle).
+		e.markLostSync()
+		return
+	}
 	e.verifyAndStore(bundle)
+}
+
+// markLostSync records that this seat received a transition for an attempt it
+// never observed -- it fell behind the group's committed ROAST attempt chain.
+func (e *RoastTransitionExchange) markLostSync() {
+	e.lostSync.Store(true)
+}
+
+// HasLostSync reports whether this seat fell behind the group's committed ROAST
+// attempt chain (it received a transition for an attempt it never observed). The
+// retry loop checks it before selection and fails closed when true.
+func (e *RoastTransitionExchange) HasLostSync() bool {
+	return e.lostSync.Load()
 }
 
 // BroadcastForcedSnapshot publishes this seat's forced (empty) proof-of-attendance

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/frost/roast"
@@ -74,7 +75,8 @@ type exchangeNode struct {
 // newExchangeTestNodes builds one node per included member: each gets its own
 // in-memory coordinator, begins the SAME attempt context (so all nodes elect the
 // same coordinator deterministically), records its observe binding, and wires an
-// exchange over its own capture bus with an already-cancelled ctx (no listener).
+// exchange over its own capture bus (the listener blocks on the unfed bus until
+// test end; the tests drive the exchange methods directly).
 func newExchangeTestNodes(
 	t *testing.T,
 	roastSessionID string,
@@ -84,8 +86,12 @@ func newExchangeTestNodes(
 	t.Helper()
 	hash := ctx.Hash()
 	nodes := map[group.MemberIndex]*exchangeNode{}
+	// A test-lifetime ctx: listen() blocks harmlessly on the capture bus's unfed
+	// streams (the bus captures broadcasts rather than delivering them), and the
+	// tests drive onSnapshot/onBundle directly. Cancelling only at test end keeps
+	// the session-end defer-clear from wiping the bindings before the assertions.
 	exchangeCtx, cancel := context.WithCancel(context.Background())
-	cancel() // listen() exits immediately; the tests drive methods directly.
+	t.Cleanup(cancel)
 	for _, m := range ctx.IncludedSet {
 		coord := roast.NewInMemoryCoordinatorWithSigning(
 			m, fixedSigner{}, roast.NoOpSignatureVerifier(),
@@ -222,6 +228,50 @@ func TestRoastTransitionExchange_ProducesRecordsAcrossNodes(t *testing.T) {
 		if _, ok := observedAttempt(roastSessionID, m, hash); ok {
 			t.Fatalf("member %d observe binding must be cleared after storing the record", m)
 		}
+	}
+}
+
+// TestRoastTransitionExchange_SessionEndClearsObserveBindings asserts that when
+// the exchange's session context ends, its listener clears the observe bindings
+// this seat did not consume per-attempt (e.g. a signing whose attempts all
+// succeeded), rather than leaking them until the TTL sweep.
+func TestRoastTransitionExchange_SessionEndClearsObserveBindings(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+
+	roastSessionID := "exchange-session-end"
+	var hash [attempt.MessageDigestLength]byte
+	hash[0] = 0x7e
+	recordObservedAttempt(roastSessionID, 1, hash, observedAttemptBinding{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = NewRoastTransitionExchange(
+		ctx,
+		log.Logger("exchange-test"),
+		&captureBus{},
+		RoastRetryDeps{
+			Coordinator: roast.NewInMemoryCoordinatorWithSigning(
+				1, fixedSigner{}, roast.NoOpSignatureVerifier(),
+			),
+			Signer:     fixedSigner{},
+			Verifier:   roast.NoOpSignatureVerifier(),
+			SelfMember: 1,
+		},
+		roastSessionID,
+		1,
+	)
+	if !ObservedAttemptStoredForTest(roastSessionID, 1) {
+		t.Fatal("binding should exist before session end")
+	}
+
+	cancel() // session end -> listener exits -> defer clears bindings.
+
+	deadline := time.Now().Add(2 * time.Second)
+	for ObservedAttemptStoredForTest(roastSessionID, 1) {
+		if time.Now().After(deadline) {
+			t.Fatal("session end must clear the observe binding")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
@@ -1,0 +1,266 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+import (
+	"context"
+	"crypto/sha256"
+	"sync"
+	"testing"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// captureBus is a RunnerBus that records broadcasts so a test can deliver them
+// to peers by hand -- driving the exchange synchronously, with no listener
+// goroutine or delivery timing. Subscribe returns an undrained subscriber; the
+// tests cancel the exchange ctx so listen() exits immediately and the test calls
+// onSnapshot/onBundle directly.
+type captureBus struct {
+	mu         sync.Mutex
+	broadcasts []RunnerMessage
+}
+
+func (b *captureBus) Broadcast(msg RunnerMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Own the payload so a later mutation cannot change what we captured.
+	cloned := msg
+	cloned.Payload = append([]byte(nil), msg.Payload...)
+	b.broadcasts = append(b.broadcasts, cloned)
+}
+
+func (b *captureBus) Subscribe() *RunnerBusSubscriber {
+	return &RunnerBusSubscriber{
+		commitments:       make(chan RunnerMessage, 1),
+		signingPackages:   make(chan RunnerMessage, 1),
+		shares:            make(chan RunnerMessage, 1),
+		evidenceSnapshots: make(chan RunnerMessage, 1),
+		transitionBundles: make(chan RunnerMessage, 1),
+		seen:              map[[sha256.Size]byte]struct{}{},
+	}
+}
+
+func (b *captureBus) only(t RunnerMessageType) []RunnerMessage {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]RunnerMessage, 0, len(b.broadcasts))
+	for _, m := range b.broadcasts {
+		if m.Type == t {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// fixedSigner returns a fixed non-empty signature. The wire encoders reject an
+// empty signature, so the NoOp signer (which returns nil) cannot be used here;
+// the NoOp verifier still accepts this fixed signature, so the test exercises the
+// exchange flow without a real signature pipeline.
+type fixedSigner struct{}
+
+func (fixedSigner) Sign(_ []byte) ([]byte, error) { return []byte{0x01}, nil }
+
+type exchangeNode struct {
+	member group.MemberIndex
+	coord  roast.Coordinator
+	bus    *captureBus
+	ex     *RoastTransitionExchange
+}
+
+// newExchangeTestNodes builds one node per included member: each gets its own
+// in-memory coordinator, begins the SAME attempt context (so all nodes elect the
+// same coordinator deterministically), records its observe binding, and wires an
+// exchange over its own capture bus with an already-cancelled ctx (no listener).
+func newExchangeTestNodes(
+	t *testing.T,
+	roastSessionID string,
+	ctx attempt.AttemptContext,
+	dkgKey []byte,
+) map[group.MemberIndex]*exchangeNode {
+	t.Helper()
+	hash := ctx.Hash()
+	nodes := map[group.MemberIndex]*exchangeNode{}
+	exchangeCtx, cancel := context.WithCancel(context.Background())
+	cancel() // listen() exits immediately; the tests drive methods directly.
+	for _, m := range ctx.IncludedSet {
+		coord := roast.NewInMemoryCoordinatorWithSigning(
+			m, fixedSigner{}, roast.NoOpSignatureVerifier(),
+		)
+		handle, err := coord.BeginAttempt(ctx)
+		if err != nil {
+			t.Fatalf("begin attempt for member %d: %v", m, err)
+		}
+		recordObservedAttempt(roastSessionID, m, hash, observedAttemptBinding{
+			handle:            handle,
+			context:           ctx,
+			dkgGroupPublicKey: dkgKey,
+		})
+		bus := &captureBus{}
+		ex := NewRoastTransitionExchange(
+			exchangeCtx,
+			log.Logger("exchange-test"),
+			bus,
+			RoastRetryDeps{
+				Coordinator: coord,
+				Signer:      fixedSigner{},
+				Verifier:    roast.NoOpSignatureVerifier(),
+				SelfMember:  uint32(m),
+			},
+			roastSessionID,
+			m,
+		)
+		nodes[m] = &exchangeNode{member: m, coord: coord, bus: bus, ex: ex}
+	}
+	return nodes
+}
+
+func newExchangeTestContext(
+	t *testing.T,
+	roastSessionID string,
+	included []group.MemberIndex,
+	dkgKey []byte,
+) attempt.AttemptContext {
+	t.Helper()
+	var digest [attempt.MessageDigestLength]byte
+	digest[0] = 0xaa
+	ctx, err := attempt.NewAttemptContextWithParking(
+		roastSessionID, "exchange-key-group", dkgKey, digest, 0, included, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("build attempt context: %v", err)
+	}
+	return ctx
+}
+
+// TestRoastTransitionExchange_ProducesRecordsAcrossNodes drives the full
+// failed-attempt exchange by hand: every seat broadcasts a forced snapshot, the
+// elected coordinator collects them and aggregates+broadcasts the bundle, and
+// every seat ends with a verified next-attempt transition record.
+func TestRoastTransitionExchange_ProducesRecordsAcrossNodes(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+
+	roastSessionID := "exchange-records-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x01, 0x02, 0x03}
+
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := ctx.Hash()
+	nodes := newExchangeTestNodes(t, roastSessionID, ctx, dkgKey)
+
+	// Find the deterministically elected coordinator.
+	var elected group.MemberIndex
+	for _, n := range nodes {
+		binding, ok := observedAttempt(roastSessionID, n.member, hash)
+		if !ok {
+			t.Fatalf("missing observe binding for member %d", n.member)
+		}
+		e, err := n.coord.SelectedCoordinator(binding.handle)
+		if err != nil {
+			t.Fatalf("selected coordinator: %v", err)
+		}
+		elected = e
+		break
+	}
+
+	// 1. Every participating seat broadcasts a forced snapshot.
+	for _, m := range included {
+		nodes[m].ex.BroadcastForcedSnapshot(hash)
+	}
+
+	// 2. Deliver each seat's snapshot to the elected coordinator's onSnapshot.
+	for _, m := range included {
+		if m == elected {
+			continue // elected already recorded its own in BroadcastForcedSnapshot
+		}
+		snaps := nodes[m].bus.only(RunnerMsgEvidenceSnapshot)
+		if len(snaps) != 1 {
+			t.Fatalf("member %d expected to broadcast 1 snapshot, got %d", m, len(snaps))
+		}
+		nodes[elected].ex.onSnapshot(snaps[0])
+	}
+
+	// 3. The elected coordinator aggregates + broadcasts the bundle (a no-op on
+	// the others).
+	for _, m := range included {
+		nodes[m].ex.AggregateAndBroadcast(hash)
+	}
+
+	bundles := nodes[elected].bus.only(RunnerMsgTransitionBundle)
+	if len(bundles) != 1 {
+		t.Fatalf("elected coordinator must broadcast exactly one bundle, got %d", len(bundles))
+	}
+	for _, m := range included {
+		if m == elected {
+			continue
+		}
+		if got := nodes[m].bus.only(RunnerMsgTransitionBundle); len(got) != 0 {
+			t.Fatalf("non-elected member %d must not broadcast a bundle, got %d", m, len(got))
+		}
+	}
+
+	// 4. Deliver the bundle to every other seat's onBundle.
+	for _, m := range included {
+		if m == elected {
+			continue
+		}
+		nodes[m].ex.onBundle(bundles[0])
+	}
+
+	// 5. Every seat must now hold a verified transition record, and its observe
+	// binding must be cleared (consumed).
+	for _, m := range included {
+		if _, ok := RoastTransitionForSession(roastSessionID, m); !ok {
+			t.Fatalf("member %d must hold a transition record after the exchange", m)
+		}
+		if _, ok := observedAttempt(roastSessionID, m, hash); ok {
+			t.Fatalf("member %d observe binding must be cleared after storing the record", m)
+		}
+	}
+}
+
+// TestRoastTransitionExchange_NonElectedDoesNotAggregate asserts a seat that is
+// not the elected coordinator produces no bundle and stores no record from
+// AggregateAndBroadcast (only the elected seat aggregates).
+func TestRoastTransitionExchange_NonElectedDoesNotAggregate(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+
+	roastSessionID := "exchange-nonelected-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x04, 0x05, 0x06}
+
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := ctx.Hash()
+	nodes := newExchangeTestNodes(t, roastSessionID, ctx, dkgKey)
+
+	var elected group.MemberIndex
+	binding, _ := observedAttempt(roastSessionID, 1, hash)
+	elected, _ = nodes[1].coord.SelectedCoordinator(binding.handle)
+
+	var nonElected group.MemberIndex
+	for _, m := range included {
+		if m != elected {
+			nonElected = m
+			break
+		}
+	}
+
+	nodes[nonElected].ex.BroadcastForcedSnapshot(hash)
+	nodes[nonElected].ex.AggregateAndBroadcast(hash)
+
+	if got := nodes[nonElected].bus.only(RunnerMsgTransitionBundle); len(got) != 0 {
+		t.Fatalf("non-elected seat must not broadcast a bundle, got %d", len(got))
+	}
+	if _, ok := RoastTransitionForSession(roastSessionID, nonElected); ok {
+		t.Fatal("non-elected seat must not store a transition record from AggregateAndBroadcast")
+	}
+}

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
@@ -231,6 +231,189 @@ func TestRoastTransitionExchange_ProducesRecordsAcrossNodes(t *testing.T) {
 	}
 }
 
+// produceTransitionBundleForTest runs the forced-snapshot + aggregate flow across
+// the included nodes by hand and returns the elected coordinator's broadcast
+// transition bundle message plus the elected member.
+func produceTransitionBundleForTest(
+	t *testing.T,
+	roastSessionID string,
+	ctx attempt.AttemptContext,
+	nodes map[group.MemberIndex]*exchangeNode,
+) (RunnerMessage, group.MemberIndex) {
+	t.Helper()
+	hash := ctx.Hash()
+
+	var elected group.MemberIndex
+	for _, n := range nodes {
+		binding, ok := observedAttempt(roastSessionID, n.member, hash)
+		if !ok {
+			t.Fatalf("missing observe binding for member %d", n.member)
+		}
+		e, err := n.coord.SelectedCoordinator(binding.handle)
+		if err != nil {
+			t.Fatalf("selected coordinator: %v", err)
+		}
+		elected = e
+		break
+	}
+
+	for _, m := range ctx.IncludedSet {
+		nodes[m].ex.BroadcastForcedSnapshot(hash)
+	}
+	for _, m := range ctx.IncludedSet {
+		if m == elected {
+			continue
+		}
+		snaps := nodes[m].bus.only(RunnerMsgEvidenceSnapshot)
+		if len(snaps) != 1 {
+			t.Fatalf("member %d expected to broadcast 1 snapshot, got %d", m, len(snaps))
+		}
+		nodes[elected].ex.onSnapshot(snaps[0])
+	}
+	nodes[elected].ex.AggregateAndBroadcast(hash)
+
+	bundles := nodes[elected].bus.only(RunnerMsgTransitionBundle)
+	if len(bundles) != 1 {
+		t.Fatalf("elected coordinator must broadcast exactly one bundle, got %d", len(bundles))
+	}
+	return bundles[0], elected
+}
+
+// TestRoastTransitionExchange_LostSyncOnUnobservedBundle asserts a seat whose
+// listener receives a transition bundle for an attempt it NEVER observed (it
+// skipped a window the others committed) trips lost sync, so the retry loop can
+// fail closed before selecting from a stale position (Codex lost-sync correction).
+func TestRoastTransitionExchange_LostSyncOnUnobservedBundle(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+
+	roastSessionID := "exchange-lost-sync-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x04, 0x05}
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	nodes := newExchangeTestNodes(t, roastSessionID, ctx, dkgKey)
+
+	bundle, _ := produceTransitionBundleForTest(t, roastSessionID, ctx, nodes)
+
+	// A lagging seat (member 4) that never observed this attempt -- its listener
+	// receives the bundle the committed seats produced.
+	var lagging group.MemberIndex = 4
+	laggingCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	laggingEx := NewRoastTransitionExchange(
+		laggingCtx,
+		log.Logger("exchange-test-lagging"),
+		&captureBus{},
+		RoastRetryDeps{
+			Coordinator: roast.NewInMemoryCoordinatorWithSigning(
+				lagging, fixedSigner{}, roast.NoOpSignatureVerifier(),
+			),
+			Signer:     fixedSigner{},
+			Verifier:   roast.NoOpSignatureVerifier(),
+			SelfMember: uint32(lagging),
+		},
+		roastSessionID,
+		lagging,
+	)
+
+	if laggingEx.HasLostSync() {
+		t.Fatal("a seat must not start in lost sync")
+	}
+	laggingEx.onBundle(bundle)
+	if !laggingEx.HasLostSync() {
+		t.Fatal("a bundle for an attempt this seat never observed must trip lost sync")
+	}
+}
+
+// TestRoastTransitionExchange_ConsumedRetransmitDoesNotLoseSync asserts that a
+// duplicate bundle for an attempt this seat already observed and consumed is a
+// benign no-op -- the observed-history marker (retained past the binding's
+// clear) keeps a retransmit from falsely tripping lost sync.
+func TestRoastTransitionExchange_ConsumedRetransmitDoesNotLoseSync(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+
+	roastSessionID := "exchange-retransmit-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x06}
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := ctx.Hash()
+	nodes := newExchangeTestNodes(t, roastSessionID, ctx, dkgKey)
+
+	bundle, elected := produceTransitionBundleForTest(t, roastSessionID, ctx, nodes)
+
+	// A non-elected receiver consumes the bundle: it stores the record and clears
+	// its observe binding, leaving only the observed-history marker.
+	var receiver group.MemberIndex
+	for _, m := range included {
+		if m != elected {
+			receiver = m
+			break
+		}
+	}
+	nodes[receiver].ex.onBundle(bundle)
+	if _, ok := RoastTransitionForSession(roastSessionID, receiver); !ok {
+		t.Fatalf("receiver %d must hold a transition record after consuming", receiver)
+	}
+	if _, ok := observedAttempt(roastSessionID, receiver, hash); ok {
+		t.Fatalf("receiver %d binding must be cleared after consuming", receiver)
+	}
+
+	// The same bundle re-delivered (a retransmit) must not trip lost sync.
+	nodes[receiver].ex.onBundle(bundle)
+	if nodes[receiver].ex.HasLostSync() {
+		t.Fatal("a retransmit of an already-consumed bundle must not trip lost sync")
+	}
+}
+
+// TestRoastTransitionExchange_SucceededSeatDoesNotStorePeerFailureBundle asserts
+// the core B3 outcome: after a seat clears its observe binding on local success, a
+// peer's failure bundle for that attempt is neither stored as a transition record
+// (the attempt was won, not failed) nor mistaken for lost sync (the observed
+// marker keeps it a benign no-op). With no fresh record the seat's next selection
+// then fails closed -- the honest fail-closed-after-success path.
+func TestRoastTransitionExchange_SucceededSeatDoesNotStorePeerFailureBundle(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+
+	roastSessionID := "exchange-success-nostore-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x07}
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := ctx.Hash()
+	nodes := newExchangeTestNodes(t, roastSessionID, ctx, dkgKey)
+
+	bundle, elected := produceTransitionBundleForTest(t, roastSessionID, ctx, nodes)
+
+	// A non-elected seat completed the attempt locally: it clears its observe
+	// binding (B3), keeping only the observed-history marker. It has not consumed a
+	// record (the helper delivered the bundle only to the elected coordinator).
+	var succeeded group.MemberIndex
+	for _, m := range included {
+		if m != elected {
+			succeeded = m
+			break
+		}
+	}
+	ClearObservedAttemptOnLocalSuccess(roastSessionID, succeeded, hash)
+
+	// The peer's failure bundle now arrives at the succeeded seat's listener.
+	nodes[succeeded].ex.onBundle(bundle)
+
+	if _, ok := RoastTransitionForSession(roastSessionID, succeeded); ok {
+		t.Fatal("a succeeded seat must not store a peer's failure transition for its won attempt")
+	}
+	if nodes[succeeded].ex.HasLostSync() {
+		t.Fatal("a bundle for a succeeded (observed) attempt must not trip lost sync")
+	}
+}
+
 // TestRoastTransitionExchange_SessionEndClearsObserveBindings asserts that when
 // the exchange's session context ends, its listener clears the observe bindings
 // this seat did not consume per-attempt (e.g. a signing whose attempts all

--- a/pkg/frost/signing/roast_transition_producer_default_build.go
+++ b/pkg/frost/signing/roast_transition_producer_default_build.go
@@ -1,0 +1,17 @@
+//go:build !(frost_native && frost_roast_retry)
+
+package signing
+
+// roastTransitionProducerAvailable reports whether this build contains the ROAST
+// transition producer (observe + exchange + elected-coordinator aggregation). That
+// producer requires BOTH frost_native and frost_roast_retry; this build lacks at
+// least one, so no producer exists and the function reports false.
+//
+// In particular a frost_roast_retry && !frost_native build has the participant
+// selector and the coordinator registry but NO producer, so RoastRetryActive
+// reports inactive and the selector falls back to the uniform legacy shuffle rather
+// than fail-closing every retry against records that can never be created. RFC-21
+// Phase 7.3 PR2b-1b (Codex P2-1).
+func roastTransitionProducerAvailable() bool {
+	return false
+}

--- a/pkg/frost/signing/roast_transition_producer_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_producer_frost_native_roast_retry.go
@@ -1,0 +1,16 @@
+//go:build frost_native && frost_roast_retry
+
+package signing
+
+// roastTransitionProducerAvailable reports whether this build contains the ROAST
+// transition PRODUCER -- the observe step, the transition exchange, and the
+// elected-coordinator aggregation that create transition records. The producer
+// lives behind frost_native && frost_roast_retry, so it is present here.
+//
+// RoastRetryActive and the participant selector gate on it: without a producer no
+// transition record can ever exist, so treating ROAST retry as active would
+// fail-close every retry (roastAttemptNumber > 0 finds no record) instead of using
+// the uniform legacy shuffle. RFC-21 Phase 7.3 PR2b-1b (Codex P2-1).
+func roastTransitionProducerAvailable() bool {
+	return true
+}

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -417,6 +417,31 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 				se.waitForBlockFn,
 			)
 
+			// RFC-21 Phase 7.3 PR2b-1b: install the per-signer ROAST transition
+			// controller, scoped to loopCtx (the session lifetime). It observes
+			// every attempt so this seat can verify the attempt's transition bundle
+			// and run NextAttempt for participant selection. nil in builds/
+			// deployments without ROAST retry, in which case the loop skips all
+			// transition steps. The request template carries the static signing
+			// material; the controller stamps each attempt's metadata itself.
+			retryLoop.setTransitionController(newRoastTransitionController(
+				loopCtx,
+				signingLogger,
+				&signing.Request{
+					Message:           message,
+					RoastSessionID:    roastSID,
+					MemberIndex:       signer.signingGroupMemberIndex,
+					SignerMaterial:    signer.signingMaterial(),
+					TaprootMerkleRoot: taprootMerkleRoot,
+					GroupSize:         wallet.groupSize(),
+					DishonestThreshold: wallet.groupDishonestThreshold(
+						se.groupParameters.HonestThreshold,
+					),
+					Channel:             se.broadcastChannel,
+					MembershipValidator: se.membershipValidator,
+				},
+			))
+
 			loopResult, err := retryLoop.start(
 				loopCtx,
 				se.waitForBlockFn,

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -472,11 +472,20 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 						)
 					}
 
+					// RFC-21 Phase 7.3 PR2b-1b: attempt.number is the committed roast
+					// attempt number under active ROAST retry (set by the loop), so the
+					// coordinator election, session id, and this AttemptContext all key
+					// off the committed identity -- matching the observe/transition
+					// context. TransientlyParkedMembersIndexes is carried through so the
+					// active context's parking is byte-identical to the observe context's
+					// (BuildAttemptContextFromRequest splits Excluded into permanent +
+					// parked from it).
 					attemptInfo := &signing.Attempt{
-						Number:                 attempt.number,
-						CoordinatorMemberIndex: coordinatorMemberIndex,
-						IncludedMembersIndexes: includedMembersIndexes,
-						ExcludedMembersIndexes: attempt.excludedMembersIndexes,
+						Number:                          attempt.number,
+						CoordinatorMemberIndex:          coordinatorMemberIndex,
+						IncludedMembersIndexes:          includedMembersIndexes,
+						ExcludedMembersIndexes:          attempt.excludedMembersIndexes,
+						TransientlyParkedMembersIndexes: attempt.transientlyParkedMembersIndexes,
 					}
 
 					signingAttemptLogger.Infof(

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -440,6 +440,7 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 					Channel:             se.broadcastChannel,
 					MembershipValidator: se.membershipValidator,
 				},
+				se.waitForBlockFn,
 			))
 
 			loopResult, err := retryLoop.start(

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -108,6 +108,14 @@ type signingRetryLoop struct {
 	attemptStartBlock uint64
 	attemptSeed       int64
 
+	// roastAttemptNumber is the 0-based COMMITTED ROAST attempt index: it advances
+	// only when an iteration reaches selection/observe (a committed attempt), NOT
+	// on the block-timing/announcement/minority-readiness skips that tick
+	// attemptCounter. The ROAST transition chain keys off it (observe context,
+	// freshness, consume) so a skipped loop iteration does not break the
+	// consecutive-transition chain across honest nodes (RFC-21 Phase 7.3 PR2b-1b).
+	roastAttemptNumber uint
+
 	doneCheck signingDoneCheckStrategy
 
 	// participantSelector dispatches qualified-operator selection.
@@ -367,7 +375,7 @@ func (srl *signingRetryLoop) start(
 			continue
 		}
 
-		includedMembersIndexes, excludedMembersIndexes, err := srl.performMembersSelection(
+		includedMembersIndexes, excludedMembersIndexes, transientlyParkedMembersIndexes, err := srl.performMembersSelection(
 			readyMembersIndexes,
 		)
 		if err != nil {
@@ -379,17 +387,25 @@ func (srl *signingRetryLoop) start(
 		}
 
 		// RFC-21 Phase 7.3 PR2b-1b: record a local observe binding for this
-		// attempt BEFORE the skip branch, so every local seat -- including one
-		// excluded from this attempt -- holds a handle to verify the attempt's
-		// transition bundle and run NextAttempt for the next attempt's selection.
-		// Inert in C1: the bindings are produced but not yet consumed.
+		// committed ROAST attempt BEFORE the skip branch, so every local seat --
+		// including one excluded from this attempt -- holds a handle to verify the
+		// attempt's transition bundle and run NextAttempt for the next attempt's
+		// selection. The observe context carries the transiently-parked set, so a
+		// one-attempt park is reinstated next time rather than made permanent.
 		if srl.transitionController != nil {
 			srl.transitionController.BeginObservedAttempt(
-				srl.attemptCounter,
+				srl.roastAttemptNumber,
 				includedMembersIndexes,
 				excludedMembersIndexes,
+				transientlyParkedMembersIndexes,
 			)
 		}
+		// This iteration reached selection/observe, so it COMMITTED to a ROAST
+		// attempt: advance the committed ROAST attempt number (the block-timing,
+		// announcement, and minority-readiness skips above did not). Every seat --
+		// included or excluded -- advances identically, keeping the transition
+		// chain consecutive across honest nodes.
+		srl.roastAttemptNumber++
 
 		attemptSkipped := slices.Contains(
 			excludedMembersIndexes,
@@ -514,49 +530,51 @@ func (srl *signingRetryLoop) start(
 }
 
 // performMembersSelection runs the member selection process for the given
-// signing attempt, returning BOTH the included member indices (the members
-// that participate) and the excluded ones (everyone else), each sorted
-// ascending.
+// signing attempt, returning the included member indices (the members that
+// participate), the excluded ones (everyone else), and the transiently-parked
+// subset, each sorted ascending.
 //
-// Selection is dispatched through participantSelector (RFC-21 Phase 6.4) so a
-// ROAST-driven implementation can be installed behind the frost_roast_retry
-// build tag without touching this call site. As of RFC-21 Phase 7.3 PR2b-1a
-// the selector is MEMBER-LEVEL: it returns the exact included member indices.
-// The legacy implementation computes them from the qualified-operator set, the
-// ready members, and the surplus trim; the ROAST implementation (PR2b-1b) will
-// return the transition's IncludedSet directly. The excluded set is the
-// complement of the included set over the whole signing group, so the two
-// partition [1, groupSize] -- which is why the downstream AttemptInfo can
-// reconstruct the exact included set from the excluded one losslessly.
+// Selection is dispatched through participantSelector (RFC-21 Phase 6.4). As of
+// Phase 7.3 PR2b-1a it is MEMBER-LEVEL; PR2b-1b's ROAST implementation returns
+// the transition's IncludedSet + TransientlyParked directly (keyed by the
+// COMMITTED roastAttemptNumber, not the block-paced attemptCounter). The excluded
+// set is the complement of the included set over the whole signing group, so the
+// two partition [1, groupSize]; the parked set is the subset of the excluded set
+// that the next attempt reinstates.
 func (srl *signingRetryLoop) performMembersSelection(
 	readyMembersIndexes []group.MemberIndex,
-) ([]group.MemberIndex, []group.MemberIndex, error) {
-	// The retry algorithm counts retries from 0. The first invocation is for
-	// attemptCounter == 1, so the retry count is attemptCounter - 1.
+) ([]group.MemberIndex, []group.MemberIndex, []group.MemberIndex, error) {
+	// The legacy retry algorithm counts retries from 0. The first invocation is
+	// for attemptCounter == 1, so the legacy retry count is attemptCounter - 1.
+	// The ROAST path instead keys off the committed roastAttemptNumber.
 	retryCount := srl.attemptCounter - 1
 
-	includedMembersIndexes, err := srl.participantSelector.Select(
+	selection, err := srl.participantSelector.Select(
 		readyMembersIndexes,
 		srl.signingGroupOperators,
 		srl.attemptSeed,
 		retryCount,
+		srl.roastAttemptNumber,
 		uint(srl.groupParameters.HonestThreshold),
 		srl.roastSessionID,
 		srl.signingGroupMemberIndex,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf(
+		return nil, nil, nil, fmt.Errorf(
 			"participant selection failed: [%w]",
 			err,
 		)
 	}
 
 	excludedMembersIndexes := membersComplement(
-		includedMembersIndexes,
+		selection.includedMembersIndexes,
 		len(srl.signingGroupOperators),
 	)
 
-	return includedMembersIndexes, excludedMembersIndexes, nil
+	return selection.includedMembersIndexes,
+		excludedMembersIndexes,
+		selection.transientlyParkedMembersIndexes,
+		nil
 }
 
 // membersComplement returns the member indices in [1, groupSize] that are NOT

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -375,6 +375,21 @@ func (srl *signingRetryLoop) start(
 			continue
 		}
 
+		// RFC-21 Phase 7.3 PR2b-1b: if this seat fell behind the group's committed
+		// ROAST attempt chain -- its listener received a transition for an attempt
+		// it never observed because it skipped a window peers committed -- selecting
+		// now would produce a divergent included set (the fracture class). Fail
+		// closed before selection; the outer layer retries the whole signing from a
+		// fresh election. The check is deterministic per seat (a nil controller or
+		// inactive ROAST is never lost-sync).
+		if srl.transitionController != nil && srl.transitionController.HasLostSync() {
+			return nil, fmt.Errorf(
+				"cannot select members for attempt [%v]: lost ROAST sync "+
+					"(received a transition for an unobserved attempt); fail closed",
+				srl.attemptCounter,
+			)
+		}
+
 		includedMembersIndexes, excludedMembersIndexes, transientlyParkedMembersIndexes, err := srl.performMembersSelection(
 			readyMembersIndexes,
 		)
@@ -460,6 +475,16 @@ func (srl *signingRetryLoop) start(
 				}
 				srl.reportAttemptOutcome(false)
 				continue
+			}
+
+			// RFC-21 Phase 7.3 PR2b-1b: the protocol round succeeded locally (a valid
+			// signature aggregated), so clear this seat's observe binding for the
+			// attempt -- no failure transition may be synthesized or stored for a
+			// succeeded attempt. If the done-check below then fails, the next attempt
+			// finds no fresh transition and fails closed (the honest outcome) instead
+			// of consuming a peer's failure transition for an attempt this seat won.
+			if srl.transitionController != nil {
+				srl.transitionController.OnAttemptSucceeded()
 			}
 
 			srl.logger.Infof(

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -432,6 +432,16 @@ func (srl *signingRetryLoop) start(
 					srl.attemptCounter,
 					err,
 				)
+				// RFC-21 Phase 7.3 PR2b-1b: this seat committed to and failed the
+				// attempt, so drive the transition exchange (forced snapshot, and
+				// the elected coordinator's aggregation) for the next attempt's
+				// selection. Inert until the selector consumes records (C3).
+				if srl.transitionController != nil {
+					srl.transitionController.OnAttemptFailed(
+						srl.attemptCounter,
+						timeoutBlock,
+					)
+				}
 				srl.reportAttemptOutcome(false)
 				continue
 			}

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -116,6 +116,14 @@ type signingRetryLoop struct {
 	// build tag once AggregateBundle production is wired upstream.
 	participantSelector signingParticipantSelector
 
+	// transitionController, when non-nil, owns the session-scoped ROAST
+	// transition machinery for this signer (RFC-21 Phase 7.3 PR2b-1b): observing
+	// each attempt so the signer holds a handle to verify the attempt's
+	// transition bundle and run NextAttempt for participant selection. nil in the
+	// default build and in deployments that do not drive ROAST retry, in which
+	// case the loop runs no transition steps.
+	transitionController roastTransitionController
+
 	// attemptOutcomeReporter, when non-nil, receives the terminal outcome
 	// of every network-wide signing attempt this loop observes (RFC-21
 	// Annex B implied-f liveness alerting). An outcome is reported when an
@@ -163,6 +171,14 @@ func (srl *signingRetryLoop) setAttemptOutcomeReporter(
 	reporter func(success bool),
 ) {
 	srl.attemptOutcomeReporter = reporter
+}
+
+// setTransitionController installs the ROAST transition controller. A nil
+// controller leaves the loop running no transition steps (the default).
+func (srl *signingRetryLoop) setTransitionController(
+	controller roastTransitionController,
+) {
+	srl.transitionController = controller
 }
 
 func (srl *signingRetryLoop) reportAttemptOutcome(success bool) {
@@ -359,6 +375,19 @@ func (srl *signingRetryLoop) start(
 				"cannot select members for attempt [%v]: [%w]",
 				srl.attemptCounter,
 				err,
+			)
+		}
+
+		// RFC-21 Phase 7.3 PR2b-1b: record a local observe binding for this
+		// attempt BEFORE the skip branch, so every local seat -- including one
+		// excluded from this attempt -- holds a handle to verify the attempt's
+		// transition bundle and run NextAttempt for the next attempt's selection.
+		// Inert in C1: the bindings are produced but not yet consumed.
+		if srl.transitionController != nil {
+			srl.transitionController.BeginObservedAttempt(
+				srl.attemptCounter,
+				includedMembersIndexes,
+				excludedMembersIndexes,
 			)
 		}
 

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -197,10 +197,21 @@ func (srl *signingRetryLoop) reportAttemptOutcome(success bool) {
 
 // signingAttemptParams represents parameters of a signing attempt.
 type signingAttemptParams struct {
+	// number is the attempt number the active signing keys its AttemptContext,
+	// coordinator election, and session id off. Under active ROAST retry this is
+	// the COMMITTED roast attempt number (roastAttemptNumber+1), so the active
+	// signing context matches the observe/transition context the loop built for
+	// the same committed attempt; otherwise it is the block-paced attemptCounter
+	// (legacy, unchanged). RFC-21 Phase 7.3 PR2b-1b.
 	number                 uint
 	startBlock             uint64
 	timeoutBlock           uint64
 	excludedMembersIndexes []group.MemberIndex
+	// transientlyParkedMembersIndexes are the members the prior ROAST transition
+	// parked for THIS attempt only. The active signing stamps them onto its
+	// AttemptContext so it is byte-identical to the observe context (which carries
+	// the same parking); empty for the legacy path.
+	transientlyParkedMembersIndexes []group.MemberIndex
 }
 
 // signingAttemptFn represents a function performing a signing attempt.
@@ -401,6 +412,13 @@ func (srl *signingRetryLoop) start(
 			)
 		}
 
+		// committedRoastAttemptNumber is this committed attempt's 0-based ROAST
+		// index, captured BEFORE the advance below so both the observe context and
+		// the active signing context key off the same value (the observe Attempt is
+		// stamped Number = committedRoastAttemptNumber+1, so the active attempt must
+		// use the same number to stay byte-identical).
+		committedRoastAttemptNumber := srl.roastAttemptNumber
+
 		// RFC-21 Phase 7.3 PR2b-1b: record a local observe binding for this
 		// committed ROAST attempt BEFORE the skip branch, so every local seat --
 		// including one excluded from this attempt -- holds a handle to verify the
@@ -409,7 +427,7 @@ func (srl *signingRetryLoop) start(
 		// one-attempt park is reinstated next time rather than made permanent.
 		if srl.transitionController != nil {
 			srl.transitionController.BeginObservedAttempt(
-				srl.roastAttemptNumber,
+				committedRoastAttemptNumber,
 				includedMembersIndexes,
 				excludedMembersIndexes,
 				transientlyParkedMembersIndexes,
@@ -449,11 +467,26 @@ func (srl *signingRetryLoop) start(
 				srl.attemptCounter,
 			)
 
+			// RFC-21 Phase 7.3 PR2b-1b: when ROAST retry is runtime-active, the
+			// active signing attempt must key off the COMMITTED roast attempt index
+			// (+ parking) so its AttemptContext is byte-identical to the
+			// observe/transition context this seat built for the same committed
+			// attempt above. Keyed off attemptCounter, the two would diverge after a
+			// pre-selection skip or whenever a member is parked, binding signing
+			// messages and transition bundles to different context hashes. ROAST
+			// inactive keeps the block-paced attemptCounter (legacy, unchanged); the
+			// gate is the deterministic, group-wide RoastRetryActive predicate.
+			activeAttemptNumber := srl.attemptCounter
+			if signing.RoastRetryActive() {
+				activeAttemptNumber = committedRoastAttemptNumber + 1
+			}
+
 			result, endBlock, err := signingAttemptFn(&signingAttemptParams{
-				number:                 srl.attemptCounter,
-				startBlock:             announcementEndBlock,
-				timeoutBlock:           timeoutBlock,
-				excludedMembersIndexes: excludedMembersIndexes,
+				number:                          activeAttemptNumber,
+				startBlock:                      announcementEndBlock,
+				timeoutBlock:                    timeoutBlock,
+				excludedMembersIndexes:          excludedMembersIndexes,
+				transientlyParkedMembersIndexes: transientlyParkedMembersIndexes,
 			})
 			if err != nil {
 				srl.logger.Warnf(

--- a/pkg/tbtc/signing_loop_active_attempt_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_active_attempt_frost_roast_retry_test.go
@@ -36,7 +36,11 @@ func TestSigningRetryLoop_ActiveAttemptUsesCommittedRoastNumber(t *testing.T) {
 		SelfMember:  1,
 	})
 	if !signing.RoastRetryActive() {
-		t.Fatal("precondition: ROAST retry must be active for this test")
+		// In a frost_roast_retry && !frost_native build there is no transition
+		// producer, so RoastRetryActive is false and the active attempt stays on the
+		// legacy attemptCounter -- the committed-number behavior this test asserts
+		// only exists with a producer (frost_native). Skip rather than fail.
+		t.Skip("requires a transition producer (frost_native); RoastRetryActive is false without one")
 	}
 
 	message := big.NewInt(100)

--- a/pkg/tbtc/signing_loop_active_attempt_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_active_attempt_frost_roast_retry_test.go
@@ -1,0 +1,175 @@
+//go:build frost_roast_retry
+
+package tbtc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// TestSigningRetryLoop_ActiveAttemptUsesCommittedRoastNumber asserts that under
+// active ROAST retry the active signing attempt keys its number off the COMMITTED
+// roast attempt index (roastAttemptNumber+1), NOT the block-paced attemptCounter,
+// so the active signing AttemptContext is byte-identical to the observe/transition
+// context the loop built for the same committed attempt (Codex's PR2b-1b review
+// P1: otherwise the two bind to different context hashes after a skip).
+//
+// A pre-selection minority-readiness skip makes attemptCounter (2) diverge from
+// the committed roast number (1); the active attempt must report 1, not 2.
+func TestSigningRetryLoop_ActiveAttemptUsesCommittedRoastNumber(t *testing.T) {
+	t.Setenv(signing.RoastRetryReadinessOptInEnvVar, "true")
+	signing.ResetRoastRetryRegistrationForTest()
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	signing.RegisterRoastRetryCoordinator(signing.RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+	if !signing.RoastRetryActive() {
+		t.Fatal("precondition: ROAST retry must be active for this test")
+	}
+
+	message := big.NewInt(100)
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(sessionID string) ([]group.MemberIndex, error) {
+			// Loop attempt 1: minority readiness (< honest threshold) -> skipped
+			// BEFORE selection, so attemptCounter advances but roastAttemptNumber
+			// does not. Loop attempt 2: full -> committed (attemptCounter=2, committed
+			// roast index 0 -> active number 1).
+			if sessionID == fmt.Sprintf("%v-%v", message, 1) {
+				return []group.MemberIndex{1, 2}, nil
+			}
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		message,
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+
+	var captured *signingAttemptParams
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(params *signingAttemptParams) (*signing.Result, uint64, error) {
+			captured = params
+			return testResult, 215, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("the committed signing attempt was never executed")
+	}
+	// The block-paced attemptCounter is 2 (one skip + one commit); the committed
+	// roast number is 1. The active attempt must use the committed number so its
+	// context matches the observe context the loop built at committed index 0.
+	if captured.number != 1 {
+		t.Fatalf(
+			"active attempt must key off the committed roast number (1), not the "+
+				"block-paced attemptCounter (2); got %d",
+			captured.number,
+		)
+	}
+}
+
+// TestSigningRetryLoop_ActiveAttemptUsesAttemptCounterWhenRoastInactive asserts
+// the legacy invariant is preserved: with ROAST retry inactive (no coordinator
+// registered), the active attempt keys off the block-paced attemptCounter
+// unchanged, even after a skip.
+func TestSigningRetryLoop_ActiveAttemptUsesAttemptCounterWhenRoastInactive(t *testing.T) {
+	// Readiness opted in but NO coordinator registered -> RoastRetryActive is false.
+	t.Setenv(signing.RoastRetryReadinessOptInEnvVar, "true")
+	signing.ResetRoastRetryRegistrationForTest()
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	if signing.RoastRetryActive() {
+		t.Fatal("precondition: ROAST retry must be inactive without a coordinator")
+	}
+
+	message := big.NewInt(100)
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(sessionID string) ([]group.MemberIndex, error) {
+			if sessionID == fmt.Sprintf("%v-%v", message, 1) {
+				return []group.MemberIndex{1, 2}, nil
+			}
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		message,
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+
+	var captured *signingAttemptParams
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(params *signingAttemptParams) (*signing.Result, uint64, error) {
+			captured = params
+			return testResult, 215, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("the committed signing attempt was never executed")
+	}
+	// Legacy: the active attempt keys off attemptCounter (2 after one skip).
+	if captured.number != 2 {
+		t.Fatalf(
+			"with ROAST inactive the active attempt must use the block-paced "+
+				"attemptCounter (2); got %d",
+			captured.number,
+		)
+	}
+}

--- a/pkg/tbtc/signing_loop_active_attempt_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_active_attempt_frost_roast_retry_test.go
@@ -103,6 +103,107 @@ func TestSigningRetryLoop_ActiveAttemptUsesCommittedRoastNumber(t *testing.T) {
 	}
 }
 
+// parkingSelector is a participant selector that returns a fixed included +
+// transiently-parked set, so a loop test can assert the parking threads from
+// selection through signingAttemptParams to the active attempt without standing
+// up a full transition record.
+type parkingSelector struct {
+	included []group.MemberIndex
+	parked   []group.MemberIndex
+}
+
+func (s parkingSelector) Select(
+	_ []group.MemberIndex,
+	_ chain.Addresses,
+	_ int64,
+	_ uint,
+	_ uint,
+	_ uint,
+	_ string,
+	_ group.MemberIndex,
+) (participantSelection, error) {
+	return participantSelection{
+		includedMembersIndexes:          s.included,
+		transientlyParkedMembersIndexes: s.parked,
+	}, nil
+}
+
+// TestSigningRetryLoop_ActiveAttemptCarriesParking asserts the transiently-parked
+// set produced by selection threads through signingAttemptParams to the active
+// signing attempt (and thus onto its AttemptContext), so the active context's
+// parking matches the observe context's. A regression dropping the field would
+// make a one-attempt park permanent (the B1 hazard) on the active path.
+func TestSigningRetryLoop_ActiveAttemptCarriesParking(t *testing.T) {
+	t.Setenv(signing.RoastRetryReadinessOptInEnvVar, "true")
+	signing.ResetRoastRetryRegistrationForTest()
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	signing.RegisterRoastRetryCoordinator(signing.RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	message := big.NewInt(100)
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		message,
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+	// Park member 3; keep the local seat (1) included so it reaches the active
+	// attempt.
+	retryLoop.participantSelector = parkingSelector{
+		included: []group.MemberIndex{1, 2},
+		parked:   []group.MemberIndex{3},
+	}
+
+	var captured *signingAttemptParams
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(params *signingAttemptParams) (*signing.Result, uint64, error) {
+			captured = params
+			return testResult, 215, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("the committed signing attempt was never executed")
+	}
+	if len(captured.transientlyParkedMembersIndexes) != 1 ||
+		captured.transientlyParkedMembersIndexes[0] != 3 {
+		t.Fatalf(
+			"active attempt must carry the parked set [3]; got %v",
+			captured.transientlyParkedMembersIndexes,
+		)
+	}
+}
+
 // TestSigningRetryLoop_ActiveAttemptUsesAttemptCounterWhenRoastInactive asserts
 // the legacy invariant is preserved: with ROAST retry inactive (no coordinator
 // registered), the active attempt keys off the block-paced attemptCounter

--- a/pkg/tbtc/signing_loop_legacy_selector.go
+++ b/pkg/tbtc/signing_loop_legacy_selector.go
@@ -39,10 +39,11 @@ func (legacySigningParticipantSelector) Select(
 	signingGroupOperators chain.Addresses,
 	seed int64,
 	retryCount uint,
+	_ uint, // roastAttemptNumber: legacy diversifies by retryCount, not the ROAST counter
 	honestThreshold uint,
 	_ string,
 	_ group.MemberIndex,
-) ([]group.MemberIndex, error) {
+) (participantSelection, error) {
 	// Build the input the retry shuffle expects: one operator address
 	// per ready member (an operator controlling k ready members appears
 	// k times, matching the pre-RFC-21 input to the algorithm).
@@ -61,7 +62,7 @@ func (legacySigningParticipantSelector) Select(
 		honestThreshold,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return participantSelection{}, fmt.Errorf(
 			"legacy participant selector: random operator selection failed: %w",
 			err,
 		)
@@ -113,5 +114,6 @@ func (legacySigningParticipantSelector) Select(
 	sort.Slice(includedMembersIndexes, func(i, j int) bool {
 		return includedMembersIndexes[i] < includedMembersIndexes[j]
 	})
-	return includedMembersIndexes, nil
+	// The legacy path never parks: parking is a ROAST-transition concept.
+	return participantSelection{includedMembersIndexes: includedMembersIndexes}, nil
 }

--- a/pkg/tbtc/signing_loop_roast_dispatcher.go
+++ b/pkg/tbtc/signing_loop_roast_dispatcher.go
@@ -28,27 +28,40 @@ import (
 // path, where one ready seat qualified ALL of an operator's seats --
 // including ones ROAST means to park or exclude.
 type signingParticipantSelector interface {
-	// Select returns the member indices included in the given signing
-	// attempt, sorted ascending. readyMembersIndexes is the set of
-	// members whose ready signal was received this attempt;
-	// signingGroupOperators is the full member->operator roster
-	// (index i is member i+1), used by the legacy path to map
-	// qualified operators back to members. seed is the per-message
-	// retry seed; retryCount is 0-based (0 for the first attempt).
-	// honestThreshold is the group's signing threshold. sessionID is
-	// the STABLE ROAST session id and memberIndex is the local
-	// signer's member; together they key the per-(session, member)
-	// transition record the ROAST selector consumes (a multi-seat
-	// operator runs one signer per seat, each with its own record).
+	// Select returns the participant selection for the given attempt.
+	// readyMembersIndexes is the set of members whose ready signal was
+	// received this attempt; signingGroupOperators is the full
+	// member->operator roster (index i is member i+1), used by the
+	// legacy path to map qualified operators back to members. seed is
+	// the per-message retry seed; retryCount is the 0-based LEGACY retry
+	// counter (the block-paced loop counter, for the legacy shuffle).
+	// roastAttemptNumber is the 0-based COMMITTED ROAST attempt index
+	// (advanced only by observed attempts), which the ROAST selector
+	// keys its freshness/consume off so block-timing skips do not break
+	// the transition chain. honestThreshold is the group's signing
+	// threshold. sessionID is the STABLE ROAST session id and
+	// memberIndex is the local signer's member.
 	Select(
 		readyMembersIndexes []group.MemberIndex,
 		signingGroupOperators chain.Addresses,
 		seed int64,
 		retryCount uint,
+		roastAttemptNumber uint,
 		honestThreshold uint,
 		sessionID string,
 		memberIndex group.MemberIndex,
-	) ([]group.MemberIndex, error)
+	) (participantSelection, error)
+}
+
+// participantSelection is one attempt's selection result: the member-level
+// included set, plus the members the prior ROAST transition parked for THIS
+// attempt ONLY (empty for the legacy path). The parked set is a subset of the
+// complement of the included set; the loop carries it so the attempt after this
+// one reinstates them -- without it a one-attempt (transient) park becomes a
+// permanent exclusion (RFC-21 Phase 7.3 PR2b-1b).
+type participantSelection struct {
+	includedMembersIndexes          []group.MemberIndex
+	transientlyParkedMembersIndexes []group.MemberIndex
 }
 
 // defaultSigningParticipantSelector returns the build-default

--- a/pkg/tbtc/signing_loop_roast_dispatcher_test.go
+++ b/pkg/tbtc/signing_loop_roast_dispatcher_test.go
@@ -30,17 +30,19 @@ func (r *recordingSelector) Select(
 	_ int64,
 	_ uint,
 	_ uint,
+	_ uint,
 	_ string,
 	_ group.MemberIndex,
-) ([]group.MemberIndex, error) {
+) (participantSelection, error) {
 	r.calls++
 	if r.err != nil {
-		return nil, r.err
+		return participantSelection{}, r.err
 	}
-	if r.result != nil {
-		return r.result, nil
+	included := r.result
+	if included == nil {
+		included = readyMembersIndexes
 	}
-	return readyMembersIndexes, nil
+	return participantSelection{includedMembersIndexes: included}, nil
 }
 
 func TestLegacySigningParticipantSelector_DelegatesToRetryShuffle(t *testing.T) {
@@ -53,14 +55,21 @@ func TestLegacySigningParticipantSelector_DelegatesToRetryShuffle(t *testing.T) 
 	}
 	readyMembers := []group.MemberIndex{1, 2, 3, 4, 5}
 	sel := legacySigningParticipantSelector{}
-	got, err := sel.Select(readyMembers, operators, 42, 0, 3, "session-x", 1)
+	// Args: ready, operators, seed, retryCount, roastAttemptNumber, honestThreshold,
+	// sessionID, memberIndex.
+	selection, err := sel.Select(readyMembers, operators, 42, 0, 0, 3, "session-x", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	got := selection.includedMembersIndexes
 	// Five members are ready and the honest threshold is 3, so the
 	// surplus trim leaves exactly the threshold count included.
 	if len(got) != 3 {
 		t.Fatalf("expected 3 included members (the honest threshold), got %d", len(got))
+	}
+	// The legacy path never parks.
+	if len(selection.transientlyParkedMembersIndexes) != 0 {
+		t.Fatalf("legacy selection must not park members, got %v", selection.transientlyParkedMembersIndexes)
 	}
 	// The result must be sorted ascending and contain only ready members.
 	for i := 1; i < len(got); i++ {
@@ -75,7 +84,7 @@ func TestLegacySigningParticipantSelector_PropagatesErrors(t *testing.T) {
 	_, err := sel.Select(
 		[]group.MemberIndex{1},
 		chain.Addresses{chain.Address("op-1")},
-		0, 0,
+		0, 0, 0,
 		99, // honest threshold higher than member count
 		"session-x",
 		1,
@@ -105,7 +114,7 @@ func TestSigningRetryLoopUsesDispatcher(t *testing.T) {
 		participantSelector: recorder,
 	}
 
-	included, excluded, err := srl.performMembersSelection(
+	included, excluded, _, err := srl.performMembersSelection(
 		[]group.MemberIndex{1, 2, 3, 4, 5},
 	)
 	if err != nil {
@@ -139,7 +148,7 @@ func TestSigningRetryLoopPropagatesSelectorError(t *testing.T) {
 		attemptSeed:         0,
 		participantSelector: &recordingSelector{err: wantErr},
 	}
-	_, _, err := srl.performMembersSelection([]group.MemberIndex{1, 2})
+	_, _, _, err := srl.performMembersSelection([]group.MemberIndex{1, 2})
 	if err == nil {
 		t.Fatal("expected selector error to propagate")
 	}

--- a/pkg/tbtc/signing_loop_roast_transition_controller.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller.go
@@ -25,9 +25,10 @@ type roastTransitionController interface {
 	// must track the transition too). Best-effort: a failure is logged, never
 	// propagated to the signing flow.
 	BeginObservedAttempt(
-		attemptNumber uint,
+		roastAttemptNumber uint,
 		includedMembersIndexes []group.MemberIndex,
 		excludedMembersIndexes []group.MemberIndex,
+		transientlyParkedMembersIndexes []group.MemberIndex,
 	)
 	// OnAttemptFailed signals that a committed attempt this seat participated in
 	// failed, so the transition exchange should run: publish this seat's forced

--- a/pkg/tbtc/signing_loop_roast_transition_controller.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller.go
@@ -1,0 +1,32 @@
+package tbtc
+
+import "github.com/keep-network/keep-core/pkg/protocol/group"
+
+// roastTransitionController owns the session-scoped ROAST transition machinery
+// for one local signer across a signing's attempts (RFC-21 Phase 7.3 PR2b-1b).
+//
+// The signing retry loop holds one per signer. A nil controller -- the default
+// build, or a deployment that does not drive ROAST retry -- makes the loop skip
+// every transition step, so behaviour is the legacy retry shuffle.
+//
+// PR2b-1b lands in three commits:
+//   - C1 (this commit) wires the observe step: every attempt, every local seat
+//     (including ones it is excluded from) records a local handle binding so it
+//     can later verify a transition bundle and run NextAttempt. INERT -- the
+//     bindings are produced but not consumed yet.
+//   - C2 adds the failed-attempt transition exchange (forced snapshots ->
+//     coordinator aggregation -> bundle distribution).
+//   - C3 adds member-level consumption + fail-closed selection (the activation).
+type roastTransitionController interface {
+	// BeginObservedAttempt records a local observe binding for the attempt so the
+	// signer can later verify the attempt's transition bundle and compute the next
+	// attempt's included set. Called for EVERY attempt, including ones this signer
+	// is excluded from (an excluded seat may be reinstated by NextAttempt, so it
+	// must track the transition too). Best-effort: a failure is logged, never
+	// propagated to the signing flow.
+	BeginObservedAttempt(
+		attemptNumber uint,
+		includedMembersIndexes []group.MemberIndex,
+		excludedMembersIndexes []group.MemberIndex,
+	)
+}

--- a/pkg/tbtc/signing_loop_roast_transition_controller.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller.go
@@ -29,4 +29,11 @@ type roastTransitionController interface {
 		includedMembersIndexes []group.MemberIndex,
 		excludedMembersIndexes []group.MemberIndex,
 	)
+	// OnAttemptFailed signals that a committed attempt this seat participated in
+	// failed, so the transition exchange should run: publish this seat's forced
+	// proof-of-attendance snapshot and, on the elected coordinator, aggregate +
+	// broadcast the transition bundle once the snapshot collection window
+	// (derived from timeoutBlock) closes. Best-effort and non-blocking: the
+	// aggregation runs off the retry-loop goroutine.
+	OnAttemptFailed(attemptNumber uint, timeoutBlock uint64)
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller.go
@@ -37,4 +37,19 @@ type roastTransitionController interface {
 	// (derived from timeoutBlock) closes. Best-effort and non-blocking: the
 	// aggregation runs off the retry-loop goroutine.
 	OnAttemptFailed(attemptNumber uint, timeoutBlock uint64)
+	// OnAttemptSucceeded signals that a committed attempt this seat participated in
+	// completed successfully (a valid signature aggregated locally). It clears this
+	// seat's observe binding for the attempt so neither an elected coordinator's
+	// aggregation nor a peer's failure bundle can synthesize or store a failure
+	// transition for an attempt that actually succeeded; a subsequent done-check
+	// failure then fails closed (no fresh record) instead of consuming a dishonest
+	// failure transition. Best-effort.
+	OnAttemptSucceeded()
+	// HasLostSync reports whether this seat fell behind the group's committed ROAST
+	// attempt chain -- it received a transition bundle for an attempt it never
+	// observed (it skipped a window peers committed). The retry loop checks it
+	// before selection and fails closed when true, since selecting from a stale
+	// position diverges from peers (the fracture class). Always false for a nil
+	// controller or inactive ROAST.
+	HasLostSync() bool
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_default.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_default.go
@@ -1,0 +1,23 @@
+//go:build !(frost_native && frost_roast_retry)
+
+package tbtc
+
+import (
+	"context"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+)
+
+// newRoastTransitionController returns nil in builds without both the
+// frost_native and frost_roast_retry tags: there is no ROAST transition
+// machinery to drive, so the signing loop skips every transition step and uses
+// the legacy retry shuffle. The nil controller is the same signal the active
+// build uses for a nil request template.
+func newRoastTransitionController(
+	_ context.Context,
+	_ log.StandardLogger,
+	_ *signing.Request,
+) roastTransitionController {
+	return nil
+}

--- a/pkg/tbtc/signing_loop_roast_transition_controller_default.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_default.go
@@ -18,6 +18,7 @@ func newRoastTransitionController(
 	_ context.Context,
 	_ log.StandardLogger,
 	_ *signing.Request,
+	_ waitForBlockFn,
 ) roastTransitionController {
 	return nil
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
@@ -97,23 +97,29 @@ func newRoastTransitionExchangeForRequest(
 }
 
 func (c *roastTransitionControllerImpl) BeginObservedAttempt(
-	attemptNumber uint,
+	roastAttemptNumber uint,
 	includedMembersIndexes []group.MemberIndex,
 	excludedMembersIndexes []group.MemberIndex,
+	transientlyParkedMembersIndexes []group.MemberIndex,
 ) {
 	// Shallow-copy the static template and stamp this attempt's metadata.
+	// Attempt.Number is 1-based; BuildAttemptContextFromRequest maps it to the
+	// 0-based AttemptContext.AttemptNumber == roastAttemptNumber, so the observe
+	// context and the transition-record freshness chain key off the committed
+	// ROAST attempt index, not the block-paced loop counter.
 	request := *c.requestTemplate
 	request.Attempt = &signing.Attempt{
-		Number:                 attemptNumber,
-		IncludedMembersIndexes: includedMembersIndexes,
-		ExcludedMembersIndexes: excludedMembersIndexes,
+		Number:                          roastAttemptNumber + 1,
+		IncludedMembersIndexes:          includedMembersIndexes,
+		ExcludedMembersIndexes:          excludedMembersIndexes,
+		TransientlyParkedMembersIndexes: transientlyParkedMembersIndexes,
 	}
 
 	hash, err := signing.ObserveAttemptForTransition(&request)
 	if err != nil {
 		c.logger.Warnf(
-			"[member:%v] roast transition: observe attempt [%v] failed: [%v]",
-			request.MemberIndex, attemptNumber, err,
+			"[member:%v] roast transition: observe roast attempt [%v] failed: [%v]",
+			request.MemberIndex, roastAttemptNumber, err,
 		)
 	}
 	// Retain the attempt hash so OnAttemptFailed can drive the exchange against

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
@@ -1,0 +1,71 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"context"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// roastTransitionControllerImpl is the active (frost_native && frost_roast_retry)
+// transition controller. It is constructed once per local signer with the static
+// signing-request material; each BeginObservedAttempt fills the per-attempt
+// metadata and delegates to signing.ObserveAttemptForTransition.
+//
+// ctx is the signer's session-lifetime loop context; C2 uses it (with the
+// channel/validator carried on requestTemplate) for the bundle exchange. C1 does
+// not read it yet.
+type roastTransitionControllerImpl struct {
+	ctx             context.Context
+	logger          log.StandardLogger
+	requestTemplate *signing.Request
+}
+
+// newRoastTransitionController builds the active controller. requestTemplate
+// carries the static (non-per-attempt) request material; a nil template yields a
+// nil controller (the loop then skips transition steps).
+func newRoastTransitionController(
+	ctx context.Context,
+	logger log.StandardLogger,
+	requestTemplate *signing.Request,
+) roastTransitionController {
+	if requestTemplate == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = log.Logger("keep-tbtc-roast-transition")
+	}
+	return &roastTransitionControllerImpl{
+		ctx:             ctx,
+		logger:          logger,
+		requestTemplate: requestTemplate,
+	}
+}
+
+func (c *roastTransitionControllerImpl) BeginObservedAttempt(
+	attemptNumber uint,
+	includedMembersIndexes []group.MemberIndex,
+	excludedMembersIndexes []group.MemberIndex,
+) {
+	// Shallow-copy the static template and stamp this attempt's metadata. The
+	// copy keeps each attempt's request independent without rebuilding the
+	// material every call.
+	request := *c.requestTemplate
+	request.Attempt = &signing.Attempt{
+		Number:                 attemptNumber,
+		IncludedMembersIndexes: includedMembersIndexes,
+		ExcludedMembersIndexes: excludedMembersIndexes,
+	}
+
+	if err := signing.ObserveAttemptForTransition(&request); err != nil {
+		c.logger.Warnf(
+			"[member:%v] roast transition: observe attempt [%v] failed: [%v]",
+			request.MemberIndex,
+			attemptNumber,
+			err,
+		)
+	}
+}

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
@@ -10,18 +10,34 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
+// roastTransitionExchange is the produce-side surface the controller drives on a
+// failed attempt. The production implementation is *signing.RoastTransitionExchange;
+// the controller tests inject a fake.
+type roastTransitionExchange interface {
+	BroadcastForcedSnapshot(attemptHash [32]byte)
+	AggregateAndBroadcast(attemptHash [32]byte)
+}
+
 // roastTransitionControllerImpl is the active (frost_native && frost_roast_retry)
-// transition controller. It is constructed once per local signer with the static
-// signing-request material; each BeginObservedAttempt fills the per-attempt
-// metadata and delegates to signing.ObserveAttemptForTransition.
+// transition controller. Constructed once per local signer, it observes each
+// attempt (C1) and, on a failed attempt, drives the transition exchange (C2): it
+// publishes this seat's forced proof-of-attendance snapshot and, after the
+// collection window, has the elected coordinator aggregate + broadcast the
+// bundle.
 //
-// ctx is the signer's session-lifetime loop context; C2 uses it (with the
-// channel/validator carried on requestTemplate) for the bundle exchange. C1 does
-// not read it yet.
+// BeginObservedAttempt and OnAttemptFailed are called only from the signer's
+// single retry-loop goroutine, sequentially within an attempt, so currentAttemptHash
+// needs no lock; the deadline goroutine captures the hash by value.
 type roastTransitionControllerImpl struct {
 	ctx             context.Context
 	logger          log.StandardLogger
 	requestTemplate *signing.Request
+	waitForBlockFn  waitForBlockFn
+	// exchange is nil when ROAST retry is inactive (readiness opted out, no
+	// coordinator, or no usable channel); the controller then observes only.
+	exchange roastTransitionExchange
+
+	currentAttemptHash [32]byte
 }
 
 // newRoastTransitionController builds the active controller. requestTemplate
@@ -31,6 +47,7 @@ func newRoastTransitionController(
 	ctx context.Context,
 	logger log.StandardLogger,
 	requestTemplate *signing.Request,
+	waitForBlockFn waitForBlockFn,
 ) roastTransitionController {
 	if requestTemplate == nil {
 		return nil
@@ -42,7 +59,41 @@ func newRoastTransitionController(
 		ctx:             ctx,
 		logger:          logger,
 		requestTemplate: requestTemplate,
+		waitForBlockFn:  waitForBlockFn,
+		exchange:        newRoastTransitionExchangeForRequest(ctx, logger, requestTemplate),
 	}
+}
+
+// newRoastTransitionExchangeForRequest builds the session-scoped transition
+// exchange when ROAST retry is active: readiness opt-in on, a coordinator
+// registered, and a usable wallet channel. It returns nil otherwise, so the
+// controller observes only (C1) and drives no exchange -- the same set of
+// deterministic static conditions ObserveAttemptForTransition gates on.
+func newRoastTransitionExchangeForRequest(
+	ctx context.Context,
+	logger log.StandardLogger,
+	template *signing.Request,
+) roastTransitionExchange {
+	if err := signing.EnsureRoastRetryReadinessOptIn(); err != nil {
+		return nil
+	}
+	deps, ok := signing.RegisteredRoastRetryCoordinator()
+	if !ok || deps.Coordinator == nil {
+		return nil
+	}
+	if template.Channel == nil || template.MembershipValidator == nil {
+		return nil
+	}
+	bus, err := signing.NewBroadcastChannelRunnerBus(
+		ctx, logger, template.Channel, template.MembershipValidator,
+	)
+	if err != nil {
+		logger.Warnf("roast transition: build transport bus: [%v]", err)
+		return nil
+	}
+	return signing.NewRoastTransitionExchange(
+		ctx, logger, bus, deps, template.RoastSessionID, template.MemberIndex,
+	)
 }
 
 func (c *roastTransitionControllerImpl) BeginObservedAttempt(
@@ -50,9 +101,7 @@ func (c *roastTransitionControllerImpl) BeginObservedAttempt(
 	includedMembersIndexes []group.MemberIndex,
 	excludedMembersIndexes []group.MemberIndex,
 ) {
-	// Shallow-copy the static template and stamp this attempt's metadata. The
-	// copy keeps each attempt's request independent without rebuilding the
-	// material every call.
+	// Shallow-copy the static template and stamp this attempt's metadata.
 	request := *c.requestTemplate
 	request.Attempt = &signing.Attempt{
 		Number:                 attemptNumber,
@@ -60,12 +109,53 @@ func (c *roastTransitionControllerImpl) BeginObservedAttempt(
 		ExcludedMembersIndexes: excludedMembersIndexes,
 	}
 
-	if err := signing.ObserveAttemptForTransition(&request); err != nil {
+	hash, err := signing.ObserveAttemptForTransition(&request)
+	if err != nil {
 		c.logger.Warnf(
 			"[member:%v] roast transition: observe attempt [%v] failed: [%v]",
-			request.MemberIndex,
-			attemptNumber,
-			err,
+			request.MemberIndex, attemptNumber, err,
 		)
 	}
+	// Retain the attempt hash so OnAttemptFailed can drive the exchange against
+	// this attempt's observe binding. Zero on a static-fallback observe, which
+	// makes OnAttemptFailed a no-op.
+	c.currentAttemptHash = hash
+}
+
+func (c *roastTransitionControllerImpl) OnAttemptFailed(
+	attemptNumber uint,
+	timeoutBlock uint64,
+) {
+	if c.exchange == nil {
+		return
+	}
+	hash := c.currentAttemptHash
+	if hash == ([32]byte{}) {
+		// No observe binding for this attempt (static fallback) -- nothing to do.
+		return
+	}
+
+	// The caller reaches the failed-attempt path only when it participated (a
+	// skipped seat never runs the attempt), so publish its forced
+	// proof-of-attendance snapshot.
+	c.exchange.BroadcastForcedSnapshot(hash)
+
+	// The elected coordinator aggregates + broadcasts the bundle once the snapshot
+	// collection window closes. Run it OFF the retry-loop goroutine so the loop
+	// proceeds on its own block schedule; AggregateAndBroadcast is a no-op on a
+	// seat that is not the elected coordinator. snapshotDeadline aligns with the
+	// cooldown between attempts, so a produced bundle reaches peers before the next
+	// attempt's selection.
+	snapshotDeadline := timeoutBlock + signingAttemptCoolDownBlocks
+	ctx := c.ctx
+	waitForBlock := c.waitForBlockFn
+	exchange := c.exchange
+	go func() {
+		if waitForBlock != nil {
+			if err := waitForBlock(ctx, snapshotDeadline); err != nil {
+				return
+			}
+		}
+		exchange.AggregateAndBroadcast(hash)
+	}()
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
@@ -16,6 +16,7 @@ import (
 type roastTransitionExchange interface {
 	BroadcastForcedSnapshot(attemptHash [32]byte)
 	AggregateAndBroadcast(attemptHash [32]byte)
+	HasLostSync() bool
 }
 
 // roastTransitionControllerImpl is the active (frost_native && frost_roast_retry)
@@ -164,4 +165,28 @@ func (c *roastTransitionControllerImpl) OnAttemptFailed(
 		}
 		exchange.AggregateAndBroadcast(hash)
 	}()
+}
+
+func (c *roastTransitionControllerImpl) OnAttemptSucceeded() {
+	hash := c.currentAttemptHash
+	if hash == ([32]byte{}) {
+		// No observe binding for this attempt (static fallback) -- nothing to clear.
+		return
+	}
+	// Clear the observe binding for the succeeded attempt so the observe handle no
+	// longer collects: the elected coordinator cannot aggregate a failure bundle,
+	// and a peer's failure bundle is not stored, for an attempt this seat won. The
+	// observed-history marker remains, so a late bundle for it is a benign
+	// retransmit rather than lost sync.
+	signing.ClearObservedAttemptOnLocalSuccess(
+		c.requestTemplate.RoastSessionID,
+		c.requestTemplate.MemberIndex,
+		hash,
+	)
+}
+
+func (c *roastTransitionControllerImpl) HasLostSync() bool {
+	// nil when ROAST retry is inactive (the controller only observes): never lost
+	// sync, since no listener runs to receive a peer's transition.
+	return c.exchange != nil && c.exchange.HasLostSync()
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
 )
 
 // fakeExchange records the produce-side calls the controller drives.
@@ -17,6 +18,7 @@ type fakeExchange struct {
 	broadcastCalls [][32]byte
 	aggregateCalls [][32]byte
 	aggregated     chan struct{}
+	lostSync       bool
 }
 
 func (f *fakeExchange) BroadcastForcedSnapshot(hash [32]byte) {
@@ -32,6 +34,12 @@ func (f *fakeExchange) AggregateAndBroadcast(hash [32]byte) {
 	if f.aggregated != nil {
 		f.aggregated <- struct{}{}
 	}
+}
+
+func (f *fakeExchange) HasLostSync() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lostSync
 }
 
 func (f *fakeExchange) broadcasts() [][32]byte {
@@ -129,5 +137,57 @@ func TestRoastTransitionController_OnAttemptFailedZeroHashIsNoOp(t *testing.T) {
 	case <-exchange.aggregated:
 		t.Fatal("zero attempt hash must not aggregate")
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestRoastTransitionController_HasLostSyncDelegatesToExchange asserts HasLostSync
+// reflects the exchange's lost-sync state, and is false when no exchange is
+// installed (ROAST retry inactive -> observe-only -> no listener -> never lost
+// sync).
+func TestRoastTransitionController_HasLostSyncDelegatesToExchange(t *testing.T) {
+	exchange := &fakeExchange{}
+	controller := &roastTransitionControllerImpl{
+		ctx:      context.Background(),
+		logger:   &testutils.MockLogger{},
+		exchange: exchange,
+	}
+	if controller.HasLostSync() {
+		t.Fatal("expected not lost sync initially")
+	}
+	exchange.mu.Lock()
+	exchange.lostSync = true
+	exchange.mu.Unlock()
+	if !controller.HasLostSync() {
+		t.Fatal("expected HasLostSync to reflect the exchange's lost-sync state")
+	}
+
+	noExchange := &roastTransitionControllerImpl{
+		ctx:    context.Background(),
+		logger: &testutils.MockLogger{},
+	}
+	if noExchange.HasLostSync() {
+		t.Fatal("a controller without an exchange must never report lost sync")
+	}
+}
+
+// TestRoastTransitionController_OnAttemptSucceededZeroHashIsNoOp asserts that
+// without a stored attempt hash (a static-fallback observe) the success hook
+// clears nothing.
+func TestRoastTransitionController_OnAttemptSucceededZeroHashIsNoOp(t *testing.T) {
+	signing.ResetObservedAttemptRegistryForTest()
+	t.Cleanup(signing.ResetObservedAttemptRegistryForTest)
+
+	controller := &roastTransitionControllerImpl{
+		ctx:    context.Background(),
+		logger: &testutils.MockLogger{},
+		requestTemplate: &signing.Request{
+			RoastSessionID: "ctrl-success-session",
+			MemberIndex:    1,
+		},
+		// currentAttemptHash is the zero value.
+	}
+	controller.OnAttemptSucceeded() // must not panic
+	if signing.ObservedAttemptStoredForTest("ctrl-success-session", 1) {
+		t.Fatal("zero attempt hash must not interact with the registry")
 	}
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry_test.go
@@ -1,0 +1,133 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+)
+
+// fakeExchange records the produce-side calls the controller drives.
+type fakeExchange struct {
+	mu             sync.Mutex
+	broadcastCalls [][32]byte
+	aggregateCalls [][32]byte
+	aggregated     chan struct{}
+}
+
+func (f *fakeExchange) BroadcastForcedSnapshot(hash [32]byte) {
+	f.mu.Lock()
+	f.broadcastCalls = append(f.broadcastCalls, hash)
+	f.mu.Unlock()
+}
+
+func (f *fakeExchange) AggregateAndBroadcast(hash [32]byte) {
+	f.mu.Lock()
+	f.aggregateCalls = append(f.aggregateCalls, hash)
+	f.mu.Unlock()
+	if f.aggregated != nil {
+		f.aggregated <- struct{}{}
+	}
+}
+
+func (f *fakeExchange) broadcasts() [][32]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([][32]byte(nil), f.broadcastCalls...)
+}
+
+func (f *fakeExchange) aggregates() [][32]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([][32]byte(nil), f.aggregateCalls...)
+}
+
+// TestRoastTransitionController_OnAttemptFailedDrivesExchange asserts a failed
+// attempt synchronously broadcasts the forced snapshot and, after the snapshot
+// deadline, aggregates + broadcasts the bundle -- both for the attempt's hash.
+func TestRoastTransitionController_OnAttemptFailedDrivesExchange(t *testing.T) {
+	hash := [32]byte{0x01, 0x02, 0x03}
+	exchange := &fakeExchange{aggregated: make(chan struct{}, 1)}
+
+	deadlineReached := make(chan uint64, 1)
+	controller := &roastTransitionControllerImpl{
+		ctx:      context.Background(),
+		logger:   &testutils.MockLogger{},
+		exchange: exchange,
+		waitForBlockFn: func(_ context.Context, block uint64) error {
+			deadlineReached <- block
+			return nil
+		},
+		currentAttemptHash: hash,
+	}
+
+	controller.OnAttemptFailed(1, 100)
+
+	// The forced snapshot broadcast is synchronous.
+	if got := exchange.broadcasts(); len(got) != 1 || got[0] != hash {
+		t.Fatalf("expected one forced-snapshot broadcast for the attempt hash, got %v", got)
+	}
+
+	// The deadline goroutine waits on the snapshot deadline (timeout + cooldown),
+	// then aggregates.
+	select {
+	case block := <-deadlineReached:
+		if block != 100+signingAttemptCoolDownBlocks {
+			t.Fatalf(
+				"expected aggregation to wait until snapshot deadline %d, got %d",
+				100+signingAttemptCoolDownBlocks, block,
+			)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the deadline goroutine to wait for a block")
+	}
+
+	select {
+	case <-exchange.aggregated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected AggregateAndBroadcast to run after the deadline")
+	}
+	if got := exchange.aggregates(); len(got) != 1 || got[0] != hash {
+		t.Fatalf("expected one aggregate for the attempt hash, got %v", got)
+	}
+}
+
+// TestRoastTransitionController_OnAttemptFailedNoExchangeIsSafe asserts a
+// controller with no exchange (ROAST retry inactive) ignores a failed attempt.
+func TestRoastTransitionController_OnAttemptFailedNoExchangeIsSafe(t *testing.T) {
+	controller := &roastTransitionControllerImpl{
+		ctx:                context.Background(),
+		logger:             &testutils.MockLogger{},
+		currentAttemptHash: [32]byte{0x01},
+	}
+	controller.OnAttemptFailed(1, 100) // must not panic
+}
+
+// TestRoastTransitionController_OnAttemptFailedZeroHashIsNoOp asserts that
+// without a stored attempt hash (a static-fallback observe) the exchange is not
+// driven.
+func TestRoastTransitionController_OnAttemptFailedZeroHashIsNoOp(t *testing.T) {
+	exchange := &fakeExchange{aggregated: make(chan struct{}, 1)}
+	controller := &roastTransitionControllerImpl{
+		ctx:            context.Background(),
+		logger:         &testutils.MockLogger{},
+		exchange:       exchange,
+		waitForBlockFn: func(context.Context, uint64) error { return nil },
+		// currentAttemptHash is the zero value.
+	}
+	controller.OnAttemptFailed(1, 100)
+
+	if got := exchange.broadcasts(); len(got) != 0 {
+		t.Fatalf("zero attempt hash must not broadcast a snapshot, got %v", got)
+	}
+	// Give any erroneously-spawned goroutine a chance to fire.
+	select {
+	case <-exchange.aggregated:
+		t.Fatal("zero attempt hash must not aggregate")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/pkg/tbtc/signing_loop_roast_transition_controller_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,11 +28,15 @@ type failedAttemptCall struct {
 }
 
 // fakeTransitionController records controller calls so the loop-wiring tests can
-// assert the loop observes each attempt (with the exact member sets) and signals
-// failed attempts.
+// assert the loop observes each attempt (with the exact member sets), signals
+// failed and succeeded attempts, and consults lost-sync before selection.
 type fakeTransitionController struct {
-	calls       []observedAttemptCall
-	failedCalls []failedAttemptCall
+	calls          []observedAttemptCall
+	failedCalls    []failedAttemptCall
+	succeededCalls int
+	// lostSync is returned by HasLostSync; a test sets it to drive the loop's
+	// fail-closed-before-selection path.
+	lostSync bool
 }
 
 func (f *fakeTransitionController) BeginObservedAttempt(
@@ -56,6 +61,14 @@ func (f *fakeTransitionController) OnAttemptFailed(
 		attemptNumber: attemptNumber,
 		timeoutBlock:  timeoutBlock,
 	})
+}
+
+func (f *fakeTransitionController) OnAttemptSucceeded() {
+	f.succeededCalls++
+}
+
+func (f *fakeTransitionController) HasLostSync() bool {
+	return f.lostSync
 }
 
 func newObserveTestRetryLoop(
@@ -295,5 +308,153 @@ func TestSigningRetryLoop_SkipDoesNotAdvanceRoastAttemptNumber(t *testing.T) {
 			"the committed attempt after a skip must be roast attempt 0, got %d",
 			controller.calls[0].roastAttemptNumber,
 		)
+	}
+}
+
+// TestSigningRetryLoop_LocalSuccessSignalsSucceeded asserts the loop signals
+// OnAttemptSucceeded -- and NOT OnAttemptFailed -- when a committed attempt the
+// seat participated in completes successfully. The succeeded signal clears the
+// observe binding so no failure transition can be synthesized for an attempt this
+// seat won (Codex B3). A 3-of-3 group keeps the local seat included.
+func TestSigningRetryLoop_LocalSuccessSignalsSucceeded(t *testing.T) {
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		big.NewInt(100),
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+	controller := &fakeTransitionController{}
+	retryLoop.setTransitionController(controller)
+
+	runOneSuccessfulAttempt(t, retryLoop)
+
+	if controller.succeededCalls != 1 {
+		t.Fatalf("expected OnAttemptSucceeded called once, got %d", controller.succeededCalls)
+	}
+	if len(controller.failedCalls) != 0 {
+		t.Fatalf("a successful attempt must not signal OnAttemptFailed, got %d", len(controller.failedCalls))
+	}
+}
+
+// TestSigningRetryLoop_DoneCheckFailureAfterSuccessDoesNotSignalFailure asserts
+// that when the protocol round succeeds locally but the done-check then fails, the
+// loop signals OnAttemptSucceeded (clearing the observe binding) and NEVER
+// OnAttemptFailed -- it must not synthesize a failure transition for an attempt
+// whose signature aggregated (Codex B3, adjudicated to mark-succeeded + fail-closed
+// over synthesizing a no-reject transition). Here the done-check fails on the first
+// attempt and succeeds on the retry; both attempts succeeded locally.
+func TestSigningRetryLoop_DoneCheckFailureAfterSuccessDoesNotSignalFailure(t *testing.T) {
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(attemptNumber uint64) (*signing.Result, uint64, error) {
+			// The protocol round (signingAttemptFn) always succeeds; the done-check
+			// coordination fails on the first attempt only.
+			if attemptNumber == 1 {
+				return nil, 0, errors.New("synthetic done-check failure after local success")
+			}
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		big.NewInt(100),
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+	controller := &fakeTransitionController{}
+	retryLoop.setTransitionController(controller)
+
+	runOneSuccessfulAttempt(t, retryLoop)
+
+	// Both attempts' protocol rounds succeeded locally, so each signals succeeded.
+	if controller.succeededCalls != 2 {
+		t.Fatalf("expected OnAttemptSucceeded for each locally-succeeded attempt (2), got %d", controller.succeededCalls)
+	}
+	// A done-check failure after a local success must NOT be reported as an attempt
+	// failure -- no failure transition is honest for an attempt that aggregated.
+	if len(controller.failedCalls) != 0 {
+		t.Fatalf(
+			"a done-check failure after local success must not signal OnAttemptFailed, got %d",
+			len(controller.failedCalls),
+		)
+	}
+}
+
+// TestSigningRetryLoop_LostSyncFailsClosedBeforeSelection asserts the loop fails
+// closed -- before selection and before observing -- when the controller reports
+// lost ROAST sync (its listener received a transition for an attempt this seat
+// never observed). Selecting from a stale position would diverge from peers (the
+// fracture class), so the loop terminates and the outer layer retries the whole
+// signing.
+func TestSigningRetryLoop_LostSyncFailsClosedBeforeSelection(t *testing.T) {
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3, 4, 5}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newObserveTestRetryLoop(announcer, doneCheck)
+	controller := &fakeTransitionController{lostSync: true}
+	retryLoop.setTransitionController(controller)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(*signingAttemptParams) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected a fail-closed error on lost ROAST sync")
+	}
+	if !strings.Contains(err.Error(), "lost ROAST sync") {
+		t.Fatalf("expected a lost-sync fail-closed error, got %v", err)
+	}
+	// Fail-closed happens BEFORE selection/observe, so no attempt is observed.
+	if len(controller.calls) != 0 {
+		t.Fatalf("lost sync must fail closed before observing any attempt, got %d", len(controller.calls))
 	}
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_test.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -18,10 +19,17 @@ type observedAttemptCall struct {
 	excluded      []group.MemberIndex
 }
 
-// fakeTransitionController records BeginObservedAttempt calls so the loop-wiring
-// tests can assert the loop observes each attempt with the exact member sets.
+type failedAttemptCall struct {
+	attemptNumber uint
+	timeoutBlock  uint64
+}
+
+// fakeTransitionController records controller calls so the loop-wiring tests can
+// assert the loop observes each attempt (with the exact member sets) and signals
+// failed attempts.
 type fakeTransitionController struct {
-	calls []observedAttemptCall
+	calls       []observedAttemptCall
+	failedCalls []failedAttemptCall
 }
 
 func (f *fakeTransitionController) BeginObservedAttempt(
@@ -33,6 +41,16 @@ func (f *fakeTransitionController) BeginObservedAttempt(
 		attemptNumber: attemptNumber,
 		included:      includedMembersIndexes,
 		excluded:      excludedMembersIndexes,
+	})
+}
+
+func (f *fakeTransitionController) OnAttemptFailed(
+	attemptNumber uint,
+	timeoutBlock uint64,
+) {
+	f.failedCalls = append(f.failedCalls, failedAttemptCall{
+		attemptNumber: attemptNumber,
+		timeoutBlock:  timeoutBlock,
 	})
 }
 
@@ -152,4 +170,71 @@ func TestSigningRetryLoop_NilTransitionControllerIsSafe(t *testing.T) {
 	retryLoop := newObserveTestRetryLoop(announcer, doneCheck)
 	// No setTransitionController -> transitionController stays nil.
 	runOneSuccessfulAttempt(t, retryLoop)
+}
+
+// TestSigningRetryLoop_SignalsFailedAttempt asserts the loop signals
+// OnAttemptFailed (with the attempt's timeout block) when a committed attempt
+// fails, and only for the failed attempt. A 3-of-3 group keeps the local seat
+// included on every attempt, so it reaches the committed-failure path.
+func TestSigningRetryLoop_SignalsFailedAttempt(t *testing.T) {
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		big.NewInt(100),
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+	controller := &fakeTransitionController{}
+	retryLoop.setTransitionController(controller)
+
+	attempts := 0
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(*signingAttemptParams) (*signing.Result, uint64, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, 0, errors.New("synthetic attempt failure")
+			}
+			return testResult, 215, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(controller.failedCalls) != 1 {
+		t.Fatalf("expected OnAttemptFailed called once, got %d", len(controller.failedCalls))
+	}
+	if controller.failedCalls[0].attemptNumber != 1 {
+		t.Fatalf(
+			"expected failed attempt number 1, got %d",
+			controller.failedCalls[0].attemptNumber,
+		)
+	}
+	// Every attempt that reaches selection is observed (the failed one and the
+	// successful retry).
+	if len(controller.calls) != 2 {
+		t.Fatalf("expected BeginObservedAttempt called twice, got %d", len(controller.calls))
+	}
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_test.go
@@ -3,6 +3,7 @@ package tbtc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -14,9 +15,10 @@ import (
 )
 
 type observedAttemptCall struct {
-	attemptNumber uint
-	included      []group.MemberIndex
-	excluded      []group.MemberIndex
+	roastAttemptNumber uint
+	included           []group.MemberIndex
+	excluded           []group.MemberIndex
+	parked             []group.MemberIndex
 }
 
 type failedAttemptCall struct {
@@ -33,14 +35,16 @@ type fakeTransitionController struct {
 }
 
 func (f *fakeTransitionController) BeginObservedAttempt(
-	attemptNumber uint,
+	roastAttemptNumber uint,
 	includedMembersIndexes []group.MemberIndex,
 	excludedMembersIndexes []group.MemberIndex,
+	transientlyParkedMembersIndexes []group.MemberIndex,
 ) {
 	f.calls = append(f.calls, observedAttemptCall{
-		attemptNumber: attemptNumber,
-		included:      includedMembersIndexes,
-		excluded:      excludedMembersIndexes,
+		roastAttemptNumber: roastAttemptNumber,
+		included:           includedMembersIndexes,
+		excluded:           excludedMembersIndexes,
+		parked:             transientlyParkedMembersIndexes,
 	})
 }
 
@@ -131,8 +135,8 @@ func TestSigningRetryLoop_ObservesEachAttempt(t *testing.T) {
 		t.Fatalf("expected BeginObservedAttempt called once, got %d", len(controller.calls))
 	}
 	call := controller.calls[0]
-	if call.attemptNumber != 1 {
-		t.Fatalf("expected attempt number 1, got %d", call.attemptNumber)
+	if call.roastAttemptNumber != 0 {
+		t.Fatalf("expected the first committed roast attempt number 0, got %d", call.roastAttemptNumber)
 	}
 	// The observed sets must partition the whole group and match the honest
 	// threshold count -- i.e. the loop passes selection's exact member-level
@@ -236,5 +240,60 @@ func TestSigningRetryLoop_SignalsFailedAttempt(t *testing.T) {
 	// successful retry).
 	if len(controller.calls) != 2 {
 		t.Fatalf("expected BeginObservedAttempt called twice, got %d", len(controller.calls))
+	}
+}
+
+// TestSigningRetryLoop_SkipDoesNotAdvanceRoastAttemptNumber asserts the committed
+// ROAST attempt number advances only on attempts that reach selection/observe,
+// not on the pre-selection skips (here a minority-readiness skip). The committed
+// attempt after a skip must still be roast attempt 0 -- otherwise the transition
+// chain would expect a record for an attempt that never ran (Codex B2).
+func TestSigningRetryLoop_SkipDoesNotAdvanceRoastAttemptNumber(t *testing.T) {
+	message := big.NewInt(100)
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(sessionID string) ([]group.MemberIndex, error) {
+			// Loop attempt 1: minority readiness (< honest threshold) -> skipped
+			// BEFORE selection/observe. Loop attempt 2: full -> committed.
+			if sessionID == fmt.Sprintf("%v-%v", message, 1) {
+				return []group.MemberIndex{1, 2}, nil
+			}
+			return []group.MemberIndex{1, 2, 3}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		message,
+		"",
+		200,
+		1,
+		chain.Addresses{"address-1", "address-2", "address-3"},
+		&GroupParameters{GroupSize: 3, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+	controller := &fakeTransitionController{}
+	retryLoop.setTransitionController(controller)
+
+	runOneSuccessfulAttempt(t, retryLoop)
+
+	// Only the committed (loop attempt 2) attempt was observed; the minority skip
+	// did not.
+	if len(controller.calls) != 1 {
+		t.Fatalf("expected 1 observed (committed) attempt, got %d", len(controller.calls))
+	}
+	if controller.calls[0].roastAttemptNumber != 0 {
+		t.Fatalf(
+			"the committed attempt after a skip must be roast attempt 0, got %d",
+			controller.calls[0].roastAttemptNumber,
+		)
 	}
 }

--- a/pkg/tbtc/signing_loop_roast_transition_controller_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_test.go
@@ -254,6 +254,14 @@ func TestSigningRetryLoop_SignalsFailedAttempt(t *testing.T) {
 	if len(controller.calls) != 2 {
 		t.Fatalf("expected BeginObservedAttempt called twice, got %d", len(controller.calls))
 	}
+	// The committed ROAST attempt number advances 0 -> 1 across the two committed
+	// attempts (no pre-selection skip here), so the transition chain is consecutive.
+	if controller.calls[0].roastAttemptNumber != 0 || controller.calls[1].roastAttemptNumber != 1 {
+		t.Fatalf(
+			"committed roast attempt numbers must advance 0,1; got %d,%d",
+			controller.calls[0].roastAttemptNumber, controller.calls[1].roastAttemptNumber,
+		)
+	}
 }
 
 // TestSigningRetryLoop_SkipDoesNotAdvanceRoastAttemptNumber asserts the committed

--- a/pkg/tbtc/signing_loop_roast_transition_controller_test.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_test.go
@@ -1,0 +1,155 @@
+package tbtc
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+type observedAttemptCall struct {
+	attemptNumber uint
+	included      []group.MemberIndex
+	excluded      []group.MemberIndex
+}
+
+// fakeTransitionController records BeginObservedAttempt calls so the loop-wiring
+// tests can assert the loop observes each attempt with the exact member sets.
+type fakeTransitionController struct {
+	calls []observedAttemptCall
+}
+
+func (f *fakeTransitionController) BeginObservedAttempt(
+	attemptNumber uint,
+	includedMembersIndexes []group.MemberIndex,
+	excludedMembersIndexes []group.MemberIndex,
+) {
+	f.calls = append(f.calls, observedAttemptCall{
+		attemptNumber: attemptNumber,
+		included:      includedMembersIndexes,
+		excluded:      excludedMembersIndexes,
+	})
+}
+
+func newObserveTestRetryLoop(
+	announcer signingAnnouncer,
+	doneCheck signingDoneCheckStrategy,
+) *signingRetryLoop {
+	return newSigningRetryLoop(
+		&testutils.MockLogger{},
+		big.NewInt(100),
+		"",  // roastSessionID
+		200, // initialStartBlock
+		1,   // signingGroupMemberIndex
+		chain.Addresses{
+			"address-1",
+			"address-2",
+			"address-3",
+			"address-4",
+			"address-5",
+		},
+		&GroupParameters{GroupSize: 5, HonestThreshold: 3},
+		announcer,
+		doneCheck,
+	)
+}
+
+func runOneSuccessfulAttempt(
+	t *testing.T,
+	retryLoop *signingRetryLoop,
+) {
+	t.Helper()
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(*signingAttemptParams) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestSigningRetryLoop_ObservesEachAttempt asserts the loop drives the
+// transition controller's observe step once per attempt, with the exact
+// member-level included/excluded sets selection produced -- the binding the
+// later commits' transition exchange and selection consume.
+func TestSigningRetryLoop_ObservesEachAttempt(t *testing.T) {
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3, 4, 5}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+
+	retryLoop := newObserveTestRetryLoop(announcer, doneCheck)
+	controller := &fakeTransitionController{}
+	retryLoop.setTransitionController(controller)
+
+	runOneSuccessfulAttempt(t, retryLoop)
+
+	if len(controller.calls) != 1 {
+		t.Fatalf("expected BeginObservedAttempt called once, got %d", len(controller.calls))
+	}
+	call := controller.calls[0]
+	if call.attemptNumber != 1 {
+		t.Fatalf("expected attempt number 1, got %d", call.attemptNumber)
+	}
+	// The observed sets must partition the whole group and match the honest
+	// threshold count -- i.e. the loop passes selection's exact member-level
+	// output, not a recomputed approximation.
+	if len(call.included) != 3 {
+		t.Fatalf("expected 3 included members (the honest threshold), got %v", call.included)
+	}
+	if len(call.included)+len(call.excluded) != 5 {
+		t.Fatalf(
+			"included+excluded must cover the group of 5, got %d+%d",
+			len(call.included), len(call.excluded),
+		)
+	}
+}
+
+// TestSigningRetryLoop_NilTransitionControllerIsSafe asserts a loop with no
+// controller installed (the default build / non-ROAST deployment) runs an
+// attempt without panicking.
+func TestSigningRetryLoop_NilTransitionControllerIsSafe(t *testing.T) {
+	testResult := &signing.Result{
+		Signature: mustFrostSignatureFromBigInts(big.NewInt(300), big.NewInt(400)),
+	}
+	announcer := &mockSigningAnnouncer{
+		outgoingAnnouncements: make(map[string]group.MemberIndex),
+		incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+			return []group.MemberIndex{1, 2, 3, 4, 5}, nil
+		},
+	}
+	doneCheck := &mockSigningDoneCheck{
+		waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+			return testResult, 215, nil
+		},
+	}
+
+	retryLoop := newObserveTestRetryLoop(announcer, doneCheck)
+	// No setTransitionController -> transitionController stays nil.
+	runOneSuccessfulAttempt(t, retryLoop)
+}

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
@@ -42,28 +42,33 @@ func (s roastSigningParticipantSelector) Select(
 	signingGroupOperators chain.Addresses,
 	seed int64,
 	retryCount uint,
+	roastAttemptNumber uint,
 	honestThreshold uint,
 	sessionID string,
 	memberIndex group.MemberIndex,
-) ([]group.MemberIndex, error) {
-	includedMembersIndexes, err := signing.ConsumeRoastTransitionForSelection(
+) (participantSelection, error) {
+	included, parked, err := signing.ConsumeRoastTransitionForSelection(
 		sessionID,
 		memberIndex,
-		retryCount,
+		roastAttemptNumber,
 		honestThreshold,
 	)
 	if err == nil {
-		return includedMembersIndexes, nil
+		return participantSelection{
+			includedMembersIndexes:          included,
+			transientlyParkedMembersIndexes: parked,
+		}, nil
 	}
 
-	// Initial attempt or ROAST retry inactive: a uniform legacy fallback every
-	// honest node makes identically.
+	// Initial ROAST attempt or ROAST retry inactive: a uniform legacy fallback
+	// every honest node makes identically.
 	if errors.Is(err, signing.ErrRoastSelectionFallBackToLegacy) {
 		return s.legacy.Select(
 			readyMembersIndexes,
 			signingGroupOperators,
 			seed,
 			retryCount,
+			roastAttemptNumber,
 			honestThreshold,
 			sessionID,
 			memberIndex,
@@ -75,5 +80,5 @@ func (s roastSigningParticipantSelector) Select(
 	// retry loop, and the outer layer retries the whole signing. Falling back to
 	// legacy here -- while peers that DID receive the transition select from it --
 	// would split the signing group into divergent included sets.
-	return nil, err
+	return participantSelection{}, err
 }

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry.go
@@ -3,39 +3,40 @@
 package tbtc
 
 import (
+	"errors"
+
 	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // roastSigningParticipantSelector is installed as the default participant
-// selector in the frost_roast_retry build. In RFC-21 Phase 7.3 PR2a it
-// delegates to the legacy retry shuffle: the cross-attempt ROAST transition
-// record is now PRODUCED and stored (the data foundation this PR lays), but
-// CONSUMING it to drive participant selection is deferred to PR2b.
+// selector in the frost_roast_retry build. RFC-21 Phase 7.3 PR2b-1b C3 activates
+// it: on a retry under active ROAST retry it consumes this seat's stored
+// transition record to select the next attempt's included set at the member
+// level; otherwise it uses the legacy retry shuffle.
 //
-// Consuming a purely-local record here would FRACTURE the signing group: only
-// the elected coordinator's cleanup produces a record locally, so on a retry it
-// would take the ROAST branch while every peer (no local record) fell back to
-// legacy -- yielding divergent IncludedSets across honest nodes. PR2b adds the
-// snapshot/transition bus exchange so every signer holds the record, AND selects
-// at the member level (the legacy address-based path loses ROAST's per-member
-// decision under multi-seat operators and partial readiness). Until then this
-// selector is observationally identical to the legacy one.
+// The transition record is produced by the (C1/C2) observe + bus exchange: every
+// signer holds the verified record for the prior attempt, so consuming it here
+// no longer fractures the group the way a purely-local record would have. The
+// crucial discipline is FAIL-CLOSED: when a committed ROAST attempt expected a
+// transition that did not arrive, this selector returns the error (terminating
+// the retry loop) rather than falling back to legacy -- mixed ROAST/legacy
+// selection across honest nodes is the fracture class.
 type roastSigningParticipantSelector struct {
 	legacy legacySigningParticipantSelector
 }
 
 // defaultSigningParticipantSelector in the frost_roast_retry build returns the
-// ROAST selector (which, in PR2a, delegates to legacy -- see the type doc).
+// ROAST selector.
 func defaultSigningParticipantSelector() signingParticipantSelector {
 	return roastSigningParticipantSelector{}
 }
 
-// Select delegates to the legacy retry shuffle in PR2a/PR2b-1a. The
-// readyMembersIndexes + signingGroupOperators + sessionID + memberIndex
-// parameters are threaded through the interface now so PR2b-1b can wire
-// distributed, member-level consumption of the transition record (it returns
-// the transition's IncludedSet directly) without touching the call site again.
+// Select consumes the stored transition record when ROAST retry drives this
+// attempt, and otherwise uses the legacy shuffle. See
+// signing.ConsumeRoastTransitionForSelection for the three-way contract
+// (consume / uniform legacy fallback / fail closed).
 func (s roastSigningParticipantSelector) Select(
 	readyMembersIndexes []group.MemberIndex,
 	signingGroupOperators chain.Addresses,
@@ -45,13 +46,34 @@ func (s roastSigningParticipantSelector) Select(
 	sessionID string,
 	memberIndex group.MemberIndex,
 ) ([]group.MemberIndex, error) {
-	return s.legacy.Select(
-		readyMembersIndexes,
-		signingGroupOperators,
-		seed,
-		retryCount,
-		honestThreshold,
+	includedMembersIndexes, err := signing.ConsumeRoastTransitionForSelection(
 		sessionID,
 		memberIndex,
+		retryCount,
+		honestThreshold,
 	)
+	if err == nil {
+		return includedMembersIndexes, nil
+	}
+
+	// Initial attempt or ROAST retry inactive: a uniform legacy fallback every
+	// honest node makes identically.
+	if errors.Is(err, signing.ErrRoastSelectionFallBackToLegacy) {
+		return s.legacy.Select(
+			readyMembersIndexes,
+			signingGroupOperators,
+			seed,
+			retryCount,
+			honestThreshold,
+			sessionID,
+			memberIndex,
+		)
+	}
+
+	// A committed ROAST attempt expected a transition that did not arrive (or
+	// NextAttempt was infeasible). FAIL CLOSED: surfacing the error terminates the
+	// retry loop, and the outer layer retries the whole signing. Falling back to
+	// legacy here -- while peers that DID receive the transition select from it --
+	// would split the signing group into divergent included sets.
+	return nil, err
 }

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
@@ -75,6 +75,13 @@ func TestROASTSelector_FailsClosedWhenTransitionMissing(t *testing.T) {
 		Verifier:    roast.NoOpSignatureVerifier(),
 		SelfMember:  1,
 	})
+	if !signing.RoastRetryActive() {
+		// In a frost_roast_retry && !frost_native build there is no transition
+		// producer, so the selector falls back to legacy rather than fail-closing --
+		// the dedicated no-producer test covers that path. The fail-closed discipline
+		// asserted here only applies when a producer (frost_native) exists.
+		t.Skip("requires a transition producer (frost_native) for the fail-closed path")
+	}
 
 	sel := roastSigningParticipantSelector{}
 	// roastAttemptNumber 1 (> 0) under active ROAST expects a transition; none is

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
@@ -41,16 +41,21 @@ func TestROASTSelector_InitialAttemptUsesLegacy(t *testing.T) {
 	t.Cleanup(signing.ResetRoastTransitionRegistryForTest)
 
 	sel := roastSigningParticipantSelector{}
+	// Args: ready, operators, seed, retryCount, roastAttemptNumber, honestThreshold,
+	// sessionID, memberIndex. roastAttemptNumber 0 == the initial ROAST attempt.
 	got, err := sel.Select(
 		[]group.MemberIndex{1, 2, 3, 4, 5},
 		selectorTestMembers(),
-		42, 0, 3, "session", 1, // retry 0
+		42, 0, 0, 3, "session", 1,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got) != 3 {
-		t.Fatalf("expected a legacy-shaped included set (the honest threshold); got %d", len(got))
+	if len(got.includedMembersIndexes) != 3 {
+		t.Fatalf(
+			"expected a legacy-shaped included set (the honest threshold); got %d",
+			len(got.includedMembersIndexes),
+		)
 	}
 }
 
@@ -72,10 +77,12 @@ func TestROASTSelector_FailsClosedWhenTransitionMissing(t *testing.T) {
 	})
 
 	sel := roastSigningParticipantSelector{}
+	// roastAttemptNumber 1 (> 0) under active ROAST expects a transition; none is
+	// stored, so the selector must fail closed.
 	_, err := sel.Select(
 		[]group.MemberIndex{1, 2, 3, 4, 5},
 		selectorTestMembers(),
-		42, 1, 3, "session", 1, // retry 1, no record stored
+		42, 1, 1, 3, "session", 1,
 	)
 	if err == nil {
 		t.Fatal("expected a fail-closed error when an expected transition is missing")

--- a/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_selector_frost_roast_retry_test.go
@@ -3,6 +3,7 @@
 package tbtc
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -31,35 +32,55 @@ func TestDefaultSigningParticipantSelector_IsROASTInTaggedBuild(t *testing.T) {
 	}
 }
 
-// In PR2a the ROAST selector delegates to legacy: the transition record is
-// produced + stored (the data foundation) but NOT consumed (consumption +
-// distribution land in PR2b, where consuming a purely-local record would no
-// longer diverge across peers). This test asserts both halves: a legacy-shaped
-// result, and that an existing record is left UNTOUCHED (not consumed).
-func TestROASTSelector_DelegatesToLegacyAndDoesNotConsumeRecord(t *testing.T) {
+// The initial attempt (retry 0) has no prior transition, so the ROAST selector
+// uses the legacy retry shuffle -- a uniform decision every honest node makes.
+func TestROASTSelector_InitialAttemptUsesLegacy(t *testing.T) {
+	signing.ResetRoastRetryRegistrationForTest()
 	signing.ResetRoastTransitionRegistryForTest()
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
 	t.Cleanup(signing.ResetRoastTransitionRegistryForTest)
-
-	signing.RecordRoastTransition("session", 1, signing.RoastTransitionRecord{
-		Bundle:            &roast.TransitionMessage{CoordinatorIDValue: 1},
-		DkgGroupPublicKey: []byte{0x01, 0x02, 0x03},
-	})
 
 	sel := roastSigningParticipantSelector{}
 	got, err := sel.Select(
 		[]group.MemberIndex{1, 2, 3, 4, 5},
 		selectorTestMembers(),
-		42, 0, 3, "session", 1,
+		42, 0, 3, "session", 1, // retry 0
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got) < 3 {
-		t.Fatalf("expected a legacy-shaped included set; got %d", len(got))
+	if len(got) != 3 {
+		t.Fatalf("expected a legacy-shaped included set (the honest threshold); got %d", len(got))
 	}
+}
 
-	// The record must be untouched: PR2a's selector does not consume it.
-	if _, ok := signing.RoastTransitionForSession("session", 1); !ok {
-		t.Fatal("PR2a selector must not consume the transition record")
+// On a retry under ACTIVE ROAST retry, a transition is expected; when none
+// arrived the selector must FAIL CLOSED (surface an error that terminates the
+// loop) rather than fall back to legacy -- mixed selection across honest nodes
+// is the fracture class. C3 activates this consumption.
+func TestROASTSelector_FailsClosedWhenTransitionMissing(t *testing.T) {
+	t.Setenv(signing.RoastRetryReadinessOptInEnvVar, "true")
+	signing.ResetRoastRetryRegistrationForTest()
+	signing.ResetRoastTransitionRegistryForTest()
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	t.Cleanup(signing.ResetRoastTransitionRegistryForTest)
+	signing.RegisterRoastRetryCoordinator(signing.RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	sel := roastSigningParticipantSelector{}
+	_, err := sel.Select(
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		selectorTestMembers(),
+		42, 1, 3, "session", 1, // retry 1, no record stored
+	)
+	if err == nil {
+		t.Fatal("expected a fail-closed error when an expected transition is missing")
+	}
+	if errors.Is(err, signing.ErrRoastSelectionFallBackToLegacy) {
+		t.Fatal("a missing expected transition must fail closed, not fall back to legacy")
 	}
 }


### PR DESCRIPTION
## Summary

RFC-21 Phase 7.3 PR2b-1b — makes the FROST/ROAST signing-retry path
**non-fracturing**. On a failed signing attempt, the elected coordinator
aggregates forced proof-of-attendance snapshots into a signed transition bundle
and broadcasts it; every node verifies it and computes the next attempt's
included set from it (member-level, fail-closed), replacing the address-based
legacy shuffle on the ROAST path.

**Gated + dormant.** Behind `frost_native && frost_roast_retry` +
`KEEP_CORE_FROST_ROAST_RETRY_ENABLED`, and no production code registers a ROAST
coordinator (zero non-test callers of `RegisterRoastRetryCoordinator`), so the
path is inert in production until the post-audit prod-wiring step. The
legacy/coarse path is byte-identical to today when ROAST is inactive.

## Commits

**Functional core:** observe foundation → transition-exchange engine → loop
wiring → member-level activation (fail-closed) → cleanup (`f4c6a1537`…`bef131ec5`).

**Review-fix set** (Codex + Gemini rounds):
- **B1/B2/B3 + lostSync** — thread transient parking (no permanent park);
  decouple a committed `roastAttemptNumber` from the block counter (pre-selection
  skips don't break the transition chain); clear the observe binding on local
  success; fail closed on a bundle for a never-observed attempt.
- **Codex P1** — key the active signing attempt off the committed
  `roastAttemptNumber` (+ parking) so its `AttemptContext` is byte-identical to
  the observe/transition context.
- **Codex P2-1** — gate "ROAST active" on transition-producer availability
  (`frost_native`), so a `frost_roast_retry`-only build falls back to legacy
  instead of fail-closing.

## Fracture-safety

Fail-closed throughout: a committed ROAST attempt expecting a transition that's
missing/inconsistent terminates the loop (outer re-sign) rather than mix
ROAST/legacy selection across nodes. Review-confirmed: no wrong/sub-threshold
signature is reachable; residual cross-node hazards degrade to liveness,
firewalled by the interactive `AttemptContextHash` filter, the coarse
`SessionID` filter, and the done-check signature-equality guard.

## Deferred

- **Multi-seat** → PR2b-1.5 (the exchange binds one process-wide coordinator).
  **Hard prerequisite: do not register a production coordinator until PR2b-1.5
  (per-seat deps) lands or the rollout gate rejects multi-seat wallets.**
  Unreachable today.
- **Announcement session-id re-key** — a cross-node liveness optimization, not
  needed for safety and double-edged on laggard liveness.
- **Blame/evidence bridge + coordinator-equivocation exclusion** → PR2b-2
  (snapshots are empty proof-of-attendance in 1b).

## Hard gates (pre-production)

`frost-secp256k1-tr =3.0.0` external audit + recovery-leaf decision.

## Testing

gofmt; build + vet + test across default / `frost_native` / `frost_roast_retry`-only
/ `frost_native frost_roast_retry` / `frost_native frost_tbtc_signer cgo`; `-race`;
full `pkg/frost/signing` (both producer states) + full `pkg/tbtc` (tagged 208s +
default 147s + `frost_roast_retry`-only 147s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
