### PR TITLE
fix(ethereum): route GetWallet's wallet-ID fallback by scheme, not error type

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -2166,13 +2166,13 @@ func (tc *TbtcChain) GetWallet(
 		return nil, fmt.Errorf("cannot parse wallet state: [%v]", err)
 	}
 
-	walletID, err := walletIDForWalletPublicKeyHash(
+	walletID, err := resolveWalletID(
 		tc.bridge,
 		walletPublicKeyHash,
+		wallet.EcdsaWalletID,
 	)
 	if err != nil {
-		// Fallback for legacy deployments where walletID accessor may not exist.
-		walletID = tbtc.DeriveLegacyWalletID(walletPublicKeyHash)
+		return nil, err
 	}
 
 	return &tbtc.WalletChainData{
@@ -2212,6 +2212,44 @@ func walletIDForWalletPublicKeyHash(
 	}
 
 	return resolver.WalletID(walletPublicKeyHash)
+}
+
+// resolveWalletID returns the canonical wallet ID for the wallet identified by
+// walletPublicKeyHash. ecdsaWalletID is that wallet's ECDSA wallet ID from the
+// Bridge record -- zero for FROST wallets, non-zero for legacy ECDSA wallets.
+//
+// On an accessor error the fallback is routed by SCHEME, not by error type
+// (which cannot reliably distinguish a legacy on-chain Bridge -- whose walletID
+// eth_call returns a normal RPC/ABI error even when the node uses the current
+// binding -- from a transient failure):
+//
+//   - A legacy ECDSA wallet's canonical wallet ID equals its legacy derivation,
+//     so falling back is correct, and it is the only option on a legacy Bridge
+//     whose contract lacks the walletID accessor.
+//   - A FROST wallet requires its canonical wallet ID; the legacy derivation
+//     would be a different value and would select the wrong (P2WPKH vs P2TR)
+//     wallet script, so the error is surfaced instead of falling back. A FROST
+//     wallet only exists on a canonical-ID Bridge, so such an error is genuinely
+//     transient.
+func resolveWalletID(
+	bridge any,
+	walletPublicKeyHash [20]byte,
+	ecdsaWalletID [32]byte,
+) ([32]byte, error) {
+	walletID, err := walletIDForWalletPublicKeyHash(bridge, walletPublicKeyHash)
+	if err == nil {
+		return walletID, nil
+	}
+
+	if ecdsaWalletID == ([32]byte{}) {
+		return [32]byte{}, fmt.Errorf(
+			"cannot resolve canonical wallet ID for FROST wallet [0x%x]: [%w]",
+			walletPublicKeyHash,
+			err,
+		)
+	}
+
+	return tbtc.DeriveLegacyWalletID(walletPublicKeyHash), nil
 }
 
 type walletPublicKeyHashForWalletIDFn interface {

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -826,6 +826,112 @@ func TestPastNewWalletRegisteredV2Events_ReturnsErrorWhenRawMissing(t *testing.T
 	}
 }
 
+type walletIDForWalletPublicKeyHashBridgeMock struct {
+	resolve func(walletPublicKeyHash [20]byte) ([32]byte, error)
+}
+
+func (m *walletIDForWalletPublicKeyHashBridgeMock) WalletID(
+	walletPublicKeyHash [20]byte,
+) ([32]byte, error) {
+	return m.resolve(walletPublicKeyHash)
+}
+
+func TestResolveWalletID(t *testing.T) {
+	walletPublicKeyHash := [20]byte{0xaa}
+	legacyEcdsaWalletID := [32]byte{0x07} // non-zero -> legacy ECDSA wallet
+	frostEcdsaWalletID := [32]byte{}      // zero -> FROST wallet
+
+	t.Run("returns the canonical wallet ID when the accessor succeeds", func(t *testing.T) {
+		expectedWalletID := [32]byte{0x01}
+
+		actualWalletID, err := resolveWalletID(
+			&walletIDForWalletPublicKeyHashBridgeMock{
+				resolve: func(actual [20]byte) ([32]byte, error) {
+					if actual != walletPublicKeyHash {
+						t.Fatalf("unexpected wallet public key hash: [%x]", actual)
+					}
+					return expectedWalletID, nil
+				},
+			},
+			walletPublicKeyHash,
+			frostEcdsaWalletID,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: [%v]", err)
+		}
+		if actualWalletID != expectedWalletID {
+			t.Fatalf(
+				"unexpected wallet ID\nexpected: [%x]\nactual:   [%x]",
+				expectedWalletID,
+				actualWalletID,
+			)
+		}
+	})
+
+	t.Run("surfaces the error for a FROST wallet when the accessor fails", func(t *testing.T) {
+		// A FROST wallet (zero ECDSA wallet ID) requires its canonical ID; the
+		// legacy derivation would be the wrong value (wrong P2WPKH vs P2TR
+		// script), so the error must surface rather than fall back.
+		_, err := resolveWalletID(
+			&walletIDForWalletPublicKeyHashBridgeMock{
+				resolve: func([20]byte) ([32]byte, error) {
+					return [32]byte{}, errors.New("execution reverted: temporary")
+				},
+			},
+			walletPublicKeyHash,
+			frostEcdsaWalletID,
+		)
+		if err == nil {
+			t.Fatal("expected an error for a FROST wallet with an unresolvable canonical ID")
+		}
+	})
+
+	t.Run("falls back to the legacy ID for a legacy ECDSA wallet on accessor error", func(t *testing.T) {
+		// Regression for legacy on-chain Bridges: the accessor exists in the
+		// binding but the contract lacks the walletID function, so the call
+		// returns a normal RPC/ABI error (NOT a typed missing-accessor signal). A
+		// legacy ECDSA wallet (non-zero ECDSA wallet ID) must still fall back.
+		actualWalletID, err := resolveWalletID(
+			&walletIDForWalletPublicKeyHashBridgeMock{
+				resolve: func([20]byte) ([32]byte, error) {
+					return [32]byte{}, errors.New("execution reverted")
+				},
+			},
+			walletPublicKeyHash,
+			legacyEcdsaWalletID,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: [%v]", err)
+		}
+		if expected := tbtcpkg.DeriveLegacyWalletID(walletPublicKeyHash); actualWalletID != expected {
+			t.Fatalf(
+				"unexpected wallet ID\nexpected: [%x]\nactual:   [%x]",
+				expected,
+				actualWalletID,
+			)
+		}
+	})
+
+	t.Run("falls back to the legacy ID for a legacy wallet on a Bridge without the accessor", func(t *testing.T) {
+		// Legacy deployment where the binding itself lacks the accessor.
+		actualWalletID, err := resolveWalletID(
+			struct{}{},
+			walletPublicKeyHash,
+			legacyEcdsaWalletID,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: [%v]", err)
+		}
+		if expected := tbtcpkg.DeriveLegacyWalletID(walletPublicKeyHash); actualWalletID != expected {
+			t.Fatalf(
+				"unexpected wallet ID\nexpected: [%x]\nactual:   [%x]",
+				expected,
+				actualWalletID,
+			)
+		}
+	})
+}
+
 type walletPublicKeyHashForWalletIDBridgeMock struct {
 	resolve func(walletID [32]byte) ([20]byte, error)
 }


### PR DESCRIPTION
## Summary

Addresses a Codex finding (relayed via the #4119 review): `TbtcChain.GetWallet` derived a **legacy** wallet ID on **any** error from the canonical `walletID` accessor. For a FROST wallet on a canonical Bridge, a transient call failure would silently yield the left-padded legacy ID — and callers use `WalletChainData.WalletID` to choose **P2TR (FROST)** vs **P2WPKH (legacy)** scripts, so the node would build or search the **wrong wallet script**.

## Why route by scheme (revised after Codex P1)

The first revision distinguished by error type (a sentinel for the missing accessor, surface everything else). Codex correctly flagged a **P1 regression**: a *legacy on-chain Bridge* built with the *current* generated binding still satisfies the accessor interface, so its missing `walletID` function returns a normal RPC/ABI error — not the sentinel — and that revision would surface it and **break `GetWallet` on exactly the legacy deployments the fallback exists for**. Error type cannot reliably separate "function absent on-chain" from "transient."

So this routes by **scheme**, using the wallet's `EcdsaWalletID` (which `GetWallet` already reads, and which the codebase already uses to infer scheme — zero ⇒ FROST):

- **Legacy ECDSA wallet** (`EcdsaWalletID != 0`): its canonical wallet ID *equals* its legacy derivation, so fall back on **any** accessor error — and it's the only option on a legacy Bridge lacking the accessor.
- **FROST wallet** (`EcdsaWalletID == 0`): requires the canonical ID; **surface** the error rather than return a wrong legacy ID. A FROST wallet only exists on a canonical-ID Bridge, so such an error is genuinely transient.

Logic is extracted into `resolveWalletID(bridge, walletPublicKeyHash, ecdsaWalletID)`.

## Tests

`TestResolveWalletID` covers all four cases: accessor success → canonical; FROST + accessor error → surfaced; **legacy + accessor error → legacy fallback** (the P1 regression guard — verified to fail if the routing surfaces errors for legacy wallets); legacy + missing-accessor binding → legacy fallback. gofmt + `go vet` clean; full `pkg/chain/ethereum` suite passes.

_Found during the Codex review batch on #4115–#4120; revised per the Codex P1 re-review._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
