### PR TITLE
ci(tbtc/signer): pin cargo dependency resolution with --locked

### DIFF
--- a/.github/workflows/tbtc-signer-formal.yml
+++ b/.github/workflows/tbtc-signer-formal.yml
@@ -34,12 +34,12 @@ jobs:
         run: cargo fmt --manifest-path pkg/tbtc/signer/Cargo.toml -- --check
 
       - name: Run clippy
-        run: cargo clippy --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets -- -D warnings
+        run: cargo clippy --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets -- -D warnings
 
       - name: Run signer tests
         env:
           TBTC_SIGNER_STATE_PATH: /tmp/tbtc-signer-ci-state-${{ github.run_id }}-${{ github.run_attempt }}.json
-        run: cargo test --manifest-path pkg/tbtc/signer/Cargo.toml
+        run: cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml
 
   signer-dependency-audit:
     name: Signer dependency audit
@@ -74,7 +74,7 @@ jobs:
         # the formal-invariant test cases run (faster + clearer signal
         # than the full suite). Matches the convention used in the
         # source monorepo's ci-formal-verification.yml.
-        run: cargo test --manifest-path pkg/tbtc/signer/Cargo.toml formal_verification_
+        run: cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml formal_verification_
 
   tla-model-checks:
     name: TLA model checks

--- a/pkg/tbtc/signer/build.sh
+++ b/pkg/tbtc/signer/build.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-cargo build --release
+# --locked: build strictly against the committed Cargo.lock so a release
+# binary is never produced from an unaudited, re-resolved dependency set.
+cargo build --release --locked


### PR DESCRIPTION
## Summary

Follow-up to #4005 (FROST/ROAST signer). Pins cargo dependency resolution in CI and the release build.

The `signer-dependency-audit` job runs `cargo-deny` against the committed `Cargo.lock`, but the clippy/test jobs and `build.sh` resolved dependencies **without** `--locked`. A PR that edits `Cargo.toml` so the committed lock no longer satisfies it would let those jobs silently re-resolve to newer, unaudited crate versions (running their build scripts and proc-macros on the runner) while the advisory gate still audits the stale lock — so the security gate and the code actually exercised could diverge.

## Fix

Adds `--locked` to the `clippy`, `test`, formal-`test`, and release-`build` invocations so a lock/manifest mismatch fails loudly instead of silently re-resolving. `cargo fmt` is intentionally left unchanged (it does not accept `--locked`).

_Found during review of #4005._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
