### PR TITLE
feat(tbtc/signer): export a structured FFI contract version (frost_tbtc_abi_version)

### DIFF
--- a/pkg/tbtc/signer/include/frost_tbtc.h
+++ b/pkg/tbtc/signer/include/frost_tbtc.h
@@ -19,6 +19,7 @@ typedef struct {
 } TbtcSignerResult;
 
 TbtcSignerResult frost_tbtc_version(void);
+TbtcSignerResult frost_tbtc_abi_version(void);
 TbtcSignerResult frost_tbtc_init_signer_config(const uint8_t* request_ptr, size_t request_len);
 TbtcSignerResult frost_tbtc_roast_liveness_policy(void);
 TbtcSignerResult frost_tbtc_hardening_metrics(void);

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -673,6 +673,22 @@ pub struct RoastLivenessPolicyResult {
     pub exclusion_evidence_policy: String,
 }
 
+/// The FFI CONTRACT version reported by `frost_tbtc_abi_version`, so a Go bridge can
+/// fail closed against an incompatible `libfrost_tbtc` rather than silently
+/// misinterpreting a changed contract.
+///
+/// `abi_major` covers any INCOMPATIBLE change to the Go<->Rust contract: C signatures,
+/// JSON field meaning, required fields, enum/status values, serialization, memory
+/// ownership, or crypto transcript/domain semantics the bridge relies on. `abi_minor`
+/// covers a cumulative ADDITIVE, backward-compatible change - a new symbol or a new
+/// optional field that old bridges safely ignore. A consumer requires
+/// `lib.abi_major == its_major` AND `lib.abi_minor >= the_minor_it_needs`.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct FrostTbtcAbiVersionResult {
+    pub abi_major: u32,
+    pub abi_minor: u32,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct SignerHardeningMetricsResult {
     pub runtime_version: String,

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -10,12 +10,12 @@ use std::sync::OnceLock;
 use api::{
     AggregateRequest, BuildTaprootTxRequest, DeriveInteractiveAttemptContextRequest,
     DifferentialFuzzRequest, DkgPart1Request, DkgPart2Request, DkgPart3Request,
-    FinalizeSignRoundRequest, GenerateNoncesAndCommitmentsRequest, InitSignerConfigRequest,
-    InteractiveAggregateRequest, InteractiveRound1Request, InteractiveRound2Request,
-    InteractiveSessionAbortRequest, InteractiveSessionOpenRequest, NewSigningPackageRequest,
-    PromoteCanaryRequest, QuarantineStatusRequest, RefreshCadenceStatusRequest,
-    RefreshSharesRequest, RollbackCanaryRequest, RunDkgRequest, SignShareRequest,
-    StartSignRoundRequest, TranscriptAuditRequest, TriggerEmergencyRekeyRequest,
+    FinalizeSignRoundRequest, FrostTbtcAbiVersionResult, GenerateNoncesAndCommitmentsRequest,
+    InitSignerConfigRequest, InteractiveAggregateRequest, InteractiveRound1Request,
+    InteractiveRound2Request, InteractiveSessionAbortRequest, InteractiveSessionOpenRequest,
+    NewSigningPackageRequest, PromoteCanaryRequest, QuarantineStatusRequest,
+    RefreshCadenceStatusRequest, RefreshSharesRequest, RollbackCanaryRequest, RunDkgRequest,
+    SignShareRequest, StartSignRoundRequest, TranscriptAuditRequest, TriggerEmergencyRekeyRequest,
     VerifyBlameProofRequest,
 };
 use ffi::{
@@ -26,6 +26,19 @@ use ffi::{
 pub use ffi::TbtcBuffer;
 
 const TBTC_SIGNER_VERSION: &str = "tbtc-signer/0.1.0-bootstrap";
+
+/// The FFI CONTRACT version (see api::FrostTbtcAbiVersionResult), reported by
+/// frost_tbtc_abi_version so a Go bridge can fail closed against an incompatible lib.
+/// Starts at 1.0 - NOT 0.x, to avoid semver pre-1.0 ambiguity - distinct from the
+/// human-readable TBTC_SIGNER_VERSION string above, which stays informational only.
+///
+/// Bump rules: bump TBTC_SIGNER_ABI_MAJOR on ANY incompatible change to the Go<->Rust
+/// contract; bump TBTC_SIGNER_ABI_MINOR on a purely ADDITIVE, backward-compatible
+/// change. A minor bump is valid ONLY if old consumers safely ignore the addition - if
+/// a new field or enum value can appear in an existing response that an old bridge does
+/// not tolerate, that is a MAJOR bump.
+const TBTC_SIGNER_ABI_MAJOR: u32 = 1;
+const TBTC_SIGNER_ABI_MINOR: u32 = 0;
 use engine::TBTC_SIGNER_ALLOW_BOOTSTRAP_ENV;
 #[cfg(test)]
 use engine::TBTC_SIGNER_PROFILE_ENV;
@@ -67,6 +80,21 @@ fn bootstrap_mode_enabled() -> bool {
 #[no_mangle]
 pub extern "C" fn frost_tbtc_version() -> TbtcSignerResult {
     success_from_string(TBTC_SIGNER_VERSION.to_string())
+}
+
+/// Reports the structured FFI CONTRACT version (api::FrostTbtcAbiVersionResult JSON)
+/// so a Go bridge can fail closed on an incompatible libfrost_tbtc. See
+/// TBTC_SIGNER_ABI_MAJOR / TBTC_SIGNER_ABI_MINOR for the bump rules. This response
+/// shape is the ROOT compatibility surface and must stay stable: {abi_major, abi_minor}
+/// as unsigned integers.
+#[no_mangle]
+pub extern "C" fn frost_tbtc_abi_version() -> TbtcSignerResult {
+    ffi_entry(|| {
+        serialize_response(&FrostTbtcAbiVersionResult {
+            abi_major: TBTC_SIGNER_ABI_MAJOR,
+            abi_minor: TBTC_SIGNER_ABI_MINOR,
+        })
+    })
 }
 
 #[no_mangle]
@@ -455,18 +483,19 @@ mod tests {
         DifferentialFuzzRequest, DifferentialFuzzResult, DkgPart1Request, DkgPart1Result,
         DkgPart2Request, DkgPart2Result, DkgPart3Request, DkgPart3Result, DkgParticipant,
         DkgRound1Package, DkgRound2Package, ErrorResponse, FinalizeSignRoundRequest,
-        GenerateNoncesAndCommitmentsRequest, GenerateNoncesAndCommitmentsResult,
-        NewSigningPackageRequest, NewSigningPackageResult, PromoteCanaryRequest,
-        QuarantineStatusRequest, QuarantineStatusResult, RefreshCadenceStatusRequest,
-        RefreshCadenceStatusResult, RefreshSharesRequest, RoastLivenessPolicyResult,
-        RollbackCanaryRequest, RoundContribution, RunDkgRequest, ShareMaterial, SignShareRequest,
-        SignShareResult, SignerHardeningMetricsResult, StartSignRoundRequest, TransactionResult,
-        TranscriptAuditRequest, TriggerEmergencyRekeyRequest, VerifyBlameProofRequest,
+        FrostTbtcAbiVersionResult, GenerateNoncesAndCommitmentsRequest,
+        GenerateNoncesAndCommitmentsResult, NewSigningPackageRequest, NewSigningPackageResult,
+        PromoteCanaryRequest, QuarantineStatusRequest, QuarantineStatusResult,
+        RefreshCadenceStatusRequest, RefreshCadenceStatusResult, RefreshSharesRequest,
+        RoastLivenessPolicyResult, RollbackCanaryRequest, RoundContribution, RunDkgRequest,
+        ShareMaterial, SignShareRequest, SignShareResult, SignerHardeningMetricsResult,
+        StartSignRoundRequest, TransactionResult, TranscriptAuditRequest,
+        TriggerEmergencyRekeyRequest, VerifyBlameProofRequest,
     };
     use crate::{
-        frost_tbtc_aggregate, frost_tbtc_build_taproot_tx, frost_tbtc_canary_rollout_status,
-        frost_tbtc_dkg_part1, frost_tbtc_dkg_part2, frost_tbtc_dkg_part3,
-        frost_tbtc_finalize_sign_round, frost_tbtc_free_buffer,
+        frost_tbtc_abi_version, frost_tbtc_aggregate, frost_tbtc_build_taproot_tx,
+        frost_tbtc_canary_rollout_status, frost_tbtc_dkg_part1, frost_tbtc_dkg_part2,
+        frost_tbtc_dkg_part3, frost_tbtc_finalize_sign_round, frost_tbtc_free_buffer,
         frost_tbtc_generate_nonces_and_commitments, frost_tbtc_hardening_metrics,
         frost_tbtc_new_signing_package, frost_tbtc_promote_canary, frost_tbtc_quarantine_status,
         frost_tbtc_refresh_cadence_status, frost_tbtc_refresh_shares,
@@ -1123,6 +1152,20 @@ mod tests {
             policy.exclusion_evidence_policy,
             "timeout_or_invalid_share_proof"
         );
+    }
+
+    #[test]
+    fn abi_version_reports_the_contract_version() {
+        let (status, payload) = call_ffi_no_input(frost_tbtc_abi_version);
+        assert_eq!(status, 0);
+
+        let abi: FrostTbtcAbiVersionResult =
+            serde_json::from_slice(&payload).expect("abi version payload decode");
+        // The enforced FFI contract starts at 1.0; bump deliberately per the
+        // TBTC_SIGNER_ABI_MAJOR / TBTC_SIGNER_ABI_MINOR rules. This test pins the
+        // current value so an accidental bump is caught.
+        assert_eq!(abi.abi_major, 1);
+        assert_eq!(abi.abi_minor, 0);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `frost_tbtc_abi_version()` — a structured **FFI contract version** `{abi_major, abi_minor}` — so the Go cgo bridge can **fail closed** against an incompatible `libfrost_tbtc` instead of silently misinterpreting a changed contract.

The bridge and the lib are compiled separately and linked at runtime via `dlsym`; a symbol that still resolves but changed *meaning* (struct/JSON contract change) is silent corruption. The existing `frost_tbtc_version` returns a human string (`tbtc-signer/0.1.0-bootstrap`) that can't be machine-checked — this is the checkable companion.

## Scheme (Codex-validated)

- **`abi_major`** — any *incompatible* change to the Go↔Rust contract: C signatures, JSON field meaning, required fields, enum/status values, serialization, memory ownership, crypto transcript semantics.
- **`abi_minor`** — a purely *additive*, backward-compatible change old consumers safely ignore.
- A consumer requires `lib.abi_major == its_major` **and** `lib.abi_minor >= the minor it needs`.
- Starts at **1.0** (not 0.x, to avoid semver pre-1.0 ambiguity). The `{abi_major, abi_minor}` JSON is the **frozen root compatibility surface**.
- `frost_tbtc_version` (human string) stays informational and unchanged.

## Notes

- The **Go-side assertion** (fail-closed preflight + the `requiredMajor`/`requiredMinMinor` constants + a CI-gate check) lands as a separate keep-core PR that also bumps the signer pin to this commit.
- 300 lib tests pass (new `abi_version_reports_the_contract_version` pins 1.0); `cargo fmt` clean; the symbol is exported in the built cdylib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)