### PR TITLE
ci(tbtc/signer): pin workflow actions to commit SHAs; disable checkout credential persistence

### DIFF
--- a/.github/workflows/tbtc-signer-formal.yml
+++ b/.github/workflows/tbtc-signer-formal.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          # Name the toolchain explicitly so it is self-documenting and
+          # independent of the pinned action's default. (This action version
+          # already defaults `toolchain` to `stable`; older versions instead
+          # derived it from the action ref, which would resolve to the SHA
+          # under this supply-chain pin -- so being explicit is the safe form.)
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Check formatting
@@ -74,6 +80,10 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          # Explicit toolchain, independent of the pinned action's default
+          # (see the Setup Rust step above).
+          toolchain: stable
 
       - name: Run signer formal invariant tests
         # Filters cargo test by the formal_verification_ prefix so only

--- a/.github/workflows/tbtc-signer-formal.yml
+++ b/.github/workflows/tbtc-signer-formal.yml
@@ -23,10 +23,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt, clippy
 
@@ -47,13 +49,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Check RustSec advisories
         # Blocking gate: a newly-published advisory against any locked
         # dependency fails the build. Accepted/unfixable advisories are
         # recorded with rationale in pkg/tbtc/signer/deny.toml.
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           manifest-path: pkg/tbtc/signer/Cargo.toml
           command: check advisories
@@ -64,10 +68,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Run signer formal invariant tests
         # Filters cargo test by the formal_verification_ prefix so only
@@ -82,10 +88,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: "17"


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/tbtc-signer-formal.yml` (introduced in #4005) against supply-chain and credential-exposure risks:

- Every `actions/checkout` step now sets `persist-credentials: false`, so the ephemeral `GITHUB_TOKEN` is not persisted into the local git config after checkout. None of the jobs perform authenticated git operations after checkout, so nothing relies on the persisted credential.
- Every `uses:` reference is pinned to a full 40-hex commit SHA with a trailing comment recording the human-readable version, replacing mutable tag/branch refs. No action major versions were changed — each pin is the current commit behind the ref that was already in use.

This addresses the two open CodeRabbit review threads on #4005 (persisted checkout credentials + unpinned action refs on `.github/workflows/tbtc-signer-formal.yml`).

## Pinned actions

| Action | Old ref | Pinned SHA (version) |
| --- | --- | --- |
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) |
| `dtolnay/rust-toolchain` | `stable` | `4be7066ada62dd38de10e7b70166bc74ed198c30` (stable branch head) |
| `EmbarkStudios/cargo-deny-action` | `v2` | `bb137d7af7e4fb67e5f82a49c4fce4fad40782fe` (v2.0.20) |
| `actions/setup-java` | `v4` | `c1e323688fd81a25caa38c78aa6df2d33d3e20d9` (v4.8.0) |

## Notes

- Stacked on `extraction/frost-signer-mirror-2026-05-26` (PR #4005); only the workflow file is touched.
- YAML validated locally after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)