### PR TITLE
feat(frost): interactive-signing observability counters (handoff §6.3)

### DIFF
--- a/pkg/frost/signing/legacy_backend.go
+++ b/pkg/frost/signing/legacy_backend.go
@@ -36,6 +36,7 @@ func (leb *legacyExecutionBackend) Execute(
 		// tECDSA/coarse signer the flag retires. Refuse at the action itself so the
 		// safety switch holds even under the DEFAULT backend selection, where the
 		// native bridge/adapter guards never run. Terminal so the retry loop aborts.
+		recordCoarseFallbackRefused()
 		return nil, fmt.Errorf(
 			"%w: interactive-only signing mode (%s) is set but the legacy (coarse "+
 				"tECDSA) backend is selected; the coarse path is retired",

--- a/pkg/frost/signing/native_backend.go
+++ b/pkg/frost/signing/native_backend.go
@@ -61,6 +61,7 @@ func (neb *nativeExecutionBackend) Execute(
 		// so an outer refusal surfaces as a bare ErrNativeCryptographyUnavailable.
 		// Promote it to TERMINAL so the tBTC signingRetryLoop aborts immediately rather
 		// than retrying a deterministic configuration failure until timeout.
+		recordCoarseFallbackRefused()
 		return nil, fmt.Errorf(
 			"%w: interactive-only signing mode (%s) and the native interactive path is "+
 				"unavailable; refusing the coarse fallback: %v",

--- a/pkg/frost/signing/native_ffi_executor_adapter.go
+++ b/pkg/frost/signing/native_ffi_executor_adapter.go
@@ -152,6 +152,7 @@ func (nefea *nativeExecutionFFIExecutorAdapter) Execute(
 		// legacy fallback is closed separately via nativeExecutionFallbackAllowed().
 		// Mark the refusal TERMINAL so the tBTC signingRetryLoop aborts immediately
 		// instead of retrying a deterministic configuration failure until timeout.
+		recordCoarseFallbackRefused()
 		return nil, fmt.Errorf(
 			"%w: interactive-only signing mode (%s) is set but interactive signing did "+
 				"not run (%s off, no engine, or static fallback); refusing the coarse fallback",

--- a/pkg/frost/signing/roast_interactive_signing_metrics.go
+++ b/pkg/frost/signing/roast_interactive_signing_metrics.go
@@ -1,0 +1,93 @@
+package signing
+
+import (
+	"sync/atomic"
+
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+)
+
+// Interactive-signing observability counters (RFC-21 Phase 7.3, handoff §6.3).
+//
+// The interactive signing runner surfaces outcomes only via return values - it emits
+// no logs or metrics of its own - so before the coordinated tECDSA->FROST flip there is
+// no operator-visible signal for "is interactive signing working, and is anything
+// failing closed?". These process-wide cumulative counters add that signal:
+//
+//   - success/failure track whether the interactive path, once driven, produces
+//     signatures or fails on a committed attempt;
+//   - coarseFallbackRefused is the FLIP-SAFETY signal: it increments whenever the
+//     no-coarse-fallback mode (KEEP_CORE_FROST_INTERACTIVE_SIGNING_ONLY) terminally
+//     refuses a would-be coarse/legacy signing. During a staged flip a misconfigured
+//     node - interactive-only on but interactive signing not actually running - shows
+//     up here instead of silently failing every signing attempt.
+//
+// They are process-wide rather than per-session (operators want "how many today?"),
+// follow the roast_retry_metrics.go pattern, are emitted in every build, and stay at
+// zero until the gated interactive path actually runs - so they are inert by default.
+var (
+	interactiveSigningSuccessEvents atomic.Uint64
+	interactiveSigningFailureEvents atomic.Uint64
+	coarseFallbackRefusedEvents     atomic.Uint64
+)
+
+// interactiveSigningMetricsApplication is the clientinfo application-label prefix; the
+// registry concatenates it with each per-source name, so the final labels look like
+// "frost_interactive_signing_success_total".
+const interactiveSigningMetricsApplication = "frost_interactive_signing"
+
+const (
+	interactiveSigningSuccessMetricName       = "success_total"
+	interactiveSigningFailureMetricName       = "failure_total"
+	interactiveSigningCoarseRefusedMetricName = "coarse_fallback_refused_total"
+)
+
+// RegisterInteractiveSigningMetrics registers the cumulative interactive-signing
+// counters with the supplied clientinfo registry. Operators call this from the node's
+// startup sequence (alongside RegisterRoastRetryMetrics) so the counters appear in the
+// Prometheus scrape. A nil registry is a no-op.
+func RegisterInteractiveSigningMetrics(registry *clientinfo.Registry) {
+	if registry == nil {
+		return
+	}
+	registry.ObserveApplicationSource(
+		interactiveSigningMetricsApplication,
+		map[string]clientinfo.Source{
+			interactiveSigningSuccessMetricName: func() float64 {
+				return float64(interactiveSigningSuccessEvents.Load())
+			},
+			interactiveSigningFailureMetricName: func() float64 {
+				return float64(interactiveSigningFailureEvents.Load())
+			},
+			interactiveSigningCoarseRefusedMetricName: func() float64 {
+				return float64(coarseFallbackRefusedEvents.Load())
+			},
+		},
+	)
+}
+
+// recordInteractiveSigningSuccess marks one interactive signing attempt that produced a
+// signature.
+func recordInteractiveSigningSuccess() {
+	interactiveSigningSuccessEvents.Add(1)
+}
+
+// recordInteractiveSigningFailure marks one committed interactive signing attempt that
+// failed (a drive error - not the inactive fall-through, which produces no signature
+// and no error).
+func recordInteractiveSigningFailure() {
+	interactiveSigningFailureEvents.Add(1)
+}
+
+// recordCoarseFallbackRefused marks one terminal no-coarse-fallback refusal
+// (interactive-only mode declined to sign via the retired coarse/legacy path).
+func recordCoarseFallbackRefused() {
+	coarseFallbackRefusedEvents.Add(1)
+}
+
+// resetInteractiveSigningMetricsForTest clears the cumulative counters. Exposed only for
+// the package's own tests; not a production helper.
+func resetInteractiveSigningMetricsForTest() {
+	interactiveSigningSuccessEvents.Store(0)
+	interactiveSigningFailureEvents.Store(0)
+	coarseFallbackRefusedEvents.Store(0)
+}

--- a/pkg/frost/signing/roast_interactive_signing_metrics_test.go
+++ b/pkg/frost/signing/roast_interactive_signing_metrics_test.go
@@ -1,0 +1,54 @@
+package signing
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ipfs/go-log/v2"
+)
+
+func TestInteractiveSigningMetrics_RecordFunctionsIncrement(t *testing.T) {
+	resetInteractiveSigningMetricsForTest()
+	t.Cleanup(resetInteractiveSigningMetricsForTest)
+
+	recordInteractiveSigningSuccess()
+	recordInteractiveSigningSuccess()
+	recordInteractiveSigningFailure()
+	recordCoarseFallbackRefused()
+	recordCoarseFallbackRefused()
+	recordCoarseFallbackRefused()
+
+	if got := interactiveSigningSuccessEvents.Load(); got != 2 {
+		t.Fatalf("success counter: got %d want 2", got)
+	}
+	if got := interactiveSigningFailureEvents.Load(); got != 1 {
+		t.Fatalf("failure counter: got %d want 1", got)
+	}
+	if got := coarseFallbackRefusedEvents.Load(); got != 3 {
+		t.Fatalf("coarse-refused counter: got %d want 3", got)
+	}
+}
+
+func TestInteractiveSigningMetrics_CoarseRefusalAtLegacyBackendIncrements(t *testing.T) {
+	// End-to-end wiring: the legacy backend's interactive-only terminal refusal bumps
+	// the flip-safety counter (the signal that a node is configured interactive-only
+	// but is still being asked to sign coarsely).
+	resetInteractiveSigningMetricsForTest()
+	t.Cleanup(resetInteractiveSigningMetricsForTest)
+	t.Setenv(InteractiveSigningOnlyEnvVar, "true")
+
+	_, err := newLegacyExecutionBackend().Execute(
+		context.Background(), log.Logger("test"), &Request{Message: big.NewInt(1)},
+	)
+	if err == nil {
+		t.Fatal("expected the interactive-only terminal refusal")
+	}
+	if got := coarseFallbackRefusedEvents.Load(); got != 1 {
+		t.Fatalf("coarse-refused counter after a legacy refusal: got %d want 1", got)
+	}
+}
+
+func TestRegisterInteractiveSigningMetrics_NilRegistryIsNoOp(t *testing.T) {
+	RegisterInteractiveSigningMetrics(nil) // must not panic
+}

--- a/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
+++ b/pkg/frost/signing/roast_retry_executor_entry_frost_native.go
@@ -128,8 +128,17 @@ func attemptRoastRetryOrchestrationFromRequest(
 	signature, err := driveInteractiveRoastSigningIfEnabled(
 		execCtx, logger, request, handle, attemptCtx,
 	)
+	// Observability (handoff §6.3): a committed interactive failure (err != nil) vs a
+	// produced signature (signature != nil) vs the inactive fall-through (both nil,
+	// interactive not enabled - counted as neither). This is the single chokepoint
+	// where the drive's outcome is interpreted, so instrument here rather than at the
+	// drive's many return points.
 	if err != nil {
+		recordInteractiveSigningFailure()
 		return nil, cleanup, err
+	}
+	if signature != nil {
+		recordInteractiveSigningSuccess()
 	}
 	return signature, cleanup, nil
 }

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
+	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
 	"github.com/keep-network/keep-core/pkg/generator"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/sortition"
@@ -145,6 +146,15 @@ func Initialize(
 				},
 			},
 		)
+
+		// RFC-21 Phase 7.3 interactive FROST signing observability. These sources
+		// are inert (report zero) until the gated interactive path actually runs;
+		// registering them only exposes the counters to the scrape and does not
+		// activate any signing behavior, so it is safe regardless of the cutover
+		// gates. Without this, the counters increment internally but never reach
+		// Prometheus.
+		frostsigning.RegisterRoastRetryMetrics(clientInfo)
+		frostsigning.RegisterInteractiveSigningMetrics(clientInfo)
 
 		if perfMetrics == nil {
 			perfMetrics = clientinfo.NewPerformanceMetrics(ctx, clientInfo)


### PR DESCRIPTION
## What

The one genuinely **buildable, non-gated** item from the handoff's §6 production-integration review. The interactive signing runner surfaces outcomes only via return values — no logs or metrics — so before the coordinated tECDSA→FROST flip there's no operator-visible signal for *"is interactive signing working, and is anything failing closed?"*

Adds process-wide cumulative counters following the existing `roast_retry_metrics.go` pattern:

- **`frost_interactive_signing_success_total` / `_failure_total`** — whether the interactive path, once driven, produces signatures or fails on a committed attempt. Emitted at the **single executor-entry chokepoint** where the drive's `(signature, error)` outcome is interpreted (the inactive fall-through — both nil — counts as neither).
- **`frost_interactive_signing_coarse_fallback_refused_total`** — the **flip-safety signal**: increments whenever no-coarse-fallback mode (`KEEP_CORE_FROST_INTERACTIVE_SIGNING_ONLY`) terminally refuses a would-be coarse/legacy signing, at all three #4101 refusal sites (legacy backend, native-backend promotion, FFI adapter). During a staged flip a misconfigured node — interactive-only on but interactive signing not running — shows up here instead of silently failing every attempt.

`RegisterInteractiveSigningMetrics` mirrors `RegisterRoastRetryMetrics`; operators wire it at startup (alongside the existing one, when the registration wiring lands). Emitted in every build, stays at zero until the gated interactive path runs — **inert by default**.

## Why this is the only code item here

From the §6 review (verified against code, in `FROST_PRODUCTION_HANDOFF.md`): §6.1 signer-material is **mostly already built** (material flows via DKG + persistence; the resolver fail-closed is already tested), §6.2 activation wiring and §6.4 wallet lifecycle are **gated** (audit/recovery-leaf/MacLane), and the rest of §6.3 is **ops/runbooks**. Observability is the one un-gated code slice — and it's exactly what the coordinated flip needs.

## Validation

Builds across all tag combos; new tests pass (incl. an end-to-end legacy-backend refusal bumping the counter); no regression in backend/executor-entry suites; cgo vet + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)