### PR TITLE
test(frost/roast): real-under-failure ROAST retry + blame tests (dropout, invalid-share, equivocation, overflow, cross-node fracture)

### DIFF
--- a/pkg/frost/signing/roast_runner_real_cgo_coordinator_equivocation_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_coordinator_equivocation_frost_native_test.go
@@ -157,7 +157,7 @@ func TestRealCgoInteractiveSigning_CoordinatorEquivocationForcesInstantPermanent
 	// bodies differ via the taproot root (0 vs 32 bytes) - signing the same body
 	// twice would give a different ECDSA signature but the SAME BodyHash, which is
 	// NOT an equivocation.
-	pkgA := newSignedPkg(nil)                                             // key-path spend
+	pkgA := newSignedPkg(nil)                                                       // key-path spend
 	pkgB := newSignedPkg(bytes.Repeat([]byte{0xab}, roast.TaprootMerkleRootLength)) // script-path spend
 
 	// ---- FAULT REACHED: a genuine equivocation, not a synthetic pass. ----

--- a/pkg/frost/signing/roast_runner_real_cgo_coordinator_equivocation_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_coordinator_equivocation_frost_native_test.go
@@ -1,0 +1,291 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test closes the fourth real-crypto-under-failure gap: a COORDINATOR
+// EQUIVOCATION - the elected coordinator distributing two VALID, coordinator-
+// signed signing packages with the same attempt context but different bytes -
+// bypasses the f+1 accuser gate and forces INSTANT PERMANENT exclusion of the
+// coordinator (verifiedCoordinatorEquivocations, next_attempt.go). Two authentic
+// bodies signed by the coordinator's own operator key are unforgeable proof, so
+// a single honest observer's evidence suffices.
+//
+// The "real crypto" that matters here is the Go-side operator-key ECDSA
+// signature over each package body (pkg/chain), NOT FROST: the equivocation
+// adjudication is a pure Go-side operation, so no FROST signing rounds run. The
+// existing policy-level test (next_attempt_coordinator_equivocation_test.go)
+// exercises this with a SHA-256 fakeVerifier; this test uses a REAL secp256k1
+// operator-key Signer/Verifier, so the two packages must genuinely authenticate
+// under the same verifier the coordinator instance carries. A non-vacuous
+// negative control (a package with a corrupted signature is rejected by the real
+// verifier and does NOT trigger exclusion) proves the verifier is genuinely
+// cryptographic and the positive exclusion is caused by two AUTHENTIC distinct
+// bodies, not a stub that accepts anything.
+//
+// A real DKG is run (as in the sibling real-cgo tests) only to produce an
+// authentic key group / seed; it is not load-bearing for the equivocation logic.
+
+// operatorKeyRoastSigner is a real roast.Signer backed by one member's
+// secp256k1 operator private key (via local_v1's chain.Signing). Unlike the
+// fixedTestSigner used elsewhere, its signatures actually verify.
+type operatorKeyRoastSigner struct{ signing chain.Signing }
+
+func (s operatorKeyRoastSigner) Sign(payload []byte) ([]byte, error) {
+	return s.signing.Sign(payload)
+}
+
+// operatorKeyRoastVerifier is a real roast.SignatureVerifier: it verifies a
+// signature attributed to a member against that member's uncompressed operator
+// public key. Any local_v1 signer serves as the verification engine because
+// VerifyWithPublicKey verifies against the SUPPLIED public key.
+type operatorKeyRoastVerifier struct {
+	signing    chain.Signing
+	publicKeys map[group.MemberIndex][]byte // uncompressed operator pubkey bytes
+}
+
+func (v operatorKeyRoastVerifier) Verify(payload, signature []byte, signer group.MemberIndex) error {
+	pub, ok := v.publicKeys[signer]
+	if !ok {
+		return fmt.Errorf("%w: no operator public key for member %d", roast.ErrSignatureInvalid, signer)
+	}
+	valid, err := v.signing.VerifyWithPublicKey(payload, signature, pub)
+	if err != nil {
+		return fmt.Errorf("%w: member %d: %s", roast.ErrSignatureInvalid, signer, err.Error())
+	}
+	if !valid {
+		return fmt.Errorf("%w: member %d", roast.ErrSignatureInvalid, signer)
+	}
+	return nil
+}
+
+func TestRealCgoInteractiveSigning_CoordinatorEquivocationForcesInstantPermanentExclusion(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	engine := &buildTaggedTBTCSignerEngine{}
+	sessionID := fmt.Sprintf("real-cgo-coord-equivocation-%d", realCgoSessionSeq.Add(1))
+
+	const n = 3
+	const threshold uint16 = 2
+	participantIDs := []byte{1, 2, 3}
+	included := []group.MemberIndex{1, 2, 3}
+
+	// Authentic key group + seed (family consistency; not load-bearing here).
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
+	keyGroupSeed := []byte(keyGroup)
+
+	var messageDigest [attempt.MessageDigestLength]byte
+	for i := range messageDigest {
+		messageDigest[i] = 0x42
+	}
+	attempt1Ctx, err := attempt.NewAttemptContext(
+		sessionID, keyGroup, keyGroupSeed, messageDigest, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt 1 context: %v", err)
+	}
+
+	// Real per-member operator keys + a real Signer/Verifier over all members.
+	privKeys := make(map[group.MemberIndex]*operator.PrivateKey, n)
+	pubKeyBytes := make(map[group.MemberIndex][]byte, n)
+	for _, m := range included {
+		priv, pub, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("operator key (seat %d): %v", m, err)
+		}
+		privKeys[m] = priv
+		pubKeyBytes[m] = operator.MarshalUncompressed(pub)
+	}
+	verifier := operatorKeyRoastVerifier{
+		signing:    local_v1.NewSigner(privKeys[included[0]]), // engine only; verifies against supplied pubkey
+		publicKeys: pubKeyBytes,
+	}
+
+	// Resolve attempt 1's deterministic elected coordinator via a probe binding.
+	probeSigner := operatorKeyRoastSigner{signing: local_v1.NewSigner(privKeys[included[0]])}
+	probeCoord := roast.NewInMemoryCoordinatorWithSigning(included[0], probeSigner, verifier)
+	probeHandle, err := probeCoord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	probeBinding, err := NewActiveRoastAttempt(probeCoord, probeHandle, attempt1Ctx, sessionID, nil, keyGroupSeed)
+	if err != nil {
+		t.Fatalf("probe binding: %v", err)
+	}
+	coordinator := probeBinding.ElectedCoordinator()
+
+	nonCoord := make([]group.MemberIndex, 0, n-1)
+	for _, m := range included {
+		if m != coordinator {
+			nonCoord = append(nonCoord, m)
+		}
+	}
+	sort.Slice(nonCoord, func(i, j int) bool { return nonCoord[i] < nonCoord[j] })
+	t.Logf("coordinator(equivocator)=%d observers=%v", coordinator, nonCoord)
+
+	// The REAL coordinator package signer uses the coordinator's own operator key.
+	coordSigner := operatorKeyRoastSigner{signing: local_v1.NewSigner(privKeys[coordinator])}
+
+	prevHash := attempt1Ctx.Hash()
+	newSignedPkg := func(root []byte) *roast.SigningPackage {
+		p := &roast.SigningPackage{
+			AttemptContextHash:  append([]byte(nil), prevHash[:]...),
+			CoordinatorIDValue:  uint32(coordinator),
+			SigningPackageBytes: []byte("frost-signing-package-bytes"),
+			TaprootMerkleRoot:   root,
+		}
+		if err := roast.SignSigningPackage(coordSigner, p); err != nil {
+			t.Fatalf("sign package: %v", err)
+		}
+		return p
+	}
+	// Two body-DISTINCT packages, SAME attempt context, SAME coordinator. The
+	// bodies differ via the taproot root (0 vs 32 bytes) - signing the same body
+	// twice would give a different ECDSA signature but the SAME BodyHash, which is
+	// NOT an equivocation.
+	pkgA := newSignedPkg(nil)                                             // key-path spend
+	pkgB := newSignedPkg(bytes.Repeat([]byte{0xab}, roast.TaprootMerkleRootLength)) // script-path spend
+
+	// ---- FAULT REACHED: a genuine equivocation, not a synthetic pass. ----
+	if err := roast.AuthenticateSigningPackage(verifier, pkgA, coordinator, prevHash[:]); err != nil {
+		t.Fatalf("pkgA must authenticate under the real verifier: %v", err)
+	}
+	if err := roast.AuthenticateSigningPackage(verifier, pkgB, coordinator, prevHash[:]); err != nil {
+		t.Fatalf("pkgB must authenticate under the real verifier: %v", err)
+	}
+	if pkgA.CoordinatorID() != coordinator || pkgB.CoordinatorID() != coordinator {
+		t.Fatalf("both packages must name the elected coordinator %d", coordinator)
+	}
+	bhA, err := pkgA.BodyHash()
+	if err != nil {
+		t.Fatalf("pkgA body hash: %v", err)
+	}
+	bhB, err := pkgB.BodyHash()
+	if err != nil {
+		t.Fatalf("pkgB body hash: %v", err)
+	}
+	if bhA == bhB {
+		t.Fatalf("packages must be byte-distinct to be an equivocation; both hashed to %x", bhA)
+	}
+	if !bytes.Equal(pkgA.AttemptContextHash, pkgB.AttemptContextHash) ||
+		!bytes.Equal(pkgA.AttemptContextHash, prevHash[:]) {
+		t.Fatalf("both packages must bind the same live attempt context")
+	}
+	if len(pkgA.CoordinatorSignature) == 0 || len(pkgB.CoordinatorSignature) == 0 {
+		t.Fatalf("both packages must carry a real coordinator signature")
+	}
+
+	proofA, err := pkgA.Marshal()
+	if err != nil {
+		t.Fatalf("marshal pkgA: %v", err)
+	}
+	proofB, err := pkgB.Marshal()
+	if err != nil {
+		t.Fatalf("marshal pkgB: %v", err)
+	}
+
+	// Split the two proofs across two honest observers (the targeted case: no
+	// single observer saw both). All live members are senders so nobody is
+	// silence-parked; excluding the coordinator leaves threshold=2 members
+	// (feasible for n=3, t=2). Every snapshot carries NO reject/conflict/overflow
+	// evidence, so the ONLY mechanism that can exclude the coordinator is the
+	// equivocation path (not an f+1 tally).
+	snaps := []roast.LocalEvidenceSnapshot{
+		{SenderIDValue: uint32(coordinator), AttemptContextHash: append([]byte(nil), prevHash[:]...)},
+		{SenderIDValue: uint32(nonCoord[0]), AttemptContextHash: append([]byte(nil), prevHash[:]...), CoordinatorPackageProofs: [][]byte{proofA}},
+		{SenderIDValue: uint32(nonCoord[1]), AttemptContextHash: append([]byte(nil), prevHash[:]...), CoordinatorPackageProofs: [][]byte{proofB}},
+	}
+	sort.Slice(snaps, func(i, j int) bool { return snaps[i].SenderIDValue < snaps[j].SenderIDValue })
+	for i := range snaps {
+		if len(snaps[i].Rejects) != 0 || len(snaps[i].Conflicts) != 0 || len(snaps[i].Overflows) != 0 {
+			t.Fatalf("snapshot %d must carry no accusation entries (pin causation to equivocation)", i)
+		}
+	}
+	bundle := &roast.TransitionMessage{
+		AttemptContextHash: append([]byte(nil), prevHash[:]...),
+		CoordinatorIDValue: uint32(coordinator),
+		Bundle:             snaps,
+	}
+
+	// Drive the REAL policy through the REAL verifier.
+	coord := roast.NewInMemoryCoordinatorWithSigning(coordinator, coordSigner, verifier)
+	handle, err := coord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	next, err := coord.NextAttempt(handle, bundle, uint(threshold), keyGroupSeed)
+	if err != nil {
+		t.Fatalf("NextAttempt: %v", err)
+	}
+
+	// ---- Assert INSTANT PERMANENT exclusion of the coordinator. ----
+	if !containsMember(next.ExcludedSet, coordinator) {
+		t.Fatalf("equivocating coordinator %d must be permanently excluded; excluded=%v", coordinator, next.ExcludedSet)
+	}
+	if containsMember(next.IncludedSet, coordinator) {
+		t.Fatalf("excluded coordinator %d must drop from the next included set %v", coordinator, next.IncludedSet)
+	}
+	if containsMember(next.TransientlyParked, coordinator) {
+		t.Fatalf("coordinator %d must be excluded, not merely parked; parked=%v", coordinator, next.TransientlyParked)
+	}
+	wantIncluded := append([]group.MemberIndex{}, nonCoord...)
+	gotIncluded := append([]group.MemberIndex{}, next.IncludedSet...)
+	sort.Slice(gotIncluded, func(i, j int) bool { return gotIncluded[i] < gotIncluded[j] })
+	if !memberSlicesEqualLocal(gotIncluded, wantIncluded) {
+		t.Fatalf("attempt 2 included = %v, want %v", gotIncluded, wantIncluded)
+	}
+	t.Logf("coordinator %d instantly + permanently excluded on two authentic distinct packages", coordinator)
+
+	// ---- NON-VACUOUS negative control: same verifier, corrupted signature. ----
+	// A single AUTHENTIC package plus a package whose real signature is corrupted
+	// (rejected by the real verifier) is only ONE distinct authentic body -> no
+	// equivocation, no exclusion. This proves the verifier is genuinely
+	// cryptographic (not NoOp) and the positive exclusion above required TWO
+	// authentic bodies.
+	pkgBad := newSignedPkg(bytes.Repeat([]byte{0xcd}, roast.TaprootMerkleRootLength)) // third distinct body
+	pkgBad.CoordinatorSignature[0] ^= 0x01                                            // break the real signature
+	if err := roast.AuthenticateSigningPackage(verifier, pkgBad, coordinator, prevHash[:]); !errors.Is(err, roast.ErrSignatureInvalid) {
+		t.Fatalf("real verifier must reject a corrupted signature (proves it is not NoOp); got %v", err)
+	}
+	proofBad, err := pkgBad.Marshal()
+	if err != nil {
+		t.Fatalf("marshal pkgBad: %v", err)
+	}
+	negSnaps := []roast.LocalEvidenceSnapshot{
+		{SenderIDValue: uint32(coordinator), AttemptContextHash: append([]byte(nil), prevHash[:]...)},
+		{SenderIDValue: uint32(nonCoord[0]), AttemptContextHash: append([]byte(nil), prevHash[:]...), CoordinatorPackageProofs: [][]byte{proofA}},
+		{SenderIDValue: uint32(nonCoord[1]), AttemptContextHash: append([]byte(nil), prevHash[:]...), CoordinatorPackageProofs: [][]byte{proofBad}},
+	}
+	sort.Slice(negSnaps, func(i, j int) bool { return negSnaps[i].SenderIDValue < negSnaps[j].SenderIDValue })
+	negBundle := &roast.TransitionMessage{
+		AttemptContextHash: append([]byte(nil), prevHash[:]...),
+		CoordinatorIDValue: uint32(coordinator),
+		Bundle:             negSnaps,
+	}
+	handle2, err := coord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("begin attempt (negative control): %v", err)
+	}
+	nextNeg, err := coord.NextAttempt(handle2, negBundle, uint(threshold), keyGroupSeed)
+	if err != nil {
+		t.Fatalf("NextAttempt (negative control): %v", err)
+	}
+	if containsMember(nextNeg.ExcludedSet, coordinator) {
+		t.Fatalf("only one AUTHENTIC distinct body: coordinator %d must NOT be excluded; excluded=%v", coordinator, nextNeg.ExcludedSet)
+	}
+	t.Logf("negative control: one authentic + one corrupted package did NOT exclude the coordinator (verifier is real)")
+}

--- a/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -189,6 +190,10 @@ func TestRealCgoInteractiveSigning_DropoutForcesNextAttemptAndReshuffledSubsetFi
 	<-coordErr.done
 	<-targetErr.done
 
+	// The coordinator must fail SPECIFICALLY by starving on the missing share: it
+	// built + broadcast the package, produced its own round-2 share, then timed
+	// out collecting the target's. Pinning the failure to share collection (not a
+	// generic early error) is what makes this the withheld-share path.
 	if coordErr.err == nil {
 		t.Fatalf(
 			"attempt 1: the coordinator aggregated a signature despite the selected co-signer (seat %d) "+
@@ -196,7 +201,32 @@ func TestRealCgoInteractiveSigning_DropoutForcesNextAttemptAndReshuffledSubsetFi
 			target,
 		)
 	}
-	t.Logf("attempt 1 coordinator failed as expected: %v", coordErr.err)
+	if !strings.Contains(coordErr.err.Error(), "collect shares") {
+		t.Fatalf(
+			"attempt 1: coordinator must starve at round-2 share collection; got a different failure: %v",
+			coordErr.err,
+		)
+	}
+	t.Logf("attempt 1 coordinator starved at share collection as expected: %v", coordErr.err)
+
+	// Crucially, the target must actually have REACHED round 2 and produced the
+	// share it withheld -- otherwise the coordinator's timeout would be vacuous (an
+	// early target failure, e.g. an undelivered signing package or a pre-round-2
+	// engine error, would starve the coordinator identically). Because only the
+	// target's OUTBOUND share is dropped, the target still receives the
+	// coordinator's share and aggregates locally off the shared engine; that local
+	// success -- or, failing that, its own collect-shares timeout -- is the proof
+	// it produced (and the bus withheld) a genuine round-2 share. A failure BEFORE
+	// round 2 must fail this test.
+	if targetErr.err != nil && !strings.Contains(targetErr.err.Error(), "collect shares") {
+		t.Fatalf(
+			"attempt 1: target seat %d must reach round 2 and produce its withheld share, but it "+
+				"failed before round 2 (so the coordinator's starvation would be vacuous): %v",
+			target, targetErr.err,
+		)
+	}
+	t.Logf("attempt 1 target reached round 2 and produced its withheld share (err=%v sigLen=%d)",
+		targetErr.err, len(targetErr.sig))
 
 	// ---- Transition: build the bundle from the LIVE senders (target absent). ----
 	prevHash := attempt1Ctx.Hash()

--- a/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
@@ -1,0 +1,327 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	netlocal "github.com/keep-network/keep-core/pkg/net/local"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test closes the highest-value ROAST-retry coverage gap: NO test combined
+// REAL threshold crypto with an INDUCED signer failure AND a retry. The real-cgo
+// e2es (roast_runner_real_cgo_multinode_e2e_frost_native_test.go) are happy-path
+// only; the retry/parking machinery (next_attempt.go) is unit-tested with fakes.
+// This wires them together end to end:
+//
+//	attempt 1 (REAL crypto): a SELECTED signer withholds its round-2 share ->
+//	  the elected coordinator (the aggregator) starves and fails;
+//	NextAttempt (REAL policy): the silent member is missing from the transition
+//	  bundle senders, so it is transiently PARKED;
+//	attempt 2 (REAL crypto): the reshuffled subset (silent member excluded)
+//	  aggregates a real BIP-340 signature.
+//
+// DETERMINISM in the single-process shared-engine harness. Subset selection is
+// first-come-first-served over the responsive committers, and the one engine is
+// shared by all local seats. To make attempt 1 fail deterministically (rather
+// than depend on which seat commits first, or let a co-resident seat aggregate),
+// attempt 1 runs ONLY {coordinator, target}: the target is therefore necessarily
+// the coordinator's sole co-signer, and by withholding its share it starves the
+// coordinator's collection. We assert on the COORDINATOR's failure (the
+// aggregator) - a co-resident target may aggregate locally off the shared engine,
+// which is a harness artifact of the shared engine, not a real outcome (a real
+// per-node deployment gives the faulty node its own engine and it broadcasts
+// nothing). The offline third seat is absent from attempt 1 and is supplied as a
+// live bundle sender for the transition, exactly as a real non-selected-but-live
+// member would broadcast its evidence snapshot.
+
+// shareDroppingBus wraps a RunnerBus and silently drops the wrapped seat's own
+// round-2 share submissions, modelling a signer that goes silent mid-collection
+// after being selected. All other traffic (commitments, the coordinator package,
+// evidence) passes through, and inbound delivery via Subscribe is untouched.
+type shareDroppingBus struct{ inner RunnerBus }
+
+func (b shareDroppingBus) Broadcast(msg RunnerMessage) {
+	if msg.Type == RunnerMsgShareSubmission {
+		return
+	}
+	b.inner.Broadcast(msg)
+}
+
+func (b shareDroppingBus) Subscribe() *RunnerBusSubscriber { return b.inner.Subscribe() }
+
+// dropoutSeat bundles one seat's coordinator, attempt handle, binding, and runner
+// so the test can run a chosen subset and later drive NextAttempt from the
+// elected coordinator's coordinator instance.
+type dropoutSeat struct {
+	member  group.MemberIndex
+	coord   roast.Coordinator
+	handle  roast.AttemptHandle
+	binding *ActiveRoastAttempt
+	runner  *interactiveSigningRunner
+}
+
+func TestRealCgoInteractiveSigning_DropoutForcesNextAttemptAndReshuffledSubsetFinalizes(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	engine := &buildTaggedTBTCSignerEngine{}
+	sessionID := fmt.Sprintf("real-cgo-dropout-retry-%d", realCgoSessionSeq.Add(1))
+
+	const n = 3
+	const threshold uint16 = 2
+	participantIDs := []byte{1, 2, 3}
+	included := []group.MemberIndex{1, 2, 3}
+
+	// One real DKG; both attempts sign under the same key group.
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
+	keyGroupSeed := []byte(keyGroup)
+
+	var messageDigest [attempt.MessageDigestLength]byte
+	for i := range messageDigest {
+		messageDigest[i] = 0x42
+	}
+
+	attempt1Ctx, err := attempt.NewAttemptContext(
+		sessionID, keyGroup, keyGroupSeed, messageDigest, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt 1 context: %v", err)
+	}
+
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	logger := &testutils.MockLogger{}
+
+	// Resolve attempt 1's elected coordinator from a probe binding (the election
+	// is a property of the attempt context), so we can designate a NON-coordinator
+	// target to withhold its share and the offline seat.
+	probeCoord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	probeHandle, err := probeCoord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	probeBinding, err := NewActiveRoastAttempt(probeCoord, probeHandle, attempt1Ctx, sessionID, nil, keyGroupSeed)
+	if err != nil {
+		t.Fatalf("probe binding: %v", err)
+	}
+	coordinator := probeBinding.ElectedCoordinator()
+	nonCoordinators := make([]group.MemberIndex, 0, n-1)
+	for _, m := range included {
+		if m != coordinator {
+			nonCoordinators = append(nonCoordinators, m)
+		}
+	}
+	sort.Slice(nonCoordinators, func(i, j int) bool { return nonCoordinators[i] < nonCoordinators[j] })
+	target := nonCoordinators[0]  // withholds its share in attempt 1
+	offline := nonCoordinators[1] // absent in attempt 1, live sender for the transition
+	t.Logf("attempt 1: coordinator=%d target(silent)=%d offline=%d", coordinator, target, offline)
+
+	// Shared operator identities + membership validator over all 3 seats, so any
+	// subset's broadcasts authenticate.
+	chainSigning := local_v1.Connect(n, n).Signing()
+	publicKeys := make(map[group.MemberIndex]*operator.PublicKey, n)
+	addresses := make([]chain.Address, 0, n)
+	for _, m := range included {
+		_, publicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("operator key (seat %d): %v", m, err)
+		}
+		publicKeys[m] = publicKey
+		addresses = append(addresses, chainSigning.PublicKeyBytesToAddress(
+			operator.MarshalUncompressed(publicKey),
+		))
+	}
+	validator := group.NewMembershipValidator(&testutils.MockLogger{}, addresses, chainSigning)
+
+	newSeat := func(ctx context.Context, member group.MemberIndex, attemptCtx attempt.AttemptContext, dropShares bool) *dropoutSeat {
+		channel, err := netlocal.ConnectWithKey(publicKeys[member]).
+			BroadcastChannelFor("frost-roast-interactive-signing")
+		if err != nil {
+			t.Fatalf("broadcast channel (seat %d): %v", member, err)
+		}
+		var bus RunnerBus
+		bus, err = NewBroadcastChannelRunnerBus(ctx, logger, channel, validator)
+		if err != nil {
+			t.Fatalf("runner bus (seat %d): %v", member, err)
+		}
+		if dropShares {
+			bus = shareDroppingBus{inner: bus}
+		}
+		coord := roast.NewInMemoryCoordinatorWithSigning(member, signer, verifier)
+		handle, err := coord.BeginAttempt(attemptCtx)
+		if err != nil {
+			t.Fatalf("begin attempt (seat %d): %v", member, err)
+		}
+		binding, err := NewActiveRoastAttempt(coord, handle, attemptCtx, sessionID, nil, keyGroupSeed)
+		if err != nil {
+			t.Fatalf("active attempt (seat %d): %v", member, err)
+		}
+		collector := roast.NewRound2Collector(verifier)
+		runner, err := newInteractiveSigningRunner(
+			binding, member, threshold, engine, collector, coord, signer, bus,
+		)
+		if err != nil {
+			t.Fatalf("runner (seat %d): %v", member, err)
+		}
+		return &dropoutSeat{member: member, coord: coord, handle: handle, binding: binding, runner: runner}
+	}
+
+	// ---- Attempt 1: coordinator + silent target only; coordinator must fail. ----
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel1()
+
+	coordSeat := newSeat(ctx1, coordinator, attempt1Ctx, false)
+	targetSeat := newSeat(ctx1, target, attempt1Ctx, true) // withholds its share
+
+	coordErr := runSeatAsync(coordSeat, ctx1)
+	targetErr := runSeatAsync(targetSeat, ctx1)
+	<-coordErr.done
+	<-targetErr.done
+
+	if coordErr.err == nil {
+		t.Fatalf(
+			"attempt 1: the coordinator aggregated a signature despite the selected co-signer (seat %d) "+
+				"withholding its share; expected the coordinator's collection to starve and fail",
+			target,
+		)
+	}
+	t.Logf("attempt 1 coordinator failed as expected: %v", coordErr.err)
+
+	// ---- Transition: build the bundle from the LIVE senders (target absent). ----
+	prevHash := attempt1Ctx.Hash()
+	senders := []group.MemberIndex{coordinator, offline}
+	sort.Slice(senders, func(i, j int) bool { return senders[i] < senders[j] })
+	bundleSnapshots := make([]roast.LocalEvidenceSnapshot, 0, len(senders))
+	for _, s := range senders {
+		bundleSnapshots = append(bundleSnapshots, roast.LocalEvidenceSnapshot{
+			SenderIDValue:      uint32(s),
+			AttemptContextHash: append([]byte{}, prevHash[:]...),
+		})
+	}
+	bundle := &roast.TransitionMessage{
+		AttemptContextHash: append([]byte{}, prevHash[:]...),
+		CoordinatorIDValue: uint32(coordinator),
+		Bundle:             bundleSnapshots,
+	}
+
+	attempt2Ctx, err := coordSeat.coord.NextAttempt(
+		coordSeat.handle, bundle, uint(threshold), keyGroupSeed,
+	)
+	if err != nil {
+		t.Fatalf("NextAttempt: %v", err)
+	}
+
+	// ---- Assert the real parking policy excluded the silent target. ----
+	if !containsMember(attempt2Ctx.TransientlyParked, target) {
+		t.Fatalf("silent target %d must be transiently parked; parked=%v", target, attempt2Ctx.TransientlyParked)
+	}
+	if containsMember(attempt2Ctx.IncludedSet, target) {
+		t.Fatalf("silent target %d must not be in attempt 2's included set %v", target, attempt2Ctx.IncludedSet)
+	}
+	wantIncluded := []group.MemberIndex{coordinator, offline}
+	sort.Slice(wantIncluded, func(i, j int) bool { return wantIncluded[i] < wantIncluded[j] })
+	gotIncluded := append([]group.MemberIndex{}, attempt2Ctx.IncludedSet...)
+	sort.Slice(gotIncluded, func(i, j int) bool { return gotIncluded[i] < gotIncluded[j] })
+	if !memberSlicesEqualLocal(gotIncluded, wantIncluded) {
+		t.Fatalf("attempt 2 included set = %v, want %v (silent target parked)", gotIncluded, wantIncluded)
+	}
+	if attempt2Ctx.AttemptNumber != attempt1Ctx.AttemptNumber+1 {
+		t.Fatalf("attempt 2 number = %d, want %d", attempt2Ctx.AttemptNumber, attempt1Ctx.AttemptNumber+1)
+	}
+
+	// ---- Attempt 2: reshuffled subset {coordinator, offline} finalizes for real. ----
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+
+	var seats2 []*dropoutSeat
+	for _, m := range attempt2Ctx.IncludedSet {
+		seats2 = append(seats2, newSeat(ctx2, m, attempt2Ctx, false))
+	}
+	results := make([]seatResult, len(seats2))
+	dones := make([]*seatRunResult, len(seats2))
+	for i, s := range seats2 {
+		dones[i] = runSeatAsync(s, ctx2)
+	}
+	for i := range dones {
+		<-dones[i].done
+		results[i] = seatResult{sig: dones[i].sig, err: dones[i].err}
+	}
+
+	winners := 0
+	for i, r := range results {
+		switch {
+		case r.err == nil:
+			if len(r.sig) != 64 {
+				t.Fatalf("attempt 2 seat %d: want a 64-byte BIP-340 signature, got %d bytes", seats2[i].member, len(r.sig))
+			}
+			winners++
+			state, err := seats2[i].coord.State(seats2[i].handle)
+			if err != nil {
+				t.Fatalf("attempt 2 seat %d state: %v", seats2[i].member, err)
+			}
+			if state != roast.AttemptStateSucceeded {
+				t.Fatalf("attempt 2 seat %d aggregated but is not Succeeded: %v", seats2[i].member, state)
+			}
+		case isInteractiveAlreadyAggregated(r.err):
+			// Co-resident seat: the shared engine already finalized this attempt.
+		default:
+			t.Fatalf("attempt 2 seat %d failed unexpectedly: %v", seats2[i].member, r.err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("attempt 2: expected exactly one seat to aggregate the reshuffled-subset signature, got %d", winners)
+	}
+}
+
+type seatResult struct {
+	sig []byte
+	err error
+}
+
+type seatRunResult struct {
+	done chan struct{}
+	sig  []byte
+	err  error
+}
+
+// runSeatAsync runs a seat's runner in a goroutine and signals completion.
+func runSeatAsync(s *dropoutSeat, ctx context.Context) *seatRunResult {
+	r := &seatRunResult{done: make(chan struct{})}
+	go func() {
+		r.sig, r.err = s.runner.Run(ctx)
+		close(r.done)
+	}()
+	return r
+}
+
+func containsMember(set []group.MemberIndex, m group.MemberIndex) bool {
+	for _, x := range set {
+		if x == m {
+			return true
+		}
+	}
+	return false
+}
+
+func memberSlicesEqualLocal(a, b []group.MemberIndex) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/frost/signing/roast_runner_real_cgo_invalid_share_exclusion_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_invalid_share_exclusion_frost_native_test.go
@@ -1,0 +1,289 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	netlocal "github.com/keep-network/keep-core/pkg/net/local"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test closes the second real-crypto-under-failure gap: an INVALID signature
+// share, detected by the REAL cgo engine, driving a PERMANENT exclusion. Prior
+// coverage was disjoint - the real engine's share-verification and the f+1
+// reject-blame exclusion policy (next_attempt.go) were only ever exercised
+// separately, the latter with fakes.
+//
+// Flow (companion to the dropout/transient-park test, which parks; this one
+// EXCLUDES):
+//	attempt 1 (REAL crypto): a selected signer submits a structurally valid but
+//	  cryptographically WRONG round-2 share; the coordinator's real aggregate
+//	  fails with a typed share-verification error that NAMES the culprit;
+//	NextAttempt (REAL policy): an f+1 reject-accusation quorum against the culprit
+//	  PERMANENTLY excludes it (ExcludedSet, not a transient park);
+//	attempt 2 (REAL crypto): the surviving subset aggregates a real BIP-340
+//	  signature without the excluded member.
+//
+// Determinism: as in the dropout test, attempt 1 runs only {coordinator, target}
+// so the target is necessarily the coordinator's co-signer and its bad share is
+// aggregated (not observed away). The reject quorum is supplied from the genuine
+// verdict - the target's share IS invalid (the coordinator's real aggregate
+// proves it), so every honest observer would reject it; we encode the
+// ExclusionAccuserQuorum-many accusers a live deployment would produce.
+
+// corruptingRound2Engine wraps the engine so the wrapped seat's round-2 share is
+// mangled after the engine produces it: still a well-formed scalar (low byte
+// flipped), but the wrong value. The seat then signs and broadcasts that share,
+// modelling an invalid-share submitter. Every other engine call passes through
+// the embedded engine unchanged.
+type corruptingRound2Engine struct {
+	interactiveSigningEngine
+}
+
+func (e corruptingRound2Engine) InteractiveRound2(
+	sessionID string, attemptID string, memberIdentifier uint16, signingPackage []byte,
+) ([]byte, error) {
+	share, err := e.interactiveSigningEngine.InteractiveRound2(sessionID, attemptID, memberIdentifier, signingPackage)
+	if err != nil || len(share) == 0 {
+		return share, err
+	}
+	corrupted := append([]byte{}, share...)
+	corrupted[len(corrupted)-1] ^= 0x01 // valid scalar, wrong value
+	return corrupted, nil
+}
+
+func TestRealCgoInteractiveSigning_InvalidShareBlameForcesPermanentExclusion(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	engine := &buildTaggedTBTCSignerEngine{}
+	sessionID := fmt.Sprintf("real-cgo-invalid-share-%d", realCgoSessionSeq.Add(1))
+
+	const n = 3
+	const threshold uint16 = 2
+	participantIDs := []byte{1, 2, 3}
+	included := []group.MemberIndex{1, 2, 3}
+
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
+	keyGroupSeed := []byte(keyGroup)
+
+	var messageDigest [attempt.MessageDigestLength]byte
+	for i := range messageDigest {
+		messageDigest[i] = 0x42
+	}
+
+	attempt1Ctx, err := attempt.NewAttemptContext(
+		sessionID, keyGroup, keyGroupSeed, messageDigest, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt 1 context: %v", err)
+	}
+
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	logger := &testutils.MockLogger{}
+
+	probeCoord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	probeHandle, err := probeCoord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	probeBinding, err := NewActiveRoastAttempt(probeCoord, probeHandle, attempt1Ctx, sessionID, nil, keyGroupSeed)
+	if err != nil {
+		t.Fatalf("probe binding: %v", err)
+	}
+	coordinator := probeBinding.ElectedCoordinator()
+
+	nonCoordinators := make([]group.MemberIndex, 0, n-1)
+	for _, m := range included {
+		if m != coordinator {
+			nonCoordinators = append(nonCoordinators, m)
+		}
+	}
+	sort.Slice(nonCoordinators, func(i, j int) bool { return nonCoordinators[i] < nonCoordinators[j] })
+	target := nonCoordinators[0]  // submits the invalid share
+	offline := nonCoordinators[1] // absent in attempt 1, second live accuser + attempt-2 signer
+	t.Logf("attempt 1: coordinator=%d target(invalid-share)=%d offline=%d", coordinator, target, offline)
+
+	chainSigning := local_v1.Connect(n, n).Signing()
+	publicKeys := make(map[group.MemberIndex]*operator.PublicKey, n)
+	addresses := make([]chain.Address, 0, n)
+	for _, m := range included {
+		_, publicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("operator key (seat %d): %v", m, err)
+		}
+		publicKeys[m] = publicKey
+		addresses = append(addresses, chainSigning.PublicKeyBytesToAddress(
+			operator.MarshalUncompressed(publicKey),
+		))
+	}
+	validator := group.NewMembershipValidator(&testutils.MockLogger{}, addresses, chainSigning)
+
+	newSeat := func(ctx context.Context, member group.MemberIndex, attemptCtx attempt.AttemptContext, corruptShare bool) *dropoutSeat {
+		channel, err := netlocal.ConnectWithKey(publicKeys[member]).
+			BroadcastChannelFor("frost-roast-interactive-signing")
+		if err != nil {
+			t.Fatalf("broadcast channel (seat %d): %v", member, err)
+		}
+		bus, err := NewBroadcastChannelRunnerBus(ctx, logger, channel, validator)
+		if err != nil {
+			t.Fatalf("runner bus (seat %d): %v", member, err)
+		}
+		var eng interactiveSigningEngine = engine
+		if corruptShare {
+			eng = corruptingRound2Engine{interactiveSigningEngine: engine}
+		}
+		coord := roast.NewInMemoryCoordinatorWithSigning(member, signer, verifier)
+		handle, err := coord.BeginAttempt(attemptCtx)
+		if err != nil {
+			t.Fatalf("begin attempt (seat %d): %v", member, err)
+		}
+		binding, err := NewActiveRoastAttempt(coord, handle, attemptCtx, sessionID, nil, keyGroupSeed)
+		if err != nil {
+			t.Fatalf("active attempt (seat %d): %v", member, err)
+		}
+		collector := roast.NewRound2Collector(verifier)
+		runner, err := newInteractiveSigningRunner(binding, member, threshold, eng, collector, coord, signer, bus)
+		if err != nil {
+			t.Fatalf("runner (seat %d): %v", member, err)
+		}
+		return &dropoutSeat{member: member, coord: coord, handle: handle, binding: binding, runner: runner}
+	}
+
+	// ---- Attempt 1: coordinator + invalid-share target; aggregate must name it. ----
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel1()
+
+	coordSeat := newSeat(ctx1, coordinator, attempt1Ctx, false)
+	targetSeat := newSeat(ctx1, target, attempt1Ctx, true)
+	coordRes := runSeatAsync(coordSeat, ctx1)
+	targetRes := runSeatAsync(targetSeat, ctx1)
+	<-coordRes.done
+	<-targetRes.done
+
+	// The REAL engine's aggregate must detect the invalid share and name the
+	// target. Accept the detection from whichever co-resident seat aggregated it
+	// (shared engine); both run aggregate and see the same bad share.
+	var svErr *InteractiveAggregateShareVerificationError
+	switch {
+	case errors.As(coordRes.err, &svErr):
+	case errors.As(targetRes.err, &svErr):
+	default:
+		t.Fatalf(
+			"attempt 1: want a share-verification failure naming the culprit; coord err=%v target err=%v",
+			coordRes.err, targetRes.err,
+		)
+	}
+	if !containsUint16(svErr.CandidateCulprits, uint16(target)) {
+		t.Fatalf("aggregate must name target %d as a candidate culprit; culprits=%v", target, svErr.CandidateCulprits)
+	}
+	t.Logf("attempt 1: real aggregate named culprit(s) %v (target=%d)", svErr.CandidateCulprits, target)
+
+	// ---- Transition: an f+1 reject-accusation quorum against the target. ----
+	quorum := roast.ExclusionAccuserQuorum(uint(n), uint(threshold)) // = n - t + 1 = 2
+	accusers := []group.MemberIndex{coordinator, offline}
+	if uint(len(accusers)) < quorum {
+		t.Fatalf("test setup: need >= %d accusers, have %d", quorum, len(accusers))
+	}
+	sort.Slice(accusers, func(i, j int) bool { return accusers[i] < accusers[j] })
+
+	prevHash := attempt1Ctx.Hash()
+	snapshots := make([]roast.LocalEvidenceSnapshot, 0, len(accusers))
+	for _, a := range accusers {
+		snapshots = append(snapshots, roast.LocalEvidenceSnapshot{
+			SenderIDValue:      uint32(a),
+			AttemptContextHash: append([]byte{}, prevHash[:]...),
+			Rejects: []roast.RejectEntry{{
+				Sender: target, // the accused
+				Reason: "aggregate_share_verification_failed",
+				Count:  1,
+			}},
+		})
+	}
+	bundle := &roast.TransitionMessage{
+		AttemptContextHash: append([]byte{}, prevHash[:]...),
+		CoordinatorIDValue: uint32(coordinator),
+		Bundle:             snapshots,
+	}
+
+	attempt2Ctx, err := coordSeat.coord.NextAttempt(coordSeat.handle, bundle, uint(threshold), keyGroupSeed)
+	if err != nil {
+		t.Fatalf("NextAttempt: %v", err)
+	}
+
+	// ---- Assert PERMANENT exclusion (not a transient park). ----
+	if !containsMember(attempt2Ctx.ExcludedSet, target) {
+		t.Fatalf("invalid-share target %d must be PERMANENTLY excluded; excluded=%v", target, attempt2Ctx.ExcludedSet)
+	}
+	if containsMember(attempt2Ctx.TransientlyParked, target) {
+		t.Fatalf("target %d must be excluded, not merely parked; parked=%v", target, attempt2Ctx.TransientlyParked)
+	}
+	if containsMember(attempt2Ctx.IncludedSet, target) {
+		t.Fatalf("excluded target %d must not be in attempt 2's included set %v", target, attempt2Ctx.IncludedSet)
+	}
+	wantIncluded := []group.MemberIndex{coordinator, offline}
+	sort.Slice(wantIncluded, func(i, j int) bool { return wantIncluded[i] < wantIncluded[j] })
+	gotIncluded := append([]group.MemberIndex{}, attempt2Ctx.IncludedSet...)
+	sort.Slice(gotIncluded, func(i, j int) bool { return gotIncluded[i] < gotIncluded[j] })
+	if !memberSlicesEqualLocal(gotIncluded, wantIncluded) {
+		t.Fatalf("attempt 2 included set = %v, want %v (culprit excluded)", gotIncluded, wantIncluded)
+	}
+
+	// ---- Attempt 2: surviving subset finalizes for real without the culprit. ----
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+
+	var seats2 []*dropoutSeat
+	for _, m := range attempt2Ctx.IncludedSet {
+		seats2 = append(seats2, newSeat(ctx2, m, attempt2Ctx, false))
+	}
+	dones := make([]*seatRunResult, len(seats2))
+	for i, s := range seats2 {
+		dones[i] = runSeatAsync(s, ctx2)
+	}
+	winners := 0
+	for i := range dones {
+		<-dones[i].done
+		switch {
+		case dones[i].err == nil:
+			if len(dones[i].sig) != 64 {
+				t.Fatalf("attempt 2 seat %d: want a 64-byte signature, got %d", seats2[i].member, len(dones[i].sig))
+			}
+			winners++
+			state, err := seats2[i].coord.State(seats2[i].handle)
+			if err != nil {
+				t.Fatalf("attempt 2 seat %d state: %v", seats2[i].member, err)
+			}
+			if state != roast.AttemptStateSucceeded {
+				t.Fatalf("attempt 2 seat %d not Succeeded: %v", seats2[i].member, state)
+			}
+		case isInteractiveAlreadyAggregated(dones[i].err):
+		default:
+			t.Fatalf("attempt 2 seat %d failed unexpectedly: %v", seats2[i].member, dones[i].err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("attempt 2: expected exactly one seat to aggregate the surviving-subset signature, got %d", winners)
+	}
+}
+
+func containsUint16(set []uint16, m uint16) bool {
+	for _, x := range set {
+		if x == m {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/frost/signing/roast_runner_real_cgo_overflow_park_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_overflow_park_frost_native_test.go
@@ -1,0 +1,274 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test closes the fifth real-under-failure gap: a member that FLOODS a
+// receive loop faster than it drains genuinely OVERFLOWS the bounded inbound
+// channel, and that real, recorded overflow evidence - carried by an f+1 quorum
+// of honest observers - drives a TRANSIENT PARK of the flooder in the next
+// attempt (transport pressure costs one attempt of liveness, then the member
+// rejoins), NOT a permanent exclusion. Prior coverage was disjoint: the overflow
+// primitive (enqueueOrRecordOverflow, evidence_overflow.go) was unit-tested with
+// synthetic recorder-count assertions, and the park policy (next_attempt.go) was
+// unit-tested with hand-authored OverflowEntry bundles - never wired together, so
+// the overflow evidence the policy parked on was never the evidence the real
+// primitive produced.
+//
+// This wires them end to end:
+//
+//	OVERFLOW (real primitive): two honest observers each drive the REAL
+//	  enqueueOrRecordOverflow against a REAL full bounded channel with messages
+//	  from the flooder; each channel rejects the enqueue and each observer's REAL
+//	  bounded recorder records overflow against the flooder.
+//	PARK (real policy): each observer's recorded Evidence is turned into a REAL
+//	  LocalEvidenceSnapshot; an f+1 overflow-accusation quorum drives NextAttempt
+//	  to TRANSIENTLY PARK the flooder (not exclude it). The flooder is itself a
+//	  bundle sender, so silence-parking cannot account for the park - only the
+//	  overflow quorum can.
+//	REINSTATE (transient proof): a following attempt with no accusations
+//	  re-includes the parked flooder, proving the park is transient, not permanent
+//	  exclusion.
+//
+// A quorum-gate negative control (a single overflow accuser, below f+1) does NOT
+// park the flooder, proving the quorum is genuinely enforced.
+//
+// Determinism: overflow is a transport phenomenon adjudicated in pure Go - no
+// FROST rounds, bus, or shared engine - so the flood is driven synchronously
+// against a pre-filled channel (every enqueue after the first deterministically
+// hits the overflow branch) and the policy is a pure function of the bundle. A
+// real DKG is run only for an authentic attempt context, as in the sibling
+// real-cgo tests; it is not load-bearing for the overflow/park logic.
+
+// recordRealOverflow drives the REAL enqueueOrRecordOverflow primitive against a
+// REAL pre-filled bounded channel `floodCount` times with messages from
+// `flooder`, and returns the observer's genuinely-recorded evidence plus the
+// number of enqueues the full channel rejected. Every attempt after the channel
+// is filled falls to the overflow branch, so the recorder observes real,
+// primitive-produced overflow - not a hand-set counter.
+func recordRealOverflow(t *testing.T, flooder group.MemberIndex, floodCount int) (attempt.Evidence, int) {
+	t.Helper()
+	ch := make(chan *buildTaggedTBTCSignerRoundContributionMessage, 1)
+	ch <- &buildTaggedTBTCSignerRoundContributionMessage{SenderIDValue: 0xff} // fill it; no consumer drains
+	recorder := attempt.NewBoundedRecorder()
+
+	rejected := 0
+	for i := 0; i < floodCount; i++ {
+		enqueued := enqueueOrRecordOverflow(
+			&buildTaggedTBTCSignerRoundContributionMessage{SenderIDValue: uint32(flooder)},
+			ch,
+			recorder,
+		)
+		if !enqueued {
+			rejected++
+		}
+	}
+	return recorder.Snapshot(), rejected
+}
+
+// overflowCountFor returns the OverflowEntry count a snapshot reports against
+// `accused` (0 if none), and whether such an entry exists.
+func overflowCountFor(snap *roast.LocalEvidenceSnapshot, accused group.MemberIndex) (uint, bool) {
+	for _, e := range snap.Overflows {
+		if e.Sender == accused {
+			return e.Count, true
+		}
+	}
+	return 0, false
+}
+
+func TestRealCgoInteractiveSigning_TransportOverflowTransientlyParksFlooder(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	engine := &buildTaggedTBTCSignerEngine{}
+	sessionID := fmt.Sprintf("real-cgo-overflow-park-%d", realCgoSessionSeq.Add(1))
+
+	const n = 3
+	const threshold uint16 = 2
+	participantIDs := []byte{1, 2, 3}
+	included := []group.MemberIndex{1, 2, 3}
+
+	// Authentic attempt context (family consistency; not load-bearing here).
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
+	keyGroupSeed := []byte(keyGroup)
+
+	var messageDigest [attempt.MessageDigestLength]byte
+	for i := range messageDigest {
+		messageDigest[i] = 0x42
+	}
+	attempt1Ctx, err := attempt.NewAttemptContext(
+		sessionID, keyGroup, keyGroupSeed, messageDigest, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt 1 context: %v", err)
+	}
+
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+
+	// Resolve the deterministic elected coordinator so the flooder is a
+	// non-coordinator (matches the sibling structure; the overflow park itself is
+	// coordinator-agnostic).
+	probeCoord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	probeHandle, err := probeCoord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	probeBinding, err := NewActiveRoastAttempt(probeCoord, probeHandle, attempt1Ctx, sessionID, nil, keyGroupSeed)
+	if err != nil {
+		t.Fatalf("probe binding: %v", err)
+	}
+	coordinator := probeBinding.ElectedCoordinator()
+	nonCoord := make([]group.MemberIndex, 0, n-1)
+	for _, m := range included {
+		if m != coordinator {
+			nonCoord = append(nonCoord, m)
+		}
+	}
+	sort.Slice(nonCoord, func(i, j int) bool { return nonCoord[i] < nonCoord[j] })
+	flooder := nonCoord[0]
+	// The two honest overflow accusers (f+1 = n-t+1 = 2 for n=3, t=2).
+	observers := []group.MemberIndex{coordinator, nonCoord[1]}
+	t.Logf("coordinator=%d flooder=%d observers=%v", coordinator, flooder, observers)
+
+	quorum := roast.ExclusionAccuserQuorum(uint(n), uint(threshold))
+	if uint(len(observers)) < quorum {
+		t.Fatalf("test setup: need >= %d overflow accusers, have %d", quorum, len(observers))
+	}
+
+	prevHash := attempt1Ctx.Hash()
+
+	// ---- OVERFLOW: each observer genuinely overflows the real bounded channel. ----
+	const floodCount = 12 // > OverflowQuotaDefault (8); the channel holds 1 and never drains
+	observerSnaps := make([]roast.LocalEvidenceSnapshot, 0, len(observers))
+	for _, obs := range observers {
+		evidence, rejected := recordRealOverflow(t, flooder, floodCount)
+
+		// FAULT REACHED: the channel really rejected enqueues, and the real
+		// recorder really recorded overflow against the flooder - not a
+		// hand-authored entry.
+		if rejected == 0 {
+			t.Fatalf("observer %d: the full channel never rejected an enqueue; overflow was not reached", obs)
+		}
+		if got := evidence.Overflows[flooder]; got == 0 {
+			t.Fatalf("observer %d: recorder shows no overflow against flooder %d", obs, flooder)
+		}
+		snap := roast.NewLocalEvidenceSnapshot(obs, prevHash, evidence)
+		// The real recorded overflow must have propagated into the wire snapshot.
+		count, ok := overflowCountFor(snap, flooder)
+		if !ok || count == 0 {
+			t.Fatalf("observer %d snapshot must carry an overflow entry (count>0) against flooder %d; overflows=%v",
+				obs, flooder, snap.Overflows)
+		}
+		observerSnaps = append(observerSnaps, *snap)
+	}
+
+	// The flooder is ALSO a bundle sender (an empty self-snapshot), so it cannot
+	// be silence-parked: any park it receives is due to the overflow quorum alone.
+	flooderSnap := roast.NewLocalEvidenceSnapshot(flooder, prevHash, attempt.Evidence{})
+
+	buildBundle := func(snaps []roast.LocalEvidenceSnapshot) *roast.TransitionMessage {
+		sorted := append([]roast.LocalEvidenceSnapshot{}, snaps...)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].SenderIDValue < sorted[j].SenderIDValue })
+		return &roast.TransitionMessage{
+			AttemptContextHash: append([]byte(nil), prevHash[:]...),
+			CoordinatorIDValue: uint32(coordinator),
+			Bundle:             sorted,
+		}
+	}
+
+	bundle := buildBundle(append(append([]roast.LocalEvidenceSnapshot{}, observerSnaps...), *flooderSnap))
+
+	// ---- PARK: an f+1 overflow quorum transiently parks the flooder. ----
+	coord := roast.NewInMemoryCoordinatorWithSigning(coordinator, signer, verifier)
+	handle, err := coord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	attempt2Ctx, err := coord.NextAttempt(handle, bundle, uint(threshold), keyGroupSeed)
+	if err != nil {
+		t.Fatalf("NextAttempt: %v", err)
+	}
+
+	if !containsMember(attempt2Ctx.TransientlyParked, flooder) {
+		t.Fatalf("flooder %d must be transiently parked; parked=%v", flooder, attempt2Ctx.TransientlyParked)
+	}
+	if containsMember(attempt2Ctx.ExcludedSet, flooder) {
+		t.Fatalf("overflow must PARK, not permanently exclude; flooder %d in excluded=%v", flooder, attempt2Ctx.ExcludedSet)
+	}
+	if containsMember(attempt2Ctx.IncludedSet, flooder) {
+		t.Fatalf("parked flooder %d must not be in attempt 2's included set %v", flooder, attempt2Ctx.IncludedSet)
+	}
+	if attempt2Ctx.AttemptNumber != attempt1Ctx.AttemptNumber+1 {
+		t.Fatalf("attempt 2 number = %d, want %d", attempt2Ctx.AttemptNumber, attempt1Ctx.AttemptNumber+1)
+	}
+	t.Logf("flooder %d transiently parked (excluded=%v included=%v parked=%v)",
+		flooder, attempt2Ctx.ExcludedSet, attempt2Ctx.IncludedSet, attempt2Ctx.TransientlyParked)
+
+	// ---- REINSTATE: the following attempt with no accusations re-includes the
+	// parked flooder, proving the park is transient (not permanent exclusion). ----
+	prevHash2 := attempt2Ctx.Hash()
+	reinstateSnaps := make([]roast.LocalEvidenceSnapshot, 0, len(attempt2Ctx.IncludedSet))
+	for _, m := range attempt2Ctx.IncludedSet {
+		reinstateSnaps = append(reinstateSnaps, *roast.NewLocalEvidenceSnapshot(m, prevHash2, attempt.Evidence{}))
+	}
+	sort.Slice(reinstateSnaps, func(i, j int) bool { return reinstateSnaps[i].SenderIDValue < reinstateSnaps[j].SenderIDValue })
+	reinstateBundle := &roast.TransitionMessage{
+		AttemptContextHash: append([]byte(nil), prevHash2[:]...),
+		CoordinatorIDValue: uint32(coordinator),
+		Bundle:             reinstateSnaps,
+	}
+	handle2, err := coord.BeginAttempt(attempt2Ctx)
+	if err != nil {
+		t.Fatalf("begin attempt (reinstate): %v", err)
+	}
+	attempt3Ctx, err := coord.NextAttempt(handle2, reinstateBundle, uint(threshold), keyGroupSeed)
+	if err != nil {
+		t.Fatalf("NextAttempt (reinstate): %v", err)
+	}
+	if !containsMember(attempt3Ctx.IncludedSet, flooder) {
+		t.Fatalf("transiently-parked flooder %d must rejoin the following attempt; included=%v parked=%v",
+			flooder, attempt3Ctx.IncludedSet, attempt3Ctx.TransientlyParked)
+	}
+	if containsMember(attempt3Ctx.TransientlyParked, flooder) {
+		t.Fatalf("flooder %d must not remain parked after reinstatement; parked=%v", flooder, attempt3Ctx.TransientlyParked)
+	}
+	t.Logf("flooder %d reinstated on attempt 3 (included=%v) - the park was transient", flooder, attempt3Ctx.IncludedSet)
+
+	// ---- QUORUM GATE (negative control): a single overflow accuser (below f+1)
+	// does NOT park the flooder. Same real overflow evidence, one accuser. ----
+	singleEvidence, rejected := recordRealOverflow(t, flooder, floodCount)
+	if rejected == 0 || singleEvidence.Overflows[flooder] == 0 {
+		t.Fatalf("single-accuser control: overflow evidence was not genuinely produced")
+	}
+	singleAccuserBundle := buildBundle([]roast.LocalEvidenceSnapshot{
+		*roast.NewLocalEvidenceSnapshot(observers[0], prevHash, singleEvidence), // lone accuser
+		*roast.NewLocalEvidenceSnapshot(observers[1], prevHash, attempt.Evidence{}),
+		*flooderSnap,
+	})
+	handle3, err := coord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("begin attempt (quorum gate): %v", err)
+	}
+	singleAccuserCtx, err := coord.NextAttempt(handle3, singleAccuserBundle, uint(threshold), keyGroupSeed)
+	if err != nil {
+		t.Fatalf("NextAttempt (quorum gate): %v", err)
+	}
+	if containsMember(singleAccuserCtx.TransientlyParked, flooder) {
+		t.Fatalf("one overflow accuser is below the f+1 quorum (%d); flooder %d must NOT be parked; parked=%v",
+			quorum, flooder, singleAccuserCtx.TransientlyParked)
+	}
+	if !containsMember(singleAccuserCtx.IncludedSet, flooder) {
+		t.Fatalf("un-parked flooder %d must remain in the included set %v", flooder, singleAccuserCtx.IncludedSet)
+	}
+	t.Logf("quorum gate holds: one accuser (< f+1=%d) did not park flooder %d", quorum, flooder)
+}

--- a/pkg/frost/signing/roast_runner_real_cgo_share_conflict_equivocation_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_share_conflict_equivocation_frost_native_test.go
@@ -1,0 +1,439 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	netlocal "github.com/keep-network/keep-core/pkg/net/local"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test closes the third real-crypto-under-failure gap: a Byzantine signer
+// that DOUBLE-SIGNS its round-2 share (member equivocation), detected over the
+// real bus by an honest Round2Collector as EquivocationKindShareConflict. Prior
+// coverage was disjoint - the collector's conflict detection
+// (round2_collector.go) was unit-tested with synthetic ShareSubmissions and
+// fakes, never over a genuine engine-produced FROST share submitted through the
+// real transport.
+//
+// Flow (a companion to the dropout/invalid-share tests, which force a retry;
+// this one exercises the BLAME-EVIDENCE path - a share conflict is recorded as
+// self-incriminating proof for the f+1 adjudication of Phase 7.2b-4, it does not
+// abort the live attempt):
+//
+//	attempt 1 (REAL crypto): a selected signer runs round 2 and produces a
+//	  genuine FROST signature share, then broadcasts TWO body-different signed
+//	  share submissions for the SAME attempt - its real share and a re-signed copy
+//	  with a mutated signature_share. Both name the elected coordinator and bind
+//	  the authoritative signing package, so both are ACCEPTED aggregation shares
+//	  (not divergent evidence): a second accepted-but-different signed body is
+//	  member double-signing.
+//	DETECTION (REAL collector): an honest Round2Collector fed the coordinator's
+//	  authoritative package and then both shares flags the second as
+//	  EquivocationKindShareConflict and returns ErrShareConflict, and the
+//	  process-wide equivocation observer receives the evidence naming the
+//	  Byzantine submitter.
+//
+// DETERMINISM. The Byzantine seat genuinely BROADCASTS both shares on the live
+// bus (an honest receiver may also detect the conflict - a bonus we do not rely
+// on), but the runner's collect-shares loop stops at the threshold and only
+// opportunistically drains buffered duplicates, so which collector observes the
+// second share over the wire is timing-dependent. To make DETECTION
+// deterministic without depending on that race, the test also drives an
+// independent honest collector directly with the exact bytes the Byzantine
+// broadcast (captured at the point of broadcast) plus the coordinator's
+// authoritative package (captured from its broadcast). Those are the real
+// on-wire envelopes - the same bytes an honest node receives - so feeding them
+// is behaviourally identical to reception, only order-guaranteed. Attempt 1 runs
+// only {coordinator, target} (the deterministic co-signer trick from the sibling
+// tests) so the target is necessarily the coordinator's sole co-signer and its
+// real round-2 share is actually produced.
+
+// signingPackageCapturingBus wraps a RunnerBus and records a copy of every
+// signing-package envelope the wrapped seat broadcasts (the elected
+// coordinator's authoritative package), so the test can feed the real,
+// coordinator-signed package to an honest auditor collector. All traffic passes
+// through unchanged.
+type signingPackageCapturingBus struct {
+	inner RunnerBus
+	mu    *sync.Mutex
+	pkgs  *[][]byte
+}
+
+func (b signingPackageCapturingBus) Broadcast(msg RunnerMessage) {
+	if msg.Type == RunnerMsgSigningPackage {
+		b.mu.Lock()
+		*b.pkgs = append(*b.pkgs, append([]byte(nil), msg.Payload...))
+		b.mu.Unlock()
+	}
+	b.inner.Broadcast(msg)
+}
+
+func (b signingPackageCapturingBus) Subscribe() *RunnerBusSubscriber { return b.inner.Subscribe() }
+
+// shareEquivocatingBus wraps a RunnerBus so the wrapped seat DOUBLE-SIGNS its
+// round-2 share: when it broadcasts its genuine share submission, the wrapper
+// captures that real envelope, derives a body-different conflicting one (same
+// attempt/coordinator/package binding, one bit flipped in the signature_share,
+// re-signed by the same seat), captures it too, and broadcasts BOTH. Keeping the
+// coordinator and signing-package binding identical is what makes the second
+// share an ACCEPTED conflict (member double-signing) rather than a divergent
+// share. All other traffic passes through untouched.
+type shareEquivocatingBus struct {
+	inner    RunnerBus
+	signer   roast.Signer
+	mu       *sync.Mutex
+	real     *[][]byte
+	conflict *[][]byte
+	buildErr *[]error
+}
+
+func (b shareEquivocatingBus) Broadcast(msg RunnerMessage) {
+	if msg.Type != RunnerMsgShareSubmission {
+		b.inner.Broadcast(msg)
+		return
+	}
+	realEnvelope := append([]byte(nil), msg.Payload...)
+	conflictEnvelope, err := buildConflictingShareEnvelope(realEnvelope, b.signer)
+
+	b.mu.Lock()
+	*b.real = append(*b.real, realEnvelope)
+	if err != nil {
+		*b.buildErr = append(*b.buildErr, err)
+	} else {
+		*b.conflict = append(*b.conflict, conflictEnvelope)
+	}
+	b.mu.Unlock()
+
+	// The real share first, then the body-different double-sign. Both are
+	// delivered by the bus (it never dedups body-different messages from a
+	// sender - that suppression would destroy the very equivocation evidence).
+	b.inner.Broadcast(msg)
+	if err == nil {
+		b.inner.Broadcast(RunnerMessage{
+			Type:    RunnerMsgShareSubmission,
+			Sender:  msg.Sender,
+			Attempt: msg.Attempt,
+			Payload: conflictEnvelope,
+		})
+	}
+}
+
+func (b shareEquivocatingBus) Subscribe() *RunnerBusSubscriber { return b.inner.Subscribe() }
+
+// buildConflictingShareEnvelope derives a second, body-different signed share
+// submission from a genuine one: it keeps the attempt, submitter, coordinator,
+// and signing-package binding (so an honest collector classifies it as an
+// ACCEPTED share, eligible for aggregation - the prerequisite for the conflict,
+// not a divergent share) and flips one bit of the FROST signature_share so the
+// signed BODY differs. It re-signs with the same seat's signer, modelling a
+// member that authored two different shares for one instruction.
+func buildConflictingShareEnvelope(realEnvelope []byte, signer roast.Signer) ([]byte, error) {
+	var real roast.ShareSubmission
+	if err := real.Unmarshal(realEnvelope); err != nil {
+		return nil, fmt.Errorf("unmarshal real share: %w", err)
+	}
+	if len(real.SignatureShare) == 0 {
+		return nil, errors.New("real share has an empty signature share")
+	}
+	conflict := &roast.ShareSubmission{
+		AttemptContextHash: append([]byte(nil), real.AttemptContextHash...),
+		SubmitterIDValue:   real.SubmitterIDValue,
+		CoordinatorIDValue: real.CoordinatorIDValue,
+		SigningPackageHash: append([]byte(nil), real.SigningPackageHash...),
+		SignatureShare:     append([]byte(nil), real.SignatureShare...),
+	}
+	conflict.SignatureShare[len(conflict.SignatureShare)-1] ^= 0x01
+	payload, err := conflict.SignableBytes()
+	if err != nil {
+		return nil, err
+	}
+	sig, err := signer.Sign(payload)
+	if err != nil {
+		return nil, err
+	}
+	conflict.SubmitterSignature = sig
+	envelope, err := conflict.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return envelope, nil
+}
+
+func TestRealCgoInteractiveSigning_DoubleSignedShareIsDetectedAsEquivocation(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	engine := &buildTaggedTBTCSignerEngine{}
+	sessionID := fmt.Sprintf("real-cgo-share-conflict-%d", realCgoSessionSeq.Add(1))
+
+	const n = 3
+	const threshold uint16 = 2
+	participantIDs := []byte{1, 2, 3}
+	included := []group.MemberIndex{1, 2, 3}
+
+	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
+	keyGroupSeed := []byte(keyGroup)
+
+	var messageDigest [attempt.MessageDigestLength]byte
+	for i := range messageDigest {
+		messageDigest[i] = 0x42
+	}
+
+	attempt1Ctx, err := attempt.NewAttemptContext(
+		sessionID, keyGroup, keyGroupSeed, messageDigest, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt 1 context: %v", err)
+	}
+
+	signer := fixedTestSigner{}
+	verifier := roast.NoOpSignatureVerifier()
+	logger := &testutils.MockLogger{}
+
+	// Capture the equivocation evidence the collector emits process-wide. Only a
+	// single observer is supported; clear any stale registration first so serial
+	// tests in this package do not collide, and unregister on exit.
+	var evMu sync.Mutex
+	var conflictEvents []roast.EquivocationEvidence
+	roast.UnregisterEquivocationEvidenceObserver()
+	if err := roast.RegisterEquivocationEvidenceObserver(func(ev roast.EquivocationEvidence) {
+		evMu.Lock()
+		defer evMu.Unlock()
+		conflictEvents = append(conflictEvents, ev)
+	}); err != nil {
+		t.Fatalf("register equivocation observer: %v", err)
+	}
+	defer roast.UnregisterEquivocationEvidenceObserver()
+
+	// Resolve attempt 1's elected coordinator from a probe binding, so the
+	// non-coordinator target is necessarily the coordinator's co-signer.
+	probeCoord := roast.NewInMemoryCoordinatorWithSigning(1, signer, verifier)
+	probeHandle, err := probeCoord.BeginAttempt(attempt1Ctx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	probeBinding, err := NewActiveRoastAttempt(probeCoord, probeHandle, attempt1Ctx, sessionID, nil, keyGroupSeed)
+	if err != nil {
+		t.Fatalf("probe binding: %v", err)
+	}
+	coordinator := probeBinding.ElectedCoordinator()
+	nonCoordinators := make([]group.MemberIndex, 0, n-1)
+	for _, m := range included {
+		if m != coordinator {
+			nonCoordinators = append(nonCoordinators, m)
+		}
+	}
+	sort.Slice(nonCoordinators, func(i, j int) bool { return nonCoordinators[i] < nonCoordinators[j] })
+	target := nonCoordinators[0] // double-signs its round-2 share
+	t.Logf("attempt 1: coordinator=%d target(double-signer)=%d", coordinator, target)
+
+	// Shared operator identities + membership validator over all 3 seats.
+	chainSigning := local_v1.Connect(n, n).Signing()
+	publicKeys := make(map[group.MemberIndex]*operator.PublicKey, n)
+	addresses := make([]chain.Address, 0, n)
+	for _, m := range included {
+		_, publicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("operator key (seat %d): %v", m, err)
+		}
+		publicKeys[m] = publicKey
+		addresses = append(addresses, chainSigning.PublicKeyBytesToAddress(
+			operator.MarshalUncompressed(publicKey),
+		))
+	}
+	validator := group.NewMembershipValidator(&testutils.MockLogger{}, addresses, chainSigning)
+
+	var (
+		captureMu        sync.Mutex
+		capturedPackages [][]byte
+		capturedReal     [][]byte
+		capturedConflict [][]byte
+		buildErrs        []error
+	)
+
+	newSeat := func(ctx context.Context, member group.MemberIndex) *dropoutSeat {
+		channel, err := netlocal.ConnectWithKey(publicKeys[member]).
+			BroadcastChannelFor("frost-roast-interactive-signing")
+		if err != nil {
+			t.Fatalf("broadcast channel (seat %d): %v", member, err)
+		}
+		var bus RunnerBus
+		bus, err = NewBroadcastChannelRunnerBus(ctx, logger, channel, validator)
+		if err != nil {
+			t.Fatalf("runner bus (seat %d): %v", member, err)
+		}
+		switch member {
+		case coordinator:
+			bus = signingPackageCapturingBus{inner: bus, mu: &captureMu, pkgs: &capturedPackages}
+		case target:
+			bus = shareEquivocatingBus{
+				inner:    bus,
+				signer:   signer,
+				mu:       &captureMu,
+				real:     &capturedReal,
+				conflict: &capturedConflict,
+				buildErr: &buildErrs,
+			}
+		}
+		coord := roast.NewInMemoryCoordinatorWithSigning(member, signer, verifier)
+		handle, err := coord.BeginAttempt(attempt1Ctx)
+		if err != nil {
+			t.Fatalf("begin attempt (seat %d): %v", member, err)
+		}
+		binding, err := NewActiveRoastAttempt(coord, handle, attempt1Ctx, sessionID, nil, keyGroupSeed)
+		if err != nil {
+			t.Fatalf("active attempt (seat %d): %v", member, err)
+		}
+		collector := roast.NewRound2Collector(verifier)
+		runner, err := newInteractiveSigningRunner(binding, member, threshold, engine, collector, coord, signer, bus)
+		if err != nil {
+			t.Fatalf("runner (seat %d): %v", member, err)
+		}
+		return &dropoutSeat{member: member, coord: coord, handle: handle, binding: binding, runner: runner}
+	}
+
+	// ---- Attempt 1: coordinator + double-signing target. ----
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel1()
+
+	coordSeat := newSeat(ctx1, coordinator)
+	targetSeat := newSeat(ctx1, target)
+	coordRes := runSeatAsync(coordSeat, ctx1)
+	targetRes := runSeatAsync(targetSeat, ctx1)
+	<-coordRes.done
+	<-targetRes.done
+	t.Logf("attempt 1 outcomes: coordinator err=%v sigLen=%d, target err=%v sigLen=%d",
+		coordRes.err, len(coordRes.sig), targetRes.err, len(targetRes.sig))
+
+	captureMu.Lock()
+	packages := append([][]byte{}, capturedPackages...)
+	realShares := append([][]byte{}, capturedReal...)
+	conflictShares := append([][]byte{}, capturedConflict...)
+	buildErrsCopy := append([]error{}, buildErrs...)
+	captureMu.Unlock()
+
+	if len(buildErrsCopy) != 0 {
+		t.Fatalf("building the conflicting share failed: %v", buildErrsCopy)
+	}
+
+	// FAULT REACHED (crypto side): the target actually ran round 2 and produced a
+	// genuine FROST share, then broadcast it. Without a captured real share, the
+	// equivocation would be synthetic and the test vacuous.
+	if len(realShares) == 0 {
+		t.Fatalf("target %d never broadcast a round-2 share; its equivocation was not reached", target)
+	}
+	if len(conflictShares) == 0 {
+		t.Fatalf("no conflicting share was derived from the target's real share")
+	}
+	if len(packages) == 0 {
+		t.Fatalf("coordinator %d never broadcast an authoritative signing package", coordinator)
+	}
+
+	realEnvelope := realShares[0]
+	conflictEnvelope := conflictShares[0]
+
+	// FAULT REACHED (equivocation is genuine): two byte-different signed share
+	// envelopes, both parseable, both binding the SAME attempt / coordinator /
+	// authoritative package - so both are ACCEPTED shares and the second is a true
+	// double-sign, not a divergent share that would be classified differently.
+	if bytes.Equal(realEnvelope, conflictEnvelope) {
+		t.Fatalf("the two share envelopes are byte-identical; no equivocation was produced")
+	}
+	var realSub, conflictSub roast.ShareSubmission
+	if err := realSub.Unmarshal(realEnvelope); err != nil {
+		t.Fatalf("unmarshal real share: %v", err)
+	}
+	if err := conflictSub.Unmarshal(conflictEnvelope); err != nil {
+		t.Fatalf("unmarshal conflicting share: %v", err)
+	}
+	if realSub.SubmitterID() != target || conflictSub.SubmitterID() != target {
+		t.Fatalf("both shares must be submitted by target %d; got real=%d conflict=%d",
+			target, realSub.SubmitterID(), conflictSub.SubmitterID())
+	}
+	if realSub.CoordinatorID() != coordinator || conflictSub.CoordinatorID() != coordinator {
+		t.Fatalf("both shares must name coordinator %d; got real=%d conflict=%d",
+			coordinator, realSub.CoordinatorID(), conflictSub.CoordinatorID())
+	}
+	if !bytes.Equal(realSub.SigningPackageHash, conflictSub.SigningPackageHash) {
+		t.Fatalf("both shares must bind the same authoritative package (else it is a divergent share, not a conflict)")
+	}
+	if bytes.Equal(realSub.SignatureShare, conflictSub.SignatureShare) {
+		t.Fatalf("the two shares must differ in their signature_share (the double-signed field)")
+	}
+
+	// ---- Deterministic detection: an honest collector fed the authoritative
+	// package and both shares must flag the second as a member conflict. ----
+	pkg := &roast.SigningPackage{}
+	if err := pkg.Unmarshal(packages[0]); err != nil {
+		t.Fatalf("unmarshal authoritative signing package: %v", err)
+	}
+	// The shares must answer THIS captured package, or they would be divergent.
+	pkgBodyHash, err := pkg.BodyHash()
+	if err != nil {
+		t.Fatalf("authoritative package body hash: %v", err)
+	}
+	if !bytes.Equal(realSub.SigningPackageHash, pkgBodyHash[:]) {
+		t.Fatalf("the target's shares do not bind the coordinator's authoritative package; they would be divergent, not a conflict")
+	}
+
+	prevHash := attempt1Ctx.Hash()
+	auditor := roast.NewRound2Collector(verifier)
+	if err := auditor.BeginAttempt(prevHash[:], coordinator, included); err != nil {
+		t.Fatalf("auditor begin attempt: %v", err)
+	}
+	if err := auditor.RecordSigningPackage(pkg); err != nil {
+		t.Fatalf("auditor record authoritative package: %v", err)
+	}
+	// The genuine share is accepted; the second, body-different accepted share
+	// from the same submitter is member double-signing.
+	if err := auditor.RecordShareSubmission(&realSub); err != nil {
+		t.Fatalf("auditor must accept the target's genuine share; got: %v", err)
+	}
+	conflictErr := auditor.RecordShareSubmission(&conflictSub)
+	if !errors.Is(conflictErr, roast.ErrShareConflict) {
+		t.Fatalf("auditor must reject the double-signed share as a conflict (ErrShareConflict); got: %v", conflictErr)
+	}
+
+	// ---- The equivocation evidence names the culprit. ----
+	evMu.Lock()
+	events := append([]roast.EquivocationEvidence{}, conflictEvents...)
+	evMu.Unlock()
+
+	var conflictEvidence *roast.EquivocationEvidence
+	for i := range events {
+		if events[i].Kind == roast.EquivocationKindShareConflict && events[i].Sender == target {
+			conflictEvidence = &events[i]
+			break
+		}
+	}
+	if conflictEvidence == nil {
+		t.Fatalf("expected a %s equivocation event naming submitter %d; got events=%v",
+			roast.EquivocationKindShareConflict, target, events)
+	}
+	// The evidence must carry the two distinct signed envelopes (the proof
+	// material an f+1 adjudication compares), not empty placeholders.
+	if len(conflictEvidence.ExistingEnvelope) == 0 || len(conflictEvidence.ConflictingEnvelope) == 0 {
+		t.Fatalf("conflict evidence must carry both signed envelopes; got existing=%d conflicting=%d bytes",
+			len(conflictEvidence.ExistingEnvelope), len(conflictEvidence.ConflictingEnvelope))
+	}
+	if bytes.Equal(conflictEvidence.ExistingEnvelope, conflictEvidence.ConflictingEnvelope) {
+		t.Fatalf("conflict evidence envelopes must differ (self-incriminating double-sign)")
+	}
+	t.Logf("honest collector detected member double-signing: %s from submitter %d (existing=%d conflicting=%d bytes)",
+		conflictEvidence.Kind, conflictEvidence.Sender,
+		len(conflictEvidence.ExistingEnvelope), len(conflictEvidence.ConflictingEnvelope))
+}

--- a/pkg/tbtc/signing_loop_selector_cross_node_fracture_frost_native_roast_retry_test.go
+++ b/pkg/tbtc/signing_loop_selector_cross_node_fracture_frost_native_roast_retry_test.go
@@ -1,0 +1,244 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test closes the cross-node ROAST/legacy fracture gap: two honest nodes
+// with DIVERGENT selection state selecting for the same committed attempt would
+// broadcast DIFFERENT NextAttempt included sets (a ROAST-consumed set vs a legacy
+// shuffle) -- the fracture class that splits the signing group -- and the
+// fail-closed guard (signing_loop_selector_frost_roast_retry.go:83 via
+// signing.ConsumeRoastTransitionForSelection) must make BOTH fail closed
+// deterministically instead. Prior coverage tested the fail-closed branches in
+// isolation with fakes; nothing proved the two configs would ACTUALLY diverge
+// and that the guard collapses that divergence to a deterministic fail-closed
+// decision on both nodes.
+//
+// The "two nodes with divergent config" are two seats sharing the process-global
+// ROAST registries: node A (the elected coordinator) is registered and ROAST-
+// active, node B is an unregistered seat that -- absent the guard -- would fall
+// back to the legacy shuffle. The proof is a before/after flip on node B's
+// IDENTICAL Select call: with the registry empty it returns a concrete legacy
+// set; after node A registers (RoastRetryActive true) the same call FAILS CLOSED
+// and does NOT return that set. Node A, whose expected transition is absent for
+// the fail-closed session, also fails closed. Neither emits a NextAttempt set, so
+// they cannot converge on divergent ones: the network fails closed rather than
+// splitting.
+//
+// Pure-Go: no FROST rounds, bus, or block timing. The whole test is synchronous
+// direct calls into the selector and the two package-global registries; the only
+// determinism that matters is that the fail-closed decision is a deterministic
+// per-seat function of registry state (asserted by repeating each call).
+
+// fracFixedSigner returns a fixed non-empty signature; the wire encoder rejects
+// an empty signature during AggregateBundle and the NoOp verifier accepts this
+// one. Defined locally because pkg/frost/signing's fixedSigner is not exported to
+// this package.
+type fracFixedSigner struct{}
+
+func (fracFixedSigner) Sign(_ []byte) ([]byte, error) { return []byte{0x01}, nil }
+
+func fracSignedSnapshot(
+	member group.MemberIndex,
+	hash [attempt.MessageDigestLength]byte,
+) *roast.LocalEvidenceSnapshot {
+	snap := roast.NewLocalEvidenceSnapshot(member, hash, attempt.Evidence{})
+	payload, _ := snap.SignableBytes()
+	sig, _ := fracFixedSigner{}.Sign(payload)
+	snap.OperatorSignature = sig
+	return snap
+}
+
+func fracSameMembers(a, b []group.MemberIndex) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestROASTSelector_CrossNodeLegacyFractureFailsClosed(t *testing.T) {
+	t.Setenv(signing.RoastRetryReadinessOptInEnvVar, "true")
+	signing.ResetRoastRetryRegistrationForTest()
+	signing.ResetRoastTransitionRegistryForTest()
+	t.Cleanup(signing.ResetRoastRetryRegistrationForTest)
+	t.Cleanup(signing.ResetRoastTransitionRegistryForTest)
+
+	roastSel := roastSigningParticipantSelector{}
+	ready := []group.MemberIndex{1, 2, 3, 4, 5}
+	ops := selectorTestMembers()
+	const seed int64 = 42
+	const honestThreshold uint = 3
+	dkgKey := []byte{0x0a, 0x0b}
+	var digest [attempt.MessageDigestLength]byte
+	digest[0] = 0xaa
+
+	// ---- Phase A: prove the two configs produce DIVERGENT NextAttempt sets. ----
+	recordedSession := "frac-recorded-session"
+	prevCtx, err := attempt.NewAttemptContextWithParking(
+		recordedSession, "frac-key-group", dkgKey, digest, 0, ready, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("build prev attempt context: %v", err)
+	}
+	hash := prevCtx.Hash()
+
+	// Discover the deterministically elected coordinator for prevCtx.
+	probe := roast.NewInMemoryCoordinatorWithSigning(0, fracFixedSigner{}, roast.NoOpSignatureVerifier())
+	probeHandle, err := probe.BeginAttempt(prevCtx)
+	if err != nil {
+		t.Fatalf("probe begin attempt: %v", err)
+	}
+	elected, err := probe.SelectedCoordinator(probeHandle)
+	if err != nil {
+		t.Fatalf("selected coordinator: %v", err)
+	}
+	// Node B is any seat that is NOT elected; it is left UNREGISTERED.
+	var memberB group.MemberIndex
+	for _, m := range ready {
+		if m != elected {
+			memberB = m
+			break
+		}
+	}
+	t.Logf("elected(node A)=%d unregistered(node B)=%d", elected, memberB)
+
+	// Register node A's coordinator and build a real, verifiable transition record
+	// so the ROAST selection path is live for recordedSession.
+	coordA := roast.NewInMemoryCoordinatorWithSigning(elected, fracFixedSigner{}, roast.NoOpSignatureVerifier())
+	registerNodeA := func() {
+		signing.RegisterRoastRetryCoordinator(signing.RoastRetryDeps{
+			Coordinator: coordA,
+			Signer:      fracFixedSigner{},
+			Verifier:    roast.NoOpSignatureVerifier(),
+			SelfMember:  uint32(elected),
+		})
+	}
+	registerNodeA()
+	if !signing.RoastRetryActive() {
+		t.Skip("requires a transition producer (frost_native) for the fail-closed path")
+	}
+	handle, err := coordA.BeginAttempt(prevCtx)
+	if err != nil {
+		t.Fatalf("node A begin attempt: %v", err)
+	}
+	for _, m := range ready {
+		if err := coordA.RecordEvidence(handle, fracSignedSnapshot(m, hash)); err != nil {
+			t.Fatalf("record evidence for member %d: %v", m, err)
+		}
+	}
+	bundle, err := coordA.AggregateBundle(handle)
+	if err != nil {
+		t.Fatalf("aggregate bundle: %v", err)
+	}
+	signing.RecordRoastTransition(recordedSession, elected, signing.RoastTransitionRecord{
+		Bundle:            bundle,
+		PreviousHandle:    handle,
+		PreviousContext:   prevCtx,
+		DkgGroupPublicKey: dkgKey,
+	})
+
+	// ROAST-config node: consumes the transition -> the full 5-member set (all
+	// submitted evidence, none silence-parked).
+	sRoast, err := roastSel.Select(ready, ops, seed, 1, 1, honestThreshold, recordedSession, elected)
+	if err != nil {
+		t.Fatalf("ROAST selection must succeed with a fresh record: %v", err)
+	}
+	if len(sRoast.includedMembersIndexes) != len(ready) {
+		t.Fatalf("expected the full %d-member ROAST set, got %v", len(ready), sRoast.includedMembersIndexes)
+	}
+	// legacy-config node: trims to the honest threshold via a seeded shuffle.
+	sLegacy, err := legacySigningParticipantSelector{}.Select(ready, ops, seed, 1, 1, honestThreshold, recordedSession, elected)
+	if err != nil {
+		t.Fatalf("legacy selection failed: %v", err)
+	}
+	if len(sLegacy.includedMembersIndexes) != int(honestThreshold) {
+		t.Fatalf("expected a %d-member legacy set, got %v", honestThreshold, sLegacy.includedMembersIndexes)
+	}
+	// FAULT REACHED: the two node configs genuinely select DIFFERENT NextAttempt
+	// sets -- exactly the fracture the guard exists to prevent.
+	if fracSameMembers(sRoast.includedMembersIndexes, sLegacy.includedMembersIndexes) {
+		t.Fatalf("fracture not induced: ROAST and legacy selected the same set %v", sRoast.includedMembersIndexes)
+	}
+	t.Logf("divergence induced: ROAST set %v vs legacy set %v", sRoast.includedMembersIndexes, sLegacy.includedMembersIndexes)
+
+	// ---- Phase B: node B WOULD diverge to a concrete legacy set (guard OFF). ----
+	freshSess := "frac-fail-closed-session"
+	signing.ResetRoastRetryRegistrationForTest() // RoastRetryActive() now false
+	signing.ResetRoastTransitionRegistryForTest()
+	if signing.RoastRetryActive() {
+		t.Fatalf("precondition: registry must be empty (RoastRetryActive false)")
+	}
+	legacyB, err := roastSel.Select(ready, ops, seed, 1, 1, honestThreshold, freshSess, memberB)
+	if err != nil {
+		t.Fatalf("node B must fall back to legacy when ROAST is inactive: %v", err)
+	}
+	if len(legacyB.includedMembersIndexes) != int(honestThreshold) {
+		t.Fatalf("expected node B legacy set of size %d, got %v", honestThreshold, legacyB.includedMembersIndexes)
+	}
+	t.Logf("node B would broadcast the divergent legacy set %v (before the guard engages)", legacyB.includedMembersIndexes)
+
+	// ---- Phase C: guard ON -> the SAME node-B call, and node A, FAIL CLOSED. ----
+	registerNodeA()
+	if !signing.RoastRetryActive() {
+		t.Fatalf("precondition: ROAST must be active after registering node A")
+	}
+
+	assertFailClosed := func(who string, sel participantSelection, err error, wantSubstr string) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s must FAIL CLOSED, got selection %v", who, sel.includedMembersIndexes)
+		}
+		if errors.Is(err, signing.ErrRoastSelectionFallBackToLegacy) {
+			t.Fatalf("%s must fail closed, NOT fall back to legacy: %v", who, err)
+		}
+		if len(sel.includedMembersIndexes) != 0 {
+			t.Fatalf("%s fail-closed selection must be empty, got %v", who, sel.includedMembersIndexes)
+		}
+		if !strings.Contains(err.Error(), wantSubstr) {
+			t.Fatalf("%s error %q missing %q", who, err.Error(), wantSubstr)
+		}
+	}
+
+	// Node B: unregistered seat under active ROAST -> partial-registration fail-closed.
+	gotB, errB := roastSel.Select(ready, ops, seed, 1, 1, honestThreshold, freshSess, memberB)
+	assertFailClosed("node B (would-be legacy)", gotB, errB, "no registered coordinator")
+	// The guard specifically suppressed the divergent legacy set node B had emitted.
+	if fracSameMembers(gotB.includedMembersIndexes, legacyB.includedMembersIndexes) {
+		t.Fatalf("guard failed: node B still emitted the divergent legacy set %v", legacyB.includedMembersIndexes)
+	}
+
+	// Node A: registered ROAST seat, but no record for freshSess -> missing-record fail-closed.
+	gotA, errA := roastSel.Select(ready, ops, seed, 1, 1, honestThreshold, freshSess, elected)
+	assertFailClosed("node A (ROAST-active)", gotA, errA, "no transition record")
+
+	// NEITHER produced a NextAttempt set, so they cannot have converged on
+	// divergent (or each other's) sets: the network fails closed instead of
+	// splitting.
+	if len(gotA.includedMembersIndexes) != 0 || len(gotB.includedMembersIndexes) != 0 {
+		t.Fatalf("both nodes must emit an EMPTY selection when failing closed; A=%v B=%v",
+			gotA.includedMembersIndexes, gotB.includedMembersIndexes)
+	}
+
+	// Determinism: the fail-closed decision is a stable per-seat function of
+	// registry state, not order/timing dependent.
+	gotB2, errB2 := roastSel.Select(ready, ops, seed, 1, 1, honestThreshold, freshSess, memberB)
+	assertFailClosed("node B (repeat)", gotB2, errB2, "no registered coordinator")
+	gotA2, errA2 := roastSel.Select(ready, ops, seed, 1, 1, honestThreshold, freshSess, elected)
+	assertFailClosed("node A (repeat)", gotA2, errA2, "no transition record")
+	t.Logf("both nodes fail closed deterministically (node A: missing record; node B: unregistered seat)")
+}


### PR DESCRIPTION
## What

Adds **real-under-failure** ROAST retry/blame tests. Prior coverage was disjoint: the real-cgo interactive e2es are happy-path only, and the retry/parking/blame machinery (`next_attempt.go`, the round-2 collector, the overflow primitive, the cross-node selector guard) is unit-tested with fakes — nothing wired the real component + an induced fault + its retry/blame outcome together. Each test asserts the induced fault was **actually reached** (not merely that the outcome happened), so a synthetic bundle can't make it pass vacuously.

## The tests

Over the real `pkg/net` transport against the real cgo FROST engine (`pkg/frost/signing`, `frost_native frost_tbtc_signer cgo`):

- **`..._dropout_retry_...`** (#1) — a *selected* signer withholds its round-2 share → the elected coordinator (the aggregator) starves on a real collect-shares timeout → `NextAttempt` **transiently parks** the silent seat → the reshuffled subset aggregates a real BIP-340 signature and reaches `Succeeded`. Asserts the coordinator starves *specifically* at share collection AND the target actually reached round 2 and produced the share it withheld.
- **`..._invalid_share_exclusion_...`** (#2) — a selected signer submits a structurally valid but cryptographically **wrong** round-2 share → the real aggregate fails with a typed share-verification error naming the culprit → an f+1 reject quorum **permanently excludes** it → the surviving subset finalizes for real.
- **`..._share_conflict_equivocation_...`** (#3b) — a selected signer runs round 2, produces a genuine FROST share, then broadcasts **two body-different signed share submissions** (its real share + a re-signed copy with a mutated `signature_share`), both binding the authoritative package so both are *accepted* shares. An honest `Round2Collector` flags the second as `EquivocationKindShareConflict` (`ErrShareConflict`) and the process-wide observer receives the culprit-naming evidence. Asserts the two envelopes are distinct, same-package-bound accepted shares (a genuine double-sign, not a divergent share).
- **`..._coordinator_equivocation_...`** (#3a) — the elected coordinator distributes **two VALID coordinator-signed packages** (distinct taproot roots) for the same attempt → `verifiedCoordinatorEquivocations` bypasses the f+1 gate and forces **instant permanent exclusion**, even when the two proofs are split across two observers. Uses a **real secp256k1 operator-key Signer/Verifier** (not the NoOp pair), with a non-vacuous negative control: one authentic package + one whose signature is corrupted (rejected by the real verifier) is only one distinct authentic body and does **not** exclude — proving the verifier is genuinely cryptographic.
- **`..._overflow_park_...`** (#3c) — a member floods a receive loop faster than it drains, genuinely overflowing the bounded inbound channel via the real `enqueueOrRecordOverflow` primitive → the real recorded overflow evidence, carried by an f+1 quorum, drives a **transient park** (not exclusion). Asserts the channel actually rejected enqueues and the recorder recorded overflow, that the park is transient (a following attempt reinstates the flooder), and that the f+1 quorum is genuinely enforced (a single accuser does not park). The flooder is itself a bundle sender, so silence-parking can't account for the park.

In `pkg/tbtc` (`frost_native frost_roast_retry`, pure-Go):

- **`..._cross_node_fracture_...`** (#4) — two nodes with divergent selection state would broadcast **different NextAttempt sets** (a ROAST-consumed set vs a legacy shuffle) — the fracture class that splits the group. The test proves the divergence is real (registered ROAST-active node selects the full transition set; a would-be-legacy node trims to the honest threshold), then proves the **fail-closed guard** collapses it: the SAME node-B `Select` call that returned a concrete legacy set with the registry empty fails closed once ROAST is active, and node A fails closed on its missing expected transition. Neither emits a set, so they can't converge on divergent ones. Each fail-closed decision is repeated to show it is deterministic per-seat.

## CI coverage

- #1/#2/#3a/#3b/#3c run under **frost-cgo-integration** (`frost_native frost_tbtc_signer frost_roast_retry`, linked libfrost_tbtc).
- #4 runs under the **client** `frost_native frost_roast_retry` tag set over `./pkg/tbtc/...`.

All six are green locally, stable across repeated runs, with no regression to the existing real-cgo suite.
