### PR TITLE
fix(tbtc/signer): fail closed on unknown profile and degenerate signing window

### DIFF
--- a/pkg/tbtc/signer/src/engine/config.rs
+++ b/pkg/tbtc/signer/src/engine/config.rs
@@ -387,18 +387,33 @@ pub(crate) fn bench_restart_hook_enabled() -> bool {
         .unwrap_or(false)
 }
 
+static PROFILE_VALUE_WARNING_EMITTED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
 pub(crate) fn signer_profile_is_production() -> bool {
     let raw = signer_env_var(TBTC_SIGNER_PROFILE_ENV).unwrap_or_default();
     let normalized = raw.trim().to_ascii_lowercase();
     match normalized.as_str() {
         TBTC_SIGNER_PROFILE_PRODUCTION | "" => true,
         TBTC_SIGNER_PROFILE_DEVELOPMENT => false,
-        other => panic!(
-            "{} must be '{}' or '{}'; got {:?}",
-            TBTC_SIGNER_PROFILE_ENV,
-            TBTC_SIGNER_PROFILE_PRODUCTION,
-            TBTC_SIGNER_PROFILE_DEVELOPMENT,
-            other
-        ),
+        other => {
+            // Fail closed: an unrecognized profile is treated as production
+            // (the strictest gate set) instead of panicking. The previous
+            // panic turned a single typo in TBTC_SIGNER_PROFILE into a
+            // process-wide denial of service, because this is consulted on the
+            // unvalidated env-fallback path and every profile-gated FFI
+            // operation would abort and surface as a generic internal error.
+            // Warn once so the misconfiguration stays visible to operators.
+            PROFILE_VALUE_WARNING_EMITTED.get_or_init(|| {
+                eprintln!(
+                    "warning: {} value {:?} is not '{}' or '{}'; treating as '{}' (fail-closed)",
+                    TBTC_SIGNER_PROFILE_ENV,
+                    other,
+                    TBTC_SIGNER_PROFILE_PRODUCTION,
+                    TBTC_SIGNER_PROFILE_DEVELOPMENT,
+                    TBTC_SIGNER_PROFILE_PRODUCTION,
+                );
+            });
+            true
+        }
     }
 }

--- a/pkg/tbtc/signer/src/engine/policy.rs
+++ b/pkg/tbtc/signer/src/engine/policy.rs
@@ -285,6 +285,27 @@ pub(crate) fn load_signing_policy_firewall_config(
         )));
     }
 
+    if let (Some(start_hour), Some(end_hour)) = (allowed_utc_start_hour, allowed_utc_end_hour) {
+        if start_hour >= 24 || end_hour >= 24 {
+            return Err(EngineError::Internal(format!(
+                "env [{}] and [{}] must be hours in the range 0..=23",
+                TBTC_SIGNER_POLICY_ALLOWED_UTC_START_HOUR_ENV,
+                TBTC_SIGNER_POLICY_ALLOWED_UTC_END_HOUR_ENV
+            )));
+        }
+        // Reject a zero-width window. utc_hour_in_window treats start == end as
+        // "always in window", so silently accepting equal bounds would disable
+        // the time-of-day control entirely (fail-open) rather than restricting
+        // it. An operator who wants no time restriction must leave both unset.
+        if start_hour == end_hour {
+            return Err(EngineError::Internal(format!(
+                "env [{}] and [{}] must differ; an equal start and end hour does not define a restricted window",
+                TBTC_SIGNER_POLICY_ALLOWED_UTC_START_HOUR_ENV,
+                TBTC_SIGNER_POLICY_ALLOWED_UTC_END_HOUR_ENV
+            )));
+        }
+    }
+
     Ok(Some(SigningPolicyFirewallConfig {
         allowed_script_classes,
         max_output_count,

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -820,6 +820,24 @@ fn production_profile_forces_provenance_gate_without_env_flag() {
 }
 
 #[test]
+fn unknown_profile_value_fails_closed_to_production() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+
+    // A typo / unknown profile value must be treated as production
+    // (fail-closed) rather than panicking. The previous panic on the
+    // unvalidated env-fallback path turned one typo into a process-wide DoS.
+    std::env::set_var(TBTC_SIGNER_PROFILE_ENV, "staging");
+    assert!(
+        signer_profile_is_production(),
+        "unrecognized profile must fail closed to production"
+    );
+
+    std::env::remove_var(TBTC_SIGNER_PROFILE_ENV);
+}
+
+#[test]
 fn run_dkg_rejects_malformed_seed_as_validation_input() {
     let _guard = lock_test_state();
     reset_for_tests();
@@ -1855,6 +1873,34 @@ fn build_taproot_tx_signing_policy_firewall_rejects_outside_utc_window() {
         panic!("unexpected error variant");
     };
     assert_eq!(reason_code, "request_outside_allowed_utc_window");
+
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn signing_policy_firewall_rejects_equal_utc_window_bounds() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+
+    // A degenerate equal-bounds window (start == end) must be rejected at load
+    // time. utc_hour_in_window treats start == end as "always in window", so
+    // accepting it would silently disable the time-of-day control (fail-open).
+    std::env::set_var(TBTC_SIGNER_ENFORCE_SIGNING_POLICY_FIREWALL_ENV, "true");
+    std::env::set_var(TBTC_SIGNER_POLICY_ALLOWED_SCRIPT_CLASSES_ENV, "p2tr,p2wpkh");
+    configure_required_signing_policy_limits_for_tests();
+    std::env::set_var(TBTC_SIGNER_POLICY_ALLOWED_UTC_START_HOUR_ENV, "12");
+    std::env::set_var(TBTC_SIGNER_POLICY_ALLOWED_UTC_END_HOUR_ENV, "12");
+
+    let err = load_signing_policy_firewall_config()
+        .expect_err("equal-bounds UTC window must be rejected at load time");
+    let EngineError::Internal(message) = err else {
+        panic!("unexpected error variant: {err:?}");
+    };
+    assert!(
+        message.contains("must differ"),
+        "unexpected validation message: {message}"
+    );
 
     clear_state_storage_policy_overrides();
 }


### PR DESCRIPTION
## Summary

Follow-up to #4005 (FROST/ROAST signer). Two fail-open / DoS fixes in the signing-policy config surface.

### 1. `signer_profile_is_production()` panicked on an unknown profile value

On the env-fallback path `TBTC_SIGNER_PROFILE` is unvalidated, so any value other than `production`/`development`/empty hit `panic!`. The panic is caught at the FFI boundary and redacted to a generic internal error, so a single typo (e.g. `staging`) aborted **every** profile-gated operation — a process-wide denial of service until the env var was corrected.

Now an unrecognized profile is treated as `production` (fail-closed: the strictest gate set) with a one-time warning, instead of panicking. Production is the safe/strict direction for every caller (provenance gate, bootstrap-dealer-DKG disable, transitional-signing disable, ROAST strict mode, env state-key-provider rejection). The install path (`init_config`) still validates the profile, so this only affects the env-fallback path.

### 2. `load_signing_policy_firewall_config()` accepted a zero-width UTC window

`utc_hour_in_window` treats `start == end` as "always in window", so an equal-bounds window silently disabled the time-of-day control (fail-open) rather than restricting it. The loader now rejects equal bounds — and out-of-range (`>= 24`) hours — at load time.

## Tests

- `unknown_profile_value_fails_closed_to_production`
- `signing_policy_firewall_rejects_equal_utc_window_bounds`

_Found during review of #4005._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
