### PR TITLE
fix(signer): defer sign-round clear + persist before idempotent serve

### DIFF
--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -1043,6 +1043,31 @@ pub(crate) fn persist_engine_state_to_storage(
     persist_engine_state_to_storage_with_key(engine_state, &key_material)
 }
 
+/// Process-local marker tracking whether `start_sign_round` has established a
+/// round in memory whose durable persist has not yet succeeded. It lets the
+/// idempotent cached serve persist ONLY when the round is not yet durable (so a
+/// lost-consumed-marker hole on the original-persist-failure path is closed),
+/// while still serving the cached round WITHOUT persisting -- so an idempotent
+/// replay survives a state-key-provider outage -- once the round is durable.
+/// SET by `start_sign_round` on a fresh-round mutation and CLEARED by ANY
+/// successful persist (see `persist_engine_state_to_storage_with_key`): a
+/// successful persist writes the whole engine state, so the round becomes durable
+/// regardless of which operation triggered it. Accessed only while the
+/// ENGINE_STATE guard is held, so `Relaxed` ordering suffices.
+static SIGN_ROUND_PERSIST_PENDING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Marks that `start_sign_round` established an in-memory round not yet durably
+/// persisted. Cleared by the next successful persist of any kind.
+pub(crate) fn mark_sign_round_persist_pending() {
+    SIGN_ROUND_PERSIST_PENDING.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Returns true while a `start_sign_round` round is in memory but not yet durable.
+pub(crate) fn sign_round_persist_pending() -> bool {
+    SIGN_ROUND_PERSIST_PENDING.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 pub(crate) fn persist_engine_state_to_storage_with_key(
     engine_state: &EngineState,
     key_material: &StateEncryptionKeyMaterial,
@@ -1122,6 +1147,16 @@ pub(crate) fn persist_engine_state_to_storage_with_key(
     }
 
     bytes.zeroize();
+    if persist_result.is_ok() {
+        // A successful persist writes the entire engine state durably -- including
+        // any in-memory start_sign_round round -- so the sign-round persist-pending
+        // marker no longer applies, regardless of which operation triggered this
+        // persist. Clearing it here (rather than only at the start_sign_round
+        // persist sites) keeps an idempotent replay of an already-durable round
+        // from being forced to re-persist, which would otherwise fail during a
+        // state-key-provider outage.
+        SIGN_ROUND_PERSIST_PENDING.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
     persist_result
 }
 

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -1043,29 +1043,61 @@ pub(crate) fn persist_engine_state_to_storage(
     persist_engine_state_to_storage_with_key(engine_state, &key_material)
 }
 
-/// Process-local marker tracking whether `start_sign_round` has established a
-/// round in memory whose durable persist has not yet succeeded. It lets the
-/// idempotent cached serve persist ONLY when the round is not yet durable (so a
-/// lost-consumed-marker hole on the original-persist-failure path is closed),
-/// while still serving the cached round WITHOUT persisting -- so an idempotent
-/// replay survives a state-key-provider outage -- once the round is durable.
-/// SET by `start_sign_round` on a fresh-round mutation and CLEARED by ANY
-/// successful persist (see `persist_engine_state_to_storage_with_key`): a
-/// successful persist writes the whole engine state, so the round becomes durable
-/// regardless of which operation triggered it. Accessed only while the
-/// ENGINE_STATE guard is held, so `Relaxed` ordering suffices.
-static SIGN_ROUND_PERSIST_PENDING: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+/// Process-local set of session IDs whose `start_sign_round` round is established
+/// in memory but whose durable persist has not yet succeeded. It lets the
+/// idempotent cached serve persist ONLY for a session whose round is not yet
+/// durable (closing the lost-consumed-marker hole on the original-persist-failure
+/// path), while still serving an already-durable session's cached round WITHOUT
+/// persisting -- so an idempotent replay survives a state-key-provider outage.
+///
+/// The marker is scoped PER SESSION, not process-wide: one session's failed
+/// persist must NOT force an unrelated, already-durable session's idempotent
+/// replay to re-persist (and fail) during the same outage. A session is INSERTED
+/// by `start_sign_round` on a fresh-round mutation and the whole set is CLEARED
+/// by ANY successful persist (see `persist_engine_state_to_storage_with_key`): a
+/// successful persist writes the entire engine state, so every in-memory round
+/// becomes durable at once, regardless of which operation triggered it.
+///
+/// Mutual exclusion is provided by the inner mutex itself, NOT by the ENGINE_STATE
+/// guard. `mark`/`pending` and the common clear-on-persist do run under that
+/// guard, but the clear ALSO runs off-guard -- on the startup legacy-envelope
+/// rewrite (`load_engine_state_from_storage` persists before serving begins) and
+/// in `reset_for_tests`. Those off-guard accesses are single-threaded, so the
+/// mutex is effectively uncontended, but it must not be downgraded to a
+/// non-locking primitive on the assumption that ENGINE_STATE serializes access.
+static SIGN_ROUND_PERSIST_PENDING_SESSIONS: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
 
-/// Marks that `start_sign_round` established an in-memory round not yet durably
-/// persisted. Cleared by the next successful persist of any kind.
-pub(crate) fn mark_sign_round_persist_pending() {
-    SIGN_ROUND_PERSIST_PENDING.store(true, std::sync::atomic::Ordering::Relaxed);
+fn sign_round_persist_pending_sessions() -> &'static Mutex<BTreeSet<String>> {
+    SIGN_ROUND_PERSIST_PENDING_SESSIONS.get_or_init(|| Mutex::new(BTreeSet::new()))
 }
 
-/// Returns true while a `start_sign_round` round is in memory but not yet durable.
-pub(crate) fn sign_round_persist_pending() -> bool {
-    SIGN_ROUND_PERSIST_PENDING.load(std::sync::atomic::Ordering::Relaxed)
+/// Marks that `start_sign_round` established an in-memory round for `session_id`
+/// that is not yet durably persisted. Cleared by the next successful persist of
+/// any kind.
+pub(crate) fn mark_sign_round_persist_pending(session_id: &str) {
+    sign_round_persist_pending_sessions()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(session_id.to_string());
+}
+
+/// Returns true while `session_id`'s `start_sign_round` round is in memory but
+/// not yet durable.
+pub(crate) fn sign_round_persist_pending(session_id: &str) -> bool {
+    sign_round_persist_pending_sessions()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .contains(session_id)
+}
+
+/// Clears every pending sign-round marker. Called on any successful persist (the
+/// whole engine state -- and thus every in-memory round -- is now durable) and on
+/// test reset.
+pub(crate) fn clear_sign_round_persist_pending() {
+    sign_round_persist_pending_sessions()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clear();
 }
 
 pub(crate) fn persist_engine_state_to_storage_with_key(
@@ -1149,13 +1181,13 @@ pub(crate) fn persist_engine_state_to_storage_with_key(
     bytes.zeroize();
     if persist_result.is_ok() {
         // A successful persist writes the entire engine state durably -- including
-        // any in-memory start_sign_round round -- so the sign-round persist-pending
-        // marker no longer applies, regardless of which operation triggered this
-        // persist. Clearing it here (rather than only at the start_sign_round
-        // persist sites) keeps an idempotent replay of an already-durable round
-        // from being forced to re-persist, which would otherwise fail during a
-        // state-key-provider outage.
-        SIGN_ROUND_PERSIST_PENDING.store(false, std::sync::atomic::Ordering::Relaxed);
+        // every in-memory start_sign_round round -- so no session's persist-pending
+        // marker still applies, regardless of which operation triggered this
+        // persist. Clearing the whole set here (rather than only at the
+        // start_sign_round persist sites) keeps an idempotent replay of an
+        // already-durable round from being forced to re-persist, which would
+        // otherwise fail during a state-key-provider outage.
+        clear_sign_round_persist_pending();
     }
     persist_result
 }

--- a/pkg/tbtc/signer/src/engine/signing.rs
+++ b/pkg/tbtc/signer/src/engine/signing.rs
@@ -5,11 +5,14 @@ use super::*;
 pub(crate) const BOOTSTRAP_SYNTHETIC_CONTRIBUTION_DOMAIN: &str =
     "tbtc-signer-bootstrap-contribution-v1";
 
-// The sign-round persist-pending marker lives in the persistence module
-// (`mark_sign_round_persist_pending` / `sign_round_persist_pending`) so that ANY
-// successful persist clears it, not only `start_sign_round`'s own -- otherwise a
-// later unrelated persist that makes the round durable would leave the marker
-// stale and force an idempotent replay to re-persist during a state-key outage.
+// The sign-round persist-pending markers live in the persistence module
+// (`mark_sign_round_persist_pending` / `sign_round_persist_pending`), keyed PER
+// SESSION. ANY successful persist clears them all, not only `start_sign_round`'s
+// own -- otherwise a later unrelated persist that makes the round durable would
+// leave the marker stale and force an idempotent replay to re-persist during a
+// state-key outage. They are keyed per session so one session's failed persist
+// cannot force an unrelated, already-durable session's replay to re-persist (and
+// fail) during the same outage.
 
 pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState, EngineError> {
     record_hardening_telemetry(|telemetry| {
@@ -264,9 +267,11 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                 // (the common case) serve the cached round WITHOUT persisting, so
                 // the idempotent replay still survives a state-key-provider
                 // outage, as build_taproot_tx does.
-                if matches_legacy_fingerprint || sign_round_persist_pending() {
-                    // persist_engine_state_to_storage clears the pending marker on
-                    // success (see the persistence module).
+                if matches_legacy_fingerprint || sign_round_persist_pending(&request.session_id) {
+                    // persist_engine_state_to_storage clears the pending markers on
+                    // success (see the persistence module). Only THIS session's own
+                    // not-yet-durable round forces a re-persist here; an unrelated
+                    // session's pending persist does not.
                     persist_engine_state_to_storage(&guard)?;
                 }
 
@@ -412,11 +417,12 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
             session.consumed_attempt_ids.insert(attempt_id);
         }
         session.consumed_sign_round_ids.insert(round_id);
-        // The round is now established in memory but not yet durable. Mark a
-        // persist as pending so a later idempotent cached serve re-persists if
-        // the persist below fails; cleared by the next successful persist (of any
-        // kind).
-        mark_sign_round_persist_pending();
+        // The round is now established in memory but not yet durable. Mark this
+        // session's persist as pending so a later idempotent cached serve
+        // re-persists if the persist below fails; cleared by the next successful
+        // persist (of any kind). Keyed per session so an unrelated, already-durable
+        // session's replay is not forced to re-persist during an outage.
+        mark_sign_round_persist_pending(&request.session_id);
 
         round_state
     };

--- a/pkg/tbtc/signer/src/engine/signing.rs
+++ b/pkg/tbtc/signer/src/engine/signing.rs
@@ -5,17 +5,11 @@ use super::*;
 pub(crate) const BOOTSTRAP_SYNTHETIC_CONTRIBUTION_DOMAIN: &str =
     "tbtc-signer-bootstrap-contribution-v1";
 
-/// Process-local marker: set when `start_sign_round` establishes a round in
-/// memory whose durable persist has not yet succeeded, and cleared after a
-/// successful `start_sign_round` persist. It lets the idempotent cached serve
-/// persist ONLY when the round is not yet durable -- closing the
-/// lost-consumed-marker hole on the original-persist-failure path -- while still
-/// serving the cached round WITHOUT persisting (so an idempotent replay survives
-/// a state-key-provider outage, matching `build_taproot_tx`) when the original
-/// persist already succeeded. Read/written only while the ENGINE_STATE guard is
-/// held, so `Relaxed` ordering suffices.
-static SIGN_ROUND_PERSIST_PENDING: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+// The sign-round persist-pending marker lives in the persistence module
+// (`mark_sign_round_persist_pending` / `sign_round_persist_pending`) so that ANY
+// successful persist clears it, not only `start_sign_round`'s own -- otherwise a
+// later unrelated persist that makes the round durable would leave the marker
+// stale and force an idempotent replay to re-persist during a state-key outage.
 
 pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState, EngineError> {
     record_hardening_telemetry(|telemetry| {
@@ -270,11 +264,10 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                 // (the common case) serve the cached round WITHOUT persisting, so
                 // the idempotent replay still survives a state-key-provider
                 // outage, as build_taproot_tx does.
-                if matches_legacy_fingerprint
-                    || SIGN_ROUND_PERSIST_PENDING.load(std::sync::atomic::Ordering::Relaxed)
-                {
+                if matches_legacy_fingerprint || sign_round_persist_pending() {
+                    // persist_engine_state_to_storage clears the pending marker on
+                    // success (see the persistence module).
                     persist_engine_state_to_storage(&guard)?;
-                    SIGN_ROUND_PERSIST_PENDING.store(false, std::sync::atomic::Ordering::Relaxed);
                 }
 
                 return Ok(round_state);
@@ -421,8 +414,9 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
         session.consumed_sign_round_ids.insert(round_id);
         // The round is now established in memory but not yet durable. Mark a
         // persist as pending so a later idempotent cached serve re-persists if
-        // the persist below fails; cleared once that persist succeeds.
-        SIGN_ROUND_PERSIST_PENDING.store(true, std::sync::atomic::Ordering::Relaxed);
+        // the persist below fails; cleared by the next successful persist (of any
+        // kind).
+        mark_sign_round_persist_pending();
 
         round_state
     };
@@ -437,7 +431,6 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
     }
 
     persist_engine_state_to_storage(&guard)?;
-    SIGN_ROUND_PERSIST_PENDING.store(false, std::sync::atomic::Ordering::Relaxed);
     record_hardening_telemetry(|telemetry| {
         telemetry.start_sign_round_success_total =
             telemetry.start_sign_round_success_total.saturating_add(1);

--- a/pkg/tbtc/signer/src/engine/signing.rs
+++ b/pkg/tbtc/signer/src/engine/signing.rs
@@ -5,6 +5,18 @@ use super::*;
 pub(crate) const BOOTSTRAP_SYNTHETIC_CONTRIBUTION_DOMAIN: &str =
     "tbtc-signer-bootstrap-contribution-v1";
 
+/// Process-local marker: set when `start_sign_round` establishes a round in
+/// memory whose durable persist has not yet succeeded, and cleared after a
+/// successful `start_sign_round` persist. It lets the idempotent cached serve
+/// persist ONLY when the round is not yet durable -- closing the
+/// lost-consumed-marker hole on the original-persist-failure path -- while still
+/// serving the cached round WITHOUT persisting (so an idempotent replay survives
+/// a state-key-provider outage, matching `build_taproot_tx`) when the original
+/// persist already succeeded. Read/written only while the ENGINE_STATE guard is
+/// held, so `Relaxed` ordering suffices.
+static SIGN_ROUND_PERSIST_PENDING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState, EngineError> {
     record_hardening_telemetry(|telemetry| {
         telemetry.start_sign_round_calls_total =
@@ -122,6 +134,10 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
             .map(canonical_attempt_context);
         let mut attempt_transition_telemetry = None;
         let mut attempt_transition_record = None;
+        // Set when an attempt advance is authorized below. The actual clear of
+        // the prior round is deferred until the replacement round has passed
+        // every fallible check, so a failed advance cannot strand the session.
+        let mut attempt_transition_authorized = false;
         if let Some(active_attempt_context) = session.active_attempt_context.as_ref() {
             let active_attempt_match_outcome = enforce_active_attempt_context_match(
                 active_attempt_context,
@@ -167,14 +183,10 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                     transition_evidence,
                 )?);
                 // Validate the incoming attempt context against the
-                // deterministic RFC-21 coordinator selection BEFORE destroying
-                // the active round. A malformed advance (e.g. a forged
+                // deterministic RFC-21 coordinator selection BEFORE the active
+                // round is touched. A malformed advance (e.g. a forged
                 // coordinator_identifier that satisfies the transition evidence
                 // but fails deterministic validation) must be rejected here.
-                // Rejecting it only after clear_active_sign_round_for_attempt_transition
-                // has run would leave the in-memory round destroyed while the
-                // attempt id stays in consumed_attempt_ids, bricking the
-                // session until the durable state is reloaded on restart.
                 validate_attempt_context(
                     &request.session_id,
                     &dkg.key_group,
@@ -184,11 +196,27 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
                     request.attempt_context.as_ref(),
                     strict_roast_mode_enabled,
                 )?;
-                clear_active_sign_round_for_attempt_transition(session);
+                // Authorize the advance but DEFER clearing the active round.
+                // The replacement round must still pass several fallible
+                // fresh-path checks below (participant resolution, included-set
+                // equality, quarantine, consumed-replay, share construction).
+                // Clearing here would let any of those failures destroy the
+                // in-memory active round with no validated, persisted
+                // replacement -- stranding the session (round material gone,
+                // transition record unwritten) so the next StartSignRound could
+                // start a fresh attempt without transition evidence until a
+                // restart reloads durable state. The clear runs just before the
+                // replacement round is installed and persisted.
+                attempt_transition_authorized = true;
             }
         }
 
-        if let Some(existing) = &session.sign_request_fingerprint {
+        if attempt_transition_authorized {
+            // An authorized attempt advance is in progress: the prior round
+            // material is still in memory, but a new attempt is starting. Skip
+            // the idempotent/conflict match against the old fingerprint and fall
+            // through to establish (and persist) the replacement round below.
+        } else if let Some(existing) = &session.sign_request_fingerprint {
             let matches_canonical_fingerprint = existing == &request_fingerprint;
             let matches_legacy_fingerprint = !matches_canonical_fingerprint
                 && (existing == &legacy_member_request_fingerprint
@@ -228,7 +256,25 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
 
                 if matches_legacy_fingerprint {
                     session.sign_request_fingerprint = Some(request_fingerprint.clone());
+                }
+
+                // Persist the cached round before serving it when either (a) we
+                // just upgraded a legacy fingerprint, or (b) the round was
+                // established in memory but its original persist has not yet
+                // succeeded -- e.g. a prior StartSignRound mutated the
+                // consumed-replay markers and round state, then failed to persist
+                // (state-key-provider or disk error) and returned an error,
+                // serving no shares. Serving shares here without persisting in
+                // that case would let a restart replay the round with no durable
+                // consumed marker. When the original persist already succeeded
+                // (the common case) serve the cached round WITHOUT persisting, so
+                // the idempotent replay still survives a state-key-provider
+                // outage, as build_taproot_tx does.
+                if matches_legacy_fingerprint
+                    || SIGN_ROUND_PERSIST_PENDING.load(std::sync::atomic::Ordering::Relaxed)
+                {
                     persist_engine_state_to_storage(&guard)?;
+                    SIGN_ROUND_PERSIST_PENDING.store(false, std::sync::atomic::Ordering::Relaxed);
                 }
 
                 return Ok(round_state);
@@ -357,6 +403,14 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
             own_contribution,
         };
 
+        // Every fallible fresh-round check has now passed and the replacement
+        // round is fully built. Scrub the prior round material as part of the
+        // attempt transition -- deferred to here (not the AdvanceAuthorized
+        // decision) so a malformed advance that failed a later check could not
+        // have destroyed the active round without a validated replacement.
+        if attempt_transition_authorized {
+            clear_active_sign_round_for_attempt_transition(session);
+        }
         session.sign_request_fingerprint = Some(request_fingerprint);
         session.sign_message_bytes = Some(Zeroizing::new(message_bytes));
         session.round_state = Some(round_state.clone());
@@ -365,6 +419,10 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
             session.consumed_attempt_ids.insert(attempt_id);
         }
         session.consumed_sign_round_ids.insert(round_id);
+        // The round is now established in memory but not yet durable. Mark a
+        // persist as pending so a later idempotent cached serve re-persists if
+        // the persist below fails; cleared once that persist succeeds.
+        SIGN_ROUND_PERSIST_PENDING.store(true, std::sync::atomic::Ordering::Relaxed);
 
         round_state
     };
@@ -379,6 +437,7 @@ pub fn start_sign_round(mut request: StartSignRoundRequest) -> Result<RoundState
     }
 
     persist_engine_state_to_storage(&guard)?;
+    SIGN_ROUND_PERSIST_PENDING.store(false, std::sync::atomic::Ordering::Relaxed);
     record_hardening_telemetry(|telemetry| {
         telemetry.start_sign_round_success_total =
             telemetry.start_sign_round_success_total.saturating_add(1);

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -2476,7 +2476,7 @@ fn idempotent_sign_round_replay_persists_before_serving_after_persist_outage() {
     // still only in memory: with the key command still failing it surfaces the
     // persist error rather than serving shares without a durable consumed
     // marker (which a restart could otherwise replay). This is the behaviour the
-    // SIGN_ROUND_PERSIST_PENDING marker enforces.
+    // per-session sign-round persist-pending marker enforces.
     start_sign_round(request())
         .expect_err("idempotent replay must not serve shares before the round is durable");
 
@@ -2583,6 +2583,102 @@ fn idempotent_sign_round_replay_survives_outage_after_unrelated_persist_clears_p
     std::env::set_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV, "exit 7");
     start_sign_round(request())
         .expect("idempotent replay of a now-durable round must survive a state-key outage");
+
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV);
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_PROVIDER_ENV);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn idempotent_sign_round_replay_of_durable_session_survives_unrelated_session_persist_failure() {
+    let _guard = lock_test_state();
+    let _state_path =
+        configure_test_state_path("sign_round_replay_durable_survives_unrelated_persist_failure");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    let _roast_strict_mode = RoastStrictModeGuard::enable();
+
+    let durable_session = "session-sign-round-pending-durable";
+    let failing_session = "session-sign-round-pending-failing";
+    let message_hex = "deadbeef";
+
+    let participants = || {
+        vec![
+            crate::api::DkgParticipant {
+                identifier: 1,
+                public_key_hex: "02aa".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 2,
+                public_key_hex: "02bb".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 3,
+                public_key_hex: "02cc".to_string(),
+            },
+        ]
+    };
+
+    let durable_dkg = run_dkg(RunDkgRequest {
+        session_id: durable_session.to_string(),
+        participants: participants(),
+        threshold: 2,
+        dkg_seed_hex: None,
+    })
+    .expect("run dkg for durable session");
+    let failing_dkg = run_dkg(RunDkgRequest {
+        session_id: failing_session.to_string(),
+        participants: participants(),
+        threshold: 2,
+        dkg_seed_hex: None,
+    })
+    .expect("run dkg for failing session");
+
+    let durable_attempt =
+        build_deterministic_attempt_context(durable_session, message_hex, 1, vec![1, 2, 3]);
+    let durable_request = || StartSignRoundRequest {
+        session_id: durable_session.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: durable_dkg.key_group.clone(),
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(durable_attempt.clone()),
+        attempt_transition_evidence: None,
+    };
+    let failing_attempt =
+        build_deterministic_attempt_context(failing_session, message_hex, 1, vec![1, 2, 3]);
+    let failing_request = StartSignRoundRequest {
+        session_id: failing_session.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: failing_dkg.key_group.clone(),
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(failing_attempt),
+        attempt_transition_evidence: None,
+    };
+
+    // The durable session establishes and durably persists its round under a
+    // healthy state key.
+    start_sign_round(durable_request()).expect("durable session round must persist");
+
+    // A state-key outage begins. A DIFFERENT session establishes a round whose
+    // persist fails, leaving ONLY that session's persist-pending marker set.
+    std::env::set_var(
+        TBTC_SIGNER_STATE_KEY_PROVIDER_ENV,
+        TBTC_SIGNER_STATE_KEY_PROVIDER_COMMAND,
+    );
+    std::env::set_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV, "exit 7");
+    start_sign_round(failing_request)
+        .expect_err("unrelated session round must fail when its persist fails");
+
+    // The durable session's idempotent replay, during the SAME outage, must serve
+    // its cached shares WITHOUT persisting. A process-wide pending marker would
+    // wrongly force it to re-persist and fail here; the per-session marker does
+    // not, because this session's round is already durable.
+    start_sign_round(durable_request())
+        .expect("durable session replay must survive an unrelated session's persist failure");
 
     std::env::remove_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV);
     std::env::remove_var(TBTC_SIGNER_STATE_KEY_PROVIDER_ENV);

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -2318,6 +2318,180 @@ fn rejected_forged_advance_preserves_active_sign_round() {
 }
 
 #[test]
+fn authorized_advance_failing_later_check_preserves_active_sign_round() {
+    let _guard = lock_test_state();
+    let _state_path = configure_test_state_path("authorized_advance_late_failure_preserves_round");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    let _roast_strict_mode = RoastStrictModeGuard::enable();
+
+    let session_id = "session-authorized-advance-late-failure";
+    let message_hex = "deadbeef";
+    let dkg_result = run_dkg(RunDkgRequest {
+        session_id: session_id.to_string(),
+        participants: vec![
+            crate::api::DkgParticipant {
+                identifier: 1,
+                public_key_hex: "02aa".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 2,
+                public_key_hex: "02bb".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 3,
+                public_key_hex: "02cc".to_string(),
+            },
+        ],
+        threshold: 2,
+        dkg_seed_hex: None,
+    })
+    .expect("run dkg");
+
+    // Establish active attempt 1 over participants [1, 2, 3].
+    let attempt_one =
+        build_deterministic_attempt_context(session_id, message_hex, 1, vec![1, 2, 3]);
+    start_sign_round(StartSignRoundRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: dkg_result.key_group.clone(),
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(attempt_one.clone()),
+        attempt_transition_evidence: None,
+    })
+    .expect("start sign round attempt 1");
+
+    // A genuinely authorized advance to attempt 2 over [1, 2] (excluding 3), but
+    // whose request signing-participant set [1, 2, 3] does NOT match the attempt
+    // context's included participants [1, 2]. The advance clears authorization
+    // and the RFC-21 coordinator validation, then fails the included-set
+    // equality check -- which runs AFTER the point at which the active round
+    // used to be cleared. With the clear deferred, the active round survives.
+    let mut transition_evidence = build_attempt_transition_evidence_from_active_session(session_id);
+    transition_evidence.exclusion_evidence = Some(AttemptExclusionEvidence {
+        reason: ROAST_EXCLUSION_REASON_INVALID_SHARE_PROOF.to_string(),
+        excluded_member_identifiers: vec![3],
+        invalid_share_proof_fingerprint: Some("ab".repeat(32)),
+    });
+    let attempt_two = build_deterministic_attempt_context(session_id, message_hex, 2, vec![1, 2]);
+
+    let advance_err = start_sign_round(StartSignRoundRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: dkg_result.key_group.clone(),
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(attempt_two),
+        attempt_transition_evidence: Some(transition_evidence),
+    })
+    .expect_err("authorized advance with mismatched included set must be rejected");
+    assert!(
+        matches!(
+            &advance_err,
+            EngineError::Validation(message)
+                if message.contains("must match resolved signing_participants")
+        ),
+        "expected included-set validation error, got {advance_err:?}"
+    );
+
+    // The active attempt-1 round must survive the late-failing advance:
+    // re-submitting the original attempt-1 request is idempotent and still
+    // succeeds, rather than failing with ConsumedAttemptReplay against a round
+    // that an eager clear would have destroyed.
+    start_sign_round(StartSignRoundRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: dkg_result.key_group,
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(attempt_one),
+        attempt_transition_evidence: None,
+    })
+    .expect("attempt 1 remains signable after the rejected late-failing advance");
+
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn idempotent_sign_round_replay_persists_before_serving_after_persist_outage() {
+    let _guard = lock_test_state();
+    let _state_path = configure_test_state_path("sign_round_replay_persist_after_outage");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    let _roast_strict_mode = RoastStrictModeGuard::enable();
+
+    let session_id = "session-sign-round-persist-outage";
+    let message_hex = "deadbeef";
+    let dkg_result = run_dkg(RunDkgRequest {
+        session_id: session_id.to_string(),
+        participants: vec![
+            crate::api::DkgParticipant {
+                identifier: 1,
+                public_key_hex: "02aa".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 2,
+                public_key_hex: "02bb".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 3,
+                public_key_hex: "02cc".to_string(),
+            },
+        ],
+        threshold: 2,
+        dkg_seed_hex: None,
+    })
+    .expect("run dkg");
+
+    let attempt_one =
+        build_deterministic_attempt_context(session_id, message_hex, 1, vec![1, 2, 3]);
+    let request = || StartSignRoundRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: dkg_result.key_group.clone(),
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(attempt_one.clone()),
+        attempt_transition_evidence: None,
+    };
+
+    // Establish the round in memory but make the durable persist fail: the
+    // state-key `command` provider exits non-zero. The round's consumed-replay
+    // markers and round state are mutated in memory, but the persist -- and the
+    // call -- fails, so no shares are served.
+    std::env::set_var(
+        TBTC_SIGNER_STATE_KEY_PROVIDER_ENV,
+        TBTC_SIGNER_STATE_KEY_PROVIDER_COMMAND,
+    );
+    std::env::set_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV, "exit 7");
+
+    start_sign_round(request()).expect_err("fresh round must fail when its persist fails");
+
+    // The idempotent cached serve must NOT return shares while the round is
+    // still only in memory: with the key command still failing it surfaces the
+    // persist error rather than serving shares without a durable consumed
+    // marker (which a restart could otherwise replay). This is the behaviour the
+    // SIGN_ROUND_PERSIST_PENDING marker enforces.
+    start_sign_round(request())
+        .expect_err("idempotent replay must not serve shares before the round is durable");
+
+    // Once the state-key provider recovers, the replay persists the markers and
+    // then serves the cached round.
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV);
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_PROVIDER_ENV);
+
+    start_sign_round(request())
+        .expect("idempotent replay must persist then serve once the state key recovers");
+
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn roast_transcript_audit_records_persist_across_reload() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("transcript_audit_persist_reload");

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -2492,6 +2492,104 @@ fn idempotent_sign_round_replay_persists_before_serving_after_persist_outage() {
 }
 
 #[test]
+fn idempotent_sign_round_replay_survives_outage_after_unrelated_persist_clears_pending() {
+    let _guard = lock_test_state();
+    let _state_path =
+        configure_test_state_path("sign_round_replay_unrelated_persist_clears_pending");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    let _roast_strict_mode = RoastStrictModeGuard::enable();
+
+    let session_id = "session-sign-round-pending-cross-op";
+    let message_hex = "deadbeef";
+    let dkg_result = run_dkg(RunDkgRequest {
+        session_id: session_id.to_string(),
+        participants: vec![
+            crate::api::DkgParticipant {
+                identifier: 1,
+                public_key_hex: "02aa".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 2,
+                public_key_hex: "02bb".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 3,
+                public_key_hex: "02cc".to_string(),
+            },
+        ],
+        threshold: 2,
+        dkg_seed_hex: None,
+    })
+    .expect("run dkg");
+
+    let attempt_one =
+        build_deterministic_attempt_context(session_id, message_hex, 1, vec![1, 2, 3]);
+    let request = || StartSignRoundRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: message_hex.to_string(),
+        key_group: dkg_result.key_group.clone(),
+        taproot_merkle_root_hex: None,
+        signing_participants: Some(vec![1, 2, 3]),
+        attempt_context: Some(attempt_one.clone()),
+        attempt_transition_evidence: None,
+    };
+
+    // Establish the round in memory but fail its persist, leaving the persist-
+    // pending marker set.
+    std::env::set_var(
+        TBTC_SIGNER_STATE_KEY_PROVIDER_ENV,
+        TBTC_SIGNER_STATE_KEY_PROVIDER_COMMAND,
+    );
+    std::env::set_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV, "exit 7");
+    start_sign_round(request()).expect_err("fresh round must fail when its persist fails");
+
+    // An UNRELATED operation now persists successfully once the key recovers: a
+    // DKG for a different session writes the entire engine state -- including the
+    // round above -- so that round becomes durable. This must clear the
+    // persist-pending marker even though it was not start_sign_round's own
+    // persist.
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV);
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_PROVIDER_ENV);
+    run_dkg(RunDkgRequest {
+        session_id: "session-sign-round-pending-cross-op-other".to_string(),
+        participants: vec![
+            crate::api::DkgParticipant {
+                identifier: 1,
+                public_key_hex: "02aa".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 2,
+                public_key_hex: "02bb".to_string(),
+            },
+            crate::api::DkgParticipant {
+                identifier: 3,
+                public_key_hex: "02cc".to_string(),
+            },
+        ],
+        threshold: 2,
+        dkg_seed_hex: None,
+    })
+    .expect("unrelated dkg persists the whole engine state");
+
+    // With the round now durable, an idempotent replay during a fresh state-key
+    // outage must serve the cached round WITHOUT persisting -- a stale marker
+    // must not force it to re-persist and fail.
+    std::env::set_var(
+        TBTC_SIGNER_STATE_KEY_PROVIDER_ENV,
+        TBTC_SIGNER_STATE_KEY_PROVIDER_COMMAND,
+    );
+    std::env::set_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV, "exit 7");
+    start_sign_round(request())
+        .expect("idempotent replay of a now-durable round must survive a state-key outage");
+
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_COMMAND_ENV);
+    std::env::remove_var(TBTC_SIGNER_STATE_KEY_PROVIDER_ENV);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn roast_transcript_audit_records_persist_across_reload() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("transcript_audit_persist_reload");

--- a/pkg/tbtc/signer/src/engine/testsupport.rs
+++ b/pkg/tbtc/signer/src/engine/testsupport.rs
@@ -86,6 +86,7 @@ pub fn reset_for_tests() {
     if let Ok(mut limiter) = build_tx_rate_limiter_state().lock() {
         *limiter = BuildTxRateLimiterState::default();
     }
+    clear_sign_round_persist_pending();
 
     if let Ok(state) = state() {
         if let Ok(mut guard) = state.lock() {


### PR DESCRIPTION
## Summary

Fixes two Codex-flagged P2 state-consistency holes in `start_sign_round` (`pkg/tbtc/signer/src/engine/signing.rs`), where a failed persist or a later validation error could leave in-memory state diverged from durable state and bypass the ROAST replay/transition protections.

### 1. Persist before serving the idempotent cached round (bug #1)

The fresh-round path mutates the session (consumed-replay markers + round state) and then persists. If that persist failed (state-key-provider or disk error) it returned an error and served no shares — but the **canonical idempotent serve** then returned signature shares **without persisting**, so a restart could replay the round with no durable consumed marker.

Fix: the idempotent cached serve now persists before serving **when the round is not yet durable**, tracked by a process-local `SIGN_ROUND_PERSIST_PENDING` marker (set on fresh-round mutation, cleared after a successful persist). When the original persist already succeeded — the common case — it still serves the cached round **without** persisting, preserving the "idempotent replay survives a state-key-provider outage" property that `build_taproot_tx` relies on. (Rollback is impossible here: the transition clear zeroizes the prior round material.)

### 2. Defer clearing the active attempt until validation finishes (bug #2)

On an authorized ROAST attempt advance, `clear_active_sign_round_for_attempt_transition` ran **before** the fresh-path checks (participant resolution, included-set equality, quarantine, consumed-replay, share construction). A malformed advance that passed authorization + the RFC-21 coordinator check but failed a **later** check destroyed the in-memory active round with no validated/persisted replacement — so `active_attempt_context` was dropped and the next `StartSignRound` could start a fresh attempt **without transition evidence** until a restart reloaded durable state.

Fix: the advance is authorized but the clear is **deferred** until every fallible fresh-path check has passed, immediately before the replacement round is installed and persisted (the idempotent/conflict branch is skipped for an authorized advance via a flag).

## Tests

Two regression tests, both **verified to fail against the pre-fix code**:
- `authorized_advance_failing_later_check_preserves_active_sign_round` — an authorized advance that fails the included-set check leaves attempt 1 idempotently signable (pre-fix: `ConsumedAttemptReplay`).
- `idempotent_sign_round_replay_persists_before_serving_after_persist_outage` — a sign round whose persist fails does not serve shares on idempotent replay until the state-key provider recovers (pre-fix: served shares with the key down).

Full lib suite: **308 passing** (`cargo test --lib`), `cargo fmt --check` clean. Design validated with Codex.

_Found during the Codex review of #4005._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
