### PR TITLE
hardening(frost): zeroize DKG FFI secret buffers (parity with Sign path)

### DIFF
--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -678,6 +678,12 @@ func (bttse *buildTaggedTBTCSignerEngine) RunDKGWithSeed(
 	if err != nil {
 		return nil, err
 	}
+	// The request embeds the DKG seed, which deterministically drives key
+	// generation and therefore reconstructs the group secret; scrub the
+	// Go-side buffer on every return path, mirroring the Sign path. The C copy
+	// is separately scrubbed in callBuildTaggedTBTCSignerOperation. The RunDKG
+	// response carries only public metadata, so it is not zeroized.
+	defer zeroBytes(requestPayload)
 
 	responsePayload, err := callBuildTaggedTBTCSignerRunDKG(requestPayload)
 	if err != nil {
@@ -705,6 +711,11 @@ func (bttse *buildTaggedTBTCSignerEngine) Part1(
 	if err != nil {
 		return nil, err
 	}
+	// The response carries the round-1 secret package (private polynomial
+	// coefficients that must never be broadcast). Scrub the Go-side transport
+	// buffer once decoded, mirroring the Sign path's zeroBytes hygiene; the
+	// decoded secret returned to the caller is a fresh, independent copy.
+	defer zeroBytes(responsePayload)
 
 	return decodeBuildTaggedTBTCSignerDKGPart1Response(responsePayload)
 }
@@ -720,11 +731,19 @@ func (bttse *buildTaggedTBTCSignerEngine) Part2(
 	if err != nil {
 		return nil, err
 	}
+	// The request embeds the round-1 secret package; scrub the Go-side buffer
+	// on every return path (including a failed FFI call), mirroring the Sign
+	// path. The C copy is separately scrubbed in callBuildTaggedTBTCSignerOperation.
+	defer zeroBytes(requestPayload)
 
 	responsePayload, err := callBuildTaggedTBTCSignerDKGPart2(requestPayload)
 	if err != nil {
 		return nil, err
 	}
+	// The response carries the round-2 secret package and the per-recipient
+	// round-2 packages (secret shares). Scrub the Go-side transport buffer once
+	// decoded; the decoded values returned to the caller are fresh copies.
+	defer zeroBytes(responsePayload)
 
 	return decodeBuildTaggedTBTCSignerDKGPart2Response(responsePayload)
 }
@@ -742,11 +761,20 @@ func (bttse *buildTaggedTBTCSignerEngine) Part3(
 	if err != nil {
 		return nil, err
 	}
+	// The request embeds the round-2 secret package and the received round-2
+	// packages (incoming secret shares); scrub the Go-side buffer on every
+	// return path, mirroring the Sign path. The C copy is separately scrubbed
+	// in callBuildTaggedTBTCSignerOperation.
+	defer zeroBytes(requestPayload)
 
 	responsePayload, err := callBuildTaggedTBTCSignerDKGPart3(requestPayload)
 	if err != nil {
 		return nil, err
 	}
+	// The response carries the final key package (the long-term signing share).
+	// Scrub the Go-side transport buffer once decoded; the decoded key package
+	// returned to the caller is a fresh copy.
+	defer zeroBytes(responsePayload)
 
 	return decodeBuildTaggedTBTCSignerDKGPart3Response(responsePayload)
 }


### PR DESCRIPTION
## Finding

The native tbtc-signer **Sign** path scrubs its Go-heap FFI transport buffers that carry secret material — `defer zeroBytes(...)` on the request payload, response payload, and nonces slices (`native_frost_engine_tbtc_signer_registration_frost_native.go`). The **DKG** path in the same file did **not**, leaving long-term share / DKG secret material resident in the Go heap after use. This is a memory-hygiene inconsistency: DKG secrets (private polynomial coefficients, per-recipient secret shares, and the final long-term signing share) linger in reclaimable-but-unwiped Go heap buffers, whereas the equivalent Sign secrets are wiped.

## Sites zeroed

Each DKG engine method marshals a Go-heap JSON request, hands a **copy** to Rust via `C.CBytes`, and receives the response as a **fresh** Go slice via `C.GoBytes`. Only the genuinely secret-bearing Go-side buffers are wiped (public-only buffers are left untouched):

| Method | Buffer | Secret it carries |
| --- | --- | --- |
| `Part1` (`~L718`) | response | round-1 secret package (private polynomial coefficients, "must never be broadcast") |
| `Part2` (`~L737`) | request | round-1 secret package |
| `Part2` (`~L746`) | response | round-2 secret package + per-recipient round-2 secret shares |
| `Part3` (`~L768`) | request | round-2 secret package + received round-2 secret shares |
| `Part3` (`~L777`) | response | final key package (long-term signing share) |
| `RunDKGWithSeed` (`~L686`) | request | DKG seed that deterministically reconstructs the group secret |

Left untouched because they carry no secret: `RunDKG` request/response (participant public keys + metadata), `RunDKGWithSeed` response (public metadata only), `Part1` request (participant id + signer counts).

## How it mirrors the Sign path

The Sign path uses the package-local `zeroBytes(data []byte)` helper (`native_frost_engine_frost_native.go:59`) via `defer`:
- `GenerateNoncesAndCommitments`: `defer zeroBytes(responsePayload)` (response carries one-time nonces).
- `Sign`: `defer zeroBytes(noncesData)` and `defer zeroBytes(requestPayload)`.

This change reuses the same helper and the same `defer` placement (right after a secret request is built / a secret response is received), so a mid-function or error return still wipes. No new/divergent mechanism is introduced.

## cgo-safety reasoning

- `callBuildTaggedTBTCSignerOperation` already `C.CBytes`-copies the request to the C heap and, on defer, `zeroBytes`+`C.free`s that C copy. The Go-side request slice is a **separate** `json.Marshal` allocation, so zeroing it after the call returns neither races the C side nor risks a double-free.
- The response is a `C.GoBytes` copy; the C-side response buffer is freed separately by `tbtc_signer_free_buffer`. Wiping the Go copy is independent and safe.
- The deferred `zeroBytes` runs **after** the decoder evaluates the return value, and the decoders return freshly hex-decoded copies (independent of the transport buffer), so wiping never corrupts the returned secret. Identical ordering to the existing `GenerateNoncesAndCommitments`.

## Validation

- `gofmt -l` clean on the touched file.
- `go vet -tags "frost_native frost_tbtc_signer" ./pkg/frost/signing/` clean.
- `go build -tags "frost_native frost_tbtc_signer" ./pkg/frost/...` succeeds (cgo path uses runtime `dlopen`, so it compiles the touched file without the Rust lib present).
- `go build -tags "frost_roast_retry" ./pkg/frost/...` succeeds (non-cgo compile check).
- DKG/RunDKG/Sign/Nonces unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)