### PR TITLE
test(frost): real-cgo interactive signing — single-signer real-crypto bridge test

### DIFF
--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -5,12 +5,20 @@ package signing
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
 	"github.com/keep-network/keep-core/pkg/operator"
 )
+
+// realCgoSessionSeq gives each invocation a unique session id so that in-process
+// repeats (go test -count=N) over the shared, process-stable signer state path add
+// a fresh DKG session instead of conflicting on a fixed one.
+var realCgoSessionSeq atomic.Uint64
 
 // This file is the REAL-cgo interactive signing test: a full FROST DKG that
 // PERSISTS a key group, followed by one signer's interactive ROAST contribution
@@ -68,16 +76,28 @@ func TestRealCgoInteractiveSigning_MemberContribution(t *testing.T) {
 	t.Setenv("TBTC_SIGNER_PROFILE", "development")
 	t.Setenv("TBTC_SIGNER_ENFORCE_PROVENANCE_GATE", "false")
 	// RunDKG persists the DKG result in the signer's ENCRYPTED state, so a linked
-	// signer needs a state encryption key and an ISOLATED, fresh state path. Without
-	// them a clean linked environment fails before signing (missing key), and a
-	// shared/default state path makes reruns conflict on the fixed session id.
-	// t.TempDir() yields a fresh path per run, so each run starts clean.
+	// signer needs a state encryption key and a state path. The path must be STABLE
+	// within the process: the signer binds its process-global state-file lock to the
+	// first path it sees and refuses to switch, so a fresh t.TempDir() per invocation
+	// would break in-process repeats (go test -count=2 fails on the second run). Use
+	// a per-PROCESS path (stable across -count=N, unique across processes so separate
+	// runs do not contend on one lock) plus a unique session id per invocation
+	// (below), so repeats add a fresh DKG session rather than conflicting on a fixed
+	// one. The encryption key is fixed so the persisted state stays decryptable across
+	// in-process repeats.
 	stateKey := make([]byte, 32)
 	for i := range stateKey {
 		stateKey[i] = byte(i + 1)
 	}
 	t.Setenv("TBTC_SIGNER_STATE_ENCRYPTION_KEY_HEX", hex.EncodeToString(stateKey))
-	t.Setenv("TBTC_SIGNER_STATE_PATH", filepath.Join(t.TempDir(), "signer-state"))
+	stateDir := filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf("keep-frost-realcgo-state-%d", os.Getpid()),
+	)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("create signer state dir: %v", err)
+	}
+	t.Setenv("TBTC_SIGNER_STATE_PATH", filepath.Join(stateDir, "signer-state"))
 
 	engine := &buildTaggedTBTCSignerEngine{}
 
@@ -85,8 +105,10 @@ func TestRealCgoInteractiveSigning_MemberContribution(t *testing.T) {
 	// {1,2} over a 3-party DKG. This process drives the one local signer (member 1).
 	const threshold = 2
 	// One session id for the whole flow: the engine keys the interactive session by
-	// the DKG session id, so RunDKG, derive, and open all use sessionID.
-	const sessionID = "real-cgo-session-1"
+	// the DKG session id, so RunDKG, derive, and open all use sessionID. It is unique
+	// per invocation so in-process repeats over the stable state path add a fresh
+	// session instead of conflicting on a fixed one.
+	sessionID := fmt.Sprintf("real-cgo-session-%d", realCgoSessionSeq.Add(1))
 	const localMember = uint16(1)
 	participantIDs := []byte{1, 2, 3}
 	includedMembers := []byte{1, 2}

--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -5,6 +5,7 @@ package signing
 import (
 	"encoding/hex"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
@@ -50,6 +51,17 @@ import (
 func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 	t.Setenv("TBTC_SIGNER_PROFILE", "development")
 	t.Setenv("TBTC_SIGNER_ENFORCE_PROVENANCE_GATE", "false")
+	// RunDKG persists the DKG result in the signer's ENCRYPTED state, so a linked
+	// signer needs a state encryption key and an ISOLATED, fresh state path. Without
+	// them a clean linked environment fails before signing (missing key), and a
+	// shared/default state path makes reruns conflict on the fixed session id.
+	// t.TempDir() yields a fresh path per run, so each run starts clean.
+	stateKey := make([]byte, 32)
+	for i := range stateKey {
+		stateKey[i] = byte(i + 1)
+	}
+	t.Setenv("TBTC_SIGNER_STATE_ENCRYPTION_KEY_HEX", hex.EncodeToString(stateKey))
+	t.Setenv("TBTC_SIGNER_STATE_PATH", filepath.Join(t.TempDir(), "signer-state"))
 
 	engine := &buildTaggedTBTCSignerEngine{}
 

--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -5,7 +5,6 @@ package signing
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -13,52 +12,54 @@ import (
 	"github.com/keep-network/keep-core/pkg/operator"
 )
 
-// This file is the REAL-cgo interactive signing end-to-end test: a full FROST DKG
-// that PERSISTS a key group, followed by an interactive ROAST signing round
+// This file is the REAL-cgo interactive signing test: a full FROST DKG that
+// PERSISTS a key group, followed by one signer's interactive ROAST contribution
 // driven through the engine's INTERACTIVE session API
-// (DeriveInteractiveAttemptContext -> InteractiveSessionOpen -> InteractiveRound1
-// -> NewSigningPackage -> InteractiveRound2 -> InteractiveAggregate) with real
-// frost-secp256k1-tr cryptography. It complements:
+// (DeriveInteractiveAttemptContext -> InteractiveSessionOpen -> InteractiveRound1)
+// with real frost-secp256k1-tr cryptography. It complements:
 //   - TestBuildTaggedTBTCSignerInteractiveFROSTBridge_WithLinkedSigner, which
 //     proves the real crypto over the LOW-LEVEL Sign/Aggregate API by feeding
 //     KeyPackage bytes directly; and
-//   - the fake-engine runner suite, which proves the Go-side orchestration
-//     without crypto.
-// This is the missing combination: the INTERACTIVE session API the runner uses,
-// with real crypto, the prerequisite toward coarse-path retirement.
+//   - the fake-engine runner suite (roast_runner_bus_net_e2e_frost_native_test.go),
+//     which proves the multi-node Go-side orchestration - a t-subset across nodes,
+//     observers, the real pkg/net transport - without crypto.
+// This test covers the remaining gap: the interactive session API the runner uses,
+// with the REAL engine and REAL crypto.
+//
+// Scope and why it is one member: the signer engine state is a PROCESS GLOBAL (a
+// single Mutex<EngineState>) that holds ONE open interactive member per session -
+// InteractiveSessionOpen is fingerprinted once per session and
+// interactive_state_for_attempt_mut rejects any member_identifier other than the
+// opener's. That is by design: each production node is its own process. The engine
+// also requires threshold >= 2. So a SINGLE process can faithfully drive exactly
+// one signer's real contribution (open + round 1), but NOT the full t-of-n
+// finalize (NewSigningPackage over t commitments -> round 2 per member -> aggregate),
+// which needs the other members' contributions from their own processes. A
+// complete real-crypto signature therefore requires a multi-process harness; the
+// multi-member orchestration itself is covered with the fake engine over the real
+// transport in the runner net e2e.
 //
 // The DKG -> interactive keyGroup glue is RunDKG: InteractiveSessionOpen resolves
 // the signing key by a keyGroup IDENTIFIER (engine-internal persisted material),
-// not KeyPackage bytes - so the low-level DKG (Part1/2/3) result, which the test
-// holds as bytes, is NOT loadable as an interactive keyGroup. RunDKG runs the full
-// DKG and PERSISTS the result under a returned keyGroup the interactive (and
-// coarse) signing path then resolves - the same flow production uses (the wallet
-// layer runs DKG, gets a keyGroup, then signs).
-//
-// Correctness is proven by the engine's SUCCESSFUL InteractiveAggregate: FROST
-// validates the signature shares and the aggregate internally, so a non-error
-// 64-byte BIP-340 signature is a valid threshold signature over the message under
-// the keyGroup's group key. An ADDITIONAL external schnorr.Verify is intentionally
-// NOT done here: the engine exposes no API to retrieve a keyGroup's group public
-// key (RunDKG returns only the keyGroup id, and ExtractDkgGroupPublicKeyFromMaterial
-// needs the persisted material bytes the test does not hold), so external
-// verification would need a new keyGroup->group-pubkey accessor. That is the one
-// remaining nicety; the e2e itself is complete via the internal validation.
+// not KeyPackage bytes. RunDKG runs the full DKG and PERSISTS the result, keyed by
+// the SESSION ID, under a returned keyGroup the interactive path resolves - the
+// same flow production uses. Open then requires a completed DKG session of the
+// same session_id, so RunDKG and the interactive flow share one session id.
 //
 // To run it, link the signer library so the frost_tbtc_* symbols resolve, e.g.:
 //
 //	CGO_ENABLED=1 \
 //	  CGO_LDFLAGS="-L<dir> -lfrost_tbtc -Wl,-rpath,<dir>" \
 //	  go test -tags "frost_native frost_tbtc_signer" \
-//	    -run TestRealCgoInteractiveSigning_EndToEnd ./pkg/frost/signing/
+//	    -run TestRealCgoInteractiveSigning_MemberContribution ./pkg/frost/signing/
 //
 // Every engine call is guarded by skipFrostUnavailable: when the lib is absent, or
 // present but stale (an older dylib missing a newer symbol such as
-// frost_tbtc_derive_interactive_attempt_context), the test SKIPS with a message
-// naming the operation, rather than failing - so it is inert in CI builds that do
-// not link the Rust signer and runs to completion only against a current lib.
+// frost_tbtc_derive_interactive_attempt_context), the test SKIPS naming the
+// operation, rather than failing - so it is inert in CI builds that do not link
+// the Rust signer and runs only against a current lib.
 
-func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
+func TestRealCgoInteractiveSigning_MemberContribution(t *testing.T) {
 	t.Setenv("TBTC_SIGNER_PROFILE", "development")
 	t.Setenv("TBTC_SIGNER_ENFORCE_PROVENANCE_GATE", "false")
 	// RunDKG persists the DKG result in the signer's ENCRYPTED state, so a linked
@@ -75,102 +76,63 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 
 	engine := &buildTaggedTBTCSignerEngine{}
 
+	// The engine requires threshold >= 2; the attempt's included set is the t-subset
+	// {1,2} over a 3-party DKG. This process drives the one local signer (member 1).
 	const threshold = 2
+	// One session id for the whole flow: the engine keys the interactive session by
+	// the DKG session id, so RunDKG, derive, and open all use sessionID.
+	const sessionID = "real-cgo-session-1"
+	const localMember = uint16(1)
 	participantIDs := []byte{1, 2, 3}
-	signingMembers := []byte{1, 2}
+	includedMembers := []byte{1, 2}
 	message := bytesOf(0x42, 32)
 
-	// 1. Full DKG that persists a key group. RunDKG runs the whole DKG over the
-	// participants and returns a keyGroup the signing path resolves.
-	keyGroup := runRealCgoDKGKeyGroup(t, engine, participantIDs, threshold)
+	// 1. Full DKG that persists a key group under sessionID, returning the keyGroup
+	// the signing path resolves.
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
 
-	// 2. Interactive signing over the chosen t-subset, driven through the engine's
-	// interactive session API - the same calls the interactiveSigningRunner makes,
+	// 2. Derive the attempt context for the t-subset, then drive the local signer's
+	// interactive contribution - the same calls the interactiveSigningRunner makes,
 	// here with real crypto against the DKG-persisted keyGroup.
 	derived, err := engine.DeriveInteractiveAttemptContext(
-		"real-cgo-session-1",
+		sessionID,
 		message,
 		keyGroup,
 		threshold,
 		0, // 0-based attempt number; the bridge converts to the 1-based wire value
-		uint16sOf(signingMembers),
+		uint16sOf(includedMembers),
 	)
 	skipFrostUnavailable(t, "derive interactive attempt context", err)
-	frostIDByMember := map[byte]string{}
-	for _, id := range derived.FrostIdentifiers {
-		frostIDByMember[byte(id.ParticipantIdentifier)] = id.FrostIdentifier
-	}
 
-	attemptIDByMember := make(map[byte]string, len(signingMembers))
-	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
-	for _, member := range signingMembers {
-		open, err := engine.InteractiveSessionOpen(
-			"real-cgo-session-1",
-			uint16(member),
-			message,
-			keyGroup,
-			threshold,
-			nil, // key-path spend
-			derived.AttemptContext,
-		)
-		skipFrostUnavailable(t, fmt.Sprintf("interactive session open (member %d)", member), err)
-		attemptIDByMember[member] = open.AttemptID
-
-		commitmentData, err := engine.InteractiveRound1(
-			"real-cgo-session-1", open.AttemptID, uint16(member),
-		)
-		skipFrostUnavailable(t, fmt.Sprintf("interactive round 1 (member %d)", member), err)
-		commitments = append(commitments, nativeFROSTCommitment{
-			Identifier: frostIDByMember[member],
-			Data:       commitmentData,
-		})
-	}
-
-	signingPackage, err := engine.NewSigningPackage(message, commitments)
-	skipFrostUnavailable(t, "new signing package", err)
-
-	signatureShares := make([]nativeFROSTSignatureShare, 0, len(signingMembers))
-	for _, member := range signingMembers {
-		shareData, err := engine.InteractiveRound2(
-			"real-cgo-session-1",
-			attemptIDByMember[member],
-			uint16(member),
-			signingPackage,
-		)
-		skipFrostUnavailable(t, fmt.Sprintf("interactive round 2 (member %d)", member), err)
-		signatureShares = append(signatureShares, nativeFROSTSignatureShare{
-			Identifier: frostIDByMember[member],
-			Data:       shareData,
-		})
-	}
-
-	// A failed aggregate (other than an unavailable symbol) IS the verification:
-	// real FROST rejects invalid shares or a key/package mismatch here, so a
-	// non-error result is the proof the interactive round produced a valid
-	// threshold signature.
-	signatureBytes, err := engine.InteractiveAggregate(
-		"real-cgo-session-1",
-		attemptIDByMember[signingMembers[0]],
-		signingPackage,
-		signatureShares,
-		nil,
+	open, err := engine.InteractiveSessionOpen(
+		sessionID,
+		localMember,
+		message,
+		keyGroup,
+		threshold,
+		nil, // key-path spend
+		derived.AttemptContext,
 	)
-	skipFrostUnavailable(t, "interactive aggregate", err)
+	skipFrostUnavailable(t, "interactive session open", err)
+	if open.AttemptID == "" {
+		t.Fatal("interactive session open returned an empty attempt id")
+	}
 
-	// 3. The successful aggregate is a valid 64-byte BIP-340 signature (the engine
-	// validated the shares and the aggregate internally). External schnorr.Verify
-	// is omitted only for want of a keyGroup->group-pubkey accessor (see the file
-	// comment); assert well-formedness.
-	if len(signatureBytes) != 64 {
-		t.Fatalf("unexpected interactive signature length: %d", len(signatureBytes))
+	// Round 1: the real engine generates this member's signing nonces and returns
+	// its public commitments. A non-empty commitment is the proof the real
+	// interactive crypto path (DKG-persisted key resolution -> commit) works.
+	commitmentData, err := engine.InteractiveRound1(sessionID, open.AttemptID, localMember)
+	skipFrostUnavailable(t, "interactive round 1", err)
+	if len(commitmentData) == 0 {
+		t.Fatal("interactive round 1 returned an empty commitment from the real engine")
 	}
 }
 
 // skipFrostUnavailable turns an engine-call error into the right outcome: a missing
 // FFI symbol (lib absent, or present but stale and missing a newer symbol) SKIPS
 // the test naming the operation, while any other error is a real failure. nil is a
-// no-op. Centralizing this makes every step of the e2e robust to an incomplete lib
-// rather than only the first (RunDKG) call.
+// no-op. Centralizing this makes every step robust to an incomplete lib rather than
+// only the first (RunDKG) call.
 func skipFrostUnavailable(t *testing.T, op string, err error) {
 	t.Helper()
 	if err == nil {
@@ -187,13 +149,15 @@ func skipFrostUnavailable(t *testing.T, op string, err error) {
 }
 
 // runRealCgoDKGKeyGroup runs a full real FROST DKG over the participants via
-// RunDKG, which persists the result and returns the keyGroup the signing path
-// resolves. It skips the test if the linked tbtc-signer FFI symbols are absent.
-// Each participant carries a freshly generated operator public key (the DKG's
-// per-participant identifying key), so the request is well-formed.
+// RunDKG under sessionID, which persists the result (keyed by that session id) and
+// returns the keyGroup the signing path resolves. It skips the test if the linked
+// tbtc-signer FFI symbols are absent. Each participant carries a freshly generated
+// operator public key (the DKG's per-participant identifying key), so the request
+// is well-formed.
 func runRealCgoDKGKeyGroup(
 	t *testing.T,
 	engine *buildTaggedTBTCSignerEngine,
+	sessionID string,
 	participantIDs []byte,
 	threshold uint16,
 ) string {
@@ -211,7 +175,7 @@ func runRealCgoDKGKeyGroup(
 		})
 	}
 
-	result, err := engine.RunDKG("real-cgo-dkg-session-1", participants, threshold)
+	result, err := engine.RunDKG(sessionID, participants, threshold)
 	skipFrostUnavailable(t, "run DKG", err)
 	if result.KeyGroup == "" {
 		t.Fatal("RunDKG returned an empty key group")

--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -1,0 +1,206 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/operator"
+)
+
+// This file is the REAL-cgo interactive signing end-to-end test: a full FROST DKG
+// that PERSISTS a key group, followed by an interactive ROAST signing round
+// driven through the engine's INTERACTIVE session API
+// (DeriveInteractiveAttemptContext -> InteractiveSessionOpen -> InteractiveRound1
+// -> NewSigningPackage -> InteractiveRound2 -> InteractiveAggregate) with real
+// frost-secp256k1-tr cryptography. It complements:
+//   - TestBuildTaggedTBTCSignerInteractiveFROSTBridge_WithLinkedSigner, which
+//     proves the real crypto over the LOW-LEVEL Sign/Aggregate API by feeding
+//     KeyPackage bytes directly; and
+//   - the fake-engine runner suite, which proves the Go-side orchestration
+//     without crypto.
+// This is the missing combination: the INTERACTIVE session API the runner uses,
+// with real crypto, the prerequisite toward coarse-path retirement.
+//
+// The DKG -> interactive keyGroup glue is RunDKG: InteractiveSessionOpen resolves
+// the signing key by a keyGroup IDENTIFIER (engine-internal persisted material),
+// not KeyPackage bytes - so the low-level DKG (Part1/2/3) result, which the test
+// holds as bytes, is NOT loadable as an interactive keyGroup. RunDKG runs the full
+// DKG and PERSISTS the result under a returned keyGroup the interactive (and
+// coarse) signing path then resolves - the same flow production uses (the wallet
+// layer runs DKG, gets a keyGroup, then signs).
+//
+// Correctness is proven by the engine's SUCCESSFUL InteractiveAggregate: FROST
+// validates the signature shares and the aggregate internally, so a non-error
+// 64-byte BIP-340 signature is a valid threshold signature over the message under
+// the keyGroup's group key. An ADDITIONAL external schnorr.Verify is intentionally
+// NOT done here: the engine exposes no API to retrieve a keyGroup's group public
+// key (RunDKG returns only the keyGroup id, and ExtractDkgGroupPublicKeyFromMaterial
+// needs the persisted material bytes the test does not hold), so external
+// verification would need a new keyGroup->group-pubkey accessor. That is the one
+// remaining nicety; the e2e itself is complete via the internal validation.
+//
+// The whole test is skip-guarded for the absence of the linked tbtc-signer FFI
+// symbols, matching the other real-cgo tests, so it is inert in CI builds that do
+// not link the Rust signer and runs only where the lib is present.
+
+func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
+	t.Setenv("TBTC_SIGNER_PROFILE", "development")
+	t.Setenv("TBTC_SIGNER_ENFORCE_PROVENANCE_GATE", "false")
+
+	engine := &buildTaggedTBTCSignerEngine{}
+
+	const groupSize = 3
+	const threshold = 2
+	participantIDs := []byte{1, 2, 3}
+	signingMembers := []byte{1, 2}
+	message := bytesOf(0x42, 32)
+
+	// 1. Full DKG that persists a key group. RunDKG runs the whole DKG over the
+	// participants and returns a keyGroup the signing path resolves. Skips if the
+	// linked tbtc-signer FFI symbols are absent (no Rust lib in this build).
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, participantIDs, threshold)
+
+	// 2. Interactive signing over the chosen t-subset, driven through the engine's
+	// interactive session API - the same calls the interactiveSigningRunner makes,
+	// here with real crypto against the DKG-persisted keyGroup.
+	derived, err := engine.DeriveInteractiveAttemptContext(
+		"real-cgo-session-1",
+		message,
+		keyGroup,
+		threshold,
+		0, // 0-based attempt number; the bridge converts to the 1-based wire value
+		uint16sOf(signingMembers),
+	)
+	if err != nil {
+		t.Fatalf("derive interactive attempt context: %v", err)
+	}
+	frostIDByMember := map[byte]string{}
+	for _, id := range derived.FrostIdentifiers {
+		frostIDByMember[byte(id.ParticipantIdentifier)] = id.FrostIdentifier
+	}
+
+	attemptIDByMember := make(map[byte]string, len(signingMembers))
+	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
+	for _, member := range signingMembers {
+		open, err := engine.InteractiveSessionOpen(
+			"real-cgo-session-1",
+			uint16(member),
+			message,
+			keyGroup,
+			threshold,
+			nil, // key-path spend
+			derived.AttemptContext,
+		)
+		if err != nil {
+			t.Fatalf("interactive session open (member %d): %v", member, err)
+		}
+		attemptIDByMember[member] = open.AttemptID
+
+		commitmentData, err := engine.InteractiveRound1(
+			"real-cgo-session-1", open.AttemptID, uint16(member),
+		)
+		if err != nil {
+			t.Fatalf("interactive round 1 (member %d): %v", member, err)
+		}
+		commitments = append(commitments, nativeFROSTCommitment{
+			Identifier: frostIDByMember[member],
+			Data:       commitmentData,
+		})
+	}
+
+	signingPackage, err := engine.NewSigningPackage(message, commitments)
+	if err != nil {
+		t.Fatalf("new signing package: %v", err)
+	}
+
+	signatureShares := make([]nativeFROSTSignatureShare, 0, len(signingMembers))
+	for _, member := range signingMembers {
+		shareData, err := engine.InteractiveRound2(
+			"real-cgo-session-1",
+			attemptIDByMember[member],
+			uint16(member),
+			signingPackage,
+		)
+		if err != nil {
+			t.Fatalf("interactive round 2 (member %d): %v", member, err)
+		}
+		signatureShares = append(signatureShares, nativeFROSTSignatureShare{
+			Identifier: frostIDByMember[member],
+			Data:       shareData,
+		})
+	}
+
+	signatureBytes, err := engine.InteractiveAggregate(
+		"real-cgo-session-1",
+		attemptIDByMember[signingMembers[0]],
+		signingPackage,
+		signatureShares,
+		nil,
+	)
+	if err != nil {
+		// A failed aggregate IS the verification: real FROST would reject invalid
+		// shares or a key/package mismatch here, so a non-error result is the
+		// proof the interactive round produced a valid threshold signature.
+		t.Fatalf("interactive aggregate: %v", err)
+	}
+
+	// 3. The successful aggregate is a valid 64-byte BIP-340 signature (the engine
+	// validated the shares and the aggregate internally). External schnorr.Verify
+	// is omitted only for want of a keyGroup->group-pubkey accessor (see the file
+	// comment); assert well-formedness.
+	if len(signatureBytes) != 64 {
+		t.Fatalf("unexpected interactive signature length: %d", len(signatureBytes))
+	}
+}
+
+// runRealCgoDKGKeyGroup runs a full real FROST DKG over the participants via
+// RunDKG, which persists the result and returns the keyGroup the signing path
+// resolves. It skips the test if the linked tbtc-signer FFI symbols are absent.
+// Each participant carries a freshly generated operator public key (the DKG's
+// per-participant identifying key), so the request is well-formed.
+func runRealCgoDKGKeyGroup(
+	t *testing.T,
+	engine *buildTaggedTBTCSignerEngine,
+	participantIDs []byte,
+	threshold uint16,
+) string {
+	t.Helper()
+
+	participants := make([]NativeTBTCSignerDKGParticipant, 0, len(participantIDs))
+	for _, id := range participantIDs {
+		_, publicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("operator key (participant %d): %v", id, err)
+		}
+		participants = append(participants, NativeTBTCSignerDKGParticipant{
+			Identifier:   uint16(id),
+			PublicKeyHex: hex.EncodeToString(operator.MarshalUncompressed(publicKey)),
+		})
+	}
+
+	result, err := engine.RunDKG("real-cgo-dkg-session-1", participants, threshold)
+	if err != nil {
+		if errors.Is(err, ErrNativeCryptographyUnavailable) {
+			t.Skip("linked tbtc-signer FFI symbols unavailable")
+		}
+		t.Fatalf("run DKG: %v", err)
+	}
+	if result.KeyGroup == "" {
+		t.Fatal("RunDKG returned an empty key group")
+	}
+	return result.KeyGroup
+}
+
+// uint16sOf widens member ids to the uint16 participant list the engine's
+// DeriveInteractiveAttemptContext expects.
+func uint16sOf(members []byte) []uint16 {
+	out := make([]uint16, 0, len(members))
+	for _, member := range members {
+		out = append(out, uint16(member))
+	}
+	return out
+}

--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -5,6 +5,7 @@ package signing
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -44,9 +45,18 @@ import (
 // verification would need a new keyGroup->group-pubkey accessor. That is the one
 // remaining nicety; the e2e itself is complete via the internal validation.
 //
-// The whole test is skip-guarded for the absence of the linked tbtc-signer FFI
-// symbols, matching the other real-cgo tests, so it is inert in CI builds that do
-// not link the Rust signer and runs only where the lib is present.
+// To run it, link the signer library so the frost_tbtc_* symbols resolve, e.g.:
+//
+//	CGO_ENABLED=1 \
+//	  CGO_LDFLAGS="-L<dir> -lfrost_tbtc -Wl,-rpath,<dir>" \
+//	  go test -tags "frost_native frost_tbtc_signer" \
+//	    -run TestRealCgoInteractiveSigning_EndToEnd ./pkg/frost/signing/
+//
+// Every engine call is guarded by skipFrostUnavailable: when the lib is absent, or
+// present but stale (an older dylib missing a newer symbol such as
+// frost_tbtc_derive_interactive_attempt_context), the test SKIPS with a message
+// naming the operation, rather than failing - so it is inert in CI builds that do
+// not link the Rust signer and runs to completion only against a current lib.
 
 func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 	t.Setenv("TBTC_SIGNER_PROFILE", "development")
@@ -65,15 +75,13 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 
 	engine := &buildTaggedTBTCSignerEngine{}
 
-	const groupSize = 3
 	const threshold = 2
 	participantIDs := []byte{1, 2, 3}
 	signingMembers := []byte{1, 2}
 	message := bytesOf(0x42, 32)
 
 	// 1. Full DKG that persists a key group. RunDKG runs the whole DKG over the
-	// participants and returns a keyGroup the signing path resolves. Skips if the
-	// linked tbtc-signer FFI symbols are absent (no Rust lib in this build).
+	// participants and returns a keyGroup the signing path resolves.
 	keyGroup := runRealCgoDKGKeyGroup(t, engine, participantIDs, threshold)
 
 	// 2. Interactive signing over the chosen t-subset, driven through the engine's
@@ -87,9 +95,7 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 		0, // 0-based attempt number; the bridge converts to the 1-based wire value
 		uint16sOf(signingMembers),
 	)
-	if err != nil {
-		t.Fatalf("derive interactive attempt context: %v", err)
-	}
+	skipFrostUnavailable(t, "derive interactive attempt context", err)
 	frostIDByMember := map[byte]string{}
 	for _, id := range derived.FrostIdentifiers {
 		frostIDByMember[byte(id.ParticipantIdentifier)] = id.FrostIdentifier
@@ -107,17 +113,13 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 			nil, // key-path spend
 			derived.AttemptContext,
 		)
-		if err != nil {
-			t.Fatalf("interactive session open (member %d): %v", member, err)
-		}
+		skipFrostUnavailable(t, fmt.Sprintf("interactive session open (member %d)", member), err)
 		attemptIDByMember[member] = open.AttemptID
 
 		commitmentData, err := engine.InteractiveRound1(
 			"real-cgo-session-1", open.AttemptID, uint16(member),
 		)
-		if err != nil {
-			t.Fatalf("interactive round 1 (member %d): %v", member, err)
-		}
+		skipFrostUnavailable(t, fmt.Sprintf("interactive round 1 (member %d)", member), err)
 		commitments = append(commitments, nativeFROSTCommitment{
 			Identifier: frostIDByMember[member],
 			Data:       commitmentData,
@@ -125,9 +127,7 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 	}
 
 	signingPackage, err := engine.NewSigningPackage(message, commitments)
-	if err != nil {
-		t.Fatalf("new signing package: %v", err)
-	}
+	skipFrostUnavailable(t, "new signing package", err)
 
 	signatureShares := make([]nativeFROSTSignatureShare, 0, len(signingMembers))
 	for _, member := range signingMembers {
@@ -137,15 +137,17 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 			uint16(member),
 			signingPackage,
 		)
-		if err != nil {
-			t.Fatalf("interactive round 2 (member %d): %v", member, err)
-		}
+		skipFrostUnavailable(t, fmt.Sprintf("interactive round 2 (member %d)", member), err)
 		signatureShares = append(signatureShares, nativeFROSTSignatureShare{
 			Identifier: frostIDByMember[member],
 			Data:       shareData,
 		})
 	}
 
+	// A failed aggregate (other than an unavailable symbol) IS the verification:
+	// real FROST rejects invalid shares or a key/package mismatch here, so a
+	// non-error result is the proof the interactive round produced a valid
+	// threshold signature.
 	signatureBytes, err := engine.InteractiveAggregate(
 		"real-cgo-session-1",
 		attemptIDByMember[signingMembers[0]],
@@ -153,12 +155,7 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 		signatureShares,
 		nil,
 	)
-	if err != nil {
-		// A failed aggregate IS the verification: real FROST would reject invalid
-		// shares or a key/package mismatch here, so a non-error result is the
-		// proof the interactive round produced a valid threshold signature.
-		t.Fatalf("interactive aggregate: %v", err)
-	}
+	skipFrostUnavailable(t, "interactive aggregate", err)
 
 	// 3. The successful aggregate is a valid 64-byte BIP-340 signature (the engine
 	// validated the shares and the aggregate internally). External schnorr.Verify
@@ -167,6 +164,26 @@ func TestRealCgoInteractiveSigning_EndToEnd(t *testing.T) {
 	if len(signatureBytes) != 64 {
 		t.Fatalf("unexpected interactive signature length: %d", len(signatureBytes))
 	}
+}
+
+// skipFrostUnavailable turns an engine-call error into the right outcome: a missing
+// FFI symbol (lib absent, or present but stale and missing a newer symbol) SKIPS
+// the test naming the operation, while any other error is a real failure. nil is a
+// no-op. Centralizing this makes every step of the e2e robust to an incomplete lib
+// rather than only the first (RunDKG) call.
+func skipFrostUnavailable(t *testing.T, op string, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Skipf(
+			"linked tbtc-signer FFI symbol for %s unavailable (lib absent or stale; "+
+				"rebuild libfrost_tbtc): %v",
+			op, err,
+		)
+	}
+	t.Fatalf("%s: %v", op, err)
 }
 
 // runRealCgoDKGKeyGroup runs a full real FROST DKG over the participants via
@@ -195,12 +212,7 @@ func runRealCgoDKGKeyGroup(
 	}
 
 	result, err := engine.RunDKG("real-cgo-dkg-session-1", participants, threshold)
-	if err != nil {
-		if errors.Is(err, ErrNativeCryptographyUnavailable) {
-			t.Skip("linked tbtc-signer FFI symbols unavailable")
-		}
-		t.Fatalf("run DKG: %v", err)
-	}
+	skipFrostUnavailable(t, "run DKG", err)
 	if result.KeyGroup == "" {
 		t.Fatal("RunDKG returned an empty key group")
 	}

--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -39,6 +39,11 @@ import (
 // multi-member orchestration itself is covered with the fake engine over the real
 // transport in the runner net e2e.
 //
+// What this test does NOT prove: interactive round 2 or aggregate over the cgo
+// session surface (those need >= 2 signers, i.e. multiple processes). It is a
+// real-crypto round-1 / FFI-bridge / persisted-state integration test, not a full
+// interactive end-to-end signature.
+//
 // The DKG -> interactive keyGroup glue is RunDKG: InteractiveSessionOpen resolves
 // the signing key by a keyGroup IDENTIFIER (engine-internal persisted material),
 // not KeyPackage bytes. RunDKG runs the full DKG and PERSISTS the result, keyed by


### PR DESCRIPTION
## What

A REAL-cgo interactive signing integration test: a full FROST DKG that **persists a key group** (`RunDKG`), then one signer's interactive contribution driven through the engine's interactive session API (`DeriveInteractiveAttemptContext` → `InteractiveSessionOpen` → `InteractiveRound1`) with real `frost-secp256k1-tr` crypto. It produces a real signing commitment.

This fills the gap fake-engine tests can't: it proves the Go cgo bridge runs **real persisted DKG state** through the interactive session surface — FFI marshaling, persisted-state resolution by keyGroup, and real round-1 commitment generation.

It complements:
- `_WithLinkedSigner` — real-crypto 2-of-3 **aggregate** over the low-level API (the FROST math);
- the fake-engine **net e2e** (#4095) — interactive multi-node **orchestration** (t-subset, observers, real transport).

## What it does NOT prove

Interactive **round 2 or aggregate** over the cgo session surface. Those require ≥ 2 signers, and the signer engine state is a **process global holding one open interactive member per session** (`Open` is fingerprinted once per session; the round state rejects any non-opener member) — by design, each production node is its own process. `RunDKG` also requires **threshold ≥ 2**. So a single test process can drive exactly one signer's contribution; a full interactive multi-member signature needs a multi-process harness, which (per review) isn't worth building given the two halves above are already covered. This is a real-crypto round-1 / bridge / state-integration test, **not** a full interactive e2e.

## Verification

`frost_native && frost_tbtc_signer && cgo`, test-only. **Skip-guarded** on any unavailable FFI symbol (lib absent or stale) naming the operation, so it's inert in CI builds that don't link the Rust signer.

- Without the lib: skips cleanly. cgo vet + gofmt clean.
- **Against a freshly built `libfrost_tbtc`: passes** — RunDKG, derive, open, and round 1 all execute with real crypto.

To run it: `CGO_ENABLED=1 CGO_LDFLAGS="-L<dir> -lfrost_tbtc -Wl,-rpath,<dir>" go test -tags "frost_native frost_tbtc_signer" -run TestRealCgoInteractiveSigning_MemberContribution ./pkg/frost/signing/`

> Note: surfaced a production-readiness item — multi-seat operators run concurrent same-session interactive signing in one process, which the engine's one-opener-per-session state would reject. Tracked separately (needs an engine fix keyed by `(session_id, member_identifier)` or a multi-seat gate before enabling interactive signing for multi-seat operators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)