### PR TITLE
Retain ROAST self-snapshot mutation evidence

### DIFF
--- a/pkg/frost/roast/bundle_aggregation_test.go
+++ b/pkg/frost/roast/bundle_aggregation_test.go
@@ -400,6 +400,74 @@ func TestVerifyBundle_DetectsCensorship(t *testing.T) {
 	}
 }
 
+func TestVerifyBundle_RetainsMutatedSelfSnapshotEvidenceBeforeSignatureFailure(t *testing.T) {
+	captured := captureEquivocationEvidence(t)
+
+	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
+	ctx := newTestContext(t)
+	h0, _ := scratch.BeginAttempt(ctx)
+	elected, _ := scratch.SelectedCoordinator(h0)
+	receiverID := pickNonCoordinatorMember(t, ctx.IncludedSet, elected)
+
+	receiver := NewInMemoryCoordinatorWithSigning(
+		receiverID,
+		&fakeSigner{id: receiverID},
+		fakeVerifier{},
+	).(*inMemoryCoordinator)
+	rh, err := receiver.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("receiver begin: %v", err)
+	}
+	selfSnap := signSnapshotForTest(
+		t,
+		NewLocalEvidenceSnapshot(receiverID, ctx.Hash(), attempt.Evidence{}),
+	)
+	if err := receiver.RecordEvidence(rh, selfSnap); err != nil {
+		t.Fatalf("receiver record self: %v", err)
+	}
+
+	mutated := *selfSnap
+	mutated.OperatorSignature = bytes.Repeat([]byte{0xff}, len(mutated.OperatorSignature))
+	mutated.bodyCache = nil
+	mutated.signaturePayloadCache = nil
+	mutated.wireEnvelope = nil
+
+	contextHash := ctx.Hash()
+	bundle := &TransitionMessage{
+		AttemptContextHash: append([]byte(nil), contextHash[:]...),
+		CoordinatorIDValue: uint32(elected),
+		Bundle:             []LocalEvidenceSnapshot{mutated},
+	}
+	payload, err := bundle.SignableBytes()
+	if err != nil {
+		t.Fatalf("bundle signable bytes: %v", err)
+	}
+	signature, err := (&fakeSigner{id: elected}).Sign(payload)
+	if err != nil {
+		t.Fatalf("sign bundle: %v", err)
+	}
+	bundle.CoordinatorSignature = signature
+
+	err = receiver.VerifyBundle(rh, bundle)
+	if !errors.Is(err, ErrCensorshipDetected) {
+		t.Fatalf("expected ErrCensorshipDetected, got %v", err)
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 evidence event, got %d", len(*captured))
+	}
+	evidence := (*captured)[0]
+	if evidence.Kind != EquivocationKindOwnSnapshotMutatedInBundle {
+		t.Fatalf("kind = %q", evidence.Kind)
+	}
+	wantSelf, _ := selfSnap.Marshal()
+	if !bytes.Equal(evidence.ExistingEnvelope, wantSelf) {
+		t.Fatal("existing envelope must be the self submission verbatim")
+	}
+	if len(evidence.ConflictingEnvelope) == 0 {
+		t.Fatal("conflicting envelope must carry the bundled snapshot")
+	}
+}
+
 func TestVerifyBundle_DetectsCoordinatorSignatureForgery(t *testing.T) {
 	scratch := NewInMemoryCoordinator().(*inMemoryCoordinator)
 	ctx := newTestContext(t)

--- a/pkg/frost/roast/coordinator_state.go
+++ b/pkg/frost/roast/coordinator_state.go
@@ -525,13 +525,13 @@ func (c *inMemoryCoordinator) VerifyBundle(
 	if err := verifyBundleSignature(c.verifier, msg, expectedCoordinator); err != nil {
 		return fmt.Errorf("coordinator: %w", err)
 	}
+	if err := verifyOwnObservationsPresent(msg, c.selfMember, selfSubmission); err != nil {
+		return err
+	}
 	for i := range msg.Bundle {
 		if err := verifySnapshotSignature(c.verifier, &msg.Bundle[i]); err != nil {
 			return fmt.Errorf("coordinator: bundle[%d]: %w", i, err)
 		}
-	}
-	if err := verifyOwnObservationsPresent(msg, c.selfMember, selfSubmission); err != nil {
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes a ROAST evidence-retention gap found during the Codex Security scan of PR #3866.

`VerifyBundle` used to verify every bundled snapshot signature before checking whether the bundle mutated this node's own previously submitted snapshot. That meant a coordinator-signed bundle carrying a mutated self snapshot returned `ErrSignatureInvalid` before `own_snapshot_mutated_in_bundle` evidence could be emitted.

This PR moves the self-observation check immediately after the coordinator bundle signature is verified and before the generic per-snapshot signature loop. The bundle still fails closed, but the submitted-vs-bundled evidence is retained first.

## Validation

- `go test ./pkg/frost/roast -run TestVerifyBundle_RetainsMutatedSelfSnapshotEvidenceBeforeSignatureFailure -count=1`
- `go test ./pkg/frost/roast -count=1`
- `git diff --check origin/feat/frost-schnorr-migration-scaffold...HEAD`

## Notes

The new regression test failed before the ordering fix with:

`expected ErrCensorshipDetected, got coordinator: bundle[0]: roast: signature is invalid`

After the fix, it passes and verifies that `own_snapshot_mutated_in_bundle` evidence is retained.
