### PR TITLE
fix(frost): harden the cgo native-signer FFI boundary

### DIFF
--- a/pkg/frost/signing/native_ffi_executor_adapter.go
+++ b/pkg/frost/signing/native_ffi_executor_adapter.go
@@ -73,7 +73,20 @@ func (nefea *nativeExecutionFFIExecutorAdapter) Execute(
 	ctx context.Context,
 	logger log.StandardLogger,
 	request *Request,
-) (*Result, error) {
+) (result *Result, err error) {
+	// Recover any panic originating along the cgo/FFI signing path (e.g. a
+	// malformed or oversized response from the native signer) and surface it as
+	// a failed attempt instead of crashing the whole signing process. The outer
+	// tBTC signingRetryLoop then handles this attempt cleanly.
+	defer func() {
+		if r := recover(); r != nil {
+			result = nil
+			err = fmt.Errorf(
+				"native FFI signing panicked at the cgo boundary: %v", r,
+			)
+		}
+	}()
+
 	if request == nil {
 		return nil, fmt.Errorf("request is nil")
 	}

--- a/pkg/frost/signing/native_ffi_executor_adapter_test.go
+++ b/pkg/frost/signing/native_ffi_executor_adapter_test.go
@@ -39,6 +39,47 @@ func (mnefsp *mockNativeExecutionFFISigningPrimitive) RegisterUnmarshallers(
 	mnefsp.lastChannel = channel
 }
 
+// panickingFFISigningPrimitive panics in Sign, standing in for a panic raised
+// along the cgo/FFI path (e.g. a C.GoBytes length-out-of-range on a malformed
+// native-signer response).
+type panickingFFISigningPrimitive struct{}
+
+func (panickingFFISigningPrimitive) Sign(
+	ctx context.Context,
+	logger log.StandardLogger,
+	request *NativeExecutionFFISigningRequest,
+) (*frost.Signature, error) {
+	panic("simulated cgo boundary panic")
+}
+
+func (panickingFFISigningPrimitive) RegisterUnmarshallers(channel net.BroadcastChannel) {}
+
+func TestNativeExecutionFFIExecutorAdapter_Execute_RecoversCgoBoundaryPanic(
+	t *testing.T,
+) {
+	executor, err := NewNativeExecutionFFIExecutorAdapter(panickingFFISigningPrimitive{})
+	if err != nil {
+		t.Fatalf("unexpected adapter setup error: [%v]", err)
+	}
+
+	result, err := executor.Execute(context.Background(), nil, &Request{
+		Message:        big.NewInt(1),
+		SignerMaterial: []byte{0x01},
+	})
+	if err == nil {
+		t.Fatal("expected an error from the recovered panic, got nil")
+	}
+	if result != nil {
+		t.Fatalf("expected a nil result on a recovered panic, got [%v]", result)
+	}
+	if !strings.Contains(err.Error(), "panicked at the cgo boundary") {
+		t.Fatalf(
+			"expected a cgo-boundary panic error, got: [%v]",
+			err,
+		)
+	}
+}
+
 func TestNewNativeExecutionFFIExecutorAdapter_NilPrimitive(t *testing.T) {
 	_, err := NewNativeExecutionFFIExecutorAdapter(nil)
 	if err == nil {

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -378,6 +378,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"unsafe"
 )
 
@@ -2636,7 +2637,15 @@ func callBuildTaggedTBTCSignerOperation(
 	}
 
 	requestPtr := C.CBytes(requestPayload)
-	defer C.free(requestPtr)
+	requestLen := len(requestPayload)
+	defer func() {
+		// Scrub the secret request bytes from the C heap before releasing them.
+		// The request payload can carry signing-share / nonce material, and a
+		// plain C.free does not overwrite; this mirrors the Go-side zeroBytes
+		// hygiene applied to the caller's own copy.
+		zeroBytes(unsafe.Slice((*byte)(requestPtr), requestLen))
+		C.free(requestPtr)
+	}()
 
 	result := call((*C.uint8_t)(requestPtr), C.size_t(len(requestPayload)))
 	return parseBuildTaggedTBTCSignerResult(operation, result)
@@ -2659,6 +2668,20 @@ func parseBuildTaggedTBTCSignerResult(
 
 	var payload []byte
 	if result.buffer.ptr != nil && result.buffer.len > 0 {
+		// Guard the size_t -> C.int narrowing in C.GoBytes: a length that does
+		// not fit in a C.int (>= 2^31) would overflow to a negative value and
+		// panic ("length out of range") at the cgo boundary, or silently
+		// truncate to a wrong length. A response that large is never valid, so
+		// reject it; the buffer is still released by the deferred free above.
+		if uint64(result.buffer.len) > uint64(math.MaxInt32) {
+			return nil, buildTaggedTBTCSignerOperationError(
+				operation,
+				fmt.Sprintf(
+					"response buffer length [%d] exceeds maximum [%d]",
+					uint64(result.buffer.len), math.MaxInt32,
+				),
+			)
+		}
 		payload = C.GoBytes(unsafe.Pointer(result.buffer.ptr), C.int(result.buffer.len))
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #3866 (Go FROST/ROAST coordinator). Three defensive fixes at the cgo Go↔Rust signer FFI boundary in `pkg/frost/signing`, so a malformed/oversized response — or a panic — from the native signer fails a single attempt instead of crashing the node or leaking secrets.

## Fixes

1. **Bounds-check the response length before `C.GoBytes`** (`parseBuildTaggedTBTCSignerResult`). The Rust-supplied `buffer.len` (`C.size_t`) was narrowed to `C.int` with no check: a length `≥ 2³¹` overflows to a negative value → `C.GoBytes` panics (`length out of range`) at the cgo boundary, or silently truncates to a wrong length. Now rejected with a clear error (the buffer is still freed by the deferred free).

2. **Zeroize the secret request bytes on the C heap before `C.free`** (the request-call helper). `C.CBytes(requestPayload)` copies the request (which can carry signing-share / nonce material) to the C heap; plain `C.free` does not overwrite, so the secret lingered in freed memory. Now scrubbed via the existing `zeroBytes`, mirroring the Go-side hygiene already applied to the caller's own copy.

3. **`recover()` at the FFI boundary** (`nativeExecutionFFIExecutorAdapter.Execute`). A panic anywhere along the cgo signing path (e.g. fix #1's overflow panic, or a nil-deref decoding a malformed engine response) previously took down the whole signing process. It's now converted to a failed attempt the outer tBTC `signingRetryLoop` handles cleanly.

## Tests / verification

- `TestNativeExecutionFFIExecutorAdapter_Execute_RecoversCgoBoundaryPanic` — a panicking primitive; verified to **crash the process without the recover** and pass with it. Full untagged `pkg/frost/signing` suite stays green.
- The cgo-tagged changes (#1, #2) are **compile-verified** under `-tags 'frost_native frost_tbtc_signer cgo'` (build + `go vet`). They still need a **runtime pass in the cgo + linked-`libfrost_tbtc` environment** — I can't exercise the real FFI here.

Addresses the cgo-boundary cluster from the review of #3866 (length-narrowing crash, secret-in-C-heap, missing recover). _Found during review of #3866._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
