### PR TITLE
feat(frost/roast): attribute lost-sync triggers; document permissioned-set acceptance

### DIFF
--- a/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
+++ b/pkg/frost/signing/roast_transition_exchange_frost_native_roast_retry.go
@@ -166,7 +166,22 @@ func (e *RoastTransitionExchange) onBundle(msg RunnerMessage) {
 		// bridge addresses (PR2b-2) and that stays within 1b's accepted
 		// fail-closed-terminate liveness regression (a single bad actor can already
 		// kill a round by withholding a bundle).
-		e.markLostSync()
+		//
+		// Under the PERMISSIONED operator set this residual is accepted: the
+		// triggering seat is operator-authenticated (logged below for attribution),
+		// the action is liveness-only (fail-closed, never an unsafe/divergent
+		// signature), and a misbehaving operator is governance-removable. REVISIT
+		// before any move to a PERMISSIONLESS operator set, where an anonymous,
+		// costless, non-attributable DoS would warrant the f+1 snapshot-corroboration
+		// (or resync) fix rather than accepting it.
+		if e.markLostSync() {
+			e.logger.Warnf(
+				"roast transition exchange: seat %d entered lost-sync from an "+
+					"unobserved-attempt bundle sent by seat %d (attempt context "+
+					"hash %x); failing closed before next selection",
+				e.member, msg.Sender, hash,
+			)
+		}
 		return
 	}
 	e.verifyAndStore(bundle)
@@ -174,8 +189,11 @@ func (e *RoastTransitionExchange) onBundle(msg RunnerMessage) {
 
 // markLostSync records that this seat received a transition for an attempt it
 // never observed -- it fell behind the group's committed ROAST attempt chain.
-func (e *RoastTransitionExchange) markLostSync() {
-	e.lostSync.Store(true)
+// It returns true only on the first transition into lost-sync, so the caller can
+// attribute the triggering bundle exactly once (the listener may keep receiving
+// such bundles -- including a spammer's -- while lost-sync stays latched).
+func (e *RoastTransitionExchange) markLostSync() bool {
+	return e.lostSync.CompareAndSwap(false, true)
 }
 
 // HasLostSync reports whether this seat fell behind the group's committed ROAST


### PR DESCRIPTION
## Summary

Follow-up to #3866. A small, behavior-preserving hardening + decision record for the ROAST transition-exchange lost-sync path (review finding #2).

**Background.** In `onBundle`, a seat that receives a transition bundle for an attempt it **never observed** trips `markLostSync()` — failing the wallet's signing retry loop closed — *before* any verification (a behind-seat lacks the observe handle full `VerifyBundle` needs). So an authenticated group member can broadcast a structurally-valid bundle with a bogus, never-committed attempt hash and halt every honest seat's signing. The blame bridge (PR2b-2) does **not** close this: a never-committed attempt produces no evidence to attribute the sender.

**Decision (after Codex review + threat analysis).** Under the **permissioned** operator set this residual is **accepted**: it's liveness-only (fail-closed — never an unsafe/divergent signature), the triggering seat is operator-authenticated (so attribution is immediate), and a misbehaving operator is governance-removable + economically deterred. The proper fix (f+1 snapshot-corroboration, or a resync state) is a real ROAST protocol change whose simple form can fracture the group on legitimate *sparse-failure* bundles — disproportionate while the set stays permissioned.

## Change

- **Attribution logging.** When a seat enters lost-sync from an unobserved-attempt bundle, log the **sending seat** and the **claimed attempt-context hash** — once per lost-sync episode — so the operational runbook can identify and remove/slash a member spamming bogus-attempt bundles.
- `markLostSync` now uses `CompareAndSwap` and returns whether it transitioned, so the attribution is logged exactly once even while the listener keeps receiving such bundles. **No change to the fail-closed semantics.**
- **Decision record in-code:** documents the permissioned-set acceptance and marks it as a **hard item to revisit before any move to a permissionless operator set**, where an anonymous/costless/non-attributable DoS would warrant the corroboration/resync fix.

## Verification

`gofmt` + `go vet` clean; builds under `-tags 'frost_native frost_roast_retry cgo frost_tbtc_signer'`; the transition-exchange / lost-sync / bundle tests pass. The only caller of `markLostSync` is the updated site.

_Found during review of #3866._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
