### PR TITLE
test(tbtc): tag signer-material resolver tests to their build flavour

### DIFF
--- a/pkg/tbtc/signer_material_encoding_frost_native_test.go
+++ b/pkg/tbtc/signer_material_encoding_frost_native_test.go
@@ -1,4 +1,4 @@
-//go:build frost_native
+//go:build frost_native && !(frost_tbtc_signer && cgo)
 
 package tbtc
 

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer_test.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_tbtc_signer_test.go
@@ -1,0 +1,64 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package tbtc
+
+import (
+	"strings"
+	"testing"
+
+	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
+)
+
+// TestRegisterSignerMaterialResolverForBuild_DefaultProviderRefusesScaffoldWithoutOptIn
+// asserts the cgo frost_tbtc_signer resolver REFUSES to surface scaffold-era
+// signer material unless the operator opts in via AcceptScaffoldKeyGroupEnvVar.
+//
+// This is cgo-only behaviour: only the frost_tbtc_signer (cgo) resolver carries
+// the resolver-level refusal guard. The non-cgo frost_native resolver
+// intentionally PERMITS scaffold resolution -- it is the transitional build, and
+// the deeper native_ffi_primitive guard refuses scaffold material at signing
+// time instead. The migration tests in signer_material_encoding_frost_native_test.go
+// (tagged for the non-cgo build) assert that permissive behaviour. This test
+// therefore lives behind the cgo tag so it exercises the resolver whose contract
+// it describes; previously it was tagged plain frost_native and failed under any
+// non-cgo frost_native build.
+func TestRegisterSignerMaterialResolverForBuild_DefaultProviderRefusesScaffoldWithoutOptIn(
+	t *testing.T,
+) {
+	// Force the env var to "" so a stray external value cannot suppress the
+	// scaffold refusal during this regression test.
+	t.Setenv(frostsigning.AcceptScaffoldKeyGroupEnvVar, "")
+
+	UnregisterSignerMaterialResolver()
+	UnregisterSignerMaterialResolverProviderForBuild()
+	t.Cleanup(UnregisterSignerMaterialResolver)
+	t.Cleanup(UnregisterSignerMaterialResolverProviderForBuild)
+
+	err := RegisterSignerMaterialResolverForBuild()
+	if err != nil {
+		t.Fatalf("unexpected build resolver registration error: [%v]", err)
+	}
+
+	privateKeyShare := createMockSigner(t).privateKeyShare
+	_, err = resolveSignerMaterial(privateKeyShare)
+	if err == nil {
+		t.Fatal(
+			"expected scaffold-refusal error from default resolver without opt-in",
+		)
+	}
+
+	if !strings.Contains(err.Error(), frostsigning.AcceptScaffoldKeyGroupEnvVar) {
+		t.Fatalf(
+			"expected scaffold-refusal error to reference %s; got: [%v]",
+			frostsigning.AcceptScaffoldKeyGroupEnvVar,
+			err,
+		)
+	}
+	if !strings.Contains(err.Error(), frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey) {
+		t.Fatalf(
+			"expected scaffold-refusal error to reference %s; got: [%v]",
+			frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+			err,
+		)
+	}
+}

--- a/pkg/tbtc/signer_material_resolver_build_frost_native_test.go
+++ b/pkg/tbtc/signer_material_resolver_build_frost_native_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
@@ -197,46 +196,5 @@ func TestRegisterSignerMaterialResolverForBuild_ProviderReturnsNilResolver(
 	err = RegisterSignerMaterialResolverForBuild()
 	if err == nil {
 		t.Fatal("expected build resolver registration error")
-	}
-}
-
-func TestRegisterSignerMaterialResolverForBuild_DefaultProviderRefusesScaffoldWithoutOptIn(
-	t *testing.T,
-) {
-	// Force the env var to "" so a stray external value cannot suppress the
-	// scaffold refusal during this regression test.
-	t.Setenv(frostsigning.AcceptScaffoldKeyGroupEnvVar, "")
-
-	UnregisterSignerMaterialResolver()
-	UnregisterSignerMaterialResolverProviderForBuild()
-	t.Cleanup(UnregisterSignerMaterialResolver)
-	t.Cleanup(UnregisterSignerMaterialResolverProviderForBuild)
-
-	err := RegisterSignerMaterialResolverForBuild()
-	if err != nil {
-		t.Fatalf("unexpected build resolver registration error: [%v]", err)
-	}
-
-	privateKeyShare := createMockSigner(t).privateKeyShare
-	_, err = resolveSignerMaterial(privateKeyShare)
-	if err == nil {
-		t.Fatal(
-			"expected scaffold-refusal error from default resolver without opt-in",
-		)
-	}
-
-	if !strings.Contains(err.Error(), frostsigning.AcceptScaffoldKeyGroupEnvVar) {
-		t.Fatalf(
-			"expected scaffold-refusal error to reference %s; got: [%v]",
-			frostsigning.AcceptScaffoldKeyGroupEnvVar,
-			err,
-		)
-	}
-	if !strings.Contains(err.Error(), frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey) {
-		t.Fatalf(
-			"expected scaffold-refusal error to reference %s; got: [%v]",
-			frostsigning.NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
-			err,
-		)
 	}
 }


### PR DESCRIPTION
## Problem

Three signer-material resolver tests were tagged plain `//go:build frost_native`, but each asserts behaviour that exists only under **one** build flavour — so no single build ran them all green. The failure surfaced when `pkg/tbtc` was exercised under a non-cgo `frost_native` combo (e.g. `frost_native frost_roast_retry`).

| Test (was `frost_native`) | non-cgo `frost_native` | cgo `frost_native frost_tbtc_signer` |
|---|---|---|
| `...DefaultProviderRefusesScaffoldWithoutOptIn` | ❌ FAIL | ✅ PASS |
| `...LegacyEncodingResolvesNativeMaterialOnFrostNativeBuild` | ✅ PASS | ❌ FAIL |
| `...LegacyRoundtripMigratesToNativeEnvelopeOnFrostNativeBuild` | ✅ PASS | ❌ FAIL |

The two resolvers differ **by design**:

- The **cgo** `frost_tbtc_signer` resolver (`signer_material_resolver_build_frost_native_tbtc_signer.go`) **refuses** to surface scaffold-era placeholder material unless the operator opts in via `KEEP_CORE_FROST_TBTC_SIGNER_ACCEPT_SCAFFOLD_KEY_GROUP`.
- The **non-cgo** `frost_native` resolver (`signer_material_resolver_build_frost_native.go`) **permits** it — it is the transitional build, and the deeper `native_ffi_primitive` guard refuses scaffold material at *signing* time instead.

The refusal test asserts the cgo contract; the two migration tests assert the non-cgo contract. They were just mis-tagged.

## Fix

Re-tag each test to the build whose resolver contract it exercises, mirroring the resolver files' own tag split:

- Move the refusal test into a new cgo-tagged file `signer_material_resolver_build_frost_native_tbtc_signer_test.go` (`frost_native && frost_tbtc_signer && cgo`).
- Tag the migration tests `frost_native && !(frost_tbtc_signer && cgo)`.

**Test-only change; no production behaviour changes.**

## Verification

- `gofmt` clean.
- Signer-material suite green under `frost_native`, `frost_native frost_roast_retry`, and `frost_native frost_tbtc_signer` (cgo).
- Confirmed each moved test **executes** in its target build and is **excluded** (`no tests to run`) from the other — no test stranded in zero builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)