### PR TITLE
feat(frost): member-key the ROAST session-handle binding (7.3 PR2b-2 step 1)

### DIFF
--- a/pkg/frost/signing/attempt_context_binding_validation_default_build_test.go
+++ b/pkg/frost/signing/attempt_context_binding_validation_default_build_test.go
@@ -14,7 +14,7 @@ func TestVerifyMessageAttemptContextHash_DefaultBuildPassesEverything(t *testing
 	// build, matching the rollback promise made in the rollout
 	// guide (docs/development/frost-roast-retry-rollout.adoc).
 	msg := stubDefaultBuildMessage{}
-	if err := verifyMessageAttemptContextHash(msg, "any-session"); err != nil {
+	if err := verifyMessageAttemptContextHash(msg, "any-session", 1); err != nil {
 		t.Fatalf(
 			"default build must always pass; got %v",
 			err,

--- a/pkg/frost/signing/attempt_context_binding_validation_frost_native.go
+++ b/pkg/frost/signing/attempt_context_binding_validation_frost_native.go
@@ -5,6 +5,8 @@ package signing
 import (
 	"errors"
 	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // attemptContextHashCarrier is implemented by every protocol
@@ -49,11 +51,17 @@ var ErrAttemptContextHashMismatch = errors.New(
 // optional to required at the receive boundary, but only when the
 // session has a ROAST-attempt binding registered.
 //
-// When no session-handle binding exists for sessionID (the typical
-// state for non-ROAST sessions and for default builds), this
+// When no session-handle binding exists for (sessionID, member) (the
+// typical state for non-ROAST sessions and for default builds), this
 // function returns nil and lets the message through. The receive
 // loop's other gates (shouldAcceptNativeFROSTMessage, etc.) still
 // apply.
+//
+// member is the LOCAL receiver seat's member index (request.MemberIndex),
+// NOT the inbound message's sender: the binding being enforced is the
+// one THIS seat's orchestration set for the attempt it is running. A
+// multi-seat operator keys its bindings per seat (RFC-21 Phase 7.3
+// PR2b-2), so looking up by sender would read the wrong (or no) binding.
 //
 // When a binding exists -- i.e. the orchestration layer has begun
 // an attempt for this session and is expecting the receive loops
@@ -64,8 +72,9 @@ var ErrAttemptContextHashMismatch = errors.New(
 func verifyMessageAttemptContextHash(
 	msg attemptContextHashCarrier,
 	sessionID string,
+	member group.MemberIndex,
 ) error {
-	_, ctx, ok := currentAttemptHandleForCollect(sessionID)
+	_, ctx, ok := currentAttemptHandleForCollect(sessionID, member)
 	if !ok {
 		// No binding: legacy / non-ROAST mode. Skip enforcement
 		// so default builds and non-ROAST sessions stay
@@ -91,12 +100,16 @@ func verifyMessageAttemptContextHash(
 // setMessageAttemptContextHashIfBound attaches the current ROAST
 // attempt binding to an outbound message. Default/non-ROAST sessions
 // have no binding, so the field stays absent for backward
-// compatibility.
+// compatibility. member is the local sender seat's member index
+// (request.MemberIndex); the binding is looked up per (sessionID,
+// member) so a multi-seat operator tags each seat's outbound message
+// with that seat's own bound context (RFC-21 Phase 7.3 PR2b-2).
 func setMessageAttemptContextHashIfBound(
 	msg outboundAttemptContextHashCarrier,
 	sessionID string,
+	member group.MemberIndex,
 ) {
-	_, ctx, ok := currentAttemptHandleForCollect(sessionID)
+	_, ctx, ok := currentAttemptHandleForCollect(sessionID, member)
 	if !ok {
 		return
 	}

--- a/pkg/frost/signing/attempt_context_binding_validation_frost_native_test.go
+++ b/pkg/frost/signing/attempt_context_binding_validation_frost_native_test.go
@@ -62,7 +62,7 @@ func TestVerifyMessageAttemptContextHash_NoBindingPasses(t *testing.T) {
 		{present: true, hash: [AttemptContextHashFieldLength]byte{0x01}},
 	}
 	for _, msg := range cases {
-		if err := verifyMessageAttemptContextHash(msg, "session-x"); err != nil {
+		if err := verifyMessageAttemptContextHash(msg, "session-x", 1); err != nil {
 			t.Fatalf(
 				"no-binding path must pass; got %v for msg %+v",
 				err, msg,
@@ -76,11 +76,11 @@ func TestVerifyMessageAttemptContextHash_BindingPresent_MatchingHashPasses(t *te
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContextForValidation(t)
-	SetCurrentAttemptHandleForSession("session-match", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-match", 1, roast.AttemptHandle{}, ctx)
 
 	expected := ctx.Hash()
 	msg := stubMessage{hash: expected, present: true}
-	if err := verifyMessageAttemptContextHash(msg, "session-match"); err != nil {
+	if err := verifyMessageAttemptContextHash(msg, "session-match", 1); err != nil {
 		t.Fatalf("matching hash must pass; got %v", err)
 	}
 }
@@ -90,10 +90,10 @@ func TestVerifyMessageAttemptContextHash_BindingPresent_MissingHashFails(t *test
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContextForValidation(t)
-	SetCurrentAttemptHandleForSession("session-missing", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-missing", 1, roast.AttemptHandle{}, ctx)
 
 	msg := stubMessage{present: false}
-	err := verifyMessageAttemptContextHash(msg, "session-missing")
+	err := verifyMessageAttemptContextHash(msg, "session-missing", 1)
 	if !errors.Is(err, ErrAttemptContextHashMissing) {
 		t.Fatalf(
 			"expected ErrAttemptContextHashMissing; got %v",
@@ -107,19 +107,50 @@ func TestVerifyMessageAttemptContextHash_BindingPresent_MismatchedHashFails(t *t
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContextForValidation(t)
-	SetCurrentAttemptHandleForSession("session-mismatch", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-mismatch", 1, roast.AttemptHandle{}, ctx)
 
 	wrong := [AttemptContextHashFieldLength]byte{}
 	for i := range wrong {
 		wrong[i] = 0xff
 	}
 	msg := stubMessage{hash: wrong, present: true}
-	err := verifyMessageAttemptContextHash(msg, "session-mismatch")
+	err := verifyMessageAttemptContextHash(msg, "session-mismatch", 1)
 	if !errors.Is(err, ErrAttemptContextHashMismatch) {
 		t.Fatalf(
 			"expected ErrAttemptContextHashMismatch; got %v",
 			err,
 		)
+	}
+}
+
+// TestVerifyMessageAttemptContextHash_BindingIsMemberScoped asserts the binding
+// lookup is keyed by the LOCAL receiver seat's member (request.MemberIndex), not
+// shared across seats: a binding set for member 1 enforces the hash for member 1
+// but is invisible to member 2's receive loop (which has its own binding or, here,
+// none -> passes through). This is the PR2b-2 member-keying applied to the receive
+// validation path; under the old sessionID-only key, member 2 would have enforced
+// member 1's binding.
+func TestVerifyMessageAttemptContextHash_BindingIsMemberScoped(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	ctx := newOrchestrationTestContextForValidation(t)
+	SetCurrentAttemptHandleForSession("session-scoped", 1, roast.AttemptHandle{}, ctx)
+
+	// A message that does NOT match the bound context.
+	wrong := [AttemptContextHashFieldLength]byte{}
+	for i := range wrong {
+		wrong[i] = 0xff
+	}
+	msg := stubMessage{hash: wrong, present: true}
+
+	// Member 1 has the binding -> enforcement runs -> mismatch.
+	if err := verifyMessageAttemptContextHash(msg, "session-scoped", 1); !errors.Is(err, ErrAttemptContextHashMismatch) {
+		t.Fatalf("member 1 must enforce its binding; got %v", err)
+	}
+	// Member 2 has no binding for this session -> passes through (no enforcement).
+	if err := verifyMessageAttemptContextHash(msg, "session-scoped", 2); err != nil {
+		t.Fatalf("member 2 (no binding) must pass through; got %v", err)
 	}
 }
 
@@ -132,7 +163,7 @@ func TestVerifyMessageAttemptContextHash_RealMessageTypeIntegration(t *testing.T
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContextForValidation(t)
-	SetCurrentAttemptHandleForSession("session-real-msg", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-real-msg", 1, roast.AttemptHandle{}, ctx)
 
 	expected := ctx.Hash()
 	msg := &buildTaggedTBTCSignerRoundContributionMessage{
@@ -143,7 +174,7 @@ func TestVerifyMessageAttemptContextHash_RealMessageTypeIntegration(t *testing.T
 	}
 	msg.SetAttemptContextHash(expected)
 
-	if err := verifyMessageAttemptContextHash(msg, "session-real-msg"); err != nil {
+	if err := verifyMessageAttemptContextHash(msg, "session-real-msg", 1); err != nil {
 		t.Fatalf("real-message integration must pass; got %v", err)
 	}
 
@@ -157,9 +188,9 @@ func TestVerifyMessageAttemptContextHash_RealMessageTypeIntegration(t *testing.T
 		[]group.MemberIndex{1, 2, 3, 4, 5},
 		nil,
 	)
-	SetCurrentAttemptHandleForSession("session-real-msg", roast.AttemptHandle{}, differentCtx)
+	SetCurrentAttemptHandleForSession("session-real-msg", 1, roast.AttemptHandle{}, differentCtx)
 
-	err := verifyMessageAttemptContextHash(msg, "session-real-msg")
+	err := verifyMessageAttemptContextHash(msg, "session-real-msg", 1)
 	if !errors.Is(err, ErrAttemptContextHashMismatch) {
 		t.Fatalf("rebinding must cause mismatch; got %v", err)
 	}
@@ -170,10 +201,10 @@ func TestSetMessageAttemptContextHashIfBound_AttachesBoundHash(t *testing.T) {
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContextForValidation(t)
-	SetCurrentAttemptHandleForSession("session-outbound", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-outbound", 1, roast.AttemptHandle{}, ctx)
 
 	msg := &stubMessage{}
-	setMessageAttemptContextHashIfBound(msg, "session-outbound")
+	setMessageAttemptContextHashIfBound(msg, "session-outbound", 1)
 
 	got, present := msg.GetAttemptContextHash()
 	if !present {
@@ -189,7 +220,7 @@ func TestSetMessageAttemptContextHashIfBound_NoBindingLeavesAbsent(t *testing.T)
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	msg := &stubMessage{}
-	setMessageAttemptContextHashIfBound(msg, "session-no-binding")
+	setMessageAttemptContextHashIfBound(msg, "session-no-binding", 1)
 
 	if _, present := msg.GetAttemptContextHash(); present {
 		t.Fatal("expected no attempt context hash without a session binding")
@@ -201,7 +232,7 @@ func TestSetMessageAttemptContextHashIfBound_AllOutboundMessageTypes(t *testing.
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContextForValidation(t)
-	SetCurrentAttemptHandleForSession("session-all-types", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-all-types", 1, roast.AttemptHandle{}, ctx)
 	expected := ctx.Hash()
 
 	messages := []attemptContextHashCarrier{
@@ -214,7 +245,7 @@ func TestSetMessageAttemptContextHashIfBound_AllOutboundMessageTypes(t *testing.
 			t.Fatalf("%T does not implement outbound carrier", msg)
 		}
 
-		setMessageAttemptContextHashIfBound(outbound, "session-all-types")
+		setMessageAttemptContextHashIfBound(outbound, "session-all-types", 1)
 
 		got, present := msg.GetAttemptContextHash()
 		if !present {

--- a/pkg/frost/signing/attempt_context_bound_exchange_frost_native_test.go
+++ b/pkg/frost/signing/attempt_context_bound_exchange_frost_native_test.go
@@ -38,7 +38,14 @@ func bindAttemptContextHashForExchangeTest(
 		t.Fatalf("failed creating attempt context: [%v]", err)
 	}
 
-	SetCurrentAttemptHandleForSession(sessionID, roast.AttemptHandle{}, ctx)
+	// Bind the (identical, group-level) attempt context for EVERY participating
+	// local member seat. The bootstrap round runs one receive loop per member, and
+	// each loop looks the binding up by its own (sessionID, member) after PR2b-2
+	// member-keyed the registry; binding only one member would leave the others'
+	// loops unbound and silently skip the hash enforcement this test exercises.
+	for _, member := range members {
+		SetCurrentAttemptHandleForSession(sessionID, member, roast.AttemptHandle{}, ctx)
+	}
 }
 
 func TestBuildTaggedTBTCSignerBootstrapCoarseRound_BoundAttemptContextHashExchange(

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -1086,7 +1086,7 @@ func buildTaggedTBTCSignerRoundContributions(
 		ContributionIdentifier: ownContribution.Identifier,
 		ContributionData:       append([]byte{}, ownContribution.Data...),
 	}
-	setMessageAttemptContextHashIfBound(roundContributionMessage, request.SessionID)
+	setMessageAttemptContextHashIfBound(roundContributionMessage, request.SessionID, request.MemberIndex)
 
 	if err := request.Channel.Send(
 		ctx,
@@ -1102,7 +1102,7 @@ func buildTaggedTBTCSignerRoundContributions(
 	// when nothing is registered preserves Phase 2 receive
 	// semantics.
 	contributionsRecorder := roastRetryRecorderForCollect()
-	defer submitSnapshotIfActive(request.SessionID, contributionsRecorder)
+	defer submitSnapshotIfActive(request.SessionID, request.MemberIndex, contributionsRecorder)
 	peerMessages, err := collectBuildTaggedTBTCSignerRoundContributionMessages(
 		ctx,
 		request,
@@ -1237,7 +1237,7 @@ func collectBuildTaggedTBTCSignerRoundContributionMessages(
 			return
 		}
 
-		if err := verifyMessageAttemptContextHash(payload, request.SessionID); err != nil {
+		if err := verifyMessageAttemptContextHash(payload, request.SessionID, request.MemberIndex); err != nil {
 			evidence.RecordReject(payload.SenderID(), "attempt_context_hash_mismatch")
 			return
 		}

--- a/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_default_build.go
@@ -5,14 +5,16 @@ package signing
 import (
 	"github.com/keep-network/keep-core/pkg/frost/roast"
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // SetCurrentAttemptHandleForSession is a no-op in the default build:
-// the receive loops will never find a handle for any session, so the
-// snapshot submission path is dormant. The build-tagged
+// the receive loops will never find a handle for any (session, member),
+// so the snapshot submission path is dormant. The build-tagged
 // implementation does the real registration.
 func SetCurrentAttemptHandleForSession(
 	_ string,
+	_ group.MemberIndex,
 	_ roast.AttemptHandle,
 	_ attempt.AttemptContext,
 ) {
@@ -20,7 +22,7 @@ func SetCurrentAttemptHandleForSession(
 
 // ClearCurrentAttemptHandleForSession is a no-op in the default
 // build.
-func ClearCurrentAttemptHandleForSession(_ string) {}
+func ClearCurrentAttemptHandleForSession(_ string, _ group.MemberIndex) {}
 
 // ResetSessionHandleRegistryForTest is a no-op in the default
 // build.
@@ -35,6 +37,7 @@ func StartSessionHandleSweeper() {}
 // the RecordEvidence call.
 func currentAttemptHandleForCollect(
 	_ string,
+	_ group.MemberIndex,
 ) (roast.AttemptHandle, attempt.AttemptContext, bool) {
 	return roast.AttemptHandle{}, attempt.AttemptContext{}, false
 }
@@ -45,6 +48,7 @@ func currentAttemptHandleForCollect(
 // always returns ok=false.
 func CurrentAttemptHandleForSession(
 	sessionID string,
+	member group.MemberIndex,
 ) (roast.AttemptHandle, attempt.AttemptContext, bool) {
-	return currentAttemptHandleForCollect(sessionID)
+	return currentAttemptHandleForCollect(sessionID, member)
 }

--- a/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_attempt_handle_frost_roast_retry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/frost/roast"
 	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
 // SessionHandleBindingTTL is the maximum age the eviction sweep
@@ -25,9 +26,24 @@ const SessionHandleBindingTTL = 2 * time.Hour
 // goroutine churn.
 const SessionHandleSweepInterval = 15 * time.Minute
 
+// sessionMemberKey identifies a binding by the signing session AND the
+// local member seat it belongs to. RFC-21 Phase 7.3 PR2b-2 re-keyed the
+// registry from sessionID alone to (sessionID, member): a multi-seat
+// operator runs one receive loop per local seat, and each seat mints its
+// own attempt handle from its own coordinator. Keying by sessionID alone
+// let sibling seats collide -- the later Set overwrote the earlier seat's
+// handle (mis-attributing its evidence) and one seat's cleanup deleted the
+// shared binding out from under the survivor (silently disabling the
+// survivor's inbound attempt-context-hash enforcement). The member
+// component isolates each seat's binding so neither happens.
+type sessionMemberKey struct {
+	sessionID string
+	member    group.MemberIndex
+}
+
 // sessionAttemptBinding records the current attempt's handle and
-// context for a session. The orchestration layer (Phase 5+) sets
-// the binding via SetCurrentAttemptHandleForSession before driving
+// context for a (session, member). The orchestration layer (Phase 5+)
+// sets the binding via SetCurrentAttemptHandleForSession before driving
 // the round-one / round-two / contribution receive loops; the
 // receive loops read it at end-of-collect to know which attempt to
 // submit their evidence snapshot against.
@@ -43,33 +59,41 @@ type sessionAttemptBinding struct {
 
 var (
 	sessionAttemptBindingMu sync.RWMutex
-	sessionAttemptBindings  = map[string]sessionAttemptBinding{}
+	sessionAttemptBindings  = map[sessionMemberKey]sessionAttemptBinding{}
 
 	sweeperOnce sync.Once
 	sweeperStop chan struct{}
 )
 
 // SetCurrentAttemptHandleForSession records the in-flight attempt
-// handle and context for the named session. Callers in the
-// orchestration layer (Phase 5+) invoke this immediately after
-// Coordinator.BeginAttempt so receive loops can correlate their
+// handle and context for the named session and local member seat.
+// Callers in the orchestration layer (Phase 5+) invoke this immediately
+// after Coordinator.BeginAttempt so receive loops can correlate their
 // captured evidence with the right attempt.
 //
-// Later calls for the same session overwrite earlier ones (this is
-// the documented behaviour: a session whose attempt has transitioned
-// re-binds to the new attempt's handle).
+// The binding is keyed by (sessionID, member): a multi-seat operator's
+// sibling seats each record under their own member so neither overwrites
+// the other (RFC-21 Phase 7.3 PR2b-2).
+//
+// Later calls for the same (session, member) overwrite earlier ones (this
+// is the documented behaviour: a session whose attempt has transitioned
+// re-binds to the new attempt's handle). Begin/cleanup are scoped to a
+// single Execute and the signingRetryLoop drives attempts strictly
+// sequentially per session, so the overwrite never races a live earlier
+// attempt's binding.
 //
 // The binding's createdAt is set to the current wall-clock time so
 // the background sweeper can evict it if Clear is never called
 // (panic before the deferred clear, etc.).
 func SetCurrentAttemptHandleForSession(
 	sessionID string,
+	member group.MemberIndex,
 	handle roast.AttemptHandle,
 	ctx attempt.AttemptContext,
 ) {
 	sessionAttemptBindingMu.Lock()
 	defer sessionAttemptBindingMu.Unlock()
-	sessionAttemptBindings[sessionID] = sessionAttemptBinding{
+	sessionAttemptBindings[sessionMemberKey{sessionID, member}] = sessionAttemptBinding{
 		handle:    handle,
 		context:   ctx,
 		createdAt: time.Now(),
@@ -77,12 +101,14 @@ func SetCurrentAttemptHandleForSession(
 }
 
 // ClearCurrentAttemptHandleForSession removes any binding for the
-// named session. Callers invoke this when a session terminates so
-// the registry does not grow unbounded.
-func ClearCurrentAttemptHandleForSession(sessionID string) {
+// named session and member. Callers invoke this when a session
+// terminates so the registry does not grow unbounded. Because the
+// binding is member-keyed, a seat only clears its OWN binding -- a
+// sibling seat's binding for the same session is untouched.
+func ClearCurrentAttemptHandleForSession(sessionID string, member group.MemberIndex) {
 	sessionAttemptBindingMu.Lock()
 	defer sessionAttemptBindingMu.Unlock()
-	delete(sessionAttemptBindings, sessionID)
+	delete(sessionAttemptBindings, sessionMemberKey{sessionID, member})
 }
 
 // ResetSessionHandleRegistryForTest clears every binding and stops
@@ -91,7 +117,7 @@ func ClearCurrentAttemptHandleForSession(sessionID string) {
 func ResetSessionHandleRegistryForTest() {
 	sessionAttemptBindingMu.Lock()
 	defer sessionAttemptBindingMu.Unlock()
-	sessionAttemptBindings = map[string]sessionAttemptBinding{}
+	sessionAttemptBindings = map[sessionMemberKey]sessionAttemptBinding{}
 	if sweeperStop != nil {
 		close(sweeperStop)
 		sweeperStop = nil
@@ -148,9 +174,9 @@ func evictStaleSessionHandleBindings(maxAge time.Duration) int {
 	sessionAttemptBindingMu.Lock()
 	defer sessionAttemptBindingMu.Unlock()
 	evicted := 0
-	for sessionID, binding := range sessionAttemptBindings {
+	for key, binding := range sessionAttemptBindings {
 		if binding.createdAt.Before(cutoff) {
-			delete(sessionAttemptBindings, sessionID)
+			delete(sessionAttemptBindings, key)
 			evicted++
 		}
 	}
@@ -158,16 +184,17 @@ func evictStaleSessionHandleBindings(maxAge time.Duration) int {
 }
 
 // currentAttemptHandleForCollect reads the binding the orchestration
-// layer set for this session. Returns (zero, zero, false) when no
-// binding exists -- the typical Phase-4 state, where no orchestration
+// layer set for this (session, member). Returns (zero, zero, false) when
+// no binding exists -- the typical Phase-4 state, where no orchestration
 // is wired yet. The submit helper takes ok=false as the signal to
 // skip the RecordEvidence call.
 func currentAttemptHandleForCollect(
 	sessionID string,
+	member group.MemberIndex,
 ) (roast.AttemptHandle, attempt.AttemptContext, bool) {
 	sessionAttemptBindingMu.RLock()
 	defer sessionAttemptBindingMu.RUnlock()
-	binding, ok := sessionAttemptBindings[sessionID]
+	binding, ok := sessionAttemptBindings[sessionMemberKey{sessionID, member}]
 	if !ok {
 		return roast.AttemptHandle{}, attempt.AttemptContext{}, false
 	}
@@ -179,6 +206,7 @@ func currentAttemptHandleForCollect(
 // pkg/tbtc). It is identical to currentAttemptHandleForCollect.
 func CurrentAttemptHandleForSession(
 	sessionID string,
+	member group.MemberIndex,
 ) (roast.AttemptHandle, attempt.AttemptContext, bool) {
-	return currentAttemptHandleForCollect(sessionID)
+	return currentAttemptHandleForCollect(sessionID, member)
 }

--- a/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
+++ b/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
@@ -88,11 +88,12 @@ func attemptRoastRetryOrchestrationFromRequest(
 		request.SignerMaterial.Format,
 	)
 
-	// The handle registry stays keyed by the attempt-specific request.SessionID:
+	// The handle registry is keyed by (request.SessionID, request.MemberIndex):
 	// the coarse receive-loop binding validation + snapshot submission look the
-	// handle up by that id, so keying it otherwise would silently disable them.
-	// The cross-attempt transition record is produced + keyed (by the stable
-	// RoastSessionID) entirely in the transition exchange now, not here.
+	// handle up by that pair (RFC-21 Phase 7.3 PR2b-2), so a multi-seat operator's
+	// sibling seats stay isolated. The cross-attempt transition record is produced
+	// + keyed (by the stable RoastSessionID) entirely in the transition exchange
+	// now, not here.
 	handle, cleanup, err := BeginOrchestrationForSession(
 		request.SessionID, request.MemberIndex, attemptCtx,
 	)

--- a/pkg/frost/signing/roast_retry_executor_entry_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_executor_entry_frost_roast_retry_test.go
@@ -108,12 +108,12 @@ func TestEntry_HappyPath_ActivatesOrchestration(t *testing.T) {
 		t.Fatal("happy path must return a cleanup function")
 	}
 
-	// Binding must exist for the session.
-	if _, _, ok := currentAttemptHandleForCollect(req.SessionID); !ok {
+	// Binding must exist for the session under this seat's member.
+	if _, _, ok := currentAttemptHandleForCollect(req.SessionID, req.MemberIndex); !ok {
 		t.Fatal("binding must exist after orchestration entry")
 	}
 	cleanup()
-	if _, _, ok := currentAttemptHandleForCollect(req.SessionID); ok {
+	if _, _, ok := currentAttemptHandleForCollect(req.SessionID, req.MemberIndex); ok {
 		t.Fatal("binding must be cleared after cleanup")
 	}
 }

--- a/pkg/frost/signing/roast_retry_orchestration.go
+++ b/pkg/frost/signing/roast_retry_orchestration.go
@@ -35,12 +35,15 @@ package signing
 //                     because the fault may be transient and clear.
 //
 //   TERMINAL errors -> ABORT THE RETRY LOOP. A STATIC condition that no
-//                     future attempt can resolve, e.g. multi-seat
-//                     interactive ROAST orchestration, which is not yet
-//                     member-safe (the session handle binding is keyed
-//                     by sessionID alone, so sibling seats collide;
-//                     member-keyed handles land in a later PR). Unlike a
-//                     RUNTIME error, retrying is FUTILE: every attempt
+//                     future attempt can resolve, e.g. a partially-
+//                     registered multi-seat operator: THIS seat has no
+//                     ROAST coordinator while a sibling seat is ROAST-
+//                     active, so this seat can neither drive ROAST nor
+//                     safely fall back to legacy (that would fracture
+//                     the attempt). (PR2b-2 member-keyed the handle
+//                     binding, so a FULLY-registered multi-seat operator
+//                     is no longer terminal -- it proceeds per-seat.)
+//                     Unlike a RUNTIME error, retrying is FUTILE: every attempt
 //                     re-derives the same static outcome, so the loop
 //                     would spin until timeout AND synthesize garbage
 //                     failed-attempt transitions (OnAttemptFailed).
@@ -102,8 +105,10 @@ var ErrNoRoastRetryCoordinatorRegistered = errors.New(
 // TERMINAL error is futile to retry and unsafe to coarse-fall-back, so the only
 // non-fracturing disposition is to stop.
 //
-// Current sole producer: BeginOrchestrationForSession, for a multi-seat operator
-// whose interactive ROAST orchestration is not yet member-safe.
+// Current sole producer: BeginOrchestrationForSession, for a partially-registered
+// multi-seat operator -- this seat has no registered coordinator while a sibling
+// seat is ROAST-active. (A fully-registered multi-seat operator is no longer
+// terminal as of PR2b-2's member-keyed handle binding.)
 //
 // Use errors.Is to detect.
 var ErrTerminalSigningFailure = errors.New(
@@ -143,34 +148,26 @@ func BeginOrchestrationForSession(
 		)
 	}
 	// RFC-21 Phase 7.3 PR2b-1.5: mint the handle from THIS seat's coordinator, so a
-	// multi-seat operator's elected seat aggregates with its own binding.
+	// multi-seat operator's elected seat aggregates with its own binding. PR2b-2
+	// member-keyed the handle binding below (SetCurrentAttemptHandleForSession), so a
+	// fully-registered multi-seat operator now proceeds per-seat with isolated
+	// bindings -- the PR2b-1.5 `count > 1` fail-closed guard that stood here is gone.
 	deps, ok := RegisteredRoastRetryCoordinatorForMember(member)
-	memberCount := registeredRoastRetryMemberCount()
-	// Multi-seat is not yet member-safe here: the session handle binding below
-	// (SetCurrentAttemptHandleForSession) is keyed by sessionID alone, so two local
-	// seats in the same attempt would collide. Fail CLOSED for any multi-seat operator
-	// -- a hard (non-sentinel) error the dispatcher treats as terminal, NEVER the
-	// legacy-fallback sentinel -- until PR2b-2 wires member-keyed handles. Returning the
-	// sentinel here would let this seat run the coarse/legacy path while sibling seats
-	// drive bound ROAST messages, splitting the attempt into mixed bound/unbound. This
-	// mirrors the coarse evidence path's multi-seat guard (submitSnapshotIfActive) in
-	// this same PR.
-	if memberCount > 1 {
-		return roast.AttemptHandle{}, nil, fmt.Errorf(
-			"%w: multi-seat orchestration is not yet member-aware; "+
-				"fail closed for session %q until PR2b-2",
-			ErrTerminalSigningFailure,
-			sessionID,
-		)
-	}
 	if !ok {
-		// memberCount is 0 or 1 here. count==0: no seat is registered anywhere, so ROAST
-		// is not active for the process -- a uniform, group-wide condition every honest
-		// node decides identically -> safe legacy fallback (the sentinel). count==1: a
-		// sibling seat IS registered but not THIS one (a partially-registered operator),
-		// so advertising the legacy fallback for this seat while the sibling drives bound
-		// ROAST would fracture the attempt -> fail CLOSED instead (Codex re-review).
-		if memberCount == 0 {
+		// THIS seat has no registered coordinator. Whether that means legacy fallback
+		// or fail-closed hinges on whether the PROCESS is ROAST-active, which is
+		// group-uniform (the selector uses any-entry RoastRetryActive()):
+		//   - count == 0: no seat is registered anywhere, so ROAST is inactive
+		//     process-wide -- a uniform condition every honest node decides
+		//     identically -> safe legacy fallback (the static sentinel).
+		//   - count > 0: a sibling seat IS ROAST-active (a partially-registered
+		//     operator). Advertising the legacy fallback for THIS seat while the
+		//     sibling drives bound ROAST would fracture the attempt (some seats bound,
+		//     one seat legacy-shuffle) -> fail CLOSED (terminal). Member-keying the
+		//     handle binding does NOTHING here: a seat with no coordinator cannot
+		//     participate in ROAST regardless of key shape, so this fail-closed
+		//     survives PR2b-2 (only the fully-registered multi-seat guard was retired).
+		if registeredRoastRetryMemberCount() == 0 {
 			return roast.AttemptHandle{}, nil, fmt.Errorf(
 				"%w: caller should fall back to legacy behaviour",
 				ErrNoRoastRetryCoordinatorRegistered,
@@ -196,7 +193,10 @@ func BeginOrchestrationForSession(
 			err,
 		)
 	}
-	SetCurrentAttemptHandleForSession(sessionID, handle, ctx)
+	// RFC-21 Phase 7.3 PR2b-2: bind per (sessionID, member). A multi-seat
+	// operator's sibling seats each bind their own handle here, so neither
+	// overwrites the other and each seat's cleanup clears only its own binding.
+	SetCurrentAttemptHandleForSession(sessionID, member, handle, ctx)
 	cleanup := func() {
 		// RFC-21 Phase 7.3 PR2b-1b: the cleanup ONLY clears the per-attempt
 		// handle binding. It no longer produces a transition record -- the
@@ -205,7 +205,7 @@ func BeginOrchestrationForSession(
 		// keyed by the observe handle. Producing here too would let this drive
 		// handle's (empty) aggregation write a SECOND, possibly divergent record
 		// for the same (sessionID, member) the exchange owns -- a fracture risk.
-		ClearCurrentAttemptHandleForSession(sessionID)
+		ClearCurrentAttemptHandleForSession(sessionID, member)
 	}
 	return handle, cleanup, nil
 }
@@ -214,7 +214,8 @@ func BeginOrchestrationForSession(
 // did not capture the cleanup function from
 // BeginOrchestrationForSession (e.g. callers that pass session
 // ownership across function boundaries). It is equivalent to
-// invoking the cleanup function returned by Begin.
-func EndOrchestrationForSession(sessionID string) {
-	ClearCurrentAttemptHandleForSession(sessionID)
+// invoking the cleanup function returned by Begin, so it clears the
+// binding for this (session, member) seat.
+func EndOrchestrationForSession(sessionID string, member group.MemberIndex) {
+	ClearCurrentAttemptHandleForSession(sessionID, member)
 }

--- a/pkg/frost/signing/roast_retry_orchestration_bundle_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_bundle_test.go
@@ -77,7 +77,7 @@ func TestCleanup_ClearsBindingAndProducesNoTransitionRecord(t *testing.T) {
 	if _, ok := RoastTransitionForSession(ctx.SessionID, elected); ok {
 		t.Fatal("cleanup must not produce a transition record (the exchange is the sole producer)")
 	}
-	if _, _, ok := currentAttemptHandleForCollect(sessionID); ok {
+	if _, _, ok := currentAttemptHandleForCollect(sessionID, elected); ok {
 		t.Fatal("cleanup must clear the per-attempt handle binding")
 	}
 }

--- a/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_orchestration_frost_roast_retry_test.go
@@ -53,8 +53,8 @@ func TestBeginOrchestrationForSession_HappyPath(t *testing.T) {
 		t.Fatal("cleanup must not be nil")
 	}
 
-	// Binding must exist.
-	gotHandle, gotCtx, ok := currentAttemptHandleForCollect("session-A")
+	// Binding must exist under (session, member).
+	gotHandle, gotCtx, ok := currentAttemptHandleForCollect("session-A", 1)
 	if !ok {
 		t.Fatal("binding must exist after Begin")
 	}
@@ -66,7 +66,7 @@ func TestBeginOrchestrationForSession_HappyPath(t *testing.T) {
 	}
 
 	cleanup()
-	if _, _, ok := currentAttemptHandleForCollect("session-A"); ok {
+	if _, _, ok := currentAttemptHandleForCollect("session-A", 1); ok {
 		t.Fatal("binding must be cleared after cleanup")
 	}
 }
@@ -86,6 +86,14 @@ func TestBeginOrchestrationForSession_ErrorsWhenRegistryEmpty(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no coordinator registered") {
 		t.Fatalf("error must mention missing registration; got %v", err)
+	}
+	// Empty registry => count==0 => the STATIC legacy-fallback sentinel, NOT
+	// the terminal fail-closed (which is reserved for partial registration).
+	if !errors.Is(err, ErrNoRoastRetryCoordinatorRegistered) {
+		t.Fatalf("empty registry must return the static sentinel; got %v", err)
+	}
+	if errors.Is(err, ErrTerminalSigningFailure) {
+		t.Fatalf("empty registry must NOT be terminal; got %v", err)
 	}
 }
 
@@ -164,8 +172,9 @@ func TestBeginOrchestrationForSession_PropagatesBeginAttemptError(t *testing.T) 
 }
 
 // assertOrchestrationFailedClosed asserts err is a HARD fail-closed: non-nil,
-// neither static-fallback sentinel, and that no session binding leaked.
-func assertOrchestrationFailedClosed(t *testing.T, sessionID string, cleanup func(), err error) {
+// neither static-fallback sentinel, classified terminal, and that no session
+// binding leaked for (sessionID, member).
+func assertOrchestrationFailedClosed(t *testing.T, sessionID string, member group.MemberIndex, cleanup func(), err error) {
 	t.Helper()
 	if err == nil {
 		t.Fatal("expected a fail-closed error, got nil")
@@ -177,14 +186,14 @@ func assertOrchestrationFailedClosed(t *testing.T, sessionID string, cleanup fun
 		t.Fatalf("must NOT return the readiness sentinel; got %v", err)
 	}
 	// Must be classified TERMINAL so the signingRetryLoop aborts instead of
-	// retrying the (static, never-resolving) multi-seat condition.
+	// retrying the (static, never-resolving) fail-closed condition.
 	if !errors.Is(err, ErrTerminalSigningFailure) {
-		t.Fatalf("multi-seat fail-closed must be classified terminal (ErrTerminalSigningFailure); got %v", err)
+		t.Fatalf("fail-closed must be classified terminal (ErrTerminalSigningFailure); got %v", err)
 	}
 	if cleanup != nil {
 		t.Fatal("a failed begin must not return a cleanup")
 	}
-	if _, _, ok := currentAttemptHandleForCollect(sessionID); ok {
+	if _, _, ok := currentAttemptHandleForCollect(sessionID, member); ok {
 		t.Fatal("fail-closed must not create a session binding")
 	}
 }
@@ -193,7 +202,9 @@ func assertOrchestrationFailedClosed(t *testing.T, sessionID string, cleanup fun
 // re-review case: a multi-seat operator that has at least one seat registered but
 // NOT this one. The member-aware lookup misses, and rather than returning the
 // legacy-fallback sentinel (which would let this seat run coarse/legacy while the
-// registered sibling drives bound ROAST -> fracture), Begin fails CLOSED.
+// registered sibling drives bound ROAST -> fracture), Begin fails CLOSED. PR2b-2
+// keeps this fail-closed: member-keying the handle binding does nothing for a seat
+// with no coordinator at all.
 func TestBeginOrchestrationForSession_FailsClosedPartialMultiSeat(t *testing.T) {
 	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
 	ResetRoastRetryRegistrationForTest()
@@ -208,24 +219,30 @@ func TestBeginOrchestrationForSession_FailsClosedPartialMultiSeat(t *testing.T) 
 	})
 
 	_, cleanup, err := BeginOrchestrationForSession("session-partial", 2, newOrchestrationTestContext(t))
-	assertOrchestrationFailedClosed(t, "session-partial", cleanup, err)
+	assertOrchestrationFailedClosed(t, "session-partial", 2, cleanup, err)
 	if !strings.Contains(err.Error(), "fail closed") {
 		t.Fatalf("error must explain the fail-closed; got %v", err)
 	}
 }
 
-// TestBeginOrchestrationForSession_FailsClosedFullMultiSeat asserts the
-// fully-registered multi-seat case also fails closed: the session-handle binding
-// is still keyed by sessionID alone, so two local seats would collide. Deferred
-// to PR2b-2; until then any multi-seat operator fails closed rather than mis-bind.
-func TestBeginOrchestrationForSession_FailsClosedFullMultiSeat(t *testing.T) {
+// TestBeginOrchestrationForSession_MultiSeatProceedsPerSeat asserts that PR2b-2
+// retired the fully-registered multi-seat fail-closed guard: with both local
+// seats registered, EACH seat begins its own attempt and binds its OWN handle
+// under (sessionID, member), so sibling seats stay isolated. The load-bearing
+// isolation proof is that one seat's cleanup does NOT tear down the sibling's
+// binding -- under the old sessionID-only key, seat 1's cleanup deleted the
+// shared binding and seat 2 lost its hash enforcement. (The two handles are equal
+// here because both coordinators mint id=1 for the same ctx; equality is expected,
+// so survival-after-sibling-cleanup -- not handle distinctness -- is the proof.
+// TestSessionHandleBinding_IsolatesByMember exercises distinct handles directly.)
+func TestBeginOrchestrationForSession_MultiSeatProceedsPerSeat(t *testing.T) {
 	t.Setenv(RoastRetryReadinessOptInEnvVar, "true")
 	ResetRoastRetryRegistrationForTest()
 	ResetSessionHandleRegistryForTest()
 	t.Cleanup(ResetRoastRetryRegistrationForTest)
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
-	// Both local seats registered -> multi-seat; call with a registered member.
+	// Both local seats registered -> multi-seat.
 	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{
 		Coordinator: roast.NewInMemoryCoordinatorWithSigning(1, roast.NoOpSigner(), roast.NoOpSignatureVerifier()),
 		SelfMember:  1,
@@ -235,10 +252,109 @@ func TestBeginOrchestrationForSession_FailsClosedFullMultiSeat(t *testing.T) {
 		SelfMember:  2,
 	})
 
-	_, cleanup, err := BeginOrchestrationForSession("session-multiseat", 1, newOrchestrationTestContext(t))
-	assertOrchestrationFailedClosed(t, "session-multiseat", cleanup, err)
-	if !strings.Contains(err.Error(), "multi-seat") {
-		t.Fatalf("error must explain the multi-seat fail-closed; got %v", err)
+	ctx := newOrchestrationTestContext(t)
+
+	handle1, cleanup1, err := BeginOrchestrationForSession("session-multiseat", 1, ctx)
+	if err != nil {
+		t.Fatalf("seat 1 begin must succeed (no longer fail-closed): %v", err)
+	}
+	if cleanup1 == nil {
+		t.Fatal("seat 1 cleanup must not be nil")
+	}
+	handle2, cleanup2, err := BeginOrchestrationForSession("session-multiseat", 2, ctx)
+	if err != nil {
+		t.Fatalf("seat 2 begin must succeed (no longer fail-closed): %v", err)
+	}
+	if cleanup2 == nil {
+		t.Fatal("seat 2 cleanup must not be nil")
+	}
+
+	// Each seat reads back its own binding.
+	got1, _, ok := currentAttemptHandleForCollect("session-multiseat", 1)
+	if !ok {
+		t.Fatal("seat 1 binding must exist")
+	}
+	if got1 != handle1 {
+		t.Fatal("seat 1 must read back its own handle")
+	}
+	got2, _, ok := currentAttemptHandleForCollect("session-multiseat", 2)
+	if !ok {
+		t.Fatal("seat 2 binding must exist")
+	}
+	if got2 != handle2 {
+		t.Fatal("seat 2 must read back its own handle")
+	}
+
+	// ISOLATION: seat 1's cleanup must clear ONLY seat 1's binding; seat 2's
+	// binding must survive (this is exactly the multi-seat bug being fixed).
+	cleanup1()
+	if _, _, ok := currentAttemptHandleForCollect("session-multiseat", 1); ok {
+		t.Fatal("seat 1 binding must be cleared after its own cleanup")
+	}
+	if _, _, ok := currentAttemptHandleForCollect("session-multiseat", 2); !ok {
+		t.Fatal("seat 2 binding must SURVIVE seat 1's cleanup (member isolation)")
+	}
+	cleanup2()
+	if _, _, ok := currentAttemptHandleForCollect("session-multiseat", 2); ok {
+		t.Fatal("seat 2 binding must be cleared after its own cleanup")
+	}
+}
+
+// TestSessionHandleBinding_IsolatesByMember exercises the (sessionID, member)
+// re-keying directly with DISTINCT handles: two contexts (differing only in
+// attempt number) minted by one coordinator yield distinct handles, bound under
+// the same session for two different members. Each member must read back its own
+// handle, and clearing one member must leave the other intact.
+func TestSessionHandleBinding_IsolatesByMember(t *testing.T) {
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	coord := roast.NewInMemoryCoordinator()
+	ctxA := newOrchestrationTestContext(t)
+	ctxB, err := attempt.NewAttemptContext(
+		"orchestration-session",
+		"key-group-orchestration",
+		[]byte{0x01, 0x02},
+		[attempt.MessageDigestLength]byte{0x77},
+		1, // distinct attempt number -> distinct context hash -> distinct handle
+		[]group.MemberIndex{1, 2, 3, 4, 5},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ctxB: %v", err)
+	}
+
+	handleA, err := coord.BeginAttempt(ctxA)
+	if err != nil {
+		t.Fatalf("beginA: %v", err)
+	}
+	handleB, err := coord.BeginAttempt(ctxB)
+	if err != nil {
+		t.Fatalf("beginB: %v", err)
+	}
+	if handleA == handleB {
+		t.Fatal("setup: the two handles must be distinct for a meaningful isolation test")
+	}
+
+	SetCurrentAttemptHandleForSession("shared-session", 1, handleA, ctxA)
+	SetCurrentAttemptHandleForSession("shared-session", 2, handleB, ctxB)
+
+	got1, gotCtx1, ok := currentAttemptHandleForCollect("shared-session", 1)
+	if !ok || got1 != handleA || gotCtx1.Hash() != ctxA.Hash() {
+		t.Fatalf("member 1 must read back its own (handle, ctx); ok=%v", ok)
+	}
+	got2, gotCtx2, ok := currentAttemptHandleForCollect("shared-session", 2)
+	if !ok || got2 != handleB || gotCtx2.Hash() != ctxB.Hash() {
+		t.Fatalf("member 2 must read back its own (handle, ctx); ok=%v", ok)
+	}
+
+	// Clearing member 1 must not disturb member 2.
+	ClearCurrentAttemptHandleForSession("shared-session", 1)
+	if _, _, ok := currentAttemptHandleForCollect("shared-session", 1); ok {
+		t.Fatal("member 1 binding must be gone after clear")
+	}
+	if got, _, ok := currentAttemptHandleForCollect("shared-session", 2); !ok || got != handleB {
+		t.Fatal("member 2 binding must survive member 1's clear")
 	}
 }
 
@@ -247,13 +363,13 @@ func TestEndOrchestrationForSession_RemovesBinding(t *testing.T) {
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContext(t)
-	SetCurrentAttemptHandleForSession("session-end", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-end", 3, roast.AttemptHandle{}, ctx)
 
-	if _, _, ok := currentAttemptHandleForCollect("session-end"); !ok {
+	if _, _, ok := currentAttemptHandleForCollect("session-end", 3); !ok {
 		t.Fatal("setup: binding must exist")
 	}
-	EndOrchestrationForSession("session-end")
-	if _, _, ok := currentAttemptHandleForCollect("session-end"); ok {
+	EndOrchestrationForSession("session-end", 3)
+	if _, _, ok := currentAttemptHandleForCollect("session-end", 3); ok {
 		t.Fatal("binding must be removed after End")
 	}
 }
@@ -264,25 +380,26 @@ func TestEvictStaleSessionHandleBindings_RemovesOldEntries(t *testing.T) {
 
 	// Two bindings with different ages.
 	ctx := newOrchestrationTestContext(t)
-	SetCurrentAttemptHandleForSession("session-old", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-old", 1, roast.AttemptHandle{}, ctx)
 	// Backdate by forcing the timestamp.
 	sessionAttemptBindingMu.Lock()
-	b := sessionAttemptBindings["session-old"]
+	oldKey := sessionMemberKey{"session-old", 1}
+	b := sessionAttemptBindings[oldKey]
 	b.createdAt = time.Now().Add(-10 * time.Minute)
-	sessionAttemptBindings["session-old"] = b
+	sessionAttemptBindings[oldKey] = b
 	sessionAttemptBindingMu.Unlock()
 
-	SetCurrentAttemptHandleForSession("session-new", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-new", 1, roast.AttemptHandle{}, ctx)
 
 	// Sweep with 5-minute TTL: old must be evicted, new must survive.
 	evicted := evictStaleSessionHandleBindings(5 * time.Minute)
 	if evicted != 1 {
 		t.Fatalf("expected 1 eviction, got %d", evicted)
 	}
-	if _, _, ok := currentAttemptHandleForCollect("session-old"); ok {
+	if _, _, ok := currentAttemptHandleForCollect("session-old", 1); ok {
 		t.Fatal("session-old must be evicted")
 	}
-	if _, _, ok := currentAttemptHandleForCollect("session-new"); !ok {
+	if _, _, ok := currentAttemptHandleForCollect("session-new", 1); !ok {
 		t.Fatal("session-new must survive")
 	}
 }
@@ -292,7 +409,7 @@ func TestEvictStaleSessionHandleBindings_LeavesFreshEntries(t *testing.T) {
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newOrchestrationTestContext(t)
-	SetCurrentAttemptHandleForSession("session-fresh", roast.AttemptHandle{}, ctx)
+	SetCurrentAttemptHandleForSession("session-fresh", 1, roast.AttemptHandle{}, ctx)
 
 	// Sweep with the default 2-hour TTL: nothing should be evicted.
 	evicted := evictStaleSessionHandleBindings(SessionHandleBindingTTL)

--- a/pkg/frost/signing/roast_retry_registration_default_build.go
+++ b/pkg/frost/signing/roast_retry_registration_default_build.go
@@ -64,9 +64,9 @@ func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
 	return RoastRetryDeps{}, false
 }
 
-// registeredRoastRetryMemberCount returns 0 in the default build: no
-// seats are ever registered, so the coarse evidence path's multi-seat
-// guard (submitSnapshotIfActive) is never tripped here.
+// registeredRoastRetryMemberCount returns 0 in the default build: no seats are
+// ever registered, so BeginOrchestrationForSession's partial-registration
+// fail-closed branch (count>0) is never reached here.
 func registeredRoastRetryMemberCount() int { return 0 }
 
 // ResetRoastRetryRegistrationForTest is a no-op in the default

--- a/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_registration_frost_roast_retry.go
@@ -97,10 +97,13 @@ func RegisteredRoastRetryCoordinator() (RoastRetryDeps, bool) {
 }
 
 // registeredRoastRetryMemberCount returns how many local seats currently have a
-// coordinator registered. A count > 1 means a multi-seat operator; the
-// not-yet-member-aware coarse/drive evidence path (submitSnapshotIfActive) uses it
-// to disable itself for multi-seat rather than mis-attribute one seat's evidence to
-// a sibling (RFC-21 Phase 7.3 PR2b-1.5).
+// coordinator registered. BeginOrchestrationForSession uses it for the one
+// distinction that depends on process-wide ROAST activation: when THIS seat has no
+// coordinator, count==0 means ROAST is inactive everywhere (safe legacy fallback)
+// while count>0 means a sibling seat IS ROAST-active, so this unregistered seat
+// must fail closed rather than fracture the attempt. (RFC-21 Phase 7.3 PR2b-2
+// retired the former submitSnapshotIfActive multi-seat no-op that also used this;
+// the evidence path is now member-keyed and isolates seats directly.)
 func registeredRoastRetryMemberCount() int {
 	roastRetryRegistrationMu.RLock()
 	defer roastRetryRegistrationMu.RUnlock()

--- a/pkg/frost/signing/roast_retry_submit.go
+++ b/pkg/frost/signing/roast_retry_submit.go
@@ -17,48 +17,43 @@ var roastRetryLogger = log.Logger("keep-frost-roast-retry")
 
 // submitSnapshotIfActive is invoked at end-of-collect to push the
 // receive loop's accumulated evidence into the ROAST coordinator's
-// RecordEvidence pipeline. The function is a no-op when any of the
-// following is true:
+// RecordEvidence pipeline. member is the local seat whose receive loop
+// is submitting (request.MemberIndex). The path is fully member-aware
+// (RFC-21 Phase 7.3 PR2b-2): a multi-seat operator's sibling seats each
+// submit their own evidence against their own coordinator and attempt
+// handle, so they no longer mis-attribute or collide (which is why the
+// PR2b-1.5 multi-seat no-op guard is gone). The function is a no-op when
+// any of the following is true:
 //
-//   - the ROAST-retry registry is empty (default build, no caller
-//     has invoked RegisterRoastRetryCoordinator);
-//   - more than one local seat is registered (multi-seat): this path
-//     is not yet member-aware (PR2b-1.5), so it disables itself rather
-//     than mis-attribute one seat's evidence to a sibling;
-//   - no session-handle binding exists for sessionID (the typical
-//     Phase-4 state, where the orchestration layer that calls
+//   - this member has no registered ROAST-retry coordinator (default
+//     build where RegisterRoastRetryCoordinator is a no-op, or a
+//     partially-registered operator where only a sibling seat is wired);
+//   - no session-handle binding exists for (sessionID, member) (the
+//     typical Phase-4 state, where the orchestration layer that calls
 //     SetCurrentAttemptHandleForSession is not yet implemented);
-//   - the recorder is a NoOp (no events were captured).
+//   - the recorder is nil / a NoOp (no events were captured).
 //
-// When all three preconditions hold, the function builds a
-// LocalEvidenceSnapshot, signs it with the registered Signer, and
-// submits it via Coordinator.RecordEvidence. Errors at any step are
-// logged at WARN level and otherwise swallowed -- snapshot
-// submission must not break the receive loop's primary signing
-// behaviour.
+// Otherwise the function builds a LocalEvidenceSnapshot, signs it with
+// this member's registered Signer, and submits it via
+// Coordinator.RecordEvidence. Errors at any step are logged at WARN
+// level and otherwise swallowed -- snapshot submission must not break
+// the receive loop's primary signing behaviour.
 func submitSnapshotIfActive(
 	sessionID string,
+	member group.MemberIndex,
 	recorder attempt.EvidenceRecorder,
 ) {
 	if recorder == nil {
 		return
 	}
-	// RFC-21 Phase 7.3 PR2b-1.5: the coarse/drive evidence path is not yet
-	// member-aware -- it looks up deps via any-entry RegisteredRoastRetryCoordinator
-	// and keys the drive handle by sessionID alone. Under a MULTI-SEAT operator
-	// (more than one local seat registered) that would attribute one local seat's
-	// evidence to an arbitrary sibling and collide their drive handles, so disable
-	// it for multi-seat until PR2b-2 wires the member-aware coarse/drive path (where
-	// this evidence is consumed by the blame bridge). Single-seat is unchanged, and
-	// the whole path is inert in 1b/1.5 (no production caller submits yet).
-	if registeredRoastRetryMemberCount() > 1 {
-		return
-	}
-	deps, ok := RegisteredRoastRetryCoordinator()
+	// Member-aware lookup: a multi-seat operator's elected seat aggregates with
+	// its OWN coordinator and the snapshot is attributed to deps.SelfMember ==
+	// member. A seat with no coordinator (partial registration) submits nothing.
+	deps, ok := RegisteredRoastRetryCoordinatorForMember(member)
 	if !ok {
 		return
 	}
-	handle, ctx, ok := currentAttemptHandleForCollect(sessionID)
+	handle, ctx, ok := currentAttemptHandleForCollect(sessionID, member)
 	if !ok {
 		return
 	}

--- a/pkg/frost/signing/roast_retry_submit.go
+++ b/pkg/frost/signing/roast_retry_submit.go
@@ -58,13 +58,20 @@ func submitSnapshotIfActive(
 		return
 	}
 	evidence := recorder.Snapshot()
-	if len(evidence.Overflows) == 0 {
-		// Nothing observed worth submitting; emitting an empty
+	if len(evidence.Overflows) == 0 &&
+		len(evidence.Rejects) == 0 &&
+		len(evidence.Conflicts) == 0 {
+		// Truly nothing observed worth submitting; emitting an empty
 		// snapshot is still meaningful in the ROAST protocol
-		// (proof-of-attendance) but adds noise to the bundle.
-		// Phase 4.3 chooses to skip empty submissions; Phase 5
-		// orchestration may revisit this if attestations need to
-		// be unconditional.
+		// (proof-of-attendance) but adds noise to the bundle, so we
+		// skip it. The emptiness test MUST consider all three evidence
+		// categories, not just overflows: a validation-blamable Reject
+		// (e.g. an attempt-context-hash mismatch) or a first-write-wins
+		// Conflict populates Rejects/Conflicts WITHOUT any Overflow, and
+		// NextAttempt's exclusion path consumes snapshot.Rejects
+		// (next_attempt.go). Dropping a reject/conflict-only snapshot
+		// here would silently starve the blame pipeline of exactly the
+		// validation evidence it needs.
 		return
 	}
 	snap := buildSignedSnapshot(deps, ctx, evidence)

--- a/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
@@ -119,7 +119,7 @@ func TestSubmitSnapshotIfActive_NoOpWhenRegistryEmpty(t *testing.T) {
 	// No registration, no binding. submit should be a no-op.
 	recorder := attempt.NewBoundedRecorder()
 	recorder.RecordOverflow(7)
-	submitSnapshotIfActive("session-x", recorder)
+	submitSnapshotIfActive("session-x", 1, recorder)
 	// Nothing to assert observably: success is the absence of a
 	// panic and no calls to a non-existent coordinator.
 }
@@ -141,7 +141,7 @@ func TestSubmitSnapshotIfActive_NoOpWhenSessionUnbound(t *testing.T) {
 
 	recorder := attempt.NewBoundedRecorder()
 	recorder.RecordOverflow(7)
-	submitSnapshotIfActive("session-with-no-binding", recorder)
+	submitSnapshotIfActive("session-with-no-binding", 1, recorder)
 
 	if len(cap.recordedFor) != 0 {
 		t.Fatalf(
@@ -175,11 +175,11 @@ func TestSubmitSnapshotIfActive_NoOpWhenRecorderEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
-	SetCurrentAttemptHandleForSession("session-empty", handle, ctx)
+	SetCurrentAttemptHandleForSession("session-empty", 1, handle, ctx)
 
 	// Recorder is bounded but has captured zero events.
 	recorder := attempt.NewBoundedRecorder()
-	submitSnapshotIfActive("session-empty", recorder)
+	submitSnapshotIfActive("session-empty", 1, recorder)
 
 	if len(cap.recordedFor) != 0 {
 		t.Fatalf(
@@ -214,13 +214,13 @@ func TestSubmitSnapshotIfActive_SubmitsSignedSnapshotWhenBoundAndPopulated(t *te
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
-	SetCurrentAttemptHandleForSession("session-real", handle, ctx)
+	SetCurrentAttemptHandleForSession("session-real", selfMember, handle, ctx)
 
 	recorder := attempt.NewBoundedRecorder()
 	recorder.RecordOverflow(3)
 	recorder.RecordOverflow(3)
 	recorder.RecordOverflow(5)
-	submitSnapshotIfActive("session-real", recorder)
+	submitSnapshotIfActive("session-real", selfMember, recorder)
 
 	if len(cap.recordedFor) != 1 {
 		t.Fatalf("expected 1 RecordEvidence; got %d", len(cap.recordedFor))
@@ -241,6 +241,72 @@ func TestSubmitSnapshotIfActive_SubmitsSignedSnapshotWhenBoundAndPopulated(t *te
 	}
 }
 
+// TestSubmitSnapshotIfActive_MultiSeatSubmitsPerSeat asserts the PR2b-2 member-
+// aware submit path: with two local seats registered, each seat submits its own
+// evidence against ITS OWN coordinator and attempt handle. The PR2b-1.5 count>1
+// no-op guard is gone, so both submissions land -- and neither lands on the
+// sibling's coordinator.
+func TestSubmitSnapshotIfActive_MultiSeatSubmitsPerSeat(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	cap1 := newCaptureCoordinator(roast.NewInMemoryCoordinatorWithSigning(
+		1, &deterministicSigner{id: 1}, deterministicVerifier{},
+	))
+	cap2 := newCaptureCoordinator(roast.NewInMemoryCoordinatorWithSigning(
+		2, &deterministicSigner{id: 2}, deterministicVerifier{},
+	))
+	RegisterRoastRetryCoordinatorForMember(1, RoastRetryDeps{
+		Coordinator: cap1,
+		Signer:      &deterministicSigner{id: 1},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  1,
+	})
+	RegisterRoastRetryCoordinatorForMember(2, RoastRetryDeps{
+		Coordinator: cap2,
+		Signer:      &deterministicSigner{id: 2},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  2,
+	})
+
+	ctx := newTestContextForSubmit(t, "session-ms")
+	handle1, err := cap1.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("seat 1 begin: %v", err)
+	}
+	handle2, err := cap2.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("seat 2 begin: %v", err)
+	}
+	SetCurrentAttemptHandleForSession("session-ms", 1, handle1, ctx)
+	SetCurrentAttemptHandleForSession("session-ms", 2, handle2, ctx)
+
+	rec1 := attempt.NewBoundedRecorder()
+	rec1.RecordOverflow(3)
+	rec2 := attempt.NewBoundedRecorder()
+	rec2.RecordOverflow(4)
+
+	submitSnapshotIfActive("session-ms", 1, rec1)
+	submitSnapshotIfActive("session-ms", 2, rec2)
+
+	// Each seat's evidence landed on ITS OWN coordinator (no mis-attribution),
+	// each against its own handle and signed as its own member.
+	if len(cap1.recordedFor) != 1 || cap1.recordedFor[0] != handle1 {
+		t.Fatalf("seat 1 must record once against its own handle; got %+v", cap1.recordedFor)
+	}
+	if len(cap2.recordedFor) != 1 || cap2.recordedFor[0] != handle2 {
+		t.Fatalf("seat 2 must record once against its own handle; got %+v", cap2.recordedFor)
+	}
+	if cap1.recordedSnp[0].SenderID() != 1 {
+		t.Fatalf("seat 1 snapshot sender: got %d want 1", cap1.recordedSnp[0].SenderID())
+	}
+	if cap2.recordedSnp[0].SenderID() != 2 {
+		t.Fatalf("seat 2 snapshot sender: got %d want 2", cap2.recordedSnp[0].SenderID())
+	}
+}
+
 func TestSetCurrentAttemptHandleForSession_LaterBindingOverwrites(t *testing.T) {
 	ResetSessionHandleRegistryForTest()
 	t.Cleanup(ResetSessionHandleRegistryForTest)
@@ -254,8 +320,8 @@ func TestSetCurrentAttemptHandleForSession_LaterBindingOverwrites(t *testing.T) 
 	h1 := roast.AttemptHandle{}
 	h2 := roast.AttemptHandle{}
 
-	SetCurrentAttemptHandleForSession("session-overwrite", h1, ctxA)
-	gotHandle, gotCtx, ok := currentAttemptHandleForCollect("session-overwrite")
+	SetCurrentAttemptHandleForSession("session-overwrite", 1, h1, ctxA)
+	gotHandle, gotCtx, ok := currentAttemptHandleForCollect("session-overwrite", 1)
 	if !ok {
 		t.Fatal("expected binding after first Set")
 	}
@@ -266,8 +332,8 @@ func TestSetCurrentAttemptHandleForSession_LaterBindingOverwrites(t *testing.T) 
 		t.Fatal("first binding context mismatch")
 	}
 
-	SetCurrentAttemptHandleForSession("session-overwrite", h2, ctxB)
-	_, gotCtx2, ok := currentAttemptHandleForCollect("session-overwrite")
+	SetCurrentAttemptHandleForSession("session-overwrite", 1, h2, ctxB)
+	_, gotCtx2, ok := currentAttemptHandleForCollect("session-overwrite", 1)
 	if !ok {
 		t.Fatal("expected binding after second Set")
 	}
@@ -281,12 +347,12 @@ func TestClearCurrentAttemptHandleForSession_RemovesBinding(t *testing.T) {
 	t.Cleanup(ResetSessionHandleRegistryForTest)
 
 	ctx := newTestContextForSubmit(t, "session-clear")
-	SetCurrentAttemptHandleForSession("session-clear", roast.AttemptHandle{}, ctx)
-	if _, _, ok := currentAttemptHandleForCollect("session-clear"); !ok {
+	SetCurrentAttemptHandleForSession("session-clear", 1, roast.AttemptHandle{}, ctx)
+	if _, _, ok := currentAttemptHandleForCollect("session-clear", 1); !ok {
 		t.Fatal("setup: binding must exist")
 	}
-	ClearCurrentAttemptHandleForSession("session-clear")
-	if _, _, ok := currentAttemptHandleForCollect("session-clear"); ok {
+	ClearCurrentAttemptHandleForSession("session-clear", 1)
+	if _, _, ok := currentAttemptHandleForCollect("session-clear", 1); ok {
 		t.Fatal("binding must be cleared")
 	}
 }
@@ -311,11 +377,11 @@ func TestSubmitSnapshotIfActive_RecordEvidenceFailureIsLoggedNotPropagated(t *te
 
 	ctx := newTestContextForSubmit(t, "session-failure")
 	handle, _ := cap.BeginAttempt(ctx)
-	SetCurrentAttemptHandleForSession("session-failure", handle, ctx)
+	SetCurrentAttemptHandleForSession("session-failure", 1, handle, ctx)
 
 	recorder := attempt.NewBoundedRecorder()
 	recorder.RecordOverflow(3)
 
 	// Must not panic. Caller is unaffected.
-	submitSnapshotIfActive("session-failure", recorder)
+	submitSnapshotIfActive("session-failure", 1, recorder)
 }

--- a/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
@@ -307,6 +307,53 @@ func TestSubmitSnapshotIfActive_MultiSeatSubmitsPerSeat(t *testing.T) {
 	}
 }
 
+// TestSubmitSnapshotIfActive_SubmitsRejectOnlySnapshot guards the fold of Codex's
+// PR2b-2 P2: a snapshot carrying ONLY reject evidence -- no overflow, no conflict
+// -- must still be signed and submitted. A validation-blamable Reject (e.g. an
+// attempt-context-hash mismatch) populates Evidence.Rejects without any Overflow,
+// and NextAttempt's exclusion path consumes snapshot.Rejects; the old overflow-only
+// emptiness check silently dropped such snapshots, starving the blame pipeline.
+func TestSubmitSnapshotIfActive_SubmitsRejectOnlySnapshot(t *testing.T) {
+	ResetRoastRetryRegistrationForTest()
+	ResetSessionHandleRegistryForTest()
+	t.Cleanup(ResetRoastRetryRegistrationForTest)
+	t.Cleanup(ResetSessionHandleRegistryForTest)
+
+	const selfMember group.MemberIndex = 1
+	cap := newCaptureCoordinator(roast.NewInMemoryCoordinatorWithSigning(
+		selfMember, &deterministicSigner{id: selfMember}, deterministicVerifier{},
+	))
+	RegisterRoastRetryCoordinator(RoastRetryDeps{
+		Coordinator: cap,
+		Signer:      &deterministicSigner{id: selfMember},
+		Verifier:    deterministicVerifier{},
+		SelfMember:  uint32(selfMember),
+	})
+
+	ctx := newTestContextForSubmit(t, "session-reject-only")
+	handle, err := cap.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	SetCurrentAttemptHandleForSession("session-reject-only", selfMember, handle, ctx)
+
+	// Only a reject -- no overflow, no conflict.
+	recorder := attempt.NewBoundedRecorder()
+	recorder.RecordReject(2, "attempt_context_hash_mismatch")
+	submitSnapshotIfActive("session-reject-only", selfMember, recorder)
+
+	if len(cap.recordedFor) != 1 {
+		t.Fatalf("reject-only snapshot must be submitted; got %d RecordEvidence calls", len(cap.recordedFor))
+	}
+	snap := cap.recordedSnp[0]
+	if len(snap.Rejects) == 0 {
+		t.Fatal("submitted snapshot must carry the reject evidence")
+	}
+	if len(snap.OperatorSignature) == 0 {
+		t.Fatal("reject-only snapshot must be signed")
+	}
+}
+
 func TestSetCurrentAttemptHandleForSession_LaterBindingOverwrites(t *testing.T) {
 	ResetSessionHandleRegistryForTest()
 	t.Cleanup(ResetSessionHandleRegistryForTest)


### PR DESCRIPTION
## What

RFC-21 Phase 7.3 PR2b-2 **step 1**: member-key the ROAST session-handle binding.

Re-keys `sessionAttemptBindings` in `pkg/frost/signing` from `sessionID` alone to `(sessionID, member)`, threading the local member (`request.MemberIndex`) through the receive-loop validators and the evidence-submission path.

## Why

A multi-seat operator runs one receive loop per local seat. With the binding keyed by `sessionID` alone, sibling seats collided:
- the later seat's `Set` **overwrote** the earlier seat's binding, so evidence submission used the wrong handle (mis-attribution);
- one seat's cleanup `Clear(sessionID)` deleted the **shared** binding, silently disabling the surviving seat's inbound attempt-context-hash enforcement (a security regression).

PR2b-1.5 papered over this with multi-seat fail-closed guards; this PR makes the path actually member-safe and retires those guards.

## Changes
- **Registry** (both build flavors): `sessionMemberKey{sessionID, member}` key; `Set`/`Clear`/`currentAttemptHandleForCollect`/`CurrentAttemptHandleForSession` take `group.MemberIndex`.
- **Read path**: `verifyMessageAttemptContextHash` / `setMessageAttemptContextHashIfBound` take `member`; the 3 receive-loop callers pass `request.MemberIndex` (the local receiver, **never** the inbound sender).
- **Write path**: `BeginOrchestrationForSession` / `EndOrchestrationForSession` / cleanup bind & clear per `(sessionID, member)`.
- **Submit**: `submitSnapshotIfActive` becomes member-aware (`RegisteredRoastRetryCoordinatorForMember`).
- **Guards retired**: `count>1` terminal in `Begin`; `count>1` no-op in submit. A fully-registered multi-seat operator now proceeds per-seat with isolated bindings.
- **Guard kept**: partial-registration fail-closed.

## Design note — partial-registration fail-closed is kept deliberately

Member-keying isolates *registered* seats; it does nothing for a seat with **no** coordinator. The ROAST-vs-legacy selector is process-uniform, so an unregistered sibling running legacy while siblings drive bound ROAST would fracture the attempt. So `!ok && count>0 → ErrTerminalSigningFailure` (fail closed); only `count==0` (no seat registered anywhere) → the static legacy sentinel. Design locked via Codex + Gemini consult (both ratified).

## Why it's safe
`AttemptContext` has no per-seat fields, so `ctx.Hash()` is identical across sibling seats — member-keying does **not** change validation semantics; it only isolates handles and prevents cross-seat cleanup.

## Tests / verification
- New: `_MultiSeatProceedsPerSeat` (isolation via survival-after-sibling-cleanup; sibling handles are equal so cleanup-survival is the proof), `_IsolatesByMember` (registry, distinct handles), `_MultiSeatSubmitsPerSeat`, `_BindingIsMemberScoped`. Flipped the old full-multi-seat fail-closed test; kept the partial one.
- All 5 tag combos build+vet+test green; `-race` green on the combined combo; gofmt clean; `pkg/tbtc` signing-loop tests green (tagged + default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)