### PR TITLE
feat(frost): fail closed on an incompatible libfrost_tbtc FFI contract version

### DIFF
--- a/.github/workflows/frost-cgo-integration.yml
+++ b/.github/workflows/frost-cgo-integration.yml
@@ -85,7 +85,8 @@ jobs:
             frost_tbtc_new_signing_package \
             frost_tbtc_interactive_aggregate \
             frost_tbtc_verify_signature_share \
-            frost_tbtc_version; do
+            frost_tbtc_version \
+            frost_tbtc_abi_version; do
             if ! nm -D --defined-only "$lib" | grep -q " ${sym}$"; then
               echo "missing exported symbol: ${sym}"
               missing=1

--- a/.github/workflows/frost-cgo-integration.yml
+++ b/.github/workflows/frost-cgo-integration.yml
@@ -104,5 +104,10 @@ jobs:
           # references its symbols only via dlsym (no direct references), so the loader
           # makes them resolvable at runtime; rpath lets the test binary find the .so.
           export CGO_LDFLAGS="-L${FROST_LIB_DIR} -Wl,--no-as-needed -lfrost_tbtc -Wl,-rpath,${FROST_LIB_DIR}"
+          # The real-crypto suite (exercises the engine + the ABI preflight against the
+          # linked lib) plus the ABI fail-closed test (proves a present-but-incompatible
+          # lib refuses to fall back to legacy signing; uses the seam, so it does not need
+          # an actually-incompatible lib). This gate is the only CI that builds these tags.
           go test -tags "frost_native frost_tbtc_signer" -count=1 \
-            -run 'TestRealCgoInteractiveSigning' ./pkg/frost/signing/
+            -run 'TestRealCgoInteractiveSigning|TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_ABIIncompatible_DoesNotFallback' \
+            ./pkg/frost/signing/

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=25e4f277a1baeb2a872c1ee9cf075fb8eb01896d
+FROST_SIGNER_MIRROR_REF=6e3718ba00455c7a89499592ef57648c6e9b2c69

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=83b7bff4ef3b104eeb43908b13bd6a5e37cf3208
+FROST_SIGNER_MIRROR_REF=25e4f277a1baeb2a872c1ee9cf075fb8eb01896d

--- a/pkg/frost/signing/native_ffi_primitive_abi_preflight_frost_native_default.go
+++ b/pkg/frost/signing/native_ffi_primitive_abi_preflight_frost_native_default.go
@@ -1,0 +1,8 @@
+//go:build frost_native && (!frost_tbtc_signer || !cgo)
+
+package signing
+
+// tbtcSignerABIIncompatibility is a no-op in builds without the linked cgo engine: there
+// is no real libfrost_tbtc to be incompatible with. The cgo-tagged variant
+// (native_ffi_primitive_abi_preflight_frost_native_tbtc_signer.go) does the real check.
+func tbtcSignerABIIncompatibility() error { return nil }

--- a/pkg/frost/signing/native_ffi_primitive_abi_preflight_frost_native_tbtc_signer.go
+++ b/pkg/frost/signing/native_ffi_primitive_abi_preflight_frost_native_tbtc_signer.go
@@ -1,0 +1,18 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import "errors"
+
+// tbtcSignerABIIncompatibility reports a PRESENT-but-incompatible linked libfrost_tbtc
+// (a wrong or malformed FFI contract version) so the coarse engine path can fail closed
+// BEFORE its legacy fallback can mask it. It returns nil for a MISSING/absent lib
+// (ErrNativeCryptographyUnavailable, not ErrTBTCSignerABIIncompatible): that case is the
+// intended transitional "no engine -> legacy" fallback, not an incompatibility. The
+// underlying preflight is cached (sync.Once), so this is cheap to call per signing.
+func tbtcSignerABIIncompatibility() error {
+	if err := ensureTBTCSignerABICompatible(); errors.Is(err, ErrTBTCSignerABIIncompatible) {
+		return err
+	}
+	return nil
+}

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native.go
@@ -257,11 +257,29 @@ func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive)
 	}
 }
 
+// tbtcSignerABIIncompatibilityCheck is the engine-lib ABI preflight the coarse signing
+// path consults before any legacy fallback. It points at the build-split
+// tbtcSignerABIIncompatibility (the real cgo check, or the non-cgo no-op); a test seam
+// so the fail-closed-no-fallback behavior is exercisable in the frost_native build.
+var tbtcSignerABIIncompatibilityCheck = tbtcSignerABIIncompatibility
+
 func (btlcnnefsp *buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive) signWithTBTCSignerCoarseEngine(
 	ctx context.Context,
 	logger log.StandardLogger,
 	request *NativeExecutionFFISigningRequest,
 ) (*frost.Signature, error) {
+	// Fail closed on a PRESENT-but-incompatible engine lib BEFORE any legacy fallback
+	// below can mask it (Codex #4105 P2). The FFI preflight surfaces a wrong/malformed
+	// contract version as ErrTBTCSignerABIIncompatible; every fallbackTBTCSignerLegacySigning
+	// path below would otherwise swallow that into a legacy tECDSA signature if the
+	// material carries a private key share. A MISSING/absent lib is NOT this sentinel
+	// (it is ErrNativeCryptographyUnavailable) and still falls back as intended.
+	// Indirected through a var so the no-fallback behavior is testable in the
+	// frost_native build, where tbtcSignerABIIncompatibility is the non-cgo no-op.
+	if err := tbtcSignerABIIncompatibilityCheck(); err != nil {
+		return nil, err
+	}
+
 	payload, err := decodeBuildTaggedTBTCSignerMaterialPayload(request.SignerMaterial)
 	if err != nil {
 		return nil, err

--- a/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
+++ b/pkg/frost/signing/native_ffi_primitive_transitional_frost_native_test.go
@@ -3041,6 +3041,90 @@ func TestBuildTaggedTBTCSignerErrorPayload(t *testing.T) {
 	}
 }
 
+func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_ABIIncompatible_DoesNotFallback(
+	t *testing.T,
+) {
+	// Codex #4105 P2: a PRESENT-but-incompatible engine lib must fail CLOSED. The coarse
+	// path must NOT fall back to legacy tECDSA signing even though the material carries a
+	// legacy private key share (the ABI error was previously swallowed by the fallback,
+	// signing anyway). A valid attempt is used so the only thing stopping a signature is
+	// the ABI guard.
+	t.Setenv(AcceptScaffoldKeyGroupEnvVar, "true")
+
+	// Force the engine-lib ABI preflight to report a present-but-incompatible lib.
+	originalCheck := tbtcSignerABIIncompatibilityCheck
+	tbtcSignerABIIncompatibilityCheck = func() error { return ErrTBTCSignerABIIncompatible }
+	t.Cleanup(func() { tbtcSignerABIIncompatibilityCheck = originalCheck })
+
+	fixtures, err := tecdsatest.LoadPrivateKeyShareTestFixtures(3)
+	if err != nil {
+		t.Fatalf("failed loading key share fixtures: [%v]", err)
+	}
+	privateKeyShare := tecdsa.NewPrivateKeyShare(fixtures[0])
+	privateKeySharePayload, err := privateKeyShare.Marshal()
+	if err != nil {
+		t.Fatalf("failed marshaling private key share: [%v]", err)
+	}
+	signerMaterialPayload, err := json.Marshal(&NativeTBTCSignerMaterialPayload{
+		KeyGroup:                 "group-1",
+		KeyGroupSource:           NativeTBTCSignerKeyGroupSourceLegacyWalletPubKey,
+		LegacyPrivateKeyShareHex: hex.EncodeToString(privateKeySharePayload),
+	})
+	if err != nil {
+		t.Fatalf("cannot marshal signer material payload: [%v]", err)
+	}
+
+	UnregisterNativeTBTCSignerEngine()
+	UnregisterNativeTBTCSignerFallbackObserver()
+	t.Cleanup(UnregisterNativeTBTCSignerEngine)
+	t.Cleanup(UnregisterNativeTBTCSignerFallbackObserver)
+	if err := RegisterNativeTBTCSignerEngine(
+		&mockBuildTaggedTBTCSignerEngine{version: "tbtc-signer/0.1.0-bootstrap"},
+	); err != nil {
+		t.Fatalf("unexpected registration error: [%v]", err)
+	}
+
+	var observedEvents []NativeTBTCSignerFallbackEvent
+	if err := RegisterNativeTBTCSignerFallbackObserver(
+		func(event NativeTBTCSignerFallbackEvent) {
+			observedEvents = append(observedEvents, event)
+		},
+	); err != nil {
+		t.Fatalf("unexpected observer registration error: [%v]", err)
+	}
+
+	primitive := &buildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive{}
+	signature, err := primitive.Sign(nil, nil, &NativeExecutionFFISigningRequest{
+		Message:            big.NewInt(123),
+		SessionID:          "session-1",
+		MemberIndex:        1,
+		GroupSize:          3,
+		DishonestThreshold: 1,
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: signerMaterialPayload,
+		},
+		Attempt: &Attempt{
+			Number:                 1,
+			CoordinatorMemberIndex: 1,
+			IncludedMembersIndexes: []group.MemberIndex{1, 2},
+		},
+	})
+
+	if signature != nil {
+		t.Fatal("an incompatible engine lib must not produce a signature (no legacy fallback)")
+	}
+	if !errors.Is(err, ErrTBTCSignerABIIncompatible) {
+		t.Fatalf("expected ErrTBTCSignerABIIncompatible, got: [%v]", err)
+	}
+	if len(observedEvents) != 0 {
+		t.Fatalf(
+			"legacy fallback must NOT be reached on ABI incompatibility; got %d fallback event(s)",
+			len(observedEvents),
+		)
+	}
+}
+
 func TestBuildTaggedLegacyCompatibleNativeExecutionFFISigningPrimitive_Sign_TBTCSignerPath_ConsumedAttemptReplay_DoesNotFallback(
 	t *testing.T,
 ) {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -22,6 +22,7 @@ typedef struct {
 } TbtcSignerResult;
 
 typedef TbtcSignerResult (*tbtc_version_fn)(void);
+typedef TbtcSignerResult (*tbtc_abi_version_fn)(void);
 typedef TbtcSignerResult (*tbtc_run_dkg_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -118,6 +119,18 @@ static TbtcSignerResult tbtc_signer_version(void) {
   }
 
   return version();
+}
+
+static TbtcSignerResult tbtc_signer_abi_version(void) {
+  tbtc_abi_version_fn abi_version = (tbtc_abi_version_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_abi_version"
+  );
+  if (abi_version == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return abi_version();
 }
 
 static TbtcSignerResult tbtc_signer_run_dkg(const uint8_t* request_ptr, size_t request_len) {
@@ -2445,6 +2458,16 @@ func callBuildTaggedTBTCSignerVersion() ([]byte, error) {
 	return parseBuildTaggedTBTCSignerResult("Version", result)
 }
 
+// callBuildTaggedTBTCSignerABIVersion fetches the structured FFI contract version. A
+// missing frost_tbtc_abi_version symbol surfaces as ErrNativeCryptographyUnavailable
+// (the lib predates ABI versioning), which the ABI preflight turns into an explicit
+// incompatibility. It deliberately does NOT pass through callBuildTaggedTBTCSignerOperation
+// (it takes no request and must not recurse into the ABI gate).
+func callBuildTaggedTBTCSignerABIVersion() ([]byte, error) {
+	result := C.tbtc_signer_abi_version()
+	return parseBuildTaggedTBTCSignerResult("ABIVersion", result)
+}
+
 func callBuildTaggedTBTCSignerRunDKG(
 	requestPayload []byte,
 ) ([]byte, error) {
@@ -2597,6 +2620,14 @@ func callBuildTaggedTBTCSignerOperation(
 	requestPayload []byte,
 	call func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult,
 ) ([]byte, error) {
+	// ABI preflight (once per process): every request-taking engine operation funnels
+	// through here, so a libfrost_tbtc whose FFI contract version is incompatible with
+	// this bridge fails CLOSED before any contract-sensitive call rather than risking a
+	// silently misinterpreted struct/JSON contract. The no-arg version/abi-version
+	// calls bypass this helper, so the check does not recurse.
+	if err := ensureTBTCSignerABICompatible(); err != nil {
+		return nil, err
+	}
 	if len(requestPayload) == 0 {
 		return nil, buildTaggedTBTCSignerOperationError(
 			operation,

--- a/pkg/frost/signing/native_tbtc_signer_abi_version.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version.go
@@ -1,6 +1,7 @@
 package signing
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -23,6 +24,34 @@ const (
 var ErrTBTCSignerABIIncompatible = errors.New(
 	"linked libfrost_tbtc FFI contract version is incompatible with this build",
 )
+
+// parseTBTCSignerABIVersion decodes the frozen {abi_major, abi_minor} root compatibility
+// surface from the lib's frost_tbtc_abi_version response and rejects anything malformed
+// as incompatible. BOTH fields are required: pointer fields distinguish "absent" from a
+// legitimate zero, because Go's json.Unmarshal silently zero-fills a missing field - and
+// a missing abi_minor would otherwise default to 0 and pass the (>= 0) rule, letting a
+// partial/broken lib bypass the fail-closed guard. Extra/unknown fields are tolerated by
+// design (an additive minor bump may add fields old bridges ignore). Pure (no cgo), so
+// it is unit-tested in the default build.
+func parseTBTCSignerABIVersion(payload []byte) (major, minor uint32, err error) {
+	var decoded struct {
+		AbiMajor *uint32 `json:"abi_major"`
+		AbiMinor *uint32 `json:"abi_minor"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return 0, 0, fmt.Errorf(
+			"%w: malformed FFI contract version response: %v",
+			ErrTBTCSignerABIIncompatible, err,
+		)
+	}
+	if decoded.AbiMajor == nil || decoded.AbiMinor == nil {
+		return 0, 0, fmt.Errorf(
+			"%w: FFI contract version response is missing abi_major and/or abi_minor",
+			ErrTBTCSignerABIIncompatible,
+		)
+	}
+	return *decoded.AbiMajor, *decoded.AbiMinor, nil
+}
 
 // checkTBTCSignerABICompatibility applies the compatibility rule to a lib-reported FFI
 // contract version against this build's required version. Pure (no cgo) so the rule is

--- a/pkg/frost/signing/native_tbtc_signer_abi_version.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version.go
@@ -1,0 +1,54 @@
+package signing
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The FFI CONTRACT version this bridge requires from libfrost_tbtc (the Rust
+// frost_tbtc_abi_version export / api::FrostTbtcAbiVersionResult). The bridge requires
+// the lib's abi_major to MATCH exactly - a higher major broke something this bridge
+// does not know, a lower major is too old - and the lib's abi_minor to be AT LEAST the
+// minor this bridge uses (additive features are backward-compatible; a higher minor is
+// fine and its extras are ignored). Bump these in lockstep with the Rust constants, in
+// the SAME PR that bumps ci/frost-signer-pin.env to the lib commit that provides them.
+const (
+	requiredTBTCSignerABIMajor    uint32 = 1
+	requiredTBTCSignerABIMinMinor uint32 = 0
+)
+
+// ErrTBTCSignerABIIncompatible marks a linked libfrost_tbtc whose FFI contract version
+// is incompatible with this build. It is fatal: the engine fails closed rather than
+// risk a silently misinterpreted struct/JSON contract.
+var ErrTBTCSignerABIIncompatible = errors.New(
+	"linked libfrost_tbtc FFI contract version is incompatible with this build",
+)
+
+// checkTBTCSignerABICompatibility applies the compatibility rule to a lib-reported FFI
+// contract version against this build's required version. Pure (no cgo) so the rule is
+// unit-tested in the default build.
+func checkTBTCSignerABICompatibility(libMajor, libMinor uint32) error {
+	return checkABIContractCompatibility(
+		libMajor, libMinor, requiredTBTCSignerABIMajor, requiredTBTCSignerABIMinMinor,
+	)
+}
+
+// checkABIContractCompatibility is the rule, parameterized over the required version so
+// every branch (wrong major either direction, too-old minor, higher-minor-ok) is
+// testable independent of the current constants: lib major must equal the required
+// major, and lib minor must be >= the required minimum minor.
+func checkABIContractCompatibility(libMajor, libMinor, reqMajor, reqMinMinor uint32) error {
+	if libMajor != reqMajor {
+		return fmt.Errorf(
+			"%w: lib reports abi_major %d, this build requires exactly %d",
+			ErrTBTCSignerABIIncompatible, libMajor, reqMajor,
+		)
+	}
+	if libMinor < reqMinMinor {
+		return fmt.Errorf(
+			"%w: lib reports abi_minor %d, this build requires at least %d (major %d)",
+			ErrTBTCSignerABIIncompatible, libMinor, reqMinMinor, reqMajor,
+		)
+	}
+	return nil
+}

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_frost_native.go
@@ -3,18 +3,10 @@
 package signing
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
 )
-
-// nativeTBTCSignerABIVersion is the frozen root compatibility surface: the JSON shape
-// frost_tbtc_abi_version returns. Keep it in lockstep with api::FrostTbtcAbiVersionResult.
-type nativeTBTCSignerABIVersion struct {
-	AbiMajor uint32 `json:"abi_major"`
-	AbiMinor uint32 `json:"abi_minor"`
-}
 
 // assertTBTCSignerABICompatible fetches the linked lib's FFI contract version and
 // applies the compatibility rule, failing closed. It distinguishes two cases:
@@ -43,15 +35,12 @@ func assertTBTCSignerABICompatible() error {
 		)
 	}
 
-	var version nativeTBTCSignerABIVersion
-	if err := json.Unmarshal(payload, &version); err != nil {
-		return fmt.Errorf(
-			"%w: malformed FFI contract version response: %v",
-			ErrTBTCSignerABIIncompatible, err,
-		)
+	major, minor, err := parseTBTCSignerABIVersion(payload)
+	if err != nil {
+		return err
 	}
 
-	return checkTBTCSignerABICompatibility(version.AbiMajor, version.AbiMinor)
+	return checkTBTCSignerABICompatibility(major, minor)
 }
 
 var (

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_frost_native.go
@@ -1,0 +1,78 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// nativeTBTCSignerABIVersion is the frozen root compatibility surface: the JSON shape
+// frost_tbtc_abi_version returns. Keep it in lockstep with api::FrostTbtcAbiVersionResult.
+type nativeTBTCSignerABIVersion struct {
+	AbiMajor uint32 `json:"abi_major"`
+	AbiMinor uint32 `json:"abi_minor"`
+}
+
+// assertTBTCSignerABICompatible fetches the linked lib's FFI contract version and
+// applies the compatibility rule, failing closed. It distinguishes two cases:
+//
+//   - MISSING frost_tbtc_abi_version symbol (lib predates ABI versioning, or absent):
+//     keeps ErrNativeCryptographyUnavailable in the chain - explicitly worded, but still
+//     "unavailable", so the existing skip/require-cgo handling applies (a stale/absent
+//     lib SKIPS in dev and is FATAL under the require-cgo gate, like any missing newer
+//     symbol).
+//   - PRESENT but wrong (malformed response, wrong major, too-old minor): a real,
+//     responding-but-incompatible lib -> ErrTBTCSignerABIIncompatible, which fails loudly
+//     ALWAYS (not skippable). A node must not sign through a lib whose contract diverges.
+func assertTBTCSignerABICompatible() error {
+	payload, err := callBuildTaggedTBTCSignerABIVersion()
+	if err != nil {
+		if errors.Is(err, ErrNativeCryptographyUnavailable) {
+			return fmt.Errorf(
+				"linked libfrost_tbtc is missing frost_tbtc_abi_version; it predates FFI "+
+					"contract versioning or is absent (this build requires major %d, minor >= %d): %w",
+				requiredTBTCSignerABIMajor, requiredTBTCSignerABIMinMinor, err,
+			)
+		}
+		return fmt.Errorf(
+			"%w: fetching the lib FFI contract version: %v",
+			ErrTBTCSignerABIIncompatible, err,
+		)
+	}
+
+	var version nativeTBTCSignerABIVersion
+	if err := json.Unmarshal(payload, &version); err != nil {
+		return fmt.Errorf(
+			"%w: malformed FFI contract version response: %v",
+			ErrTBTCSignerABIIncompatible, err,
+		)
+	}
+
+	return checkTBTCSignerABICompatibility(version.AbiMajor, version.AbiMinor)
+}
+
+var (
+	tbtcSignerABIOnce sync.Once
+	tbtcSignerABIErr  error
+)
+
+// ensureTBTCSignerABICompatible runs the ABI preflight ONCE per process and caches the
+// verdict; every subsequent engine operation sees the same result. The library is
+// process-global and not hot-swapped, so a single check before the first contract-
+// sensitive call is sufficient and deterministic (a per-call check would add no safety).
+func ensureTBTCSignerABICompatible() error {
+	tbtcSignerABIOnce.Do(func() {
+		tbtcSignerABIErr = assertTBTCSignerABICompatible()
+	})
+	return tbtcSignerABIErr
+}
+
+// resetTBTCSignerABIOnceForTest clears the cached preflight verdict so a test can
+// re-run it. Test-only.
+func resetTBTCSignerABIOnceForTest() {
+	tbtcSignerABIOnce = sync.Once{}
+	tbtcSignerABIErr = nil
+}

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_frost_native_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_frost_native_test.go
@@ -1,0 +1,31 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTBTCSignerABIPreflight_CompatibleAgainstLinkedLib asserts the linked libfrost_tbtc
+// reports an FFI contract version this build accepts. With no/old lib (the abi symbol is
+// absent), assertTBTCSignerABICompatible keeps ErrNativeCryptographyUnavailable in the
+// chain, so the test skips - matching the rest of the cgo suite. Against a current lib it
+// must be compatible; an incompatibility here is a real, fail-loud finding.
+func TestTBTCSignerABIPreflight_CompatibleAgainstLinkedLib(t *testing.T) {
+	resetTBTCSignerABIOnceForTest()
+	t.Cleanup(resetTBTCSignerABIOnceForTest)
+
+	err := assertTBTCSignerABICompatible()
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Skip("libfrost_tbtc not linked or predates frost_tbtc_abi_version")
+	}
+	if err != nil {
+		t.Fatalf("linked libfrost_tbtc must be ABI-compatible with this build: %v", err)
+	}
+
+	// ensure caches the same verdict.
+	if err := ensureTBTCSignerABICompatible(); err != nil {
+		t.Fatalf("cached preflight verdict diverged: %v", err)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
@@ -1,0 +1,56 @@
+package signing
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckABIContractCompatibility(t *testing.T) {
+	// req = major 1, min minor 2, to exercise every branch (the too-old-minor branch is
+	// unreachable against the real requiredTBTCSignerABIMinMinor of 0).
+	const reqMajor, reqMinMinor = uint32(1), uint32(2)
+	tests := []struct {
+		name           string
+		libMajor       uint32
+		libMinor       uint32
+		wantCompatible bool
+	}{
+		{"exact match", 1, 2, true},
+		{"higher minor is additive-compatible", 1, 9, true},
+		{"minor too old", 1, 1, false},
+		{"major too high (lib broke something newer)", 2, 0, false},
+		{"major too low (lib too old)", 0, 9, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkABIContractCompatibility(tt.libMajor, tt.libMinor, reqMajor, reqMinMinor)
+			if tt.wantCompatible && err != nil {
+				t.Fatalf("expected compatible, got error: %v", err)
+			}
+			if !tt.wantCompatible {
+				if err == nil {
+					t.Fatal("expected incompatibility error, got nil")
+				}
+				if !errors.Is(err, ErrTBTCSignerABIIncompatible) {
+					t.Fatalf("error must wrap ErrTBTCSignerABIIncompatible: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckTBTCSignerABICompatibility_CurrentContract(t *testing.T) {
+	// Pins the bridge's current required contract (major 1, min minor 0): the matching
+	// lib version is compatible; a different major is not. A regression here means the
+	// required constants drifted from what the bridge actually speaks.
+	if err := checkTBTCSignerABICompatibility(requiredTBTCSignerABIMajor, requiredTBTCSignerABIMinMinor); err != nil {
+		t.Fatalf("the required contract version must be self-compatible: %v", err)
+	}
+	if err := checkTBTCSignerABICompatibility(requiredTBTCSignerABIMajor+1, requiredTBTCSignerABIMinMinor); err == nil {
+		t.Fatal("a higher major must be incompatible")
+	}
+	// Any minor >= the required minimum is accepted (additive).
+	if err := checkTBTCSignerABICompatibility(requiredTBTCSignerABIMajor, requiredTBTCSignerABIMinMinor+3); err != nil {
+		t.Fatalf("a higher minor must be accepted: %v", err)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
@@ -39,6 +39,55 @@ func TestCheckABIContractCompatibility(t *testing.T) {
 	}
 }
 
+func TestParseTBTCSignerABIVersion(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		major, minor, err := parseTBTCSignerABIVersion([]byte(`{"abi_major":2,"abi_minor":3}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if major != 2 || minor != 3 {
+			t.Fatalf("got (%d,%d), want (2,3)", major, minor)
+		}
+	})
+
+	// Both fields are REQUIRED: a missing field must be rejected, not zero-filled - else
+	// a partial lib omitting abi_minor would default to 0 and pass the (>= 0) rule.
+	rejected := map[string]string{
+		"missing abi_minor": `{"abi_major":1}`,
+		"missing abi_major": `{"abi_minor":0}`,
+		"empty object":      `{}`,
+		"malformed json":    `{"abi_major":1,`,
+		"not an object":     `42`,
+	}
+	for name, payload := range rejected {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := parseTBTCSignerABIVersion([]byte(payload))
+			if err == nil {
+				t.Fatalf("payload %q must be rejected", payload)
+			}
+			if !errors.Is(err, ErrTBTCSignerABIIncompatible) {
+				t.Fatalf("rejection must wrap ErrTBTCSignerABIIncompatible: %v", err)
+			}
+		})
+	}
+
+	// A present zero minor with major present is VALID (abi 1.0 is a real version).
+	t.Run("zero minor is valid when present", func(t *testing.T) {
+		major, minor, err := parseTBTCSignerABIVersion([]byte(`{"abi_major":1,"abi_minor":0}`))
+		if err != nil || major != 1 || minor != 0 {
+			t.Fatalf("got (%d,%d,%v), want (1,0,nil)", major, minor, err)
+		}
+	})
+
+	// Extra/unknown fields are tolerated (additive minor may add fields old bridges ignore).
+	t.Run("extra fields tolerated", func(t *testing.T) {
+		major, minor, err := parseTBTCSignerABIVersion([]byte(`{"abi_major":1,"abi_minor":0,"future":"x"}`))
+		if err != nil || major != 1 || minor != 0 {
+			t.Fatalf("got (%d,%d,%v), want (1,0,nil)", major, minor, err)
+		}
+	})
+}
+
 func TestCheckTBTCSignerABICompatibility_CurrentContract(t *testing.T) {
 	// Pins the bridge's current required contract (major 1, min minor 0): the matching
 	// lib version is compatible; a different major is not. A regression here means the


### PR DESCRIPTION
## What

The Go-side companion to the mirror's `frost_tbtc_abi_version` export (#4104). The bridge and `libfrost_tbtc` are linked at runtime via `dlsym`; a symbol that resolves but changed **meaning** is silent corruption. This adds a **fail-closed preflight** that asserts the linked lib's FFI contract version before any contract-sensitive call.

> **Depends on #4104** (the mirror PR adding `frost_tbtc_abi_version`). This PR bumps `ci/frost-signer-pin.env` to that mirror commit (`25e4f277a`), so the CI gate builds a lib whose ABI the preflight accepts. Merge #4104 first (or together).

## Design (Codex-validated)

- **Rule** (`major.minor`): lib `abi_major` must **equal** the bridge's required major (a higher major broke something newer; a lower major is too old), and lib `abi_minor` must be **>=** the required minimum minor (additive is backward-compatible; higher minor's extras are ignored). Required = `1.0`.
- **Missing symbol** (old/absent lib) → keeps `ErrNativeCryptographyUnavailable` in the chain (explicit message): **skips** in dev, **fatal** under the require-cgo gate — same as any stale lib.
- **Present-but-wrong** (malformed / wrong major / too-old minor) → `ErrTBTCSignerABIIncompatible`, **fails loudly always**. A node must not sign through a lib whose contract diverges.
- **Once-per-process** preflight (`sync.Once`; the lib is process-global, not hot-swapped), gated at `callBuildTaggedTBTCSignerOperation` — the single chokepoint every request-taking engine op funnels through. The no-arg version calls bypass it (no recursion).

## Tests

- Untagged unit tests cover **every branch** of the rule via a parameterized helper (default build, no cgo needed).
- cgo preflight test asserts the linked lib is compatible (skips without it).
- Validated: builds across tag combos; require-cgo full run green against the ABI lib; no-lib skips; default suite unchanged; vet + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)