### PR TITLE
feat(frost): carry coordinator-equivocation proofs into the bundle (7.3 PR2b-2 step 2b)

### DIFF
--- a/pkg/frost/signing/roast_interactive_signing_drive_frost_native.go
+++ b/pkg/frost/signing/roast_interactive_signing_drive_frost_native.go
@@ -26,10 +26,11 @@ import (
 // Retry-loop ownership (per the Phase 7.3 executor-wiring design consult): the
 // existing tBTC signingRetryLoop owns retries -- it re-invokes the executor
 // (and therefore this helper) once per attempt with a fresh attempt context.
-// This helper drives exactly one attempt; it never loops. On a runner failure
-// it returns the error so the outer loop advances, and the deferred
-// orchestration cleanup stashes the transition bundle the (later PR) blame/retry
-// selector consumes.
+// This helper drives exactly one attempt; it never loops. On a runner failure it
+// stashes any coordinator-equivocation proofs the collector retained (consumed by
+// the transition exchange's BroadcastForcedSnapshot) and returns the error so the
+// outer loop advances and drives the transition. The deferred orchestration
+// cleanup only clears the per-attempt handle binding.
 //
 // Return contract -- (signature, error):
 //   - (sig, nil)  the interactive attempt completed; the executor returns sig
@@ -144,9 +145,22 @@ func driveInteractiveRoastSigningIfEnabled(
 
 	signatureBytes, err := runner.Run(ctx)
 	if err != nil {
-		// The attempt was driven and failed. Propagate so the outer tBTC
-		// signingRetryLoop advances; the deferred orchestration cleanup stashes
-		// the transition bundle for the next attempt's selector.
+		// The attempt was driven and failed. Before propagating, surface any
+		// coordinator-signed package proofs the collector retained -- it is NOT
+		// pruned on failure (roast_runner_frost_native.go), so the authoritative
+		// package (plus any body-different one the coordinator equivocated to this
+		// seat) is still held. Stashing them lets BroadcastForcedSnapshot carry them
+		// in this seat's snapshot; the bundle's aggregated proofs let NextAttempt
+		// instant-exclude an equivocating coordinator (RFC-21 Phase 7.3 PR2b-2 step
+		// 2b). An empty / unknown-attempt result stashes nothing.
+		attemptHash := attemptCtx.Hash()
+		if proofs, perr := collector.CoordinatorPackageProofs(attemptHash[:]); perr == nil {
+			stashPendingCoordinatorProofs(
+				attemptCtx.SessionID, request.MemberIndex, attemptHash, proofs,
+			)
+		}
+		// Propagate so the outer signingRetryLoop advances and drives the transition
+		// exchange (OnAttemptFailed -> BroadcastForcedSnapshot).
 		return nil, fmt.Errorf("interactive ROAST signing attempt: %w", err)
 	}
 

--- a/pkg/frost/signing/roast_retry_evidence_stash_default_build.go
+++ b/pkg/frost/signing/roast_retry_evidence_stash_default_build.go
@@ -18,3 +18,15 @@ func stashPendingEvidence(
 	_ attempt.Evidence,
 ) {
 }
+
+// stashPendingCoordinatorProofs is a no-op in the default build, mirroring
+// stashPendingEvidence: the interactive drive path (frost_native) calls it, but
+// with no ROAST-retry orchestration there is no transition exchange to consume the
+// proofs. The build-tagged implementation does the real stashing.
+func stashPendingCoordinatorProofs(
+	_ string,
+	_ group.MemberIndex,
+	_ [attempt.MessageDigestLength]byte,
+	_ [][]byte,
+) {
+}

--- a/pkg/frost/signing/roast_retry_evidence_stash_frost_roast_retry.go
+++ b/pkg/frost/signing/roast_retry_evidence_stash_frost_roast_retry.go
@@ -39,8 +39,15 @@ type pendingEvidenceKey struct {
 }
 
 type pendingEvidenceEntry struct {
-	evidence  attempt.Evidence
-	createdAt time.Time
+	evidence attempt.Evidence
+	// coordinatorProofs holds the coordinator-signed signing-package proof
+	// envelope(s) the interactive path retained for the attempt (RFC-21 Phase 7.3
+	// PR2b-2 step 2b). Empty for a coarse attempt. The two sources are mutually
+	// exclusive per attempt, so in practice an entry carries evidence XOR proofs --
+	// but both fields are independent so an entry carrying both stays structurally
+	// valid (NextAttempt reads the categories independently).
+	coordinatorProofs [][]byte
+	createdAt         time.Time
 }
 
 var (
@@ -61,33 +68,63 @@ func stashPendingEvidence(
 	key := pendingEvidenceKey{sessionID, member, attemptHash}
 	pendingEvidenceMu.Lock()
 	defer pendingEvidenceMu.Unlock()
-	pendingEvidenceRegistry[key] = pendingEvidenceEntry{
-		evidence:  copyEvidence(evidence),
-		createdAt: time.Now(),
-	}
+	// Upsert the evidence field, preserving any coordinator proofs already stashed
+	// for this attempt. The coarse and interactive paths are mutually exclusive per
+	// attempt, so normally only one writer fires; preserving the sibling field keeps
+	// the entry valid if that ever changes, never an XOR assumption that drops data.
+	entry := pendingEvidenceRegistry[key]
+	entry.evidence = copyEvidence(evidence)
+	entry.createdAt = time.Now()
+	pendingEvidenceRegistry[key] = entry
 }
 
-// takePendingEvidence returns the stashed evidence for (sessionID, member,
-// attemptHash) and a presence flag, REMOVING it (consume-on-read). The returned
-// value is the sole reference -- the entry is deleted from the registry -- so the
-// caller owns it exclusively without a further copy. BroadcastForcedSnapshot calls
-// it: a present entry means the coarse receive loop observed real evidence for the
-// attempt; absent means none was captured (the broadcast then carries an empty
-// proof-of-attendance snapshot).
+// stashPendingCoordinatorProofs stores deep COPIES of the coordinator-signed
+// signing-package proof envelope(s) the interactive runner's Round2Collector
+// retained for (sessionID, member, attemptHash). BroadcastForcedSnapshot carries
+// them in this seat's snapshot so the bundle's aggregated proofs let NextAttempt
+// instant-exclude an equivocating coordinator (RFC-21 Phase 7.3 PR2b-2 step 2b).
+// A no-op when proofs is empty. Like stashPendingEvidence it upserts only its own
+// field, preserving any coarse evidence already stashed for the attempt.
+func stashPendingCoordinatorProofs(
+	sessionID string,
+	member group.MemberIndex,
+	attemptHash [attempt.MessageDigestLength]byte,
+	proofs [][]byte,
+) {
+	if len(proofs) == 0 {
+		return
+	}
+	key := pendingEvidenceKey{sessionID, member, attemptHash}
+	pendingEvidenceMu.Lock()
+	defer pendingEvidenceMu.Unlock()
+	entry := pendingEvidenceRegistry[key]
+	entry.coordinatorProofs = copyProofs(proofs)
+	entry.createdAt = time.Now()
+	pendingEvidenceRegistry[key] = entry
+}
+
+// takePendingEvidence returns the stashed evidence AND coordinator proofs for
+// (sessionID, member, attemptHash) plus a presence flag, REMOVING the entry
+// (consume-on-read). The returned values are the sole references -- the entry is
+// deleted from the registry -- so the caller owns them exclusively without a
+// further copy. BroadcastForcedSnapshot calls it: a present entry means the coarse
+// receive loop observed evidence (Evidence) and/or the interactive path retained
+// coordinator-equivocation proofs ([][]byte) for the attempt; absent means neither
+// was captured (the broadcast then carries an empty proof-of-attendance snapshot).
 func takePendingEvidence(
 	sessionID string,
 	member group.MemberIndex,
 	attemptHash [attempt.MessageDigestLength]byte,
-) (attempt.Evidence, bool) {
+) (attempt.Evidence, [][]byte, bool) {
 	key := pendingEvidenceKey{sessionID, member, attemptHash}
 	pendingEvidenceMu.Lock()
 	defer pendingEvidenceMu.Unlock()
 	entry, ok := pendingEvidenceRegistry[key]
 	if !ok {
-		return attempt.Evidence{}, false
+		return attempt.Evidence{}, nil, false
 	}
 	delete(pendingEvidenceRegistry, key)
-	return entry.evidence, true
+	return entry.evidence, entry.coordinatorProofs, true
 }
 
 // clearPendingEvidence removes any stashed evidence for (sessionID, member,
@@ -199,6 +236,20 @@ func copyEvidence(e attempt.Evidence) attempt.Evidence {
 		for k, v := range e.Conflicts {
 			out.Conflicts[k] = v
 		}
+	}
+	return out
+}
+
+// copyProofs returns a deep copy of a slice of proof envelopes: the outer slice
+// and each inner []byte are re-allocated, so a later mutation of the caller's
+// slice cannot race the exchange's read. nil/empty stays nil.
+func copyProofs(proofs [][]byte) [][]byte {
+	if len(proofs) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(proofs))
+	for i, p := range proofs {
+		out[i] = append([]byte(nil), p...)
 	}
 	return out
 }

--- a/pkg/frost/signing/roast_retry_evidence_stash_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_evidence_stash_frost_roast_retry_test.go
@@ -3,6 +3,7 @@
 package signing
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -36,14 +37,14 @@ func TestPendingEvidenceStash_StoreTakeConsumes(t *testing.T) {
 	if !PendingEvidenceStashedForTest("s", 1) {
 		t.Fatal("entry must be present after store")
 	}
-	got, ok := takePendingEvidence("s", 1, hash)
+	got, _, ok := takePendingEvidence("s", 1, hash)
 	if !ok {
 		t.Fatal("take must find the stored entry")
 	}
 	if got.Overflows[2] != 1 || got.Conflicts[4] != 1 || len(got.Rejects[3]) != 1 {
 		t.Fatalf("taken evidence does not match stored: %+v", got)
 	}
-	if _, ok := takePendingEvidence("s", 1, hash); ok {
+	if _, _, ok := takePendingEvidence("s", 1, hash); ok {
 		t.Fatal("take must consume: a second take finds nothing")
 	}
 	if PendingEvidenceStashedForTest("s", 1) {
@@ -68,7 +69,7 @@ func TestPendingEvidenceStash_DeepCopyIsolatesCallerMutation(t *testing.T) {
 	src.Rejects[3][0].Count = 99
 	src.Conflicts[4] = 99
 
-	got, ok := takePendingEvidence("s", 1, hash)
+	got, _, ok := takePendingEvidence("s", 1, hash)
 	if !ok {
 		t.Fatal("take must find the stored entry")
 	}
@@ -97,8 +98,8 @@ func TestPendingEvidenceStash_MemberKeyedIsolation(t *testing.T) {
 	stashPendingEvidence("s", 1, hash, attempt.Evidence{Overflows: map[group.MemberIndex]uint{7: 1}})
 	stashPendingEvidence("s", 2, hash, attempt.Evidence{Overflows: map[group.MemberIndex]uint{8: 1}})
 
-	got1, ok1 := takePendingEvidence("s", 1, hash)
-	got2, ok2 := takePendingEvidence("s", 2, hash)
+	got1, _, ok1 := takePendingEvidence("s", 1, hash)
+	got2, _, ok2 := takePendingEvidence("s", 2, hash)
 	if !ok1 || !ok2 {
 		t.Fatalf("both member entries must exist; ok1=%v ok2=%v", ok1, ok2)
 	}
@@ -161,5 +162,97 @@ func TestEvictStalePendingEvidence(t *testing.T) {
 	}
 	if PendingEvidenceStashedForTest("s", 1) {
 		t.Fatal("entry must be gone after the sweep")
+	}
+}
+
+// TestStashPendingCoordinatorProofs_StoreTakeConsumes is the 2b proof path: the
+// interactive drive stashes coordinator-package proofs; takePendingEvidence returns
+// them (with empty Evidence) and consumes the entry.
+func TestStashPendingCoordinatorProofs_StoreTakeConsumes(t *testing.T) {
+	ResetPendingEvidenceRegistryForTest()
+	t.Cleanup(ResetPendingEvidenceRegistryForTest)
+
+	hash := stashTestHash(0x61)
+	proofs := [][]byte{[]byte("auth-package"), []byte("conflicting-package")}
+	stashPendingCoordinatorProofs("s", 1, hash, proofs)
+
+	if !PendingEvidenceStashedForTest("s", 1) {
+		t.Fatal("entry must be present after stashing proofs")
+	}
+	gotEv, gotProofs, ok := takePendingEvidence("s", 1, hash)
+	if !ok {
+		t.Fatal("take must find the stored proofs")
+	}
+	if len(gotEv.Overflows)+len(gotEv.Rejects)+len(gotEv.Conflicts) != 0 {
+		t.Fatalf("proof-only entry must carry empty evidence; got %+v", gotEv)
+	}
+	if len(gotProofs) != 2 ||
+		!bytes.Equal(gotProofs[0], proofs[0]) ||
+		!bytes.Equal(gotProofs[1], proofs[1]) {
+		t.Fatalf("taken proofs do not match stored: %q", gotProofs)
+	}
+	if _, _, ok := takePendingEvidence("s", 1, hash); ok {
+		t.Fatal("take must consume the proof entry")
+	}
+}
+
+// TestStashPendingCoordinatorProofs_EmptyIsNoOp guards the empty guard: an attempt
+// with no retained packages (CoordinatorPackageProofs returned nothing) stashes
+// nothing.
+func TestStashPendingCoordinatorProofs_EmptyIsNoOp(t *testing.T) {
+	ResetPendingEvidenceRegistryForTest()
+	t.Cleanup(ResetPendingEvidenceRegistryForTest)
+
+	stashPendingCoordinatorProofs("s", 1, stashTestHash(0x62), nil)
+	stashPendingCoordinatorProofs("s", 1, stashTestHash(0x62), [][]byte{})
+	if PendingEvidenceStashedForTest("s", 1) {
+		t.Fatal("empty proofs must not create a stash entry")
+	}
+}
+
+// TestStashPendingCoordinatorProofs_DeepCopied proves copyProofs isolates the
+// stash from later caller mutation of the proof bytes.
+func TestStashPendingCoordinatorProofs_DeepCopied(t *testing.T) {
+	ResetPendingEvidenceRegistryForTest()
+	t.Cleanup(ResetPendingEvidenceRegistryForTest)
+
+	hash := stashTestHash(0x63)
+	proof := []byte("package-bytes")
+	stashPendingCoordinatorProofs("s", 1, hash, [][]byte{proof})
+
+	proof[0] = 'X' // mutate the caller's slice after the store
+
+	_, gotProofs, ok := takePendingEvidence("s", 1, hash)
+	if !ok || len(gotProofs) != 1 {
+		t.Fatalf("expected one stashed proof; ok=%v got=%q", ok, gotProofs)
+	}
+	if !bytes.Equal(gotProofs[0], []byte("package-bytes")) {
+		t.Fatalf("proof must reflect store-time bytes, not the mutation; got %q", gotProofs[0])
+	}
+}
+
+// TestPendingEvidenceStash_EvidenceAndProofsUnion asserts the union entry: stashing
+// evidence and proofs under the SAME key (which the mutually-exclusive coarse and
+// interactive paths normally never do) carries BOTH -- neither writer clobbers the
+// other's field (Codex's "never an XOR assumption that drops data").
+func TestPendingEvidenceStash_EvidenceAndProofsUnion(t *testing.T) {
+	ResetPendingEvidenceRegistryForTest()
+	t.Cleanup(ResetPendingEvidenceRegistryForTest)
+
+	hash := stashTestHash(0x64)
+	stashPendingEvidence("s", 1, hash, attempt.Evidence{
+		Overflows: map[group.MemberIndex]uint{9: 1},
+	})
+	stashPendingCoordinatorProofs("s", 1, hash, [][]byte{[]byte("pkg")})
+
+	gotEv, gotProofs, ok := takePendingEvidence("s", 1, hash)
+	if !ok {
+		t.Fatal("union entry must exist")
+	}
+	if gotEv.Overflows[9] != 1 {
+		t.Fatalf("proof stash must not clobber the evidence field; got %+v", gotEv.Overflows)
+	}
+	if len(gotProofs) != 1 || !bytes.Equal(gotProofs[0], []byte("pkg")) {
+		t.Fatalf("evidence stash must not clobber the proofs field; got %q", gotProofs)
 	}
 }

--- a/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_retry_submit_frost_roast_retry_test.go
@@ -104,7 +104,7 @@ func TestSubmitSnapshotIfActive_StashesEvidenceWhenBoundAndPopulated(t *testing.
 	recorder.RecordOverflow(5)
 	submitSnapshotIfActive("session-real", selfMember, recorder)
 
-	evidence, ok := takePendingEvidence(ctx.SessionID, selfMember, ctx.Hash())
+	evidence, _, ok := takePendingEvidence(ctx.SessionID, selfMember, ctx.Hash())
 	if !ok {
 		t.Fatal("expected stashed evidence after a populated submit")
 	}
@@ -116,7 +116,7 @@ func TestSubmitSnapshotIfActive_StashesEvidenceWhenBoundAndPopulated(t *testing.
 		t.Fatalf("stashed overflow counts wrong: %+v", evidence.Overflows)
 	}
 	// take consumes: a second take finds nothing.
-	if _, ok := takePendingEvidence(ctx.SessionID, selfMember, ctx.Hash()); ok {
+	if _, _, ok := takePendingEvidence(ctx.SessionID, selfMember, ctx.Hash()); ok {
 		t.Fatal("take must consume the stash entry")
 	}
 }
@@ -141,7 +141,7 @@ func TestSubmitSnapshotIfActive_StashesRejectOnlySnapshot(t *testing.T) {
 	recorder.RecordReject(2, "attempt_context_hash_mismatch")
 	submitSnapshotIfActive("session-reject-only", selfMember, recorder)
 
-	evidence, ok := takePendingEvidence(ctx.SessionID, selfMember, ctx.Hash())
+	evidence, _, ok := takePendingEvidence(ctx.SessionID, selfMember, ctx.Hash())
 	if !ok {
 		t.Fatal("reject-only snapshot must be stashed")
 	}
@@ -173,8 +173,8 @@ func TestSubmitSnapshotIfActive_MultiSeatStashesPerSeat(t *testing.T) {
 	submitSnapshotIfActive("session-ms", 1, rec1)
 	submitSnapshotIfActive("session-ms", 2, rec2)
 
-	ev1, ok1 := takePendingEvidence(ctx.SessionID, 1, ctx.Hash())
-	ev2, ok2 := takePendingEvidence(ctx.SessionID, 2, ctx.Hash())
+	ev1, _, ok1 := takePendingEvidence(ctx.SessionID, 1, ctx.Hash())
+	ev2, _, ok2 := takePendingEvidence(ctx.SessionID, 2, ctx.Hash())
 	if !ok1 || !ok2 {
 		t.Fatalf("both seats must stash their own evidence; got ok1=%v ok2=%v", ok1, ok2)
 	}

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
@@ -205,11 +205,14 @@ func (e *RoastTransitionExchange) BroadcastForcedSnapshot(
 	if !ok {
 		return
 	}
-	// takePendingEvidence returns the zero Evidence on a miss, which
+	// takePendingEvidence returns the zero Evidence + nil proofs on a miss, which
 	// NewLocalEvidenceSnapshot renders as the empty proof-of-attendance snapshot --
-	// still broadcast so the seat is not silence-parked.
-	evidence, _ := takePendingEvidence(e.roastSessionID, e.member, attemptHash)
-	snapshot := roast.NewLocalEvidenceSnapshot(e.member, attemptHash, evidence)
+	// still broadcast so the seat is not silence-parked. When present, the snapshot
+	// carries the coarse path's evidence and/or the interactive path's
+	// coordinator-equivocation proofs (RFC-21 Phase 7.3 PR2b-2 step 2b); the
+	// constructor sorts + owns the proofs and the single signing happens below.
+	evidence, proofs, _ := takePendingEvidence(e.roastSessionID, e.member, attemptHash)
+	snapshot := roast.NewLocalEvidenceSnapshot(e.member, attemptHash, evidence, proofs...)
 	payload, err := snapshot.SignableBytes()
 	if err != nil {
 		e.logger.Warnf("roast transition: forced snapshot signable bytes: [%v]", err)

--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry_test.go
@@ -729,3 +729,117 @@ func TestRoastTransitionExchange_StashedEvidenceDrivesExclusion(t *testing.T) {
 		}
 	}
 }
+
+// TestRoastTransitionExchange_StashedProofsDriveCoordinatorEquivocationExclusion is
+// the end-to-end blame bridge for coordinator equivocation (RFC-21 Phase 7.3 PR2b-2
+// step 2b): coordinator-signed package proofs the interactive path stashes are
+// carried by BroadcastForcedSnapshot into the aggregated bundle, where NextAttempt's
+// cross-observer proof tally instantly excludes a coordinator that signed two
+// body-different packages -- the TARGETED case where no single observer saw both.
+func TestRoastTransitionExchange_StashedProofsDriveCoordinatorEquivocationExclusion(t *testing.T) {
+	ResetObservedAttemptRegistryForTest()
+	ResetRoastTransitionRegistryForTest()
+	ResetPendingEvidenceRegistryForTest()
+	t.Cleanup(ResetObservedAttemptRegistryForTest)
+	t.Cleanup(ResetRoastTransitionRegistryForTest)
+	t.Cleanup(ResetPendingEvidenceRegistryForTest)
+
+	roastSessionID := "exchange-equivocation-session"
+	included := []group.MemberIndex{1, 2, 3}
+	dkgKey := []byte{0x0b, 0x0c}
+	const threshold uint = 2 // excluding the single coordinator leaves 2 >= threshold
+
+	ctx := newExchangeTestContext(t, roastSessionID, included, dkgKey)
+	hash := ctx.Hash()
+	nodes := newExchangeTestNodes(t, roastSessionID, ctx, dkgKey)
+
+	// Determine the deterministically elected coordinator.
+	binding, ok := observedAttempt(roastSessionID, 1, hash)
+	if !ok {
+		t.Fatal("missing observe binding for member 1")
+	}
+	elected, err := nodes[1].coord.SelectedCoordinator(binding.handle)
+	if err != nil {
+		t.Fatalf("selected coordinator: %v", err)
+	}
+
+	// The coordinator distributed TWO body-different signed packages for this
+	// attempt; members 1 and 2 each retained a DIFFERENT one (the targeted split:
+	// no single observer saw both). Build them as authentic coordinator-signed
+	// proofs -- the harness's NoOpSignatureVerifier accepts the signature, and
+	// AuthenticateSigningPackage still checks coordinator id + attempt hash.
+	makeProof := func(body string) []byte {
+		pkg := &roast.SigningPackage{
+			AttemptContextHash:   append([]byte(nil), hash[:]...),
+			CoordinatorIDValue:   uint32(elected),
+			SigningPackageBytes:  []byte(body),
+			CoordinatorSignature: []byte{0x01},
+		}
+		env, perr := pkg.Marshal()
+		if perr != nil {
+			t.Fatalf("marshal proof: %v", perr)
+		}
+		return env
+	}
+	stashPendingCoordinatorProofs(roastSessionID, 1, hash, [][]byte{makeProof("frost-package-A")})
+	stashPendingCoordinatorProofs(roastSessionID, 2, hash, [][]byte{makeProof("frost-package-B")})
+
+	bundleMsg, electedFromBundle := produceTransitionBundleForTest(t, roastSessionID, ctx, nodes)
+	if electedFromBundle != elected {
+		t.Fatalf("elected mismatch: %d vs %d", electedFromBundle, elected)
+	}
+
+	bundle := &roast.TransitionMessage{}
+	if err := bundle.Unmarshal(bundleMsg.Payload); err != nil {
+		t.Fatalf("unmarshal bundle: %v", err)
+	}
+	// The bundle must carry >=2 proof envelopes across its snapshots (the pre-2b
+	// design carried none), and the stash must be consumed.
+	totalProofs := 0
+	for i := range bundle.Bundle {
+		totalProofs += len(bundle.Bundle[i].CoordinatorPackageProofs)
+	}
+	if totalProofs < 2 {
+		t.Fatalf("bundle must carry >=2 coordinator package proofs; got %d", totalProofs)
+	}
+	if PendingEvidenceStashedForTest(roastSessionID, 1) ||
+		PendingEvidenceStashedForTest(roastSessionID, 2) {
+		t.Fatal("BroadcastForcedSnapshot must consume the proof stash")
+	}
+
+	// A non-elected seat verifies the bundle and computes the next attempt: two
+	// distinct authentic coordinator-signed bodies -> instant coordinator exclusion.
+	var verifier group.MemberIndex
+	for _, m := range included {
+		if m != elected {
+			verifier = m
+			break
+		}
+	}
+	vbinding, ok := observedAttempt(roastSessionID, verifier, hash)
+	if !ok {
+		t.Fatalf("non-elected seat %d must still hold its observe binding", verifier)
+	}
+	if err := nodes[verifier].coord.VerifyBundle(vbinding.handle, bundle); err != nil {
+		t.Fatalf("verify bundle: %v", err)
+	}
+	next, err := nodes[verifier].coord.NextAttempt(vbinding.handle, bundle, threshold, dkgKey)
+	if err != nil {
+		t.Fatalf("next attempt: %v", err)
+	}
+
+	excludedCoord := false
+	for _, m := range next.ExcludedSet {
+		if m == elected {
+			excludedCoord = true
+		}
+	}
+	if !excludedCoord {
+		t.Fatalf("equivocating coordinator %d must be excluded; excluded=%v", elected, next.ExcludedSet)
+	}
+	for _, m := range next.IncludedSet {
+		if m == elected {
+			t.Fatalf("excluded coordinator %d must not remain in the included set; included=%v", elected, next.IncludedSet)
+		}
+	}
+}


### PR DESCRIPTION
## RFC-21 Phase 7.3 PR2b-2 step 2b — coordinator-equivocation exclusion wiring

Follows step 2a (#4088). 2a routed the coarse f+1 evidence (rejects/overflows/conflicts) into the transition bundle; 2b wires the **other** exclusion path — proof-carrying coordinator equivocation.

### The gap
`verifiedCoordinatorEquivocations` (`next_attempt.go`) scans every bundle snapshot's `CoordinatorPackageProofs`, authenticates each (coordinator operator-sig over body + attempt), dedupes by body hash, and **instant-excludes** a coordinator that signed ≥2 distinct authentic bodies — no f+1 gate, unforgeable. But nothing populated those proofs in the live path: the interactive runner's `Round2Collector` retains the coordinator-signed packages (and is **not** pruned on failure), yet they never reached the broadcast snapshot.

### The bridge
Reuse 2a's pending-evidence stash, extended to a union `{evidence, coordinatorProofs}`:

- On an interactive `runner.Run` failure, `driveInteractiveRoastSigningIfEnabled` surfaces `collector.CoordinatorPackageProofs(hash)` and **stashes** them by `(RoastSessionID, member, attemptHash)`.
- `BroadcastForcedSnapshot` **consumes** them and passes them to the variadic `NewLocalEvidenceSnapshot(member, hash, evidence, proofs...)` — the seat's **one** signed snapshot carries them (the constructor sorts + owns them; `VerifyBundle`'s censorship check is over the body already compared).

### Why publish-always
Publishing the authoritative package on **every** failed interactive attempt (1 envelope when honest, 2 when the coordinator equivocated to this seat) is what lets `NextAttempt` aggregate bodies **across observers** and catch **targeted** equivocation — a coordinator that sends different packages to different members, where no single observer sees both. Identical authoritative proofs dedupe to one body → no false positive. Wire cost is bounded (`MaxCoordinatorPackageProofs = 2`, failure-path only).

### Safety
- Each writer **upserts only its own field** — coarse and interactive are mutually exclusive per attempt, but the union never assumes XOR and never drops the sibling's data.
- Proofs deep-copied on store; lifecycle (consume-on-broadcast, clear-on-success, session-end, TTL) unchanged.
- **No publish on success** (the runner prunes the collector and the failure block is skipped).
- A Byzantine observer cannot frame an honest coordinator (`AuthenticateSigningPackage` requires the coordinator's own signature).
- Default-build no-op stub added (the drive path is `frost_native`). Stale "deferred cleanup stashes the transition bundle" comments retired.

### Scope / gating
Prod-dormant until the cgo interactive engine is registered (gated on the `frost-secp256k1-tr` audit). **2c** (fault injection) follows.

### Verification
- build + vet across 5 tag combos (default / `frost_native` / `frost_roast_retry` / `frost_native frost_roast_retry` / `frost_native frost_tbtc_signer` w/ CGO)
- tests green incl. an e2e (two observers stash **distinct** coordinator proofs → bundle → `NextAttempt` instant-excludes the coordinator — the targeted-split case) + union/deep-copy/consume unit tests; `-race` on `pkg/frost/signing`; gofmt clean
- design locked via Codex + Gemini consult (both PROCEED, no holes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)