### PR TITLE
fix(tbtc): monitor the ECDSA and FROST sortition pools independently

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -333,6 +333,13 @@ func initTbtcFlags(cmd *cobra.Command, cfg *config.Config) {
 		false,
 		"Disable legacy ECDSA sortition pool monitoring for FROST-only deployments.",
 	)
+
+	cmd.Flags().BoolVar(
+		&cfg.Tbtc.DisableFrostSortitionPoolMonitoring,
+		"tbtc.disableFrostSortitionPoolMonitoring",
+		false,
+		"Disable FROST sortition pool monitoring for operators that manage FROST pool membership out of band.",
+	)
 }
 
 // Initialize flags for Maintainer configuration.

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -250,6 +250,15 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: true,
 		defaultValue:          false,
 	},
+	"tbtc.disableFrostSortitionPoolMonitoring": {
+		readValueFunc: func(c *config.Config) interface{} {
+			return c.Tbtc.DisableFrostSortitionPoolMonitoring
+		},
+		flagName:              "--tbtc.disableFrostSortitionPoolMonitoring",
+		flagValue:             "", // don't provide any value
+		expectedValueFromFlag: true,
+		defaultValue:          false,
+	},
 	"maintainer.bitcoinDifficulty": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.BitcoinDifficulty.Enabled },
 		flagName:              "--bitcoinDifficulty",

--- a/pkg/chain/ethereum/tbtc_sortition_chain_views.go
+++ b/pkg/chain/ethereum/tbtc_sortition_chain_views.go
@@ -1,0 +1,245 @@
+package ethereum
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	ecdsacontract "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen/contract"
+	"github.com/keep-network/keep-core/pkg/sortition"
+)
+
+// The seven sortition.Chain methods that TbtcChain routes through
+// hasFrostAuthorization() are inherently a process-global switch: a single
+// MonitorPool loop reads them and therefore maintains exactly one pool. During
+// the ECDSA->FROST migration an operator participates in BOTH the legacy ECDSA
+// and the FROST sortition pools at once (existing ECDSA wallets keep draining
+// while FROST is live), and each pool needs its own maintenance loop. These two
+// views bind the sortition.Chain surface to one specific pool/registry with NO
+// hasFrostAuthorization() switch, so the caller can run one MonitorPool per pool.
+//
+// They are used ONLY by the pool-monitoring loops; TbtcChain's own
+// sortition.Chain methods (consumed by the heartbeat and other callers) are left
+// unchanged, so this introduces no behavior change outside the monitor loops.
+// GetOperatorID stays bound to whichever pool the view targets, matching the
+// per-pool member IDs (the legacy view's GetOperatorID equals TbtcChain's
+// deliberately-ECDSA-bound GetOperatorID).
+
+// sortitionPoolView implements the pool-bound subset of sortition.Chain shared by
+// both views. The FROST and ECDSA sortition pools are the same contract type
+// (ecdsacontract.EcdsaSortitionPool), distinct instances, so these seven methods
+// are identical apart from which pool instance they target.
+type sortitionPoolView struct {
+	pool            *ecdsacontract.EcdsaSortitionPool
+	operatorAddress common.Address
+}
+
+func (v *sortitionPoolView) IsPoolLocked() (bool, error) {
+	return v.pool.IsLocked()
+}
+
+func (v *sortitionPoolView) IsEligibleForRewards() (bool, error) {
+	return v.pool.IsEligibleForRewards(v.operatorAddress)
+}
+
+func (v *sortitionPoolView) CanRestoreRewardEligibility() (bool, error) {
+	return v.pool.CanRestoreRewardEligibility(v.operatorAddress)
+}
+
+func (v *sortitionPoolView) RestoreRewardEligibility() error {
+	_, err := v.pool.RestoreRewardEligibility(v.operatorAddress)
+	return err
+}
+
+func (v *sortitionPoolView) IsChaosnetActive() (bool, error) {
+	return v.pool.IsChaosnetActive()
+}
+
+func (v *sortitionPoolView) IsBetaOperator() (bool, error) {
+	return v.pool.IsBetaOperator(v.operatorAddress)
+}
+
+func (v *sortitionPoolView) GetOperatorID(
+	operatorAddress chain.Address,
+) (chain.OperatorID, error) {
+	return getOperatorID(v.pool, common.HexToAddress(operatorAddress.String()))
+}
+
+// ecdsaSortitionChain is a sortition.Chain bound explicitly to the legacy ECDSA
+// WalletRegistry and sortition pool. Its registry methods mirror the non-FROST
+// branch of the corresponding TbtcChain methods.
+type ecdsaSortitionChain struct {
+	sortitionPoolView
+	walletRegistry *ecdsacontract.WalletRegistry
+}
+
+func (c *ecdsaSortitionChain) OperatorToStakingProvider() (chain.Address, bool, error) {
+	stakingProvider, err := c.walletRegistry.OperatorToStakingProvider(c.operatorAddress)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"failed to map operator [%v] to a staking provider: [%v]",
+			c.operatorAddress,
+			err,
+		)
+	}
+
+	if (stakingProvider == common.Address{}) {
+		return "", false, nil
+	}
+
+	return chain.Address(stakingProvider.Hex()), true, nil
+}
+
+func (c *ecdsaSortitionChain) EligibleStake(
+	stakingProvider chain.Address,
+) (*big.Int, error) {
+	eligibleStake, err := c.walletRegistry.EligibleStake(
+		common.HexToAddress(stakingProvider.String()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get eligible stake for staking provider %s: [%w]",
+			stakingProvider,
+			err,
+		)
+	}
+
+	return eligibleStake, nil
+}
+
+func (c *ecdsaSortitionChain) IsOperatorInPool() (bool, error) {
+	return c.walletRegistry.IsOperatorInPool(c.operatorAddress)
+}
+
+func (c *ecdsaSortitionChain) IsOperatorUpToDate() (bool, error) {
+	return c.walletRegistry.IsOperatorUpToDate(c.operatorAddress)
+}
+
+func (c *ecdsaSortitionChain) JoinSortitionPool() error {
+	_, err := c.walletRegistry.JoinSortitionPool()
+	return err
+}
+
+func (c *ecdsaSortitionChain) UpdateOperatorStatus() error {
+	_, err := c.walletRegistry.UpdateOperatorStatus(c.operatorAddress)
+	return err
+}
+
+// frostSortitionChain is a sortition.Chain bound explicitly to the FROST
+// WalletRegistry and sortition pool. Its registry methods mirror the FROST
+// branch of the corresponding TbtcChain methods, including the explicit CallOpts
+// and the transaction-mutex/nonce-serialized submission helper (shared with the
+// ECDSA registry binding, so the two monitor loops never race on the operator
+// account nonce).
+type frostSortitionChain struct {
+	sortitionPoolView
+	tc *TbtcChain
+}
+
+func (c *frostSortitionChain) OperatorToStakingProvider() (chain.Address, bool, error) {
+	stakingProvider, err := c.tc.frostWalletRegistry.OperatorToStakingProvider(
+		&bind.CallOpts{From: c.operatorAddress},
+		c.operatorAddress,
+	)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"failed to map operator [%v] to a staking provider: [%v]",
+			c.operatorAddress,
+			err,
+		)
+	}
+
+	if (stakingProvider == common.Address{}) {
+		return "", false, nil
+	}
+
+	return chain.Address(stakingProvider.Hex()), true, nil
+}
+
+func (c *frostSortitionChain) EligibleStake(
+	stakingProvider chain.Address,
+) (*big.Int, error) {
+	eligibleStake, err := c.tc.frostWalletRegistry.EligibleStake(
+		&bind.CallOpts{From: c.operatorAddress},
+		common.HexToAddress(stakingProvider.String()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get eligible stake for staking provider %s: [%w]",
+			stakingProvider,
+			err,
+		)
+	}
+
+	return eligibleStake, nil
+}
+
+func (c *frostSortitionChain) IsOperatorInPool() (bool, error) {
+	return c.tc.frostWalletRegistry.IsOperatorInPool(
+		&bind.CallOpts{From: c.operatorAddress},
+		c.operatorAddress,
+	)
+}
+
+func (c *frostSortitionChain) IsOperatorUpToDate() (bool, error) {
+	return c.tc.frostWalletRegistry.IsOperatorUpToDate(
+		&bind.CallOpts{From: c.operatorAddress},
+		c.operatorAddress,
+	)
+}
+
+func (c *frostSortitionChain) JoinSortitionPool() error {
+	return c.tc.submitFrostWalletRegistryTransaction(
+		"joinSortitionPool",
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return c.tc.frostWalletRegistry.JoinSortitionPool(opts)
+		},
+	)
+}
+
+func (c *frostSortitionChain) UpdateOperatorStatus() error {
+	return c.tc.submitFrostWalletRegistryTransaction(
+		"updateOperatorStatus",
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return c.tc.frostWalletRegistry.UpdateOperatorStatus(
+				opts,
+				c.operatorAddress,
+			)
+		},
+	)
+}
+
+// LegacyECDSASortitionChain returns a sortition.Chain bound explicitly to the
+// legacy ECDSA sortition pool, for ECDSA pool monitoring during the FROST
+// migration drain (independent of whether FROST authorization is configured).
+func (tc *TbtcChain) LegacyECDSASortitionChain() sortition.Chain {
+	return &ecdsaSortitionChain{
+		sortitionPoolView: sortitionPoolView{
+			pool:            tc.sortitionPool,
+			operatorAddress: tc.key.Address,
+		},
+		walletRegistry: tc.walletRegistry,
+	}
+}
+
+// FrostSortitionChain returns a sortition.Chain bound explicitly to the FROST
+// sortition pool, and a flag reporting whether FROST authorization is configured
+// for this node. When the flag is false, the returned chain is nil and FROST
+// pool monitoring must not be started.
+func (tc *TbtcChain) FrostSortitionChain() (sortition.Chain, bool) {
+	if !tc.hasFrostAuthorization() {
+		return nil, false
+	}
+
+	return &frostSortitionChain{
+		sortitionPoolView: sortitionPoolView{
+			pool:            tc.frostSortitionPool,
+			operatorAddress: tc.key.Address,
+		},
+		tc: tc,
+	}, true
+}

--- a/pkg/chain/ethereum/tbtc_sortition_chain_views_test.go
+++ b/pkg/chain/ethereum/tbtc_sortition_chain_views_test.go
@@ -1,0 +1,116 @@
+package ethereum
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+
+	ecdsacontract "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen/contract"
+	frostabi "github.com/keep-network/keep-core/pkg/chain/ethereum/frost/gen/abi"
+)
+
+// The pool-monitoring defect these views fix is a WRONG-POOL binding: a single
+// hasFrostAuthorization()-switched monitor maintained the FROST pool while
+// labeled "legacy ECDSA" (and, post-cutover, nothing). These tests pin each view
+// to its intended pool/registry so a regression that crosses the wiring fails.
+
+func newTbtcChainForSortitionViewTest(withFrost bool) (
+	tc *TbtcChain,
+	ecdsaPool *ecdsacontract.EcdsaSortitionPool,
+	frostPool *ecdsacontract.EcdsaSortitionPool,
+	operatorAddress common.Address,
+) {
+	operatorAddress = common.HexToAddress(
+		"0x1111111111111111111111111111111111111111",
+	)
+	ecdsaPool = &ecdsacontract.EcdsaSortitionPool{}
+	frostPool = &ecdsacontract.EcdsaSortitionPool{}
+
+	tc = &TbtcChain{
+		baseChain: &baseChain{
+			key: &keystore.Key{Address: operatorAddress},
+		},
+		walletRegistry: &ecdsacontract.WalletRegistry{},
+		sortitionPool:  ecdsaPool,
+	}
+	if withFrost {
+		tc.frostWalletRegistry = &frostabi.FrostWalletRegistry{}
+		tc.frostSortitionPool = frostPool
+	}
+
+	return tc, ecdsaPool, frostPool, operatorAddress
+}
+
+func TestLegacyECDSASortitionChainBindsToECDSAPool(t *testing.T) {
+	// Even with FROST configured, the legacy view must bind to the ECDSA pool --
+	// this is the exact crossing the switched monitor got wrong.
+	tc, ecdsaPool, frostPool, operatorAddress := newTbtcChainForSortitionViewTest(true)
+
+	view := tc.LegacyECDSASortitionChain()
+
+	ecdsaView, ok := view.(*ecdsaSortitionChain)
+	if !ok {
+		t.Fatalf("expected *ecdsaSortitionChain, got [%T]", view)
+	}
+	if ecdsaView.pool != ecdsaPool {
+		t.Fatal("legacy view must target the ECDSA sortition pool")
+	}
+	if ecdsaView.pool == frostPool {
+		t.Fatal("legacy view must NOT target the FROST sortition pool")
+	}
+	if ecdsaView.walletRegistry != tc.walletRegistry {
+		t.Fatal("legacy view must target the ECDSA wallet registry")
+	}
+	if ecdsaView.operatorAddress != operatorAddress {
+		t.Fatalf(
+			"unexpected operator address\nexpected: [%v]\nactual:   [%v]",
+			operatorAddress,
+			ecdsaView.operatorAddress,
+		)
+	}
+}
+
+func TestFrostSortitionChainBindsToFrostPoolWhenConfigured(t *testing.T) {
+	tc, ecdsaPool, frostPool, operatorAddress := newTbtcChainForSortitionViewTest(true)
+
+	view, configured := tc.FrostSortitionChain()
+
+	if !configured {
+		t.Fatal("FROST view must be configured when FROST contracts are set")
+	}
+	frostView, ok := view.(*frostSortitionChain)
+	if !ok {
+		t.Fatalf("expected *frostSortitionChain, got [%T]", view)
+	}
+	if frostView.pool != frostPool {
+		t.Fatal("FROST view must target the FROST sortition pool")
+	}
+	if frostView.pool == ecdsaPool {
+		t.Fatal("FROST view must NOT target the ECDSA sortition pool")
+	}
+	if frostView.tc != tc {
+		t.Fatal("FROST view must reference the owning chain for tx submission")
+	}
+	if frostView.operatorAddress != operatorAddress {
+		t.Fatalf(
+			"unexpected operator address\nexpected: [%v]\nactual:   [%v]",
+			operatorAddress,
+			frostView.operatorAddress,
+		)
+	}
+}
+
+func TestFrostSortitionChainUnconfiguredWhenFrostAbsent(t *testing.T) {
+	// No FROST contracts -> the FROST monitor loop must not start.
+	tc, _, _, _ := newTbtcChainForSortitionViewTest(false)
+
+	view, configured := tc.FrostSortitionChain()
+
+	if configured {
+		t.Fatal("FROST view must be unconfigured when FROST contracts are absent")
+	}
+	if view != nil {
+		t.Fatal("FROST view must be nil when FROST is not configured")
+	}
+}

--- a/pkg/sortition/sortition.go
+++ b/pkg/sortition/sortition.go
@@ -12,7 +12,12 @@ const (
 	DefaultStatusCheckTick = 6 * time.Hour
 )
 
-var errOperatorUnknown = fmt.Errorf("operator not registered for the staking provider, check Threshold dashboard")
+// ErrOperatorUnknown indicates the operator is not registered for a staking
+// provider in the targeted sortition pool. Callers running more than one pool
+// monitor (e.g. a legacy ECDSA pool and a FROST pool during migration) can
+// treat this as a non-fatal, per-pool condition: absence from one pool must not
+// abort monitoring of another.
+var ErrOperatorUnknown = fmt.Errorf("operator not registered for the staking provider, check Threshold dashboard")
 
 // MonitorPool periodically checks the status of the operator in the sortition
 // pool. If the operator is supposed to be in the sortition pool but is not
@@ -32,7 +37,7 @@ func MonitorPool(
 	}
 
 	if !isRegistered {
-		return errOperatorUnknown
+		return ErrOperatorUnknown
 	}
 
 	err = checkOperatorStatus(logger, chain, policy)

--- a/pkg/sortition/sortition_test.go
+++ b/pkg/sortition/sortition_test.go
@@ -48,7 +48,7 @@ func TestMonitorPool_NotRegisteredOperator(t *testing.T) {
 		statusCheckTick,
 		UnconditionalJoinPolicy,
 	)
-	testutils.AssertErrorsSame(t, errOperatorUnknown, err)
+	testutils.AssertErrorsSame(t, ErrOperatorUnknown, err)
 }
 
 func TestMonitorPool_NoStake(t *testing.T) {

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"time"
@@ -113,6 +114,13 @@ type Config struct {
 	// deployments where operators are authorized through FrostAllowlist and no
 	// longer have TokenStaking-backed ECDSA operator state.
 	DisableLegacySortitionPoolMonitoring bool
+	// DisableFrostSortitionPoolMonitoring skips monitoring and auto-joining the
+	// FROST sortition pool. FROST pool monitoring is enabled by default whenever
+	// FROST authorization is configured, independent of DisableLegacyECDSA, so
+	// that operators stay selectable for new FROST wallet DKG both during the
+	// ECDSA drain and after the legacy pool is retired. This flag is an opt-out
+	// for operators that manage FROST pool membership out of band.
+	DisableFrostSortitionPoolMonitoring bool
 }
 
 // Initialize kicks off the TBTC by initializing internal state, ensuring
@@ -232,14 +240,29 @@ func Initialize(
 		)
 	}
 
+	// During the ECDSA->FROST migration an operator is a member of BOTH the
+	// legacy ECDSA and the FROST sortition pools at once (existing ECDSA wallets
+	// keep draining while FROST is live), so each pool needs its own monitor
+	// loop bound explicitly to that pool. A single hasFrostAuthorization()-
+	// switched loop would maintain only one pool -- and, once the legacy flag is
+	// disabled post-cutover, neither. Resolve a sortition.Chain bound explicitly
+	// to the legacy ECDSA pool; fall back to the chain itself for chains that do
+	// not expose the explicit view (e.g. test chains, which are not FROST-dual).
+	legacyECDSASortitionChain := sortition.Chain(chain)
+	if provider, ok := chain.(interface {
+		LegacyECDSASortitionChain() sortition.Chain
+	}); ok {
+		legacyECDSASortitionChain = provider.LegacyECDSASortitionChain()
+	}
+
 	if shouldMonitorLegacySortitionPool(config) {
 		err = sortition.MonitorPool(
 			ctx,
 			logger,
-			chain,
+			legacyECDSASortitionChain,
 			sortition.DefaultStatusCheckTick,
 			sortition.NewConjunctionPolicy(
-				sortition.NewBetaOperatorPolicy(chain, logger),
+				sortition.NewBetaOperatorPolicy(legacyECDSASortitionChain, logger),
 				&enoughPreParamsInPoolPolicy{
 					node:   node,
 					config: config,
@@ -248,12 +271,54 @@ func Initialize(
 		)
 		if err != nil {
 			return fmt.Errorf(
-				"could not set up sortition pool monitoring: [%v]",
+				"could not set up legacy ECDSA sortition pool monitoring: [%v]",
 				err,
 			)
 		}
 	} else {
 		logger.Infof("legacy ECDSA sortition pool monitoring disabled")
+	}
+
+	// FROST sortition pool monitoring runs whenever FROST authorization is
+	// configured, independent of DisableLegacyECDSA, so operators stay selectable
+	// for new FROST wallet DKG during the drain AND after the legacy pool is
+	// retired. The FROST loop uses the beta-operator policy only: the ECDSA
+	// pre-params gate does not apply to FROST DKG.
+	if provider, ok := chain.(interface {
+		FrostSortitionChain() (sortition.Chain, bool)
+	}); ok {
+		if frostSortitionChain, frostConfigured := provider.FrostSortitionChain(); frostConfigured {
+			if config.DisableFrostSortitionPoolMonitoring {
+				logger.Infof("FROST sortition pool monitoring disabled")
+			} else {
+				err = sortition.MonitorPool(
+					ctx,
+					logger,
+					frostSortitionChain,
+					sortition.DefaultStatusCheckTick,
+					sortition.NewBetaOperatorPolicy(frostSortitionChain, logger),
+				)
+				if err != nil {
+					// Absence from the FROST pool is a recoverable, per-pool
+					// state: an operator may register for FROST after node start,
+					// or remain ECDSA-only during the drain. It must not abort
+					// node startup nor the legacy pool's monitoring. Other
+					// monitoring failures remain fatal.
+					if errors.Is(err, sortition.ErrOperatorUnknown) {
+						logger.Warnf(
+							"operator is not registered in the FROST sortition " +
+								"pool; FROST pool monitoring is inactive until the " +
+								"operator is registered and the node is restarted",
+						)
+					} else {
+						return fmt.Errorf(
+							"could not set up FROST sortition pool monitoring: [%v]",
+							err,
+						)
+					}
+				}
+			}
+		}
 	}
 
 	if shouldRunLegacyECDSA(config) {


### PR DESCRIPTION
## Summary

Follow-up to #3866 (review finding #3). Fixes sortition-pool monitoring for the dual-pool window of the ECDSA→FROST migration.

During the migration an operator is a member of **both** sortition pools at once: existing ECDSA wallets keep draining via redemptions while FROST is live. The seven `sortition.Chain` methods on `TbtcChain` switch on `hasFrostAuthorization()` (true whenever FROST is configured), and a **single** `MonitorPool` loop consumed them — so:

- **During overlap** (`DisableLegacyECDSA=false`): the loop labeled *"legacy ECDSA sortition pool monitoring"* actually maintained the **FROST** pool; the ECDSA pool got no maintenance.
- **Post-cutover** (`DisableLegacyECDSA=true`): the only loop stopped entirely, leaving the **FROST** pool — the one new FROST wallet DKG selects from — **unmonitored**.

> The ECDSA drain itself is unaffected either way: signing an existing wallet uses the locally-held key share + the wallet's fixed roster, never sortition-pool state. This is a pool-membership/selection-eligibility fix, not a fund-availability one.

## Change

Bind monitoring **explicitly per pool**. Two `sortition.Chain` views (`ecdsaSortitionChain`, `frostSortitionChain`) route directly to their own registry/pool with **no** `hasFrostAuthorization()` switch, and the node runs **one `MonitorPool` loop per pool**:

- **ECDSA loop** — existing flags + policy, now correctly ECDSA-bound (data path *and* beta policy read the ECDSA pool).
- **FROST loop** — new `DisableFrostSortitionPoolMonitoring` flag (**default-on**), beta policy only (the ECDSA pre-params gate doesn't apply to FROST DKG), gated on FROST being configured and **independent of `DisableLegacyECDSA`** so the FROST pool stays monitored during the drain *and* after the legacy pool is retired.

The operator isn't necessarily registered in both pools, so the FROST loop treats `sortition.ErrOperatorUnknown` (now exported) as **non-fatal** — it warns and leaves FROST monitoring inactive rather than aborting startup. The legacy loop keeps its existing fail-fast (the operator is ECDSA-registered during the drain).

`TbtcChain`'s own `sortition.Chain` methods are **left unchanged**, so heartbeat and other callers are unaffected; `GetOperatorID` stays ECDSA-bound. Both loops' join/update txs already share `tc.transactionMutex` + `tc.nonceManager`, so they cannot race on the operator account nonce.

### Design input baked in (per maintainer + Codex)
- FROST loop join policy = beta-operator only (no FROST equivalent of the ECDSA pre-params gate; FROST DKG readiness is announced separately).
- Operator compensation is out-of-band, so ECDSA-pool staleness during the drain is benign; the FROST loop is the load-bearing one.
- `GetOperatorID` asymmetry preserved (separate `GetFrostOperatorID` exists).

## Known limitation
`MonitorPool` (shared with the beacon) hard-returns at startup without starting its ticker, so an operator that registers for FROST *after* node start needs a restart to begin FROST monitoring. Logged clearly; deliberately not changing the shared `MonitorPool` here.

## Tests / verification
- New `tbtc_sortition_chain_views_test.go` pins each view to its intended pool (legacy→ECDSA, FROST→FROST, unconfigured→nil) — **negative-checked** (mis-binding the legacy view to the FROST pool makes it fail).
- gofmt + `go vet` clean; untagged `go build ./...` clean; builds under `-tags 'frost_native frost_tbtc_signer cgo frost_roast_retry'`; `pkg/sortition` + `pkg/chain/ethereum` tests pass; full `pkg/tbtc` suite passes.
- Adversarial review (3 angles → verify): 0 confirmed findings; adapter fidelity confirmed line-for-line across all 13 methods; cross-loop nonce safety confirmed.

_Found during review of #3866._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
