### PR TITLE
feat(frost): multi-seat per-seat ROAST coordinator deps (7.3 PR2b-1.5)

### DIFF
--- a/pkg/frost/signing/roast_interactive_signing_drive_frost_native.go
+++ b/pkg/frost/signing/roast_interactive_signing_drive_frost_native.go
@@ -82,7 +82,7 @@ func driveInteractiveRoastSigningIfEnabled(
 	// SelectedCoordinator(handle) return ErrUnknownAttempt and hard-fail below --
 	// safe (no wrong signature), and only reachable by reconfiguring the
 	// coordinator mid-session. An absent registration falls back to coarse.
-	deps, ok := RegisteredRoastRetryCoordinator()
+	deps, ok := RegisteredRoastRetryCoordinatorForMember(request.MemberIndex)
 	if !ok || deps.Coordinator == nil {
 		return nil, nil
 	}

--- a/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_observe_attempt_frost_native_roast_retry.go
@@ -36,18 +36,19 @@ func ObserveAttemptForTransition(
 		return zeroHash, fmt.Errorf("observe attempt: request is nil")
 	}
 
-	// Respect the readiness opt-in gate, exactly as BeginOrchestrationForSession
-	// does: when ROAST retry is opted out, observing is pointless (nothing
-	// consumes the binding) and must stay inert. Opt-out is a deterministic
-	// static condition every honest node sees identically.
-	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
+	// Respect the per-seat readiness + registration gate, exactly as the selector
+	// and BeginOrchestrationForSession do: when THIS seat has no registered
+	// coordinator (or readiness is opted out), observing is pointless (nothing
+	// consumes the binding) and must stay inert. A deterministic static condition
+	// every honest node sees identically per seat. RFC-21 Phase 7.3 PR2b-1.5: a
+	// multi-seat operator observes per local seat with that seat's coordinator.
+	if !RoastRetryActiveForMember(request.MemberIndex) {
 		return zeroHash, nil
 	}
 
-	deps, ok := RegisteredRoastRetryCoordinator()
+	deps, ok := RegisteredRoastRetryCoordinatorForMember(request.MemberIndex)
 	if !ok || deps.Coordinator == nil {
-		// No orchestration registered -- static fallback, every honest node
-		// observes the same empty registry.
+		// No coordinator registered for this seat -- static fallback.
 		return zeroHash, nil
 	}
 

--- a/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
+++ b/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
@@ -94,7 +94,7 @@ func attemptRoastRetryOrchestrationFromRequest(
 	// The cross-attempt transition record is produced + keyed (by the stable
 	// RoastSessionID) entirely in the transition exchange now, not here.
 	handle, cleanup, err := BeginOrchestrationForSession(
-		request.SessionID, attemptCtx,
+		request.SessionID, request.MemberIndex, attemptCtx,
 	)
 	if err != nil {
 		switch {

--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -5,7 +5,7 @@ package signing
 // The orchestration layer in this file participates in a load-bearing
 // decision that prevents split-brain group fracture in the ROAST retry
 // path. Errors returned through the orchestration boundary are
-// classified into one of two categories, and the consumer (the
+// classified into one of three categories, and the consumer (the
 // signing-loop dispatcher) routes them accordingly:
 //
 //   STATIC errors  -> safe to fall back to the legacy retry path.
@@ -18,19 +18,39 @@ package signing
 //                     Detected via errors.Is in
 //                     signing_loop_roast_dispatcher.go.
 //
-//   RUNTIME errors -> HARD FAIL. No fallback. Any error that arises
-//                     from per-attempt protocol state (BeginAttempt
-//                     internals, AttemptContext binding mismatches,
-//                     transition-bundle verification failures, etc.)
-//                     can be observed by some participants and not
-//                     others within the same attempt. Falling back to
-//                     legacy under those conditions would leave some
-//                     operators running the new code path and others
-//                     running legacy on the same attempt -- the canonical
-//                     definition of split-brain fracture. The
-//                     orchestration layer therefore returns these as
-//                     bare (non-sentinel) errors that the dispatcher
-//                     treats as terminal.
+//   RUNTIME errors -> NO FALLBACK, RETRY THE NEXT ATTEMPT. Any error
+//                     that arises from per-attempt protocol state
+//                     (BeginAttempt internals, AttemptContext binding
+//                     mismatches, transition-bundle verification
+//                     failures, etc.) can be observed by some
+//                     participants and not others within the same
+//                     attempt. Falling back to legacy under those
+//                     conditions would leave some operators running the
+//                     new code path and others running legacy on the
+//                     same attempt -- the canonical definition of
+//                     split-brain fracture. The orchestration layer
+//                     therefore returns these as bare (non-sentinel)
+//                     errors; the signingRetryLoop does NOT fall back to
+//                     coarse, but it DOES retry on the next attempt
+//                     because the fault may be transient and clear.
+//
+//   TERMINAL errors -> ABORT THE RETRY LOOP. A STATIC condition that no
+//                     future attempt can resolve, e.g. multi-seat
+//                     interactive ROAST orchestration, which is not yet
+//                     member-safe (the session handle binding is keyed
+//                     by sessionID alone, so sibling seats collide;
+//                     member-keyed handles land in a later PR). Unlike a
+//                     RUNTIME error, retrying is FUTILE: every attempt
+//                     re-derives the same static outcome, so the loop
+//                     would spin until timeout AND synthesize garbage
+//                     failed-attempt transitions (OnAttemptFailed).
+//                     Coarse fallback is also unsafe (interactive<->coarse
+//                     mixing fractures the group), so terminating is the
+//                     only non-fracturing option. The orchestration layer
+//                     wraps ErrTerminalSigningFailure; the signingRetryLoop
+//                     matches it via errors.Is and exits immediately
+//                     (return nil, err) BEFORE the retry/transition
+//                     machinery.
 //
 // The classification is enforced at this file's boundary: any error
 // surfaced from this package that is intended to permit fallback MUST
@@ -70,6 +90,24 @@ import (
 // Use errors.Is to detect.
 var ErrNoRoastRetryCoordinatorRegistered = errors.New(
 	"roast orchestration: no coordinator registered",
+)
+
+// ErrTerminalSigningFailure classifies an orchestration error as TERMINAL: a
+// static condition no future attempt can resolve, so the signingRetryLoop must
+// ABORT the loop (return nil, err) rather than retry the next attempt. It is the
+// third disposition in the taxonomy above. Orchestration code wraps it
+// (fmt.Errorf("%w: ...", ErrTerminalSigningFailure)) and the loop matches it via
+// errors.Is. It is distinct from ErrNoRoastRetryCoordinatorRegistered (STATIC,
+// coarse-fallback) and from bare RUNTIME errors (no fallback, but retried): a
+// TERMINAL error is futile to retry and unsafe to coarse-fall-back, so the only
+// non-fracturing disposition is to stop.
+//
+// Current sole producer: BeginOrchestrationForSession, for a multi-seat operator
+// whose interactive ROAST orchestration is not yet member-safe.
+//
+// Use errors.Is to detect.
+var ErrTerminalSigningFailure = errors.New(
+	"terminal signing failure",
 )
 
 // BeginOrchestrationForSession encapsulates the per-session
@@ -119,8 +157,9 @@ func BeginOrchestrationForSession(
 	// this same PR.
 	if memberCount > 1 {
 		return roast.AttemptHandle{}, nil, fmt.Errorf(
-			"roast orchestration: multi-seat orchestration is not yet member-aware; "+
+			"%w: multi-seat orchestration is not yet member-aware; "+
 				"fail closed for session %q until PR2b-2",
+			ErrTerminalSigningFailure,
 			sessionID,
 		)
 	}
@@ -138,8 +177,9 @@ func BeginOrchestrationForSession(
 			)
 		}
 		return roast.AttemptHandle{}, nil, fmt.Errorf(
-			"roast orchestration: seat %d has no registered coordinator while a sibling "+
+			"%w: seat %d has no registered coordinator while a sibling "+
 				"seat is ROAST-active; fail closed",
+			ErrTerminalSigningFailure,
 			member,
 		)
 	}

--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -55,6 +55,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/frost/roast"
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // ErrNoRoastRetryCoordinatorRegistered is returned by
@@ -94,6 +95,7 @@ var ErrNoRoastRetryCoordinatorRegistered = errors.New(
 // this no longer takes the DKG group public key.
 func BeginOrchestrationForSession(
 	sessionID string,
+	member group.MemberIndex,
 	ctx attempt.AttemptContext,
 ) (roast.AttemptHandle, func(), error) {
 	if err := EnsureRoastRetryReadinessOptIn(); err != nil {
@@ -102,7 +104,9 @@ func BeginOrchestrationForSession(
 			err,
 		)
 	}
-	deps, ok := RegisteredRoastRetryCoordinator()
+	// RFC-21 Phase 7.3 PR2b-1.5: mint the handle from THIS seat's coordinator, so a
+	// multi-seat operator's elected seat aggregates with its own binding.
+	deps, ok := RegisteredRoastRetryCoordinatorForMember(member)
 	if !ok {
 		return roast.AttemptHandle{}, nil, fmt.Errorf(
 			"%w: caller should fall back to legacy behaviour",

--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -107,10 +107,40 @@ func BeginOrchestrationForSession(
 	// RFC-21 Phase 7.3 PR2b-1.5: mint the handle from THIS seat's coordinator, so a
 	// multi-seat operator's elected seat aggregates with its own binding.
 	deps, ok := RegisteredRoastRetryCoordinatorForMember(member)
-	if !ok {
+	memberCount := registeredRoastRetryMemberCount()
+	// Multi-seat is not yet member-safe here: the session handle binding below
+	// (SetCurrentAttemptHandleForSession) is keyed by sessionID alone, so two local
+	// seats in the same attempt would collide. Fail CLOSED for any multi-seat operator
+	// -- a hard (non-sentinel) error the dispatcher treats as terminal, NEVER the
+	// legacy-fallback sentinel -- until PR2b-2 wires member-keyed handles. Returning the
+	// sentinel here would let this seat run the coarse/legacy path while sibling seats
+	// drive bound ROAST messages, splitting the attempt into mixed bound/unbound. This
+	// mirrors the coarse evidence path's multi-seat guard (submitSnapshotIfActive) in
+	// this same PR.
+	if memberCount > 1 {
 		return roast.AttemptHandle{}, nil, fmt.Errorf(
-			"%w: caller should fall back to legacy behaviour",
-			ErrNoRoastRetryCoordinatorRegistered,
+			"roast orchestration: multi-seat orchestration is not yet member-aware; "+
+				"fail closed for session %q until PR2b-2",
+			sessionID,
+		)
+	}
+	if !ok {
+		// memberCount is 0 or 1 here. count==0: no seat is registered anywhere, so ROAST
+		// is not active for the process -- a uniform, group-wide condition every honest
+		// node decides identically -> safe legacy fallback (the sentinel). count==1: a
+		// sibling seat IS registered but not THIS one (a partially-registered operator),
+		// so advertising the legacy fallback for this seat while the sibling drives bound
+		// ROAST would fracture the attempt -> fail CLOSED instead (Codex re-review).
+		if memberCount == 0 {
+			return roast.AttemptHandle{}, nil, fmt.Errorf(
+				"%w: caller should fall back to legacy behaviour",
+				ErrNoRoastRetryCoordinatorRegistered,
+			)
+		}
+		return roast.AttemptHandle{}, nil, fmt.Errorf(
+			"roast orchestration: seat %d has no registered coordinator while a sibling "+
+				"seat is ROAST-active; fail closed",
+			member,
 		)
 	}
 	if deps.Coordinator == nil {

--- a/pkg/frost/signing/roast_retry_orchestration_bundle_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_bundle_test.go
@@ -60,7 +60,7 @@ func TestCleanup_ClearsBindingAndProducesNoTransitionRecord(t *testing.T) {
 	})
 
 	const sessionID = "cleanup-no-record-session"
-	handle, cleanup, err := BeginOrchestrationForSession(sessionID, ctx)
+	handle, cleanup, err := BeginOrchestrationForSession(sessionID, elected, ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -45,7 +45,7 @@ func TestBeginOrchestrationForSession_HappyPath(t *testing.T) {
 	})
 
 	ctx := newOrchestrationTestContext(t)
-	handle, cleanup, err := BeginOrchestrationForSession("session-A", ctx)
+	handle, cleanup, err := BeginOrchestrationForSession("session-A", 1, ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestBeginOrchestrationForSession_ErrorsWhenRegistryEmpty(t *testing.T) {
 
 	// Readiness env var is set; the registry is empty -- we expect
 	// the registry-empty error, not the env-var error.
-	_, _, err := BeginOrchestrationForSession("session-X", newOrchestrationTestContext(t))
+	_, _, err := BeginOrchestrationForSession("session-X", 1, newOrchestrationTestContext(t))
 	if err == nil {
 		t.Fatal("expected error when registry is empty")
 	}
@@ -110,7 +110,7 @@ func TestBeginOrchestrationForSession_ErrorsWhenReadinessOptInUnset(t *testing.T
 		SelfMember:  1,
 	})
 
-	_, _, err := BeginOrchestrationForSession("session-no-optin", newOrchestrationTestContext(t))
+	_, _, err := BeginOrchestrationForSession("session-no-optin", 1, newOrchestrationTestContext(t))
 	if !errors.Is(err, ErrRoastRetryReadinessOptOut) {
 		t.Fatalf("expected ErrRoastRetryReadinessOptOut, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestBeginOrchestrationForSession_ErrorsWhenCoordinatorNil(t *testing.T) {
 		SelfMember:  1,
 	})
 
-	_, _, err := BeginOrchestrationForSession("session-Y", newOrchestrationTestContext(t))
+	_, _, err := BeginOrchestrationForSession("session-Y", 1, newOrchestrationTestContext(t))
 	if err == nil {
 		t.Fatal("expected error when Coordinator is nil")
 	}
@@ -154,7 +154,7 @@ func TestBeginOrchestrationForSession_PropagatesBeginAttemptError(t *testing.T) 
 		SelfMember:  1,
 	})
 
-	_, _, err := BeginOrchestrationForSession("session-Z", newOrchestrationTestContext(t))
+	_, _, err := BeginOrchestrationForSession("session-Z", 1, newOrchestrationTestContext(t))
 	if err == nil {
 		t.Fatal("expected error from coordinator")
 	}

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -176,6 +176,11 @@ func assertOrchestrationFailedClosed(t *testing.T, sessionID string, cleanup fun
 	if errors.Is(err, ErrRoastRetryReadinessOptOut) {
 		t.Fatalf("must NOT return the readiness sentinel; got %v", err)
 	}
+	// Must be classified TERMINAL so the signingRetryLoop aborts instead of
+	// retrying the (static, never-resolving) multi-seat condition.
+	if !errors.Is(err, ErrTerminalSigningFailure) {
+		t.Fatalf("multi-seat fail-closed must be classified terminal (ErrTerminalSigningFailure); got %v", err)
+	}
 	if cleanup != nil {
 		t.Fatal("a failed begin must not return a cleanup")
 	}

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -163,6 +163,80 @@ func TestBeginOrchestrationForSession_PropagatesBeginAttemptError(t *testing.T) 
 	}
 }
 
+// assertOrchestrationFailedClosed asserts err is a HARD fail-closed: non-nil,
+// neither static-fallback sentinel, and that no session binding leaked.
+func assertOrchestrationFailedClosed(t *testing.T, sessionID string, cleanup func(), err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a fail-closed error, got nil")
+	}
+	if errors.Is(err, ErrNoRoastRetryCoordinatorRegistered) {
+		t.Fatalf("must NOT return the legacy-fallback sentinel; got %v", err)
+	}
+	if errors.Is(err, ErrRoastRetryReadinessOptOut) {
+		t.Fatalf("must NOT return the readiness sentinel; got %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("a failed begin must not return a cleanup")
+	}
+	if _, _, ok := currentAttemptHandleForCollect(sessionID); ok {
+		t.Fatal("fail-closed must not create a session binding")
+	}
+}
+
+// TestBeginOrchestrationForSession_FailsClosedPartialMultiSeat is the Codex
+// re-review case: a multi-seat operator that has at least one seat registered but
+// NOT this one. The member-aware lookup misses, and rather than returning the
+// legacy-fallback sentinel (which would let this seat run coarse/legacy while the
+// registered sibling drives bound ROAST -> fracture), Begin fails CLOSED.
+func TestBeginOrchestrationForSession_FailsClosedPartialMultiSeat(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	// Only seat 1 is registered; this Execute is for the unregistered seat 2.
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier()),
+		SelfMember:  1,
+	})
+
+	_, cleanup, err := BeginOrchestrationForSession("session-partial", 2, newOrchestrationTestContext(t))
+	assertOrchestrationFailedClosed(t, "session-partial", cleanup, err)
+	if !strings.Contains(err.Error(), "fail closed") {
+		t.Fatalf("error must explain the fail-closed; got %v", err)
+	}
+}
+
+// TestBeginOrchestrationForSession_FailsClosedFullMultiSeat asserts the
+// fully-registered multi-seat case also fails closed: the session-handle binding
+// is still keyed by sessionID alone, so two local seats would collide. Deferred
+// to PR2b-2; until then any multi-seat operator fails closed rather than mis-bind.
+func TestBeginOrchestrationForSession_FailsClosedFullMultiSeat(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	// Both local seats registered -> multi-seat; call with a registered member.
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier()),
+		SelfMember:  1,
+	})
+	RegisterRoastRetryCoordinatorForMember(2, RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinatorWithSigning(2, roast.NoOpSigner(), roast.NoOpSignatureVerifier()),
+		SelfMember:  2,
+	})
+
+	_, cleanup, err := BeginOrchestrationForSession("session-multiseat", 1, newOrchestrationTestContext(t))
+	assertOrchestrationFailedClosed(t, "session-multiseat", cleanup, err)
+	if !strings.Contains(err.Error(), "multi-seat") {
+		t.Fatalf("error must explain the multi-seat fail-closed; got %v", err)
+	}
+}
+
 func TestEndOrchestrationForSession_RemovesBinding(t *testing.T) {
 	ResetSessionHandleRegistryForTest()
 	t.Cleanup(ResetSessionHandleRegistryForTest)

--- a/pkg/frost/signing/roast_retry_orchestration_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_test.go
@@ -30,7 +30,7 @@ func TestBeginOrchestrationForSession_DefaultBuildReturnsError(t *testing.T) {
 		t.Fatalf("ctx: %v", err)
 	}
 
-	_, _, err = BeginOrchestrationForSession("session-default-build", ctx)
+	_, _, err = BeginOrchestrationForSession("session-default-build", 1, ctx)
 	if err == nil {
 		t.Fatal("default build must return error from BeginOrchestrationForSession")
 	}

--- a/pkg/frost/signing/roast_retry_readiness.go
+++ b/pkg/frost/signing/roast_retry_readiness.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // RoastRetryReadinessOptInEnvVar is the environment variable name
@@ -83,5 +85,24 @@ func RoastRetryActive() bool {
 		return false
 	}
 	_, ok := RegisteredRoastRetryCoordinator()
+	return ok
+}
+
+// RoastRetryActiveForMember reports whether ROAST retry is runtime-active for a
+// SPECIFIC local seat: readiness opt-in AND the producer is built in AND THIS
+// member has a coordinator registered. Member-aware paths (the per-seat signing
+// loop, the per-member selector, observe, and the exchange) use it so a multi-seat
+// operator activates ROAST per seat -- a seat with no registered coordinator stays
+// on the legacy path rather than fail-closing. Always false in builds without the
+// frost_roast_retry tag (the per-member registration default stub reports
+// not-registered). RFC-21 Phase 7.3 PR2b-1.5.
+func RoastRetryActiveForMember(member group.MemberIndex) bool {
+	if !RoastRetryReadinessOptInEnabled() {
+		return false
+	}
+	if !roastTransitionProducerAvailable() {
+		return false
+	}
+	_, ok := RegisteredRoastRetryCoordinatorForMember(member)
 	return ok
 }

--- a/pkg/frost/signing/roast_retry_readiness.go
+++ b/pkg/frost/signing/roast_retry_readiness.go
@@ -77,11 +77,16 @@ func RoastRetryReadinessOptInEnabled() bool {
 // can never be created instead of using the uniform legacy shuffle (Codex P2-1).
 // Always false in builds without the frost_roast_retry tag (the registration and
 // producer default stubs both report unavailable).
+// readinessAndProducerReady is the build+env prefix shared by RoastRetryActive and
+// RoastRetryActiveForMember: the readiness opt-in is set AND the transition producer
+// is built in (frost_native). Both gates additionally require a registered
+// coordinator (any entry / the specific member's).
+func readinessAndProducerReady() bool {
+	return RoastRetryReadinessOptInEnabled() && roastTransitionProducerAvailable()
+}
+
 func RoastRetryActive() bool {
-	if !RoastRetryReadinessOptInEnabled() {
-		return false
-	}
-	if !roastTransitionProducerAvailable() {
+	if !readinessAndProducerReady() {
 		return false
 	}
 	_, ok := RegisteredRoastRetryCoordinator()
@@ -97,10 +102,7 @@ func RoastRetryActive() bool {
 // frost_roast_retry tag (the per-member registration default stub reports
 // not-registered). RFC-21 Phase 7.3 PR2b-1.5.
 func RoastRetryActiveForMember(member group.MemberIndex) bool {
-	if !RoastRetryReadinessOptInEnabled() {
-		return false
-	}
-	if !roastTransitionProducerAvailable() {
+	if !readinessAndProducerReady() {
 		return false
 	}
 	_, ok := RegisteredRoastRetryCoordinatorForMember(member)

--- a/pkg/frost/signing/roast_retry_registration_default_build.go
+++ b/pkg/frost/signing/roast_retry_registration_default_build.go
@@ -2,7 +2,10 @@
 
 package signing
 
-import "github.com/keep-network/keep-core/pkg/frost/roast"
+import (
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
 
 // RoastRetryDeps bundles the per-process dependencies the FROST
 // receive loops need to participate in RFC-21 Phase-4 coordinator-
@@ -39,6 +42,19 @@ type RoastRetryDeps struct {
 // registration only takes effect when the `frost_roast_retry` build
 // tag is active.
 func RegisterRoastRetryCoordinator(_ RoastRetryDeps) {}
+
+// RegisterRoastRetryCoordinatorForMember is a no-op in the default
+// build. Production multi-seat wiring may invoke it unconditionally;
+// the per-member registration only takes effect under the
+// `frost_roast_retry` build tag.
+func RegisterRoastRetryCoordinatorForMember(_ group.MemberIndex, _ RoastRetryDeps) {}
+
+// RegisteredRoastRetryCoordinatorForMember returns (zero, false) in
+// the default build: no ROAST-retry plumbing is active for any seat,
+// so member-aware receivers use the Phase-2 NoOp fallback.
+func RegisteredRoastRetryCoordinatorForMember(_ group.MemberIndex) (RoastRetryDeps, bool) {
+	return RoastRetryDeps{}, false
+}
 
 // RegisteredRoastRetryCoordinator returns (zero, false) in the
 // default build, signalling to receivers that ROAST-retry plumbing

--- a/pkg/frost/signing/roast_retry_registration_default_build.go
+++ b/pkg/frost/signing/roast_retry_registration_default_build.go
@@ -64,6 +64,11 @@ func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
 	return RoastRetryDeps{}, false
 }
 
+// registeredRoastRetryMemberCount returns 0 in the default build: no
+// seats are ever registered, so the coarse evidence path's multi-seat
+// guard (submitSnapshotIfActive) is never tripped here.
+func registeredRoastRetryMemberCount() int { return 0 }
+
 // ResetRoastRetryRegistrationForTest is a no-op in the default
 // build. Exposed so tests can call it unconditionally regardless of
 // which build is active.

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -96,6 +96,17 @@ func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
 	return RoastRetryDeps{}, false
 }
 
+// registeredRoastRetryMemberCount returns how many local seats currently have a
+// coordinator registered. A count > 1 means a multi-seat operator; the
+// not-yet-member-aware coarse/drive evidence path (submitSnapshotIfActive) uses it
+// to disable itself for multi-seat rather than mis-attribute one seat's evidence to
+// a sibling (RFC-21 Phase 7.3 PR2b-1.5).
+func registeredRoastRetryMemberCount() int {
+	roastRetryRegistrationMu.RLock()
+	defer roastRetryRegistrationMu.RUnlock()
+	return len(roastRetryRegistrationByMember)
+}
+
 // ResetRoastRetryRegistrationForTest clears the registry. Exposed so tests in this
 // and downstream packages can reset between cases without leaking state. Not
 // intended for production code paths.

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -47,8 +47,13 @@ func RegisterRoastRetryCoordinatorForMember(member group.MemberIndex, deps Roast
 		// Member indices are 1-based; a coordinator bound to selfMember 0 is the
 		// "disabled" sentinel that NEVER aggregates (coordinator_state.go), so
 		// registering under member 0 -- or under any member that disagrees with
-		// deps.SelfMember -- would silently mis-bind. Reject (the seat stays
-		// ROAST-inactive -> legacy) rather than register a non-aggregating entry.
+		// deps.SelfMember -- would silently mis-bind. REMOVE any existing entry for
+		// this member so a bad re-registration deactivates the seat (fail-safe to
+		// legacy) rather than leaving STALE deps active (Codex P2-2); member 0 never
+		// has an entry, so the delete is a no-op there.
+		roastRetryRegistrationMu.Lock()
+		delete(roastRetryRegistrationByMember, member)
+		roastRetryRegistrationMu.Unlock()
 		return
 	}
 	roastRetryRegistrationMu.Lock()

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // RoastRetryDeps bundles the per-process dependencies the FROST
@@ -19,53 +20,77 @@ type RoastRetryDeps struct {
 	SelfMember  uint32
 }
 
-// roastRetryRegistration is the package-private registry slot. Only
-// one set of dependencies can be registered at a time; later
-// registrations overwrite earlier ones. Callers wanting to test
-// reset behaviour use ResetRoastRetryRegistrationForTest.
+// roastRetryRegistrationByMember holds one set of ROAST-retry dependencies PER
+// local seat (member). A multi-seat operator registers one entry per member, each
+// with a Coordinator bound to THAT member (deps.SelfMember == member) so whichever
+// local seat is the elected ROAST coordinator for an attempt can aggregate; the
+// Signer and Verifier are the shared operator key. A single-seat node has one
+// entry. A later registration for the same member replaces the earlier one
+// (runtime reconfiguration is intentional). RFC-21 Phase 7.3 PR2b-1.5.
 var (
-	roastRetryRegistrationMu sync.RWMutex
-	roastRetryRegistration   RoastRetryDeps
-	roastRetryRegistered     bool
+	roastRetryRegistrationMu       sync.RWMutex
+	roastRetryRegistrationByMember = map[group.MemberIndex]RoastRetryDeps{}
 )
 
-// RegisterRoastRetryCoordinator stores the per-process ROAST-retry
-// dependencies the receive loops will pick up on their next call.
-// Safe for concurrent registration / lookup; a later registration
-// fully replaces an earlier one (this is the documented behaviour --
-// reconfiguring at runtime is intentional).
+// RegisterRoastRetryCoordinatorForMember stores the ROAST-retry dependencies for
+// one local seat. deps.SelfMember MUST equal member: the Coordinator is bound to
+// deps.SelfMember at construction, so registering it under a different member
+// would let AggregateBundle run as the wrong seat. A mismatch is rejected with no
+// registration (the seat stays ROAST-inactive -> legacy) rather than silently
+// mis-binding.
 //
-// As a side effect, the first registration starts the
-// session-handle sweeper goroutine that evicts orphaned bindings
-// (RFC-21 Phase 5.2 defence-in-depth backstop). Subsequent
-// registrations do not restart the sweeper.
-func RegisterRoastRetryCoordinator(deps RoastRetryDeps) {
+// As a side effect, the first registration starts the session-handle sweeper
+// goroutine that evicts orphaned bindings (defence-in-depth backstop); subsequent
+// registrations do not restart it.
+func RegisterRoastRetryCoordinatorForMember(member group.MemberIndex, deps RoastRetryDeps) {
+	if deps.SelfMember != uint32(member) {
+		return
+	}
 	roastRetryRegistrationMu.Lock()
-	roastRetryRegistration = deps
-	roastRetryRegistered = true
+	roastRetryRegistrationByMember[member] = deps
 	roastRetryRegistrationMu.Unlock()
 	StartSessionHandleSweeper()
 }
 
-// RegisteredRoastRetryCoordinator returns the currently-registered
-// dependencies and true, or the zero value and false if nothing has
-// been registered yet. Receivers use the boolean to decide between
-// the bounded recorder path and the Phase-2 NoOp fallback.
+// RegisteredRoastRetryCoordinatorForMember returns the dependencies registered for
+// the given local seat and true, or the zero value and false if that seat has
+// none. Member-aware receive/selection paths use this so a multi-seat operator's
+// elected seat aggregates with its OWN coordinator.
+func RegisteredRoastRetryCoordinatorForMember(member group.MemberIndex) (RoastRetryDeps, bool) {
+	roastRetryRegistrationMu.RLock()
+	defer roastRetryRegistrationMu.RUnlock()
+	deps, ok := roastRetryRegistrationByMember[member]
+	return deps, ok
+}
+
+// RegisterRoastRetryCoordinator is the legacy single-seat registration: it
+// registers deps under deps.SelfMember. Kept for single-seat wiring and the
+// existing test callers; production multi-seat wiring calls
+// RegisterRoastRetryCoordinatorForMember once per local seat.
+func RegisterRoastRetryCoordinator(deps RoastRetryDeps) {
+	RegisterRoastRetryCoordinatorForMember(group.MemberIndex(deps.SelfMember), deps)
+}
+
+// RegisteredRoastRetryCoordinator is the legacy single-seat lookup: it returns
+// SOME registered entry and true, or the zero value and false if none. For a
+// single-seat node it returns that node's only entry; under multi-seat it returns
+// an ARBITRARY entry (map order) and must not be used by member-aware code --
+// those paths use RegisteredRoastRetryCoordinatorForMember. Kept for the readiness
+// gate's any-registered check and single-seat/test compatibility.
 func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
 	roastRetryRegistrationMu.RLock()
 	defer roastRetryRegistrationMu.RUnlock()
-	if !roastRetryRegistered {
-		return RoastRetryDeps{}, false
+	for _, deps := range roastRetryRegistrationByMember {
+		return deps, true
 	}
-	return roastRetryRegistration, true
+	return RoastRetryDeps{}, false
 }
 
-// ResetRoastRetryRegistrationForTest clears the registry. Exposed
-// so tests in this and downstream packages can reset between cases
-// without leaking state. Not intended for production code paths.
+// ResetRoastRetryRegistrationForTest clears the registry. Exposed so tests in this
+// and downstream packages can reset between cases without leaking state. Not
+// intended for production code paths.
 func ResetRoastRetryRegistrationForTest() {
 	roastRetryRegistrationMu.Lock()
 	defer roastRetryRegistrationMu.Unlock()
-	roastRetryRegistration = RoastRetryDeps{}
-	roastRetryRegistered = false
+	roastRetryRegistrationByMember = map[group.MemberIndex]RoastRetryDeps{}
 }

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -43,7 +43,12 @@ var (
 // goroutine that evicts orphaned bindings (defence-in-depth backstop); subsequent
 // registrations do not restart it.
 func RegisterRoastRetryCoordinatorForMember(member group.MemberIndex, deps RoastRetryDeps) {
-	if deps.SelfMember != uint32(member) {
+	if member == 0 || deps.SelfMember != uint32(member) {
+		// Member indices are 1-based; a coordinator bound to selfMember 0 is the
+		// "disabled" sentinel that NEVER aggregates (coordinator_state.go), so
+		// registering under member 0 -- or under any member that disagrees with
+		// deps.SelfMember -- would silently mis-bind. Reject (the seat stays
+		// ROAST-inactive -> legacy) rather than register a non-aggregating entry.
 		return
 	}
 	roastRetryRegistrationMu.Lock()

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
@@ -79,18 +79,87 @@ func TestRoastRetryActive_GatesOnReadinessAndRegistration(t *testing.T) {
 	}
 }
 
-func TestRoastRetryRegistration_LaterRegistrationOverwrites(t *testing.T) {
+// TestRoastRetryActiveForMember_GatesPerMember asserts per-member activation: a
+// seat with a registered coordinator is active (given readiness + a producer); a
+// seat WITHOUT one is inactive even when a sibling seat is registered.
+func TestRoastRetryActiveForMember_GatesPerMember(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
 	ResetRoastRetryRegistrationForTest()
 	t.Cleanup(ResetRoastRetryRegistrationForTest)
 
-	RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: 1})
-	RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: 2})
-	got, ok := RegisteredRoastRetryCoordinator()
-	if !ok {
-		t.Fatal("expected ok=true after register")
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier()),
+		SelfMember:  1,
+	})
+
+	// Member 1 active iff a producer is built in; member 2 (unregistered) never.
+	if RoastRetryActiveForMember(1) != roastTransitionProducerAvailable() {
+		t.Fatalf("member 1: active must equal producer availability (%v); got %v",
+			roastTransitionProducerAvailable(), RoastRetryActiveForMember(1))
 	}
-	if got.SelfMember != 2 {
-		t.Fatalf("later registration must win: got %d want 2", got.SelfMember)
+	if RoastRetryActiveForMember(2) {
+		t.Fatal("member 2 (unregistered) must be inactive even with a sibling registered")
+	}
+
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "false")
+	if RoastRetryActiveForMember(1) {
+		t.Fatal("readiness off must yield inactive even for a registered member")
+	}
+}
+
+// TestRoastRetryRegistration_PerMemberOverwriteAndCoexist asserts the per-member
+// registry semantics (PR2b-1.5): registering the SAME member twice overwrites that
+// member's entry, while DIFFERENT members coexist (a multi-seat operator registers
+// one coordinator per local seat).
+func TestRoastRetryRegistration_PerMemberOverwriteAndCoexist(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	coord1a := roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier())
+	coord1b := roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier())
+	coord2 := roast.NewInMemoryCoordinatorWithSigning(2, roast.NoOpSigner(), roast.NoOpSignatureVerifier())
+
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{Coordinator: coord1a, SelfMember: 1})
+	RegisterRoastRetryCoordinatorForMember(2, RoastRetryDeps{Coordinator: coord2, SelfMember: 2})
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{Coordinator: coord1b, SelfMember: 1}) // overwrite 1
+
+	got1, ok := RegisteredRoastRetryCoordinatorForMember(1)
+	if !ok || got1.Coordinator != coord1b {
+		t.Fatalf("member 1 must hold the later (overwriting) coordinator; ok=%v", ok)
+	}
+	got2, ok := RegisteredRoastRetryCoordinatorForMember(2)
+	if !ok || got2.Coordinator != coord2 {
+		t.Fatalf("member 2 must coexist with member 1; ok=%v", ok)
+	}
+}
+
+// TestRoastRetryRegistration_RejectsSelfMemberMismatch asserts a coordinator
+// registered under a member that does not match deps.SelfMember is rejected -- the
+// coordinator is bound to deps.SelfMember at construction, so registering it under
+// a different member would let it aggregate as the wrong seat.
+func TestRoastRetryRegistration_RejectsSelfMemberMismatch(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	RegisterRoastRetryCoordinatorForMember(5, RoastRetryDeps{SelfMember: 3})
+	if _, ok := RegisteredRoastRetryCoordinatorForMember(5); ok {
+		t.Fatal("a SelfMember/member mismatch must not register")
+	}
+}
+
+// TestRoastRetryRegistration_LegacyWrapperRegistersUnderSelfMember asserts the
+// legacy single-arg RegisterRoastRetryCoordinator registers under deps.SelfMember,
+// so existing single-seat callers + RegisteredRoastRetryCoordinator round-trip.
+func TestRoastRetryRegistration_LegacyWrapperRegistersUnderSelfMember(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	RegisterRoastRetryCoordinator(RoastRetryDeps{SelfMember: 4})
+	if _, ok := RegisteredRoastRetryCoordinatorForMember(4); !ok {
+		t.Fatal("legacy register must place the entry under deps.SelfMember (4)")
+	}
+	if got, ok := RegisteredRoastRetryCoordinator(); !ok || got.SelfMember != 4 {
+		t.Fatalf("legacy lookup must round-trip the single entry; got %d ok=%v", got.SelfMember, ok)
 	}
 }
 

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry_test.go
@@ -147,6 +147,30 @@ func TestRoastRetryRegistration_RejectsSelfMemberMismatch(t *testing.T) {
 	}
 }
 
+// TestRoastRetryRegistration_RejectDropsExistingEntry asserts a rejected
+// re-registration (member 0 or a SelfMember mismatch) REMOVES any existing entry,
+// so a bad reconfiguration deactivates the seat (fail-safe to legacy) rather than
+// leaving stale deps active (Codex P2-2).
+func TestRoastRetryRegistration_RejectDropsExistingEntry(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier()),
+		SelfMember:  1,
+	})
+	if _, ok := RegisteredRoastRetryCoordinatorForMember(1); !ok {
+		t.Fatal("member 1 must be registered after a valid registration")
+	}
+
+	// A later mis-registration for member 1 (deps bound to member 2) must DROP the
+	// existing entry, not silently keep the stale one.
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{SelfMember: 2})
+	if _, ok := RegisteredRoastRetryCoordinatorForMember(1); ok {
+		t.Fatal("a rejected re-registration must drop the existing entry (fail-safe to inactive)")
+	}
+}
+
 // TestRoastRetryRegistration_LegacyWrapperRegistersUnderSelfMember asserts the
 // legacy single-arg RegisterRoastRetryCoordinator registers under deps.SelfMember,
 // so existing single-seat callers + RegisteredRoastRetryCoordinator round-trip.

--- a/pkg/frost/signing/roast_retry_submit.go
+++ b/pkg/frost/signing/roast_retry_submit.go
@@ -22,6 +22,9 @@ var roastRetryLogger = log.Logger("keep-frost-roast-retry")
 //
 //   - the ROAST-retry registry is empty (default build, no caller
 //     has invoked RegisterRoastRetryCoordinator);
+//   - more than one local seat is registered (multi-seat): this path
+//     is not yet member-aware (PR2b-1.5), so it disables itself rather
+//     than mis-attribute one seat's evidence to a sibling;
 //   - no session-handle binding exists for sessionID (the typical
 //     Phase-4 state, where the orchestration layer that calls
 //     SetCurrentAttemptHandleForSession is not yet implemented);
@@ -38,6 +41,17 @@ func submitSnapshotIfActive(
 	recorder attempt.EvidenceRecorder,
 ) {
 	if recorder == nil {
+		return
+	}
+	// RFC-21 Phase 7.3 PR2b-1.5: the coarse/drive evidence path is not yet
+	// member-aware -- it looks up deps via any-entry RegisteredRoastRetryCoordinator
+	// and keys the drive handle by sessionID alone. Under a MULTI-SEAT operator
+	// (more than one local seat registered) that would attribute one local seat's
+	// evidence to an arbitrary sibling and collide their drive handles, so disable
+	// it for multi-seat until PR2b-2 wires the member-aware coarse/drive path (where
+	// this evidence is consumed by the blame bridge). Single-seat is unchanged, and
+	// the whole path is inert in 1b/1.5 (no production caller submits yet).
+	if registeredRoastRetryMemberCount() > 1 {
 		return
 	}
 	deps, ok := RegisteredRoastRetryCoordinator()

--- a/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_native_roast_retry_test.go
@@ -73,6 +73,30 @@ func TestConsumeRoastTransitionForSelection_FailsClosedNoRecord(t *testing.T) {
 	}
 }
 
+// TestConsumeRoastTransitionForSelection_PartialRegistrationFailsClosed asserts the
+// multi-seat partial-activation fracture guard (Codex P2-1): when ROAST is active
+// for the process (one local seat registered) but the SELECTING seat has no
+// registered coordinator, selection FAILS CLOSED rather than falling back to legacy
+// -- a legacy fallback for the unregistered seat while a sibling selects from the
+// transition would split the included set.
+func TestConsumeRoastTransitionForSelection_PartialRegistrationFailsClosed(t *testing.T) {
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+	resetSelectionRegistries(t)
+	// One of the operator's seats (member 1) is registered; member 2 is NOT, so ROAST
+	// retry is active for the process but member 2 has no coordinator.
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: roast.NewInMemoryCoordinator(),
+		Signer:      roast.NoOpSigner(),
+		Verifier:    roast.NoOpSignatureVerifier(),
+		SelfMember:  1,
+	})
+
+	_, _, err := ConsumeRoastTransitionForSelection("session", 2, 1, 3)
+	if err == nil || errors.Is(err, ErrRoastSelectionFallBackToLegacy) {
+		t.Fatalf("partial registration must fail closed, not fall back to legacy; got %v", err)
+	}
+}
+
 func TestConsumeRoastTransitionForSelection_FailsClosedStaleRecord(t *testing.T) {
 	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
 	resetSelectionRegistries(t)

--- a/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
@@ -64,18 +64,29 @@ func ConsumeRoastTransitionForSelection(
 		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
 
-	// ROAST retry inactive (readiness opted out, no coordinator registered, or no
-	// transition producer built in -- frost_roast_retry && !frost_native): a uniform
-	// legacy fallback. This MUST mirror the observe/exchange gating, so a node that
-	// produced no records also does not expect to consume one; in particular,
-	// without a producer (RoastRetryActive false on the build) the selector must NOT
-	// fail-close every retry against records that can never be created (Codex P2-1).
-	if !RoastRetryActiveForMember(member) {
+	// The legacy-fallback decision is PROCESS-level (group-uniform), NOT per-member:
+	// readiness opted out, NO coordinator registered ANYWHERE in this process, or no
+	// transition producer built in (frost_roast_retry && !frost_native) -> a uniform
+	// legacy fallback every honest node makes identically. It must NOT be
+	// RoastRetryActiveForMember here: a multi-seat operator with member A registered
+	// and member B not would otherwise drive A via the transition and B via the
+	// legacy shuffle for the SAME attempt -> divergent included sets (fracture). The
+	// fallback sentinel is only safe when uniform (RFC-21 Phase 7.3 PR2b-1.5, Codex
+	// P2-1).
+	if !RoastRetryActive() {
 		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
+	// ROAST retry is active for the process, so THIS seat must have its own
+	// registered coordinator. A missing one is partial registration (a wiring bug)
+	// and FAILS CLOSED -- never legacy: falling back to legacy here while the
+	// registered sibling seats select from the transition would split the included
+	// set (the fracture class the sentinel must not enable).
 	deps, ok := RegisteredRoastRetryCoordinatorForMember(member)
 	if !ok || deps.Coordinator == nil {
-		return nil, nil, ErrRoastSelectionFallBackToLegacy
+		return nil, nil, fmt.Errorf(
+			"roast selection: seat %d has no registered coordinator under active ROAST retry; fail closed",
+			member,
+		)
 	}
 
 	// From here a transition from the prior COMMITTED attempt IS expected; its

--- a/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_selection_consume_frost_roast_retry.go
@@ -70,10 +70,10 @@ func ConsumeRoastTransitionForSelection(
 	// produced no records also does not expect to consume one; in particular,
 	// without a producer (RoastRetryActive false on the build) the selector must NOT
 	// fail-close every retry against records that can never be created (Codex P2-1).
-	if !RoastRetryActive() {
+	if !RoastRetryActiveForMember(member) {
 		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}
-	deps, ok := RegisteredRoastRetryCoordinator()
+	deps, ok := RegisteredRoastRetryCoordinatorForMember(member)
 	if !ok || deps.Coordinator == nil {
 		return nil, nil, ErrRoastSelectionFallBackToLegacy
 	}

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
@@ -117,8 +117,11 @@ func (e *RoastTransitionExchange) onSnapshot(msg RunnerMessage) {
 		return
 	}
 	elected, err := e.deps.Coordinator.SelectedCoordinator(binding.handle)
-	if err != nil || elected != group.MemberIndex(e.deps.SelfMember) {
-		// Only the elected coordinator collects snapshots for aggregation.
+	if err != nil || elected != e.member {
+		// Only the elected coordinator collects snapshots for aggregation. Compare
+		// against THIS exchange's seat (e.member), not deps.SelfMember: under
+		// PR2b-1.5 multi-seat, deps is per-seat so the two agree, but e.member is
+		// the unambiguous seat identity and avoids relying on the deps binding.
 		return
 	}
 	if err := e.deps.Coordinator.RecordEvidence(binding.handle, snapshot); err != nil {

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
@@ -370,6 +370,114 @@ func TestRoastTransitionExchange_ConsumedRetransmitDoesNotLoseSync(t *testing.T)
 	}
 }
 
+// TestRoastTransitionExchange_MultiSeatElectedSeatAggregates is the PR2b-1.5
+// acceptance test: when an operator controls multiple local seats and the elected
+// ROAST coordinator is one of them, that seat aggregates the transition bundle
+// using ITS OWN per-member coordinator (from the per-member registry). Pre-fix a
+// single process-wide coordinator bound to ONE SelfMember returned ErrNotAggregator
+// whenever the elected seat differed from it -> no bundle -> the next retry
+// fail-closed for the whole group.
+//
+// NOTE on local fanout (Codex's guardrail): this test delivers the sibling seats'
+// snapshots to the elected seat's exchange directly. In production the per-seat
+// exchanges share ONE wallet BroadcastChannel; a node's own broadcast reaches its
+// OTHER local seats' subscribers via the channel's self-delivery (libp2p FloodSub
+// delivers a node's publishes to its own subscriptions, and the membership
+// validator passes own-author). That self-delivery is a transport-contract
+// assumption to confirm at prod-wiring; if a transport does not self-deliver,
+// explicit local fanout is the remedy. The aggregation fix proven here is
+// independent of how the sibling snapshot arrives.
+func TestRoastTransitionExchange_MultiSeatElectedSeatAggregates(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	ResetRoastRetryRegistrationForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
+
+	roastSessionID := "multiseat-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x0d}
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := ctx.Hash()
+
+	// Deterministic elected coordinator for this context.
+	probe := roast.NewInMemoryCoordinatorWithSigning(0, fixedSigner{}, roast.NoOpSignatureVerifier())
+	probeHandle, err := probe.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("probe begin: %v", err)
+	}
+	elected, err := probe.SelectedCoordinator(probeHandle)
+	if err != nil {
+		t.Fatalf("probe elected: %v", err)
+	}
+
+	// One operator controls ALL included seats (the extreme multi-seat case): each
+	// seat gets its OWN coordinator bound to its member, registered per-member,
+	// sharing the operator key (fixedSigner).
+	for _, m := range included {
+		RegisterRoastRetryCoordinatorForMember(m, RoastRetryDeps{
+			Coordinator: roast.NewInMemoryCoordinatorWithSigning(m, fixedSigner{}, roast.NoOpSignatureVerifier()),
+			Signer:      fixedSigner{},
+			Verifier:    roast.NoOpSignatureVerifier(),
+			SelfMember:  uint32(m),
+		})
+	}
+
+	// Every seat observes the attempt with ITS OWN registered coordinator.
+	for _, m := range included {
+		deps, ok := RegisteredRoastRetryCoordinatorForMember(m)
+		if !ok {
+			t.Fatalf("deps for member %d missing", m)
+		}
+		handle, err := deps.Coordinator.BeginAttempt(ctx)
+		if err != nil {
+			t.Fatalf("begin attempt for %d: %v", m, err)
+		}
+		recordObservedAttempt(roastSessionID, m, hash, observedAttemptBinding{
+			handle:            handle,
+			context:           ctx,
+			dkgGroupPublicKey: dkgKey,
+		})
+	}
+
+	// Build the ELECTED seat's exchange from ITS registered deps (the coordinator
+	// bound to `elected`, NOT a process-default seat).
+	electedDeps, _ := RegisteredRoastRetryCoordinatorForMember(elected)
+	exCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	electedExchange := NewRoastTransitionExchange(
+		exCtx, log.Logger("multiseat"), &captureBus{}, electedDeps, roastSessionID, elected,
+	)
+
+	// Elected seat records its own forced snapshot; the sibling seats' forced
+	// snapshots arrive at the elected seat's exchange.
+	electedExchange.BroadcastForcedSnapshot(hash)
+	for _, m := range included {
+		if m == elected {
+			continue
+		}
+		payload, err := signedForcedSnapshot(m, hash).Marshal()
+		if err != nil {
+			t.Fatalf("marshal snapshot for %d: %v", m, err)
+		}
+		electedExchange.onSnapshot(RunnerMessage{
+			Type:    RunnerMsgEvidenceSnapshot,
+			Sender:  m,
+			Attempt: hash,
+			Payload: payload,
+		})
+	}
+
+	// The elected seat aggregates + stores the transition record with ITS own
+	// per-member coordinator -- the multi-seat fix.
+	electedExchange.AggregateAndBroadcast(hash)
+	if _, ok := RoastTransitionForSession(roastSessionID, elected); !ok {
+		t.Fatal("the elected local seat must aggregate + store a transition record with its own per-member coordinator")
+	}
+}
+
 // TestRoastTransitionExchange_SucceededSeatDoesNotStorePeerFailureBundle asserts
 // the core B3 outcome: after a seat clears its observe binding on local success, a
 // peer's failure bundle for that attempt is neither stored as a transition record

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
@@ -425,7 +425,13 @@ func TestRoastTransitionExchange_MultiSeatElectedSeatAggregates(t *testing.T) {
 		})
 	}
 
-	// Every seat observes the attempt with ITS OWN registered coordinator.
+	// Build an exchange + observe binding for EVERY local seat from ITS OWN
+	// registered per-member deps (the path the controller takes per signer); keep
+	// each seat's capture bus to inspect what it broadcasts.
+	exCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	buses := map[group.MemberIndex]*captureBus{}
+	exchanges := map[group.MemberIndex]*RoastTransitionExchange{}
 	for _, m := range included {
 		deps, ok := RegisteredRoastRetryCoordinatorForMember(m)
 		if !ok {
@@ -440,41 +446,63 @@ func TestRoastTransitionExchange_MultiSeatElectedSeatAggregates(t *testing.T) {
 			context:           ctx,
 			dkgGroupPublicKey: dkgKey,
 		})
+		bus := &captureBus{}
+		buses[m] = bus
+		exchanges[m] = NewRoastTransitionExchange(exCtx, log.Logger("multiseat"), bus, deps, roastSessionID, m)
 	}
 
-	// Build the ELECTED seat's exchange from ITS registered deps (the coordinator
-	// bound to `elected`, NOT a process-default seat).
-	electedDeps, _ := RegisteredRoastRetryCoordinatorForMember(elected)
-	exCtx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	electedExchange := NewRoastTransitionExchange(
-		exCtx, log.Logger("multiseat"), &captureBus{}, electedDeps, roastSessionID, elected,
-	)
-
-	// Elected seat records its own forced snapshot; the sibling seats' forced
-	// snapshots arrive at the elected seat's exchange.
-	electedExchange.BroadcastForcedSnapshot(hash)
+	// Every seat broadcasts its forced snapshot; the elected seat collects all (its
+	// own recorded in BroadcastForcedSnapshot, the siblings' delivered to it).
+	for _, m := range included {
+		exchanges[m].BroadcastForcedSnapshot(hash)
+	}
 	for _, m := range included {
 		if m == elected {
 			continue
 		}
-		payload, err := signedForcedSnapshot(m, hash).Marshal()
-		if err != nil {
-			t.Fatalf("marshal snapshot for %d: %v", m, err)
+		snaps := buses[m].only(RunnerMsgEvidenceSnapshot)
+		if len(snaps) != 1 {
+			t.Fatalf("member %d expected to broadcast 1 forced snapshot, got %d", m, len(snaps))
 		}
-		electedExchange.onSnapshot(RunnerMessage{
-			Type:    RunnerMsgEvidenceSnapshot,
-			Sender:  m,
-			Attempt: hash,
-			Payload: payload,
-		})
+		exchanges[elected].onSnapshot(snaps[0])
 	}
 
-	// The elected seat aggregates + stores the transition record with ITS own
-	// per-member coordinator -- the multi-seat fix.
-	electedExchange.AggregateAndBroadcast(hash)
+	// Each seat runs aggregation.
+	for _, m := range included {
+		exchanges[m].AggregateAndBroadcast(hash)
+	}
+
+	// The elected local seat aggregated with ITS OWN per-member coordinator: a
+	// transition record + exactly one broadcast bundle.
 	if _, ok := RoastTransitionForSession(roastSessionID, elected); !ok {
-		t.Fatal("the elected local seat must aggregate + store a transition record with its own per-member coordinator")
+		t.Fatal("the elected local seat must aggregate + store a record with its own per-member coordinator")
+	}
+	if got := buses[elected].only(RunnerMsgTransitionBundle); len(got) != 1 {
+		t.Fatalf("the elected seat must broadcast exactly one bundle, got %d", len(got))
+	}
+
+	// The NON-elected sibling seats must NOT aggregate. This is the non-vacuous half:
+	// pre-fix all seats shared ONE coordinator bound to the elected member, so a
+	// sibling's AggregateBundle would have run as the elected member and broadcast a
+	// bundle; per-member coordinators (bound to members != elected) make it
+	// ErrNotAggregator -> no bundle.
+	var sibling group.MemberIndex
+	for _, m := range included {
+		if m == elected {
+			continue
+		}
+		if got := buses[m].only(RunnerMsgTransitionBundle); len(got) != 0 {
+			t.Fatalf("non-elected local seat %d must not aggregate a bundle, got %d", m, len(got))
+		}
+		sibling = m
+	}
+
+	// A sibling seat receives the elected seat's bundle and stores ITS OWN
+	// next-attempt record with its own coordinator (the multi-seat sibling-unparking
+	// path that lets a non-elected local seat advance).
+	exchanges[sibling].onBundle(buses[elected].only(RunnerMsgTransitionBundle)[0])
+	if _, ok := RoastTransitionForSession(roastSessionID, sibling); !ok {
+		t.Fatal("a sibling local seat must store its own transition record from the elected seat's bundle")
 	}
 }
 

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -477,7 +477,7 @@ func (srl *signingRetryLoop) start(
 			// inactive keeps the block-paced attemptCounter (legacy, unchanged); the
 			// gate is the deterministic, group-wide RoastRetryActive predicate.
 			activeAttemptNumber := srl.attemptCounter
-			if signing.RoastRetryActive() {
+			if signing.RoastRetryActiveForMember(srl.signingGroupMemberIndex) {
 				activeAttemptNumber = committedRoastAttemptNumber + 1
 			}
 

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -474,8 +474,10 @@ func (srl *signingRetryLoop) start(
 			// attempt above. Keyed off attemptCounter, the two would diverge after a
 			// pre-selection skip or whenever a member is parked, binding signing
 			// messages and transition bundles to different context hashes. ROAST
-			// inactive keeps the block-paced attemptCounter (legacy, unchanged); the
-			// gate is the deterministic, group-wide RoastRetryActive predicate.
+			// inactive keeps the block-paced attemptCounter (legacy, unchanged). The
+			// gate is the PER-SEAT RoastRetryActiveForMember predicate (PR2b-1.5): a
+			// multi-seat operator may have one seat registered and another not, so
+			// activation is a per-member property; it stays deterministic per seat.
 			activeAttemptNumber := srl.attemptCounter
 			if signing.RoastRetryActiveForMember(srl.signingGroupMemberIndex) {
 				activeAttemptNumber = committedRoastAttemptNumber + 1

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -491,6 +492,25 @@ func (srl *signingRetryLoop) start(
 				transientlyParkedMembersIndexes: transientlyParkedMembersIndexes,
 			})
 			if err != nil {
+				// RFC-21 Phase 7.3 PR2b-1.5 (Codex/Gemini consult): a TERMINAL
+				// orchestration error is a STATIC condition no future attempt can
+				// resolve (e.g. multi-seat interactive ROAST orchestration that is not
+				// yet member-safe). Retrying is futile -- every attempt re-derives the
+				// same outcome -- and would spin until timeout while synthesizing garbage
+				// failed-attempt transitions via OnAttemptFailed below. Abort the loop
+				// immediately, BEFORE the retry/transition machinery; the outer
+				// wallet-signing layer gives up cleanly for this action. Coarse fallback
+				// is not an option here: interactive<->coarse mixing fractures the group.
+				if errors.Is(err, signing.ErrTerminalSigningFailure) {
+					srl.logger.Errorf(
+						"[member:%v] terminal signing failure on attempt [%v]: [%v]; "+
+							"aborting retry loop",
+						srl.signingGroupMemberIndex,
+						srl.attemptCounter,
+						err,
+					)
+					return nil, err
+				}
 				srl.logger.Warnf(
 					"[member:%v] failed attempt [%v]: [%v]; "+
 						"starting next attempt",

--- a/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_transition_controller_frost_native_roast_retry.go
@@ -75,10 +75,13 @@ func newRoastTransitionExchangeForRequest(
 	logger log.StandardLogger,
 	template *signing.Request,
 ) roastTransitionExchange {
-	if err := signing.EnsureRoastRetryReadinessOptIn(); err != nil {
+	// RFC-21 Phase 7.3 PR2b-1.5: gate + fetch deps for THIS seat, so a multi-seat
+	// operator's exchange uses the coordinator bound to template.MemberIndex (the
+	// elected-but-not-process-default seat can then collect + aggregate).
+	if !signing.RoastRetryActiveForMember(template.MemberIndex) {
 		return nil
 	}
-	deps, ok := signing.RegisteredRoastRetryCoordinator()
+	deps, ok := signing.RegisteredRoastRetryCoordinatorForMember(template.MemberIndex)
 	if !ok || deps.Coordinator == nil {
 		return nil
 	}

--- a/pkg/tbtc/signing_loop_test.go
+++ b/pkg/tbtc/signing_loop_test.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -748,6 +749,88 @@ func TestSigningRetryLoop_GetCurrentBlockErrorCausesRetry(t *testing.T) {
 			"unexpected error\nexpected: [%v]\nactual:   [%v]",
 			context.DeadlineExceeded,
 			err,
+		)
+	}
+}
+
+// TestSigningRetryLoop_TerminalErrorAbortsWithoutRetry asserts that a terminal
+// signing failure from the attempt function (signing.ErrTerminalSigningFailure,
+// e.g. multi-seat interactive ROAST orchestration that is not yet member-safe)
+// ABORTS the loop after a single attempt instead of being retried. A retryable
+// error would re-invoke the attempt fn until the context deadline; a terminal one
+// must surface immediately so the outer wallet layer fails closed cleanly.
+func TestSigningRetryLoop_TerminalErrorAbortsWithoutRetry(t *testing.T) {
+	message := big.NewInt(100)
+
+	groupParameters := &GroupParameters{
+		GroupSize:       10,
+		HonestThreshold: 6,
+	}
+
+	signingGroupOperators := chain.Addresses{
+		"address-1", "address-2", "address-8", "address-4",
+		"address-2", "address-6", "address-7", "address-8",
+		"address-9", "address-8",
+	}
+
+	allMembers := make([]group.MemberIndex, 0, len(signingGroupOperators))
+	for i := range signingGroupOperators {
+		allMembers = append(allMembers, group.MemberIndex(i+1))
+	}
+
+	retryLoop := newSigningRetryLoop(
+		&testutils.MockLogger{},
+		message,
+		"",
+		200,
+		1,
+		signingGroupOperators,
+		groupParameters,
+		&mockSigningAnnouncer{
+			outgoingAnnouncements: make(map[string]group.MemberIndex),
+			incomingAnnouncementsFn: func(string) ([]group.MemberIndex, error) {
+				return allMembers, nil
+			},
+		},
+		&mockSigningDoneCheck{
+			waitUntilAllDoneOutcomeFn: func(uint64) (*signing.Result, uint64, error) {
+				panic("should not be reached: a terminal error aborts before the done check")
+			},
+		},
+	)
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelCtx()
+
+	// A wrapped terminal sentinel, exactly as BeginOrchestrationForSession produces
+	// for a multi-seat operator.
+	terminalErr := fmt.Errorf(
+		"%w: synthetic multi-seat orchestration",
+		signing.ErrTerminalSigningFailure,
+	)
+	attemptCalls := 0
+
+	_, err := retryLoop.start(
+		ctx,
+		func(context.Context, uint64) error { return nil },
+		func() (uint64, error) { return 200, nil },
+		func(*signingAttemptParams) (*signing.Result, uint64, error) {
+			attemptCalls++
+			return nil, 0, terminalErr
+		},
+	)
+
+	if !errors.Is(err, signing.ErrTerminalSigningFailure) {
+		t.Errorf(
+			"expected a terminal signing failure to propagate; got [%v]",
+			err,
+		)
+	}
+	if attemptCalls != 1 {
+		t.Errorf(
+			"terminal error must abort after exactly one attempt (no retry); "+
+				"got %d attempt calls",
+			attemptCalls,
 		)
 	}
 }


### PR DESCRIPTION
## Summary

RFC-21 Phase 7.3 PR2b-1.5 — multi-seat ROAST per-seat coordinator deps. A
multi-seat operator (one node controlling multiple signing-group members) runs one
signer goroutine per local seat, but ROAST deps were registered ONCE process-wide
(one `Coordinator` bound to one `SelfMember`). So when the elected ROAST
coordinator for a failed attempt was a local seat OTHER than `deps.SelfMember`,
that seat could neither collect snapshots nor aggregate (`AggregateBundle` →
`ErrNotAggregator`) → no transition bundle → the next retry fail-closed for the
whole group.

**Fix (consult-locked Option A — Codex+Gemini converged):** a member-keyed registry
(`map[MemberIndex]RoastRetryDeps`) + per-member API, so each local seat uses ITS OWN
coordinator (bound to that member). Whichever local seat is elected aggregates with
its own binding.

**Gated + dormant.** Behind `frost_native && frost_roast_retry` + the readiness env
gate; no production code registers a coordinator (the path is inert until post-audit
prod-wiring). **Single-seat is byte-identical** — the legacy any-entry helpers are
kept as back-compat wrappers, so the ~20 test callers + default stubs are untouched.

## Commits

- **Foundation** (`4829c9223`) — member-keyed registry + `…ForMember` API +
  back-compat wrappers + `RoastRetryActiveForMember`
- **Activation** (`3b0017c4e`) — thread per-member deps through observe / exchange
  (`elected == e.member`) / selector / orchestration / interactive drive /
  controller / loop
- **Acceptance test** (`e031eca19`) + **non-vacuous rewrite + review folds**
  (`649ca2802`) — the elected seat aggregates with its own coordinator AND the
  siblings do NOT; member-0 reject; doc/DRY cleanups

## Fracture-safety

A multi-seat operator's seats are cryptographically indistinguishable from
independent single-seat nodes: each has its own isolated coordinator instance,
observe handle, and exchange. Signing a bundle "as" the elected local member
(CoordinatorID = elected) with the operator-scoped key is sound — the payload
commits to the member, and the operator key verifies for multiple member IDs.

## Out of scope / deferred (documented)

- **Local fanout** — the per-seat exchanges share one wallet `BroadcastChannel`; a
  sibling's broadcast reaches the elected seat via libp2p FloodSub self-delivery
  (`channel.deliver` fans to all handlers, no self-filter). A transport-contract
  assumption to confirm at prod-wiring; explicit local fanout is the remedy if a
  transport does not self-deliver.
- **Coarse evidence path** (`submitSnapshotIfActive` / the session-keyed coarse
  handle registry) keeps the legacy any-entry lookup — a *pre-existing* latent
  multi-seat issue (the coarse receive-loop binding registry is not member-keyed;
  no live binding producer is wired). Separate from the transition-aggregation fix.

## Hard gates (pre-production)

`frost-secp256k1-tr =3.0.0` external audit + recovery-leaf decision.
**Prod-wiring prerequisite:** the step that first registers a ROAST coordinator must
register per-seat (one per local member); single-seat-only registration would
re-introduce the multi-seat fail-close.

## Testing

gofmt; build + vet across default / `frost_native` / `frost_roast_retry`-only /
`frost_native frost_roast_retry` / `frost_native frost_tbtc_signer cgo`; `-race`;
full `pkg/frost/signing` × 3 producer states; full `pkg/tbtc` tagged 208s +
`frost_roast_retry`-only 146.7s + default 146.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
